### PR TITLE
Hide table if there are no feedback responses

### DIFF
--- a/app/views/feedback_form_responses/index.html.haml
+++ b/app/views/feedback_form_responses/index.html.haml
@@ -1,13 +1,16 @@
 .container
   %h1 Feedback Form Responses
 
-  %table.list-basic
-    %tr
-      %th Date/Time
-      %th Subject
-      %th Body
-    - @responses.each do |response|
+  - if @responses.empty?
+    %p= I18n.t 'feedback_form_responses.no_responses'
+  - else
+    %table.list-basic
       %tr
-        %td= response.created_at
-        %td= response.topic
-        %td= link_to response.body.truncate(100), "/feedback_form_responses/#{response.id}"
+        %th Date/Time
+        %th Subject
+        %th Body
+      - @responses.each do |response|
+        %tr
+          %td= response.created_at
+          %td= response.topic
+          %td= link_to response.body.truncate(200, separator: ' '), "/feedback_form_responses/#{response.id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,3 +799,6 @@ en:
       link: "Take Survey"
     follow_up:
       message: "This is a reminder about the survey for your course, %{course_title}. Feedback from this survey helps us to improve our support for Wikipedia assignments like yours."
+
+  feedback_form_responses:
+    no_responses: "There are no feedback responses yet."


### PR DESCRIPTION
- Show more of response body(200 characters) and use `' '` as a separator
- Hide table if there are no feedback responses

Fixes #1131 && #990