### PR TITLE
Support alternative Rails server host in Guardfile

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -19,7 +19,7 @@ guard :bundler do
   files.each { |file| watch(helper.real_path(file)) }
 end
 
-guard 'rails', environment: 'development' do
+guard 'rails', environment: 'development', host: ENV['RAILS_HOST'] || 'localhost' do
   watch('Gemfile.lock')
   watch(%r{^(config|lib)/.*})
   watch(%r{training_content/.+\.yml})


### PR DESCRIPTION
Tweaked the `Guardfile` to set the Rails host according to a
`RAILS_HOST` environment variable if it's set. Otherwise, default to
'localhost' per usual.