### PR TITLE
Parse language out of locale for RTL detection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,8 +12,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :rtl?
   def rtl?
-    # FIXME: This doesn't work for compound language tags such as he-IL.
-    I18n.locale.in? [:he, :ar, :yi, :ur, :fa, :ps, :sd, :ug, :ku, :dv]
+    tag = I18n::Locale::Tag::Rfc4646.tag(I18n.locale)
+    tag.language.in? ["ar", "dv", "fa", "he", "ku", "ps", "sd", "ug", "ur", "yi"]
   end
 
   def set_locale


### PR DESCRIPTION
This allows us to match e.g. he-IL as a regional variant of Hebrew.