### PR TITLE
Fix sandbox training for students

### DIFF
--- a/training_content/wiki_ed/slides/9-sandboxes/902-what-is-a-sandbox.yml
+++ b/training_content/wiki_ed/slides/9-sandboxes/902-what-is-a-sandbox.yml
@@ -3,7 +3,7 @@ title: "What's a sandbox?"
 summary:
 content: |
   A "sandbox" is your personal wiki page where you can practice editing, plan
-  out articles, draft articles, or just experiment, without impacting the
+  out work, draft articles, or just experiment, without impacting the
   article "mainspace” on Wikipedia—which is what we call live articles.
 
   To go to your default sandbox page, simply click the sandbox link, which can
@@ -15,4 +15,4 @@ content: |
   Anyone can still see your sandbox, so it's important that the content you put
   there isn't something you don't want people to see.
 
-  Don't copy and paste things there that might violate copyright rules.
+  Do not copy and paste things there that might violate copyright rules.

--- a/training_content/wiki_ed/slides/9-sandboxes/903-edit-an-existing-article.yml
+++ b/training_content/wiki_ed/slides/9-sandboxes/903-edit-an-existing-article.yml
@@ -2,13 +2,17 @@ id: 903
 title: Edit an existing article
 summary:
 content: |
-  If you're editing an existing article, a sandbox can be a good place to copy
-  and paste a few sentences or a paragraph to develop. Do not try and overhaul
-  an entire article from the sandbox.
+  If you're editing an existing article, a sandbox can be a good place to prepare your first updates
+  by copying a small portion of the article that you want to change or extend.
+  Do not try to overhaul an entire article from the sandbox.
 
-  Instead, small additions (paragraphs at most) from your sandbox while in the
-  "Edit" mode--references and other templates will break if you copy from the
-  sandbox without editing first.
+  1. Open the original article in **Edit** mode. (References and other templates will break if you copy from **Read** mode.)
+  2. Select the portion you want to work on — a few paragraphs at most — and copy it.
+  3. Open your sandbox in Edit mode and paste the copied article content, then save it.
+  4. Re-enter edit mode in your sandbox, make your changes, and save them.
+  5. When you're ready to move your small updates back into the article, use the same procedure in reverse: copy from your sandbox in **Edit** mode, and paste the updated content into the article.
+
+  Once you've gotten the hang of it you can make further edits directly in the article, or repeat the sandbox procedure one portion at a time.
   
   If you're working with a new article that you've created, and doesn't exist on
   Wikipedia already, you can "move" your sandbox page into mainspace. In the

--- a/training_content/wiki_ed/slides/9-sandboxes/903-edit-an-existing-article.yml
+++ b/training_content/wiki_ed/slides/9-sandboxes/903-edit-an-existing-article.yml
@@ -3,12 +3,13 @@ title: Edit an existing article
 summary:
 content: |
   If you're editing an existing article, a sandbox can be a good place to copy
-  and paste a few sentences or a paragraph to develop. Don't copy and paste the
-  entire article into your sandbox, however.
+  and paste a few sentences or a paragraph to develop. Do not try and overhaul
+  an entire article from the sandbox.
 
-  Instead, copy the paragraph or sentences you want to work with back into the
-  article, and then save the change.
-
+  Instead, small additions (paragraphs at most) from your sandbox while in the
+  "Edit" mode--references and other templates will break if you copy from the
+  sandbox without editing first.
+  
   If you're working with a new article that you've created, and doesn't exist on
   Wikipedia already, you can "move" your sandbox page into mainspace. In the
   next slides, we'll show you how. 

--- a/training_content/wiki_ed/slides/9-sandboxes/908-move-your-page.yml
+++ b/training_content/wiki_ed/slides/9-sandboxes/908-move-your-page.yml
@@ -4,7 +4,9 @@ summary:
 content: |
   The new page will say "Move page." In a big window in the center of that page
   (marked "Move page") you'll be asked for two fields.
-
+  <figure style="width: 100%;">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/2/2d/Page_move_dialog_closeup_with_example_fields.png" />
+  </figure>
   1. First, to the left, you'll see a box that says "User." Click and change it to "(Article)"
   This field is the "namespace". Be sure that it says "(Article)" and **not**
   "Wikipedia"

--- a/training_content/wiki_ed/slides/9-sandboxes/908-move-your-page.yml
+++ b/training_content/wiki_ed/slides/9-sandboxes/908-move-your-page.yml
@@ -5,9 +5,9 @@ content: |
   The new page will say "Move page." In a big window in the center of that page
   (marked "Move page") you'll be asked for two fields.
 
-  1. First, to the left, you'll see a box that says "User." Click and change it
-  to "Article." That tells the page that you want to change your sandbox into an
-  article.
+  1. First, to the left, you'll see a box that says "User." Click and change it to "(Article)"
+  This field is the "namespace". Be sure that it says "(Article)" and **not**
+  "Wikipedia"
   2. To the right of that, you'll see a box asking for a title. Write out your
   article's title. Pay attention to punctuation and spelling, because this can
   be hard to change once you make it!


### PR DESCRIPTION
Correct errors in sandbox training, inc:
* Correct article namespace
* Warn students about copying from edit mode