### PR TITLE
Rename User.wiki_id to User.username

### DIFF
--- a/app/assets/javascripts/components/activity/activity_table.cjsx
+++ b/app/assets/javascripts/components/activity/activity_table.cjsx
@@ -27,7 +27,7 @@ ActivityTable = React.createClass(
     activity = @state.activity.map (revision) =>
       roundedRevisionScore = Math.round(revision.revision_score) or 'unknown'
       revisionDateTime = moment(revision.datetime).format('YYYY/MM/DD h:mm a')
-      talkPageLink = "https://en.wikipedia.org/wiki/User_talk:#{revision.user_wiki_id}"
+      talkPageLink = "https://en.wikipedia.org/wiki/User_talk:#{revision.username}"
 
       <ActivityTableRow
         key={revision.key}
@@ -38,7 +38,7 @@ ActivityTable = React.createClass(
         reportUrl={revision.report_url}
         title={revision.title}
         revisionScore={roundedRevisionScore}
-        author={revision.user_wiki_id}
+        author={revision.username}
         revisionDateTime={revisionDateTime}
       />
 
@@ -46,7 +46,7 @@ ActivityTable = React.createClass(
       courses = revision.courses.map (course) ->
         <li key={"#{revision.key}-#{course.slug}"}><a href="/courses/#{course.slug}">{course.title}</a></li>
 
-      <tr key={"#{revision.key}-#{revision.user_wiki_id}"} className='activity-table-drawer'>
+      <tr key={"#{revision.key}-#{revision.username}"} className='activity-table-drawer'>
         <td colSpan=6>
           <span>
             <h5>Article is active in</h5>

--- a/app/assets/javascripts/components/activity/did_you_know_handler.cjsx
+++ b/app/assets/javascripts/components/activity/did_you_know_handler.cjsx
@@ -25,7 +25,7 @@ DidYouKnowHandler = React.createClass(
     headers = [
       { title: 'Article Title',      key: 'title' },
       { title: 'Revision Score',     key: 'revision_score' },
-      { title: 'Revision Author',    key: 'user_wiki_id' },
+      { title: 'Revision Author',    key: 'username' },
       { title: 'Revision Date/Time', key: 'revision_datetime' },
     ]
 

--- a/app/assets/javascripts/components/activity/plagiarism_handler.cjsx
+++ b/app/assets/javascripts/components/activity/plagiarism_handler.cjsx
@@ -24,7 +24,7 @@ PlagiarismHandler = React.createClass(
     headers = [
       { title: 'Article Title',      key: 'title' },
       { title: 'Plagiarism Report',  key: 'report_url' },
-      { title: 'Revision Author',    key: 'user_wiki_id' },
+      { title: 'Revision Author',    key: 'username' },
       { title: 'Revision Date/Time', key: 'revision_datetime' },
     ]
     noActivityMessage = 'There are not currently any recent revisions suspected of plagiarism.'

--- a/app/assets/javascripts/components/activity/recent_edits_handler.cjsx
+++ b/app/assets/javascripts/components/activity/recent_edits_handler.cjsx
@@ -26,7 +26,7 @@ RecentEditsHandler = React.createClass(
     headers = [
       { title: 'Article Title',      key: 'title' },
       { title: 'Revision Score',     key: 'revision_score' },
-      { title: 'Revision Author',    key: 'user_wiki_id' },
+      { title: 'Revision Author',    key: 'username' },
       { title: 'Revision Date/Time', key: 'revision_datetime' },
     ]
     noActivityMessage = 'Loading recent edits...'

--- a/app/assets/javascripts/components/assignments/assignment.cjsx
+++ b/app/assets/javascripts/components/assignments/assignment.cjsx
@@ -1,8 +1,8 @@
 React        = require 'react'
 ArticleStore = require '../../stores/article_store'
 
-userLink = (wiki_id) ->
-  <a key={wiki_id} href="https://en.wikipedia.org/wiki/User:#{wiki_id}">{wiki_id}</a>
+userLink = (username) ->
+  <a key={username} href="https://en.wikipedia.org/wiki/User:#{username}">{username}</a>
 
 Assignment = React.createClass(
   displayName: 'Assignment'
@@ -26,12 +26,12 @@ Assignment = React.createClass(
 
     assignees = []
     reviewers = []
-    for assignment in _.sortBy @props.assign_group, 'user_wiki_id'
+    for assignment in _.sortBy @props.assign_group, 'username'
       if assignment.role == 0
-        assignees.push userLink(assignment.user_wiki_id)
+        assignees.push userLink(assignment.username)
         assignees.push ', '
       else if assignment.role == 1
-        reviewers.push userLink(assignment.user_wiki_id)
+        reviewers.push userLink(assignment.username)
         reviewers.push ', '
 
     assignees.pop() if assignees.length

--- a/app/assets/javascripts/components/onboarding/index.cjsx
+++ b/app/assets/javascripts/components/onboarding/index.cjsx
@@ -39,7 +39,7 @@ Intro = React.createClass(
   render: ->
     return (
       <div className="intro text-center">
-        <h1>Hi {@state.user.real_name || @state.user.wiki_id}</h1>
+        <h1>Hi {@state.user.real_name || @state.user.username}</h1>
         <p>We’re excited that you’re here!</p>
         <Link to={{ pathname: '/onboarding/form', query: { return_to: decodeURIComponent(getReturnToParam()) } }}  className="button border inverse-border">Start <i className="icon icon-rt_arrow"></i></Link>
       </div>

--- a/app/assets/javascripts/components/overview/inline_users.cjsx
+++ b/app/assets/javascripts/components/overview/inline_users.cjsx
@@ -7,14 +7,14 @@ InlineUsers = React.createClass(
     key = @props.title + '_' + @props.role
     last_user_index = @props.users.length - 1
     user_list = @props.users.map (user, index) ->
-      link = "https://en.wikipedia.org/wiki/User:#{user.wiki_id}"
+      link = "https://en.wikipedia.org/wiki/User:#{user.username}"
       if user.real_name?
         extra_info = " (#{user.real_name}#{if user.email? then " / " + user.email else ""})"
       else
         extra_info = ''
       extra_info = extra_info + ', ' unless index == last_user_index
 
-      <span key={user.wiki_id}><a href={link}>{user.wiki_id}</a>{extra_info}</span>
+      <span key={user.username}><a href={link}>{user.username}</a>{extra_info}</span>
 
     user_list = if user_list.length > 0 then user_list else 'None'
     if @props.users.length > 0 || @props.editable

--- a/app/assets/javascripts/components/students/assign_button.cjsx
+++ b/app/assets/javascripts/components/students/assign_button.cjsx
@@ -47,7 +47,7 @@ AssignButton = React.createClass(
     # Confirm
     return unless confirm I18n.t('assignments.confirm_addition', {
       title: article_title,
-      username: @props.student.wiki_id
+      username: @props.student.username
     })
 
     # Send

--- a/app/assets/javascripts/components/students/enroll_button.cjsx
+++ b/app/assets/javascripts/components/students/enroll_button.cjsx
@@ -13,25 +13,25 @@ EnrollButton = React.createClass(
   displayname: 'EnrollButton'
   mixins: [UserStore.mixin]
   storeDidChange: ->
-    return unless @refs.wiki_id?
-    wiki_id = @refs.wiki_id.value
-    user_obj = { wiki_id: wiki_id }
-    if UserStore.getFiltered({ wiki_id: wiki_id, role: @props.role }).length > 0
-      alert (wiki_id + ' successfully enrolled!')
-      @refs.wiki_id.value = ''
+    return unless @refs.username?
+    username = @refs.username.value
+    user_obj = { username: username }
+    if UserStore.getFiltered({ username: username, role: @props.role }).length > 0
+      alert (username + ' successfully enrolled!')
+      @refs.username.value = ''
   enroll: (e) ->
     e.preventDefault()
-    wiki_id = @refs.wiki_id.value
-    user_obj = { wiki_id: wiki_id, role: @props.role }
-    if UserStore.getFiltered({ wiki_id: wiki_id, role: @props.role }).length == 0 &&
-       confirm 'Are you sure you want to add ' + wiki_id + ' to this course?'
+    username = @refs.username.value
+    user_obj = { username: username, role: @props.role }
+    if UserStore.getFiltered({ username: username, role: @props.role }).length == 0 &&
+       confirm 'Are you sure you want to add ' + username + ' to this course?'
         ServerActions.add 'user', @props.course_id, { user: user_obj }
     else
       alert I18n.t('users.already_enrolled')
   unenroll: (user_id) ->
     user = UserStore.getFiltered({ id: user_id, role: @props.role })[0]
     user_obj = { user_id: user_id, role: @props.role }
-    if confirm 'Are you sure you want to remove ' + user.wiki_id + ' from this course?'
+    if confirm 'Are you sure you want to remove ' + user.username + ' from this course?'
       ServerActions.remove 'user', @props.course_id, { user: user_obj }
   stop: (e) ->
     e.stopPropagation()
@@ -46,7 +46,7 @@ EnrollButton = React.createClass(
         <button className='button border plus' onClick={@unenroll.bind(@, user.id)}>-</button>
       ) unless @props.role == 1 && @props.users.length < 2
       <tr key={user.id + '_enrollment'}>
-        <td>{user.wiki_id}{remove_button}</td>
+        <td>{user.username}{remove_button}</td>
       </tr>
 
     enroll_url = window.location.href.replace(window.location.pathname, "") + @_courseLinkParams() + "?enroll=" + @props.course.passcode
@@ -62,14 +62,14 @@ EnrollButton = React.createClass(
       </tr>
     ) if @props.role == 0
 
-    # This row allows permitted users to add usrs to the course by wiki_id
+    # This row allows permitted users to add usrs to the course by username
     # @props.role controls its presence in the Enrollment popup on /students
     # @props.allowed controls its presence in Edit Details mode on Overview
     edit_rows.push (
       <tr className='edit' key='add_students'>
         <td>
           <form onSubmit={@enroll}>
-            <input type="text" ref='wiki_id' placeholder='Username' />
+            <input type="text" ref='username' placeholder='Username' />
             <button className='button border' type='submit'>Enroll</button>
           </form>
         </td>
@@ -80,7 +80,7 @@ EnrollButton = React.createClass(
     button_class += if @props.inline then ' border plus' else ' dark'
     button_text = if @props.inline then '+' else 'Enrollment'
 
-    # Remove this check when we re-enable adding users by wiki_id
+    # Remove this check when we re-enable adding users by username
     button = <button className={button_class} onClick={@props.open}>{button_text}</button>
 
     <div className='pop__container' onClick={@stop}>

--- a/app/assets/javascripts/components/students/student.cjsx
+++ b/app/assets/javascripts/components/students/student.cjsx
@@ -41,12 +41,12 @@ Student = React.createClass(
         <strong>{@props.student.real_name.trunc()}</strong>
         &nbsp;
         (<a onClick={@stop} href={@props.student.contribution_url} target="_blank" className="inline">
-          {@props.student.wiki_id.trunc()}
+          {@props.student.username.trunc()}
         </a>)
       </span>
     ) else (
       <span><a onClick={@stop} href={@props.student.contribution_url} target="_blank" className="inline">
-        {@props.student.wiki_id.trunc()}
+        {@props.student.username.trunc()}
       </a></span>
     )
 

--- a/app/assets/javascripts/components/students/student_list.cjsx
+++ b/app/assets/javascripts/components/students/student_list.cjsx
@@ -49,7 +49,7 @@ StudentList = React.createClass(
       notify_overdue = <button className='notify_overdue' onClick={@notify} key='notify'></button>
 
     keys =
-      'wiki_id':
+      'username':
         'label': I18n.t('users.name')
         'desktop_only': false
       'assignment_title':

--- a/app/assets/javascripts/components/students/students_handler.cjsx
+++ b/app/assets/javascripts/components/students/students_handler.cjsx
@@ -19,7 +19,7 @@ StudentsHandler = React.createClass(
         <h3>{CourseUtils.i18n('students', @props.course.string_prefix)}</h3>
         <div className='sort-select'>
           <select className='sorts' name='sorts' onChange={@sortSelect}>
-            <option value='wiki_id'>Name</option>
+            <option value='username'>Name</option>
             <option value='character_sum_ms'>MS Chars Added</option>
             <option value='character_sum_us'>US Chars Added</option>
           </select>

--- a/app/assets/javascripts/stores/user_store.coffee
+++ b/app/assets/javascripts/stores/user_store.coffee
@@ -1,14 +1,14 @@
 StockStore = require './stock_store'
 
 UserStore = new StockStore(
-  sortKey: 'wiki_id'
+  sortKey: 'username'
   sortAsc: true
   descKeys:
     character_sum_ms: true
     character_sum_us: true
   modelKey: 'user'
   defaultModel:
-    wiki_id: ""
+    username: ""
   uniqueKeys: ['id', 'role']
 )
 

--- a/app/controllers/feedback_form_responses_controller.rb
+++ b/app/controllers/feedback_form_responses_controller.rb
@@ -13,7 +13,7 @@ class FeedbackFormResponsesController < ApplicationController
     check_user_auth
     @response = FeedbackFormResponse.find(params[:id])
     if @response.user_id
-      @username = User.find(@response.user_id).wiki_id
+      @username = User.find(@response.user_id).username
     else
       @username = nil
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,7 +55,7 @@ class UsersController < ApplicationController
   end
 
   def enroll_params
-    params.require(:user).permit(:user_id, :wiki_id, :role)
+    params.require(:user).permit(:user_id, :username, :role)
   end
 
   def fetch_enroll_records
@@ -64,10 +64,10 @@ class UsersController < ApplicationController
     @course = Course.find_by_slug(params[:id])
     if enroll_params.key? :user_id
       @user = User.find(enroll_params[:user_id])
-    elsif enroll_params.key? :wiki_id
-      wiki_id = enroll_params[:wiki_id]
-      @user = User.find_by(wiki_id: wiki_id)
-      @user = UserImporter.new_from_wiki_id(wiki_id) if @user.nil?
+    elsif enroll_params.key? :username
+      username = enroll_params[:username]
+      @user = User.find_by(username: username)
+      @user = UserImporter.new_from_username(username) if @user.nil?
     end
   end
 
@@ -90,7 +90,7 @@ class UsersController < ApplicationController
       WikiCourseEdits.new(action: :update_course, course: @course, current_user: current_user)
       render 'users', formats: :json
     else
-      username = enroll_params[:user_id] || enroll_params[:wiki_id]
+      username = enroll_params[:user_id] || enroll_params[:username]
       render json: { message: I18n.t('courses.error.user_exists',
                                      username: username) },
              status: 404
@@ -124,7 +124,7 @@ class UsersController < ApplicationController
 
   def user_params
     params.permit(
-      users: [:id, :wiki_id, :deleted, :email],
+      users: [:id, :username, :deleted, :email],
       assignments: [:id, :user_id, :article_title, :role, :course_id, :deleted]
     )
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,6 +2,6 @@
 module UsersHelper
   def contribution_link(user, text=nil, css_class=nil)
     options = { target: '_blank', class: css_class }
-    link_to((text || user.wiki_id), user.contribution_url, options)
+    link_to((text || user.username), user.contribution_url, options)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id                  :integer          not null, primary key
-#  wiki_id             :string(255)
+#  username             :string(255)
 #  created_at          :datetime
 #  updated_at          :datetime
 #  character_sum       :integer          default(0)
@@ -27,6 +27,8 @@ require "#{Rails.root}/lib/utils"
 
 #= User model
 class User < ActiveRecord::Base
+  alias_attribute :wiki_id, :username
+
   validates :permissions, inclusion: { in: [0, 1, 2] }
 
   #############
@@ -78,16 +80,16 @@ class User < ActiveRecord::Base
 
   def contribution_url
     language = ENV['wiki_language']
-    "https://#{language}.wikipedia.org/wiki/Special:Contributions/#{wiki_id}"
+    "https://#{language}.wikipedia.org/wiki/Special:Contributions/#{username}"
   end
 
   def sandbox_url
     language = ENV['wiki_language']
-    "https://#{language}.wikipedia.org/wiki/Special:PrefixIndex/User:#{wiki_id}"
+    "https://#{language}.wikipedia.org/wiki/Special:PrefixIndex/User:#{username}"
   end
 
   def talk_page
-    "User_talk:#{wiki_id}"
+    "User_talk:#{username}"
   end
 
   def admin?

--- a/app/views/courses/_assignments.json.jbuilder
+++ b/app/views/courses/_assignments.json.jbuilder
@@ -8,5 +8,5 @@ json.assignments course.assignments do |assignment|
   end
 
   json.article_url assignment.page_url
-  json.user_wiki_id assignment.user.wiki_id
+  json.username assignment.user.username
 end

--- a/app/views/courses/_users.json.jbuilder
+++ b/app/views/courses/_users.json.jbuilder
@@ -1,6 +1,6 @@
 json.users course.courses_users.eager_load(:user) do |cu|
   json.call(cu, :character_sum_ms, :character_sum_us, :role)
-  json.call(cu.user, :id, :wiki_id, :contribution_url, :sandbox_url)
+  json.call(cu.user, :id, :username, :contribution_url, :sandbox_url)
   json.admin cu.user.permissions == User::Permissions::ADMIN
   json.recent_revisions RevisionStat.recent_revisions_for_user_and_course(cu.user, cu.course).count
 

--- a/app/views/courses/revisions.json.jbuilder
+++ b/app/views/courses/revisions.json.jbuilder
@@ -8,6 +8,6 @@ json.course do
     json.rating_num rating_priority(rev.article.rating)
     json.pretty_rating rating_display(rev.article.rating)
 
-    json.revisor rev.user.wiki_id
+    json.revisor rev.user.username
   end
 end

--- a/app/views/courses/uploads.json.jbuilder
+++ b/app/views/courses/uploads.json.jbuilder
@@ -3,6 +3,6 @@ json.course do
     json.call(upload, :id, :uploaded_at, :usage_count, :url, :thumburl)
     json.url upload.url
     json.file_name pretty_filename(upload)
-    json.uploader upload.user.wiki_id
+    json.uploader upload.user.username
   end
 end

--- a/app/views/dashboard/_course_row.html.haml
+++ b/app/views/dashboard/_course_row.html.haml
@@ -9,7 +9,7 @@
         = t("courses.instructors")
       .course-details_value
         - course.instructors.each do |user|
-          = user.wiki_id
+          = user.username
     .col
       .course-details_title
         = t("courses.school")

--- a/app/views/onboarding/index.html.haml
+++ b/app/views/onboarding/index.html.haml
@@ -1,3 +1,3 @@
--user =  current_user.to_json(only: [:real_name, :email, :permissions, :wiki_id]).to_str
+-user =  current_user.to_json(only: [:real_name, :email, :permissions, :username]).to_str
 
 %div#react_root{"data-current_user" => user}

--- a/app/views/revision_analytics/dyk_eligible.json.jbuilder
+++ b/app/views/revision_analytics/dyk_eligible.json.jbuilder
@@ -6,7 +6,7 @@ json.articles do
     json.article_url article_url(article)
     json.diff_url revision.url
     json.revision_score revision.wp10
-    json.user_wiki_id revision.user.wiki_id
+    json.username revision.user.username
     json.datetime revision.date
     json.courses revision.infer_courses_from_user.each do |course|
       json.title course.title

--- a/app/views/revision_analytics/recent_edits.json.jbuilder
+++ b/app/views/revision_analytics/recent_edits.json.jbuilder
@@ -6,7 +6,7 @@ json.revisions do
     json.article_url article_url(article)
     json.diff_url revision.url
     json.revision_score revision.wp10
-    json.user_wiki_id revision.user.nil? ? '' : revision.user.wiki_id
+    json.username revision.user.nil? ? '' : revision.user.username
     json.datetime revision.date
     json.courses revision.infer_courses_from_user.each do |course|
       json.title course.title

--- a/app/views/revision_analytics/suspected_plagiarism.json.jbuilder
+++ b/app/views/revision_analytics/suspected_plagiarism.json.jbuilder
@@ -6,7 +6,7 @@ json.revisions do
     json.article_url article_url(article)
     json.report_url revision.report_url
     json.diff_url revision.url
-    json.user_wiki_id revision.user.wiki_id
+    json.username revision.user.username
     json.datetime revision.date
     json.courses revision.infer_courses_from_user.each do |course|
       json.title course.title

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -20,7 +20,7 @@
     %ul.top-nav__login-links
       - if user_signed_in?
         %li
-          %b>= link_to current_user.wiki_id, root_path, class: 'current-user'
+          %b>= link_to current_user.username, root_path, class: 'current-user'
         %li= link_to t('application.log_out'), destroy_user_session_path
       - else
         %li

--- a/db/migrate/20160303010838_rename_wiki_id_to_username.rb
+++ b/db/migrate/20160303010838_rename_wiki_id_to_username.rb
@@ -1,0 +1,5 @@
+class RenameWikiIdToUsername < ActiveRecord::Migration
+  def change
+    rename_column :users, :wiki_id, :username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160127203440) do
+ActiveRecord::Schema.define(version: 20160303010838) do
 
   create_table "articles", force: :cascade do |t|
     t.string   "title",                    limit: 255
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 20160127203440) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "wiki_id",             limit: 255
+    t.string   "username",             limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "trained",                         default: false

--- a/lib/analytics/scripts/usernames_to_csv.rb
+++ b/lib/analytics/scripts/usernames_to_csv.rb
@@ -4,7 +4,7 @@
 require 'csv'
 
 # all the usernames
-usernames = User.joins(:courses_users).uniq.pluck(:wiki_id)
+usernames = User.joins(:courses_users).uniq.pluck(:username)
 CSV.open('/root/all_course_participants.csv', 'wb') do |csv|
   usernames.each do |username|
     csv << [username]
@@ -15,7 +15,7 @@ end
 Cohort.all.each do |cohort|
   CSV.open("/root/#{cohort.slug}_students.csv", 'wb') do |csv|
     cohort.students.each do |student|
-      csv << [student.wiki_id]
+      csv << [student.username]
     end
   end
 end
@@ -25,7 +25,7 @@ Cohort.all.each do |cohort|
   CSV.open("/root/#{cohort.slug}_students.csv", 'wb') do |csv|
     cohort.courses.each do |course|
       course.students.each do |student|
-        csv << [student.wiki_id, course.slug]
+        csv << [student.username, course.slug]
       end
     end
   end
@@ -36,7 +36,7 @@ CSV.open("/root/course_instructors.csv", 'wb') do |csv|
   csv << ['course', 'instructor_user_id', 'instructor username']
   Course.all.each do |course|
     course.instructors.each do |instructor|
-      csv << [course.slug, instructor.id, instructor.wiki_id]
+      csv << [course.slug, instructor.id, instructor.username]
     end
   end
 end

--- a/lib/commons.rb
+++ b/lib/commons.rb
@@ -70,7 +70,7 @@ class Commons
   end
 
   def self.build_upload_query(users)
-    usernames = users.map(&:wiki_id)
+    usernames = users.map(&:username)
     upload_query = { list: 'usercontribs',
                      ucuser: usernames,
                      ucnamespace: 6, # File: namespace

--- a/lib/importers/upload_importer.rb
+++ b/lib/importers/upload_importer.rb
@@ -45,7 +45,7 @@ class UploadImporter
         uploaded_at = file['timestamp']
         file_name = file['title']
         username = file['user']
-        user_id = User.find_by(wiki_id: username).id
+        user_id = User.find_by(username: username).id
         id = file['pageid']
         upload = CommonsUpload.new(id: id,
                                    uploaded_at: uploaded_at,

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -3,7 +3,7 @@ require "#{Rails.root}/lib/replica"
 #= Imports and updates users from Wikipedia into the dashboard database
 class UserImporter
   def self.from_omniauth(auth)
-    user = User.find_by(wiki_id: auth.info.name)
+    user = User.find_by(username: auth.info.name)
     if user.nil?
       user = new_from_omniauth(auth)
     else
@@ -22,7 +22,7 @@ class UserImporter
     id = WikiApi.get_user_id(auth.info.name)
     user = User.create(
       id: id,
-      wiki_id: auth.info.name,
+      username: auth.info.name,
       global_id: auth.uid,
       wiki_token: auth.credentials.token,
       wiki_secret: auth.credentials.secret
@@ -30,9 +30,9 @@ class UserImporter
     user
   end
 
-  def self.new_from_wiki_id(wiki_id)
+  def self.new_from_username(username)
     require "#{Rails.root}/lib/wiki_api"
-    id = WikiApi.get_user_id(wiki_id)
+    id = WikiApi.get_user_id(username)
     return unless id
 
     if User.exists?(id)
@@ -40,7 +40,7 @@ class UserImporter
     else
       user = User.create(
         id: id,
-        wiki_id: wiki_id
+        username: username
       )
     end
 
@@ -56,7 +56,7 @@ class UserImporter
   def self.add_user(user, role, course, save=true)
     empty_user = User.new(id: user['id'])
     new_user = save ? User.find_or_create_by(id: user['id']) : empty_user
-    new_user.wiki_id = user['username']
+    new_user.username = user['username']
     if save
       if !role.nil? && !course.nil?
         role_index = %w(student instructor online_volunteer

--- a/lib/student_greeter.rb
+++ b/lib/student_greeter.rb
@@ -74,7 +74,7 @@ class StudentGreeter
   end
 
   def first_name(user)
-    name = user.real_name || user.wiki_id
+    name = user.real_name || user.username
     # Split on either whitespace or underscore, so that it works for usernames
     # like Ian_(Wiki Ed) too.
     name.split(/[\s_]/)[0]

--- a/lib/wiki_assignment_output.rb
+++ b/lib/wiki_assignment_output.rb
@@ -101,7 +101,7 @@ class WikiAssignmentOutput
   def self.build_wikitext_user_list(assignments, role)
     user_ids = assignments.select { |assignment| assignment.role == role }
                .map(&:user_id)
-    User.where(id: user_ids).pluck(:wiki_id)
-      .map { |wiki_id| "[[User:#{wiki_id}|#{wiki_id}]]" }.join(', ')
+    User.where(id: user_ids).pluck(:username)
+      .map { |username| "[[User:#{username}|#{username}]]" }.join(', ')
   end
 end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -42,7 +42,7 @@ class WikiCourseEdits
   def announce_course(instructor: nil)
     instructor ||= @current_user
     course_title = @course.wiki_title
-    user_page = "User:#{instructor.wiki_id}"
+    user_page = "User:#{instructor.username}"
     template = "{{course instructor|course = [[#{course_title}]] }}\n"
     summary = "New course announcement: [[#{course_title}]]."
 
@@ -53,7 +53,7 @@ class WikiCourseEdits
     announcement_page = ENV['course_announcement_page']
     # rubocop:disable Metrics/LineLength
     announcement = "I have created a new course — #{@course.title} — at #{@dashboard_url}/courses/#{@course.slug}. If you'd like to see more details about my course, check out my course page.--~~~~"
-    section_title = "New course announcement: [[#{course_title}]] (instructor: [[User:#{instructor.wiki_id}]])"
+    section_title = "New course announcement: [[#{course_title}]] (instructor: [[User:#{instructor.username}]])"
     # rubocop:enable Metrics/LineLength
     message = { sectiontitle: section_title,
                 text: announcement,
@@ -69,7 +69,7 @@ class WikiCourseEdits
     # Add a template to the user page
     course_title = @course.wiki_title
     template = "{{student editor|course = [[#{course_title}]] }}\n"
-    user_page = "User:#{@current_user.wiki_id}"
+    user_page = "User:#{@current_user.username}"
     summary = "I am enrolled in [[#{course_title}]]."
     WikiEdits.add_to_page_top(user_page, @current_user, template, summary)
 

--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -40,9 +40,9 @@ class WikiCourseOutput
     dashboard_url = ENV['dashboard_url']
     course_details = "{{course details
      | course_name = #{course.title}
-     | instructor_username = #{instructor.wiki_id unless instructor.nil?}
+     | instructor_username = #{instructor.username unless instructor.nil?}
      | instructor_realname = #{instructor.real_name unless instructor.nil?}
-     | support_staff = #{support_staff.wiki_id unless support_staff.nil?}
+     | support_staff = #{support_staff.username unless support_staff.nil?}
      | subject = #{course.subject}
      | start_date = #{course.start}
      | end_date = #{course.end}
@@ -82,7 +82,7 @@ class WikiCourseOutput
     return '' if students.blank?
     table = "{{students table}}\r"
     students.each do |student|
-      username = student.wiki_id
+      username = student.username
       assignments = student.assignments.where(course_id: course.id)
       assigned_titles = assignments.assigned.pluck(:article_title)
       assigned = titles_to_wikilinks assigned_titles

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -25,7 +25,7 @@ class WikiEdits
     Raven.capture_message 'WikiEdits.notify_untrained',
                           level: 'info',
                           culprit: 'WikiEdits.notify_untrained',
-                          extra: { sender: current_user.wiki_id,
+                          extra: { sender: current_user.username,
                                    course_name: course.slug,
                                    untrained_count: untrained_users.count }
   end

--- a/lib/wiki_response.rb
+++ b/lib/wiki_response.rb
@@ -11,7 +11,7 @@ class WikiResponse
     sorting_info = parse_api_response(response_data, type, current_user)
     Raven.capture_message sorting_info[:title],
                           level: sorting_info[:level],
-                          tags: { username: current_user[:wiki_id],
+                          tags: { username: current_user[:username],
                                   action_type: type },
                           extra: { response_data: response_data,
                                    post_data: post_data,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id                  :integer          not null, primary key
-#  wiki_id             :string(255)
+#  username            :string(255)
 #  created_at          :datetime
 #  updated_at          :datetime
 #  character_sum       :integer          default(0)
@@ -25,25 +25,25 @@
 
 FactoryGirl.define do
   factory :test_user, class: User do
-    wiki_id 'Pizza'
+    username 'Pizza'
     onboarded true
   end
 
   factory :user do
     id '4543197'
-    wiki_id 'Ragesock'
+    username 'Ragesock'
     onboarded true
   end
 
   factory :trained, class: User do
     id '319203'
-    wiki_id 'Ragesoss'
+    username 'Ragesoss'
     onboarded true
   end
 
   factory :admin, class: User do
     id '1'
-    wiki_id 'Ragesauce'
+    username 'Ragesauce'
     permissions '1'
     onboarded true
   end

--- a/spec/features/admin_role_spec.rb
+++ b/spec/features/admin_role_spec.rb
@@ -10,7 +10,7 @@ describe 'Admin users', type: :feature, js: true do
   before :each do
     create(:user,
            id: 100,
-           wiki_id: 'Professor Sage')
+           username: 'Professor Sage')
 
     create(:course,
            id: 10001,

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -41,7 +41,7 @@ describe 'the course page', type: :feature, js: true do
     (1..user_count).each do |i|
       create(:user,
              id: i.to_s,
-             wiki_id: "Student #{i}",
+             username: "Student #{i}",
              trained: i % 2)
       create(:courses_user,
              id: i.to_s,
@@ -251,10 +251,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.last.wiki_id)
+      expect(page).to have_content(User.last.username)
       student_row = 'table.users tbody tr.students:first-child'
       within(student_row) do
-        expect(page).to have_content User.first.wiki_id
+        expect(page).to have_content User.first.username
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -10,16 +10,16 @@ describe 'Instructor users', type: :feature, js: true do
   before :each do
     instructor = create(:user,
                         id: 100,
-                        wiki_id: 'Professor Sage',
+                        username: 'Professor Sage',
                         wiki_token: 'foo',
                         wiki_secret: 'bar')
 
     create(:user,
            id: 101,
-           wiki_id: 'Student A')
+           username: 'Student A')
     create(:user,
            id: 102,
-           wiki_id: 'Student B')
+           username: 'Student B')
     create(:course,
            id: 10001,
            title: 'My Active Course',

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -23,7 +23,7 @@ describe 'Student users', type: :feature, js: true do
            end: '2020-01-01'.to_date)
     create(:user,
            id: 100,
-           wiki_id: 'Professor Sage')
+           username: 'Professor Sage')
     create(:courses_user,
            user_id: 100,
            course_id: 10001,
@@ -33,7 +33,7 @@ describe 'Student users', type: :feature, js: true do
            course_id: 10001)
     create(:user,
            id: 101,
-           wiki_id: 'Classmate')
+           username: 'Classmate')
     create(:courses_user,
            id: 2,
            user_id: 101,
@@ -76,7 +76,7 @@ describe 'Student users', type: :feature, js: true do
       end
 
       visit "/courses/#{Course.first.slug}/students"
-      expect(find('tbody', match: :first)).to have_content User.last.wiki_id
+      expect(find('tbody', match: :first)).to have_content User.last.username
 
       # now unenroll
       visit "/courses/#{Course.first.slug}"
@@ -87,7 +87,7 @@ describe 'Student users', type: :feature, js: true do
       sleep 1
 
       visit "/courses/#{Course.first.slug}/students"
-      expect(find('tbody', match: :first)).not_to have_content User.last.wiki_id
+      expect(find('tbody', match: :first)).not_to have_content User.last.username
     end
 
     it 'redirects to an error page if passcode is incorrect' do
@@ -106,11 +106,11 @@ describe 'Student users', type: :feature, js: true do
       stub_oauth_edit
 
       visit "/courses/#{Course.first.slug}?enroll=passcode"
-      expect(page).to have_content User.last.wiki_id
+      expect(page).to have_content User.last.username
       click_link 'Join'
       sleep 1
       visit "/courses/#{Course.first.slug}/students"
-      expect(find('tbody', match: :first)).to have_content User.last.wiki_id
+      expect(find('tbody', match: :first)).to have_content User.last.username
       # Now try enrolling again, which shouldn't cause any errors
       visit "/courses/#{Course.first.slug}/enroll/passcode"
     end

--- a/spec/features/students_page_spec.rb
+++ b/spec/features/students_page_spec.rb
@@ -32,7 +32,7 @@ describe 'Students Page', type: :feature, js: true do
                    # why is there an `id` in the user factory
                    # anyway?
                    id: rand(534384389),
-                   wiki_id: 'Mr_Tester',
+                   username: 'Mr_Tester',
                    real_name: 'Mr. Tester',
                    trained: true)
 
@@ -66,7 +66,7 @@ describe 'Students Page', type: :feature, js: true do
   it 'should display a list of students' do
     js_visit "/courses/#{@course.slug}/students"
     sleep 1 # Try to avoid issue where this test fails with 0 rows found.
-    expect(page).to have_content @user.wiki_id
+    expect(page).to have_content @user.username
   end
 
   it 'should open a list of individual student revisions' do

--- a/spec/lib/assignments_manager_spec.rb
+++ b/spec/lib/assignments_manager_spec.rb
@@ -8,7 +8,7 @@ describe AssignmentsManager do
 
     it 'creates new assignments for existing articles' do
       create(:article, id: 1, namespace: 0, title: 'Existing_article')
-      params = { 'users' => [{ 'id' => 1, 'wiki_id' => 'Ragesock' }],
+      params = { 'users' => [{ 'id' => 1, 'username' => 'Ragesock' }],
                  'assignments' => [{ 'user_id' => 1,
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
@@ -21,7 +21,7 @@ describe AssignmentsManager do
     end
 
     it 'creates new assignments for non-existent articles' do
-      params = { 'users' => [{ 'id' => 1, 'wiki_id' => 'Ragesock' }],
+      params = { 'users' => [{ 'id' => 1, 'username' => 'Ragesock' }],
                  'assignments' => [{ 'user_id' => 1,
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }
@@ -41,7 +41,7 @@ describe AssignmentsManager do
              article_title: 'Existing_article',
              course_id: 1,
              role: 0)
-      params = { 'users' => [{ 'id' => 1, 'wiki_id' => 'Ragesock' }],
+      params = { 'users' => [{ 'id' => 1, 'username' => 'Ragesock' }],
                  'assignments' => [{ 'user_id' => 1,
                                      'id' => 1,
                                      'article_title' => 'existing article',
@@ -55,7 +55,7 @@ describe AssignmentsManager do
     end
 
     it 'handles deletion of already-deleted assignments gracefully' do
-      params = { 'users' => [{ 'id' => 1, 'wiki_id' => 'Ragesock' }],
+      params = { 'users' => [{ 'id' => 1, 'username' => 'Ragesock' }],
                  'assignments' => [{ 'user_id' => 1,
                                      'id' => 1,
                                      'article_title' => 'existing article',
@@ -76,7 +76,7 @@ describe AssignmentsManager do
              course_id: 1,
              role: 0)
       create(:article, id: 1, namespace: 0, title: 'Existing_article')
-      params = { 'users' => [{ 'id' => 1, 'wiki_id' => 'Ragesock' }],
+      params = { 'users' => [{ 'id' => 1, 'username' => 'Ragesock' }],
                  'assignments' => [{ 'user_id' => 1,
                                      'article_title' => 'existing article',
                                      'role' => 0 }] }

--- a/spec/lib/cleaners/revisions_cleaner_spec.rb
+++ b/spec/lib/cleaners/revisions_cleaner_spec.rb
@@ -15,7 +15,7 @@ describe RevisionsCleaner do
              namespace: 0)
       create(:user,
              id: 24593901,
-             wiki_id: 'Rothscak')
+             username: 'Rothscak')
       create(:courses_user,
              course_id: 1,
              user_id: 24593901)

--- a/spec/lib/cleaners_spec.rb
+++ b/spec/lib/cleaners_spec.rb
@@ -68,7 +68,7 @@ describe Cleaners do
              namespace: 0)
       create(:user,
              id: 24593901,
-             wiki_id: 'Rothscak')
+             username: 'Rothscak')
       create(:courses_user,
              course_id: 1,
              user_id: 24593901)

--- a/spec/lib/commons_spec.rb
+++ b/spec/lib/commons_spec.rb
@@ -6,7 +6,7 @@ describe Commons do
     it 'should get upload data for a user with many uploads' do
       VCR.use_cassette 'commons/get_uploads_many' do
         user = create(:user,
-                      wiki_id: 'Ragesoss')
+                      username: 'Ragesoss')
         response = Commons.get_uploads [user]
         expect(response.count).to satisfy { |x| x > 3000 }
         expect(response[0]['timestamp']).not_to be_nil
@@ -19,7 +19,7 @@ describe Commons do
     it 'should handle a user with no uploads' do
       VCR.use_cassette 'commons/get_uploads_none' do
         user = create(:user,
-                      wiki_id: 'Ragetest 7')
+                      username: 'Ragetest 7')
         response = Commons.get_uploads [user]
         expect(response).to eq([])
       end
@@ -28,7 +28,7 @@ describe Commons do
     it 'should handle a user with one upload' do
       VCR.use_cassette 'commons/get_uploads_one' do
         user = create(:user,
-                      wiki_id: 'Ameily radke')
+                      username: 'Ameily radke')
         response = Commons.get_uploads [user]
         expect(response.count).to eq(1)
       end

--- a/spec/lib/importers/upload_importer_spec.rb
+++ b/spec/lib/importers/upload_importer_spec.rb
@@ -5,7 +5,7 @@ describe UploadImporter do
   describe '.import_all_uploads' do
     it 'should find and record files uploaded to Commons' do
       create(:user,
-             wiki_id: 'Guettarda')
+             username: 'Guettarda')
       VCR.use_cassette 'commons/import_all_uploads' do
         UploadImporter.import_all_uploads(User.all)
         expect(CommonsUpload.all.count).to be > 50
@@ -16,7 +16,7 @@ describe UploadImporter do
   describe '.update_usage_count' do
     it 'should count and record how many times files are used' do
       create(:user,
-             wiki_id: 'Guettarda')
+             username: 'Guettarda')
       VCR.use_cassette 'commons/import_all_uploads' do
         UploadImporter.import_all_uploads(User.all)
       end
@@ -51,7 +51,7 @@ describe UploadImporter do
   describe '.import_urls_in_batches' do
     it 'should find and record Commons thumbnail urls' do
       create(:user,
-             wiki_id: 'Guettarda')
+             username: 'Guettarda')
       VCR.use_cassette 'commons/import_all_uploads' do
         UploadImporter.import_all_uploads(User.all)
       end

--- a/spec/lib/importers/user_importer_spec.rb
+++ b/spec/lib/importers/user_importer_spec.rb
@@ -28,28 +28,28 @@ describe UserImporter do
     end
   end
 
-  describe '.new_from_wiki_id' do
+  describe '.new_from_username' do
     it 'should create a new user' do
-      VCR.use_cassette 'user/new_from_wiki_id' do
+      VCR.use_cassette 'user/new_from_username' do
         username = 'Ragesoss'
-        user = UserImporter.new_from_wiki_id(username)
+        user = UserImporter.new_from_username(username)
         expect(user.id).to eq(319203)
       end
     end
 
     it 'should return an existing user' do
-      VCR.use_cassette 'user/new_from_wiki_id' do
-        create(:user, id: 319203, wiki_id: 'Ragesoss')
+      VCR.use_cassette 'user/new_from_username' do
+        create(:user, id: 319203, username: 'Ragesoss')
         username = 'Ragesoss'
-        user = UserImporter.new_from_wiki_id(username)
+        user = UserImporter.new_from_username(username)
         expect(user.id).to eq(319203)
       end
     end
 
     it 'should not create a user if the username is not registered' do
-      VCR.use_cassette 'user/new_from_wiki_id_nonexistent' do
+      VCR.use_cassette 'user/new_from_username_nonexistent' do
         username = 'RagesossRagesossRagesoss'
-        user = UserImporter.new_from_wiki_id(username)
+        user = UserImporter.new_from_username(username)
         expect(user).to be_nil
       end
     end

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -14,9 +14,9 @@ describe Replica do
       stub_request(:any, %r{http://tools.wmflabs.org/.*})
         .to_raise(Errno::ETIMEDOUT)
       all_users = [
-        build(:user, wiki_id: 'ELE427', id: 22905965),
-        build(:user, wiki_id: 'Ragesoss', id: 319203),
-        build(:user, wiki_id: 'Mrbauer1234', id: 23011474)
+        build(:user, username: 'ELE427', id: 22905965),
+        build(:user, username: 'Ragesoss', id: 319203),
+        build(:user, username: 'Mrbauer1234', id: 23011474)
       ]
       rev_start = 2014_01_01_003430
       rev_end = 2014_12_31_003430
@@ -29,9 +29,9 @@ describe Replica do
       stub_request(:any, %r{http://tools.wmflabs.org/.*})
         .to_raise(Errno::ECONNREFUSED)
       all_users = [
-        build(:user, wiki_id: 'ELE427', id: 22905965),
-        build(:user, wiki_id: 'Ragesoss', id: 319203),
-        build(:user, wiki_id: 'Mrbauer1234', id: 23011474)
+        build(:user, username: 'ELE427', id: 22905965),
+        build(:user, username: 'Ragesoss', id: 319203),
+        build(:user, username: 'Mrbauer1234', id: 23011474)
       ]
 
       response = Replica.get_user_info(all_users)
@@ -41,9 +41,9 @@ describe Replica do
     it 'should return revisions from this term' do
       VCR.use_cassette 'replica/revisions' do
         all_users = [
-          build(:user, wiki_id: 'ELE427', id: 22905965),
-          build(:user, wiki_id: 'Ragesoss', id: 319203),
-          build(:user, wiki_id: 'Mrbauer1234', id: 23011474)
+          build(:user, username: 'ELE427', id: 22905965),
+          build(:user, username: 'Ragesoss', id: 319203),
+          build(:user, username: 'Mrbauer1234', id: 23011474)
         ]
         rev_start = 2014_01_01_003430
         rev_end = 2014_12_31_003430
@@ -73,7 +73,7 @@ describe Replica do
       VCR.use_cassette 'replica/comma' do
         comma_user = build(:user,
                            id: 17137867,
-                           wiki_id: 'JRicker,PhD')
+                           username: 'JRicker,PhD')
         rev_start = 2015_01_01
         rev_end = 2016_01_01
         response = Replica.get_revisions([comma_user], rev_start, rev_end)
@@ -81,13 +81,13 @@ describe Replica do
 
         ampersand_user = build(:user,
                                id: 22403865,
-                               wiki_id: 'Evol&Glass')
+                               username: 'Evol&Glass')
         response = Replica.get_revisions([ampersand_user], rev_start, rev_end)
         expect(response.count).to be > 1
 
         apostrophe_user = build(:user,
                                 id: 26211578,
-                                wiki_id: "Jack's nomadic mind")
+                                username: "Jack's nomadic mind")
         response = Replica.get_revisions([apostrophe_user], rev_start, rev_end)
         expect(response.count).to be > 1
 
@@ -95,7 +95,7 @@ describe Replica do
         rev_end = 2010_01_01
         exclamation_user = build(:user,
                                  id: 11274650,
-                                 wiki_id: '!!Aaapplesauce')
+                                 username: '!!Aaapplesauce')
         response = Replica.get_revisions([exclamation_user], rev_start, rev_end)
         expect(response.count).to be > 1
       end
@@ -136,8 +136,8 @@ describe Replica do
 
     it 'should update usernames after name changes' do
       VCR.use_cassette 'replica/training' do
-        create(:user, wiki_id: 'old_username')
-        expect(User.all.first.wiki_id).to eq('old_username')
+        create(:user, username: 'old_username')
+        expect(User.all.first.username).to eq('old_username')
         response = Replica.get_user_info User.all
         expect(response[0]['wiki_id']).to eq('Ragesock')
       end
@@ -164,9 +164,9 @@ describe Replica do
     it 'should function identically on non-English wikis' do
       VCR.use_cassette 'replica/es_revisions' do
         all_users = [
-          build(:user, wiki_id: 'AndresAlvarezGalina95', id: 3556537),
-          build(:user, wiki_id: 'Patyelena25', id: 3471984),
-          build(:user, wiki_id: 'Lizmich91', id: 3558536)
+          build(:user, username: 'AndresAlvarezGalina95', id: 3556537),
+          build(:user, username: 'Patyelena25', id: 3471984),
+          build(:user, username: 'Lizmich91', id: 3558536)
         ]
 
         rev_start = 2015_02_12_003430

--- a/spec/lib/revision_analytics_service_spec.rb
+++ b/spec/lib/revision_analytics_service_spec.rb
@@ -12,7 +12,7 @@ describe RevisionAnalyticsService do
 
   let(:opts)       { {} }
   let(:course)     { create(:course, id: 10001, start: 1.month.ago, end: 1.month.from_now) }
-  let(:user)       { create(:user, id: 1, wiki_id: 'Student_1') }
+  let(:user)       { create(:user, id: 1, username: 'Student_1') }
   let!(:c_user)    { create(:courses_user, user_id: user.id, course_id: course.id, role: 0) }
   let!(:article)   { create(:article, id: 1, title: 'Student_1/A_great_draft', namespace: 2) }
   let!(:revision5) do
@@ -20,7 +20,7 @@ describe RevisionAnalyticsService do
   end
 
   let(:course2)    { create(:course, id: 10002, start: 1.month.ago, end: 1.month.from_now) }
-  let(:user2)      { create(:user, id: 2, wiki_id: 'Student_2') }
+  let(:user2)      { create(:user, id: 2, username: 'Student_2') }
   let!(:c_user2)   { create(:courses_user, user_id: user2.id, course_id: course2.id, role: 0) }
   let!(:article4)  { create(:article, id: 4, title: 'Student_2/Another_good_draft', namespace: 2) }
   let!(:revision4) do
@@ -29,7 +29,7 @@ describe RevisionAnalyticsService do
 
   # Articles/Revisions that should not show up
   let(:course3)    { create(:course, id: 10003, start: 1.month.ago, end: 1.month.from_now) }
-  let(:user3)      { create(:user, id: 3, wiki_id: 'Student_3') }
+  let(:user3)      { create(:user, id: 3, username: 'Student_3') }
   let!(:c_user3)   { create(:courses_user, user_id: user3.id, course_id: course3.id, role: 0) }
 
   let!(:article2)  { create(:article, id: 2, title: 'Student_3/A_poor_draft', namespace: 2) }

--- a/spec/lib/student_greeter_spec.rb
+++ b/spec/lib/student_greeter_spec.rb
@@ -7,9 +7,9 @@ describe StudentGreeter do
 
     before do
       create(:course, id: 1, start: 2.weeks.ago, end: Date.today + 2.weeks)
-      create(:user, id: 1, wiki_id: 'Greeter', greeter: true)
+      create(:user, id: 1, username: 'Greeter', greeter: true)
       create(:courses_user, id: 1, course_id: 1, user_id: 1, role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
-      create(:user, id: 2, wiki_id: 'Ungreeted Student')
+      create(:user, id: 2, username: 'Ungreeted Student')
       create(:courses_user, id: 2, course_id: 1, user_id: 2, role: CoursesUsers::Roles::STUDENT_ROLE)
     end
 

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -18,7 +18,7 @@ describe WikiAssignmentOutput do
            role: Assignment::Roles::REVIEWING_ROLE)
     create(:user,
            id: 3,
-           wiki_id: 'Ragesock')
+           username: 'Ragesock')
     create(:courses_user,
            user_id: 3,
            course_id: 10001)

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -68,7 +68,7 @@ describe WikiCourseOutput do
       week2.blocks = [block2]
       create(:user,
              id: 1,
-             wiki_id: 'Ragesock')
+             username: 'Ragesock')
       markdown_with_image = 'The course description with ![image]'\
       '(https://upload.wikimedia.org/wikipedia/commons/6/6b/View_from_Imperia_Tower'\
       '_Moscow_04-2014_img12.jpg)'

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -28,7 +28,7 @@ describe ArticlesCourses, type: :model do
       # Add a user, a course, and an article.
       create(:user,
              id: 1,
-             wiki_id: 'Ragesoss')
+             username: 'Ragesoss')
 
       create(:course,
              id: 1,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -103,7 +103,7 @@ describe Course, type: :model do
 
       expect(Assignment.where(role: Assignment::Roles::ASSIGNED_ROLE).count).to eq(81)
       # Check that users with multiple assignments are handled properly.
-      user = User.where(wiki_id: 'AndrewHamsha').first
+      user = User.where(username: 'AndrewHamsha').first
       expect(user.assignments.assigned.count).to eq(2)
     end
   end
@@ -164,10 +164,10 @@ describe Course, type: :model do
 
     build(:user,
           id: 1,
-          wiki_id: 'Ragesoss').save
+          username: 'Ragesoss').save
     build(:user,
           id: 2,
-          wiki_id: 'Ntdb').save
+          username: 'Ntdb').save
 
     build(:courses_user,
           id: 1,
@@ -211,7 +211,7 @@ describe Course, type: :model do
   it 'should cache revision data for students' do
     build(:user,
           id: 1,
-          wiki_id: 'Ragesoss').save
+          username: 'Ragesoss').save
 
     build(:course,
           id: 1,

--- a/spec/models/courses_users_spec.rb
+++ b/spec/models/courses_users_spec.rb
@@ -22,7 +22,7 @@ describe CoursesUsers, type: :model do
       # Add a user, a course, an article, and a revision.
       create(:user,
              id: 1,
-             wiki_id: 'Ragesoss')
+             username: 'Ragesoss')
 
       create(:course,
              id: 1,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id                  :integer          not null, primary key
-#  wiki_id             :string(255)
+#  username            :string(255)
 #  created_at          :datetime
 #  updated_at          :datetime
 #  character_sum       :integer          default(0)
@@ -31,7 +31,7 @@ describe User do
       ragesock = build(:user)
       ragesoss = build(:trained)
       ragesauce = build(:admin)
-      expect(ragesock.wiki_id).to eq('Ragesock')
+      expect(ragesock.username).to eq('Ragesock')
       # rubocop:disable Metrics/LineLength
       expect(ragesoss.contribution_url).to eq("https://#{Figaro.env.wiki_language}.wikipedia.org/wiki/Special:Contributions/Ragesoss")
       # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
The loose ends of this are that the Replica endpoint still had 'wiki_id' in its output, and a few update methods rely on that matching up with an attribute on User. We can first push this update to all dashboard instances that rely on the replica endpoint, then we can change the replica endpoint to return 'username', and then we can remove the alias_attribute on User.

FYI @adamwight @AndrewGreen 