### PR TITLE
Change course interface strings depending on course type

### DIFF
--- a/app/assets/javascripts/components/articles/article_list.cjsx
+++ b/app/assets/javascripts/components/articles/article_list.cjsx
@@ -5,6 +5,7 @@ List          = require '../common/list'
 Article       = require './article'
 ArticleStore  = require '../../stores/article_store'
 ServerActions = require '../../actions/server_actions'
+CourseUtils   = require '../../utils/course_utils'
 
 getState = ->
   articles: ArticleStore.getModels()
@@ -36,6 +37,7 @@ ArticleList = React.createClass(
       elements={elements}
       keys={keys}
       table_key='articles'
+      none_message={CourseUtils.i18n('articles_none', @props.course.string_prefix)}
       store={ArticleStore}
     />
 )

--- a/app/assets/javascripts/components/assignments/assignment_list.cjsx
+++ b/app/assets/javascripts/components/assignments/assignment_list.cjsx
@@ -6,6 +6,7 @@ Assignment        = require './assignment'
 AssignmentStore   = require '../../stores/assignment_store'
 ArticleStore      = require '../../stores/article_store'
 ServerActions     = require '../../actions/server_actions'
+CourseUtils       = require '../../utils/course_utils'
 
 getState = ->
   assignments: AssignmentStore.getModels()
@@ -43,6 +44,7 @@ AssignmentList = React.createClass(
       elements={elements}
       keys={keys}
       table_key='assignments'
+      none_message={CourseUtils.i18n('assignments_none', @props.course.string_prefix)}
       store={AssignmentStore}
       sortable=false
     />

--- a/app/assets/javascripts/components/common/list.cjsx
+++ b/app/assets/javascripts/components/common/list.cjsx
@@ -37,7 +37,8 @@ List = React.createClass(
     elements = @props.elements
     if elements.length == 0
       if @props.store.isLoaded()
-        text = I18n.t(@props.table_key + '.none')
+        text = @props.none_message
+        text ||= I18n.t(@props.table_key + '.none')
         text ||= 'This course has no ' + @props.table_key
       else
         text = I18n.t(@props.table_key + '.loading')

--- a/app/assets/javascripts/components/course.cjsx
+++ b/app/assets/javascripts/components/course.cjsx
@@ -8,6 +8,7 @@ CourseStore       = require '../stores/course_store'
 UserStore         = require '../stores/user_store'
 CohortStore       = require '../stores/cohort_store'
 Affix             = require './common/affix'
+CourseUtils       = require '../utils/course_utils'
 
 getState = ->
   current = $('#react_root').data('current_user')
@@ -16,9 +17,6 @@ getState = ->
     course: CourseStore.getCourse()
     current_user: cu || current
   }
-
-usersTabLabel = (string_prefix = 'courses') ->
-  I18n.t("#{string_prefix}.students_short")
 
 Course = React.createClass(
   displayName: 'Course'
@@ -198,7 +196,7 @@ Course = React.createClass(
               </div>
               {timeline}
               <div className="nav__item" id="students-link">
-                <p><Link to="#{@_courseLinkParams()}/students" activeClassName="active">{usersTabLabel(@state.course.string_prefix)}</Link></p>
+                <p><Link to="#{@_courseLinkParams()}/students" activeClassName="active">{CourseUtils.i18n('students_short',@state.course.string_prefix)}</Link></p>
               </div>
               <div className="nav__item" id="articles-link">
                 <p><Link to="#{@_courseLinkParams()}/articles" activeClassName="active">Articles</Link></p>

--- a/app/assets/javascripts/components/course.cjsx
+++ b/app/assets/javascripts/components/course.cjsx
@@ -119,7 +119,7 @@ Course = React.createClass(
         <div className='notification' key='enroll'>
           <div className='container'>
             <div>
-              <p>Your course has been published! Students may enroll in the course by visiting the following URL:</p>
+              <p>{CourseUtils.i18n('published', @state.course.string_prefix)}</p>
               <a href={url}>{url}</a>
             </div>
           </div>

--- a/app/assets/javascripts/components/course.cjsx
+++ b/app/assets/javascripts/components/course.cjsx
@@ -47,6 +47,20 @@ Course = React.createClass(
     alerts = []
     route_params = @props.params
 
+    courseLink =
+      if @state.course.url?
+        (<a href={@state.course.url} target="_blank">
+          <h2 className="title">{@state.course.title}</h2>
+        </a>)
+      else
+        (<a><h2 className="title">{@state.course.title}</h2></a>)
+
+    # Set interface strings based on course type
+    if @state.course.type == 'ClassroomProgramCourse'
+      usersTabLabel = I18n.t('courses.students_short')
+    else
+      usersTabLabel = I18n.t('courses.editors')
+
     if @getCurrentUser().id?
       user_obj = UserStore.getFiltered({ id: @getCurrentUser().id })[0]
     user_role = if user_obj? then user_obj.role else -1
@@ -180,16 +194,14 @@ Course = React.createClass(
       <Affix className="course-nav__wrapper" offset=55>
         <div className="course_navigation">
           <div className="container">
-            <a href={@state.course.url} target="_blank">
-              <h2 className="title">{@state.course.title}</h2>
-            </a>
+            {courseLink}
             <nav>
               <div className="nav__item" id="overview-link">
                 <p><Link to="#{@_courseLinkParams()}/overview" className={overviewLinkClassName} activeClassName="active">Overview</Link></p>
               </div>
               {timeline}
               <div className="nav__item" id="students-link">
-                <p><Link to="#{@_courseLinkParams()}/students" activeClassName="active">Students</Link></p>
+                <p><Link to="#{@_courseLinkParams()}/students" activeClassName="active">{usersTabLabel}</Link></p>
               </div>
               <div className="nav__item" id="articles-link">
                 <p><Link to="#{@_courseLinkParams()}/articles" activeClassName="active">Articles</Link></p>

--- a/app/assets/javascripts/components/course.cjsx
+++ b/app/assets/javascripts/components/course.cjsx
@@ -17,6 +17,9 @@ getState = ->
     current_user: cu || current
   }
 
+usersTabLabel = (string_prefix = 'courses') ->
+  I18n.t("#{string_prefix}.students_short")
+
 Course = React.createClass(
   displayName: 'Course'
   mixins: [CourseStore.mixin, UserStore.mixin]
@@ -54,12 +57,6 @@ Course = React.createClass(
         </a>)
       else
         (<a><h2 className="title">{@state.course.title}</h2></a>)
-
-    # Set interface strings based on course type
-    if @state.course.type == 'ClassroomProgramCourse'
-      usersTabLabel = I18n.t('courses.students_short')
-    else
-      usersTabLabel = I18n.t('courses.editors')
 
     if @getCurrentUser().id?
       user_obj = UserStore.getFiltered({ id: @getCurrentUser().id })[0]
@@ -201,7 +198,7 @@ Course = React.createClass(
               </div>
               {timeline}
               <div className="nav__item" id="students-link">
-                <p><Link to="#{@_courseLinkParams()}/students" activeClassName="active">{usersTabLabel}</Link></p>
+                <p><Link to="#{@_courseLinkParams()}/students" activeClassName="active">{usersTabLabel(@state.course.string_prefix)}</Link></p>
               </div>
               <div className="nav__item" id="articles-link">
                 <p><Link to="#{@_courseLinkParams()}/articles" activeClassName="active">Articles</Link></p>

--- a/app/assets/javascripts/components/overview/details.cjsx
+++ b/app/assets/javascripts/components/overview/details.cjsx
@@ -13,6 +13,8 @@ TagStore          = require '../../stores/tag_store'
 UserStore         = require '../../stores/user_store'
 CohortStore       = require '../../stores/cohort_store'
 
+CourseUtils       = require '../../utils/course_utils'
+
 # For some reason getState is not being triggered when CohortStore gets updated
 
 getState = (course_id) ->
@@ -23,9 +25,6 @@ getState = (course_id) ->
   campus: UserStore.getFiltered({ role: 3 })
   staff: UserStore.getFiltered({ role: 4 })
   tags: TagStore.getModels()
-
-expectedLabel = (string_prefix = 'courses') ->
-  I18n.t("#{string_prefix}.expected_students")
 
 Details = React.createClass(
   displayName: 'Details'
@@ -90,7 +89,7 @@ Details = React.createClass(
             value_key='expected_students'
             editable={@props.editable}
             type='number'
-            label={expectedLabel(@props.course.string_prefix)}
+            label={CourseUtils.i18n('expected_students', @props.course.string_prefix)}
           />
         </fieldset>
         <fieldset>

--- a/app/assets/javascripts/components/overview/details.cjsx
+++ b/app/assets/javascripts/components/overview/details.cjsx
@@ -31,6 +31,12 @@ Details = React.createClass(
     to_pass[value_key] = value
     CourseActions.updateCourse to_pass
   render: ->
+    if @props.course.type == 'ClassroomProgramCourse'
+      expectedLabel = I18n.t('courses.expected_students')
+    else
+      expectedLabel = I18n.t('courses.expected_editors')
+
+
     instructors = <InlineUsers {...@props} users={@props.instructors} role={1} title='Instructors' />
     online = <InlineUsers {...@props} users={@props.online} role={2} title='Online Volunteers' />
     campus = <InlineUsers {...@props} users={@props.campus} role={3} title='Campus Volunteers' />
@@ -87,7 +93,7 @@ Details = React.createClass(
             value_key='expected_students'
             editable={@props.editable}
             type='number'
-            label='Expected Students'
+            label={expectedLabel}
           />
         </fieldset>
         <fieldset>

--- a/app/assets/javascripts/components/overview/details.cjsx
+++ b/app/assets/javascripts/components/overview/details.cjsx
@@ -24,6 +24,9 @@ getState = (course_id) ->
   staff: UserStore.getFiltered({ role: 4 })
   tags: TagStore.getModels()
 
+expectedLabel = (string_prefix = 'courses') ->
+  I18n.t("#{string_prefix}.expected_students")
+
 Details = React.createClass(
   displayName: 'Details'
   updateDetails: (value_key, value) ->
@@ -31,12 +34,6 @@ Details = React.createClass(
     to_pass[value_key] = value
     CourseActions.updateCourse to_pass
   render: ->
-    if @props.course.type == 'ClassroomProgramCourse'
-      expectedLabel = I18n.t('courses.expected_students')
-    else
-      expectedLabel = I18n.t('courses.expected_editors')
-
-
     instructors = <InlineUsers {...@props} users={@props.instructors} role={1} title='Instructors' />
     online = <InlineUsers {...@props} users={@props.online} role={2} title='Online Volunteers' />
     campus = <InlineUsers {...@props} users={@props.campus} role={3} title='Campus Volunteers' />
@@ -93,7 +90,7 @@ Details = React.createClass(
             value_key='expected_students'
             editable={@props.editable}
             type='number'
-            label={expectedLabel}
+            label={expectedLabel(@props.course.string_prefix)}
           />
         </fieldset>
         <fieldset>

--- a/app/assets/javascripts/components/overview/details.cjsx
+++ b/app/assets/javascripts/components/overview/details.cjsx
@@ -33,7 +33,7 @@ Details = React.createClass(
     to_pass[value_key] = value
     CourseActions.updateCourse to_pass
   render: ->
-    instructors = <InlineUsers {...@props} users={@props.instructors} role={1} title='Instructors' />
+    instructors = <InlineUsers {...@props} users={@props.instructors} role={1} title={CourseUtils.i18n('instructors', @props.course.string_prefix)} />
     online = <InlineUsers {...@props} users={@props.online} role={2} title='Online Volunteers' />
     campus = <InlineUsers {...@props} users={@props.campus} role={3} title='Campus Volunteers' />
     staff = <InlineUsers {...@props} users={@props.staff} role={4} title='Wiki Ed Staff' />
@@ -79,8 +79,8 @@ Details = React.createClass(
         {online}
         {campus}
         {staff}
-        <p>School: {@props.course.school}</p>
-        <p>Term: {@props.course.term}</p>
+        <p>{CourseUtils.i18n('school', @props.course.string_prefix)}: {@props.course.school}</p>
+        <p>{CourseUtils.i18n('term', @props.course.string_prefix)}: {@props.course.term}</p>
         {passcode}
         <fieldset>
           <TextInput
@@ -123,7 +123,7 @@ Details = React.createClass(
             value_key='timeline_start'
             editable={@props.editable}
             type='date'
-            label='Assignment Start'
+            label={CourseUtils.i18n('assignment_start', @props.course.string_prefix)}
             date_props={timeline_start_props}
             required=true
           />
@@ -135,7 +135,7 @@ Details = React.createClass(
             value_key='timeline_end'
             editable={@props.editable}
             type='date'
-            label='Assignment End'
+            label={CourseUtils.i18n('assignment_end', @props.course.string_prefix)}
             date_props={timeline_end_props}
             required=true
           />

--- a/app/assets/javascripts/components/overview/milestones.cjsx
+++ b/app/assets/javascripts/components/overview/milestones.cjsx
@@ -3,6 +3,7 @@ BlockStore     = require '../../stores/block_store'
 WeekStore      = require '../../stores/week_store'
 CourseStore    = require '../../stores/course_store'
 md             = require('markdown-it')({ html: true, linkify: true })
+CourseUtils   = require '../../utils/course_utils'
 
 getState = ->
   weeks: WeekStore.getWeeks()
@@ -35,7 +36,7 @@ Milestones = React.createClass(
             </div>
           </div>
         )
-    @emptyMessage = if !blocks.length then I18n.t('blocks.milestones.empty') else ''
+    @emptyMessage = if !blocks.length then CourseUtils.i18n('milestones_none', @props.course.string_prefix) else ''
 
     <div className='module milestones'>
       <div className="section-header">
@@ -47,4 +48,3 @@ Milestones = React.createClass(
 )
 
 module.exports = Milestones
-

--- a/app/assets/javascripts/components/overview/overview_handler.cjsx
+++ b/app/assets/javascripts/components/overview/overview_handler.cjsx
@@ -18,6 +18,9 @@ getState = ->
   weeks: WeekStore.getWeeks()
   current: CourseStore.getCurrentWeek()
 
+userLabel = (string_prefix = 'courses')->
+  I18n.t("#{string_prefix}.student_editors")
+
 Overview = React.createClass(
   displayName: 'Overview'
   mixins: [WeekStore.mixin, CourseStore.mixin]
@@ -30,12 +33,6 @@ Overview = React.createClass(
   getInitialState: ->
     getState()
   render: ->
-    # Set interface strings based on course type
-    if @props.course.type == 'ClassroomProgramCourse'
-      userLabel = I18n.t('users.student_editors')
-    else
-      userLabel = I18n.t('users.editors')
-
     if @props.location.query.modal is 'true' && @state.course.id
       return (
         <CourseClonedModal
@@ -80,7 +77,7 @@ Overview = React.createClass(
         </div>
         <div className="stat-display__stat popover-trigger" id="student-editors">
           <div className="stat-display__value">{@props.course.student_count}</div>
-          <small>{userLabel}</small>
+          <small>{userLabel(@props.course.string_prefix)}</small>
           <div className="popover dark" id="trained-count">
             <h4 className="stat-display__value">{@props.course.trained_count}</h4>
             <p>are up-to-date with training</p>

--- a/app/assets/javascripts/components/overview/overview_handler.cjsx
+++ b/app/assets/javascripts/components/overview/overview_handler.cjsx
@@ -30,6 +30,12 @@ Overview = React.createClass(
   getInitialState: ->
     getState()
   render: ->
+    # Set interface strings based on course type
+    if @props.course.type == 'ClassroomProgramCourse'
+      userLabel = I18n.t('users.student_editors')
+    else
+      userLabel = I18n.t('users.editors')
+
     if @props.location.query.modal is 'true' && @state.course.id
       return (
         <CourseClonedModal
@@ -74,7 +80,7 @@ Overview = React.createClass(
         </div>
         <div className="stat-display__stat popover-trigger" id="student-editors">
           <div className="stat-display__value">{@props.course.student_count}</div>
-          <small>Student Editors</small>
+          <small>{userLabel}</small>
           <div className="popover dark" id="trained-count">
             <h4 className="stat-display__value">{@props.course.trained_count}</h4>
             <p>are up-to-date with training</p>

--- a/app/assets/javascripts/components/overview/overview_handler.cjsx
+++ b/app/assets/javascripts/components/overview/overview_handler.cjsx
@@ -10,6 +10,7 @@ WeekStore     = require '../../stores/week_store'
 ServerActions = require '../../actions/server_actions'
 Loading       = require '../common/loading'
 CourseClonedModal  = require './course_cloned_modal'
+CourseUtils   = require '../../utils/course_utils'
 
 
 getState = ->
@@ -17,9 +18,6 @@ getState = ->
   loading: WeekStore.getLoadingStatus()
   weeks: WeekStore.getWeeks()
   current: CourseStore.getCurrentWeek()
-
-userLabel = (string_prefix = 'courses')->
-  I18n.t("#{string_prefix}.student_editors")
 
 Overview = React.createClass(
   displayName: 'Overview'
@@ -77,7 +75,7 @@ Overview = React.createClass(
         </div>
         <div className="stat-display__stat popover-trigger" id="student-editors">
           <div className="stat-display__value">{@props.course.student_count}</div>
-          <small>{userLabel(@props.course.string_prefix)}</small>
+          <small>{CourseUtils.i18n('student_editors', @props.course.string_prefix)}</small>
           <div className="popover dark" id="trained-count">
             <h4 className="stat-display__value">{@props.course.trained_count}</h4>
             <p>are up-to-date with training</p>

--- a/app/assets/javascripts/components/revisions/revision_list.cjsx
+++ b/app/assets/javascripts/components/revisions/revision_list.cjsx
@@ -5,6 +5,7 @@ List              = require '../common/list'
 Revision          = require './revision'
 RevisionStore     = require '../../stores/revision_store'
 ServerActions     = require '../../actions/server_actions'
+CourseUtils       = require '../../utils/course_utils'
 
 getState = ->
   revisions: RevisionStore.getModels()
@@ -37,6 +38,7 @@ RevisionList = React.createClass(
       elements={elements}
       keys={keys}
       table_key='revisions'
+      none_message={CourseUtils.i18n('revisions_none', @props.course.string_prefix)}
       store={RevisionStore}
     />
 )

--- a/app/assets/javascripts/components/students/student_list.cjsx
+++ b/app/assets/javascripts/components/students/student_list.cjsx
@@ -10,6 +10,7 @@ UserStore         = require '../../stores/user_store'
 AssignmentStore   = require '../../stores/assignment_store'
 UIActions         = require '../../actions/ui_actions'
 ServerActions     = require '../../actions/server_actions'
+CourseUtils     = require '../../utils/course_utils'
 
 getState = ->
   users: UserStore.getFiltered({ role: 0 })
@@ -75,6 +76,7 @@ StudentList = React.createClass(
         elements={elements}
         keys={keys}
         table_key='users'
+        none_message={CourseUtils.i18n('students_none', @props.course.string_prefix)}
         store={UserStore}
         editable={@props.editable}
       />

--- a/app/assets/javascripts/components/students/students_handler.cjsx
+++ b/app/assets/javascripts/components/students/students_handler.cjsx
@@ -5,10 +5,7 @@ Router            = ReactRouter.Router
 StudentList       = require './student_list'
 UIActions         = require '../../actions/ui_actions'
 ServerActions     = require '../../actions/server_actions'
-
-
-usersLabel = (string_prefix = 'courses') ->
-  I18n.t("#{string_prefix}.students")
+CourseUtils       = require '../../utils/course_utils'
 
 StudentsHandler = React.createClass(
   displayName: 'StudentsHandler'
@@ -19,7 +16,7 @@ StudentsHandler = React.createClass(
   render: ->
     <div id='users'>
       <div className='section-header'>
-        <h3>{usersLabel(@props.course.string_prefix)}</h3>
+        <h3>{CourseUtils.i18n('students', @props.course.string_prefix)}</h3>
         <div className='sort-select'>
           <select className='sorts' name='sorts' onChange={@sortSelect}>
             <option value='wiki_id'>Name</option>

--- a/app/assets/javascripts/components/students/students_handler.cjsx
+++ b/app/assets/javascripts/components/students/students_handler.cjsx
@@ -14,9 +14,15 @@ StudentsHandler = React.createClass(
   sortSelect: (e) ->
     UIActions.sort 'users', e.target.value
   render: ->
+    # Set interface strings based on course type
+    if @props.course.type == 'ClassroomProgramCourse'
+      userLabel = I18n.t('courses.students')
+    else
+      userLabel = I18n.t('courses.editors')
+
     <div id='users'>
       <div className='section-header'>
-        <h3>Students</h3>
+        <h3>{userLabel}</h3>
         <div className='sort-select'>
           <select className='sorts' name='sorts' onChange={@sortSelect}>
             <option value='wiki_id'>Name</option>

--- a/app/assets/javascripts/components/students/students_handler.cjsx
+++ b/app/assets/javascripts/components/students/students_handler.cjsx
@@ -7,6 +7,9 @@ UIActions         = require '../../actions/ui_actions'
 ServerActions     = require '../../actions/server_actions'
 
 
+usersLabel = (string_prefix = 'courses') ->
+  I18n.t("#{string_prefix}.students")
+
 StudentsHandler = React.createClass(
   displayName: 'StudentsHandler'
   componentWillMount: ->
@@ -14,15 +17,9 @@ StudentsHandler = React.createClass(
   sortSelect: (e) ->
     UIActions.sort 'users', e.target.value
   render: ->
-    # Set interface strings based on course type
-    if @props.course.type == 'ClassroomProgramCourse'
-      userLabel = I18n.t('courses.students')
-    else
-      userLabel = I18n.t('courses.editors')
-
     <div id='users'>
       <div className='section-header'>
-        <h3>{userLabel}</h3>
+        <h3>{usersLabel(@props.course.string_prefix)}</h3>
         <div className='sort-select'>
           <select className='sorts' name='sorts' onChange={@sortSelect}>
             <option value='wiki_id'>Name</option>

--- a/app/assets/javascripts/components/timeline/timeline.cjsx
+++ b/app/assets/javascripts/components/timeline/timeline.cjsx
@@ -16,6 +16,7 @@ BlockStore      = require '../../stores/block_store'
 WeekStore       = require '../../stores/week_store'
 
 DateCalculator  = require '../../utils/date_calculator'
+CourseUtils     = require '../../utils/course_utils'
 
 Timeline = React.createClass(
   displayName: 'Timeline'
@@ -33,7 +34,6 @@ Timeline = React.createClass(
     saveBlockChanges: React.PropTypes.func
     cancelBlockEditable: React.PropTypes.func
     all_training_modules: React.PropTypes.array
-
 
   getInitialState: ->
     unscrolled: true
@@ -219,7 +219,7 @@ Timeline = React.createClass(
         )
 
       edit_course_dates = (
-        <CourseLink className="week-nav__action week-nav__link" to="/courses/#{@props.course?.slug}/timeline/dates">Edit Course Dates</CourseLink>
+        <CourseLink className="week-nav__action week-nav__link" to="/courses/#{@props.course?.slug}/timeline/dates">{CourseUtils.i18n('edit_course_dates', @props.course.string_prefix)}</CourseLink>
       )
 
       start = moment(@props.course.timeline_start)

--- a/app/assets/javascripts/components/uploads/upload_list.cjsx
+++ b/app/assets/javascripts/components/uploads/upload_list.cjsx
@@ -5,6 +5,7 @@ List          = require '../common/list'
 Upload        = require './upload'
 UploadStore   = require '../../stores/upload_store'
 ServerActions = require '../../actions/server_actions'
+CourseUtils   = require '../../utils/course_utils'
 
 getState = ->
   uploads: UploadStore.getModels()
@@ -37,6 +38,7 @@ UploadList = React.createClass(
       elements={elements}
       keys={keys}
       table_key='uploads'
+      none_message={CourseUtils.i18n('uploads_none', @props.course.string_prefix)}
       store={UploadStore}
     />
 )

--- a/app/assets/javascripts/utils/course_utils.coffee
+++ b/app/assets/javascripts/utils/course_utils.coffee
@@ -15,4 +15,10 @@ class CourseUtils
     cleanedCourse.term = course.term.trim()
     return cleanedCourse
 
+  # This builds i18n interface strings that vary based on state/props.
+  i18n: (message_key, prefix, default_prefix = 'courses') ->
+    key_prefix = prefix
+    key_prefix ||= default_prefix
+    I18n.t("#{key_prefix}.#{message_key}")
+
 module.exports = new CourseUtils()

--- a/app/models/classroom_program_course.rb
+++ b/app/models/classroom_program_course.rb
@@ -8,4 +8,8 @@ class ClassroomProgramCourse < Course
     escaped_slug = slug.tr(' ', '_')
     "#{prefix}#{escaped_slug}"
   end
+
+  def string_prefix
+    'courses'
+  end
 end

--- a/app/models/classroom_program_course.rb
+++ b/app/models/classroom_program_course.rb
@@ -2,4 +2,10 @@ class ClassroomProgramCourse < Course
   def wiki_edits_enabled?
     true
   end
+
+  def wiki_title
+    prefix = ENV['course_prefix'] + '/'
+    escaped_slug = slug.tr(' ', '_')
+    "#{prefix}#{escaped_slug}"
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -156,7 +156,11 @@ class Course < ActiveRecord::Base
     TrainingModule.all.select { |tm| ids.include?(tm.id) }
   end
 
+  # The url for the on-wiki version of the course.
   def url
+    # wiki_title is implemented by the specific course type.
+    # Some types do not have corresponding on-wiki pages, so they have no
+    # wiki_title or url.
     return unless wiki_title
     language = ENV['wiki_language']
     "https://#{language}.wikipedia.org/wiki/#{wiki_title}"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -156,14 +156,8 @@ class Course < ActiveRecord::Base
     TrainingModule.all.select { |tm| ids.include?(tm.id) }
   end
 
-  # LegacyCourse overrides this.
-  def wiki_title
-    prefix = ENV['course_prefix'] + '/'
-    escaped_slug = slug.tr(' ', '_')
-    "#{prefix}#{escaped_slug}"
-  end
-
   def url
+    return unless wiki_title
     language = ENV['wiki_language']
     "https://#{language}.wikipedia.org/wiki/#{wiki_title}"
   end

--- a/app/models/editathon.rb
+++ b/app/models/editathon.rb
@@ -2,4 +2,8 @@ class Editathon < Course
   def wiki_edits_enabled?
     false
   end
+
+  def wiki_title
+    nil
+  end
 end

--- a/app/models/editathon.rb
+++ b/app/models/editathon.rb
@@ -6,4 +6,8 @@ class Editathon < Course
   def wiki_title
     nil
   end
+
+  def string_prefix
+    'courses_generic'
+  end
 end

--- a/app/models/legacy_course.rb
+++ b/app/models/legacy_course.rb
@@ -16,4 +16,8 @@ class LegacyCourse < Course
   def update(data={}, should_save=true)
     CourseUpdateManager.update_from_wiki(self, data, should_save)
   end
+
+  def string_prefix
+    'courses'
+  end
 end

--- a/app/models/visiting_scholarship.rb
+++ b/app/models/visiting_scholarship.rb
@@ -8,4 +8,8 @@ class VisitingScholarship < Course
   def wiki_edits_enabled?
     false
   end
+
+  def wiki_title
+    nil
+  end
 end

--- a/app/models/visiting_scholarship.rb
+++ b/app/models/visiting_scholarship.rb
@@ -12,4 +12,8 @@ class VisitingScholarship < Course
   def wiki_title
     nil
   end
+
+  def string_prefix
+    'courses_generic'
+  end
 end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -4,7 +4,7 @@ json.course do
   json.call(@course, :id, :title, :description, :start, :end, :school,
             :subject, :slug, :url, :listed, :submitted, :listed,
             :expected_students, :timeline_start, :timeline_end, :day_exceptions,
-            :weekdays, :no_day_exceptions, :updated_at)
+            :weekdays, :no_day_exceptions, :updated_at, :type)
 
   json.term @course.cloned_status == 1 ? '' : @course.term
   json.legacy @course.id < 10000

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -4,7 +4,7 @@ json.course do
   json.call(@course, :id, :title, :description, :start, :end, :school,
             :subject, :slug, :url, :listed, :submitted, :listed,
             :expected_students, :timeline_start, :timeline_end, :day_exceptions,
-            :weekdays, :no_day_exceptions, :updated_at, :type)
+            :weekdays, :no_day_exceptions, :updated_at, :string_prefix)
 
   json.term @course.cloned_status == 1 ? '' : @course.term
   json.legacy @course.id < 10000

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,15 +118,14 @@ en:
     current: Current Courses
     duration: Course Duration
     expected_students: Expected Students
-    expected_editors: Expected Editors
     gradeables_none: This course has no gradeable assignments.
     instructor:
       one: Instructor
       other: Instructors
     students: Students
+    student_editors: Student Editors
     students_none: This course has no students.
     students_short: Students
-    editors: Editors
     timeline: Assignment Details
     weeks_none: This course does not have a timeline yet.
     new_week: Add New Week
@@ -147,6 +146,13 @@ en:
       school). Click the date to change between unselected, selected, and
       holiday state. The dates of course activities will change to account for
       weeks that have no scheduled meetings.
+
+  # These are strings that are not specific to education/classroom contexts
+  courses_generic:
+    expected_students: Expected Editors
+    students: Editors
+    students_short: Editors
+    student_editors: Editors
 
   course_creator:
     create_new: Create a New Course
@@ -180,7 +186,6 @@ en:
     date_time: Date/Time
     edit_count_description: Total Edits
     revisions: Recent Edits
-    student_editors: Student Editors
     view: Views
     view_count_description: Article Views
     word_count: Words Added
@@ -230,7 +235,6 @@ en:
     contributions: User Contributions
     contributions_more: View More Contributions
     student_editors: Student Editors
-    editors: Editors
     loading: Loading users...
     name: Name
     none: This course has no students.
@@ -243,7 +247,7 @@ en:
       other: "are up-to-date with training"
     training_complete_count: "%{count} training up-to-date"
     training_doc: >
-      Student editors who have completed the all assigned training modules that
+      Editors who have completed the all assigned training modules that
       have come due are counted as up-to-date with their training.
     training_incomplete: Training Incomplete
     up_to_date_with_training: 'up-to-date with training'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,6 @@ en:
   blocks:
     milestones:
       title: Milestones
-      empty: This course does not currently have any milestones.
 
   cohort:
     view_other: View other cohorts
@@ -108,7 +107,12 @@ en:
   courses:
     activity: Activity
     articles: Articles
+    articles_none: This course has not edited any articles.
+    assignment_end: Assignment End
+    assignment_start: Assignment Start
+    assignments_none: This course has no assigned Wikipedia articles.
     character_doc: The sum of characters added to mainspace articles by the course's students during the course term
+    edit_course_dates: Edit Course Dates
     revisions_doc: The number of edits in the past %{timeframe} days
     word_count_doc: An estimate of the number of words added to mainspace articles by the course's students during the course term
     course_description: Courses
@@ -122,11 +126,18 @@ en:
     instructor:
       one: Instructor
       other: Instructors
+    instructors: Instructors
+    milestones_none: This course does not currently have any milestones.
+    published: "Your course has been published! Students may enroll in the course by visiting the following URL:"
+    revisions_none: This course has no recent Wikipedia editing activity.
+    school: School
     students: Students
     student_editors: Student Editors
     students_none: This course has no students.
     students_short: Students
+    term: Term
     timeline: Assignment Details
+    uploads_none: This class has not contributed any images or other media files to Wikimedia Commons.
     weeks_none: This course does not have a timeline yet.
     new_week: Add New Week
     overview: Overview
@@ -149,10 +160,23 @@ en:
 
   # These are strings that are not specific to education/classroom contexts
   courses_generic:
+    articles_none: There are no edited articles for this project yet.
+    assignment_end: Timeline End
+    assignment_start: Timeline Start
+    assignments_none: This project has no assigned Wikipedia articles.
+    edit_course_dates: Edit Project Dates
     expected_students: Expected Editors
+    instructors: Facilitators
+    published: "This project has been published! Editors may enroll by visiting the following URL:"
+    revisions_none: This project has no recent Wikipedia editing activity.
+    school: Institution
     students: Editors
     students_short: Editors
     student_editors: Editors
+    students_none: This project has no editors enrolled.
+    term: When
+    uploads_none: This project has not contributed any images or other media files to Wikimedia Commons.
+    milestones_none: This project does not currently have any milestones.
 
   course_creator:
     create_new: Create a New Course

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,8 @@ en:
     nocourses: You are not participating in any courses.
     current: Current Courses
     duration: Course Duration
+    expected_students: Expected Students
+    expected_editors: Expected Editors
     gradeables_none: This course has no gradeable assignments.
     instructor:
       one: Instructor
@@ -124,6 +126,7 @@ en:
     students: Students
     students_none: This course has no students.
     students_short: Students
+    editors: Editors
     timeline: Assignment Details
     weeks_none: This course does not have a timeline yet.
     new_week: Add New Week
@@ -226,7 +229,8 @@ en:
       Characters Added<br>(mainspace | userspace)
     contributions: User Contributions
     contributions_more: View More Contributions
-    editors: Student Editors
+    student_editors: Student Editors
+    editors: Editors
     loading: Loading users...
     name: Name
     none: This course has no students.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,17 +65,17 @@ en:
     loading: Loading articles...
     assigned: Assigned Articles
     assigned_to: Assigned To
-    character_doc: The sum of characters added to articles by the course's students during the course term
+    character_doc: The sum of characters added to articles by enrolled editors betweent the start and end dates
     edited: Articles Edited
     edited_mobile: Articles
     no_assignee: No user assigned
     rating: Class
     rating_doc: The rating an article has been assigned by WikiProjects on Wikipedia. These ratings may corresponds to much older versions, so they are just a rough indicator of article maturity.
     rating_docs:
-      fa: Featured article — Wikipedia's highest rating, probably too mature an article for a student editor's main project
+      fa: Featured article — Wikipedia's highest rating, probably too mature an article for a new editor's main project
       fl: Featured list — Wikipedia's highest rating for lists
-      a: A-class — very developed article that may be too mature an article for a student editor's main project
-      ga: Good article — a well-developed article that may be too mature an article for a student editor's main project
+      a: A-class — very developed article that may be too mature an article for a new editor's main project
+      ga: Good article — a well-developed article that may be too mature an article for a new editor's main project
       b: B-class — a moderately developed article
       c: C-class — an intermediate article with room for improvement
       start: Start-class — a preliminary article with plenty of room for improvement
@@ -144,7 +144,7 @@ en:
     title: Title
     view: View Course
     view_wiki: View on Wikipedia
-    view_doc: The sum of all views to articles edited by students since the students made their first edit to each article
+    view_doc: The sum of all views to articles edited by enrolled editors since the editor made their first edit to each article
     volunteer:
       one: Volunteer
       other: Volunteers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
     loading: Loading articles...
     assigned: Assigned Articles
     assigned_to: Assigned To
-    character_doc: The sum of characters added to articles by enrolled editors betweent the start and end dates
+    character_doc: The sum of characters added to articles by enrolled editors between the start and end dates
     edited: Articles Edited
     edited_mobile: Articles
     no_assignee: No user assigned

--- a/test/utils/course_utils.coffee
+++ b/test/utils/course_utils.coffee
@@ -1,4 +1,5 @@
 require '../testHelper'
+require '../../public/assets/javascripts/i18n/en'
 CourseUtils = require '../../app/assets/javascripts/utils/course_utils'
 
 describe 'CourseUtils.generateTempId', ->
@@ -28,3 +29,14 @@ describe 'CourseUtils.cleanupCourseSlugComponents', ->
     expect(course.term).to.eq 'Fall 2015'
     expect(course.school).to.eq 'University of Wikipedia'
     expect(course.title).to.eq 'Introduction to Editing'
+
+describe 'CourseUtils.i18n', ->
+  it 'outputs an interface message based on a message key and prefix', ->
+    message = CourseUtils.i18n('students', 'courses_generic')
+    expect(message).to.eq 'Editors'
+  it 'defaults to the "courses" prefix if prefix is null', ->
+    message = CourseUtils.i18n('students', null)
+    expect(message).to.eq 'Students'
+  it 'takes an optional fallback prefix for if prefix is null', ->
+    message = CourseUtils.i18n('class', null, 'revisions')
+    expect(message).to.eq 'Class'


### PR DESCRIPTION
@bmathews @thenickcox @adamwight 

This is my first pass at having different types of courses use different interface strings appropriate to their type. For example, an edit-a-thon event (Editathon course type) should call the participants 'Editors' rather than 'Students'.

The strategy I've taken is to add a `#string_prefix` to each course type, and then use that to determine which string from the i18n file to use, via the function `CourseUtils.i18n` (which sets a default for before `@state.course` gets set on initial page load). This makes it pretty easy to further customize strings for different course types, but it doesn't seem very elegant.

If anyone has a better idea for implementing this, I'm eager to hear it.