### PR TITLE
Only show strictly current courses to admins.

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,11 +6,13 @@ class DashboardController < ApplicationController
     current = current_user.courses.current_and_future.listed
     past = current_user.courses.archived.listed
     submitted = []
+    strictly_current = []
 
     if current_user.admin?
       submitted = Course.submitted_listed
+      strictly_current = current_user.courses.strictly_current
     end
 
-    @pres = DashboardPresenter.new(current, past, submitted, current_user)
+    @pres = DashboardPresenter.new(current, past, submitted, strictly_current, current_user)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -93,10 +93,11 @@ class Course < ActiveRecord::Base
     'COMPLETED' => 2
   }
 
+  scope :strictly_current, -> { where('start < ? < end', Time.zone.now) }
   scope :current, -> { current_and_future.where('start < ?', Time.zone.now) }
-
   # A course stays "current" for a while after the end date, during which time
-  # we still check for new data and update page views.
+  # we still check for new data and update page views. To exclude those courses
+  # use "strictly_current".
   UPDATE_LENGTH = ENV['update_length'].to_i.days.seconds.to_i
 
   scope :current_and_future, lambda {

--- a/app/views/courses/_user_courses.html.erb
+++ b/app/views/courses/_user_courses.html.erb
@@ -28,13 +28,13 @@
     </div>
   </div>
   <ul class="list">
-  <% if @pres.current.empty? %>
+  <% if @pres.strictly_current.empty? %>
     <li class="row view-all">
       <div><%= t("courses.nocourses") %></div>
     </li>
   <% else %>
-    <% @pres.current.each do |c| %>
-      <%= render 'courses/row', course: c, admin: false, user: true %>
+    <% @pres.strictly_current.each do |c| %>
+      <%= render 'courses/row', course: c, user: true %>
     <% end %>
   <% end %>
   </ul>


### PR DESCRIPTION
Admins have so many courses, and the distance between terms is so short, that we want to immediately remove courses from the list when they end.

@bmathews Does this look okay to you? It's the case that we now only use the _user_courses partial for admins, right?