### PR TITLE
Add custom titles for campaigns index and show pages

### DIFF
--- a/app/views/analytics/index.html.haml
+++ b/app/views/analytics/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :after_title do " - Analytics" end
+- content_for :after_title, ' - Analytics'
 %header.main-page
   .container
     %h1 Analytics Tools

--- a/app/views/article_finder/index.html.haml
+++ b/app/views/article_finder/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :after_title do " - Article Finder" end
+- content_for :after_title, ' - Article Finder'
 %header.main-page
   .container
     %h1= @title

--- a/app/views/article_finder/results.html.haml
+++ b/app/views/article_finder/results.html.haml
@@ -1,4 +1,4 @@
-- content_for :after_title do " - Article Finder" end
+- content_for :after_title, ' - Article Finder'
 %header.main-page
   .container
     %h1

--- a/app/views/campaigns/index.html.haml
+++ b/app/views/campaigns/index.html.haml
@@ -1,3 +1,5 @@
+- content_for :before_title, 'Campaigns — '
+
 = hot_javascript_tag 'campaigns'
 
 .container.dashboard

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -1,4 +1,7 @@
+- content_for :before_title, "#{@campaign.title} Overview  — "
+
 = render 'nav'
+
 = hot_javascript_tag 'campaigns'
 
 - if @campaign.errors.any?

--- a/app/views/campaigns/programs.html.haml
+++ b/app/views/campaigns/programs.html.haml
@@ -1,3 +1,5 @@
+- content_for :before_title, "#{@campaign.title} Programs — "
+
 = render 'nav'
 
 %header.main-page

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :after_title, " - " + t("application.my_dashboard")
+- content_for :after_title, " - #{t("application.my_dashboard")}"
 
 #react_root{data: {default_course_type: @pres.default_course_type,
                    course_string_prefix: Features.default_course_string_prefix,


### PR DESCRIPTION
Fixes #1108 

Tasks done:

- Add titles for campaigns index and show pages
- Clean up other `before_title` and `after_title` blocks to use single quotes wherever possible