### PR TITLE
Allow user to enter and be shown times in their own time zone

### DIFF
--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -42,7 +42,7 @@ const DatePicker = React.createClass({
 
   getInitialState() {
     if (this.props.value) {
-      const dateObj = moment(this.props.value).utc();
+      const dateObj = moment(this.props.value);
       return {
         value: dateObj.format('YYYY-MM-DD'),
         hour: dateObj.hour(),
@@ -59,7 +59,7 @@ const DatePicker = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const dateObj = moment(nextProps.value).utc();
+    const dateObj = moment(nextProps.value);
     if (dateObj.isValid()) {
       this.setState({
         value: dateObj.format('YYYY-MM-DD'),
@@ -84,7 +84,7 @@ const DatePicker = React.createClass({
    * @return {moment}
    */
   getDate() {
-    let dateObj = moment(this.state.value, 'YYYY-MM-DD').utc();
+    let dateObj = moment(this.state.value, 'YYYY-MM-DD');
     dateObj = dateObj.hour(this.state.hour);
     return dateObj.minute(this.state.minute);
   },
@@ -113,7 +113,7 @@ const DatePicker = React.createClass({
   },
 
   handleDatePickerChange(e, selectedDate) {
-    const date = moment(selectedDate).utc();
+    const date = moment(selectedDate);
     if (this.isDayDisabled(date)) {
       return;
     }
@@ -191,19 +191,19 @@ const DatePicker = React.createClass({
   },
 
   isDaySelected(date) {
-    const currentDate = moment(date).utc().format('YYYY-MM-DD');
+    const currentDate = moment(date).format('YYYY-MM-DD');
     return currentDate === this.state.value;
   },
 
   isDayDisabled(date) {
-    const currentDate = moment(date).utc();
+    const currentDate = moment(date);
     if (this.props.date_props) {
-      const minDate = moment(this.props.date_props.minDate, 'YYYY-MM-DD').utc().startOf('day');
+      const minDate = moment(this.props.date_props.minDate, 'YYYY-MM-DD').startOf('day');
       if (minDate.isValid() && currentDate < minDate) {
         return true;
       }
 
-      const maxDate = moment(this.props.date_props.maxDate, 'YYYY-MM-DD').utc().endOf('day');
+      const maxDate = moment(this.props.date_props.maxDate, 'YYYY-MM-DD').endOf('day');
       if (maxDate.isValid() && currentDate > maxDate) {
         return true;
       }
@@ -258,7 +258,7 @@ const DatePicker = React.createClass({
 
       let minDate;
       if (this.props.date_props && this.props.date_props.minDate) {
-        const minDateValue = moment(this.props.date_props.minDate, 'YYYY-MM-DD').utc();
+        const minDateValue = moment(this.props.date_props.minDate, 'YYYY-MM-DD');
         if (minDateValue.isValid()) {
           minDate = minDateValue;
         }
@@ -267,11 +267,11 @@ const DatePicker = React.createClass({
       // don't validate YYYY-MM-DD format so we can update the daypicker as they type
       const date = moment(this.state.value, 'YYYY-MM-DD');
       if (date.isValid()) {
-        currentMonth = date.utc().toDate();
+        currentMonth = date.toDate();
       } else if (minDate) {
-        currentMonth = minDate.utc().toDate();
+        currentMonth = minDate.toDate();
       } else {
-        currentMonth = moment().utc().toDate();
+        currentMonth = moment().toDate();
       }
 
       const modifiers = {

--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -42,7 +42,7 @@ const DatePicker = React.createClass({
 
   getInitialState() {
     if (this.props.value) {
-      const dateObj = moment(this.props.value);
+      const dateObj = this.moment(this.props.value);
       return {
         value: dateObj.format('YYYY-MM-DD'),
         hour: dateObj.hour(),
@@ -59,7 +59,7 @@ const DatePicker = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const dateObj = moment(nextProps.value);
+    const dateObj = this.moment(nextProps.value);
     if (dateObj.isValid()) {
       this.setState({
         value: dateObj.format('YYYY-MM-DD'),
@@ -84,7 +84,7 @@ const DatePicker = React.createClass({
    * @return {moment}
    */
   getDate() {
-    let dateObj = moment(this.state.value, 'YYYY-MM-DD');
+    let dateObj = this.moment(this.state.value, 'YYYY-MM-DD');
     dateObj = dateObj.hour(this.state.hour);
     return dateObj.minute(this.state.minute);
   },
@@ -113,7 +113,7 @@ const DatePicker = React.createClass({
   },
 
   handleDatePickerChange(e, selectedDate) {
-    const date = moment(selectedDate);
+    const date = this.moment(selectedDate);
     if (this.isDayDisabled(date)) {
       return;
     }
@@ -191,19 +191,19 @@ const DatePicker = React.createClass({
   },
 
   isDaySelected(date) {
-    const currentDate = moment(date).format('YYYY-MM-DD');
+    const currentDate = this.moment(date).format('YYYY-MM-DD');
     return currentDate === this.state.value;
   },
 
   isDayDisabled(date) {
-    const currentDate = moment(date);
+    const currentDate = this.moment(date);
     if (this.props.date_props) {
-      const minDate = moment(this.props.date_props.minDate, 'YYYY-MM-DD').startOf('day');
+      const minDate = this.moment(this.props.date_props.minDate, 'YYYY-MM-DD').startOf('day');
       if (minDate.isValid() && currentDate < minDate) {
         return true;
       }
 
-      const maxDate = moment(this.props.date_props.maxDate, 'YYYY-MM-DD').endOf('day');
+      const maxDate = this.moment(this.props.date_props.maxDate, 'YYYY-MM-DD').endOf('day');
       if (maxDate.isValid() && currentDate > maxDate) {
         return true;
       }
@@ -219,6 +219,10 @@ const DatePicker = React.createClass({
   isValidDate(value) {
     const validationRegex = /^20\d\d\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])/;
     return validationRegex.test(value) && moment(value, 'YYYY-MM-DD').isValid();
+  },
+
+  moment(...args) {
+    return this.props.showTime ? moment(...args) : moment(...args).utc();
   },
 
   showCurrentDate() {
@@ -258,7 +262,7 @@ const DatePicker = React.createClass({
 
       let minDate;
       if (this.props.date_props && this.props.date_props.minDate) {
-        const minDateValue = moment(this.props.date_props.minDate, 'YYYY-MM-DD');
+        const minDateValue = this.moment(this.props.date_props.minDate, 'YYYY-MM-DD');
         if (minDateValue.isValid()) {
           minDate = minDateValue;
         }
@@ -271,7 +275,7 @@ const DatePicker = React.createClass({
       } else if (minDate) {
         currentMonth = minDate.toDate();
       } else {
-        currentMonth = moment().toDate();
+        currentMonth = this.moment().toDate();
       }
 
       const modifiers = {

--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -271,9 +271,9 @@ const DatePicker = React.createClass({
       // don't validate YYYY-MM-DD format so we can update the daypicker as they type
       const date = moment(this.state.value, 'YYYY-MM-DD');
       if (date.isValid()) {
-        currentMonth = date.toDate();
+        currentMonth = this.moment(date).toDate();
       } else if (minDate) {
-        currentMonth = minDate.toDate();
+        currentMonth = this.moment(minDate).toDate();
       } else {
         currentMonth = this.moment().toDate();
       }

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -224,6 +224,12 @@ const CourseCreator = React.createClass({
 
     const dateProps = CourseDateUtils.dateProps(this.state.course, this.state.default_course_type);
 
+    const timeZoneMessage = (
+      <p className="form-help-text">
+        {I18n.t('courses.time_zone_message')}
+      </p>
+    );
+
     return (
       <TransitionGroup
         transitionName="wizard"
@@ -312,6 +318,7 @@ const CourseCreator = React.createClass({
                   isClearable={false}
                   showTime={this.state.use_start_and_end_times}
                 />
+                {this.state.use_start_and_end_times ? timeZoneMessage : null}
               </div>
             </div>
             <div className={controlClass}>

--- a/app/assets/javascripts/utils/course_date_utils.coffee
+++ b/app/assets/javascripts/utils/course_date_utils.coffee
@@ -8,8 +8,8 @@ module.exports = {
 
   formattedDateTime: (datetime, showTime = false) ->
     timeZoneAbbr = ' ' + moment(datetime).toDate().toString().split('(')[1].slice(0, -1)
-    format = "YYYY-MM-DD#{if showTime then ' HH:mm'}"
-    return moment(datetime).format(format) + "#{if showTime then timeZoneAbbr}";
+    format = "YYYY-MM-DD#{if showTime then ' HH:mm' else ''}"
+    return moment(datetime).format(format) + "#{if showTime then timeZoneAbbr else ''}";
 
   # Returns an object of minDate and maxDate props for each date field of a course
   dateProps: (course, type) ->

--- a/app/assets/javascripts/utils/course_date_utils.coffee
+++ b/app/assets/javascripts/utils/course_date_utils.coffee
@@ -7,8 +7,9 @@ module.exports = {
     return /^20\d{2}\-\d{2}\-\d{2}/.test(date) && moment(date).isValid()
 
   formattedDateTime: (datetime, showTime = false) ->
-    format = "YYYY-MM-DD#{if showTime then ' HH:mm (UTC)' else ''}"
-    return moment(datetime).format(format);
+    timeZoneAbbr = ' ' + (new Date).toString().split('(')[1].slice(0, -1)
+    format = "YYYY-MM-DD#{if showTime then ' HH:mm'}"
+    return moment(datetime).format(format) + "#{if showTime then timeZoneAbbr}";
 
   # Returns an object of minDate and maxDate props for each date field of a course
   dateProps: (course, type) ->

--- a/app/assets/javascripts/utils/course_date_utils.coffee
+++ b/app/assets/javascripts/utils/course_date_utils.coffee
@@ -7,7 +7,7 @@ module.exports = {
     return /^20\d{2}\-\d{2}\-\d{2}/.test(date) && moment(date).isValid()
 
   formattedDateTime: (datetime, showTime = false) ->
-    timeZoneAbbr = ' ' + (new Date).toString().split('(')[1].slice(0, -1)
+    timeZoneAbbr = ' ' + moment(datetime).toDate().toString().split('(')[1].slice(0, -1)
     format = "YYYY-MM-DD#{if showTime then ' HH:mm'}"
     return moment(datetime).format(format) + "#{if showTime then timeZoneAbbr}";
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,7 @@ en:
     term: Term
     timeline: Assignment Details
     timeline_link: Timeline
+    time_zone_message: Start and end times are displayed in your local time zone.
     title: Title
     training_due:
       The training module "%{title}" is assigned for this course, and is due on %{date}.
@@ -601,7 +602,7 @@ en:
     username: Username
     username_placeholder: Username
     role:
-      visitor: Visitor 
+      visitor: Visitor
       student: Student
       instructor: Instructor
       campus_volunteer: Campus Volunteer

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -350,6 +350,7 @@ qqq:
     submitted_note: Message that your course has been successfully submitted
     user_role: '{{Identical|Role}}'
     timeline_link: '{{Identical|Timeline}}'
+    time_zone_message: Message explaining that times are shown to the user in their local time zone
     title: |-
       Label for the title of each course
       {{Identical|Title}}

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -14,6 +14,8 @@ end
 describe 'open course creation', type: :feature, js: true do
   let(:user) { create(:user) }
   before do
+    @system_time_zone = Time.zone
+    Time.zone = 'Eastern Time (US & Canada)'
     ENV['default_course_type'] = 'BasicCourse'
     Capybara.current_driver = :poltergeist
     page.current_window.resize_to(1920, 1080)
@@ -24,11 +26,11 @@ describe 'open course creation', type: :feature, js: true do
   end
 
   after do
+    Time.zone = @system_time_zone
     ENV['default_course_type'] = cached_default_course_type
   end
 
   it 'lets a user create a course immediately', js: true do
-    Time.zone = 'Eastern Time (US & Canada)'
     visit root_path
     click_link 'Create a New Program'
     fill_out_open_course_creator_form

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -28,6 +28,7 @@ describe 'open course creation', type: :feature, js: true do
   end
 
   it 'lets a user create a course immediately', js: true do
+    Time.zone = 'Eastern Time (US & Canada)'
     visit root_path
     click_link 'Create a New Program'
     fill_out_open_course_creator_form
@@ -40,7 +41,7 @@ describe 'open course creation', type: :feature, js: true do
     expect(Course.last.cohorts.count).to eq(1)
     expect(Course.last.home_wiki.language).to eq('ta')
     expect(Course.last.home_wiki.project).to eq('wiktionary')
-    expect(Course.last.start).to eq(DateTime.parse('2017-01-04 15:35:00'))
+    expect(Course.last.start).to eq(Time.parse('2017-01-04 15:35:00').in_time_zone('UTC'))
   end
 
   it 'defaults to English Wikipedia' do


### PR DESCRIPTION
This shows the start and end times of courses in the user's local time zone, but still saves in UTC. The time zone abbreviation is also shown in the Details view, after the course is saved.

Bug: [T140306](https://phabricator.wikimedia.org/T140306)