### PR TITLE
Add templated description for Campaigns, to be used on programs

### DIFF
--- a/app/assets/javascripts/stores/course_store.js
+++ b/app/assets/javascripts/stores/course_store.js
@@ -108,7 +108,10 @@ const CourseStore = Flux.createStore({
       break;
     case 'RECEIVE_INITIAL_CAMPAIGN':
       setCourse(
-        { initial_campaign_id: data.campaign.id });
+        {
+          initial_campaign_id: data.campaign.id,
+          description: data.campaign.template_description
+        });
       break;
     default:
       // no default

--- a/app/assets/stylesheets/modules/_campaign.styl
+++ b/app/assets/stylesheets/modules/_campaign.styl
@@ -52,3 +52,9 @@
 
   .wizard .right
     width: 100% !important
+
+  .campaign-template-description
+    .tooltip
+      color: white
+      font-size: 12px
+      min-width: 250px

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -170,6 +170,6 @@ class CampaignsController < ApplicationController
 
   def campaign_params
     params.require(:campaign)
-          .permit(:slug, :description, :title, :start, :end)
+          .permit(:slug, :description, :template_description, :title, :start, :end)
   end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -177,7 +177,7 @@ class CoursesController < ApplicationController
   def initial_campaign_params
     params
       .require(:course)
-      .permit(:initial_campaign_id)
+      .permit(:initial_campaign_id, :template_description)
   end
 
   def wiki_params

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -4,15 +4,16 @@ require 'csv'
 #
 # Table name: campaigns
 #
-#  id          :integer          not null, primary key
-#  title       :string(255)
-#  slug        :string(255)
-#  url         :string(255)
-#  created_at  :datetime
-#  updated_at  :datetime
-#  description :text(65535)
-#  start       :datetime
-#  end         :datetime
+#  id                   :integer          not null, primary key
+#  title                :string(255)
+#  slug                 :string(255)
+#  url                  :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  description          :text(65535)
+#  start                :datetime
+#  end                  :datetime
+#  template_description :text(65535)
 #
 
 #= Campaign model

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -109,3 +109,19 @@
         = form_for(@campaign, url: campaign_path(@campaign.slug), method: :delete, html: { class: 'campaign-delete', 'data-title' => @campaign.title }) do
           %button.button.danger
             = t('campaign.delete_campaign')
+
+      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
+        .section-header
+          %span.tooltip-trigger
+            %h3
+              = t('campaign.program_template')
+            .tooltip.dark
+              = t('campaign.program_template_tooltip')
+          .controls
+            - if @editable
+              %button.button.dark.rails_editable-edit
+                = t('editable.edit_description')
+        .module__data.rails_editable-field
+          %p.rails_editable-content
+            = @campaign.template_description
+          = text_area(:campaign, :template_description, class: 'rails_editable-input', maxlength: 65535)

--- a/app/views/campaigns/show.json.jbuilder
+++ b/app/views/campaigns/show.json.jbuilder
@@ -5,5 +5,6 @@ if @campaign
     json.title @campaign.title
     json.slug @campaign.slug
     json.description @campaign.description
+    json.template_description @campaign.template_description
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,6 +192,10 @@ en:
     organizer_added: '%{user} is now an organizer of the "%{title}" campaign'
     organizer_removed: '%{user} has been removed as an organizer of the "%{title}" campaign'
     programs: '%{title} Programs'
+    program_template: Program Template
+    program_template_tooltip: >
+      When an organizer creates a program in this campaign,
+      the text in this area will be copied over as a description on the program page
     title: Title
     use_start_end_dates: Use start and end dates
 

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -213,6 +213,10 @@ qqq:
     programs: |-
       The title of a campaign followed by an identical translation for 'Programs'
       {{Identical|Program}}
+    program_template: |-
+      Label for the field to enter a default description for a program.
+      A direct translation of 'Program template' should be suitable.
+    program_template_tooltip: Tooltip explaining what the 'program template' of a campaign is.
     title: |-
       Label for the input to change the title of a campaign
       {{Identical|Title}}

--- a/db/migrate/20161215213721_add_template_description_to_campaigns.rb
+++ b/db/migrate/20161215213721_add_template_description_to_campaigns.rb
@@ -1,0 +1,5 @@
+class AddTemplateDescriptionToCampaigns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :campaigns, :template_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161117211803) do
+ActiveRecord::Schema.define(version: 20161215213721) do
 
   create_table "alerts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "course_id"
@@ -90,9 +90,10 @@ ActiveRecord::Schema.define(version: 20161117211803) do
     t.string   "url"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "description", limit: 65535
+    t.text     "description",          limit: 65535
     t.datetime "start"
     t.datetime "end"
+    t.text     "template_description", limit: 65535
   end
 
   create_table "campaigns_courses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -74,9 +74,7 @@ class CourseCreationManager
     return unless Features.open_course_creation?
 
     if @initial_campaign_params.present?
-      parent_campaign = Campaign.find_by_id(@initial_campaign_params[:initial_campaign_id])
-      @overrides[:campaigns] = [parent_campaign]
-      @overrides[:description] = parent_campaign.template_description
+      @overrides[:campaigns] = [Campaign.find_by_id(@initial_campaign_params[:initial_campaign_id])]
     else
       @overrides[:campaigns] = [Campaign.default_campaign]
     end

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -74,7 +74,9 @@ class CourseCreationManager
     return unless Features.open_course_creation?
 
     if @initial_campaign_params.present?
-      @overrides[:campaigns] = [Campaign.find_by_id(@initial_campaign_params[:initial_campaign_id])]
+      parent_campaign = Campaign.find_by_id(@initial_campaign_params[:initial_campaign_id])
+      @overrides[:campaigns] = [parent_campaign]
+      @overrides[:description] = parent_campaign.template_description
     else
       @overrides[:campaigns] = [Campaign.default_campaign]
     end

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -3,15 +3,16 @@
 #
 # Table name: campaigns
 #
-#  id          :integer          not null, primary key
-#  title       :string(255)
-#  slug        :string(255)
-#  url         :string(255)
-#  created_at  :datetime
-#  updated_at  :datetime
-#  description :text(65535)
-#  start       :datetime
-#  end         :datetime
+#  id                   :integer          not null, primary key
+#  title                :string(255)
+#  slug                 :string(255)
+#  url                  :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  description          :text(65535)
+#  start                :datetime
+#  end                  :datetime
+#  template_description :text(65535)
 #
 
 FactoryGirl.define do

--- a/spec/features/campaign_overview_spec.rb
+++ b/spec/features/campaign_overview_spec.rb
@@ -16,7 +16,7 @@ describe 'campaign overview page', type: :feature, js: true do
     it 'should not show the edit buttons' do
       login_as(user, scope: user)
       visit "/campaigns/#{campaign.slug}"
-      expect(page).to have_no_css('.campaign-description .rails_editable-edit')
+      expect(page).to have_no_css('.rails_editable-edit')
       expect(page).to have_no_css('.campaign-create')
     end
   end

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -75,6 +75,6 @@ describe 'open course creation', type: :feature, js: true do
     sleep 1
     expect(CampaignsCourses.last.campaign_id).to eq(campaign.id)
     expect(CampaignsCourses.last.course_id).to eq(Course.last.id)
-    expect(Courses.last.description).to eq(campaign.template_description)
+    expect(Course.last.description).to eq(campaign.template_description)
   end
 end

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -15,7 +15,8 @@ describe 'open course creation', type: :feature, js: true do
     create(:campaign,
            id: 10001,
            title: 'My Awesome Campaign',
-           description: 'This is the best campaign')
+           description: 'This is the best campaign',
+           template_description: 'This is the template description')
   end
 
   before do
@@ -74,5 +75,6 @@ describe 'open course creation', type: :feature, js: true do
     sleep 1
     expect(CampaignsCourses.last.campaign_id).to eq(campaign.id)
     expect(CampaignsCourses.last.course_id).to eq(Course.last.id)
+    expect(Courses.last.description).to eq(campaign.template_description)
   end
 end

--- a/spec/fixtures/campaigns.yml
+++ b/spec/fixtures/campaigns.yml
@@ -2,15 +2,16 @@
 #
 # Table name: campaigns
 #
-#  id          :integer          not null, primary key
-#  title       :string(255)
-#  slug        :string(255)
-#  url         :string(255)
-#  created_at  :datetime
-#  updated_at  :datetime
-#  description :text(65535)
-#  start       :datetime
-#  end         :datetime
+#  id                   :integer          not null, primary key
+#  title                :string(255)
+#  slug                 :string(255)
+#  url                  :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  description          :text(65535)
+#  start                :datetime
+#  end                  :datetime
+#  template_description :text(65535)
 #
 
 default:

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -3,15 +3,16 @@
 #
 # Table name: campaigns
 #
-#  id          :integer          not null, primary key
-#  title       :string(255)
-#  slug        :string(255)
-#  url         :string(255)
-#  created_at  :datetime
-#  updated_at  :datetime
-#  description :text(65535)
-#  start       :datetime
-#  end         :datetime
+#  id                   :integer          not null, primary key
+#  title                :string(255)
+#  slug                 :string(255)
+#  url                  :string(255)
+#  created_at           :datetime
+#  updated_at           :datetime
+#  description          :text(65535)
+#  start                :datetime
+#  end                  :datetime
+#  template_description :text(65535)
 #
 
 require 'rails_helper'

--- a/spec/models/feedback_form_response_spec.rb
+++ b/spec/models/feedback_form_response_spec.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
+# == Schema Information
+#
+# Table name: feedback_form_responses
+#
+#  id         :integer          not null, primary key
+#  subject    :string(255)
+#  body       :text(65535)
+#  user_id    :integer
+#  created_at :datetime
+#
+
 require 'rails_helper'
 
 describe FeedbackFormResponse do


### PR DESCRIPTION
Does not add a field to enter the template description on campaign creation.

Some missing annotations

Bug: https://phabricator.wikimedia.org/T153362