### PR TITLE
Use native ids - clean branch

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -62,7 +62,7 @@ class CoursesController < ApplicationController
     # If the user could make an edit to the course, then verify that
     # their tokens are working.
     if current_user && current_user.can_edit?(@course)
-      unless WikiEdits.oauth_credentials_valid?(current_user)
+      unless WikiEdits.new.oauth_credentials_valid?(current_user)
         redirect_to root_path
         return
       end
@@ -128,7 +128,7 @@ class CoursesController < ApplicationController
 
   def notify_untrained
     @course = find_course_by_slug(params[:id])
-    WikiEdits.notify_untrained(@course.id, current_user)
+    WikiEdits.new(@course.home_wiki).notify_untrained(@course, current_user)
     render nothing: true, status: :ok
   end
   helper_method :notify_untrained

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -15,10 +15,8 @@ module ArticleHelper
 
   def article_url(article)
     return nil if article.nil?
-    language = Figaro.env.wiki_language
     prefix = NS[article.namespace]
-    escaped_title = article.title.tr(' ', '_')
-    "https://#{language}.wikipedia.org/wiki/#{prefix}#{escaped_title}"
+    "#{article.wiki.base_url}/wiki/#{prefix}#{article.title}"
   end
 
   def full_title(article)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -105,8 +105,8 @@ class Article < ActiveRecord::Base
     # Always save titles with underscores instead of spaces, since that's the way
     # they are in the MediaWiki database.
     self.title = title.tr(' ', '_') unless title.nil?
-    # FIXME: transitional only
+    # FIXME: transitional only, until id and mw_page_id are uncoupled.
     self.wiki_id ||= Wiki.default_wiki.id
-    self.mw_page_id ||= id
+    self.mw_page_id = id
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -42,6 +42,7 @@ class Article < ActiveRecord::Base
 
   validates :title, presence: true
 
+  after_initialize :set_defaults_and_normalize
   before_validation :set_defaults_and_normalize
 
   ####################

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -107,6 +107,6 @@ class Article < ActiveRecord::Base
     self.title = title.tr(' ', '_') unless title.nil?
     # FIXME: transitional only
     self.wiki_id ||= Wiki.default_wiki.id
-    self.mw_page_id ||= self.id
+    self.mw_page_id ||= id
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -56,6 +56,6 @@ class Assignment < ActiveRecord::Base
   def set_defaults_and_normalize
     self.article_title = Utils.format_article_title(article_title) unless article_title.nil?
     # FIXME: transitional only
-    self.wiki_id ||= Wiki.default_wiki.id
+    self.wiki_id ||= course.home_wiki.id
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -39,9 +39,7 @@ class Assignment < ActiveRecord::Base
   # Instance methods #
   ####################
   def page_url
-    language = ENV['wiki_language']
-    escaped_title = article_title.tr(' ', '_')
-    "https://#{language}.wikipedia.org/wiki/#{escaped_title}"
+    "#{wiki.base_url}/wiki/#{article_title}"
   end
 
   # A sibling assignment is an assignment for a different user,

--- a/app/models/commons_wiki.rb
+++ b/app/models/commons_wiki.rb
@@ -1,0 +1,6 @@
+# Class that represents Wikimedia Commons
+class CommonsWiki < Wiki
+  def base_url
+    'https://commons.wikimedia.org/'
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -167,8 +167,7 @@ class Course < ActiveRecord::Base
     # Some types do not have corresponding on-wiki pages, so they have no
     # wiki_title or url.
     return unless wiki_title
-    language = ENV['wiki_language']
-    "https://#{language}.wikipedia.org/wiki/#{wiki_title}"
+    "#{home_wiki.base_url}/wiki/#{wiki_title}"
   end
 
   def delist
@@ -194,6 +193,14 @@ class Course < ActiveRecord::Base
   def word_count
     require "#{Rails.root}/lib/word_count"
     WordCount.from_characters(character_sum)
+  end
+
+  def home_wiki
+    # TODO: as part of the i18n project, we'll allow for choosing the home_wiki
+    # at the time of course creation (if dashboard is configured to allow that).
+    # For now, we just use the default wiki in all cases, to preserve default
+    # behavior.
+    Wiki.default_wiki
   end
 
   #################

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -44,7 +44,7 @@ class Revision < ActiveRecord::Base
     return if article.nil?
     escaped_title = article.title.tr(' ', '_')
     language = Figaro.env.wiki_language
-    "https://#{language}.wikipedia.org/w/index.php?title=#{escaped_title}&diff=prev&oldid=#{id}"
+    "#{wiki.base_url}/w/index.php?title=#{escaped_title}&diff=prev&oldid=#{id}"
   end
 
   def update(data={}, save=true)

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -43,7 +43,6 @@ class Revision < ActiveRecord::Base
     # https://en.wikipedia.org/w/index.php?title=Eva_Hesse&diff=prev&oldid=655980945
     return if article.nil?
     escaped_title = article.title.tr(' ', '_')
-    language = Figaro.env.wiki_language
     "#{wiki.base_url}/w/index.php?title=#{escaped_title}&diff=prev&oldid=#{id}"
   end
 
@@ -61,7 +60,9 @@ class Revision < ActiveRecord::Base
 
   def set_defaults
     self.wiki_id ||= Wiki.default_wiki.id
-    self.mw_rev_id ||= self.id
-    self.mw_page_id ||= self.article_id
+    # FIXME: until all the import and update routines are configured to use
+    # mw_rev_id and mw_page_id where appropriate, these should be kept in sync.
+    self.mw_rev_id = id
+    self.mw_page_id = article_id
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,17 +76,22 @@ class User < ActiveRecord::Base
   end
 
   def contribution_url
-    language = ENV['wiki_language']
-    "https://#{language}.wikipedia.org/wiki/Special:Contributions/#{username}"
+    "#{home_wiki.base_url}/wiki/Special:Contributions/#{wiki_id}"
   end
 
+  # Provides a link to the list of all of a user's subpages, ie, sandboxes.
   def sandbox_url
-    language = ENV['wiki_language']
-    "https://#{language}.wikipedia.org/wiki/Special:PrefixIndex/User:#{username}"
+    "#{home_wiki.base_url}/wiki/Special:PrefixIndex/User:#{wiki_id}"
   end
 
   def talk_page
     "User_talk:#{username}"
+  end
+
+  def home_wiki
+    # TODO: Let the user select their home_wiki in preferences, and set initial
+    # home_wiki to that of the first course the user joins.
+    Wiki.default_wiki
   end
 
   def admin?

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -47,7 +47,7 @@ class Wiki < ActiveRecord::Base
   # Is this useful?: has_many :article_wiki, :course_wiki, :user_wiki
 
   def base_url
-    "https://#{language}.#{project}.org/"
+    "https://#{language}.#{project}.org"
   end
 
   def api_url

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -51,7 +51,7 @@ class Wiki < ActiveRecord::Base
   end
 
   def api_url
-    "#{base_url}w/api.php"
+    "#{base_url}/w/api.php"
   end
 
   # Return the database name for a Wikimedia project wiki.

--- a/lib/article_status_manager.rb
+++ b/lib/article_status_manager.rb
@@ -43,7 +43,7 @@ class ArticleStatusManager
     local_articles.where(id: synced_ids).update_all(deleted: false)
     ArticlesCourses.where(article_id: deleted_ids).destroy_all
     limbo_revisions = Revision.where(article_id: deleted_ids)
-    RevisionImporter.move_or_delete_revisions limbo_revisions
+    RevisionImporter.new.move_or_delete_revisions limbo_revisions
   end
 
   ##################

--- a/lib/article_status_manager.rb
+++ b/lib/article_status_manager.rb
@@ -2,18 +2,32 @@ require "#{Rails.root}/lib/importers/revision_importer"
 
 #= Updates articles to reflect deletion and page moves on Wikipedia
 class ArticleStatusManager
+  def initialize(wiki = nil)
+    wiki ||= Wiki.default_wiki
+    @wiki = wiki
+  end
+
   ###############
   # Entry point #
   ###############
 
   # Queries deleted state and namespace for all articles
-  def self.update_article_status(articles=nil)
+  def self.update_article_status
     # TODO: Narrow this down even more. Current courses, maybe?
-    local_articles = articles || Article.all
+    Wiki.all.each do |wiki|
+      articles = Article.where(wiki_id: wiki.id)
+      new(wiki).update_status(articles)
+    end
+  end
 
+   ####################
+   # Per-wiki methods #
+   ####################
+
+   def update_status(articles)
     failed_request_count = 0
-    synced_articles = Utils.chunk_requests(local_articles, 100) do |block|
-      request_results = Replica.new.get_existing_articles_by_id block
+    synced_articles = Utils.chunk_requests(articles, 100) do |block|
+      request_results = Replica.new(@wiki).get_existing_articles_by_id block
       failed_request_count += 1 if request_results.nil?
       request_results
     end
@@ -24,7 +38,7 @@ class ArticleStatusManager
     # FIXME: A better approach would be to look for deletion logs, and only mark
     # an article as deleted if there is a corresponding deletion log.
     if failed_request_count == 0
-      deleted_ids = local_articles.pluck(:id) - synced_ids
+      deleted_ids = articles.map(&:mw_page_id) - synced_ids
     else
       deleted_ids = []
     end
@@ -39,39 +53,42 @@ class ArticleStatusManager
     update_article_ids deleted_ids
 
     # Delete articles as appropriate
-    local_articles.where(id: deleted_ids).update_all(deleted: true)
-    local_articles.where(id: synced_ids).update_all(deleted: false)
+    articles.where(mw_page_id: deleted_ids).update_all(deleted: true)
+    articles.where(mw_page_id: synced_ids).update_all(deleted: false)
     ArticlesCourses.where(article_id: deleted_ids).destroy_all
-    limbo_revisions = Revision.where(article_id: deleted_ids)
-    RevisionImporter.new.move_or_delete_revisions limbo_revisions
+    limbo_revisions = Revision.where(mw_page_id: deleted_ids)
+    RevisionImporter.new(@wiki).move_or_delete_revisions limbo_revisions
   end
 
   ##################
   # Helper methods #
   ##################
+  private
 
-  def self.update_title_and_namespace(synced_articles)
+  def update_title_and_namespace(synced_articles)
     # Update titles and namespaces based on ids (we trust ids!)
     synced_articles.map! do |sa|
       Article.new(
         id: sa['page_id'],
+        mw_page_id: sa['page_id'],
         title: sa['page_title'],
         namespace: sa['page_namespace'],
+        wiki_id: @wiki.id,
         deleted: false # Accounts for the case of undeleted articles
       )
     end
-    update_keys = [:title, :namespace, :deleted]
+    update_keys = [:title, :namespace, :deleted, :mw_page_id]
     Article.import synced_articles, on_duplicate_key_update: update_keys
   end
 
   # Check whether any deleted pages still exist with a different article_id.
   # If so, update the Article to use the new id.
-  def self.update_article_ids(deleted_ids)
-    maybe_deleted = Article.where(id: deleted_ids)
+  def update_article_ids(deleted_ids)
+    maybe_deleted = Article.where(mw_page_id: deleted_ids, wiki_id: @wiki.id)
 
     # These pages have titles that match Articles in our DB with deleted ids
     same_title_pages = Utils.chunk_requests(maybe_deleted, 100) do |block|
-      Replica.new.get_existing_articles_by_title block
+      Replica.new(@wiki).get_existing_articles_by_title block
     end
 
     # Update articles whose IDs have changed (keyed on title and namespace)
@@ -80,18 +97,19 @@ class ArticleStatusManager
     end
   end
 
-  def self.resolve_article_id(same_title_page, deleted_ids)
+  def resolve_article_id(same_title_page, deleted_ids)
     title = same_title_page['page_title']
     id = same_title_page['page_id']
     namespace = same_title_page['page_namespace']
 
     article = Article.find_by(
+      wiki_id: @wiki.id,
       title: title,
       namespace: namespace,
       deleted: false
     )
     return if article.nil?
-    return unless deleted_ids.include?(article.id)
+    return unless deleted_ids.include?(article.mw_page_id)
     # This catches false positives when the query for page_title matches
     # a case variant.
     return unless article.title == title
@@ -99,12 +117,13 @@ class ArticleStatusManager
     ArticlesCourses.where(article_id: article.id)
       .update_all(article_id: id)
 
-    if Article.exists?(id)
+    if Article.exists?(mw_page_id: id, wiki_id: @wiki.id)
       # Catches case where update_constantly has
       # already added this article under a new ID
       article.update(deleted: true)
     else
-      article.update(id: id)
+      # FIXME: This should only update mw_page_id once id and mw_page_id are decoupled.
+      article.update(mw_page_id: id, id: id)
     end
   end
 end

--- a/lib/article_status_manager.rb
+++ b/lib/article_status_manager.rb
@@ -1,3 +1,5 @@
+require "#{Rails.root}/lib/importers/revision_importer"
+
 #= Updates articles to reflect deletion and page moves on Wikipedia
 class ArticleStatusManager
   ###############
@@ -11,7 +13,7 @@ class ArticleStatusManager
 
     failed_request_count = 0
     synced_articles = Utils.chunk_requests(local_articles, 100) do |block|
-      request_results = Replica.get_existing_articles_by_id block
+      request_results = Replica.new.get_existing_articles_by_id block
       failed_request_count += 1 if request_results.nil?
       request_results
     end
@@ -69,7 +71,7 @@ class ArticleStatusManager
 
     # These pages have titles that match Articles in our DB with deleted ids
     same_title_pages = Utils.chunk_requests(maybe_deleted, 100) do |block|
-      Replica.get_existing_articles_by_title block
+      Replica.new.get_existing_articles_by_title block
     end
 
     # Update articles whose IDs have changed (keyed on title and namespace)

--- a/lib/cleaners.rb
+++ b/lib/cleaners.rb
@@ -87,7 +87,7 @@ class Cleaners
               srsearch: search_term,
               srnamespace: 0,
               srlimit: 1 }
-    response = WikiApi.query(query)
+    response = WikiApi.new.query(query)
     return '' if response.nil?
     results = response.data['search']
     return '' if results.empty?

--- a/lib/cleaners.rb
+++ b/lib/cleaners.rb
@@ -73,7 +73,7 @@ class Cleaners
     assignments.each do |assignment|
       possibly_bad_title = assignment.article_title
       next unless possibly_bad_title == Utils.format_article_title(possibly_bad_title.downcase)
-      title_search_result = first_article_search_result(possibly_bad_title)
+      title_search_result = first_article_search_result(assignment.wiki, possibly_bad_title)
       next if possibly_bad_title == title_search_result
       next unless title_search_result.downcase == possibly_bad_title.downcase.tr(' ', '_')
       assignment.article_title = title_search_result
@@ -81,13 +81,13 @@ class Cleaners
     end
   end
 
-  def self.first_article_search_result(search_term)
+  def self.first_article_search_result(wiki, search_term)
     require "#{Rails.root}/lib/wiki_api"
     query = { list: 'search',
               srsearch: search_term,
               srnamespace: 0,
               srlimit: 1 }
-    response = WikiApi.new.query(query)
+    response = WikiApi.new(wiki).query(query)
     return '' if response.nil?
     results = response.data['search']
     return '' if results.empty?

--- a/lib/cleaners/revisions_cleaner.rb
+++ b/lib/cleaners/revisions_cleaner.rb
@@ -15,10 +15,7 @@ class RevisionsCleaner
     user_ids = orphan_revisions.pluck(:user_id).uniq
     users = User.where(id: user_ids)
 
-    revision_data = RevisionImporter.get_revisions(users, start, end_date)
-    RevisionImporter.import_revisions(revision_data)
-
-    revs = RevisionImporter.get_revisions_from_import_data(revision_data)
+    revs = RevisionImporter.new.get_revisions_for_users(users, start, end_date)
     Rails.logger.info "Imported articles for #{revs.count} revisions"
 
     return if revs.blank?

--- a/lib/commons.rb
+++ b/lib/commons.rb
@@ -120,7 +120,7 @@ class Commons
     private
 
     def api_get(query)
-      WikiApi.query(query, site: 'commons.wikimedia.org')
+      WikiApi.new(CommonsWiki.new).query(query)
     end
   end
 end

--- a/lib/duplicate_article_deleter.rb
+++ b/lib/duplicate_article_deleter.rb
@@ -26,7 +26,7 @@ class DuplicateArticleDeleter
     # At this stage check to see if the deleted articles' revisions still exist
     # if so, move them to their new article ID
     limbo_revisions = Revision.where(article_id: deleted_ids)
-    RevisionImporter.move_or_delete_revisions limbo_revisions
+    RevisionImporter.new(@wiki).move_or_delete_revisions limbo_revisions
   end
 
   #################

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -22,7 +22,7 @@ class ArticleImporter
     titles.each_slice(40) do |some_article_titles|
       query = { prop: 'info',
                 titles: some_article_titles }
-      response = WikiApi.query(query)
+      response = WikiApi.new.query(query)
       next if response.nil?
       results = response.data
       next if results.empty?

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -2,28 +2,33 @@ require "#{Rails.root}/lib/replica"
 
 #= Imports articles from Wikipedia into the dashboard database
 class ArticleImporter
-  def self.import_articles(ids)
+  def initialize(wiki)
+    @wiki = wiki
+  end
+
+  def import_articles(ids)
     article_ids = ids.map { |id| { 'mw_page_id' => id } }
     articles_data = []
     article_ids.each_slice(40) do |some_article_ids|
-      articles_data += Replica.new.get_existing_articles_by_id some_article_ids
+      articles_data += Replica.new(@wiki).get_existing_articles_by_id some_article_ids
     end
     return if articles_data.empty?
     articles = []
     articles_data.each do |article_data|
       articles << Article.new(id: article_data['page_id'],
+                              mw_page_id: article_data['page_id'],
                               title: article_data['page_title'],
                               namespace: article_data['page_namespace'],
-                              wiki_id: Wiki.default_wiki.id)
+                              wiki_id: @wiki.id)
     end
     Article.import articles
   end
 
-  def self.import_articles_by_title(titles)
+  def import_articles_by_title(titles)
     titles.each_slice(40) do |some_article_titles|
       query = { prop: 'info',
                 titles: some_article_titles }
-      response = WikiApi.new.query(query)
+      response = WikiApi.new(@wiki).query(query)
       next if response.nil?
       results = response.data
       next if results.empty?
@@ -32,7 +37,9 @@ class ArticleImporter
       results.each do |_id, page_data|
         next if page_data['missing']
         articles << Article.new(id: page_data['pageid'].to_i,
+                                mw_page_id: page_data['pageid'].to_i,
                                 title: page_data['title'].tr(' ', '_'),
+                                wiki_id: @wiki.id,
                                 namespace: page_data['ns'].to_i)
       end
       Article.import articles

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -13,7 +13,8 @@ class ArticleImporter
     articles_data.each do |article_data|
       articles << Article.new(id: article_data['page_id'],
                               title: article_data['page_title'],
-                              namespace: article_data['page_namespace'])
+                              namespace: article_data['page_namespace'],
+                              wiki_id: Wiki.default_wiki.id)
     end
     Article.import articles
   end

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -3,10 +3,10 @@ require "#{Rails.root}/lib/replica"
 #= Imports articles from Wikipedia into the dashboard database
 class ArticleImporter
   def self.import_articles(ids)
-    article_ids = ids.map { |id| { 'id' => id } }
+    article_ids = ids.map { |id| { 'mw_page_id' => id } }
     articles_data = []
     article_ids.each_slice(40) do |some_article_ids|
-      articles_data += Replica.get_existing_articles_by_id some_article_ids
+      articles_data += Replica.new.get_existing_articles_by_id some_article_ids
     end
     return if articles_data.empty?
     articles = []

--- a/lib/importers/assigned_article_importer.rb
+++ b/lib/importers/assigned_article_importer.rb
@@ -20,7 +20,7 @@ class AssignedArticleImporter
   #########################
   def import_articles(assignments)
     missing_titles = assignments.map(&:article_title).uniq
-    ArticleImporter.import_articles_by_title(missing_titles)
+    ArticleImporter.new(@wiki).import_articles_by_title(missing_titles)
     newly_imported_article_titles = Article.where(namespace: 0,
                                                   title: missing_titles,
                                                   wiki_id: @wiki.id).pluck(:title)

--- a/lib/importers/assigned_article_importer.rb
+++ b/lib/importers/assigned_article_importer.rb
@@ -1,19 +1,51 @@
 require "#{Rails.root}/lib/importers/article_importer"
 
 class AssignedArticleImporter
-  ################
-  # Entry points #
-  ################
+  def initialize(wiki)
+    @wiki = wiki
+  end
+  ###############
+  # Entry point #
+  ###############
 
   def self.import_articles_for_assignments
-    titles = Assignment.where(article_id: nil).pluck(:article_title).uniq
-    ArticleImporter.import_articles_by_title(titles)
-    new_article_titles = Article.where(namespace: 0, title: titles).pluck(:title)
-    Assignment.where(article_title: new_article_titles).each do |assignment|
-      article = Article.find_by(title: assignment.article_title)
+    assignments_missing_articles = Assignment.where(article_id: nil)
+    assignments_missing_articles.group_by(&:wiki).each do |wiki, assignments|
+      new(wiki).import_articles(assignments)
+    end
+  end
+
+  #########################
+  # Wiki-specific routine #
+  #########################
+  def import_articles(assignments)
+    missing_titles = assignments.map(&:article_title).uniq
+    ArticleImporter.import_articles_by_title(missing_titles)
+    newly_imported_article_titles = Article.where(namespace: 0,
+                                                  title: missing_titles,
+                                                  wiki_id: @wiki.id).pluck(:title)
+    assignments_to_update = Assignment.where(article_title: newly_imported_article_titles,
+                                             wiki_id: @wiki.id)
+    assignments_to_update.each do |assignment|
+      article = Article.find_by(title: assignment.article_title, wiki_id: @wiki.id)
       next unless article.title == assignment.article_title # guard against case variants
       assignment.article_id = article.id
       assignment.save
     end
   end
 end
+
+
+
+#   def self.import_articles_for_assignments
+#     titles = Assignment.where(article_id: nil).pluck(:article_title).uniq
+#     ArticleImporter.import_articles_by_title(titles)
+#     new_article_titles = Article.where(namespace: 0, title: titles).pluck(:title)
+#     Assignment.where(article_title: new_article_titles).each do |assignment|
+#       article = Article.find_by(title: assignment.article_title)
+#       next unless article.title == assignment.article_title # guard against case variants
+#       assignment.article_id = article.id
+#       assignment.save
+#     end
+#   end
+# end

--- a/lib/importers/assigned_article_importer.rb
+++ b/lib/importers/assigned_article_importer.rb
@@ -34,18 +34,3 @@ class AssignedArticleImporter
     end
   end
 end
-
-
-
-#   def self.import_articles_for_assignments
-#     titles = Assignment.where(article_id: nil).pluck(:article_title).uniq
-#     ArticleImporter.import_articles_by_title(titles)
-#     new_article_titles = Article.where(namespace: 0, title: titles).pluck(:title)
-#     Assignment.where(article_title: new_article_titles).each do |assignment|
-#       article = Article.find_by(title: assignment.article_title)
-#       next unless article.title == assignment.article_title # guard against case variants
-#       assignment.article_id = article.id
-#       assignment.save
-#     end
-#   end
-# end

--- a/lib/importers/category_importer.rb
+++ b/lib/importers/category_importer.rb
@@ -91,7 +91,7 @@ class CategoryImporter
   end
 
   def self.import_articles_with_scores_and_views(article_ids)
-    ArticleImporter.import_articles article_ids
+    ArticleImporter.new(Wiki.default_wiki).import_articles article_ids
     import_latest_revision article_ids
     import_scores_for_latest_revision article_ids
     import_average_views article_ids

--- a/lib/importers/category_importer.rb
+++ b/lib/importers/category_importer.rb
@@ -114,7 +114,7 @@ class CategoryImporter
     property_values = []
     continue = true
     until continue.nil?
-      cat_response = WikiApi.query query
+      cat_response = WikiApi.new.query query
       page_data = cat_response.data['categorymembers']
       page_data.each do |page|
         property_values << page[property]
@@ -167,7 +167,7 @@ class CategoryImporter
     latest_revisions = {}
     article_ids.each_slice(50) do |fifty_ids|
       rev_query = revisions_query(fifty_ids)
-      rev_response = WikiApi.query rev_query
+      rev_response = WikiApi.new.query rev_query
       latest_revisions.merge! rev_response.data['pages']
     end
     latest_revisions

--- a/lib/importers/rating_importer.rb
+++ b/lib/importers/rating_importer.rb
@@ -4,15 +4,23 @@ class RatingImporter
   # Entry points #
   ################
   def self.update_all_ratings
+    # Since the rating scraper is only based on the English Wikipedia 1.0 rating
+    # system, we only include articles from en.wiki.
+    # If we develop scrapers for other languages that also keep track of ratings
+    # via talk page templates, this will need to be overhauled.
+    wiki_id = en_wiki.id
     articles = Article.current.live
                .namespace(0)
+               .where(wiki_id: wiki_id)
                .find_in_batches(batch_size: 30)
     update_ratings(articles)
   end
 
   def self.update_new_ratings
+    wiki_id = en_wiki.id # English Wikipedia only, see above.
     articles = Article.current
                .where(rating_updated_at: nil).namespace(0)
+               .where(wiki_id: wiki_id)
                .find_in_batches(batch_size: 30)
     update_ratings(articles)
   end
@@ -24,7 +32,8 @@ class RatingImporter
     require './lib/wiki_api'
     article_groups.with_index do |articles, _batch|
       titles = articles.map(&:title)
-      ratings = WikiApi.get_article_rating(titles).inject(&:merge)
+      # NOTE: English Wikipedia only, per above.
+      ratings = WikiApi.new(en_wiki).get_article_rating(titles).inject(&:merge)
       next if ratings.blank?
       update_article_ratings(articles, ratings)
     end
@@ -41,5 +50,13 @@ class RatingImporter
     Article.transaction do
       articles.each(&:save)
     end
+  end
+
+  ##################
+  # Helper methods #
+  ##################
+
+  def self.en_wiki
+    Wiki.find_by(language: 'en', project: 'wikipedia')
   end
 end

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -5,25 +5,28 @@ require "#{Rails.root}/lib/importers/assignment_importer"
 
 #= Imports and updates revisions from Wikipedia into the dashboard database
 class RevisionImporter
+  def initialize(wiki = nil)
+    wiki ||= Wiki.default_wiki
+    @wiki = wiki
+  end
+
   ################
   # Entry points #
   ################
 
-  ##############
-  # API Access #
-  ##############
   def self.update_all_revisions(courses=nil, all_time=false)
     courses = [courses] if courses.is_a? Course
     courses ||= all_time ? Course.all : Course.current
     courses.each do |course|
-      results = get_revisions_for_course(course)
-      import_revisions(results)
+      importer = new(course.home_wiki)
+      results = importer.get_revisions_for_course(course)
+      importer.import_revisions(results)
       ArticlesCourses.update_from_course(course)
     end
   end
 
   # Given a Course, get new revisions for the users in that course.
-  def self.get_revisions_for_course(course)
+  def get_revisions_for_course(course)
     results = []
     return results if course.students.empty?
     start = course_start_date(course)
@@ -46,83 +49,20 @@ class RevisionImporter
     results
   end
 
-  # Get revisions made by a set of users between two dates.
-  def self.get_revisions(users, start, end_date)
-    Utils.chunk_requests(users, 40) do |block|
-      Replica.new.get_revisions block, start, end_date
-    end
+  def get_revisions_for_users(users, start, end_date)
+    revision_data = get_revisions(users, start, end_date)
+    import_revisions(revision_data)
+    revisions = get_revisions_from_import_data(revision_data)
+    revisions
   end
 
-  ###########
-  # Helpers #
-  ###########
-  def self.course_start_date(course)
-    course.start.strftime('%Y%m%d')
-  end
-
-  def self.course_end_date(course)
-    course.end.strftime('%Y%m%d')
-  end
-
-  def self.users_with_no_revisions(course)
-    course.users.role('student')
-      .joins(:courses_users)
-      .where({ courses_users: { revision_count: 0 }})
-  end
-
-  def self.first_revision(course)
-    course.revisions.order('date DESC').first
-  end
-
-  def self.import_revisions(data)
-    # Use revision data fetched from Replica to add new Revisions as well as
-    # new Articles where appropriate.
-    # Limit it to 8000 per slice to avoid running out of memory.
-    data.each_slice(8000) do |sub_data|
-      import_revisions_slice(sub_data)
-    end
-
-    # Some Assignments are for article titles that don't exist initially.
-    # Some newly added Articles may correspond to those Assignments, in which
-    # case the article_ids should be added.
-    AssignmentImporter.update_assignment_article_ids
-  end
-
-  def self.get_revisions_from_import_data(data)
-    rev_ids = data.map do |_a_id, a|
-      a['revisions'].map { |r| r['id'] }
-    end
-    rev_ids = rev_ids.flatten
-    Revision.where(id: rev_ids)
-  end
-
-  def self.import_revisions_slice(sub_data)
-    articles, revisions = [], []
-
-    sub_data.each do |_a_id, a|
-      article = Article.new(id: a['article']['id'])
-      article.update(a['article'], false)
-      articles.push article
-
-      a['revisions'].each do |r|
-        revision = Revision.new(id: r['id'])
-        revision.update(r, false)
-        revisions.push revision
-      end
-    end
-
-    Article.import articles
-    AssignmentImporter.update_article_ids(articles)
-    DuplicateArticleDeleter.new.resolve_duplicates(articles)
-    Revision.import revisions
-  end
-
-  def self.move_or_delete_revisions(revisions=nil)
-    revisions ||= Revision.all
+  def move_or_delete_revisions(revisions=nil)
+    # NOTE: All revisions pased to this method should be from the same @wiki.
+    revisions ||= Revision.where(wiki_id: @wiki.id)
     return if revisions.empty?
 
     synced_revisions = Utils.chunk_requests(revisions, 100) do |block|
-      Replica.new.get_existing_revisions_by_id block
+      Replica.new(@wiki).get_existing_revisions_by_id block
     end
     synced_ids = synced_revisions.map { |r| r['rev_id'].to_i }
 
@@ -139,7 +79,80 @@ class RevisionImporter
     end
   end
 
-  def self.handle_moved_revision(moved)
+  def import_revisions(data)
+    # Use revision data fetched from Replica to add new Revisions as well as
+    # new Articles where appropriate.
+    # Limit it to 8000 per slice to avoid running out of memory.
+    data.each_slice(8000) do |sub_data|
+      import_revisions_slice(sub_data)
+    end
+
+    # Some Assignments are for article titles that don't exist initially.
+    # Some newly added Articles may correspond to those Assignments, in which
+    # case the article_ids should be added.
+    AssignmentImporter.update_assignment_article_ids
+  end
+
+  ###########
+  # Helpers #
+  ###########
+  private
+
+  # Get revisions made by a set of users between two dates.
+  def get_revisions(users, start, end_date)
+    Utils.chunk_requests(users, 40) do |block|
+      Replica.new(@wiki).get_revisions block, start, end_date
+    end
+  end
+
+  def course_start_date(course)
+    course.start.strftime('%Y%m%d')
+  end
+
+  def course_end_date(course)
+    course.end.strftime('%Y%m%d')
+  end
+
+  def users_with_no_revisions(course)
+    course.users.role('student')
+      .joins(:courses_users)
+      .where({ courses_users: { revision_count: 0 }})
+  end
+
+  def first_revision(course)
+    course.revisions.order('date DESC').first
+  end
+
+  def get_revisions_from_import_data(data)
+    rev_ids = data.map do |_a_id, a|
+      a['revisions'].map { |r| r['id'] }
+    end
+    rev_ids = rev_ids.flatten
+    Revision.where(id: rev_ids)
+  end
+
+  def import_revisions_slice(sub_data)
+    articles, revisions = [], []
+
+    sub_data.each do |_a_id, a|
+      article = Article.new(id: a['article']['id'])
+      article.update(a['article'], false)
+      articles.push article
+
+      a['revisions'].each do |r|
+        revision = Revision.new(id: r['id'])
+        revision.update(r, false)
+        revisions.push revision
+      end
+    end
+
+    Article.import articles
+    AssignmentImporter.update_article_ids(articles)
+    DuplicateArticleDeleter.new(@wiki).resolve_duplicates(articles)
+    Revision.import revisions
+  end
+
+  def handle_moved_revision(moved)
     article_id = moved['rev_page']
     Revision.find(moved['rev_id']).update(article_id: article_id)
     ArticleImporter

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -113,7 +113,7 @@ class RevisionImporter
 
     Article.import articles
     AssignmentImporter.update_article_ids(articles)
-    DuplicateArticleDeleter.resolve_duplicates(articles)
+    DuplicateArticleDeleter.new.resolve_duplicates(articles)
     Revision.import revisions
   end
 

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -49,7 +49,7 @@ class RevisionImporter
   # Get revisions made by a set of users between two dates.
   def self.get_revisions(users, start, end_date)
     Utils.chunk_requests(users, 40) do |block|
-      Replica.get_revisions block, start, end_date
+      Replica.new.get_revisions block, start, end_date
     end
   end
 
@@ -122,7 +122,7 @@ class RevisionImporter
     return if revisions.empty?
 
     synced_revisions = Utils.chunk_requests(revisions, 100) do |block|
-      Replica.get_existing_revisions_by_id block
+      Replica.new.get_existing_revisions_by_id block
     end
     synced_ids = synced_revisions.map { |r| r['rev_id'].to_i }
 

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -73,7 +73,7 @@ class RevisionScoreImporter
 
     rev_id = revision.id
     rev_query = revision_query(rev_id)
-    response = WikiApi.query rev_query
+    response = WikiApi.new(revision.wiki).query rev_query
     prev_id = response.data['pages'].values[0]['revisions'][0]['parentid']
     prev_id
   end

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -35,16 +35,7 @@ class UserImporter
     id = WikiApi.new.get_user_id(username)
     return unless id
 
-    if User.exists?(id)
-      user = User.find(id)
-    else
-      user = User.create(
-        id: id,
-        username: username
-      )
-    end
-
-    user
+    User.find_or_create_by(username: username, id: id)
   end
 
   def self.add_users(data, role, course, save=true)

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -19,7 +19,7 @@ class UserImporter
   def self.new_from_omniauth(auth)
     require "#{Rails.root}/lib/wiki_api"
 
-    id = WikiApi.get_user_id(auth.info.name)
+    id = WikiApi.new.get_user_id(auth.info.name)
     user = User.create(
       id: id,
       username: auth.info.name,
@@ -32,7 +32,7 @@ class UserImporter
 
   def self.new_from_username(username)
     require "#{Rails.root}/lib/wiki_api"
-    id = WikiApi.get_user_id(username)
+    id = WikiApi.new.get_user_id(username)
     return unless id
 
     if User.exists?(id)

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -79,7 +79,7 @@ class UserImporter
 
   def self.update_users(users=nil)
     u_users = Utils.chunk_requests(users || User.all) do |block|
-      Replica.get_user_info block
+      Replica.new.get_user_info block
     end
 
     User.transaction do

--- a/lib/importers/view_importer.rb
+++ b/lib/importers/view_importer.rb
@@ -45,9 +45,9 @@ class ViewImporter
         vua[article_id] = article.views_updated_at || start
         if vua[article_id] < Time.zone.yesterday
           since = all_time ? start : vua[article_id] + 1.day
-          views[article_id] = WikiPageviews.views_for_article(article.title,
-                                                              start_date: since,
-                                                              end_date: Time.zone.yesterday)
+          views[article_id] = WikiPageviews.new(article)
+                                           .views_for_article(
+                                             start_date: since, end_date: Time.zone.yesterday)
         end
       end
     end
@@ -60,7 +60,7 @@ class ViewImporter
     average_views = {}
     threads = articles.each_with_index.map do |article, i|
       Thread.new(i) do
-        average_views[article.id] = WikiPageviews.average_views_for_article(article.title)
+        average_views[article.id] = WikiPageviews.new(article).average_views
       end
     end
     threads.each(&:join)
@@ -99,8 +99,8 @@ class ViewImporter
     since = views_since_when(article, all_time)
 
     # Update views on all revisions and the article
-    views ||= WikiPageviews.views_for_article(article.title, start_date: since,
-                                                             end_date: Time.zone.yesterday)
+    views ||= WikiPageviews.new(article).views_for_article(start_date: since,
+                                                           end_date: Time.zone.yesterday)
     return if views.nil? # This will be the case if there are no views in the date range.
     add_views_to_revisions(article, views, all_time)
 

--- a/lib/importers/view_importer.rb
+++ b/lib/importers/view_importer.rb
@@ -7,16 +7,16 @@ class ViewImporter
   ################
   def self.update_all_views(all_time=false)
     articles = Article.current
-               .where(articles: { namespace: 0 })
-               .find_in_batches(batch_size: 30)
+                      .where(articles: { namespace: 0 })
+                      .find_in_batches(batch_size: 30)
     update_views(articles, all_time)
   end
 
   def self.update_new_views
     articles = Article.current
-               .where(articles: { namespace: 0 })
-               .where('views_updated_at IS NULL')
-               .find_in_batches(batch_size: 30)
+                      .where(articles: { namespace: 0 })
+                      .where('views_updated_at IS NULL')
+                      .find_in_batches(batch_size: 30)
     update_views(articles, true)
   end
 
@@ -41,6 +41,7 @@ class ViewImporter
     threads = articles.each_with_index.map do |article, i|
       start = earliest_course_start_date(article)
       article_id = article.id
+      article.wiki # FIXME: Non-default wiki spec fails with article.wiki -> nil without this line.
       Thread.new(i) do
         vua[article_id] = article.views_updated_at || start
         if vua[article_id] < Time.zone.yesterday

--- a/lib/legacy_courses/legacy_cohort_importer.rb
+++ b/lib/legacy_courses/legacy_cohort_importer.rb
@@ -1,5 +1,5 @@
 #= Imports and updates cohorts
-class CohortImporter
+class LegacyCohortImporter
   # Take a hash of cohorts and corresponding course_ids, and update the cohorts.
   # raw_ids is the output of WikiApi.course_list, and looks like this:
   # { "cohort_slug" => [31, 554, 1234], "cohort_slug_2" => [31, 999, 2345] }

--- a/lib/legacy_courses/legacy_course_assignments.rb
+++ b/lib/legacy_courses/legacy_course_assignments.rb
@@ -1,10 +1,12 @@
 #= Routines to create Assignments from legacy course API data
 class LegacyCourseAssignments
   def self.build_assignments_from_group_flat(course_id, group_flat)
-    new(course_id, group_flat).build_assignments_from_group_flat
+    wiki = Wiki.default_wiki
+    new(course_id, group_flat, wiki).build_assignments_from_group_flat
   end
 
-  def initialize(course_id, group_flat)
+  def initialize(course_id, group_flat, wiki)
+    @wiki = wiki
     @course_id = course_id
     @group_flat = group_flat
     @assignments = []
@@ -21,7 +23,7 @@ class LegacyCourseAssignments
 
       (0...assignment_count).each do |a|
         raw = user[a.to_s]
-        article = Article.find_by(title: raw['title'])
+        article = Article.find_by(title: raw['title'], wiki_id: @wiki.id)
         # role 0 is for assignee
         assignment = assignment_hash(user, raw, article, 0)
         new_assignment = Assignment.new(assignment)
@@ -50,6 +52,7 @@ class LegacyCourseAssignments
       'user_id' => user['id'],
       'course_id' => @course_id,
       'article_title' => raw['title'],
+      'wiki_id' => @wiki.id,
       'article_id' => article.nil? ? nil : article.id,
       'role' => role
     }

--- a/lib/legacy_courses/legacy_course_importer.rb
+++ b/lib/legacy_courses/legacy_course_importer.rb
@@ -1,6 +1,6 @@
 require "#{Rails.root}/lib/wiki_api"
 require "#{Rails.root}/lib/importers/user_importer"
-require "#{Rails.root}/lib/importers/cohort_importer"
+require "#{Rails.root}/lib/legacy_courses/legacy_cohort_importer"
 
 #= Imports and updates courses from Wikipedia into the dashboard database
 class LegacyCourseImporter
@@ -8,7 +8,7 @@ class LegacyCourseImporter
   # Entry points #
   ################
   def self.update_all_courses(initial=false, raw_ids={})
-    raw_ids = WikiApi.course_list if raw_ids.empty?
+    raw_ids = WikiApi.new.course_list if raw_ids.empty?
     listed_ids = raw_ids.values.flatten
     course_ids = listed_ids | Course.legacy.where(listed: true).pluck(:id)
 
@@ -55,7 +55,7 @@ class LegacyCourseImporter
     Course.import courses, on_duplicate_key_update: [:start, :end, :listed]
 
     # Update cohort membership
-    CohortImporter.update_cohorts raw_ids
+    LegacyCohortImporter.update_cohorts raw_ids
 
     import_users participants
     import_assignments participants

--- a/lib/legacy_courses/wiki_legacy_courses.rb
+++ b/lib/legacy_courses/wiki_legacy_courses.rb
@@ -82,9 +82,7 @@ class WikiLegacyCourses
     end
 
     def api_client
-      language = ENV['wiki_language']
-      url = "https://#{language}.wikipedia.org/w/api.php"
-      MediawikiApi::Client.new url
+      MediawikiApi::Client.new Wiki.default_wiki.api_url
     end
 
     def handle_invalid_course_id(course_ids, error_info)

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -6,8 +6,9 @@ require 'crack'
 #= For what's going on at the other end, see:
 #=   https://github.com/WikiEducationFoundation/WikiEduDashboardTools
 class Replica
-  def self.connect_to_tool
-    api_get('')
+  def initialize(wiki = nil)
+    wiki ||= Wiki.default_wiki
+    @wiki = wiki
   end
 
   ###################
@@ -16,19 +17,19 @@ class Replica
 
   # Given a list of users and a start and end date, return a nicely formatted
   # array of revisions made by those users between those dates.
-  def self.get_revisions(users, rev_start, rev_end, language=nil)
-    raw = Replica.get_revisions_raw(users, rev_start, rev_end, language)
+  def get_revisions(users, rev_start, rev_end)
+    raw = get_revisions_raw(users, rev_start, rev_end)
     data = {}
     return data unless raw.is_a?(Enumerable)
     raw.each do |revision|
-      parsed = Replica.parse_revision(revision)
-      article_id = parsed['article']['id']
-      unless data.include?(article_id)
-        data[article_id] = {}
-        data[article_id]['article'] = parsed['article']
-        data[article_id]['revisions'] = []
+      parsed = parse_revision(revision)
+      page_id = parsed['article']['mw_page_id']
+      unless data.include?(page_id)
+        data[page_id] = {}
+        data[page_id]['article'] = parsed['article']
+        data[page_id]['revisions'] = []
       end
-      data[article_id]['revisions'].push parsed['revision']
+      data[page_id]['revisions'].push parsed['revision']
     end
     data
   end
@@ -52,20 +53,28 @@ class Replica
   #       "title"=>"Babbling", "namespace"=>"0"
   #     }
   #   }
-  def self.parse_revision(revision)
+  def parse_revision(revision)
     article_data = {}
+    # TODO: decouple id from mw_page_id
     article_data['id'] = revision['page_id']
+    article_data['mw_page_id'] = revision['page_id']
     article_data['title'] = revision['page_title']
     article_data['namespace'] = revision['page_namespace']
+    article_data['wiki_id'] = @wiki.id
 
     revision_data = {}
+    # TODO: decouple id from mw_rev_id
     revision_data['id'] = revision['rev_id']
+    revision_data['mw_rev_id'] = revision['rev_id']
     revision_data['date'] = revision['rev_timestamp'].to_datetime
     revision_data['characters'] = revision['byte_change']
+    # TODO: decouple article_id from mw_page_id
     revision_data['article_id'] = revision['page_id']
+    revision_data['mw_page_id'] = revision['page_id']
     revision_data['user_id'] = revision['rev_user']
     revision_data['new_article'] = revision['new_article']
     revision_data['system'] = revision['system']
+    revision_data['wiki_id'] = @wiki.id
 
     { 'article' => article_data, 'revision' => revision_data }
   end
@@ -79,179 +88,170 @@ class Replica
   # As of 2015-02-24, revisions.php only queries namespaces:
   #   0 ([mainspace])
   #   2 (User:)
-  def self.get_revisions_raw(users, rev_start, rev_end, language=nil)
-    user_list = compile_user_ids_string(users)
+  def get_revisions_raw(users, rev_start, rev_end)
+    # TODO: query by username instead of (local home wiki) user_id, or query by
+    # global id. This will be necessary to pull revision data for a user on
+    # any wiki except their home wiki where we have their local user_id.
+    user_list = compile_user_ids_query(users)
     oauth_tags = compile_oauth_tags
     oauth_tags = oauth_tags.blank? ? oauth_tags : "&#{oauth_tags}"
     query = user_list + oauth_tags + "&start=#{rev_start}&end=#{rev_end}"
-    api_get('revisions_by_user_id.php', query, language)
+    api_get('revisions_by_user_id.php', query)
   end
 
   # Given a list of users, fetch their global_id and trained status. Completion
   # of training is defined by the users.php endpoint as having made an edit
   # to a specific page on Wikipedia:
   # [[Wikipedia:Training/For students/Training feedback]]
-  def self.get_user_info(users, language=nil)
-    query = compile_user_ids_string(users)
+  def get_user_info(users)
+    # TODO: switch to usernames to make queries wiki-agnostic.
+    query = compile_user_ids_query(users)
     if ENV['training_page_id']
       query = "#{query}&training_page_id=#{ENV['training_page_id']}"
     end
-    api_get('users.php', query, language)
+    api_get('users.php', query)
   end
 
-  # Given a list of articles, see which ones have not been deleted.
-  def self.get_existing_articles_by_id(articles, language=nil)
-    article_list = compile_article_id_string(articles)
-    existing_articles = api_get('articles.php', article_list, language)
-    existing_articles unless existing_articles.nil?
+  # Given a list of articles *or* hashes of the form { 'mw_page_id' => 1234 },
+  # see which ones have not been deleted.
+  def get_existing_articles_by_id(articles)
+    article_list = compile_article_ids_query(articles)
+    existing_articles = api_get('articles.php', article_list)
+    existing_articles
   end
 
-  # Given a list of articles, see which ones have not been deleted.
-  def self.get_existing_articles_by_title(articles, language=nil)
-    article_list = compile_article_title_string(articles)
-    existing_articles = api_get('articles.php', article_list, language)
-    existing_articles unless existing_articles.nil?
+  # Given a list of articles *or* hashes of the form { 'title' => 'Something' },
+  # see which ones have not been deleted.
+  def get_existing_articles_by_title(articles)
+    article_list = compile_article_titles_query(articles)
+    existing_articles = api_get('articles.php', article_list)
+    existing_articles
   end
 
   # Given a list of revisions, see which ones have not been deleted
-  def self.get_existing_revisions_by_id(revisions, language=nil)
-    revision_list = compile_revision_id_string(revisions)
-    existing_revisions = api_get('revisions.php', revision_list, language)
-    existing_revisions unless existing_revisions.nil?
+  def get_existing_revisions_by_id(revisions)
+    revision_list = compile_revision_ids_query(revisions)
+    existing_revisions = api_get('revisions.php', revision_list)
+    existing_revisions
   end
 
   ###################
   # Private methods #
   ###################
 
-  class << self
-    private
+  private
 
-    # Given an endpoint (either 'users.php' or 'revisions.php') and a
-    # query appropriate to that endpoint, return the parsed json response.
-    #
-    # Example users.php query with 2 users:
-    #   http://tools.wmflabs.org/wikiedudashboard/users.php?user_ids[0]=012345&user_ids[1]=678910
-    # Example users.php parsed response with 2 users:
-    # [{"id"=>"123", "wiki_id"=>"User_A", "global_id"=>"8675309", trained: 1},
-    #  {"id"=>"6789", "wiki_id"=>"User_B", "global_id"=>"9035768", trained: 0}]
-    #
-    # Example revisions.php query:
-    #   http://tools.wmflabs.org/wikiedudashboard/revisions.php?user_ids[0]=%27Example_User%27&user_ids[1]=%27Ragesoss%27&user_ids[2]=%27Sage%20(Wiki%20Ed)%27&start=20150105&end=20150108
-    #
-    # Example revisions.php parsed response:
-    # [{"page_id"=>"44962463",
-    #   "page_title"=>"Swarfe/ENGL-122-2014",
-    #   "page_namespace"=>"2",
-    #   "rev_id"=>"641297913",
-    #   "rev_timestamp"=>"20150106205746",
-    #   "rev_user_text"=>"Sage (Wiki Ed)",
-    #   "rev_user"=>"21515199",
-    #   "new_article"=>"false",
-    #   "byte_change"=>"38"},
-    #  {"page_id"=>"44962463",
-    #   "page_title"=>"Swarfe/ENGL-122-2014",
-    #   "page_namespace"=>"2",
-    #   "rev_id"=>"641298113",
-    #   "rev_timestamp"=>"20150106205902",
-    #   "rev_user_text"=>"Sage (Wiki Ed)",
-    #   "rev_user"=>"21515199",
-    #   "new_article"=>"false",
-    #   "byte_change"=>"-50"
-    #  }]
-    def api_get(endpoint, query='', language=nil)
-      tries ||= 3
-      url = compile_query_url(endpoint, query, language)
-      response = Net::HTTP::get(URI.parse(url))
-      return unless response.length > 0
-      parsed = JSON.parse response.to_s
-      parsed['data']
-    rescue StandardError => e
-      tries -= 1
-      unless tries.zero?
-        sleep 2
-        retry
-      end
-      report_exception e, endpoint, query
+  # Given an endpoint (either 'users.php' or 'revisions.php') and a
+  # query appropriate to that endpoint, return the parsed json response.
+  #
+  # Example users.php query with 2 users:
+  #   http://tools.wmflabs.org/wikiedudashboard/users.php?user_ids[0]=012345&user_ids[1]=678910
+  # Example users.php parsed response with 2 users:
+  # [{"id"=>"123", "wiki_id"=>"User_A", "global_id"=>"8675309", trained: 1},
+  #  {"id"=>"6789", "wiki_id"=>"User_B", "global_id"=>"9035768", trained: 0}]
+  #
+  # Example revisions.php query:
+  #   http://tools.wmflabs.org/wikiedudashboard/revisions.php?user_ids[0]=%27Example_User%27&user_ids[1]=%27Ragesoss%27&user_ids[2]=%27Sage%20(Wiki%20Ed)%27&start=20150105&end=20150108
+  #
+  # Example revisions.php parsed response:
+  # [{"page_id"=>"44962463",
+  #   "page_title"=>"Swarfe/ENGL-122-2014",
+  #   "page_namespace"=>"2",
+  #   "rev_id"=>"641297913",
+  #   "rev_timestamp"=>"20150106205746",
+  #   "rev_user_text"=>"Sage (Wiki Ed)",
+  #   "rev_user"=>"21515199",
+  #   "new_article"=>"false",
+  #   "byte_change"=>"38"},
+  #  {"page_id"=>"44962463",
+  #   "page_title"=>"Swarfe/ENGL-122-2014",
+  #   "page_namespace"=>"2",
+  #   "rev_id"=>"641298113",
+  #   "rev_timestamp"=>"20150106205902",
+  #   "rev_user_text"=>"Sage (Wiki Ed)",
+  #   "rev_user"=>"21515199",
+  #   "new_article"=>"false",
+  #   "byte_change"=>"-50"
+  #  }]
+  def api_get(endpoint, query='')
+    tries ||= 3
+    url = compile_query_url(endpoint, query)
+    response = Net::HTTP::get(URI.parse(url))
+    return unless response.length > 0
+    parsed = JSON.parse response.to_s
+    parsed['data']
+  rescue StandardError => e
+    tries -= 1
+    unless tries.zero?
+      sleep 2
+      retry
     end
+    report_exception e, endpoint, query
+  end
 
-    def compile_query_url(endpoint, query, language=nil)
-      language ||= ENV['wiki_language']
-      base_url = 'http://tools.wmflabs.org/wikiedudashboard/'
-      raw_url = "#{base_url}#{endpoint}?lang=#{language}&#{query}"
-      URI.encode(raw_url)
-    end
+  def compile_query_url(endpoint, query)
+    base_url = 'http://tools.wmflabs.org/wikiedudashboard/'
+    raw_url = "#{base_url}#{endpoint}?lang=#{@wiki.language}&project=#{@wiki.project}&#{query}"
+    raw_url
+  end
 
-    # Compile a user list to send to the replica endpoint, which might look
-    # something like this:
-    # "user_ids[0]='Ragesoss'&user_ids[1]='Sage (Wiki Ed)'"
-    def compile_user_ids_string(users)
-      user_list = ''
-      users.each_with_index do |user, i|
-        fail unless user.id
-        user_list += '&' if i > 0
-        user_list += "user_ids[#{i}]='#{user.id}'"
-      end
-      user_list
-    end
+  # Compile a username list to send to the replica endpoint, which might look
+  # something like this:
+  # "usernames[]='Ragesoss'&usernames[]='Sage+%28Wiki+Ed%29'"
+  def compile_usernames_query(users)
+    quoted_usernames = users.map { |user| "'#{user.username}'" }
+    { usernames: quoted_usernames }.to_query
+  end
 
-    def compile_oauth_tags
-      tag_list = ''
-      oauth_ids = ENV['oauth_ids']
-      return '' if oauth_ids.nil?
-      oauth_ids.split(',').each_with_index do |id, i|
-        tag_list += '&' if i > 0
-        tag_list += "oauth_tags[#{i}]='OAuth CID: #{id}'"
-      end
-      tag_list
-    end
+  # Compile a user id list to send to the replica endpoint, which might look
+  # something like this:
+  # "user_ids[]=572345&user_ids[]=102256"
+  def compile_user_ids_query(users)
+    { user_ids: users.map(&:id) }.to_query
+  end
 
-    # Compile an article list to send to the replica endpoint, which might look
-    # something like this:
-    # "article_ids[0]='Artist'&article_ids[1]='Microsoft_Research'"
-    def compile_article_title_string(articles)
-      article_list = ''
-      articles.each_with_index do |a, i|
-        article_list += '&' if i > 0
-        title = CGI.escape(a['title'].tr(' ', '_'))
-        article_list += "article_titles[#{i}]='#{title}'"
-      end
-      article_list
-    end
+  def compile_oauth_tags
+    oauth_ids = ENV['oauth_ids']
+    return '' if oauth_ids.nil?
+    oauth_id_tags = oauth_ids.split(',').map { |id| "'OAuth CID: #{id}'" }
+    { oauth_tags: oauth_id_tags }.to_query
+  end
 
-    # Compile an article list to send to the replica endpoint, which might look
-    # something like this:
-    # "article_ids[0]='100'&article_ids[1]='300'"
-    def compile_article_id_string(articles)
-      compile_id_string(articles, 'article_ids')
-    end
+  # Compile an article list to send to the replica endpoint, which might look
+  # something like this:
+  # "article_ids[]='Artist'&article_ids[]='Microsoft_Research'"
+  def compile_article_titles_query(articles)
+    quoted_titles = articles.map { |article| "'#{CGI.escape(article['title'])}'" }
+    { article_titles: quoted_titles }.to_query
+  end
 
-    def compile_revision_id_string(revisions)
-      compile_id_string(revisions, 'revision_ids')
-    end
+  # Compile an article list to send to the replica endpoint, which might look
+  # something like this:
+  # "article_ids[]=100&article_ids[]=300"
+  def compile_article_ids_query(articles)
+    article_page_ids = articles.map { |article| article['mw_page_id'] }
+    { article_ids: article_page_ids }.to_query
+  end
 
-    def compile_id_string(ids, prefix)
-      id_list = ''
-      ids.each_with_index do |id, index|
-        id_list += '&' if index > 0
-        id_list += "#{prefix}[#{index}]='#{id['id']}'"
-      end
-      id_list
-    end
+  def compile_revision_ids_query(revisions)
+    { revision_ids: revisions.map(&:mw_rev_id) }.to_query
+  end
 
-    def report_exception(error, endpoint, query, level='error')
-      Rails.logger
-        .error "replica.rb #{endpoint} query failed after 3 tries: #{error}"
-      # These are typical network errors that we expect to encounter.
-      typical_errors = [Errno::ETIMEDOUT,
-                        Net::ReadTimeout,
-                        Errno::ECONNREFUSED,
-                        JSON::ParserError]
-      level = 'warning' if typical_errors.include?(error.class)
-      Raven.capture_exception error,
-                              level: level,
-                              extras: { query: query, endpoint: endpoint }
-      return nil
-    end
+  def report_exception(error, endpoint, query, level='error')
+    Rails.logger
+      .error "replica.rb #{endpoint} query failed after 3 tries: #{error}"
+    # These are typical network errors that we expect to encounter.
+    typical_errors = [Errno::ETIMEDOUT,
+                      Net::ReadTimeout,
+                      Errno::ECONNREFUSED,
+                      JSON::ParserError]
+    level = 'warning' if typical_errors.include?(error.class)
+    Raven.capture_exception error,
+                            level: level,
+                            extras: { query: query,
+                                      endpoint: endpoint,
+                                      language: @wiki.language,
+                                      project: @wiki.project }
+    return nil
   end
 end

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -195,14 +195,6 @@ class Replica
     raw_url
   end
 
-  # Compile a username list to send to the replica endpoint, which might look
-  # something like this:
-  # "usernames[]='Ragesoss'&usernames[]='Sage+%28Wiki+Ed%29'"
-  def compile_usernames_query(users)
-    quoted_usernames = users.map { |user| "'#{user.username}'" }
-    { usernames: quoted_usernames }.to_query
-  end
-
   # Compile a user id list to send to the replica endpoint, which might look
   # something like this:
   # "user_ids[]=572345&user_ids[]=102256"

--- a/lib/student_greeter.rb
+++ b/lib/student_greeter.rb
@@ -1,3 +1,5 @@
+# A greeter that sends out greetings to all students who haven't been greeted,
+# on a course-by-course basis, if a greeter is assigned for that course.
 class StudentGreeter
   def self.greet_all_ungreeted_students
     new.greet_all_ungreeted_students
@@ -15,39 +17,51 @@ class StudentGreeter
       possible_greeters = @greeters & nonstudents_in_course
       next if possible_greeters.empty?
       greeter = possible_greeters[0]
+      wiki = course.home_wiki
       course.students_without_nonstudents.ungreeted.each do |student|
-        greet_if_really_ungreeted(student, greeter)
+        StudentGreeting.new(student, greeter, wiki, @greeters).greet_if_really_ungreeted
       end
+    end
+  end
+end
+
+# Issues a greeting to a single greeter, if they are actually ungreeted.
+class StudentGreeting
+  def initialize(student, greeter, wiki, greeters)
+    @student = student
+    @greeter = greeter
+    @wiki = wiki
+    @all_greeters = greeters
+  end
+
+  # Just because a user is not flagged as greeted doesn't mean they haven't
+  # actually been greeted.
+  def greet_if_really_ungreeted
+    if talk_page_blank?
+      greet
+    elsif a_greeter_already_posted?
+      return
+    else
+      greet
     end
   end
 
   private
 
-  # Just because a user is not flagged as greeted doesn't mean they haven't
-  # actually been greeted.
-  def greet_if_really_ungreeted(student, greeter)
-    if talk_page_blank? student
-      greet(student, greeter)
-      return
-    end
-    return if a_greeter_already_posted?(student)
-    greet(student, greeter)
+  def talk_page_blank?
+    WikiApi.new(@wiki).get_page_content(@student.talk_page).nil?
   end
 
-  def talk_page_blank?(student)
-    WikiApi.new.get_page_content(student.talk_page).nil?
-  end
-
-  def a_greeter_already_posted?(student)
-    contributor_ids = ids_of_contributors_to_page(student.talk_page)
-    return false if (@greeters.pluck(:id) & contributor_ids).empty?
+  def a_greeter_already_posted?
+    contributor_ids = ids_of_contributors_to_page(@student.talk_page)
+    return false if (@all_greeters.pluck(:id) & contributor_ids).empty?
     # Mark student as greeted if a greeter has already edited their talk page
-    student.update_attributes(greeted: true)
+    @student.update_attributes(greeted: true)
     true
   end
 
   def ids_of_contributors_to_page(page_title)
-    contributors_response = WikiApi.new.query contributors_query(page_title)
+    contributors_response = WikiApi.new(@wiki).query contributors_query(page_title)
     # TODO: Add exception handling for unexpected response data.
     # Currently, that will just cause a NoMethodError, which is okay but not
     # optimal, because it will likely break a rake task. But it's at the end
@@ -66,8 +80,8 @@ class StudentGreeter
       pclimit: 500 }
   end
 
-  def welcome_message(greeter)
-    name = first_name(greeter)
+  def welcome_message
+    name = first_name(@greeter)
     { sectiontitle: I18n.t("application.greeting2"),
       text: "{{subst:#{ENV['dashboard_url']} welcome|name=#{name}}}",
       summary: I18n.t("application.greeting_extended") }
@@ -80,11 +94,10 @@ class StudentGreeter
     name.split(/[\s_]/)[0]
   end
 
-  def greet(student, greeter)
-    message = welcome_message(greeter)
-    response_data = WikiEdits.notify_user(greeter, student, message)
+  def greet
+    response_data = WikiEdits.new(@wiki).notify_user(@greeter, @student, welcome_message)
     return if response_data['edit'].nil?
     return unless response_data['edit']['result'] == 'Success'
-    student.update_attributes(greeted: true)
+    @student.update_attributes(greeted: true)
   end
 end

--- a/lib/student_greeter.rb
+++ b/lib/student_greeter.rb
@@ -35,7 +35,7 @@ class StudentGreeter
   end
 
   def talk_page_blank?(student)
-    WikiApi.get_page_content(student.talk_page).nil?
+    WikiApi.new.get_page_content(student.talk_page).nil?
   end
 
   def a_greeter_already_posted?(student)
@@ -47,7 +47,7 @@ class StudentGreeter
   end
 
   def ids_of_contributors_to_page(page_title)
-    contributors_response = WikiApi.query contributors_query(page_title)
+    contributors_response = WikiApi.new.query contributors_query(page_title)
     # TODO: Add exception handling for unexpected response data.
     # Currently, that will just cause a NoMethodError, which is okay but not
     # optimal, because it will likely break a rake task. But it's at the end

--- a/lib/student_greeter.rb
+++ b/lib/student_greeter.rb
@@ -25,7 +25,7 @@ class StudentGreeter
   end
 end
 
-# Issues a greeting to a single greeter, if they are actually ungreeted.
+# Issues a greeting to a single student, if they are actually ungreeted.
 class StudentGreeting
   def initialize(student, greeter, wiki, greeters)
     @student = student
@@ -82,9 +82,9 @@ class StudentGreeting
 
   def welcome_message
     name = first_name(@greeter)
-    { sectiontitle: I18n.t("application.greeting2"),
+    { sectiontitle: I18n.t('application.greeting2'),
       text: "{{subst:#{ENV['dashboard_url']} welcome|name=#{name}}}",
-      summary: I18n.t("application.greeting_extended") }
+      summary: I18n.t('application.greeting_extended') }
   end
 
   def first_name(user)

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -1,26 +1,31 @@
 require 'mediawiki_api'
 require 'json'
 
-#= This class is for getting data directly from the Wikipedia API.
+#= This class is for getting data directly from the MediaWiki API.
 class WikiApi
+  def initialize(wiki = nil)
+    wiki ||= Wiki.default_wiki
+    @api_url = wiki.api_url
+  end
+
   ################
   # Entry points #
   ################
 
-  # General entry point for making arbitrary queries of the Wikipedia API
-  def self.query(query_parameters, opts={})
-    wikipedia('query', query_parameters, opts)
+  # General entry point for making arbitrary queries of a MediaWiki wiki's API
+  def query(query_parameters)
+    mediawiki('query', query_parameters)
   end
 
-  def self.get_page_content(page_title, language=nil)
-    response = wikipedia('get_wikitext', page_title, language: language)
+  def get_page_content(page_title)
+    response = mediawiki('get_wikitext', page_title)
     response.status == 200 ? response.body : nil
   end
 
-  def self.get_user_id(username, language=nil)
+  def get_user_id(username)
     user_query = { list: 'users',
                    ususers: username }
-    user_data = wikipedia('query', user_query, language: language)
+    user_data = mediawiki('query', user_query)
     return unless user_data.data['users'].any?
     user_id = user_data.data['users'][0]['userid']
     user_id
@@ -28,7 +33,9 @@ class WikiApi
 
   # Based on the cohorts and wiki pages defined in application.yml, get the list
   # of courses for each cohort.
-  def self.course_list
+  # TODO: Move this to a Legacy-specific class. It is only used for importing
+  # Legacy courses from the EducationProgram extension.
+  def course_list
     response = {}
     Cohort.all.each do |cohort|
       content = get_page_content(cohort.url)
@@ -43,7 +50,7 @@ class WikiApi
     response
   end
 
-  def self.get_article_rating(titles)
+  def get_article_rating(titles)
     titles = [titles] unless titles.is_a?(Array)
     titles = titles.sort_by(&:downcase)
 
@@ -64,7 +71,7 @@ class WikiApi
   # Parsing methods #
   ###################
 
-  def self.parse_article_rating(raw_talk)
+  def parse_article_rating(raw_talk)
     # Handle MediaWiki API errors
     return nil if raw_talk.nil?
     # Handle the case of nonexistent talk pages.
@@ -82,11 +89,11 @@ class WikiApi
   # find the article ratings. (The corresponding Talk page are the one with the
   # relevant info.) Example query:
   # http://en.wikipedia.org/w/api.php?action=query&prop=revisions&rvprop=content&rawcontinue=true&redirects=true&titles=Talk:Selfie
-  def self.get_raw_page_content(article_titles, language=nil)
+  def get_raw_page_content(article_titles)
     query_parameters = { titles: article_titles,
                          prop: 'revisions',
                          rvprop: 'content' }
-    info = wikipedia('query', query_parameters, language: language)
+    info = mediawiki('query', query_parameters)
     return if info.nil?
     page = info.data['pages']
     page.nil? ? nil : page
@@ -95,48 +102,38 @@ class WikiApi
   ###################
   # Private methods #
   ###################
-  class << self
-    private
+  private
 
-    def wikipedia(action, query, opts = {})
-      tries ||= 3
-      @mediawiki = api_client(opts)
-      @mediawiki.send(action, query)
-    rescue MediawikiApi::ApiError => e
-      handle_api_error e, action, query, opts
-    rescue StandardError => e
-      tries -= 1
-      typical_errors = [Faraday::TimeoutError,
-                        Faraday::ConnectionFailed,
-                        MediawikiApi::HttpError]
-      if typical_errors.include?(e.class)
-        retry if tries >= 0
-        Raven.capture_exception e, level: 'warning'
-        return nil
-      else
-        raise e
-      end
+  def mediawiki(action, query)
+    tries ||= 3
+    @mediawiki = api_client
+    @mediawiki.send(action, query)
+  rescue MediawikiApi::ApiError => e
+    handle_api_error e, action, query
+  rescue StandardError => e
+    tries -= 1
+    typical_errors = [Faraday::TimeoutError,
+                      Faraday::ConnectionFailed,
+                      MediawikiApi::HttpError]
+    if typical_errors.include?(e.class)
+      retry if tries >= 0
+      Raven.capture_exception e, level: 'warning'
+      return nil
+    else
+      raise e
     end
+  end
 
-    def api_client(opts)
-      site = opts[:site]
-      language = opts[:language] || ENV['wiki_language']
+  def api_client
+    MediawikiApi::Client.new @api_url
+  end
 
-      if site
-        url = "https://#{site}/w/api.php"
-      else
-        url = "https://#{language}.wikipedia.org/w/api.php"
-      end
-      MediawikiApi::Client.new url
-    end
-
-    def handle_api_error(e, action, query, opts)
-      Rails.logger.warn "Caught #{e}"
-      Raven.capture_exception e, level: 'warning',
-                                 extra: { action: action,
-                                          query: query,
-                                          opts: opts }
-      return nil # Do not return a Raven object
-    end
+  def handle_api_error(e, action, query)
+    Rails.logger.warn "Caught #{e}"
+    Raven.capture_exception e, level: 'warning',
+                               extra: { action: action,
+                                        query: query,
+                                        api_url: @api_url }
+    return nil # Do not return a Raven object
   end
 end

--- a/lib/wiki_assignment_output.rb
+++ b/lib/wiki_assignment_output.rb
@@ -1,23 +1,38 @@
 require './lib/wiki_api'
 #= Class for generating wikitext for updating assignment details on talk pages
 class WikiAssignmentOutput
+  def initialize(course, title, talk_title, assignments)
+    @course = course
+    @course_page = course.wiki_title
+    @wiki = course.home_wiki
+    @dashboard_url = ENV['dashboard_url']
+    @assignments = assignments
+    @title = title
+    @talk_title = talk_title
+  end
+
+  ###############
+  # Entry point #
+  ###############
+  def self.wikitext(course:, title:, talk_title:, assignments:)
+    new(course, title, talk_title, assignments).build_talk_page_update
+  end
+
   ################
-  # Entry points #
+  # Main routine #
   ################
-  def self.build_talk_page_update(title, talk_title, assignments, course_page)
-    initial_page_content = WikiApi.new.get_page_content talk_title
+  def build_talk_page_update
+    initial_page_content = WikiApi.new(@wiki).get_page_content @talk_title
     # We only want to add assignment tags to non-existant talk pages if the
     # article page actually exists. This also servces to make sure that we
     # only post to talk pages of mainspace articles, as we assume that pages
     # like Talk:Template:Citation or Talk:Wikipedia:Notability do not exist.
     if initial_page_content.nil?
-      return nil if WikiApi.new.get_page_content(title).nil?
+      return nil if WikiApi.new(@wiki).get_page_content(@title).nil?
       initial_page_content = ''
     end
 
-    course_assignments_tag = assignments_tag(course_page, assignments)
-    page_content = build_assignment_page_content(course_assignments_tag,
-                                                 course_page,
+    page_content = build_assignment_page_content(assignments_tag,
                                                  initial_page_content)
     page_content
   end
@@ -25,21 +40,20 @@ class WikiAssignmentOutput
   ###################
   # Helper methods #
   ###################
-  def self.assignments_tag(course_page, assignments)
-    return '' if assignments.empty?
+  def assignments_tag
+    return '' if @assignments.empty?
 
     # Make a list of the assignees, role 0
-    tag_assigned = build_wikitext_user_list(assignments, Assignment::Roles::ASSIGNED_ROLE)
+    tag_assigned = build_wikitext_user_list(Assignment::Roles::ASSIGNED_ROLE)
     # Make a list of the reviwers, role 1
-    tag_reviewing = build_wikitext_user_list(assignments, Assignment::Roles::REVIEWING_ROLE)
+    tag_reviewing = build_wikitext_user_list(Assignment::Roles::REVIEWING_ROLE)
 
     # Build new tag
     # NOTE: If the format of this tag gets changed, then the dashboard may
     # post duplicate tags for the same page, unless we update the way that
     # we check for the presense of existging tags to account for both the new
     # and old formats.
-    dashboard_url = ENV['dashboard_url']
-    tag = "{{#{dashboard_url} assignment | course = #{course_page}"
+    tag = "{{#{@dashboard_url} assignment | course = #{@course_page}"
     tag += " | assignments = #{tag_assigned}" unless tag_assigned.blank?
     tag += " | reviewers = #{tag_reviewing}" unless tag_reviewing.blank?
     tag += ' }}'
@@ -53,8 +67,7 @@ class WikiAssignmentOutput
   # that the user who updates the assignments for a course only introduces data
   # for that course. We also want to make as minimal a change as possible, and
   # to make sure that we're not disrupting the format of existing content.
-  def self.build_assignment_page_content(new_tag, course_page, page_content)
-    dashboard_url = ENV['dashboard_url']
+  def build_assignment_page_content(new_tag, page_content)
     # Return if tag already exists on page.
     # However, if the tag is empty, that means to blank the prior tag (if any).
     unless new_tag.blank?
@@ -62,8 +75,8 @@ class WikiAssignmentOutput
     end
 
     # Check for existing tags and replace
-    old_tag_ex = "{{course assignment | course = #{course_page}"
-    new_tag_ex = "{{#{dashboard_url} assignment | course = #{course_page}"
+    old_tag_ex = "{{course assignment | course = #{@course_page}"
+    new_tag_ex = "{{#{@dashboard_url} assignment | course = #{@course_page}"
     page_content.gsub!(/#{Regexp.quote(old_tag_ex)}[^\}]*\}\}/, new_tag)
     page_content.gsub!(/#{Regexp.quote(new_tag_ex)}[^\}]*\}\}/, new_tag)
 
@@ -86,16 +99,16 @@ class WikiAssignmentOutput
     page_content
   end
 
-  def self.starts_with_template?(page_content)
+  def starts_with_template?(page_content)
     page_content[0..1] == '{{'
   end
 
-  def self.end_of_template_is_end_of_line?(page_content)
+  def end_of_template_is_end_of_line?(page_content)
     /\}\}\n(?!\{\{)/.match(page_content)
   end
 
-  def self.build_wikitext_user_list(assignments, role)
-    user_ids = assignments.select { |assignment| assignment.role == role }
+  def build_wikitext_user_list(role)
+    user_ids = @assignments.select { |assignment| assignment.role == role }
                           .map(&:user_id)
     User.where(id: user_ids).pluck(:username)
         .map { |username| "[[User:#{username}|#{username}]]" }.join(', ')

--- a/lib/wiki_assignment_output.rb
+++ b/lib/wiki_assignment_output.rb
@@ -5,13 +5,13 @@ class WikiAssignmentOutput
   # Entry points #
   ################
   def self.build_talk_page_update(title, talk_title, assignments, course_page)
-    initial_page_content = WikiApi.get_page_content talk_title
+    initial_page_content = WikiApi.new.get_page_content talk_title
     # We only want to add assignment tags to non-existant talk pages if the
     # article page actually exists. This also servces to make sure that we
     # only post to talk pages of mainspace articles, as we assume that pages
     # like Talk:Template:Citation or Talk:Wikipedia:Notability do not exist.
     if initial_page_content.nil?
-      return nil if WikiApi.get_page_content(title).nil?
+      return nil if WikiApi.new.get_page_content(title).nil?
       initial_page_content = ''
     end
 

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -6,6 +6,9 @@ class WikiCourseEdits
   def initialize(action:, course:, current_user:, **opts)
     return unless course.wiki_edits_enabled?
     @course = course
+    # Edits can only be made to the course's home wiki through WikiCourseEdits
+    @home_wiki = course.home_wiki
+    @wiki_editor = WikiEdits.new(@home_wiki)
     @dashboard_url = ENV['dashboard_url']
     @current_user = current_user
     send(action, opts)
@@ -25,7 +28,7 @@ class WikiCourseEdits
     summary = "Updating course from #{@dashboard_url}"
 
     # Post the update
-    response = WikiEdits.post_whole_page(@current_user, wiki_title, wiki_text, summary)
+    response = @wiki_editor.post_whole_page(@current_user, wiki_title, wiki_text, summary)
     return response unless response['edit']
 
     # If it hit the spam blacklist, replace the offending links and try again.
@@ -34,7 +37,7 @@ class WikiCourseEdits
     bad_links = bad_links.split('|')
     safe_wiki_text = WikiCourseOutput
                      .substitute_bad_links(wiki_text, bad_links)
-    WikiEdits.post_whole_page(@current_user, wiki_title, safe_wiki_text, summary)
+    @wiki_editor.post_whole_page(@current_user, wiki_title, safe_wiki_text, summary)
   end
 
   # Posts to the instructor's userpage, and also makes a public
@@ -47,7 +50,7 @@ class WikiCourseEdits
     summary = "New course announcement: [[#{course_title}]]."
 
     # Add template to userpage to indicate instructor role.
-    WikiEdits.add_to_page_top(user_page, @current_user, template, summary)
+    @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)
 
     # Announce the course on the Education Noticeboard or equivalent.
     announcement_page = ENV['course_announcement_page']
@@ -59,7 +62,7 @@ class WikiCourseEdits
                 text: announcement,
                 summary: summary }
 
-    WikiEdits.add_new_section(@current_user, announcement_page, message)
+    @wiki_editor.add_new_section(@current_user, announcement_page, message)
   end
 
   # Adds a template to the enrolling student's userpage, and also
@@ -71,7 +74,7 @@ class WikiCourseEdits
     template = "{{student editor|course = [[#{course_title}]] }}\n"
     user_page = "User:#{@current_user.username}"
     summary = "I am enrolled in [[#{course_title}]]."
-    WikiEdits.add_to_page_top(user_page, @current_user, template, summary)
+    @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)
 
     # Pre-create the user's sandbox
     # TODO: Do this more selectively, replacing the default template if
@@ -79,7 +82,7 @@ class WikiCourseEdits
     sandbox = user_page + '/sandbox'
     sandbox_template = "{{#{@dashboard_url} sandbox}}"
     sandbox_summary = "adding {{#{@dashboard_url} sandbox}}"
-    WikiEdits.add_to_page_top(sandbox, @current_user, sandbox_template, sandbox_summary)
+    @wiki_editor.add_to_page_top(sandbox, @current_user, sandbox_template, sandbox_summary)
   end
 
   # Updates the assignment template for every Assignment for the course.
@@ -91,7 +94,7 @@ class WikiCourseEdits
   # is to use this for each assignment update to ensure that on-wiki assignment
   # templates remain accurate and up-to-date.
   def update_assignments(*)
-    assignments_grouped_by_article_title.each do |title, assignments_for_same_title|
+    homewiki_assignments_grouped_by_article_title.each do |title, assignments_for_same_title|
       update_assignments_for_title(
         title: title,
         assignments_for_same_title: assignments_for_same_title)
@@ -99,6 +102,9 @@ class WikiCourseEdits
   end
 
   def remove_assignment(assignment:)
+    # This is only relevant if the removed assignment is on the home wiki.
+    return unless assignment.wiki_id == @home_wiki.id
+
     article_title = assignment.article_title
     other_assignments_for_same_course_and_title = assignment.sibling_assignments
 
@@ -109,8 +115,9 @@ class WikiCourseEdits
 
   private
 
-  def assignments_grouped_by_article_title
-    @course.assignments.group_by(&:article_title)
+  def homewiki_assignments_grouped_by_article_title
+    # Only do on-wiki updates for articles that are on the course's home wiki.
+    @course.assignments.where(wiki_id: @home_wiki.id).group_by(&:article_title)
   end
 
   def update_assignments_for_title(title:, assignments_for_same_title:)
@@ -133,6 +140,6 @@ class WikiCourseEdits
     return if page_content.nil?
     course_title = @course.title
     summary = "Update [[#{course_page}|#{course_title}]] assignment details"
-    WikiEdits.post_whole_page(@current_user, talk_title, page_content, summary)
+    @wiki_editor.post_whole_page(@current_user, talk_title, page_content, summary)
   end
 end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -123,6 +123,8 @@ class WikiCourseEdits
   def update_assignments_for_title(title:, assignments_for_same_title:)
     require './lib/wiki_assignment_output'
 
+    course_page = @course.wiki_title
+
     # TODO: i18n of talk namespace
     if title[0..4] == 'Talk:'
       talk_title = title
@@ -130,12 +132,10 @@ class WikiCourseEdits
       talk_title = "Talk:#{title.tr(' ', '_')}"
     end
 
-    course_page = @course.wiki_title
-    page_content = WikiAssignmentOutput
-                   .build_talk_page_update(title,
-                                           talk_title,
-                                           assignments_for_same_title,
-                                           course_page)
+    page_content = WikiAssignmentOutput.wikitext(course: @course,
+                                                 title: title,
+                                                 talk_title: talk_title,
+                                                 assignments: assignments_for_same_title)
 
     return if page_content.nil?
     course_title = @course.title

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -2,16 +2,20 @@ require "#{Rails.root}/lib/wiki_response"
 
 #= Class for making edits to Wikipedia via OAuth, using a user's credentials
 class WikiEdits
+  def initialize(wiki = nil)
+    wiki ||= Wiki.default_wiki
+    @wiki = wiki
+  end
+
   #######################
   # Direct entry points #
   #######################
-  def self.oauth_credentials_valid?(current_user)
+  def oauth_credentials_valid?(current_user)
     get_tokens(current_user)
     current_user.wiki_token != 'invalid'
   end
 
-  def self.notify_untrained(course_id, current_user)
-    course = Course.find(course_id)
+  def notify_untrained(course, current_user)
     untrained_users = course.students.untrained
 
     message = { sectiontitle: I18n.t('wiki_edits.notify_untrained.header'),
@@ -30,7 +34,7 @@ class WikiEdits
                                    untrained_count: untrained_users.count }
   end
 
-  def self.notify_user(sender, recipient, message)
+  def notify_user(sender, recipient, message)
     add_new_section(sender, recipient.talk_page, message)
   end
 
@@ -39,7 +43,7 @@ class WikiEdits
   ####################
   # These are also entry points.
 
-  def self.post_whole_page(current_user, page_title, content, summary = nil)
+  def post_whole_page(current_user, page_title, content, summary = nil)
     params = { action: 'edit',
                title: page_title,
                text: content,
@@ -49,7 +53,7 @@ class WikiEdits
     api_post params, current_user
   end
 
-  def self.add_new_section(current_user, page_title, message)
+  def add_new_section(current_user, page_title, message)
     params = { action: 'edit',
                title: page_title,
                section: 'new',
@@ -61,7 +65,7 @@ class WikiEdits
     api_post params, current_user
   end
 
-  def self.add_to_page_top(page_title, current_user, content, summary)
+  def add_to_page_top(page_title, current_user, content, summary)
     params = { action: 'edit',
                title: page_title,
                prependtext: content,
@@ -75,7 +79,7 @@ class WikiEdits
   # Helper methods #
   ###################
 
-  def self.notify_users(current_user, recipient_users, message)
+  def notify_users(current_user, recipient_users, message)
     recipient_users.each do |recipient|
       add_new_section(current_user, recipient.talk_page, message)
     end
@@ -84,57 +88,55 @@ class WikiEdits
   ###############
   # API methods #
   ###############
-  class << self
-    private
+  private
 
-    def api_post(data, current_user)
-      return {} if ENV['disable_wiki_output'] == 'true'
-      tokens = get_tokens(current_user)
-      return tokens unless tokens['csrf_token']
-      data.merge! token: tokens.csrf_token
-      language = ENV['wiki_language']
-      url = "https://#{language}.wikipedia.org/w/api.php"
+  def api_post(data, current_user)
+    return {} if ENV['disable_wiki_output'] == 'true'
+    tokens = get_tokens(current_user)
+    return tokens unless tokens['csrf_token']
+    data.merge! token: tokens.csrf_token
+    language = ENV['wiki_language']
+    url = "https://#{language}.wikipedia.org/w/api.php"
 
-      # Make the request
-      response = tokens.access_token.post(url, data)
-      response_data = JSON.parse(response.body)
-      WikiResponse.capture(response_data, current_user: current_user,
-                                          post_data: data,
-                                          type: 'edit')
-      response_data
-    end
+    # Make the request
+    response = tokens.access_token.post(url, data)
+    response_data = JSON.parse(response.body)
+    WikiResponse.capture(response_data, current_user: current_user,
+                                        post_data: data,
+                                        type: 'edit')
+    response_data
+  end
 
-    def get_tokens(current_user)
-      return { status: 'no current user' } unless current_user
-      lang = ENV['wiki_language']
-      @consumer = oauth_consumer(lang)
-      @access_token = oauth_access_token(@consumer, current_user)
-      # rubocop:disable Metrics/LineLength
-      get_token = @access_token.get("https://#{lang}.wikipedia.org/w/api.php?action=query&meta=tokens&format=json")
-      # rubocop:enable Metrics/LineLength
+  def get_tokens(current_user)
+    return { status: 'no current user' } unless current_user
+    lang = ENV['wiki_language']
+    @consumer = oauth_consumer(lang)
+    @access_token = oauth_access_token(@consumer, current_user)
+    # rubocop:disable Metrics/LineLength
+    get_token = @access_token.get("https://#{lang}.wikipedia.org/w/api.php?action=query&meta=tokens&format=json")
+    # rubocop:enable Metrics/LineLength
 
-      token_response = JSON.parse(get_token.body)
-      WikiResponse.capture(token_response, current_user: current_user,
-                                           type: 'tokens')
-      return { status: 'failed' } unless token_response.key?('query')
-      OpenStruct.new(
-        csrf_token: token_response['query']['tokens']['csrftoken'],
-        access_token: @access_token
-      )
-    end
+    token_response = JSON.parse(get_token.body)
+    WikiResponse.capture(token_response, current_user: current_user,
+                                         type: 'tokens')
+    return { status: 'failed' } unless token_response.key?('query')
+    OpenStruct.new(
+      csrf_token: token_response['query']['tokens']['csrftoken'],
+      access_token: @access_token
+    )
+  end
 
-    def oauth_consumer(lang)
-      OAuth::Consumer.new ENV['wikipedia_token'],
-                          ENV['wikipedia_secret'],
-                          client_options: {
-                            site: "https://#{lang}.wikipedia.org"
-                          }
-    end
+  def oauth_consumer(lang)
+    OAuth::Consumer.new ENV['wikipedia_token'],
+                        ENV['wikipedia_secret'],
+                        client_options: {
+                          site: "https://#{lang}.wikipedia.org"
+                        }
+  end
 
-    def oauth_access_token(consumer, current_user)
-      OAuth::AccessToken.new consumer,
-                             current_user.wiki_token,
-                             current_user.wiki_secret
-    end
+  def oauth_access_token(consumer, current_user)
+    OAuth::AccessToken.new consumer,
+                           current_user.wiki_token,
+                           current_user.wiki_secret
   end
 end

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -1,6 +1,11 @@
 # Fetches pageview data from the Wikimedia pageviews REST API
 # Documentation: https://wikimedia.org/api/rest_v1/?doc#!/Pageviews_data/get_metrics_pageviews_per_article_project_access_agent_article_granularity_start_end
 class WikiPageviews
+  def initialize(article)
+    @article = article
+    @title = article.title
+    @wiki = article.wiki
+  end
   ################
   # Entry points #
   ################
@@ -17,12 +22,11 @@ class WikiPageviews
   # day from that date until today.
   #
   # [title]  title of a Wikipedia page (including namespace prefix, if applicable)
-  def self.views_for_article(title, opts = {})
-    language = opts[:language] || ENV['wiki_language']
+  def views_for_article(opts = {})
     start_date = opts[:start_date] || 1.month.ago
 
     end_date = opts[:end_date] || Time.zone.today
-    url = query_url(title, start_date, end_date, language)
+    url = query_url(start_date: start_date, end_date: end_date)
     data = api_get url
     return unless data
     data = Utils.parse_json(data)
@@ -36,9 +40,8 @@ class WikiPageviews
     views
   end
 
-  def self.average_views_for_article(title, opts = {})
-    language = opts[:language] || ENV['wiki_language']
-    data = recent_views(title, language)
+  def average_views
+    data = recent_views
     # TODO: better handling of unexpected or empty responses, including logging
     return unless data
     data = Utils.parse_json(data)
@@ -57,17 +60,17 @@ class WikiPageviews
   ##################
   # Helper methods #
   ##################
-  def self.recent_views(title, language)
+  def recent_views
     start_date = 50.days.ago
     end_date = 1.day.ago
-    url = query_url(title, start_date, end_date, language)
+    url = query_url(start_date: start_date, end_date: end_date)
     api_get url
   end
 
-  def self.query_url(title, start_date, end_date, language)
-    title = CGI.escape(title)
+  def query_url(start_date:, end_date:)
+    title = CGI.escape(@title)
     base_url = 'https://wikimedia.org/api/rest_v1/metrics/pageviews/'
-    configuration_params = "per-article/#{language}.wikipedia/all-access/user/"
+    configuration_params = "per-article/#{@wiki.language}.#{@wiki.project}/all-access/user/"
     start_param = start_date.strftime('%Y%m%d')
     end_param = end_date.strftime('%Y%m%d')
     title_and_date_params = "#{title}/daily/#{start_param}00/#{end_param}00"
@@ -78,19 +81,17 @@ class WikiPageviews
   ###################
   # Private methods #
   ###################
-  class << self
-    private
+  private
 
-    def api_get(url)
-      tries ||= 3
-      response = Net::HTTP::get(URI.parse(url))
-      response
-    rescue Errno::ETIMEDOUT, Errno::ENETUNREACH, SocketError
-      Rails.logger.error I18n.t('timeout', api: 'wikimedia.org/api/rest_v1', tries: (tries -= 1))
-      retry unless tries.zero?
-    rescue StandardError => e
-      Rails.logger.error "Wikimedia REST API error: #{e}"
-      raise e
-    end
+  def api_get(url)
+    tries ||= 3
+    response = Net::HTTP::get(URI.parse(url))
+    response
+  rescue Errno::ETIMEDOUT, Errno::ENETUNREACH, SocketError
+    Rails.logger.error I18n.t('timeout', api: 'wikimedia.org/api/rest_v1', tries: (tries -= 1))
+    retry unless tries.zero?
+  rescue StandardError => e
+    Rails.logger.error "Wikimedia REST API error: #{e}"
+    raise e
   end
 end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 describe AssignmentsController do
+  let!(:course) { create(:course, id: 1) }
   let!(:user) { create(:user) }
   before do
     allow(controller).to receive(:current_user).and_return(user)
   end
 
   describe 'GET index' do
-    let!(:assignment) { create(:assignment) }
+    let!(:assignment) { create(:assignment, course_id: 1) }
 
     before do
       allow(Course).to receive(:find_by_slug).and_return(OpenStruct.new(id: 1))
@@ -23,7 +24,7 @@ describe AssignmentsController do
   end
 
   describe 'DELETE destroy' do
-    let!(:assignment) { create(:assignment) }
+    let!(:assignment) { create(:assignment, course_id: 1) }
     before do
       allow(Assignment).to receive(:find).and_return(assignment)
       delete :destroy, id: assignment.id

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -291,7 +291,7 @@ describe CoursesController do
       end
 
       it 'triggers WikiEdits.notify_untrained' do
-        expect(WikiEdits).to receive(:notify_untrained)
+        expect_any_instance_of(WikiEdits).to receive(:notify_untrained)
         expect(subject.status).to eq(200)
       end
     end
@@ -302,7 +302,7 @@ describe CoursesController do
       end
 
       it 'triggers WikiEdits.notify_untrained' do
-        expect(WikiEdits).to receive(:notify_untrained)
+        expect_any_instance_of(WikiEdits).to receive(:notify_untrained)
         expect(subject.status).to eq(200)
       end
     end
@@ -313,7 +313,7 @@ describe CoursesController do
       end
 
       it 'returns a 401' do
-        expect(WikiEdits).not_to receive(:notify_untrained)
+        expect_any_instance_of(WikiEdits).not_to receive(:notify_untrained)
         expect(subject.status).to eq(401)
       end
     end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -23,8 +23,9 @@
 
 FactoryGirl.define do
   factory :article do
-    title 'History of biology'
+    title 'History_of_biology'
     namespace 0
     language 'en'
+    wiki_id 1
   end
 end

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -75,7 +75,7 @@ describe 'Instructor users', type: :feature, js: true do
     end
 
     it 'should be able to add students' do
-      allow(WikiApi).to receive(:get_user_id).and_return(123)
+      allow_any_instance_of(WikiApi).to receive(:get_user_id).and_return(123)
       visit "/courses/#{Course.first.slug}/students"
       sleep 1
       click_button 'Enrollment'
@@ -89,7 +89,7 @@ describe 'Instructor users', type: :feature, js: true do
     end
 
     it 'should not be able to add nonexistent users as students' do
-      allow(WikiApi).to receive(:get_user_id).and_return(nil)
+      allow_any_instance_of(WikiApi).to receive(:get_user_id).and_return(nil)
       visit "/courses/#{Course.first.slug}/students"
       sleep 1
       click_button 'Enrollment'

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -153,7 +153,7 @@ describe 'Student users', type: :feature, js: true do
         info: { name: 'Ragesoss' },
         credentials: { token: 'foo', secret: 'bar' }
       )
-      allow(WikiApi).to receive(:get_user_id).and_return(234567)
+      allow_any_instance_of(WikiApi).to receive(:get_user_id).and_return(234567)
       stub_oauth_edit
       logout
       visit "/courses/#{Course.first.slug}?enroll=passcode"

--- a/spec/features/students_page_spec.rb
+++ b/spec/features/students_page_spec.rb
@@ -12,7 +12,7 @@ describe 'Students Page', type: :feature, js: true do
   before do
     include Devise::TestHelpers, type: :feature
 
-    allow(WikiEdits).to receive(:oauth_credentials_valid?).and_return(true)
+    allow_any_instance_of(WikiEdits).to receive(:oauth_credentials_valid?).and_return(true)
 
     @course = create(:course,
                     id: 10001,

--- a/spec/fixtures/wikis.yml
+++ b/spec/fixtures/wikis.yml
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: wikis
+#
+#  id       :integer          not null, primary key
+#  language :string(16)
+#  project  :string(16)
+#
+
+default:
+  id: 1
+  language: en
+  project: wikipedia

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 describe ArticleHelper, type: :helper do
   before(:all) do
     # Create some articles in different namespaces
-    @article = build(:article,
-                     id: 1,
-                     title: 'Selfie',
-                     namespace: 0,
-                     views_updated_at: '2014-12-31'.to_date)
-    @sandbox = build(:article, namespace: 2, title: 'Ragesoss/sandbox')
-    @draft = build(:article, namespace: 118, title: 'My Awesome Draft!!!')
+    @article = create(:article,
+                      id: 1,
+                      title: 'Selfie',
+                      namespace: 0,
+                      views_updated_at: '2014-12-31'.to_date)
+    @sandbox = create(:article, namespace: 2, title: 'Ragesoss/sandbox')
+    @draft = create(:article, namespace: 118, title: 'My Awesome Draft!!!')
   end
 
   describe '.article_url' do

--- a/spec/helpers/article_helper_spec.rb
+++ b/spec/helpers/article_helper_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 describe ArticleHelper, type: :helper do
   before(:all) do
     # Create some articles in different namespaces
-    @article = create(:article,
-                      id: 1,
-                      title: 'Selfie',
-                      namespace: 0,
-                      views_updated_at: '2014-12-31'.to_date)
-    @sandbox = create(:article, namespace: 2, title: 'Ragesoss/sandbox')
-    @draft = create(:article, namespace: 118, title: 'My Awesome Draft!!!')
+    @article = build(:article,
+                     title: 'Selfie',
+                     namespace: 0,
+                     views_updated_at: '2014-12-31'.to_date)
+    @sandbox = build(:article, namespace: 2, title: 'Ragesoss/sandbox')
+    @draft = build(:article, namespace: 118, title: 'My_Awesome_Draft!!!')
   end
 
   describe '.article_url' do

--- a/spec/lib/article_status_manager_spec.rb
+++ b/spec/lib/article_status_manager_spec.rb
@@ -17,13 +17,26 @@ describe ArticleStatusManager do
     end
 
     it 'should update the ids of articles' do
+      # en.wikipedia - article 100 does not exist
       create(:article,
              id: 100,
+             mw_page_id: 100,
              title: 'Audi',
              namespace: 0)
 
+      # es.wikipedia
+      create(:wiki, id: 2, language: 'es', project: 'wikipedia')
+      create(:article,
+             id: 100000001,
+             mw_page_id: 100000001,
+             title: 'Audi',
+             namespace: 0,
+             wiki_id: 2)
+
       described_class.update_article_status
-      expect(Article.find_by(title: 'Audi').id).to eq(848)
+
+      expect(Article.find_by(title: 'Audi', wiki_id: 1).mw_page_id).to eq(848)
+      expect(Article.find_by(title: 'Audi', wiki_id: 2).mw_page_id).to eq(4976786)
     end
 
     it 'should delete articles when id changed but new one already exists' do

--- a/spec/lib/article_status_manager_spec.rb
+++ b/spec/lib/article_status_manager_spec.rb
@@ -106,7 +106,7 @@ describe ArticleStatusManager do
              id: 1,
              title: 'Noarticle',
              namespace: 0)
-      allow(Replica).to receive(:get_existing_articles_by_id).and_return(nil)
+      allow_any_instance_of(Replica).to receive(:get_existing_articles_by_id).and_return(nil)
       described_class.update_article_status
       expect(Article.find(848).deleted).to eq(false)
       expect(Article.find(1).deleted).to eq(false)

--- a/spec/lib/assignments_manager_spec.rb
+++ b/spec/lib/assignments_manager_spec.rb
@@ -3,7 +3,7 @@ require "#{Rails.root}/lib/assignments_manager"
 
 describe AssignmentsManager do
   describe '.update_assignments' do
-    let(:course) { create(:course, id: 1) }
+    let!(:course) { create(:course, id: 1) }
     let(:user) { create(:user, id: 1) }
 
     it 'creates new assignments for existing articles' do

--- a/spec/lib/cleaners_spec.rb
+++ b/spec/lib/cleaners_spec.rb
@@ -81,10 +81,15 @@ describe Cleaners do
   describe '.match_assignment_titles_with_case_variant_articles_that_exist' do
     it 'updates assignment article titles when it should' do
       VCR.use_cassette 'cleaners/assignment_title_cleanup' do
-        create(:assignment, id: 1, article_id: nil, article_title: 'Robert_montgomery_(artist)')
+        create(:course, id: 1)
+        create(:assignment, id: 1,
+                            article_id: nil,
+                            article_title: 'Robert_montgomery_(artist)',
+                            course_id: 1)
         create(:assignment, id: 2,
                             article_id: nil,
-                            article_title: 'American_institute_of_wine_&_food')
+                            article_title: 'American_institute_of_wine_&_food',
+                            course_id: 1)
 
         Cleaners.match_assignment_titles_with_case_variant_articles_that_exist(2)
         expect(Assignment.find(1).article_title).to eq('Robert_Montgomery_(artist)')
@@ -97,7 +102,11 @@ describe Cleaners do
     # We don't want to query the Wikipedia API for assignment that were not affected
     # by this bug, or that have already been repaired.
     it 'should not try to update titles that are mostly downcased' do
-      create(:assignment, id: 1, article_id: nil, article_title: 'Robert_Montgomery_(artist)')
+      create(:course, id: 1)
+      create(:assignment, id: 1,
+                          article_id: nil,
+                          article_title: 'Robert_Montgomery_(artist)',
+                          course_id: 1)
       # No VCR cassete is in place, so this will fail if it attempts to query Wikipedia.
       Cleaners.match_assignment_titles_with_case_variant_articles_that_exist(1)
       expect(Assignment.find(1).article_title).to eq('Robert_Montgomery_(artist)')

--- a/spec/lib/duplicate_article_deleter_spec.rb
+++ b/spec/lib/duplicate_article_deleter_spec.rb
@@ -12,7 +12,7 @@ describe DuplicateArticleDeleter do
                       id: 46349871,
                       title: 'Kostanay',
                       namespace: 0)
-      DuplicateArticleDeleter.resolve_duplicates([first])
+      DuplicateArticleDeleter.new.resolve_duplicates([first])
       undeleted = Article.where(
         title: 'Kostanay',
         namespace: 0,

--- a/spec/lib/importers/article_importer_spec.rb
+++ b/spec/lib/importers/article_importer_spec.rb
@@ -2,28 +2,46 @@ require 'rails_helper'
 require "#{Rails.root}/lib/importers/article_importer"
 
 describe ArticleImporter do
+  let(:en_wiki) { Wiki.default_wiki }
+  let(:es_wiki) { create(:wiki, language: 'es', project: 'wikipedia') }
+
   describe '.import_articles' do
-    it 'should create an Article from a Wikipedia page_id' do
-      ArticleImporter.import_articles [46349871]
+    it 'creates an Article from a English Wikipedia page_id' do
+      ArticleImporter.new(en_wiki).import_articles [46349871]
       article = Article.find(46349871)
       expect(article.title).to eq('Kostanay')
+    end
+
+    it 'works for a langauge besides the default' do
+      ArticleImporter.new(es_wiki).import_articles [100]
+      article = Article.find(100)
+      expect(article.title).to eq('Alnus')
     end
   end
 
   describe '.import_articles_by_title' do
-    it 'should create an Article from a title' do
-      titles = %w(Selfie Bombus_hortorum)
+    it 'creates an Article from a title with the correct mw_page_id' do
+      titles = %w(Selfie Bombus_hortorum Kostanay)
       VCR.use_cassette 'article_importer/existing_titles' do
-        ArticleImporter.import_articles_by_title(titles)
+        ArticleImporter.new(en_wiki).import_articles_by_title(titles)
       end
-      expect(Article.find_by(title: 'Selfie')).to be_a(Article)
+      expect(Article.find_by(title: 'Kostanay').mw_page_id).to eq(46349871)
     end
-    it 'should not create an article if there is no matching title' do
+
+    it 'does not create an article if there is no matching title' do
       titles = ['There_is_no_article_with_this_title']
       VCR.use_cassette 'article_importer/nonexistent_title' do
-        ArticleImporter.import_articles_by_title(titles)
+        ArticleImporter.new(en_wiki).import_articles_by_title(titles)
       end
       expect(Article.find_by(title: titles[0])).to be_nil
+    end
+
+    it 'works for a language besides the default' do
+      VCR.use_cassette 'article_importer/existing_titles' do
+        titles = %w(Selfie Bombus_hortorum)
+        ArticleImporter.new(es_wiki).import_articles_by_title(titles)
+        expect(Article.find_by(title: 'Selfie').mw_page_id).to eq(6210294)
+      end
     end
   end
 end

--- a/spec/lib/importers/assigned_article_importer_spec.rb
+++ b/spec/lib/importers/assigned_article_importer_spec.rb
@@ -3,10 +3,15 @@ require "#{Rails.root}/lib/importers/assigned_article_importer"
 
 describe AssignedArticleImporter do
   it 'imports articles based on assignment titles' do
-    create(:assignment, id: 101, article_title: 'Selfie', article_id: nil)
-    create(:assignment, id: 102, article_title: 'This_article_does_not_exist', article_id: nil)
+    create(:course, id: 1)
+    create(:assignment, id: 101, article_title: 'Selfie', article_id: nil, course_id: 1)
+    create(:assignment,
+      id: 102,
+      article_title: 'This_article_does_not_exist',
+      article_id: nil,
+      course_id: 1)
     (1..100).each do |i|
-      create(:assignment, id: i, article_title: i.to_s, article_id: nil)
+      create(:assignment, id: i, article_title: i.to_s, article_id: nil, course_id: 1)
     end
     VCR.use_cassette 'assignments_importer' do
       AssignedArticleImporter.import_articles_for_assignments

--- a/spec/lib/importers/revision_importer_spec.rb
+++ b/spec/lib/importers/revision_importer_spec.rb
@@ -62,6 +62,7 @@ describe RevisionImporter do
   end
 
   describe '.users_with_no_revisions' do
+    let(:subject)   { RevisionImporter.new }
     let(:user)      { create(:user) }
     let(:course_1)  { create(:course, start: '2015-01-01', end: '2015-12-31') }
     let(:course_2)  { create(:course, start: '2016-01-01', end: '2016-12-31') }
@@ -75,11 +76,11 @@ describe RevisionImporter do
     before { CoursesUsers.all.collect(&:update_cache) }
 
     it 'returns users who have no revisions for the given course' do
-      expect(described_class.users_with_no_revisions(course_2)).to include(user)
+      expect(subject.send(:users_with_no_revisions, course_2)).to include(user)
     end
 
     it 'does not return users who have revisions for the course' do
-      expect(described_class.users_with_no_revisions(course_1)).not_to include(user)
+      expect(subject.send(:users_with_no_revisions, course_1)).not_to include(user)
     end
   end
 
@@ -129,7 +130,7 @@ describe RevisionImporter do
              id: 547645475,
              article_id: 1) # Not the actual article_id
       revision = Revision.all
-      RevisionImporter.move_or_delete_revisions(revision)
+      RevisionImporter.new.move_or_delete_revisions(revision)
       article_id = Revision.find(547645475).article_id
       expect(article_id).to eq(38956275)
       expect(Article.exists?(38956275)).to be true

--- a/spec/lib/importers/revision_importer_spec.rb
+++ b/spec/lib/importers/revision_importer_spec.rb
@@ -101,14 +101,17 @@ describe RevisionImporter do
     end
 
     it 'only updates article_ids for mainspace titles' do
+      create(:course, id: 1)
       create(:assignment,
              id: 1,
              article_title: 'Foo',
-             article_id: nil)
+             article_id: nil,
+             course_id: 1)
       create(:assignment,
              id: 2,
              article_title: 'Bar',
-             article_id: nil)
+             article_id: nil,
+             course_id: 1)
       create(:article,
              id: 123,
              title: 'Foo',

--- a/spec/lib/legacy_courses/legacy_cohort_importer_spec.rb
+++ b/spec/lib/legacy_courses/legacy_cohort_importer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
-require "#{Rails.root}/lib/importers/cohort_importer"
+require "#{Rails.root}/lib/legacy_courses/legacy_cohort_importer"
 
-describe CohortImporter do
+describe LegacyCohortImporter do
   describe '.update_cohorts' do
     it 'should add and remove courses from cohorts' do
       (1..6).each do |i|
@@ -11,7 +11,7 @@ describe CohortImporter do
         'cohort_1' => [1, 2, 3],
         'cohort_2' => [3, 4, 5]
       }
-      CohortImporter.update_cohorts(cohort_data)
+      LegacyCohortImporter.update_cohorts(cohort_data)
       cohort_1 = Cohort.where(slug: 'cohort_1').first
       cohort_2 = Cohort.where(slug: 'cohort_2').first
       expect(cohort_1.courses.all.count).to eq(3)
@@ -21,7 +21,7 @@ describe CohortImporter do
         'cohort_1' => [1, 2],
         'cohort_2' => [3, 4, 5, 6]
       }
-      CohortImporter.update_cohorts(cohort_data)
+      LegacyCohortImporter.update_cohorts(cohort_data)
       expect(cohort_1.courses.all.count).to eq(2)
       expect(cohort_2.courses.all.count).to eq(4)
     end

--- a/spec/lib/student_greeter_spec.rb
+++ b/spec/lib/student_greeter_spec.rb
@@ -23,7 +23,7 @@ describe StudentGreeter do
     end
 
     it 'greets students with blank talk pages' do
-      expect(WikiApi).to receive(:get_page_content).and_return(nil)
+      expect_any_instance_of(WikiApi).to receive(:get_page_content).and_return(nil)
       stub_oauth_edit
 
       subject

--- a/spec/lib/student_greeter_spec.rb
+++ b/spec/lib/student_greeter_spec.rb
@@ -18,6 +18,8 @@ describe StudentGreeter do
       stub_contributors_query
       stub_oauth_edit
 
+      expect_any_instance_of(WikiEdits).to receive(:notify_user).and_call_original
+
       subject
       expect(User.find(2).greeted).to eq(true)
     end
@@ -26,31 +28,33 @@ describe StudentGreeter do
       expect_any_instance_of(WikiApi).to receive(:get_page_content).and_return(nil)
       stub_oauth_edit
 
+      expect_any_instance_of(WikiEdits).to receive(:notify_user).and_call_original
+
       subject
       expect(User.find(2).greeted).to eq(true)
     end
 
     it 'skips students who are already greeted' do
       User.find(2).update_attributes(greeted: true)
-      allow(WikiEdits).to receive(:get_tokens)
+      # No response stubs are active, so this will fail an edit is attempted.
       subject
       expect(User.find(2).greeted).to eq(true)
-      expect(WikiEdits).not_to have_received(:get_tokens)
     end
 
     it 'skips students whose talk pages have been edited by greeters, and marks them' do
-      allow_any_instance_of(StudentGreeter).to receive(:ids_of_contributors_to_page)
+      allow_any_instance_of(StudentGreeting).to receive(:ids_of_contributors_to_page)
         .and_return([1])
       stub_raw_action
 
-      allow(WikiEdits).to receive(:get_tokens)
+      # The relevant response stubs are not active, so this will fail an edit is attempted.
       subject
       expect(User.find(2).greeted).to eq(true)
-      expect(WikiEdits).not_to have_received(:get_tokens)
     end
 
     it 'does nothing if no Wiki Ed staff are part of the course' do
       CoursesUsers.find(1).destroy
+
+      # No response stubs are active, so this will fail an edit is attempted.
       subject
       expect(User.find(2).greeted).to eq(false)
     end

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -6,7 +6,7 @@ describe WikiApi do
     it 'should return the content of a page' do
       VCR.use_cassette 'wiki/course_list' do
         title = 'Wikipedia:Education program/Dashboard/test_ids'
-        response = WikiApi.get_page_content(title)
+        response = WikiApi.new.get_page_content(title)
         expect(response).to eq("439\n456\n351")
       end
     end
@@ -16,7 +16,7 @@ describe WikiApi do
     it 'should return the list of courses' do
       VCR.use_cassette 'wiki/course_list' do
         create(:cohort)
-        response = WikiApi.course_list
+        response = WikiApi.new.course_list
         expect(response.count).to be >= 1
       end
     end
@@ -26,11 +26,11 @@ describe WikiApi do
     it 'should return the ratings of articles' do
       VCR.use_cassette 'wiki/article_ratings' do
         # A single article
-        response = WikiApi.get_article_rating('History_of_biology')
+        response = WikiApi.new.get_article_rating('History_of_biology')
         expect(response[0]['History_of_biology']).to eq('fa')
 
         # A single non-existant article
-        response = WikiApi.get_article_rating('THIS_IS_NOT_A_REAL_ARTICLE_TITLE')
+        response = WikiApi.new.get_article_rating('THIS_IS_NOT_A_REAL_ARTICLE_TITLE')
         expect(response[0]['THIS_IS_NOT_A_REAL_ARTICLE_TITLE']).to eq(nil)
 
         # A mix of existing and non-existant, including ones with niche ratings.
@@ -58,7 +58,7 @@ describe WikiApi do
           'Sex_trafficking' # blank talk page
         ]
 
-        response = WikiApi.get_article_rating(articles)
+        response = WikiApi.new.get_article_rating(articles)
         expect(response).to include('History_of_biology' => 'fa')
         expect(response).to include('THIS_IS_NOT_A_REAL_ARTICLE_TITLE' => nil)
         expect(response.count).to eq(20)
@@ -73,33 +73,50 @@ describe WikiApi do
           'Talk:THIS_PAGE_WILL_NEVER_EXIST,_RIGHT?', # definitely doesn't exist
           'Talk:List_of_Canadian_plants_by_family_S' # exists
         ]
-        response = WikiApi.get_raw_page_content(articles)
+        response = WikiApi.new.get_raw_page_content(articles)
         expect(response.count).to eq(4)
       end
     end
   end
 
   describe '.get_user_id' do
-    it 'should take a username and return the user_id' do
-      VCR.use_cassette 'wiki/get_user_id' do
-        username = 'Ragesoss'
-        user_id_enwiki = WikiApi.get_user_id(username)
-        expect(user_id_enwiki).to eq(319203)
-        user_id_eswiki = WikiApi.get_user_id(username, 'es')
-        expect(user_id_eswiki).to eq(772153)
-        # make sure usernames with spaces get handled correctly
-        user_with_spaces = WikiApi.get_user_id('LiAnna (Wiki Ed)')
-        expect(user_with_spaces).to eq(21102089)
-        # make sure unicode works
-        unicode_name = WikiApi.get_user_id('ערן')
-        expect(unicode_name).to eq(7201119)
+    context 'for an English Wikipedia users' do
+      let(:wiki) { Wiki.new(language: 'en', project: 'wikipedia') }
+
+      it 'returns the correct user_id for all types of usernames' do
+        usernames = { 'Ragesoss' => 319203,
+                      'LiAnna (Wiki Ed)' => 21102089, # spaces and parens
+                      'ערן' => 7201119, # Hebrew characters
+                      'JRicker,PhD' => 17137867, # comma
+                      'Evol&Glass' => 22403865, # ampersand
+                      "Jack's nomadic mind" => 26211578, # apostrophe
+                      '!!Aaapplesauce' => 11274650 } # exclamation
+
+        VCR.use_cassette 'wiki/get_user_id_en_wiki' do
+          usernames.each do |username, id|
+            result = WikiApi.new(wiki).get_user_id(username)
+            expect(result).to eq(id)
+          end
+        end
+      end
+    end
+
+    context 'for a Spanish Wikipedia user' do
+      let(:wiki) { Wiki.new(language: 'es', project: 'wikipedia') }
+      let(:username) { 'Ragesoss' }
+
+      it 'returns the correct user_id' do
+        VCR.use_cassette 'wiki/get_user_id_es_wiki' do
+          result = WikiApi.new(wiki).get_user_id(username)
+          expect(result).to eq(772153)
+        end
       end
     end
 
     it 'should return nil for usernames that do not exist' do
       VCR.use_cassette 'wiki/get_user_id_nonexistent' do
         username = 'RagesossRagesossRagesoss'
-        user_id = WikiApi.get_user_id(username)
+        user_id = WikiApi.new.get_user_id(username)
         expect(user_id).to be_nil
       end
     end

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -4,6 +4,12 @@ require "#{Rails.root}/lib/wiki_assignment_output"
 
 describe WikiAssignmentOutput do
   before do
+    create(:course,
+           id: 10001,
+           title: 'Course Title',
+           school: 'School',
+           term: 'Term',
+           slug: 'School/Course_Title_(Term)')
     create(:assignment,
            id: 1,
            user_id: 3,

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -25,12 +25,6 @@ describe WikiAssignmentOutput do
     # This UTF-8 username ensures that encoding compatibility issues are handled.
     create(:user, id: 3, username: 'Keï')
     create(:courses_user, user_id: 3, course_id: 10001)
-    create(:course,
-           id: 10001,
-           title: 'Course Title',
-           school: 'School',
-           term: 'Term',
-           slug: 'School/Course_Title_(Term)')
   end
 
   describe '.build_assignment_page_content' do

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -31,7 +31,7 @@ describe WikiAssignmentOutput do
     it 'adds an assignment tag to the wikitext of a page' do
       VCR.use_cassette 'wiki_edits/assignments' do
         talk_title = 'Talk:Selfie'
-        selfie_talk = WikiApi.get_page_content(talk_title)
+        selfie_talk = WikiApi.new.get_page_content(talk_title)
         course = Course.find(10001)
         course_page = course.wiki_title
         assignment_titles = course.assignments.group_by(&:article_title)

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require "#{Rails.root}/lib/wiki_course_edits"
 
 describe WikiCourseEdits do
-  let(:course) { create(:course, id: 1, submitted: true) }
+  let!(:course) { create(:course, id: 1, submitted: true) }
   let(:user) { create(:user) }
 
   describe '#update_course' do
@@ -63,7 +63,7 @@ describe WikiCourseEdits do
              user_id: 1,
              course_id: 1,
              article_title: 'Selfie',
-             role: Assignment::Roles::ASSIGNED_ROLE)
+             role: Assignment::Roles::ASSIGNED_ROLE,)
       create(:assignment,
              id: 2,
              user_id: 1,

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -6,21 +6,26 @@ describe WikiCourseEdits do
   let(:user) { create(:user) }
 
   describe '#update_course' do
-    it 'should edit a Wikipedia page representing a course' do
+    it 'edits a Wikipedia page representing a course' do
       stub_oauth_edit
-      expect(WikiEdits).to receive(:post_whole_page).twice.and_call_original
+      expect_any_instance_of(WikiEdits).to receive(:post_whole_page).and_call_original
       WikiCourseEdits.new(action: :update_course,
                           course: course,
                           current_user: user)
+    end
+
+    it 'edits the course page with the delete option' do
+      stub_oauth_edit
+      expect_any_instance_of(WikiEdits).to receive(:post_whole_page).and_call_original
       WikiCourseEdits.new(action: :update_course,
                           course: course,
                           current_user: user,
                           delete: true)
     end
 
-    it 'should repost a clean version after hitting the spamblacklist' do
+    it 'reposts a clean version after hitting the spamblacklist' do
       stub_oauth_edit_spamblacklist
-      expect(WikiEdits).to receive(:post_whole_page).twice.and_call_original
+      expect_any_instance_of(WikiEdits).to receive(:post_whole_page).twice.and_call_original
       WikiCourseEdits.new(action: :update_course,
                           course: course,
                           current_user: user)
@@ -28,10 +33,10 @@ describe WikiCourseEdits do
   end
 
   describe '#announce_course' do
-    it 'should post to the userpage of the instructor and a noticeboard' do
+    it 'posts to the userpage of the instructor and a noticeboard' do
       stub_oauth_edit
-      expect(WikiEdits).to receive(:add_to_page_top) # userpage edit
-      expect(WikiEdits).to receive(:add_new_section) # noticeboard edit
+      expect_any_instance_of(WikiEdits).to receive(:add_to_page_top) # userpage edit
+      expect_any_instance_of(WikiEdits).to receive(:add_new_section) # noticeboard edit
       WikiCourseEdits.new(action: :announce_course,
                           course:  course,
                           current_user: user,
@@ -40,9 +45,9 @@ describe WikiCourseEdits do
   end
 
   describe '#enroll_in_course' do
-    it 'should post to the userpage of the enrolling student and their sandbox' do
+    it 'posts to the userpage of the enrolling student and their sandbox' do
       stub_oauth_edit
-      expect(WikiEdits).to receive(:add_to_page_top).twice
+      expect_any_instance_of(WikiEdits).to receive(:add_to_page_top).twice
       WikiCourseEdits.new(action: :enroll_in_course,
                           course: course,
                           current_user: user)
@@ -50,10 +55,10 @@ describe WikiCourseEdits do
   end
 
   describe '#update_assignments' do
-    it 'should update talk pages and course page with assignment info' do
+    it 'updates talk pages and course page with assignment info' do
       stub_raw_action
       stub_oauth_edit
-      expect(WikiEdits).to receive(:post_whole_page).at_least(:once)
+      expect_any_instance_of(WikiEdits).to receive(:post_whole_page).at_least(:once)
       create(:assignment,
              user_id: 1,
              course_id: 1,
@@ -77,8 +82,8 @@ describe WikiCourseEdits do
     let(:legacy_course) { create(:legacy_course) }
     let(:basic_course) { create(:basic_course, submitted: true) }
 
-    it 'should return immediately without making any edits' do
-      expect(WikiEdits).not_to receive(:post_whole_page)
+    it 'returns immediately without making any edits' do
+      expect_any_instance_of(WikiEdits).not_to receive(:post_whole_page)
       WikiCourseEdits.new(action: :update_course,
                           course: visiting_scholarship,
                           current_user: user)

--- a/spec/lib/wiki_edits_spec.rb
+++ b/spec/lib/wiki_edits_spec.rb
@@ -27,29 +27,31 @@ describe WikiEdits do
            user_id: 2)
   end
 
+  let(:course) { Course.find(1) }
+
   it 'should handle failed edits' do
     stub_oauth_edit_failure
-    WikiEdits.notify_untrained(1, User.first)
+    WikiEdits.new.notify_untrained(course, User.first)
   end
 
   it 'should handle edits that hit the abuse filter' do
     stub_oauth_edit_abusefilter
-    WikiEdits.notify_untrained(1, User.first)
+    WikiEdits.new.notify_untrained(course, User.first)
   end
 
   it 'should handle unexpected responses' do
     stub_oauth_edit_captcha
-    WikiEdits.notify_untrained(1, User.first)
+    WikiEdits.new.notify_untrained(course, User.first)
   end
 
   it 'should handle unexpected responses' do
     stub_oauth_edit_with_empty_response
-    WikiEdits.notify_untrained(1, User.first)
+    WikiEdits.new.notify_untrained(course, User.first)
   end
 
   it 'should handle failed token requests' do
     stub_token_request_failure
-    result = WikiEdits.post_whole_page(User.first, 'Foo', 'Bar')
+    result = WikiEdits.new.post_whole_page(User.first, 'Foo', 'Bar')
     expect(result[:status]).to eq('failed')
     expect(User.first.wiki_token).to eq('invalid')
   end
@@ -57,7 +59,7 @@ describe WikiEdits do
   describe '.notify_untrained' do
     it 'should post talk page messages on Wikipedia' do
       stub_oauth_edit
-      WikiEdits.notify_untrained(1, User.first)
+      WikiEdits.new.notify_untrained(course, User.first)
     end
   end
 
@@ -67,20 +69,20 @@ describe WikiEdits do
       params = { sectiontitle: 'My message headline',
                  text: 'My message to you',
                  summary: 'My edit summary' }
-      WikiEdits.notify_users(User.first, User.all, params)
+      WikiEdits.new.notify_users(User.first, User.all, params)
     end
   end
 
   describe '.oauth_credentials_valid?' do
     it 'returns true if credentials are valid' do
       stub_token_request
-      response = WikiEdits.oauth_credentials_valid?(User.first)
+      response = WikiEdits.new.oauth_credentials_valid?(User.first)
       expect(response).to eq(true)
     end
 
     it 'returns false if credentials are invalid' do
       stub_token_request_failure
-      response = WikiEdits.oauth_credentials_valid?(User.first)
+      response = WikiEdits.new.oauth_credentials_valid?(User.first)
       expect(response).to eq(false)
     end
 
@@ -89,7 +91,7 @@ describe WikiEdits do
     # that the auth is invalid, then we carry on.
     it 'returns true if Wikipedia API returns no tokens' do
       stub_request(:any, /.*/).to_return(status: 200, body: '{}', headers: {})
-      response = WikiEdits.oauth_credentials_valid?(User.first)
+      response = WikiEdits.new.oauth_credentials_valid?(User.first)
       expect(response).to eq(true)
     end
   end

--- a/spec/lib/wiki_pageviews_spec.rb
+++ b/spec/lib/wiki_pageviews_spec.rb
@@ -4,12 +4,12 @@ require "#{Rails.root}/lib/wiki_pageviews"
 describe WikiPageviews do
   describe '.views_for_article' do
     context 'for a popular article' do
-      let(:title) { 'Selfie' }
+      let(:article) { create(:article, title: 'Selfie') }
       let(:start_date) { '2015-10-01'.to_date }
       let(:end_date) { '2015-11-01'.to_date }
       let(:subject) do
-        WikiPageviews.views_for_article(title, start_date: start_date,
-                                               end_date: end_date)
+        WikiPageviews.new(article).views_for_article(start_date: start_date,
+                                                     end_date: end_date)
       end
 
       it 'returns a hash of daily views for all the requested dates' do
@@ -48,7 +48,8 @@ describe WikiPageviews do
   end
 
   describe '.average_views_for_article' do
-    let(:subject) { WikiPageviews.average_views_for_article(title) }
+    let(:subject) { WikiPageviews.new(article).average_views }
+    let(:article) { create(:article, title: title) }
 
     context 'for a popular article' do
       let(:title) { 'Selfie' }


### PR DESCRIPTION
@adamwight @AndrewGreen I've started reimplementing the changes from the use_native_ids branch (and only adding things that keep the tests passing).

If neither of you have objections, I'm going to merge this stuff to master, and we can continue cleanly adding in the necessary wiki-flexibility from here. After the far-reaching WikiApi interface change included here (which just invokes the default wiki in most cases at this point), most of the rest of what we have in `use_native_ids` is pretty isolated.