### PR TITLE
Set environment variables in config/environments/test.rb

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -67,14 +67,6 @@
 #  cohort_fall_2014: "Wikipedia:Education_program/Dashboard/Fall_2014_course_ids"
 #  cohort_spring_2015: "Wikipedia:Education_program/Dashboard/course_ids"
 
-## Tests are written with specific cohorts in mind. Uncomment these lines
-## to allow tests to run as expected.
-# test:
-#   default_cohort: "spring_2015"
-#   cohorts: "fall_2014,spring_2015"
-#   cohort_fall_2014: "Wikipedia:Education_program/Dashboard/Fall_2014_course_ids"
-#   cohort_spring_2015: "Wikipedia:Education_program/Dashboard/course_ids"
-
 # The slug for the default cohort
   default_cohort: "fall_2014"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,16 @@
+ENV['disable_wiki_output'] = 'false'
+ENV['wiki_language'] = 'en'
+ENV['enable_article_finder'] = 'true'
+ENV['oauth_ids'] = '252,212'
+ENV['training_page_id'] = '36892501'
+ENV['default_cohort'] = 'spring_2015'
+ENV['cohorts'] = 'fall_2014,spring_2015'
+ENV['cohort_fall_2014'] = 'Wikipedia:Education_program/Dashboard/Fall_2014_course_ids'
+ENV['cohort_spring_2015'] = 'Wikipedia:Education_program/Dashboard/course_ids'
+ENV['sentry_dsn'] = 'http://somelongkey:anotherlongkey@sentry.myserver.com/1'
+ENV['sentry_public_dsn'] = 'http://anotherlongkey@sentry.myserver.com/1'
+ENV['no_views'] = 'false'
+
 Rails.application.configure do
   # Settings specified here will take
   # precedence over those in config/application.rb.


### PR DESCRIPTION
This should ensure that the local application.yml settings don't interfere with specs. For example, the student_greeter_spec will fail if wiki output is disabled. This allows you to disable it for your development environment, but still have it set in the test environment to satisfy the specs.

Resolves #592 