### PR TITLE
Remove unused velocity.js dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "dependencies": {
     "jquery": "~2.1.1",
-    "list.js": "wintr/list.js#76c5632d86e11711b965878d58e1f4c90f6bcb18",
-    "velocity": "~1.2.1",
     "jquery-ujs": "~1.0.3",
+    "list.js": "wintr/list.js#76c5632d86e11711b965878d58e1f4c90f6bcb18",
     "lodash": "~3.9.0",
     "moment": "~2.10.3",
     "moment-recur": "~1.0.5"


### PR DESCRIPTION
This was being included in our vendor.js bundle but never used. We can add it back if we ever need it. 