### PR TITLE
move course id page to config, add logging for bad course ids

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -5,3 +5,4 @@
 # Values required for WikiEduDashboard include:
 #   wikipedia_username: <your Wikipedia username>
 #   wikipedia_password: <your Wikipedia password>
+#   course_id_list: "Wikipedia:Education_program/Dashboard/course_ids"

--- a/lib/wiki.rb
+++ b/lib/wiki.rb
@@ -5,7 +5,7 @@ class Wiki
 
   # Parsing methods
   def self.get_course_list
-    response = get_page_content('Wikipedia:Education_program/Dashboard/course_ids')
+    response = get_page_content(Figaro.env.course_id_list)
     response.split(/\n/)
   end
 
@@ -104,6 +104,7 @@ class Wiki
       response = @mw.send_request(options)
     rescue MediaWiki::APIError => e
       puts "Caught #{e}"
+      Rails.logger.warn "Caught #{e}"
       if(e.to_s.include?("Invalid course id"))
         api_get Wiki.handle_invalid_course_id(options, e)
       end
@@ -114,7 +115,7 @@ class Wiki
   end
 
   def self.handle_invalid_course_id(options, e)
-    id = e.to_s[(e.to_s.length - 4)..(e.to_s.length - 2)]
+    id = e.to_s[/(?<=MediaWiki::APIError: API error: code 'invalid-course', info 'Invalid course id: ).*?(?=')/]
     if(options["courseids"].include?(id+'|'))
       options["courseids"].slice! id+'|'
     else


### PR DESCRIPTION
Nate: might we want to move the wiki page that holds the course ids into the configuration file? I think this is right, but I'm going to avoid pushing substantive changes to master.