### PR TITLE
Parallel travis specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+# Run feature specs in a parallel build from the rest, to speed up the process.
+# Only run the deployment script on the faster non-feature branch.
+# We should only be pushing healthy builds to staging or production anyway.
+env:
+  - TEST_SUITE='~type:feature'
+    AFTER_SUCCESS='./travis-deploy.sh'
+  - TEST_SUITE=type:feature
+    AFTER_SUCCESS=''
+
 language: ruby
 rvm: 2.1.5
 sudo: false
@@ -49,14 +58,14 @@ before_script:
   - mysql -e "CREATE DATABASE test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
   - bundle exec rake db:migrate RAILS_ENV=test
 
-script: gulp build && npm test && bundle exec rspec --color --format documentation
+script: gulp build && npm test && bundle exec rspec --color --format documentation --tag $TEST_SUITE
 
 after_script:
   - codeclimate-test-reporter < coverage/lcov.info
   - bundle exec rubocop -R
 
 after_success:
-  - ./travis-deploy.sh
+  - $AFTER_SUCCESS
 
 notifications:
   slack:


### PR DESCRIPTION
@thenickcox @bmathews 

This puts the slow feature specs into a separate build. We could take it further and run (say) the course creation specs in on build, other feature specs in another build, and all the rest of the (fast) tests in another build.

The one significant wrinkle is automated deployment. I solved this by attaching the deployment script only to the unit-test build. Since we'll generally only be pushing to production if a build already passed on master, this shouldn't really be a problem (and it also makes deployment reliable, even if some of the feature tests fail intermittently).

What do you two think about this approach?