### PR TITLE
Minor setup edits (setup.md and .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ npm-debug.log.*
 Session.vim
 1
 .byebug_history
+.ruby-gemset

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -59,7 +59,8 @@
         - OSX: `brew install mysql`
         - Windows: Install [XAMPP](https://www.apachefriends.org/index.html)
     - Start a mysql command line:
-        - OSX/Debian: `sudo mysql`
+        - Debian: `sudo mysql`
+        - OSX: `mysql.server start` then `sudo mysql`
         - Windows: `C:\xampp\mysql\bin\mysql -u root`
     - `CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
     - `CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
@@ -97,6 +98,10 @@
     you may need to start it manually.
 
       $ `redis-server`
+
+      OR, if you used homebrew to install redis:
+
+      $ `redis-server /usr/local/etc/redis.conf`
 
 3. **Start the server**
 


### PR DESCRIPTION
Adds `.ruby-gemset` to `.gitignore`, in case you're an rvm gemset user.

Modifies `docs/setup.md` slightly to reflect OSX install of mysql & redis.
- Specifically instructs to run `mysql.server start` before `sudo mysql`
- instructs w/redis config file parameter, if user used homebrew to install redis:`redis-server /usr/local/etc/redis.conf`