### PR TITLE
Troubleshooting update

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,6 @@
 
 ## Common setup issues
 
-- **Most integration tests fail with an exception.** This is usually cased by an improperly installed/linked version of QT, particularly on OSX. [This wiki section](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#video-playback-mp4-on-osx-requires-qt-5) should set you straight.
+- **Most integration tests fail with an exception.** This is usually caused by an improperly installed/linked version of QT, particularly on OSX. [This wiki section](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#video-playback-mp4-on-osx-requires-qt-5) should set you straight.
 
 - **Timeout in "before all" hook when running `npm test`** This is caused when you allot very few resources to `npm test`. It takes too long and times out. You can increase the timeout limit in `test/mocha.opts` by adding `-t 5000` of allot more resources to run it faster.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,3 +3,5 @@
 ## Common setup issues
 
 - **Most integration tests fail with an exception.** This is usually cased by an improperly installed/linked version of QT, particularly on OSX. [This wiki section](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#video-playback-mp4-on-osx-requires-qt-5) should set you straight.
+
+- **Timeout in "before all" hook when running `npm test`** This is caused when you allot very few resources to `npm test`. It takes too long and times out. You can increase the timeout limit in `test/mocha.opts` by adding `-t 5000` of allot more resources to run it faster.


### PR DESCRIPTION
If mocha takes too long to execute the "before all" hook, it times out.
This gives and error and fails the testing. This could occur because of a
slow computer or because the process is not given sufficient resources.
This commit adds steps on how to troubleshoot this issue.