### PR TITLE
Proof of concept for confirmation dialog

### DIFF
--- a/app/assets/javascripts/actions/confirm_actions.js
+++ b/app/assets/javascripts/actions/confirm_actions.js
@@ -1,0 +1,20 @@
+import McFly from 'mcfly';
+const Flux = new McFly();
+
+const ConfirmActions = Flux.createActions({
+  actionConfirmed() {
+    return {
+      actionType: 'ACTION_CONFIRMED',
+      data: {}
+    };
+  },
+
+  actionCancelled() {
+    return {
+      actionType: 'ACTION_CANCELLED',
+      data: {}
+    };
+  }
+});
+
+export default ConfirmActions;

--- a/app/assets/javascripts/actions/confirm_actions.js
+++ b/app/assets/javascripts/actions/confirm_actions.js
@@ -2,6 +2,13 @@ import McFly from 'mcfly';
 const Flux = new McFly();
 
 const ConfirmActions = Flux.createActions({
+  confirmationInitiated() {
+    return {
+      actionType: 'CONFIRMATION_INITIATED',
+      data: {}
+    };
+  },
+
   actionConfirmed() {
     return {
       actionType: 'ACTION_CONFIRMED',

--- a/app/assets/javascripts/components/common/confirm.jsx
+++ b/app/assets/javascripts/components/common/confirm.jsx
@@ -33,8 +33,8 @@ const Confirm = React.createClass({
           <br />
           <br />
           <div className="pop_container pull-right">
-            <button className="button ghost-button" onClick={this.onCancel}>Cancel</button>
-            <button className="button dark" onClick={this.onConfirm}>Yes</button>
+            <button className="button ghost-button" onClick={this.onCancel}>{I18n.t('application.cancel')}</button>
+            <button className="button dark" onClick={this.onConfirm}>{I18n.t('application.confirm')}</button>
           </div>
         </div>
       </Modal>

--- a/app/assets/javascripts/components/common/confirm.jsx
+++ b/app/assets/javascripts/components/common/confirm.jsx
@@ -34,7 +34,7 @@ const Confirm = React.createClass({
           <br />
           <div className="pop_container pull-right">
             <button className="button ghost-button" onClick={this.onCancel}>{I18n.t('application.cancel')}</button>
-            <button className="button dark" onClick={this.onConfirm}>{I18n.t('application.confirm')}</button>
+            <button autoFocus className="button dark" onClick={this.onConfirm}>{I18n.t('application.confirm')}</button>
           </div>
         </div>
       </Modal>

--- a/app/assets/javascripts/components/common/confirm.jsx
+++ b/app/assets/javascripts/components/common/confirm.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const Confirm = React.createClass({
+  displayName: 'Confirm',
+
+  propTypes: {
+    onConfirm: React.PropTypes.func,
+    onCancel: React.PropTypes.func
+  },
+
+  getInitialState() {
+    return { open: true };
+  },
+
+  onConfirm() {
+    this.setState({ open: false });
+    this.props.onConfirm();
+  },
+
+  onCancel() {
+    this.setState({ open: false });
+    this.props.onCancel();
+  },
+
+  render() {
+    if (!this.state.open) { return <div></div>; }
+    return (
+        <div className="modal wizard">
+          Are you sure?
+          <button className="button danger" onClick={this.onCancel}>Cancel</button>
+          <button className="button dark" onClick={this.onConfirm}>Yes</button>
+        </div>
+    );
+  }
+});
+
+export default Confirm;

--- a/app/assets/javascripts/components/common/confirm.jsx
+++ b/app/assets/javascripts/components/common/confirm.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import Modal from './modal.jsx';
 
 const Confirm = React.createClass({
   displayName: 'Confirm',
 
   propTypes: {
-    onConfirm: React.PropTypes.func,
-    onCancel: React.PropTypes.func
+    onConfirm: React.PropTypes.func.isRequired,
+    onCancel: React.PropTypes.func.isRequired,
+    message: React.PropTypes.string.isRequired
   },
 
   getInitialState() {
@@ -25,11 +27,17 @@ const Confirm = React.createClass({
   render() {
     if (!this.state.open) { return <div></div>; }
     return (
-        <div className="modal wizard">
-          Are you sure?
-          <button className="button danger" onClick={this.onCancel}>Cancel</button>
-          <button className="button dark" onClick={this.onConfirm}>Yes</button>
+      <Modal>
+        <div className="confirm-modal modal">
+          {this.props.message}
+          <br />
+          <br />
+          <div className="pop_container pull-right">
+            <button className="button ghost-button" onClick={this.onCancel}>Cancel</button>
+            <button className="button dark" onClick={this.onConfirm}>Yes</button>
+          </div>
         </div>
+      </Modal>
     );
   }
 });

--- a/app/assets/javascripts/components/common/confirm.jsx
+++ b/app/assets/javascripts/components/common/confirm.jsx
@@ -27,8 +27,8 @@ const Confirm = React.createClass({
   render() {
     if (!this.state.open) { return <div></div>; }
     return (
-      <Modal>
-        <div className="confirm-modal modal">
+      <Modal modalClass="confirm-modal-overlay">
+        <div className="confirm-modal">
           {this.props.message}
           <br />
           <br />

--- a/app/assets/javascripts/components/common/confirm.jsx
+++ b/app/assets/javascripts/components/common/confirm.jsx
@@ -10,22 +10,15 @@ const Confirm = React.createClass({
     message: React.PropTypes.string.isRequired
   },
 
-  getInitialState() {
-    return { open: true };
-  },
-
   onConfirm() {
-    this.setState({ open: false });
     this.props.onConfirm();
   },
 
   onCancel() {
-    this.setState({ open: false });
     this.props.onCancel();
   },
 
   render() {
-    if (!this.state.open) { return <div></div>; }
     return (
       <Modal modalClass="confirm-modal-overlay">
         <div className="confirm-modal">

--- a/app/assets/javascripts/components/students/assign_button.jsx
+++ b/app/assets/javascripts/components/students/assign_button.jsx
@@ -123,29 +123,36 @@ const AssignButton = React.createClass({
       return;
     }
 
+    const onConfirm = function () {
+      // Update the store
+      AssignmentActions.addAssignment(assignment);
+      // Post the new assignment to the server
+      ServerActions.addAssignment(assignment);
+      // Send the confirm signal
+      return ConfirmActions.actionConfirmed();
+    };
 
-    // Confirm
+    const onCancel = function () {
+      return ConfirmActions.actionCancelled();
+    };
+
+
+    let confirmMessage;
+
+    // Confirm for assigning an article to a student
     if (this.props.student) {
-      const onConfirm = function () {
-        // Update the store
-        AssignmentActions.addAssignment(assignment);
-        // Post the new assignment to the server
-        ServerActions.addAssignment(assignment);
-        // Send the confirm signal
-        return ConfirmActions.actionConfirmed();
-      };
-
-      const onCancel = function () {
-        return ConfirmActions.actionCancelled();
-      };
-
-      const confirmMessage = I18n.t('assignments.confirm_addition', {
+      confirmMessage = I18n.t('assignments.confirm_addition', {
         title: articleTitle,
         username: this.props.student.username
       });
-
-      this.setState({ onConfirm, onCancel, confirmMessage, showConfirm: true });
+    // Confirm for adding an unassigned available article
+    } else {
+      confirmMessage = I18n.t('assignments.confirm_add_available', {
+        title: articleTitle
+      });
     }
+
+    this.setState({ onConfirm, onCancel, confirmMessage, showConfirm: true });
   },
 
   unassign(assignment) {

--- a/app/assets/javascripts/components/students/assign_button.jsx
+++ b/app/assets/javascripts/components/students/assign_button.jsx
@@ -139,18 +139,12 @@ const AssignButton = React.createClass({
         return ConfirmActions.actionCancelled();
       };
 
-      this.setState({ onConfirm, onCancel, showConfirm: true });
+      const confirmMessage = I18n.t('assignments.confirm_addition', {
+        title: articleTitle,
+        username: this.props.student.username
+      });
 
-      // if (!confirm(I18n.t('assignments.confirm_addition', {
-      //   title: articleTitle,
-      //   username: this.props.student.username
-      // }))) { return; }
-    }
-
-    if (!this.props.student) {
-      if (!confirm(I18n.t('assignments.confirm_add_available', {
-        title: articleTitle
-      }))) { return; }
+      this.setState({ onConfirm, onCancel, confirmMessage, showConfirm: true });
     }
   },
 
@@ -166,7 +160,13 @@ const AssignButton = React.createClass({
   render() {
     let confirmationDialog;
     if (this.state.showConfirm) {
-      confirmationDialog = <Confirm onConfirm={this.state.onConfirm} onCancel={this.state.onCancel} />;
+      confirmationDialog = (
+        <Confirm
+          onConfirm={this.state.onConfirm}
+          onCancel={this.state.onCancel}
+          message={this.state.confirmMessage}
+        />
+      );
     }
 
     let className = 'button border small assign-button';

--- a/app/assets/javascripts/components/students/assign_button.jsx
+++ b/app/assets/javascripts/components/students/assign_button.jsx
@@ -131,14 +131,11 @@ const AssignButton = React.createClass({
       // Send the confirm signal
       return ConfirmActions.actionConfirmed();
     };
-
     const onCancel = function () {
       return ConfirmActions.actionCancelled();
     };
 
-
     let confirmMessage;
-
     // Confirm for assigning an article to a student
     if (this.props.student) {
       confirmMessage = I18n.t('assignments.confirm_addition', {

--- a/app/assets/javascripts/stores/confirmation_store.js
+++ b/app/assets/javascripts/stores/confirmation_store.js
@@ -1,0 +1,17 @@
+import McFly from 'mcfly';
+const Flux = new McFly();
+
+const ConfirmationStore = Flux.createStore({}, (payload) => {
+  switch (payload.actionType) {
+    case 'ACTION_CONFIRMED':
+      return ConfirmationStore.emitChange();
+    case 'ACTION_CANCELLED':
+      return ConfirmationStore.emitChange();
+    default:
+      // no default
+  }
+});
+
+ConfirmationStore.setMaxListeners(0);
+
+export default ConfirmationStore;

--- a/app/assets/javascripts/stores/confirmation_store.js
+++ b/app/assets/javascripts/stores/confirmation_store.js
@@ -1,11 +1,24 @@
 import McFly from 'mcfly';
 const Flux = new McFly();
 
-const ConfirmationStore = Flux.createStore({}, (payload) => {
+let _confirmationActive = false;
+
+const storeMethods = {
+  isConfirmationActive() {
+    return _confirmationActive;
+  }
+};
+
+const ConfirmationStore = Flux.createStore(storeMethods, (payload) => {
   switch (payload.actionType) {
+    case 'CONFIRMATION_INITIATED':
+      _confirmationActive = true;
+      return ConfirmationStore.emitChange();
     case 'ACTION_CONFIRMED':
+      _confirmationActive = false;
       return ConfirmationStore.emitChange();
     case 'ACTION_CANCELLED':
+      _confirmationActive = false;
       return ConfirmationStore.emitChange();
     default:
       // no default

--- a/app/assets/stylesheets/modules/_confirm_modal.styl
+++ b/app/assets/stylesheets/modules/_confirm_modal.styl
@@ -1,5 +1,5 @@
 .confirm-modal
-  background-color white
+  background white
   padding 10px
   position fixed
   margin auto
@@ -11,3 +11,6 @@
   border-radius 3px
   box-shadow 0 0 20px 0 rgba(0, 0, 0, .6)
   z-index 12
+
+.confirm-modal-overlay
+  background-color rgba(smoke, .4) !important

--- a/app/assets/stylesheets/modules/_confirm_modal.styl
+++ b/app/assets/stylesheets/modules/_confirm_modal.styl
@@ -1,0 +1,13 @@
+.confirm-modal
+  background-color white
+  padding 10px
+  position fixed
+  margin auto
+  left 0
+  right 0
+  top 40%
+  max-width 450px
+  border 1px solid mischka
+  border-radius 3px
+  box-shadow 0 0 20px 0 rgba(0, 0, 0, .6)
+  z-index 12

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,8 @@ en:
     training: Training
     change: Change
     details: Details
+    confirm: OK
+    cancel: Cancel
 
   dashboard:
     create_note:

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -283,6 +283,7 @@ describe 'the course page', type: :feature, js: true do
       click_button 'Add an available article'
       page.first(:css, '#available-articles .pop.open').first('input').set('Education')
       click_button 'Assign'
+      click_button 'OK'
       assigned_articles_table = page.first(:css, '#available-articles table.articles')
       expect(assigned_articles_table).to have_content 'Education'
     end

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -128,9 +128,8 @@ describe 'Instructor users', type: :feature, js: true do
       sleep 1
       page.all('button.border')[0].click
       within('#users') { first('input').set('Article 1') }
-      page.accept_confirm do
-        click_button 'Assign'
-      end
+      click_button 'Assign'
+      click_button 'OK'
       sleep 1
       page.first('button.border.assign-button').click
       sleep 1
@@ -138,9 +137,8 @@ describe 'Instructor users', type: :feature, js: true do
       # Assign a review
       page.all('button.border')[1].click
       within('#users') { first('input').set('Article 2') }
-      page.accept_confirm do
-        click_button 'Assign'
-      end
+      click_button 'Assign'
+      click_button 'OK'
       sleep 1
       page.all('button.border.assign-button')[0].click
       sleep 1

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -83,9 +83,9 @@ describe 'Instructor users', type: :feature, js: true do
       sleep 1
       click_button 'Enrollment'
       within('#users') { all('input')[1].set('Risker') }
-      page.accept_confirm do
-        click_button 'Enroll'
-      end
+      click_button 'Enroll'
+      click_button 'OK'
+
       expect(page).to have_content 'Risker was added successfully'
     end
 
@@ -95,9 +95,8 @@ describe 'Instructor users', type: :feature, js: true do
       sleep 1
       click_button 'Enrollment'
       within('#users') { all('input')[1].set('NotARealUser') }
-      page.accept_confirm do
-        click_button 'Enroll'
-      end
+      click_button 'Enroll'
+      click_button 'OK'
       expect(page).to have_content 'NotARealUser is not an existing user.'
     end
 
@@ -109,9 +108,9 @@ describe 'Instructor users', type: :feature, js: true do
       click_button 'Enrollment'
       sleep 1
       # Remove a user
-      page.accept_confirm do
-        page.all('button.border.plus')[1].click
-      end
+
+      page.all('button.border.plus')[1].click
+      click_button 'OK'
       sleep 1
 
       visit "/courses/#{Course.first.slug}/students"
@@ -168,9 +167,8 @@ describe 'Instructor users', type: :feature, js: true do
       visit "/courses/#{Course.first.slug}/students"
 
       click_button 'Enrollment'
-      page.accept_confirm do
-        page.first('button.border.plus').click
-      end
+      page.first('button.border.plus').click
+      click_button 'OK'
       sleep 1
       expect(page).not_to have_content 'Student A'
     end

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -25,9 +25,8 @@ describe 'multiwiki assignments', type: :feature, js: true do
       within('#users') do
         first('input').set('https://ta.wiktionary.org/wiki/%E0%AE%86%E0%AE%99%E0%AF%8D%E0%AE%95%E0%AE%BF%E0%AE%B2%E0%AE%AE%E0%AF%8D')
       end
-      page.accept_confirm do
-        click_button 'Assign'
-      end
+      click_button 'Assign'
+      click_button 'OK'
       visit "/courses/#{course.slug}/students"
 
       expect(page).to have_content 'ta:wiktionary:ஆங்கிலம்'
@@ -56,9 +55,8 @@ describe 'multiwiki assignments', type: :feature, js: true do
         first('.project-select .Select-option', text: 'wikibooks').click
       end
 
-      page.accept_confirm do
-        click_button 'Assign'
-      end
+      click_button 'Assign'
+      click_button 'OK'
 
       visit "/courses/#{course.slug}/students"
 

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -226,9 +226,8 @@ describe 'Student users', type: :feature, js: true do
       # Add an assigned article
       find('button.border', match: :first).click
       within('#users') { find('input', match: :first).set('Selfie') }
-      accept_confirm do
-        page.all('button.border')[1].click
-      end
+      page.all('button.border')[1].click
+      click_button 'OK'
       sleep 1
       page.all('button.border')[0].click
       sleep 1
@@ -252,9 +251,8 @@ describe 'Student users', type: :feature, js: true do
 
       page.all('button.border')[1].click
       within('#users') { find('input', match: :first).set('Self-portrait') }
-      accept_confirm do
-        page.all('button.border')[2].click
-      end
+      page.all('button.border')[2].click
+      click_button 'OK'
       page.all('button.border')[1].click
       expect(page).to have_content 'Self-portrait'
     end


### PR DESCRIPTION
@mattfordham I've taken a pass at a confirmation dialog.

Is this a bad way to do it? The idea here is to use the usual React data flow, so the state gets reset by sending an action, receiving it in a store, emitting a change signal, and then reseting the state from storeDidChange. This is overkill for the use case, since no data is being passed. But it doesn't introduce any new concepts or dependencies.