### PR TITLE
#1057: Fixed the html-escaped characters on course page titles

### DIFF
--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -1,7 +1,7 @@
 %meta{content: "width=device-width, initial-scale=1.0", name: "viewport"}
 - before = content_for?(:before_title) ? yield(:before_title) : ''
 - after = content_for?(:after_title) ? yield(:after_title) : ''
-%title= "#{before}#{ENV['dashboard_title']}#{after}"
+%title= raw "#{before}#{ENV['dashboard_title']}#{after}"
 = logo_favicon_tag
 %meta{content: ENV['meta_description'] || 'Wiki Dashboard', name: "description"}
 = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600', media: 'all'


### PR DESCRIPTION
With this pull request the issue #1057 will be fixed.