### PR TITLE
Track deleted files

### DIFF
--- a/db/migrate/20151115182730_add_deleted_to_commons_uploads.rb
+++ b/db/migrate/20151115182730_add_deleted_to_commons_uploads.rb
@@ -1,0 +1,5 @@
+class AddDeletedToCommonsUploads < ActiveRecord::Migration
+  def change
+    add_column :commons_uploads, :deleted, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027174719) do
+ActiveRecord::Schema.define(version: 20151115182730) do
 
   create_table "articles", force: true do |t|
     t.string   "title"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 20151027174719) do
     t.string   "thumburl",    limit: 2000
     t.string   "thumbwidth"
     t.string   "thumbheight"
+    t.boolean  'deleted', default: false
   end
 
   create_table "courses", force: true do |t|

--- a/lib/commons.rb
+++ b/lib/commons.rb
@@ -30,6 +30,14 @@ class Commons
     usages
   end
 
+  def self.find_missing_files(commons_uploads)
+    missing_query = build_info_query(commons_uploads)
+    pages = get_image_data(missing_query, 'pageid', '')
+    missing_pages = pages.select { |page| page['missing'] }
+    missing_page_ids = missing_pages.map { |page| page['pageid'] }
+    commons_uploads.select { |file| missing_page_ids.include? file.id }
+  end
+
   def self.get_urls(commons_uploads)
     url_query = build_url_query commons_uploads
     file_urls = get_image_data(url_query, 'imageinfo', 'iicontinue')
@@ -82,6 +90,14 @@ class Commons
                     continue: ''
                   }
     usage_query
+  end
+
+  def self.build_info_query(commons_uploads)
+    file_ids = commons_uploads.map(&:id)
+    info_query = { pageids: file_ids,
+                   continue: ''
+                 }
+    info_query
   end
 
   def self.build_url_query(commons_uploads)

--- a/lib/importers/upload_importer.rb
+++ b/lib/importers/upload_importer.rb
@@ -19,6 +19,18 @@ class UploadImporter
     end
   end
 
+  def self.find_deleted_files(commons_uploads)
+    Utils.chunk_requests(commons_uploads) do |file_batch|
+      deleted_files = Commons.find_missing_files file_batch
+      CommonsUpload.transaction do
+        deleted_files.each do |file|
+          file.deleted = true
+          file.save
+        end
+      end
+    end
+  end
+
   def self.import_urls_in_batches(commons_uploads)
     # Larger values (50) per batch choke the MediaWiki API on this query.
     Utils.chunk_requests(commons_uploads, 10) do |file_batch|

--- a/lib/tasks/batch.rake
+++ b/lib/tasks/batch.rake
@@ -97,6 +97,7 @@ namespace :batch do
       Rake::Task['article:update_all_ratings'].invoke
       Rake::Task['article:update_article_status'].invoke
 
+      Rake::Task['upload:find_deleted_files'].invoke
       Rake::Task['upload:import_all_uploads'].invoke
       Rake::Task['upload:update_usage_count'].invoke
       Rake::Task['upload:get_thumbnail_urls'].invoke

--- a/lib/tasks/upload.rake
+++ b/lib/tasks/upload.rake
@@ -10,13 +10,19 @@ namespace :upload do
   desc 'Update global usage for all uploads'
   task update_usage_count: 'batch:setup_logger' do
     Rails.logger.debug 'Updating Commons uploads usage counts'
-    UploadImporter.update_usage_count(CommonsUpload.all)
+    UploadImporter.update_usage_count(CommonsUpload.where(deleted: false))
+  end
+
+  desc 'Find files that have been deleted'
+  task find_deleted_files: 'batch:setup_logger' do
+    Rails.logger.debug 'Identifying deleted Commons uploads'
+    UploadImporter.find_deleted_files(CommonsUpload.where(deleted: false))
   end
 
   desc 'Get thumbnail urls for all uploads that lack them'
   task get_thumbnail_urls: 'batch:setup_logger' do
     Rails.logger.debug 'Getting thumbnail urls for Commons uploads'
-    thumbless_uploads = CommonsUpload.where(thumburl: nil)
+    thumbless_uploads = CommonsUpload.where(thumburl: nil, deleted: false)
     UploadImporter.import_urls_in_batches(thumbless_uploads)
   end
 end

--- a/spec/lib/commons_spec.rb
+++ b/spec/lib/commons_spec.rb
@@ -83,6 +83,26 @@ describe Commons do
     end
   end
 
+  describe '.find_missing_files' do
+    let(:deleted_file) { create(:commons_upload, id: 4) }
+    let(:existing_file) { create(:commons_upload, id: 20523186) }
+
+    it 'returns CommonsUploads that are reported missing' do
+      VCR.use_cassette 'commons/find_missing_files' do
+        result = Commons.find_missing_files([deleted_file, existing_file])
+        expect(result).to include deleted_file
+        expect(result).not_to include existing_file
+      end
+    end
+
+    it 'returns an empty array if all files exist' do
+      VCR.use_cassette 'commons/find_missing_files' do
+        result = Commons.find_missing_files([existing_file])
+        expect(result).to eq([])
+      end
+    end
+  end
+
   describe '.get_urls' do
     it 'should get thumbnail url data for files' do
       VCR.use_cassette 'commons/get_urls' do

--- a/spec/lib/importers/upload_importer_spec.rb
+++ b/spec/lib/importers/upload_importer_spec.rb
@@ -28,6 +28,26 @@ describe UploadImporter do
     end
   end
 
+  describe '.find_deleted_files' do
+    before do
+      create(:commons_upload, id: 4)
+      create(:commons_upload, id: 20523186)
+      VCR.use_cassette 'commons/find_deleted_files' do
+        UploadImporter.find_deleted_files(CommonsUpload.all)
+      end
+    end
+
+    it 'marks missing files as deleted' do
+      missing_file = CommonsUpload.find(4)
+      expect(missing_file.deleted).to eq(true)
+    end
+
+    it 'does not affect non-deleted files' do
+      existing_file = CommonsUpload.find(20523186)
+      expect(existing_file.deleted).to eq(false)
+    end
+  end
+
   describe '.import_urls_in_batches' do
     it 'should find and record Commons thumbnail urls' do
       create(:user,


### PR DESCRIPTION
The first step is to get this up and running on staging, and make sure it works and doesn't hurt performance.

Then, we can adjust the Uploads tab of courses to only show non-deleted files, and adjust the Analytics routines to account for deleted files.

A goal for later on will be to surface info about deleted files — as well as deleted articles — to users (see #371).

Resolves #403