### PR TITLE
Use different view for editing vs. reading Campaign overview

### DIFF
--- a/app/assets/javascripts/utils/editable.js
+++ b/app/assets/javascripts/utils/editable.js
@@ -53,7 +53,7 @@ $(() => {
       $content.hide();
       $input.val(text);
       if ($input.prop('type') === 'textarea') {
-        $input.height(text ? $content.innerHeight() : 'auto');
+        $input.height('400px');
       }
       $input.show();
     });

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -3,12 +3,12 @@
 require "#{Rails.root}/lib/analytics/campaign_csv_builder"
 #= Controller for campaign data
 class CampaignsController < ApplicationController
-  layout 'admin', only: [:index, :create, :edit]
+  layout 'admin', only: [:index, :create]
   before_action :set_campaign, only: [:overview, :programs, :edit, :update, :destroy,
                                       :add_organizer, :remove_organizer, :remove_course]
   before_action :require_create_permissions, only: [:create]
   before_action :require_write_permissions, only: [:update, :destroy, :add_organizer,
-                                                   :remove_organizer, :remove_course]
+                                                   :remove_organizer, :remove_course, :edit]
 
   DETAILS_FIELDS = %w(title start end).freeze
 
@@ -46,11 +46,13 @@ class CampaignsController < ApplicationController
     @editable = current_user&.admin? || user_is_organizer?
   end
 
-  def programs
+  def edit
     set_presenter
   end
 
-  def edit; end
+  def programs
+    set_presenter
+  end
 
   def update
     if @campaign.update(campaign_params)

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -66,7 +66,7 @@ class CampaignsController < ApplicationController
       # used to show the Details form in 'edit mode'
       @open_details = (@campaign.errors.messages.keys & DETAILS_FIELDS).empty?
 
-      render :overview
+      render :edit
     end
   end
 

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -12,6 +12,7 @@ module CampaignHelper
   end
 
   def html_from_markdown(markdown)
+    return unless markdown
     converter = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
     raw converter.render(markdown)
   end

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -10,4 +10,9 @@ module CampaignHelper
       end
     end
   end
+
+  def html_from_markdown(markdown)
+    converter = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+    raw converter.render(markdown)
+  end
 end

--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -1,1 +1,120 @@
+- content_for :before_title, "#{@campaign.title} Overview  — "
+
 = render 'nav'
+
+= hot_javascript_tag 'campaigns'
+
+- if @campaign.errors.any?
+  .notice
+    %strong
+      = t('campaign.campaign_not_updated')
+    %ul
+      - @campaign.errors.messages.each do |_key, message|
+        %li
+          = message.first
+
+.container.campaign_main
+  %section.overview.container
+    = render 'courses/header_stats', presenter: @presenter
+    .primary
+      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-description rails_editable' }) do
+        .section-header
+          %h3
+            = succeed ':' do
+              = t('campaign.campaign')
+            = @campaign.title
+          .controls
+            %button.button.dark.rails_editable-edit
+              = t('editable.edit_description')
+        .module__data.rails_editable-field
+          %p.rails_editable-content
+            = @campaign.description
+          = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535)
+    .sidebar
+      .module.campaign-details.rails_editable{class: @open_details ? 'rails_editable-editing' : ''}
+        .section-header
+          %h3
+            = t('application.details')
+          .controls
+            %button.button.dark.rails_editable-edit
+              = t('editable.edit_details')
+        .module__data.extra-line-height
+          %div
+            %span.campaign-organizers
+              %strong
+                = succeed ':' do
+                  = t('campaign.organizers')
+              %span
+                = @campaign.organizers.collect(&:username).join(', ')
+              %span.pop__container
+                %button.button.border.plus +
+                .pop
+                  %table
+                    %tbody
+                      %tr.edit
+                        %td
+                          = form_for(@campaign, url: add_organizer_campaign_path(@campaign.slug), method: :put) do
+                            = text_field_tag(:username, '', { required: true, placeholder: t('users.username_placeholder') })
+                            %button.button.border.add-organizer-button Add organizer
+                      - @campaign.organizers.each do |organizer|
+                        %tr
+                          %td
+                            - if organizer.username == current_user&.username
+                              %span
+                                = organizer.username
+                            - else
+                              = form_for(@campaign, url: remove_organizer_campaign_path(@campaign.slug, id: organizer.id), html: { method: :put, class: 'remove-organizer-form', 'data-username' => organizer.username }) do
+                                %span
+                                  = organizer.username
+                                %button.button.border.plus -
+
+          = form_for(@campaign, url: campaign_path(@campaign.slug), html: { id: 'edit_campaign_details' }) do
+            .campaign-title.form-group.rails_editable-field
+              %label{for: 'campaign_title'}
+                = succeed ':' do
+                  = t('campaign.title')
+              %span.rails_editable-content
+                = @campaign.title
+              = text_field(:campaign, :title, required: true, class: 'rails_editable-input')
+
+            .campaign-use-dates.form-group.rails_editable-field
+              - use_dates = @campaign.start || @campaign.end
+              %label
+                = check_box_tag(:use_dates, '1', use_dates)
+                = t('campaign.use_start_end_dates')
+
+            .campaign-dates{class: use_dates ? '' : 'hidden'}
+              .campaign-start.form-group.rails_editable-field
+                %label{for: 'campaign_start'}
+                  = succeed ':' do
+                    = t('courses.creator.start_date')
+                %span.rails_editable-content
+                  = @campaign.start.try(:strftime, '%Y-%m-%d')
+                = date_field(:campaign, :start, placeholder: '2016-12-31', class: 'rails_editable-input')
+
+              .campaign-end.form-group.rails_editable-field
+                %label{for: 'campaign_end'}
+                  = succeed ':' do
+                    = t('courses.creator.end_date')
+                %span.rails_editable-content
+                  = @campaign.end.try(:strftime, '%Y-%m-%d')
+                = date_field(:campaign, :end, placeholder: '2016-12-31', class: 'rails_editable-input')
+
+      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
+        .section-header
+          %span.tooltip-trigger
+            %h3
+              = t('campaign.program_template')
+            .tooltip.dark
+              = t('campaign.program_template_tooltip')
+          .controls
+            %button.button.dark.rails_editable-edit
+              = t('editable.edit_description')
+        .module__data.rails_editable-field
+          %p.rails_editable-content
+            = @campaign.template_description
+          = text_area(:campaign, :template_description, class: 'rails_editable-input', maxlength: 65535)
+
+      = form_for(@campaign, url: campaign_path(@campaign.slug), method: :delete, html: { class: 'campaign-delete', 'data-title' => @campaign.title }) do
+        %button.button.danger
+          = t('campaign.delete_campaign')

--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -29,7 +29,7 @@
         .module__data.rails_editable-field
           %p.rails_editable-content
             = preserve @campaign.description
-          = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535, height: '60%')
+          = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535)
     .sidebar
       .module.campaign-details.rails_editable{class: @open_details ? 'rails_editable-editing' : ''}
         .section-header

--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -29,7 +29,7 @@
         .module__data.rails_editable-field
           %p.rails_editable-content
             = preserve @campaign.description
-          = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535)
+          = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535, height: '60%')
     .sidebar
       .module.campaign-details.rails_editable{class: @open_details ? 'rails_editable-editing' : ''}
         .section-header

--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -28,7 +28,7 @@
               = t('editable.edit_description')
         .module__data.rails_editable-field
           %p.rails_editable-content
-            = @campaign.description
+            = preserve @campaign.description
           = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535)
     .sidebar
       .module.campaign-details.rails_editable{class: @open_details ? 'rails_editable-editing' : ''}
@@ -112,7 +112,7 @@
               = t('editable.edit_description')
         .module__data.rails_editable-field
           %p.rails_editable-content
-            = @campaign.template_description
+            = preserve @campaign.template_description
           = text_area(:campaign, :template_description, class: 'rails_editable-input', maxlength: 65535)
 
       = form_for(@campaign, url: campaign_path(@campaign.slug), method: :delete, html: { class: 'campaign-delete', 'data-title' => @campaign.title }) do

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -23,10 +23,6 @@
             = succeed ':' do
               = t('campaign.campaign')
             = @campaign.title
-          .controls
-            - if @editable
-              %button.button.dark.rails_editable-edit
-                = t('editable.edit_description')
         .module__data.rails_editable-field
           %p.rails_editable-content
             = @campaign.description
@@ -37,17 +33,18 @@
           = hidden_field_tag(:campaign_slug, @campaign.slug)
           %button.button.dark
             = t('courses_generic.creator.create_short')
+      - if @editable
+        = form_tag('./edit', method: :get, class: 'campaign-create') do
+          = hidden_field_tag(:campaign_slug, @campaign.slug)
+          %button.button.dark
+            = t('campaigns.edit')
       .module.campaign-details.rails_editable{class: @open_details ? 'rails_editable-editing' : ''}
         .section-header
           %h3
             = t('application.details')
-          .controls
-            - if @editable
-              %button.button.dark.rails_editable-edit
-                = t('editable.edit_details')
         .module__data.extra-line-height
           %div
-            - if @editable || @campaign.organizers.any?
+            - if @campaign.organizers.any?
               %span.campaign-organizers
                 %strong
                   = succeed ':' do
@@ -108,12 +105,8 @@
                   = @campaign.end.try(:strftime, '%Y-%m-%d')
                 = date_field(:campaign, :end, placeholder: '2016-12-31', class: 'rails_editable-input')
 
-      - if @editable
-        = form_for(@campaign, url: campaign_path(@campaign.slug), method: :delete, html: { class: 'campaign-delete', 'data-title' => @campaign.title }) do
-          %button.button.danger
-            = t('campaign.delete_campaign')
 
-      - if @editable || @campaign.template_description.present?
+      - if @campaign.template_description.present?
         = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
           .section-header
             %span.tooltip-trigger
@@ -121,10 +114,6 @@
                 = t('campaign.program_template')
               .tooltip.dark
                 = t('campaign.program_template_tooltip')
-            .controls
-              - if @editable
-                %button.button.dark.rails_editable-edit
-                  = t('editable.edit_description')
           .module__data.rails_editable-field
             %p.rails_editable-content
               = @campaign.template_description

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -25,8 +25,7 @@
             = @campaign.title
         .module__data.rails_editable-field
           %p.rails_editable-content
-            = @campaign.description
-          = text_area(:campaign, :description, class: 'rails_editable-input', required: true, maxlength: 65535)
+            = html_from_markdown @campaign.description
     .sidebar
       - if current_user && (Features.open_course_creation? || current_user&.admin?)
         = form_tag(course_creator_path, method: :get, enforce_utf8: false, class: 'campaign-create') do
@@ -80,7 +79,6 @@
                   = t('campaign.title')
               %span.rails_editable-content
                 = @campaign.title
-              = text_field(:campaign, :title, required: true, class: 'rails_editable-input')
 
             .campaign-use-dates.form-group.rails_editable-field
               - use_dates = @campaign.start || @campaign.end
@@ -95,7 +93,6 @@
                     = t('courses.creator.start_date')
                 %span.rails_editable-content
                   = @campaign.start.try(:strftime, '%Y-%m-%d')
-                = date_field(:campaign, :start, placeholder: '2016-12-31', class: 'rails_editable-input')
 
               .campaign-end.form-group.rails_editable-field
                 %label{for: 'campaign_end'}
@@ -103,8 +100,6 @@
                     = t('courses.creator.end_date')
                 %span.rails_editable-content
                   = @campaign.end.try(:strftime, '%Y-%m-%d')
-                = date_field(:campaign, :end, placeholder: '2016-12-31', class: 'rails_editable-input')
-
 
       - if @campaign.template_description.present?
         = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
@@ -116,5 +111,4 @@
                 = t('campaign.program_template_tooltip')
           .module__data.rails_editable-field
             %p.rails_editable-content
-              = @campaign.template_description
-            = text_area(:campaign, :template_description, class: 'rails_editable-input', maxlength: 65535)
+              = html_from_markdown @campaign.template_description

--- a/spec/features/campaign_overview_spec.rb
+++ b/spec/features/campaign_overview_spec.rb
@@ -193,14 +193,14 @@ describe 'campaign overview page', type: :feature, js: true do
           find('#campaign_start', visible: true)
         end
 
-        it 'shows an error for invalid dates', focus: true do
+        it 'shows an error for invalid dates' do
           find('.campaign-details .rails_editable-edit').click
           find('#use_dates').click
           fill_in('campaign_start', with: '2016-01-10')
           fill_in('campaign_end', with: 'Invalid date')
           find('.campaign-details .rails_editable-save').click
           expect(page).to have_content(I18n.t('error.invalid_date', key: 'End'))
-          find('#campaign_end', visible: true) # field with the error should be visible
+          find('.campaign-end', visible: true) # field with the error should be visible
         end
 
         it "updates the date fields properly, and to nil if the 'Use start and end dates' become unchecked" do
@@ -211,11 +211,12 @@ describe 'campaign overview page', type: :feature, js: true do
           find('.campaign-details .rails_editable-save').click
           expect(campaign.reload.start).to eq(DateTime.civil(2016, 1, 10, 0, 0, 0))
           expect(campaign.end).to eq(DateTime.civil(2016, 2, 10, 23, 59, 59))
+          click_button 'Edit'
           find('.campaign-details .rails_editable-edit').click
           find('#use_dates').click # uncheck
           find('#campaign_start', visible: false)
           find('.campaign-details .rails_editable-save').click
-          find('#campaign_start', visible: false)
+          find('.campaign-start', visible: false)
           expect(campaign.reload.start).to be_nil
           expect(campaign.end).to be_nil
         end

--- a/spec/features/campaign_overview_spec.rb
+++ b/spec/features/campaign_overview_spec.rb
@@ -200,7 +200,7 @@ describe 'campaign overview page', type: :feature, js: true do
           fill_in('campaign_end', with: 'Invalid date')
           find('.campaign-details .rails_editable-save').click
           expect(page).to have_content(I18n.t('error.invalid_date', key: 'End'))
-          find('.campaign-end', visible: true) # field with the error should be visible
+          find('#campaign_end', visible: true) # field with the error should be visible
         end
 
         it "updates the date fields properly, and to nil if the 'Use start and end dates' become unchecked" do

--- a/spec/features/campaign_overview_spec.rb
+++ b/spec/features/campaign_overview_spec.rb
@@ -140,7 +140,7 @@ describe 'campaign overview page', type: :feature, js: true do
       create(:campaigns_user, user_id: user.id, campaign_id: campaign.id,
                               role: CampaignsUsers::Roles::ORGANIZER_ROLE)
       login_as(user, scope: :user)
-      visit "/campaigns/#{campaign.slug}/overview"
+      visit "/campaigns/#{campaign.slug}/edit"
     end
 
     describe 'campaign description' do
@@ -193,7 +193,7 @@ describe 'campaign overview page', type: :feature, js: true do
           find('#campaign_start', visible: true)
         end
 
-        it 'shows an error for invalid dates' do
+        it 'shows an error for invalid dates', focus: true do
           find('.campaign-details .rails_editable-edit').click
           find('#use_dates').click
           fill_in('campaign_start', with: '2016-01-10')


### PR DESCRIPTION
This makes it easier to fix issues with text formatting. The 'Edit' and 'View' modes were already moderately different, and likely to diverge further.

Resolves #1127