### PR TITLE
Prevent whitespace in slugs

### DIFF
--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -14,7 +14,7 @@ const CourseUtils = class {
   }
   slugify(text) {
     if (typeof text !== 'undefined' && text !== null) {
-      return text.split(' ').join('_');
+      return text.split(/\s/).join('_');
     }
   }
   cleanupCourseSlugComponents(course) {


### PR DESCRIPTION
[Bug T150068](https://phabricator.wikimedia.org/T150068), #985 

Prevents non-breaking spaces from slipping past the `slugify` function.