### PR TITLE
Add footer with links to privacy policy and terms of service

### DIFF
--- a/app/assets/stylesheets/_layout.styl
+++ b/app/assets/stylesheets/_layout.styl
@@ -33,6 +33,13 @@ header
   .title
     padding 0 20px
 
+footer
+  padding 10
+  text-align center
+  font-size 65%
+  .container
+    padding-bottom 10px
+
 .section-header
   overflow hidden
   padding 20px 0 20px
@@ -80,4 +87,3 @@ section
 
 .text-center
   text-align center
-

--- a/app/assets/stylesheets/training_modules/_layout.styl
+++ b/app/assets/stylesheets/training_modules/_layout.styl
@@ -36,6 +36,13 @@ header
   .title
     padding 0 20px
 
+footer
+  padding 10
+  text-align center
+  font-size 50%
+  .container
+    padding-bottom 10px
+
 .section-header
   overflow hidden
   padding 20px 0 20px

--- a/app/views/shared/_foot.html.haml
+++ b/app/views/shared/_foot.html.haml
@@ -1,1 +1,3 @@
+- if ENV['dashboard_url'] == 'dashboard.wikiedu.org'
+  = render :partial => 'shared/wiki_ed_footer'
 = piwik_tracking_tag

--- a/app/views/shared/_wiki_ed_footer.html.haml
+++ b/app/views/shared/_wiki_ed_footer.html.haml
@@ -1,0 +1,9 @@
+%footer
+  .container
+    = 'This site is a project of the'
+    = link_to 'Wiki Education Foundation', 'https://wikiedu.org'
+    = "and subject to Wiki Ed's"
+    = link_to 'Terms of Service', 'https://wikiedu.org/terms-of-service'
+    = 'and'
+    = link_to 'Privacy Policy', 'https://wikiedu.org/privacy-policy'
+    = '.'


### PR DESCRIPTION
@rileywho FYI

@thenickcox @bmathews I can't figure out how to make the footer go to the bottom when there is not enough content to fill the screen. This is especially relevant for training slides, where we want to make sure the footer isn't in the middle of the screen. Also, just hacking my way through with CSS and haml, so let me know if this is the wrong way altogether to add a footer.