### PR TITLE
Enable Wikimedia's pageviews REST api

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -35,6 +35,11 @@
 # to the wiki.
   disable_wiki_output: 'true'
 
+# Setting enable_article_finder to 'true' enables the prototype article_finder
+# tool. Large queries can make the app unresponsive, so it's not ready for
+# production yet.
+  enable_article_finder: 'true'
+
 # Comma-separated list of OAuth client IDs used by the system for Wiki edits
   oauth_ids: '252,212'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,7 +86,7 @@ Rails.application.routes.draw do
   resources :courses_users, only: [:index]
 
   # Article Finder
-  if ENV['dashboard_url'] == 'outreachdashboard.wmflabs.org'
+  if (ENV['dashboard_url'] == 'outreachdashboard.wmflabs.org') || (ENV['enable_article_finder'] == 'true')
     get 'article_finder(/*any)' => 'article_finder#index'
     post 'article_finder(/*any)' => 'article_finder#results'
   end

--- a/lib/importers/view_importer.rb
+++ b/lib/importers/view_importer.rb
@@ -1,4 +1,5 @@
 require "#{Rails.root}/lib/grok"
+require "#{Rails.root}/lib/wiki_pageviews"
 
 #= Imports and updates views for articles, revisions, and join tables
 class ViewImporter
@@ -61,7 +62,7 @@ class ViewImporter
     threads = articles.each_with_index.map do |article, i|
       article_id = article.id
       Thread.new(i) do
-        average_views[article_id] = Grok.average_views_for_article(article.title)
+        average_views[article_id] = WikiPageviews.average_views_for_article(article.title)
         avua[article_id] = datestamp
       end
     end

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -1,0 +1,52 @@
+# Fetches pageview data from the Wikimedia pageviews REST API
+# Documentation: https://wikimedia.org/api/rest_v1/?doc#!/Pageviews_data/get_metrics_pageviews_per_article_project_access_agent_article_granularity_start_end
+class WikiPageviews
+  ################
+  # Entry points #
+  ################
+
+  def self.average_views_for_article(title, language=nil)
+    language = ENV['wiki_language'] if language.nil?
+    data = recent_views(title, language)
+    return unless data
+    data = Utils.parse_json(data)
+    return unless data.include?('items')
+    daily_view_data = data['items']
+    days = daily_view_data.count
+    total_views = 0
+    daily_view_data.each do |day_data|
+      total_views += day_data['views']
+    end
+    average_views = total_views.to_f / days
+    average_views
+  end
+
+  ##################
+  # Helper methods #
+  ##################
+  def self.recent_views(title, language)
+    title = URI.escape(title)
+    base_url = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/#{language}.wikipedia/all-access/user/"
+    # TODO: make this pick a recent month, or recent two months.
+    url = base_url + "#{title}/daily/2015100100/2015103000"
+    api_get url
+  end
+
+  ###################
+  # Private methods #
+  ###################
+  class << self
+    private
+
+    def api_get(url)
+      tries ||= 3
+      Net::HTTP::get(URI.parse(url))
+    rescue Errno::ETIMEDOUT
+      Rails.logger.error I18n.t('timeout', api: 'wikimedia.org/api/rest_v1', tries: (tries -= 1))
+      retry unless tries.zero?
+    rescue StandardError => e
+      Rails.logger.error "Wikimedia REST API error: #{e}"
+      Raven.capture_exception e
+    end
+  end
+end

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -25,10 +25,13 @@ class WikiPageviews
   # Helper methods #
   ##################
   def self.recent_views(title, language)
-    title = URI.escape(title)
+    # Double escape is necessary temporarily to work around this bug: https://phabricator.wikimedia.org/T118403
+    # Switch to single escape once that is fixed.
+    title = CGI.escape(CGI.escape(title))
     base_url = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/#{language}.wikipedia/all-access/user/"
     # TODO: make this pick a recent month, or recent two months.
-    url = base_url + "#{title}/daily/2015100100/2015103000"
+    url = base_url + "#{title}/daily/2015100100/2016103000"
+    pp url
     api_get url
   end
 

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -50,8 +50,6 @@ class WikiPageviews
   # Helper methods #
   ##################
   def self.recent_views(title, language)
-    # Double escape is necessary temporarily to work around this bug: https://phabricator.wikimedia.org/T118403
-    # Switch to single escape once that is fixed.
     start_date = 50.days.ago
     end_date = 1.day.ago
     url = query_url(title, start_date, end_date, language)
@@ -59,7 +57,7 @@ class WikiPageviews
   end
 
   def self.query_url(title, start_date, end_date, language)
-    title = CGI.escape(CGI.escape(title))
+    title = CGI.escape(title)
     base_url = 'https://wikimedia.org/api/rest_v1/metrics/pageviews/'
     configuration_params = "per-article/#{language}.wikipedia/all-access/user/"
     start_param = start_date.strftime('%Y%m%d')

--- a/spec/lib/wiki_pageviews_spec.rb
+++ b/spec/lib/wiki_pageviews_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+require "#{Rails.root}/lib/wiki_pageviews"
+
+describe WikiPageviews do
+  describe '.views_for_article' do
+    context 'for a popular article' do
+      let(:title) { 'Selfie' }
+      let(:start_date) { '2015-10-01'.to_date }
+      let(:end_date) { '2015-11-01'.to_date }
+      let(:subject) do
+        WikiPageviews.views_for_article(title, start_date: start_date,
+                                               end_date: end_date)
+      end
+
+      it 'returns a hash of daily views for all the requested dates' do
+        VCR.use_cassette 'wiki_pageviews/views_for_article' do
+          expect(subject).to be_a Hash
+          expect(subject.count).to eq(32)
+        end
+      end
+
+      it 'always returns the same value for a certain date' do
+        VCR.use_cassette 'wiki_pageviews/views_for_article' do
+          expect(subject['20151001']).to eq(2164)
+        end
+      end
+    end
+  end
+
+  describe '.average_views_for_article' do
+    let(:subject) { WikiPageviews.average_views_for_article(title) }
+
+    context 'for a popular article' do
+      let(:title) { 'Selfie' }
+      it 'returns the average page views' do
+        VCR.use_cassette 'wiki_pageviews/average_views' do
+          expect(subject).to be > 500
+        end
+      end
+    end
+
+    context 'for an article with a slash in the title' do
+      let(:title) { 'HIV/AIDS' }
+      it 'returns the average page views' do
+        VCR.use_cassette 'wiki_pageviews/average_views' do
+          expect(subject).to be > 500
+        end
+      end
+    end
+
+    context 'for an article with an apostrophe in the title' do
+      let(:title) { "Broussard's" }
+      it 'returns the average page views' do
+        VCR.use_cassette 'wiki_pageviews/average_views' do
+          expect(subject).to be > 1
+        end
+      end
+    end
+
+    context 'for an article with quote marks in the title' do
+      let(:title) { '"Weird_Al"_Yankovic' }
+      it 'returns the average page views' do
+        VCR.use_cassette 'wiki_pageviews/average_views' do
+          expect(subject).to be > 50
+        end
+      end
+    end
+
+    context 'for an article with unicode characters in the title' do
+      let(:title) { 'André_the_Giant' }
+      it 'returns the average page views' do
+        VCR.use_cassette 'wiki_pageviews/average_views' do
+          expect(subject).to be > 50
+        end
+      end
+    end
+
+    context 'for an article that does not exist' do
+      let(:title) { 'THIS_IS_NOT_A_REAL_ARTICLE' }
+      it 'returns nil' do
+        VCR.use_cassette 'wiki_pageviews/average_views' do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The new WikiPageviews library is a drop-in replacement for Grok. It uses the new pageview endpoint at wikimedia.org, which is much faster and has more accurate data than stats.grok.se.

However, the new endpoint only has recent pageview data — it will eventually be backfilled to May 2015, but not further back than that. That will probably not cause any major problems, but for now, these commits only switch to the new endpoint for getting average view data (which is used only by the article_finder prototype, which is not enabled in production).