### PR TITLE
Make work on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'paper_trail'
 
 gem "paperclip"
 
+# TZ information is not available on Windows, needs to be installed separately
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+
 # If you want to be able to hack locally on rapidfire,
 # run `export RAPIDFIREHACKINGMODE=true` in your terminal.
 if ENV['RAPIDFIREHACKINGMODE'] == 'true'
@@ -87,7 +90,7 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails'
   gem 'rubocop', require: false
-  gem 'zeus'
+  gem 'zeus', platforms: :ruby # zeus doesn't work on Windows
   gem 'launchy'
   gem 'timecop'
   gem 'poltergeist'
@@ -110,3 +113,4 @@ group :production do
   gem 'uglifier'
   gem 'rails_12factor'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     arel (7.1.4)
     ast (2.3.0)
     bcrypt (3.1.11)
+    bcrypt (3.1.11-x64-mingw32)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -169,6 +170,7 @@ GEM
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.14)
+    ffi (1.9.14-x64-mingw32)
     figaro (1.1.1)
       thor (~> 0.14)
     formatador (0.2.5)
@@ -252,6 +254,7 @@ GEM
     multi_json (1.12.1)
     multipart-post (2.0.0)
     mysql2 (0.4.5)
+    mysql2 (0.4.5-x64-mingw32)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -260,6 +263,8 @@ GEM
     newrelic_rpm (3.17.1.326)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    nokogiri (1.6.8.1-x64-mingw32)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -362,6 +367,11 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rest-client (2.0.0-x64-mingw32)
+      ffi (~> 1.9)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -433,11 +443,14 @@ GEM
     timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2016.10)
+      tzinfo (>= 1.0.0)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unf_ext (0.0.7.2-x64-mingw32)
     unicode-display_width (1.1.2)
     validates_email_format_of (1.6.3)
       i18n
@@ -460,6 +473,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   activerecord-import
@@ -528,6 +542,7 @@ DEPENDENCIES
   simple_form
   simplecov
   timecop
+  tzinfo-data
   uglifier
   validates_email_format_of
   vcr
@@ -539,4 +554,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,8 +1,11 @@
 require 'raven'
 
+is_on_windows = (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+
 Raven.configure do |config|
   config.dsn = Figaro.env.sentry_dsn
   config.silence_ready = true
   config.environments = %w[development staging production]
-  config.logger = Logger.new("/dev/null")
+  config.logger = Logger.new("/dev/null") unless is_on_windows
+  config.logger = Logger.new("nul") if is_on_windows
 end


### PR DESCRIPTION
This makes the setup work on Windows. Changes:

 - Windows does not include time zone information, so added gem `tzinfo-data`
 - `zeus` is not supported on Windows
 - In the Raven initializer, `/dev/null` is replaced with `nul` on Windows

Together with #1121, fixes #1097.