### PR TITLE
Survey notification reminders

### DIFF
--- a/app/assets/stylesheets/_utils.styl
+++ b/app/assets/stylesheets/_utils.styl
@@ -140,6 +140,9 @@ show-over(breakpoint, display)
 .text-center
   text-align center
 
+.text-left
+  text-align left
+
 .no-bullets
   list-style none
   &.no-margin

--- a/app/assets/stylesheets/survey_modules/form.styl
+++ b/app/assets/stylesheets/survey_modules/form.styl
@@ -114,3 +114,6 @@ form:focus
 
 .input.string input[type=text]
   width 100%
+
+small.form__small-dark
+  color #787878

--- a/app/controllers/survey_assignments_controller.rb
+++ b/app/controllers/survey_assignments_controller.rb
@@ -109,6 +109,7 @@ class SurveyAssignmentsController < ApplicationController
     params.require(:survey_assignment)
           .permit(:survey_id, :send_before, :send_date_relative_to,
                   :send_date_days, :courses_user_role, :published,
+                  :follow_up_days_after_first_notification,
                   :notes, cohort_ids: [])
   end
 end

--- a/app/mailers/survey_mailer.rb
+++ b/app/mailers/survey_mailer.rb
@@ -1,9 +1,20 @@
 class SurveyMailer < ApplicationMailer
   def notification(notification)
+    set_ivars(notification)
+    mail(to: @user.email, subject: "A survey is available for your course, '#{@course.title}'")
+  end
+
+  def follow_up(notification)
+    set_ivars(notification)
+    mail(to: @user.email, subject: "Reminder: A survey is available for your course, '#{@course.title}'")
+  end
+
+  private
+
+  def set_ivars(notification)
     @notification = notification
     @user = notification.user
     @survey = notification.survey
     @course = notification.course
-    mail(to: @user.email, subject: "A survey is available for your course, '#{@course.title}'")
   end
 end

--- a/app/models/survey_notification.rb
+++ b/app/models/survey_notification.rb
@@ -18,7 +18,7 @@ class SurveyNotification < ActiveRecord::Base
 
   def send_follow_up
     return unless survey_assignment.follow_up_days_after_first_notification.present?
-    return if follow_up_sent_at.present? || user.email.nil?
+    return if follow_up_sent_at.present? || user.email.nil? || email_sent_at.nil?
     return if Time.now < email_sent_at + survey_assignment.follow_up_days_after_first_notification.days
     SurveyMailer.follow_up(self).deliver_now
     update_attribute(:follow_up_sent_at, Time.now)

--- a/app/views/survey_assignments/_form.html.haml
+++ b/app/views/survey_assignments/_form.html.haml
@@ -15,10 +15,19 @@
 
     .form__row
       %h4 Notification Schedule
+      %small.block-element.text-left.form__small-dark
+        %em (Leave blank if no notifications are desired.)
       = f.number_field :send_date_days
       = f.label :send_date_days, "Days", class: 'inline-label'
       = f.select :send_before, options_for_select([['Before', true], ['After', false]], selected: @survey_assignment.send_before)
       = f.select :send_date_relative_to, options_for_select(@send_relative_to_options, selected: @survey_assignment.send_date_relative_to)
+
+    .form__row
+      %h4 Follow-up Notification Schedule
+      %small.block-element.text-left.form__small-dark
+        %em (Leave blank if no follow-up notifications are desired.)
+      = f.number_field :follow_up_days_after_first_notification, label: false
+      = f.label :send_date_days, "days after first notification", class: 'inline-label'
 
     .form__row
       = f.check_box :published

--- a/app/views/survey_mailer/follow_up.html.haml
+++ b/app/views/survey_mailer/follow_up.html.haml
@@ -6,8 +6,7 @@
           %tr
             %td.main-content
               %h1{style: 'font-family: "Open Sans", sans-serif; color: #696BB1; font-size: 34px; font-weight: 300; text-align:left;'}= t('survey.email.headline', username: @user.username)
-              %p{style: 'font-family: "Open Sans", sans-serif; color: #666666; font-size: 18px; line-height: 1.5; font-weight: 300; text-align:left;'}= t('survey.email.message_line1')
-              %p{style: 'font-family: "Open Sans", sans-serif; color: #666666; font-size: 18px; line-height: 1.5; font-weight: 300; text-align:left;'}= t('survey.email.message_line2')
+              %p{style: 'font-family: "Open Sans", sans-serif; color: #666666; font-size: 18px; line-height: 1.5; font-weight: 300; text-align:left;'}= t('survey.follow_up.message')
             %td.expander
         %table
           %tr
@@ -20,6 +19,9 @@
               %div{style: 'font-family: "Open Sans", sans-serif; color: #666666; font-size: 14px; line-height: 1.5;  text-align:left; font-weight: 300;'}= t('survey.email.course', course_info: "#{@course.school} - #{@course.title} (#{@course.term})")
             %td.expander
         %table
+          %tr
+            %td.main-content
+              %em{style: 'font-family: "Open Sans", sans-serif; color: #666666; font-size: 18px; line-height: 1.5;  text-align:left; font-weight: 300;'}= t('survey.email.closing')
           %tr
             %td.main-content
               %em{style: 'font-family: "Open Sans", sans-serif; color: #666666; font-size: 18px; line-height: 1.5;  text-align:left; font-weight: 300;'}= t('survey.email.signed')

--- a/app/views/survey_mailer/follow_up.text.haml
+++ b/app/views/survey_mailer/follow_up.text.haml
@@ -1,0 +1,10 @@
+= t('survey.email.headline', username: @user.username)
+\
+= t('survey.follow_up.message', course_title: @course.title)
+\
+= survey_url(@survey)
+\
+\
+= t('survey.email.course', course_info: "#{@course.school} - #{@course.title} (#{@course.term})")
+= t('survey.email.closing')
+= t('survey.email.signed')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,3 +501,5 @@ en:
       closing: "Sincerely,"
       signed: "- the Wiki Ed team"
       link: "Take Survey"
+    follow_up:
+      message: "This is a reminder about the survey for your course, %{course_title}. Feedback from this survey helps us to improve our support for Wikipedia assignments like yours."

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,3 +28,12 @@ end
 every 1.day, at: '4:30 am' do
   rake 'batch:update_daily'
 end
+
+every 1.day, at: '12:30 am' do
+  rake 'cache:warm:homepage'
+end
+
+every [:monday, :tuesday, :wednesday, :thursday], at: '10:15 am' do
+  rake 'surveys:send_notifications'
+  rake 'surveys:send_notification_follow_ups'
+end

--- a/db/migrate/20160503182435_add_follow_up_days_after_first_notification_to_survey_assignments.rb
+++ b/db/migrate/20160503182435_add_follow_up_days_after_first_notification_to_survey_assignments.rb
@@ -1,0 +1,6 @@
+class AddFollowUpDaysAfterFirstNotificationToSurveyAssignments < ActiveRecord::Migration
+  def change
+    add_column :survey_assignments, :follow_up_days_after_first_notification, :integer
+    add_column :survey_notifications, :follow_up_sent_at, :datetime
+  end
+end

--- a/db/migrate/20160503220152_change_email_sent_on_notifications_to_datetime.rb
+++ b/db/migrate/20160503220152_change_email_sent_on_notifications_to_datetime.rb
@@ -1,0 +1,7 @@
+class ChangeEmailSentOnNotificationsToDatetime < ActiveRecord::Migration
+  def change
+    add_column :survey_notifications, :email_sent_at, :datetime, after: :email_sent
+    SurveyNotification.where(email_sent: true).update_all('email_sent_at=updated_at')
+    remove_column :survey_notifications, :email_sent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160428222013) do
+ActiveRecord::Schema.define(version: 20160503220152) do
 
   create_table "articles", force: :cascade do |t|
     t.string   "title",                    limit: 255
@@ -255,15 +255,16 @@ ActiveRecord::Schema.define(version: 20160428222013) do
   add_index "revisions", ["article_id", "date"], name: "index_revisions_on_article_id_and_date", using: :btree
 
   create_table "survey_assignments", force: :cascade do |t|
-    t.integer  "courses_user_role",     limit: 4
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.integer  "send_date_days",        limit: 4
-    t.integer  "survey_id",             limit: 4
-    t.boolean  "send_before",                         default: true
-    t.string   "send_date_relative_to", limit: 255
-    t.boolean  "published",                           default: false
-    t.text     "notes",                 limit: 65535
+    t.integer  "courses_user_role",                       limit: 4
+    t.datetime "created_at",                                                            null: false
+    t.datetime "updated_at",                                                            null: false
+    t.integer  "send_date_days",                          limit: 4
+    t.integer  "survey_id",                               limit: 4
+    t.boolean  "send_before",                                           default: true
+    t.string   "send_date_relative_to",                   limit: 255
+    t.boolean  "published",                                             default: false
+    t.text     "notes",                                   limit: 65535
+    t.integer  "follow_up_days_after_first_notification", limit: 4
   end
 
   add_index "survey_assignments", ["survey_id"], name: "index_survey_assignments_on_survey_id", using: :btree
@@ -273,10 +274,11 @@ ActiveRecord::Schema.define(version: 20160428222013) do
     t.integer  "course_id",            limit: 4
     t.integer  "survey_assignment_id", limit: 4
     t.boolean  "dismissed",                      default: false
-    t.boolean  "email_sent",                     default: false
+    t.datetime "email_sent_at"
     t.datetime "created_at",                                     null: false
     t.datetime "updated_at",                                     null: false
     t.boolean  "completed",                      default: false
+    t.datetime "follow_up_sent_at"
   end
 
   add_index "survey_notifications", ["course_id"], name: "index_survey_notifications_on_course_id", using: :btree

--- a/lib/tasks/surveys.rake
+++ b/lib/tasks/surveys.rake
@@ -12,7 +12,7 @@ namespace :surveys do
   end
 
   desc 'Send follow-up survey notifications if configured on the parent notification'
-  task send_survey_notification_follow_ups: :environment do
+  task send_notification_follow_ups: :environment do
     SurveyNotification.active.each(&:send_follow_up)
   end
 end

--- a/lib/tasks/surveys.rake
+++ b/lib/tasks/surveys.rake
@@ -10,4 +10,9 @@ namespace :surveys do
   task send_notifications: :environment do
     SurveyNotification.active.each(&:send_email)
   end
+
+  desc 'Send follow-up survey notifications if configured on the parent notification'
+  task send_survey_notification_follow_ups: :environment do
+    SurveyNotification.active.each(&:send_follow_up)
+  end
 end

--- a/spec/controllers/survey_assignments_controller_spec.rb
+++ b/spec/controllers/survey_assignments_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe SurveyAssignmentsController do
+  describe '#create' do
+    let(:follow_up)  { 7 }
+    let(:send_days)  { 7 }
+    let(:survey)     { create(:survey) }
+    let(:cohort)     { create(:cohort) }
+    let(:instructor) { 1 }
+    let(:admin)      { create(:admin) }
+    let(:post_params) {{
+      survey_assignment: {
+        survey_id: survey.id,
+        cohort_ids: cohort.id,
+        courses_user_role: instructor,
+        send_date_days: send_days,
+        send_before: false,
+        send_date_relative_to: "end",
+        follow_up_days_after_first_notification: follow_up,
+        published: true,
+        notes: "foo",
+      }
+    }}
+    before { allow(controller).to receive(:current_user).and_return(admin) }
+    it 'allows create' do
+      post :create, post_params
+      expect(SurveyAssignment.last.follow_up_days_after_first_notification).to eq(follow_up)
+    end
+  end
+end

--- a/spec/lib/tasks/surveys_rake_spec.rb
+++ b/spec/lib/tasks/surveys_rake_spec.rb
@@ -18,12 +18,19 @@ describe 'surveys:send_notifications' do
     expect(ActionMailer::Base.deliveries.last.to.include?(@user2.email)).to be(true)
   end
 
-  it 'sets SurveyNotification email_sent boolean attribute to true after sending' do
-    expect(SurveyNotification.where(email_sent: false).length).to eq(0)
+  it "sets SurveyNotification email_sent datetime attribute after sending" do
+    expect(SurveyNotification.where(email_sent_at: nil).length).to eq(0)
   end
 
   it "only sends emails for notifications which haven't been dismissed" do
     subject.invoke
     expect(ActionMailer::Base.deliveries.count).to eq(2)
+  end
+
+  private
+
+  def recipients(recipient_position)
+    deliveries = ActionMailer::Base.deliveries
+    recipient_position == :first ? deliveries.first.to : deliveries.last.to
   end
 end

--- a/spec/lib/tasks/surveys_send_notification_follow_ups_spec.rb
+++ b/spec/lib/tasks/surveys_send_notification_follow_ups_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+# https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+
+
+describe 'surveys:send_notifications' do
+  include_context "rake"
+  let!(:survey_notification) { create(:survey_notification) }
+
+  it 'calls send_follow_ups on the active survey notififications' do
+    expect_any_instance_of(SurveyNotification).to receive(:send_follow_up)
+    rake['surveys:send_notification_follow_ups'].invoke
+  end
+end

--- a/spec/lib/tasks/surveys_send_notifications_spec.rb
+++ b/spec/lib/tasks/surveys_send_notifications_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+# https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+
+
+describe 'surveys:send_notifications' do
+  include_context "rake"
+  let!(:survey_notification) { create(:survey_notification) }
+
+  it 'calls send_follow_ups on the active survey notififications' do
+    expect_any_instance_of(SurveyNotification).to receive(:send_email)
+    rake['surveys:send_notifications'].invoke
+  end
+end

--- a/spec/mailers/survey_mailer_spec.rb
+++ b/spec/mailers/survey_mailer_spec.rb
@@ -21,4 +21,25 @@ describe SurveyMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
     end
   end
+
+  describe '#follow_up' do
+    let(:user) { create(:user, email: 'user@example.com') }
+    let(:course) { create(:course, id: 1) }
+    let(:courses_user) { create(:courses_user, course_id: course.id, user_id: user.id) }
+    let(:survey) { create(:survey) }
+    let(:survey_assignment) { create(:survey_assignment, survey_id: survey.id) }
+    let(:survey_notification) do
+      create(:survey_notification,
+             course_id: course.id,
+             courses_users_id: courses_user.id,
+             survey_assignment_id: survey_assignment.id)
+    end
+
+    let(:mail) { SurveyMailer.follow_up(survey_notification).deliver_now }
+
+    it 'contains the correct user email and body' do
+      expect(mail.body.encoded).to match(user.username)
+      expect(mail.to).to eq([user.email])
+    end
+  end
 end

--- a/spec/models/survey_notification_spec.rb
+++ b/spec/models/survey_notification_spec.rb
@@ -107,7 +107,7 @@ describe SurveyNotification do
       it 'does not send the follow up' do
         expect(SurveyMailer).not_to receive(:follow_up)
         subject.send_follow_up
-        expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(false)
+        expect(subject.follow_up_sent_at).to be_nil
       end
     end
   end

--- a/spec/models/survey_notification_spec.rb
+++ b/spec/models/survey_notification_spec.rb
@@ -99,5 +99,16 @@ describe SurveyNotification do
         expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(false)
       end
     end
+    context 'follow ups set on assignment, it is time to send, user has email, but no preliminary email set' do
+      let(:email) { 'pizza@tacos.com' }
+      let(:email_sent_at)     { nil }
+      let(:follow_up_sent_at) { nil }
+      let(:survey_assignment) { create(:survey_assignment, follow_up_days_after_first_notification: 7) }
+      it 'does not send the follow up' do
+        expect(SurveyMailer).not_to receive(:follow_up)
+        subject.send_follow_up
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/survey_notification_spec.rb
+++ b/spec/models/survey_notification_spec.rb
@@ -11,41 +11,92 @@ describe SurveyNotification do
   let(:course) { create(:course) }
   let(:courses_user) { create(:courses_user, course_id: course.id, user_id: user.id) }
   let(:survey_assignment) { create(:survey_assignment) }
+  let(:email_sent_at) { 1.hour.ago }
+  let(:follow_up_sent_at) { nil }
   let(:survey_notification) do
     create(:survey_notification,
            survey_assignment_id: survey_assignment.id,
            courses_users_id: courses_user.id,
-           email_sent: email_sent)
+           email_sent_at: email_sent_at,
+           follow_up_sent_at: follow_up_sent_at)
   end
 
   let(:subject) { survey_notification }
 
   describe 'send_email' do
     context 'when email has not been sent' do
-      let(:email_sent) { false }
+      let(:email_sent_at) { nil }
       it 'sends the email' do
         expect(SurveyMailer).to receive(:notification).and_return(mock_mailer)
         subject.send_email
-        expect(subject.email_sent).to eq(true)
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.email_sent_at)).to eq(true)
       end
     end
 
     context 'when the user has no email address' do
-      let(:email_sent) { false }
+      let(:email_sent_at) { nil }
       let(:email) { nil }
       it 'returns without error' do
         expect(SurveyMailer).not_to receive(:notification)
         subject.send_email
-        expect(subject.email_sent).to eq(false)
+        expect(subject.email_sent_at).to be_nil
       end
     end
 
     context 'when the email has already been sent' do
-      let(:email_sent) { true }
       it 'does not send another email' do
         expect(SurveyMailer).not_to receive(:notification)
         subject.send_email
-        expect(subject.email_sent).to eq(true)
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.email_sent_at)).to eq(false)
+      end
+    end
+  end
+
+  describe '#send_follow_up' do
+    context 'follow up not sent, but follow ups not set on assignment' do
+      let(:survey_assignment) { create(:survey_assignment, follow_up_days_after_first_notification: nil) }
+      it 'does not send the follow up' do
+        expect(SurveyMailer).not_to receive(:follow_up)
+        subject.send_follow_up
+        expect(subject.follow_up_sent_at).to be_nil
+      end
+    end
+    context 'follow up already sent' do
+      let(:survey_assignment) { create(:survey_assignment, follow_up_days_after_first_notification: 7) }
+      let(:follow_up_sent_at) { 1.hour.ago }
+      it 'does not send the follow up' do
+        expect(SurveyMailer).not_to receive(:follow_up)
+        subject.send_follow_up
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(false)
+      end
+    end
+    context 'follow ups set on assignment, but it is not yet time to send' do
+      let(:email_sent_at)     { 1.minute.ago }
+      let(:survey_assignment) { create(:survey_assignment, follow_up_days_after_first_notification: 7) }
+      it 'does not send the follow up' do
+        expect(SurveyMailer).not_to receive(:follow_up)
+        subject.send_follow_up
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(false)
+      end
+    end
+    context 'follow ups set on assignment, it is time to send' do
+      let(:email_sent_at)     { 8.days.ago }
+      let(:survey_assignment) { create(:survey_assignment, follow_up_days_after_first_notification: 7) }
+      it 'sends the follow up' do
+        expect(SurveyMailer).to receive(:follow_up).and_return(mock_mailer)
+        subject.send_follow_up
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(true)
+      end
+    end
+    context 'follow ups set on assignment, it is time to send, but user has no email' do
+      let(:email) { nil }
+      let(:email_sent_at)     { nil }
+      let(:follow_up_sent_at) { nil }
+      let(:survey_assignment) { create(:survey_assignment, follow_up_days_after_first_notification: 7) }
+      it 'does not send the follow up' do
+        expect(SurveyMailer).not_to receive(:follow_up)
+        subject.send_follow_up
+        expect((1.minute.ago..1.minute.from_now).cover?(subject.follow_up_sent_at)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
This should be everything we need for this feature. If you're wondering where the rake spec is, it would be redundant; it just calls a `SurveyMailer` method that is itself tested. That is, in my opinion, how rake tasks should be. I did neglect, however, to delete the current spec for `send_notifications`.

If merged:

closes #790 
closes #791 

Update: stand by, running the whole test suite.