### PR TITLE
Speed up trainings load time

### DIFF
--- a/lib/training_progress_manager.rb
+++ b/lib/training_progress_manager.rb
@@ -11,6 +11,7 @@ class TrainingProgressManager
       training_module_id: @training_module&.id
     ) if @user.present?
     @due_date_manager = due_date_manager
+    @overall_due_date = @due_date_manager.overall_due_date
   end
 
   def slide_completed?
@@ -39,7 +40,7 @@ class TrainingProgressManager
   # where modules could belong to any number of courses
   def assignment_status_css_class
     return 'completed' if module_completed?
-    overall_due_date.present? && overall_due_date < Time.zone.today ? 'overdue' : nil
+    @overall_due_date.present? && @overall_due_date < Time.zone.today ? 'overdue' : nil
   end
   alias assignment_deadline_status assignment_status_css_class
 
@@ -53,7 +54,7 @@ class TrainingProgressManager
   # This is shown for the logged in user where the module is listed
   def assignment_status
     if @due_date_manager.blocks_with_module_assigned(@training_module).any?
-      parenthetical = "due #{overall_due_date}"
+      parenthetical = "due #{@overall_due_date}"
       return "Training Assignment (#{module_completed? ? 'completed' : parenthetical})"
     end
     return 'Completed' if module_completed?
@@ -73,10 +74,6 @@ class TrainingProgressManager
   end
 
   private
-
-  def overall_due_date
-    @due_date_manager.overall_due_date
-  end
 
   def due_date_manager
     TrainingModuleDueDateManager.new(course: nil, training_module: @training_module, user: @user)


### PR DESCRIPTION
Cut down trainings load time by half by caching `overall_due_date` variable.

#1008 