### PR TITLE
[multiline] Set cloned course term to empty string

### DIFF
--- a/app/assets/javascripts/components/overview/course_cloned_modal.cjsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.cjsx
@@ -32,7 +32,9 @@ CourseClonedModal = React.createClass(
     if value_key in ['title', 'school', 'term']
       ValidationActions.setValid 'exists'
     @setState valuesUpdated: true
+  cloneCompletedStatus: 2
   saveCourse: ->
+    @updateCourse('cloned_status', @clonedCompletedStatus)
     if ValidationStore.isValid()
       @setState isSubmitting: true
       ValidationActions.setInvalid 'exists', 'This course is being checked for uniqueness', true

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -178,6 +178,6 @@ class CoursesController < ApplicationController
       .permit(:id, :title, :description, :school, :term, :slug, :subject,
               :expected_students, :start, :end, :submitted, :listed, :passcode,
               :timeline_start, :timeline_end, :day_exceptions, :weekdays,
-              :no_day_exceptions)
+              :no_day_exceptions, :cloned_status)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,6 +83,11 @@ class Course < ActiveRecord::Base
 
   scope :listed, -> { where(listed: true) }
 
+  CLONED_STATUSES = {
+    'PENDING' => 1,
+    'COMPLETED' => 2
+  }
+
   ##################
   # Course content #
   ##################

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -1,9 +1,10 @@
 json.course do
   json.(@course, :id, :title, :description, :start, :end, :school,
-        :term, :subject, :slug, :url, :listed, :submitted, :listed,
+        :subject, :slug, :url, :listed, :submitted, :listed,
         :expected_students, :timeline_start, :timeline_end, :day_exceptions,
         :weekdays, :no_day_exceptions, :updated_at)
 
+  json.term @course.cloned_status == 1 ? '' : @course.term
   json.legacy @course.id < 10000
   json.ended !current?(@course) && @course.start < Time.now
   json.published CohortsCourses.exists?(course_id: @course.id)

--- a/db/migrate/20150926002358_add_cloned_status_to_course.rb
+++ b/db/migrate/20150926002358_add_cloned_status_to_course.rb
@@ -1,0 +1,5 @@
+class AddClonedStatusToCourse < ActiveRecord::Migration
+  def change
+    add_column :courses, :cloned_status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150910222730) do
+ActiveRecord::Schema.define(version: 20150926002358) do
 
   create_table "articles", force: true do |t|
     t.string   "title"
@@ -119,11 +119,11 @@ ActiveRecord::Schema.define(version: 20150910222730) do
     t.string   "day_exceptions",              default: ""
     t.string   "weekdays",                    default: "0000000"
     t.integer  "new_article_count"
+    t.integer  "order",                       default: 1,         null: false
     t.boolean  "no_day_exceptions",           default: false
     t.integer  "trained_count",               default: 0
+    t.integer  "cloned_status"
   end
-
-  add_index "courses", ["slug"], name: "index_courses_on_slug", using: :btree
 
   create_table "courses_users", force: true do |t|
     t.datetime "created_at"
@@ -156,9 +156,9 @@ ActiveRecord::Schema.define(version: 20150910222730) do
     t.datetime "date"
     t.boolean  "new_article",               default: false
     t.boolean  "deleted",                   default: false
+    t.boolean  "system",                    default: false
     t.float    "wp10",           limit: 24
     t.float    "wp10_previous",  limit: 24
-    t.boolean  "system",                    default: false
     t.integer  "ithenticate_id"
     t.string   "report_url"
   end

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -18,6 +18,7 @@ class CourseCloneManager
 
   def sanitize_clone_info
     @clone.term = "CLONED FROM #{@course.term}"
+    @clone.cloned_status = 1
     @clone.slug = course_slug(@clone)
     @clone.passcode = Course.generate_passcode
     @clone.submitted = false


### PR DESCRIPTION
The spec was to set the cloned course term to '' so that a user would be
able to set it to their desired value. This proved difficult for React
to handle on the front-end because of the interplay of state and props
in text inputs. This commit provides a back-end solution for this
problem by checking the cloned status of the course and setting it to
empty in the JSON response if the course's cloned status is pending
(which it is directly after cloning, as set by the clone manager).

@ragesoss I think you'll find this will do what we want. Unfortunately, there's no test because the acceptance test doesn't like interacting with the course cloned modal. Perhaps that'd be a case for another issue.