### PR TITLE
OAuth refactor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/ragesoss/omniauth-mediawiki.git
-  revision: 14638fbd1914a41dc380d861cc5f6d78f8ae57f2
+  revision: 731144f864ffd263eb5902e0f7dda27b4652b42f
   specs:
     omniauth-mediawiki (0.0.2)
       jwt (~> 1.0)
@@ -243,9 +243,9 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     oauth (0.4.7)
-    omniauth (1.2.2)
+    omniauth (1.3.1)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def mediawiki
     auth_hash = request.env['omniauth.auth']
-    return handle_login_failure(auth_hash) if auth_hash[:extra][:raw_info][:login_failed]
+    return handle_login_failure(auth_hash) if login_failed?(auth_hash)
 
     @user = UserImporter.from_omniauth(auth_hash)
 
@@ -25,5 +25,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     Raven.capture_message 'OAuth login failed',
                           extra: auth_hash
     return redirect_to errors_login_error_path
+  end
+
+  def login_failed?(auth_hash)
+    auth_hash[:extra].try(:[], :raw_info).try(:[], :login_failed)
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,3 @@
-require_relative '../../lib/custom_strategy'
-
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -242,7 +240,6 @@ Devise.setup do |config|
   config.omniauth :mediawiki,
                   Figaro.env.wikipedia_token,
                   Figaro.env.wikipedia_secret,
-                  strategy_class: CustomStrategy,
                   client_options: {
                     site: "https://#{Figaro.env.wiki_language}.wikipedia.org"
                   }
@@ -252,7 +249,7 @@ Devise.setup do |config|
                   Figaro.env.wikipedia_token,
                   Figaro.env.wikipedia_secret,
                   name: 'mediawiki_signup',
-                  strategy_class: CustomStrategy,
+                  strategy_class: OmniAuth::Strategies::Mediawiki,
                   client_options: {
                     site: "https://#{Figaro.env.wiki_language}.wikipedia.org",
                     signup: true

--- a/lib/custom_strategy.rb
+++ b/lib/custom_strategy.rb
@@ -1,12 +1,9 @@
-class LoginError < StandardError; end
-
 class CustomStrategy < OmniAuth::Strategies::Mediawiki
   def parse_info(jwt_data)
-    begin
-      super
-    rescue JWT::DecodeError
-      request.env['JWT_ERROR'] = true
-      request.env['JWT_DATA'] = jwt_data
-    end
+    super
+  rescue JWT::DecodeError
+    fail!(:login_error)
+    return { login_failed: true,
+             jwt_data: jwt_data.body }
   end
 end

--- a/lib/custom_strategy.rb
+++ b/lib/custom_strategy.rb
@@ -1,9 +1,0 @@
-class CustomStrategy < OmniAuth::Strategies::Mediawiki
-  def parse_info(jwt_data)
-    super
-  rescue JWT::DecodeError
-    fail!(:login_error)
-    return { login_failed: true,
-             jwt_data: jwt_data.body }
-  end
-end

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -192,6 +192,18 @@ describe 'Student users', type: :feature, js: true do
       sleep 1
       expect(first('tbody')).not_to have_content 'Ragesoss'
     end
+
+    it 'redirects to a login error page if login fails' do
+      logout
+      OmniAuth.config.test_mode = true
+      allow_any_instance_of(OmniAuth::Strategies::Mediawiki)
+        .to receive(:callback_url).and_return('/users/auth/mediawiki/callback')
+      OmniAuth.config.mock_auth[:mediawiki] = OmniAuth::AuthHash.new(
+        extra: { raw_info: { login_failed: true } }
+      )
+      visit "/courses/#{Course.first.slug}/enroll/passcode"
+      expect(page).to have_content 'Login Error'
+    end
   end
 
   describe 'inputing an assigned article' do


### PR DESCRIPTION
This replaces the monkey patch of the OAuth strategy — that patch is now part of my fork of the gem — and makes the login failure flow testable. I'm still looking for a way to have OmniAuth handle the failure more cleanly and use the typical redirect_on_failure approach, but so far, no luck.