### PR TITLE
Improve styling for training nav ellipsis and fix links that were still accessible

### DIFF
--- a/app/assets/javascripts/training/components/slide_menu.cjsx
+++ b/app/assets/javascripts/training/components/slide_menu.cjsx
@@ -16,16 +16,18 @@ SlideMenu = React.createClass(
       # need the slide index because overflow: hidden cuts off li numbering
       params = @linkParams(@props)
       slides = @props.slides.map (slide, loopIndex) =>
-        liClass = if @props.currentSlide.index == loopIndex + 1 then 'current' else ''
+        current = slide.id == @props.currentSlide.id
+        liClass = if current then 'current' else ''
         newParams = _.extend @linkParams(@props), slide_id: slide.slug
+        link = "/training/#{newParams.library_id}/#{newParams.module_id}/#{newParams.slide_id}"
         # a slide is enabled if it comes back from the API as such,
         # it is set enabled in the parent component,
         # or it's the current slide
-        enabled = slide.enabled is true || @props.enabledSlides.indexOf(slide.id) >= 0 || (slide.id == @props.currentSlide.id)
+        enabled = (slide.enabled is true || @props.enabledSlides.indexOf(slide.id) >= 0) && !current
         <li key={[slide.id, loopIndex].join('-')} onClick={@props.onClick} className={liClass}>
-          <Link to="slide" disabled={!enabled} params={newParams}>
+          <a disabled={!enabled} href={!enabled && 'javascript:void(0)' || link}>
             {loopIndex + 1}. {slide.title}
-          </Link>
+          </a>
         </li>
 
     menuClass = "slide__menu__nav__dropdown "

--- a/app/assets/javascripts/training/components/training_module_handler.cjsx
+++ b/app/assets/javascripts/training/components/training_module_handler.cjsx
@@ -22,7 +22,7 @@ TrainingModuleHandler = React.createClass(
       link = "#{@state.training_module.slug}/#{slide.slug}"
       liClassName = 'disabled' if disabled
       <li className={liClassName} key={i}>
-        <a disabled={disabled} href={link}>
+        <a disabled={disabled} href={disabled && 'javascript:void(0)' || link}>
           <h3 className="h5">{slide.title}</h3>
           <div className="ui-text small sidebar-text">{slide.summary}</div>
         </a>

--- a/app/assets/stylesheets/training_modules/_buttons.styl
+++ b/app/assets/stylesheets/training_modules/_buttons.styl
@@ -28,9 +28,6 @@
 a[disabled]
   opacity 0.5
   pointer-events none
-  *
-    opacity 0.5
-    pointer-events none
 
 .btn-primary.ghost-button
   background transparent

--- a/app/assets/stylesheets/training_modules/_nav.styl
+++ b/app/assets/stylesheets/training_modules/_nav.styl
@@ -144,7 +144,6 @@ a.slide-nav
     margin-bottom 15px
     padding 16px 16px 0
   li
-    @extends .truncated-text
     font-size 17px
     line-height 21px
     margin 10px 0
@@ -155,11 +154,13 @@ a.slide-nav
     font-weight 400
     &.current
       font-weight 600
-      pointer-events none
       color $training_primary
       a
+        opacity 1
         color $training_primary
     a
+      @extends .truncated-text
+      display block
       color $type_dark
       text-decoration none
       &:hover


### PR DESCRIPTION
Ellipsis style fix:

before:

![image](https://cloud.githubusercontent.com/assets/848347/11447442/d1b9c04c-94fa-11e5-9b3f-d0ccf9d3efef.png)

after:

![image](https://cloud.githubusercontent.com/assets/848347/11447469/13324238-94fb-11e5-8581-c4a21a72c646.png)


Also fixed links that were still accessible via non-touch interactions (keynav or otherwise bypassing `pointer-events: none`).

![image](https://cloud.githubusercontent.com/assets/848347/11447411/93cd8d40-94fa-11e5-9800-27efd522c50d.png)