### PR TITLE
Refactor WikiEdits by moving course-specific methods to WikiCourseEdits

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -145,7 +145,10 @@ class CoursesController < ApplicationController
   def handle_course_announcement(instructor)
     newly_submitted = !@course.submitted? && course_params[:submitted] == true
     return unless newly_submitted
-    WikiEdits.announce_course(@course, current_user, instructor)
+    WikiCourseEdits.new(action: 'announce_course',
+                        course: @course,
+                        current_user: current_user,
+                        instructor: instructor)
   end
 
   def should_set_slug?

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,6 @@
 require 'oauth'
 require "#{Rails.root}/lib/wiki_edits"
+require "#{Rails.root}/lib/wiki_course_edits"
 
 #= Controller for course functionality
 class CoursesController < ApplicationController
@@ -31,14 +32,19 @@ class CoursesController < ApplicationController
       :passcode, Course.generate_passcode
     ) if course_params[:passcode].nil?
 
-    WikiEdits.update_course(@course, current_user)
+    WikiCourseEdits.new(action: :update_course,
+                        course: @course,
+                        current_user: current_user)
     render json: { course: @course }
   end
 
   def destroy
     validate
     @course.destroy
-    WikiEdits.update_course(@course, current_user, true)
+    WikiCourseEdits.new(action: :update_course,
+                        course: @course,
+                        current_user: current_user,
+                        delete: true)
     render json: { success: true }
   end
 

--- a/app/controllers/self_enrollment_controller.rb
+++ b/app/controllers/self_enrollment_controller.rb
@@ -33,7 +33,10 @@ class SelfEnrollmentController < ApplicationController
       WikiCourseEdits.new(action: :enroll_in_course,
                           course: @course,
                           current_user: current_user)
-      WikiEdits.update_course(@course, current_user) # Adds user to course page
+      # Adds user to course page by updating course page with latest course info
+      WikiCourseEdits.new(action: :update_course,
+                          course: @course,
+                          current_user: current_user)
     end
 
     redirect_to course_slug_path(@course.slug, enrolled: true)

--- a/app/controllers/self_enrollment_controller.rb
+++ b/app/controllers/self_enrollment_controller.rb
@@ -27,8 +27,12 @@ class SelfEnrollmentController < ApplicationController
 
     # Check passcode, enroll if valid
     if passcode_valid?
-      add_student_to_course # Creates the CoursesUsers record
-      WikiEdits.enroll_in_course(@course, current_user) # Posts templates to userpage and sandbox
+      # Creates the CoursesUsers record
+      add_student_to_course
+      # Posts templates to userpage and sandbox
+      WikiCourseEdits.new(action: :enroll_in_course,
+                          course: @course,
+                          current_user: current_user)
       WikiEdits.update_course(@course, current_user) # Adds user to course page
     end
 

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -1,4 +1,4 @@
-require "#{Rails.root}/lib/wiki_edits"
+require "#{Rails.root}/lib/wiki_course_edits"
 
 #= Controller for timeline functionality
 class TimelineController < ApplicationController
@@ -71,7 +71,7 @@ class TimelineController < ApplicationController
     Array.wrap(timeline_params['weeks']).each do |week|
       update_week week
     end
-    WikiEdits.update_course(@course, current_user)
+    WikiCourseEdits.new(action: :update_course, course: @course, current_user: current_user)
     render 'timeline'
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 require "#{Rails.root}/lib/wiki_edits"
+require "#{Rails.root}/lib/wiki_course_edits"
 
 #= Controller for user functionality
 class UsersController < ApplicationController
@@ -87,7 +88,7 @@ class UsersController < ApplicationController
         role: enroll_params[:role]
       )
 
-      WikiEdits.update_course(@course, current_user)
+      WikiCourseEdits.new(action: :update_course, course: @course, current_user: current_user)
       render 'users', formats: :json
     else
       username = enroll_params[:user_id] || enroll_params[:wiki_id]
@@ -112,7 +113,7 @@ class UsersController < ApplicationController
 
     course_user.destroy # destroying the course_user also destroys associated Assignments.
     render 'users', formats: :json
-    WikiEdits.update_course(@course, current_user)
+    WikiCourseEdits.new(action: :update_course, course: @course, current_user: current_user)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,3 @@
-require "#{Rails.root}/lib/wiki_edits"
 require "#{Rails.root}/lib/wiki_course_edits"
 
 #= Controller for user functionality

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,7 +109,12 @@ class UsersController < ApplicationController
     )
     return if course_user.nil? # This will happen if the user was already removed.
     assignments = course_user.assignments
-    assignments.each { |assignment| WikiEdits.remove_assignment(current_user, assignment) }
+    assignments.each do |assignment|
+      WikiCourseEdits.new(action: :remove_assignment,
+                          course: @course,
+                          current_user: current_user,
+                          assignment: assignment)
+    end
 
     course_user.destroy # destroying the course_user also destroys associated Assignments.
     render 'users', formats: :json

--- a/lib/assignments_manager.rb
+++ b/lib/assignments_manager.rb
@@ -25,11 +25,13 @@ class AssignmentsManager
       assignment = Assignment.find_by(id: assignment_data['id']) if assignment_data['id']
       update_assignment assignment_data
 
-      WikiEdits
-        .remove_assignment(current_user, assignment) if assignment_data['deleted'] && assignment
+      WikiCourseEdits.new(action: :remove_assignment,
+                          course: course,
+                          current_user: current_user,
+                          assignment: assignment) if assignment_data['deleted'] && assignment
     end
 
-    WikiEdits.update_assignments(current_user, course)
+    WikiCourseEdits.new(action: :update_assignments, course: course, current_user: current_user)
     WikiCourseEdits.new(action: :update_course, course: course, current_user: current_user)
   end
 

--- a/lib/assignments_manager.rb
+++ b/lib/assignments_manager.rb
@@ -1,4 +1,5 @@
 require "#{Rails.root}/lib/wiki_edits"
+require "#{Rails.root}/lib/wiki_course_edits"
 require "#{Rails.root}/lib/utils"
 
 # Handles assignment data submitted by users
@@ -29,7 +30,7 @@ class AssignmentsManager
     end
 
     WikiEdits.update_assignments(current_user, course)
-    WikiEdits.update_course(course, current_user)
+    WikiCourseEdits.new(action: :update_course, course: course, current_user: current_user)
   end
 
   def self.update_assignment(assignment_object)

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -1,0 +1,36 @@
+require "#{Rails.root}/lib/wiki_edits"
+
+#= Class for making wiki edits for a particular course
+class WikiCourseEdits
+  def initialize(action:, course:, current_user:, **opts)
+    @course = course
+    @current_user = current_user
+    send(action, opts)
+  end
+
+  # This method both posts to the instructor's userpage and also makes a public
+  # announcement of a newly submitted course at the course announcement page.
+  def announce_course(instructor: nil)
+    instructor ||= @current_user
+    course_title = @course.wiki_title
+    user_page = "User:#{instructor.wiki_id}"
+    template = "{{course instructor|course = [[#{course_title}]] }}\n"
+    summary = "New course announcement: [[#{course_title}]]."
+
+    # Add template to userpage to indicate instructor role.
+    WikiEdits.add_to_page_top(user_page, @current_user, template, summary)
+
+    # Announce the course on the Education Noticeboard or equivalent.
+    announcement_page = ENV['course_announcement_page']
+    dashboard_url = ENV['dashboard_url']
+    # rubocop:disable Metrics/LineLength
+    announcement = "I have created a new course — #{@course.title} — at #{dashboard_url}/courses/#{@course.slug}. If you'd like to see more details about my course, check out my course page.--~~~~"
+    section_title = "New course announcement: [[#{course_title}]] (instructor: [[User:#{instructor.wiki_id}]])"
+    # rubocop:enable Metrics/LineLength
+    message = { sectiontitle: section_title,
+                text: announcement,
+                summary: summary }
+
+    WikiEdits.add_new_section(@current_user, announcement_page, message)
+  end
+end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -33,4 +33,21 @@ class WikiCourseEdits
 
     WikiEdits.add_new_section(@current_user, announcement_page, message)
   end
+
+  def enroll_in_course(*)
+    # Add a template to the user page
+    course_title = @course.wiki_title
+    template = "{{student editor|course = [[#{course_title}]] }}\n"
+    user_page = "User:#{@current_user.wiki_id}"
+    summary = "I am enrolled in [[#{course_title}]]."
+    WikiEdits.add_to_page_top(user_page, @current_user, template, summary)
+
+    # Pre-create the user's sandbox
+    # TODO: Do this more selectively, replacing the default template if
+    # it is present.
+    sandbox = user_page + '/sandbox'
+    sandbox_template = "{{#{ENV['dashboard_url']} sandbox}}"
+    sandbox_summary = "adding {{#{ENV['dashboard_url']} sandbox}}"
+    WikiEdits.add_to_page_top(sandbox, @current_user, sandbox_template, sandbox_summary)
+  end
 end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -30,16 +30,15 @@ class WikiCourseEdits
 
     # Post the update
     response = WikiEdits.post_whole_page(@current_user, wiki_title, wiki_text, summary)
+    return response unless response['edit']
 
     # If it hit the spam blacklist, replace the offending links and try again.
-    if response['edit']
-      bad_links = response['edit']['spamblacklist']
-      return response if bad_links.nil?
-      bad_links = bad_links.split('|')
-      safe_wiki_text = WikiCourseOutput
-                       .substitute_bad_links(wiki_text, bad_links)
-      WikiEdits.post_whole_page(@current_user, wiki_title, safe_wiki_text, summary)
-    end
+    bad_links = response['edit']['spamblacklist']
+    return response if bad_links.nil?
+    bad_links = bad_links.split('|')
+    safe_wiki_text = WikiCourseOutput
+                     .substitute_bad_links(wiki_text, bad_links)
+    WikiEdits.post_whole_page(@current_user, wiki_title, safe_wiki_text, summary)
   end
 
   # Posts to the instructor's userpage, and also makes a public
@@ -141,5 +140,4 @@ class WikiCourseEdits
     summary = "Update [[#{course_page}|#{course_title}]] assignment details"
     WikiEdits.post_whole_page(@current_user, talk_title, page_content, summary)
   end
-
 end

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -30,32 +30,6 @@ class WikiEdits
                                    untrained_count: untrained_users.count }
   end
 
-  # This method both posts to the instructor's userpage and also makes a public
-  # announcement of a newly submitted course at the course announcement page.
-  def self.announce_course(course, current_user, instructor = nil)
-    instructor ||= current_user
-    course_title = course.wiki_title
-    user_page = "User:#{instructor.wiki_id}"
-    template = "{{course instructor|course = [[#{course_title}]] }}\n"
-    summary = "New course announcement: [[#{course_title}]]."
-
-    # Add template to userpage to indicate instructor role.
-    add_to_page_top(user_page, current_user, template, summary)
-
-    # Announce the course on the Education Noticeboard or equivalent.
-    announcement_page = ENV['course_announcement_page']
-    dashboard_url = ENV['dashboard_url']
-    # rubocop:disable Metrics/LineLength
-    announcement = "I have created a new course — #{course.title} — at #{dashboard_url}/courses/#{course.slug}. If you'd like to see more details about my course, check out my course page.--~~~~"
-    section_title = "New course announcement: [[#{course_title}]] (instructor: [[User:#{instructor.wiki_id}]])"
-    # rubocop:enable Metrics/LineLength
-    message = { sectiontitle: section_title,
-                text: announcement,
-                summary: summary }
-
-    add_new_section(current_user, announcement_page, message)
-  end
-
   def self.enroll_in_course(course, current_user)
     # Add a template to the user page
     course_title = course.wiki_title

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -30,23 +30,6 @@ class WikiEdits
                                    untrained_count: untrained_users.count }
   end
 
-  def self.enroll_in_course(course, current_user)
-    # Add a template to the user page
-    course_title = course.wiki_title
-    template = "{{student editor|course = [[#{course_title}]] }}\n"
-    user_page = "User:#{current_user.wiki_id}"
-    summary = "I am enrolled in [[#{course_title}]]."
-    add_to_page_top(user_page, current_user, template, summary)
-
-    # Pre-create the user's sandbox
-    # TODO: Do this more selectively, replacing the default template if
-    # it is present.
-    sandbox = user_page + '/sandbox'
-    sandbox_template = "{{#{ENV['dashboard_url']} sandbox}}"
-    sandbox_summary = "adding {{#{ENV['dashboard_url']} sandbox}}"
-    add_to_page_top(sandbox, current_user, sandbox_template, sandbox_summary)
-  end
-
   def self.update_course(course, current_user, delete = false)
     require './lib/wiki_course_output'
 

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -30,37 +30,6 @@ class WikiEdits
                                    untrained_count: untrained_users.count }
   end
 
-  def self.update_course(course, current_user, delete = false)
-    require './lib/wiki_course_output'
-
-    return unless current_user && course.submitted && course.slug?
-
-    if delete == true
-      wiki_text = ''
-    else
-      wiki_text = WikiCourseOutput.translate_course(course)
-    end
-
-    course_prefix = ENV['course_prefix']
-    wiki_title = "#{course_prefix}/#{course.slug}"
-
-    dashboard_url = ENV['dashboard_url']
-    summary = "Updating course from #{dashboard_url}"
-
-    # Post the update
-    response = post_whole_page(current_user, wiki_title, wiki_text, summary)
-
-    # If it hit the spam blacklist, replace the offending links and try again.
-    if response['edit']
-      bad_links = response['edit']['spamblacklist']
-      return response if bad_links.nil?
-      bad_links = bad_links.split('|')
-      safe_wiki_text = WikiCourseOutput
-                       .substitute_bad_links(wiki_text, bad_links)
-      post_whole_page(current_user, wiki_title, safe_wiki_text, summary)
-    end
-  end
-
   def self.update_assignments(current_user, course)
     grouped_assignments = assignments_grouped_by_article_title(course)
     grouped_assignments.each do |title, assignments_for_same_title|

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -30,50 +30,6 @@ class WikiEdits
                                    untrained_count: untrained_users.count }
   end
 
-  def self.update_assignments(current_user, course)
-    grouped_assignments = assignments_grouped_by_article_title(course)
-    grouped_assignments.each do |title, assignments_for_same_title|
-      update_assignments_for_title(current_user,
-                                   title,
-                                   assignments_for_same_title,
-                                   course)
-    end
-  end
-
-  def self.remove_assignment(current_user, assignment)
-    article_title = assignment.article_title
-    other_assignments_for_same_course_and_title = assignment.sibling_assignments
-    course = assignment.course
-
-    update_assignments_for_title(current_user,
-                                 article_title,
-                                 other_assignments_for_same_course_and_title,
-                                 course)
-  end
-
-  def self.update_assignments_for_title(current_user, title, assignments_for_same_title, course)
-    require './lib/wiki_assignment_output'
-
-    # TODO: i18n of talk namespace
-    if title[0..4] == 'Talk:'
-      talk_title = title
-    else
-      talk_title = "Talk:#{title.tr(' ', '_')}"
-    end
-
-    course_page = course.wiki_title
-    page_content = WikiAssignmentOutput
-                   .build_talk_page_update(title,
-                                           talk_title,
-                                           assignments_for_same_title,
-                                           course_page)
-
-    return if page_content.nil?
-    course_title = course.title
-    summary = "Update [[#{course_page}|#{course_title}]] assignment details"
-    post_whole_page(current_user, talk_title, page_content, summary)
-  end
-
   def self.notify_user(sender, recipient, message)
     add_new_section(sender, recipient.talk_page, message)
   end
@@ -86,10 +42,6 @@ class WikiEdits
     recipient_users.each do |recipient|
       add_new_section(current_user, recipient.talk_page, message)
     end
-  end
-
-  def self.assignments_grouped_by_article_title(course)
-    course.assignments.group_by(&:article_title)
   end
 
   ####################

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -2,9 +2,9 @@ require "#{Rails.root}/lib/wiki_response"
 
 #= Class for making edits to Wikipedia via OAuth, using a user's credentials
 class WikiEdits
-  ################
-  # Entry points #
-  ################
+  #######################
+  # Direct entry points #
+  #######################
   def self.oauth_credentials_valid?(current_user)
     get_tokens(current_user)
     current_user.wiki_token != 'invalid'
@@ -34,19 +34,10 @@ class WikiEdits
     add_new_section(sender, recipient.talk_page, message)
   end
 
-  ###################
-  # Helper methods #
-  ###################
-
-  def self.notify_users(current_user, recipient_users, message)
-    recipient_users.each do |recipient|
-      add_new_section(current_user, recipient.talk_page, message)
-    end
-  end
-
   ####################
   # Basic edit types #
   ####################
+  # These are also entry points.
 
   def self.post_whole_page(current_user, page_title, content, summary = nil)
     params = { action: 'edit',
@@ -78,6 +69,16 @@ class WikiEdits
                format: 'json' }
 
     api_post params, current_user
+  end
+
+  ###################
+  # Helper methods #
+  ###################
+
+  def self.notify_users(current_user, recipient_users, message)
+    recipient_users.each do |recipient|
+      add_new_section(current_user, recipient.talk_page, message)
+    end
   end
 
   ###############

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -25,15 +25,15 @@ describe CoursesController do
       controller.instance_variable_set(:@course, course)
     end
 
-    it 'calls update methods on WikiEdits' do
-      expect(WikiEdits).to receive(:update_course)
+    it 'calls update methods via WikiCourseEdits' do
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
       delete :destroy, id: "#{course.slug}.json", format: :json
     end
 
     context 'destroy callbacks' do
       before do
         allow(WikiEdits).to receive(:update_assignments)
-        allow(WikiEdits).to receive(:update_course)
+        allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
       end
 
       it 'destroys associated models' do
@@ -90,7 +90,7 @@ describe CoursesController do
     before do
       allow(controller).to receive(:current_user).and_return(user)
       allow(controller).to receive(:user_signed_in?).and_return(true)
-      allow(WikiEdits).to receive(:update_course)
+      allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
     end
     it 'updates all values' do
       put :update, id: course.slug, course: course_params, format: :json
@@ -188,7 +188,7 @@ describe CoursesController do
             listed: false,
             day_exceptions: '',
             weekdays: '0001000',
-            no_day_exceptions: true}
+            no_day_exceptions: true }
         end
         it 'sets timeline start/end to course start/end if not in params' do
           put :create, course: course_params, format: :json

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -125,7 +125,7 @@ describe CoursesController do
       let(:submitted_1) { true }
       let(:submitted_2) { true }
       it 'does not announce course' do
-        expect(WikiEdits).not_to receive(:announce_course)
+        expect_any_instance_of(WikiCourseEdits).not_to receive(:announce_course)
         put :update, id: course.slug, course: course_params, format: :json
       end
     end
@@ -133,7 +133,7 @@ describe CoursesController do
     context 'course is new' do
       let(:submitted_2) { true }
       it 'announces course' do
-        expect(WikiEdits).to receive(:announce_course)
+        expect_any_instance_of(WikiCourseEdits).to receive(:announce_course)
         put :update, id: course.slug, course: course_params, format: :json
       end
     end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -32,7 +32,7 @@ describe CoursesController do
 
     context 'destroy callbacks' do
       before do
-        allow(WikiEdits).to receive(:update_assignments)
+        allow_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
         allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
       end
 

--- a/spec/controllers/self_enrollment_controller_spec.rb
+++ b/spec/controllers/self_enrollment_controller_spec.rb
@@ -9,7 +9,7 @@ describe SelfEnrollmentController do
     let(:user) { create(:user) }
 
     before do
-      allow(WikiEdits).to receive(:update_course)
+      allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
       allow(WikiEdits).to receive(:update_assignments)
       allow(controller).to receive(:current_user).and_return(user)
     end

--- a/spec/controllers/self_enrollment_controller_spec.rb
+++ b/spec/controllers/self_enrollment_controller_spec.rb
@@ -19,7 +19,7 @@ describe SelfEnrollmentController do
     context 'GET' do
       context 'when the user is not enrolled yet' do
         it 'enrolls user (and redirects)' do
-          expect(WikiEdits).to receive(:enroll_in_course)
+          expect_any_instance_of(WikiCourseEdits).to receive(:enroll_in_course)
           get 'enroll_self', request_params
           expect(subject).to eq(302)
           expect(course.students.count).to eq(1)
@@ -35,7 +35,7 @@ describe SelfEnrollmentController do
         end
 
         it 'redirects without enrolling the user' do
-          expect(WikiEdits).not_to receive(:enroll_in_course)
+          expect_any_instance_of(WikiCourseEdits).not_to receive(:enroll_in_course)
           get 'enroll_self', request_params
           expect(subject).to eq(302)
           expect(course.students.count).to eq(0)

--- a/spec/controllers/self_enrollment_controller_spec.rb
+++ b/spec/controllers/self_enrollment_controller_spec.rb
@@ -10,7 +10,7 @@ describe SelfEnrollmentController do
 
     before do
       allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
-      allow(WikiEdits).to receive(:update_assignments)
+      allow_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       allow(controller).to receive(:current_user).and_return(user)
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,7 +11,7 @@ describe UsersController do
 
     before do
       allow_any_instance_of(WikiCourseEdits).to receive(:enroll_in_course)
-      allow(WikiEdits).to receive(:update_course)
+      allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
       allow(WikiEdits).to receive(:remove_assignment)
       allow(WikiEdits).to receive(:update_assignments)
       allow(controller).to receive(:current_user).and_return(user)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -12,8 +12,8 @@ describe UsersController do
     before do
       allow_any_instance_of(WikiCourseEdits).to receive(:enroll_in_course)
       allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
-      allow(WikiEdits).to receive(:remove_assignment)
-      allow(WikiEdits).to receive(:update_assignments)
+      allow_any_instance_of(WikiCourseEdits).to receive(:remove_assignment)
+      allow_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       allow(controller).to receive(:current_user).and_return(user)
       allow(controller).to receive(:require_participating_user)
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -10,7 +10,7 @@ describe UsersController do
     let(:admin) { create(:admin) }
 
     before do
-      allow(WikiEdits).to receive(:enroll_in_course)
+      allow_any_instance_of(WikiCourseEdits).to receive(:enroll_in_course)
       allow(WikiEdits).to receive(:update_course)
       allow(WikiEdits).to receive(:remove_assignment)
       allow(WikiEdits).to receive(:update_assignments)

--- a/spec/lib/assignments_manager_spec.rb
+++ b/spec/lib/assignments_manager_spec.rb
@@ -12,7 +12,7 @@ describe AssignmentsManager do
                  'assignments' => [{ 'user_id' => 1,
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
-      expect(WikiEdits).to receive(:update_assignments)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
 
       AssignmentsManager.update_assignments(course, params, user)
@@ -25,7 +25,7 @@ describe AssignmentsManager do
                  'assignments' => [{ 'user_id' => 1,
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
-      expect(WikiEdits).to receive(:update_assignments)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
 
       AssignmentsManager.update_assignments(course, params, user)
@@ -47,8 +47,8 @@ describe AssignmentsManager do
                                      'article_title' => 'existing article',
                                      'role' => 0,
                                      'deleted' => 'true' }] }
-      expect(WikiEdits).to receive(:remove_assignment)
-      expect(WikiEdits).to receive(:update_assignments)
+      expect_any_instance_of(WikiCourseEdits).to receive(:remove_assignment)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
       AssignmentsManager.update_assignments(course, params, user)
       expect(Assignment.all).to be_empty
@@ -61,7 +61,7 @@ describe AssignmentsManager do
                                      'article_title' => 'existing article',
                                      'role' => 0,
                                      'deleted' => 'true' }] }
-      expect(WikiEdits).to receive(:update_assignments)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
 
       AssignmentsManager.update_assignments(course, params, user)
@@ -80,7 +80,7 @@ describe AssignmentsManager do
                  'assignments' => [{ 'user_id' => 1,
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
-      expect(WikiEdits).to receive(:update_assignments)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
       expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
       expect(Raven).to receive(:capture_exception)
 

--- a/spec/lib/assignments_manager_spec.rb
+++ b/spec/lib/assignments_manager_spec.rb
@@ -13,7 +13,7 @@ describe AssignmentsManager do
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
       expect(WikiEdits).to receive(:update_assignments)
-      expect(WikiEdits).to receive(:update_course)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
 
       AssignmentsManager.update_assignments(course, params, user)
       expect(Assignment.last.article_title).to eq('Existing_article')
@@ -26,7 +26,7 @@ describe AssignmentsManager do
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
       expect(WikiEdits).to receive(:update_assignments)
-      expect(WikiEdits).to receive(:update_course)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
 
       AssignmentsManager.update_assignments(course, params, user)
       expect(Assignment.last.article_title).to eq('Existing_article')
@@ -49,7 +49,7 @@ describe AssignmentsManager do
                                      'deleted' => 'true' }] }
       expect(WikiEdits).to receive(:remove_assignment)
       expect(WikiEdits).to receive(:update_assignments)
-      expect(WikiEdits).to receive(:update_course)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
       AssignmentsManager.update_assignments(course, params, user)
       expect(Assignment.all).to be_empty
     end
@@ -62,7 +62,7 @@ describe AssignmentsManager do
                                      'role' => 0,
                                      'deleted' => 'true' }] }
       expect(WikiEdits).to receive(:update_assignments)
-      expect(WikiEdits).to receive(:update_course)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
 
       AssignmentsManager.update_assignments(course, params, user)
       expect(Assignment.all).to be_empty
@@ -81,7 +81,7 @@ describe AssignmentsManager do
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
       expect(WikiEdits).to receive(:update_assignments)
-      expect(WikiEdits).to receive(:update_course)
+      expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
       expect(Raven).to receive(:capture_exception)
 
       AssignmentsManager.update_assignments(course, params, user)

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -37,7 +37,7 @@ describe WikiAssignmentOutput do
         selfie_talk = Wiki.get_page_content(talk_title)
         course = Course.find(10001)
         course_page = course.wiki_title
-        assignment_titles = WikiEdits.assignments_grouped_by_article_title(course)
+        assignment_titles = course.assignments.group_by(&:article_title)
         title_assignments = assignment_titles['Selfie']
         assignment_tag = WikiAssignmentOutput.assignments_tag(course_page,
                                                               title_assignments)
@@ -102,7 +102,7 @@ describe WikiAssignmentOutput do
         missing_talk_title = 'Talk:THIS PAGE DOES NOT EXIST'
         course = Course.find(10001)
         course_page = course.wiki_title
-        assignment_titles = WikiEdits.assignments_grouped_by_article_title(course)
+        assignment_titles = course.assignments.group_by(&:article_title)
         title_assignments = assignment_titles['Selfie']
 
         # Try the case of where the article exists

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require "#{Rails.root}/lib/wiki_course_edits"
 
 describe WikiCourseEdits do
-  let(:course) { create(:course, submitted: true) }
+  let(:course) { create(:course, id: 1, submitted: true) }
   let(:user) { create(:user) }
 
   describe '#update_course' do
@@ -44,6 +44,28 @@ describe WikiCourseEdits do
       stub_oauth_edit
       expect(WikiEdits).to receive(:add_to_page_top).twice
       WikiCourseEdits.new(action: :enroll_in_course,
+                          course: course,
+                          current_user: user)
+    end
+  end
+
+  describe '#update_assignments' do
+    it 'should update talk pages and course page with assignment info' do
+      stub_raw_action
+      stub_oauth_edit
+      expect(WikiEdits).to receive(:post_whole_page).at_least(:once)
+      create(:assignment,
+             user_id: 1,
+             course_id: 1,
+             article_title: 'Selfie',
+             role: Assignment::Roles::ASSIGNED_ROLE)
+      create(:assignment,
+             id: 2,
+             user_id: 1,
+             course_id: 1,
+             article_title: 'Talk:Selfie',
+             role: Assignment::Roles::REVIEWING_ROLE)
+      WikiCourseEdits.new(action: :update_assignments,
                           course: course,
                           current_user: user)
     end

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -16,4 +16,14 @@ describe WikiCourseEdits do
                           instructor: nil) # defaults to current user
     end
   end
+
+  describe '#enroll_in_course' do
+    it 'should post to the userpage of the enrolling student and their sandbox' do
+      stub_oauth_edit
+      expect(WikiEdits).to receive(:add_to_page_top).twice
+      WikiCourseEdits.new(action: :enroll_in_course,
+                          course: course,
+                          current_user: user)
+    end
+  end
 end

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -2,8 +2,30 @@ require 'rails_helper'
 require "#{Rails.root}/lib/wiki_course_edits"
 
 describe WikiCourseEdits do
-  let(:course) { create(:course) }
+  let(:course) { create(:course, submitted: true) }
   let(:user) { create(:user) }
+
+  describe '#update_course' do
+    it 'should edit a Wikipedia page representing a course' do
+      stub_oauth_edit
+      expect(WikiEdits).to receive(:post_whole_page).twice.and_call_original
+      WikiCourseEdits.new(action: :update_course,
+                          course: course,
+                          current_user: user)
+      WikiCourseEdits.new(action: :update_course,
+                          course: course,
+                          current_user: user,
+                          delete: true)
+    end
+
+    it 'should repost a clean version after hitting the spamblacklist' do
+      stub_oauth_edit_spamblacklist
+      expect(WikiEdits).to receive(:post_whole_page).twice.and_call_original
+      WikiCourseEdits.new(action: :update_course,
+                          course: course,
+                          current_user: user)
+    end
+  end
 
   describe '#announce_course' do
     it 'should post to the userpage of the instructor and a noticeboard' do

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require "#{Rails.root}/lib/wiki_course_edits"
+
+describe WikiCourseEdits do
+  let(:course) { create(:course) }
+  let(:user) { create(:user) }
+
+  describe '#announce_course' do
+    it 'should post to the userpage of the instructor and a noticeboard' do
+      stub_oauth_edit
+      expect(WikiEdits).to receive(:add_to_page_top) # userpage edit
+      expect(WikiEdits).to receive(:add_new_section) # noticeboard edit
+      WikiCourseEdits.new(action: :announce_course,
+                          course:  course,
+                          current_user: user,
+                          instructor: nil) # defaults to current user
+    end
+  end
+end

--- a/spec/lib/wiki_edits_spec.rb
+++ b/spec/lib/wiki_edits_spec.rb
@@ -61,19 +61,6 @@ describe WikiEdits do
     end
   end
 
-  describe '.update_course' do
-    it 'should edit a Wikipedia page representing a course' do
-      stub_oauth_edit
-      WikiEdits.update_course(Course.first, User.first)
-      WikiEdits.update_course(Course.first, User.first, true)
-    end
-
-    it 'should repost a clean version after hitting the spamblacklist' do
-      stub_oauth_edit_spamblacklist
-      WikiEdits.update_course(Course.first, User.first)
-    end
-  end
-
   describe '.notify_users' do
     it 'should post talk page messages on Wikipedia' do
       stub_oauth_edit

--- a/spec/lib/wiki_edits_spec.rb
+++ b/spec/lib/wiki_edits_spec.rb
@@ -61,13 +61,6 @@ describe WikiEdits do
     end
   end
 
-  describe '.announce_course' do
-    it 'should post to the userpage of the instructor and a noticeboard' do
-      stub_oauth_edit
-      WikiEdits.announce_course(Course.first, User.first)
-    end
-  end
-
   describe '.enroll_in_course' do
     it 'should post to the userpage of the enrolling student' do
       stub_oauth_edit

--- a/spec/lib/wiki_edits_spec.rb
+++ b/spec/lib/wiki_edits_spec.rb
@@ -71,25 +71,6 @@ describe WikiEdits do
     end
   end
 
-  describe '.update_assignments' do
-    it 'should update talk pages and course page with assignment info' do
-      stub_raw_action
-      stub_oauth_edit
-      create(:assignment,
-             user_id: 1,
-             course_id: 1,
-             article_title: 'Selfie',
-             role: Assignment::Roles::ASSIGNED_ROLE)
-      create(:assignment,
-             id: 2,
-             user_id: 1,
-             course_id: 1,
-             article_title: 'Talk:Selfie',
-             role: Assignment::Roles::REVIEWING_ROLE)
-      WikiEdits.update_assignments(User.first, Course.first)
-    end
-  end
-
   describe '.oauth_credentials_valid?' do
     it 'returns true if credentials are valid' do
       stub_token_request

--- a/spec/lib/wiki_edits_spec.rb
+++ b/spec/lib/wiki_edits_spec.rb
@@ -61,13 +61,6 @@ describe WikiEdits do
     end
   end
 
-  describe '.enroll_in_course' do
-    it 'should post to the userpage of the enrolling student' do
-      stub_oauth_edit
-      WikiEdits.enroll_in_course(Course.first, User.first)
-    end
-  end
-
   describe '.update_course' do
     it 'should edit a Wikipedia page representing a course' do
       stub_oauth_edit


### PR DESCRIPTION
This breaks up the overly large WikiEdits class, and isolates all the course-data-to-wiki methods into their own class. The isolation will let us easily disable wiki updates for different types of courses.