### PR TITLE
application.example.yml: Update Oauth consumer URL

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -18,7 +18,7 @@
 # sitenotice: "NOTICE: The system will go down for maintenance soon."
 
 # Wikimedia OAuth consumer details. Register a consumer at:
-# https://www.mediawiki.org/wiki/Special:OAuthConsumerRegistration/propose
+# https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose
 # No one but the user who registers the consumer will be able to log in until
 # the consumer gets approved by Wikimedia Foundation staff.
   wikipedia_token: <consumer token>


### PR DESCRIPTION
The url for OAuth Consumer Registration has changed.

Fixes https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/640