### PR TITLE
Add Course subtypes using Single Table Inheritance

### DIFF
--- a/app/models/classroom_program_course.rb
+++ b/app/models/classroom_program_course.rb
@@ -1,0 +1,5 @@
+class ClassroomProgramCourse < Course
+  def wiki_edits_enabled?
+    true
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -118,6 +118,13 @@ class Course < ActiveRecord::Base
   before_save :order_weeks
   validates :passcode, presence: true, unless: :legacy?
 
+  COURSE_TYPES = %w(
+    ClassroomProgramCourse
+    VisitingScholarship
+    Editathon
+  )
+  validates_inclusion_of :type, in: COURSE_TYPES
+
   ####################
   # Callbacks        #
   ####################

--- a/app/models/editathon.rb
+++ b/app/models/editathon.rb
@@ -1,0 +1,5 @@
+class Editathon < Course
+  def wiki_edits_enabled?
+    false
+  end
+end

--- a/app/models/visiting_scholarship.rb
+++ b/app/models/visiting_scholarship.rb
@@ -1,0 +1,5 @@
+class VisitingScholarship < Course
+  def wiki_edits_enabled?
+    false
+  end
+end

--- a/db/migrate/20160110060231_add_type_to_courses.rb
+++ b/db/migrate/20160110060231_add_type_to_courses.rb
@@ -1,0 +1,5 @@
+class AddTypeToCourses < ActiveRecord::Migration
+  def change
+    add_column :courses, :type, :string, default: 'ClassroomProgramCourse'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160108180703) do
+ActiveRecord::Schema.define(version: 20160110060231) do
 
   create_table "articles", force: :cascade do |t|
     t.string   "title",                    limit: 255
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 20160108180703) do
     t.boolean  "no_day_exceptions",               default: false
     t.integer  "trained_count",     limit: 4,     default: 0
     t.integer  "cloned_status",     limit: 4
+    t.string   "type",              limit: 255,   default: "ClassroomProgramCourse"
   end
 
   add_index "courses", ["slug"], name: "index_courses_on_slug", using: :btree

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -3,6 +3,7 @@ require "#{Rails.root}/lib/wiki_edits"
 #= Class for making wiki edits for a particular course
 class WikiCourseEdits
   def initialize(action:, course:, current_user:, **opts)
+    return unless course.wiki_edits_enabled?
     @course = course
     @current_user = current_user
     send(action, opts)

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -36,7 +36,7 @@
 #
 
 FactoryGirl.define do
-  factory :course do
+  factory :course, class: 'ClassroomProgramCourse' do
     start Date.new(2015, 01, 01)
     # end is a reserved keyword, set that in the let(:course) calls
     title 'Underwater basket-weaving'
@@ -44,6 +44,28 @@ FactoryGirl.define do
     school 'WINTR'
     term 'spring 2015'
     slug 'WINTR/Underwater_basket-weaving_(spring_2015)'
+    passcode 'pizza'
+  end
+
+  factory :visiting_scholarship, class: 'VisitingScholarship' do
+    start Date.new(2015, 01, 01)
+    # end is a reserved keyword, set that in the let(:course) calls
+    title 'Basket-weaving scholarship'
+    listed true
+    school 'UNR'
+    term 'spring 2015'
+    slug 'UNR/Basket-weaving_scholarship_(spring_2015)'
+    passcode 'pizza'
+  end
+
+  factory :editathon, class: 'Editathon' do
+    start Date.new(2015, 01, 01)
+    # end is a reserved keyword, set that in the let(:course) calls
+    title 'Basket-weaving edit-a-thon'
+    listed true
+    school 'NARA'
+    term 'spring 2015'
+    slug 'NARA/Basket-weaving_edit-a-thon_(spring_2015)'
     passcode 'pizza'
   end
 end

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -70,4 +70,19 @@ describe WikiCourseEdits do
                           current_user: user)
     end
   end
+
+  context 'for a visiting scholarship or editathon' do
+    let(:visiting_scholarship) { create(:visiting_scholarship, submitted: true) }
+    let(:editathon) { create(:editathon, submitted: true) }
+
+    it 'should return immediately without making edits' do
+      expect(WikiEdits).not_to receive(:post_whole_page)
+      WikiCourseEdits.new(action: :update_course,
+                          course: visiting_scholarship,
+                          current_user: user)
+      WikiCourseEdits.new(action: :update_course,
+                          course: editathon,
+                          current_user: user)
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -528,4 +528,32 @@ describe Course, type: :model do
       end
     end
   end
+
+  describe 'typing and validation' do
+    let(:course) { create(:course) }
+    it 'creates ClassroomProgramCourse type by default' do
+      expect(course.class).to eq(ClassroomProgramCourse)
+    end
+
+    it 'allows VisitingScholarship type' do
+      course.update_attributes(type: 'VisitingScholarship')
+      expect(Course.last.class).to eq(VisitingScholarship)
+    end
+
+    it 'allows Editathon type' do
+      course.update_attributes(type: 'Editathon')
+      expect(Course.last.class).to eq(Editathon)
+    end
+
+    let(:arbitrary_course_type) { create(:course, type: 'Foo') }
+    it 'does not allow creation of arbitrary types' do
+      expect { arbitrary_course_type }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'does not allow updating to arbitrary types' do
+      invalid_update = course.update_attributes(type: 'Bar')
+      expect(invalid_update).to eq(false)
+      expect(Course.last.class).to eq(ClassroomProgramCourse)
+    end
+  end
 end


### PR DESCRIPTION
The default ClassroomProgramCourse behaves the same as Course did previously. The new VisitingScholarship and Editathon course types have wiki edits disabled.

@thenickcox Please review this. :-)