### PR TITLE
Initial Salesforce integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem "paperclip"
 # TZ information is not available on Windows, needs to be installed separately
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 
+gem 'restforce', git: 'https://github.com/ejholmes/restforce.git'
+
 # If you want to be able to hack locally on rapidfire,
 # run `export RAPIDFIREHACKINGMODE=true` in your terminal.
 if ENV['RAPIDFIREHACKINGMODE'] == 'true'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,16 @@ GIT
       rails (>= 3.2.13)
 
 GIT
+  remote: https://github.com/ejholmes/restforce.git
+  revision: 19d70d87fcb33814dabf3d5f6b2ba3737dff2c26
+  specs:
+    restforce (2.5.0)
+      faraday (>= 0.9.0, <= 1.0)
+      faraday_middleware (>= 0.8.8, <= 1.0)
+      hashie (>= 1.2.0, < 4.0)
+      json (>= 1.7.5)
+
+GIT
   remote: https://github.com/halfdan/piwik-ruby-tracking.git
   revision: 34a3d3c8d25fa3323f054d887c64a7e249b07e58
   specs:
@@ -533,6 +543,7 @@ DEPENDENCIES
   rb-fsevent
   rb-inotify
   redcarpet
+  restforce!
   rspec-rails
   rubocop
   sentimental

--- a/app/assets/javascripts/actions/server_actions.js
+++ b/app/assets/javascripts/actions/server_actions.js
@@ -210,6 +210,12 @@ const ServerActions = Flux.createActions({
       .catch(resp => ({ actionType: 'API_FAIL', data: resp }));
   },
 
+  linkToSalesforce(courseId, salesforceId) {
+    return API.linkToSalesforce(courseId, salesforceId)
+      .then(resp => ({ actionType: 'LINKED_TO_SALESFORCE', data: resp }))
+      .catch(resp => ({ actionType: 'API_FAIL', data: resp }));
+  },
+
   notifyOverdue(courseId) {
     return API.notifyOverdue(courseId)
       .then(resp => ({ actionType: 'NOTIFIED_OVERDUE', data: resp }))

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -7,6 +7,7 @@ import CourseDateUtils from '../../utils/course_date_utils.js';
 import Confirm from '../common/confirm.jsx';
 import ConfirmActions from '../../actions/confirm_actions.js';
 import ConfirmationStore from '../../stores/confirmation_store.js';
+import SalesforceLink from './salesforce_link.jsx';
 
 const getState = () => ({ course: CourseStore.getCourse() });
 
@@ -142,6 +143,7 @@ const AvailableActions = React.createClass({
         <div className="module__data">
           {confirmationDialog}
           {controls}
+          <SalesforceLink course={this.state.course} current_user={this.props.current_user} />
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -5,7 +5,6 @@ import CampaignButton from './campaign_button.jsx';
 import TagButton from './tag_button.jsx';
 import CourseTypeSelector from './course_type_selector.jsx';
 import SubmittedSelector from './submitted_selector.jsx';
-import SalesforceLink from './salesforce_link.jsx';
 
 import Editable from '../high_order/editable.jsx';
 import TextInput from '../common/text_input.jsx';
@@ -281,7 +280,6 @@ const Details = React.createClass({
           {tags}
           {courseTypeSelector}
           {submittedSelector}
-          <SalesforceLink course={this.props.course} current_user={this.props.current_user} />
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -5,6 +5,7 @@ import CampaignButton from './campaign_button.jsx';
 import TagButton from './tag_button.jsx';
 import CourseTypeSelector from './course_type_selector.jsx';
 import SubmittedSelector from './submitted_selector.jsx';
+import SalesforceLink from './salesforce_link.jsx';
 
 import Editable from '../high_order/editable.jsx';
 import TextInput from '../common/text_input.jsx';
@@ -280,6 +281,7 @@ const Details = React.createClass({
           {tags}
           {courseTypeSelector}
           {submittedSelector}
+          <SalesforceLink course={this.props.course} current_user={this.props.current_user} />
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/overview/salesforce_link.jsx
+++ b/app/assets/javascripts/components/overview/salesforce_link.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const SalesforceLink = React.createClass({
+  propTypes: {
+    course: React.PropTypes.object,
+    current_user: React.PropTypes.object
+  },
+
+  render() {
+    // Render nothing if user isn't an admin or course lacks a Salesforce ID.
+    if (!this.props.current_user.admin || !this.props.course.flags.salesforce_id) {
+      return <div />;
+    }
+    const link = SalesforceServer + this.props.course.flags.salesforce_id;
+    return (
+      <div><a href={link} target="_blank">Salesforce record</a></div>
+    );
+  }
+});
+
+export default SalesforceLink;

--- a/app/assets/javascripts/components/overview/salesforce_link.jsx
+++ b/app/assets/javascripts/components/overview/salesforce_link.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ServerActions from '../../actions/server_actions.js';
 
 const SalesforceLink = React.createClass({
   propTypes: {
@@ -6,14 +7,29 @@ const SalesforceLink = React.createClass({
     current_user: React.PropTypes.object
   },
 
+  linkToSalesforce() {
+    const rawSalesforceId = prompt('Enter the Salesforce record ID or url for this course.');
+    // Salesforce URLs may look like this: https://cs54.salesforce.com/c1f1f010013YOsu?srPos=2&srKp=a0f
+    // We must remove both the server and the query string to extract the ID.
+    const salesforceId = rawSalesforceId.replace(SalesforceServer, '').replace(/\?.*/, '');
+    ServerActions.linkToSalesforce(this.props.course.id, salesforceId);
+  },
+
   render() {
-    // Render nothing if user isn't an admin or course lacks a Salesforce ID.
-    if (!this.props.current_user.admin || !this.props.course.flags.salesforce_id) {
+    // Render nothing if user isn't an admin, or if Salesforce isn't configured
+    if (!this.props.current_user.admin || !SalesforceServer) {
       return <div />;
     }
-    const link = SalesforceServer + this.props.course.flags.salesforce_id;
+    // If Salesforce ID is present, show the admin a link to Salesforce
+    if (this.props.course.flags.salesforce_id) {
+      const link = SalesforceServer + this.props.course.flags.salesforce_id;
+      return (
+        <p key="join"><a href={link} className="button" target="_blank">Open in Salesforce</a></p>
+      );
+    }
+    // If no Salesforce ID is present, show the "Link to Salesforce" buttton
     return (
-      <div><a href={link} target="_blank">Salesforce record</a></div>
+      <p key="join"><button onClick={this.linkToSalesforce} className="button">Link to Salesforce</button></p>
     );
   }
 });

--- a/app/assets/javascripts/stores/course_store.js
+++ b/app/assets/javascripts/stores/course_store.js
@@ -119,6 +119,11 @@ const CourseStore = Flux.createStore({
         { flags: { enable_chat: true } }
       );
       break;
+    case 'LINKED_TO_SALESFORCE':
+      setCourse(
+        { flags: data.flags }
+      );
+      break;
     default:
       // no default
   }

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -679,7 +679,6 @@ slide_id=${opts.slide_id}`,
   },
 
   linkToSalesforce(courseId, salesforceId) {
-    console.log(salesforceId);
     return new Promise((res, rej) =>
       $.ajax({
         type: 'PUT',

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -676,6 +676,23 @@ slide_id=${opts.slide_id}`,
         return rej(obj);
       })
     );
+  },
+
+  linkToSalesforce(courseId, salesforceId) {
+    console.log(salesforceId);
+    return new Promise((res, rej) =>
+      $.ajax({
+        type: 'PUT',
+        url: `/salesforce/link/${courseId}.json?salesforce_id=${salesforceId}`,
+        success(data) {
+          return res(data);
+        }
+      })
+      .fail((obj) => {
+        logErrorMessage(obj);
+        return rej(obj);
+      })
+    );
   }
 };
 

--- a/app/controllers/salesforce_controller.rb
+++ b/app/controllers/salesforce_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class SalesforceController < ApplicationController
+  respond_to :json
+  before_action :require_admin_permissions
+
+  def link
+    validate_salesforce_id
+    @course = Course.find(params[:course_id])
+    @course.flags[:salesforce_id] = params[:salesforce_id]
+    @course.save
+    render json: { success: true, flags: @course.flags }
+  end
+
+  private
+
+  # Valid Salesforce IDs are either 15 or 18 characters.
+  VALID_SALESFORCE_ID_SIZES = [15, 18].freeze
+  def validate_salesforce_id
+    return if VALID_SALESFORCE_ID_SIZES.include? params[:salesforce_id].size
+    raise InvalidSalesforceIdError
+  end
+
+  class InvalidSalesforceIdError < StandardError; end
+end

--- a/app/services/push_course_to_salesforce.rb
+++ b/app/services/push_course_to_salesforce.rb
@@ -7,21 +7,48 @@ class PushCourseToSalesforce
   def initialize(course)
     return unless Features.wiki_ed?
     @course = course
+    @salesforce_id = @course.flags[:salesforce_id]
     @client = Restforce.new
-    create_salesforce_record
+    push
   end
 
   private
 
+  def push
+    if @salesforce_id
+      update_salesforce_record
+    else
+      create_salesforce_record
+    end
+  end
+
   def create_salesforce_record
-    @result = @client.create('Course__c', course_salesforce_fields)
+    # :create returns the Salesforce id of the new record
+    @salesforce_id = @client.create!('Course__c', course_salesforce_fields)
+    @course.flags[:salesforce_id] = @salesforce_id
+    @course.save
+    @result = @salesforce_id
+  end
+
+  def update_salesforce_record
+    @result = @client.update!('Course__c', { Id: @salesforce_id }.merge(course_salesforce_fields))
   end
 
   def course_salesforce_fields
     {
       Name: @course.title,
       Course_Page__c: @course.url,
-      Course_Dashboard__c: "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
+      Course_Dashboard__c: "https://#{ENV['dashboard_url']}/courses/#{@course.slug}",
+      Program__c: program_id
     }
+  end
+
+  def program_id
+    case @course.type
+    when 'ClassroomProgramCourse'
+      ENV['SF_CLASSROOM_PROGRAM_ID']
+    when 'VisitingScholarship'
+      ENV['SF_VISITING_SCHOLARS_PROGRAM_ID']
+    end
   end
 end

--- a/app/services/push_course_to_salesforce.rb
+++ b/app/services/push_course_to_salesforce.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "#{Rails.root}/lib/word_count"
 
 #= Enables chat features for a course and adds all participants to course chat channel
 class PushCourseToSalesforce
@@ -39,7 +40,12 @@ class PushCourseToSalesforce
       Name: @course.title,
       Course_Page__c: @course.url,
       Course_Dashboard__c: "https://#{ENV['dashboard_url']}/courses/#{@course.slug}",
-      Program__c: program_id
+      Program__c: program_id,
+      Estimated_No_of_Participants__c: @course.expected_students,
+      Articles_edited__c: @course.article_count,
+      Total_edits__c: @course.revision_count,
+      Words_added_in_thousands__c: words_added_in_thousands,
+      Actual_No_of_Participants__c: @course.user_count
     }
   end
 
@@ -50,5 +56,9 @@ class PushCourseToSalesforce
     when 'VisitingScholarship'
       ENV['SF_VISITING_SCHOLARS_PROGRAM_ID']
     end
+  end
+
+  def words_added_in_thousands
+    WordCount.from_characters(@course.character_sum).to_f / 1000
   end
 end

--- a/app/services/push_course_to_salesforce.rb
+++ b/app/services/push_course_to_salesforce.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#= Enables chat features for a course and adds all participants to course chat channel
+class PushCourseToSalesforce
+  attr_reader :result
+
+  def initialize(course)
+    return unless Features.wiki_ed?
+    @course = course
+    @client = Restforce.new
+    create_salesforce_record
+  end
+
+  private
+
+  def create_salesforce_record
+    @result = @client.create('Course__c', course_salesforce_fields)
+  end
+
+  def course_salesforce_fields
+    {
+      Name: @course.title,
+      Course_Page__c: @course.url,
+      Course_Dashboard__c: "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
+    }
+  end
+end

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -31,6 +31,7 @@
   WikiLanguages = #{Wiki::LANGUAGES}
 
   SentryDsn = "#{ENV['sentry_public_dsn']}"
+  SalesforceServer = "#{ENV['SF_SERVER']}"
 
 - unless ENV['DISABLE_SENTRY']
   = hot_javascript_tag("raven")

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,7 @@ ENV['enable_chat'] = 'true'
 ENV['chat_admin_username'] = 'username'
 ENV['chat_admin_password'] = 'password'
 ENV['chat_server'] = 'https://dashboardchat.wmflabs.org'
+ENV['SF_SERVER'] = 'https://cs54.salesforce.com/'
 
 Rails.application.configure do
   # Settings specified here will take

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,11 @@ Rails.application.routes.draw do
     put '/chat/enable_for_course/:course_id' => 'chat#enable_for_course'
   end
 
+  # Salesforce
+  if true # Features.wiki_ed?
+    put '/salesforce/link/:course_id' => 'salesforce#link'
+  end
+
   resources :admin
   resources :alerts_list
 

--- a/docs/salesforce_scripts/connect_courses_to_salesforce.rb
+++ b/docs/salesforce_scripts/connect_courses_to_salesforce.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ConnectCoursesToSalesforce
+  def initialize(dry_run: false)
+    @dry_run = dry_run
+    @client = Restforce.new
+    @courses = Course.all.select { |course| course.flags[:salesforce_id].nil? }
+  end
+
+  def call
+    @courses.each do |course|
+      matching_record = find_matching_salesforce_record(course)
+      next if matching_record.blank?
+      course.flags[:salesforce_id] = matching_record.Id
+      if @dry_run
+        puts course.slug
+      else
+        puts course.slug
+        course.save
+      end
+    end
+  end
+
+  def find_matching_salesforce_record(course)
+    search_results = search_salesforce_for(course)
+    search_results.searchRecords.find do |record|
+      includes_course_slug?(record, course.slug)
+    end
+  end
+
+  def search_salesforce_for(course)
+    # some characters are not allowed in Salesforce queries, including colon, dash, apostrophe
+    sanitized_title = course.title.gsub(/[:\-\']/, '')
+    @client.search('FIND {' + sanitized_title + '} RETURNING Course__c (Course_Dashboard__c, Id)')
+  end
+
+  def includes_course_slug?(record, slug)
+    record_url = record.Course_Dashboard__c
+    return false unless record_url
+    return true if record_url.include? slug
+    return true if record_url.include? CGI.escape(slug).gsub('%2F', '/')
+    false
+  end
+end

--- a/spec/controllers/salesforce_controller_spec.rb
+++ b/spec/controllers/salesforce_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe SalesforceController do
+  let(:course) { create(:course) }
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+
+  describe '#link' do
+    context 'when user is an admin' do
+      before { allow(controller).to receive(:current_user).and_return(admin) }
+
+      it 'saves a valid Salesforce ID on the course' do
+        put :link, params: { course_id: course.id, salesforce_id: 'a0f1a000001Wyar' }
+        expect(course.reload.flags[:salesforce_id]).to eq('a0f1a000001Wyar')
+      end
+
+      it 'raises an error for an invalid Salesforce ID' do
+        expect { put :link, params: { course_id: course.id, salesforce_id: '1234' } }
+          .to raise_error(SalesforceController::InvalidSalesforceIdError)
+      end
+    end
+
+    context 'when user is not an admin' do
+      before { allow(controller).to receive(:current_user).and_return(user) }
+      it 'does not allow the action' do
+        put :link, params: { course_id: course.id, salesforce_id: 'a0f1a000001Wyar' }
+        expect(response.code).to eq('401')
+      end
+    end
+  end
+end

--- a/spec/features/admin_role_spec.rb
+++ b/spec/features/admin_role_spec.rb
@@ -160,6 +160,18 @@ describe 'Admin users', type: :feature, js: true do
     end
   end
 
+  describe 'linking a course to its Salesforce record' do
+    it 'makes the Link to Salesforce button appear' do
+      stub_token_request
+      visit "/courses/#{Course.first.slug}"
+      accept_prompt(with: 'https://cs54.salesforce.com/a0f1a011101Xyas?foo=bar') do
+        click_button 'Link to Salesforce'
+      end
+      expect(page).to have_content 'Open in Salesforce'
+      expect(Course.first.flags[:salesforce_id]).to eq('a0f1a011101Xyas')
+    end
+  end
+
   after do
     logout
   end

--- a/spec/services/push_course_to_salesforce_spec.rb
+++ b/spec/services/push_course_to_salesforce_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe PushCourseToSalesforce do
+  let(:course) { create(:course, flags: flags) }
+  let(:subject) { described_class.new(course) }
+  let(:salesforce_id) { 'a2qQ0101015h4HF' }
+
+  context 'when a course has a Salesforce record already' do
+    let(:flags) { { salesforce_id: salesforce_id } }
+    it 'updates the record' do
+      expect_any_instance_of(Restforce::Data::Client).to receive(:update!).and_return(true)
+      expect(subject.result).to eq(true)
+    end
+  end
+
+  context 'when a course does not have a Salesforce record' do
+    let(:flags) { {} }
+    it 'creates the record and saves the ID as a course flag' do
+      expect_any_instance_of(Restforce::Data::Client).to receive(:create!).and_return(salesforce_id)
+      expect(subject.result).to eq(salesforce_id)
+      expect(course.reload.flags[:salesforce_id]).to eq(salesforce_id)
+    end
+  end
+end


### PR DESCRIPTION
So far this provides a service for pushing course data to Salesforce (either as new records or updating existing ones) but it does not use that service anywhere.

It also provides a way to add the Salesforce ID for a course and links to the Salesforce record of courses that have such IDs.

Next steps include automatically pushing data to Salesforce, both during linking and regularly during the update cycle (and possibly manually as well).