### PR TITLE
Print Greeked passcode when it might be helpful

### DIFF
--- a/app/assets/javascripts/components/overview/details.cjsx
+++ b/app/assets/javascripts/components/overview/details.cjsx
@@ -38,7 +38,7 @@ Details = React.createClass(
     campus = <InlineUsers {...@props} users={@props.campus} role={3} title='Campus Volunteers' />
     staff = <InlineUsers {...@props} users={@props.staff} role={4} title='Wiki Ed Staff' />
 
-    if @props.current_user.role > 0 || @props.current_user.admin
+    if @props.course.passcode
       passcode = (
         <fieldset>
           <TextInput
@@ -47,7 +47,7 @@ Details = React.createClass(
             value_key='passcode'
             editable={@props.editable}
             type='text'
-            label='Passcode'
+            label={I18n.t('courses.passcode')}
             placeholder='Not set'
             required=true
           />

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -27,5 +27,7 @@ json.course do
 
   if user_signed_in? && current_user.role(@course) > 0
     json.passcode @course.passcode
+  elsif @course.passcode
+    json.passcode '****'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,7 @@ en:
     new_week: Add New Week
     nocourses: You are not participating in any courses.
     overview: Overview
+    passcode: Passcode
     published: "Your course has been published! Students may enroll in the course by visiting the following URL:"
     review_timeline: >
       Please review this timeline and make changes. Once you're satisfied with

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -162,6 +162,7 @@ qqq:
     new_week: Button text for adding a new week to the timeline
     nocourses: Message indicating that the logged in user is not part of any courses
     overview: Label for link to the overview page for a course
+    passcode: Label for course passcode field
     review_timeline: Message prompting user to review the timeline
     students: Label for link to the list of students for a course
     students_count: |-


### PR DESCRIPTION
Differentiate between a course with no passcode, and one in which the passcode
is hidden from your role, by displaying a bunch of asterisks if a course is
passcode-protected but you do not have permissions to see the code.

This might help to set expectations for people hoping to join the course.

Also provides i18n for the field.