### PR TITLE
Add method for admins to create Salesforce media records

### DIFF
--- a/app/assets/javascripts/components/articles/article_drawer.jsx
+++ b/app/assets/javascripts/components/articles/article_drawer.jsx
@@ -12,7 +12,9 @@ const ArticleDrawer = React.createClass({
 
   propTypes: {
     article: React.PropTypes.object,
-    is_open: React.PropTypes.bool
+    is_open: React.PropTypes.bool,
+    current_user: React.PropTypes.object,
+    course: React.PropTypes.object
   },
 
   mixins: [ArticleDetailsStore.mixin],
@@ -41,12 +43,17 @@ const ArticleDrawer = React.createClass({
 
     let diffViewer;
     if (this.state.articleDetails.first_revision) {
+      const showSalesforceButton = Boolean(Features.wikiEd && this.props.current_user.admin);
       diffViewer = (
         <DiffViewer
           revision={this.state.articleDetails.last_revision}
           first_revision={this.state.articleDetails.first_revision}
           showButtonLabel={I18n.t('articles.show_cumulative_changes')}
           largeButton={true}
+          editors={this.state.articleDetails.editors}
+          showSalesforceButton={showSalesforceButton}
+          course={this.props.course}
+          article={this.props.article}
         />
       );
     } else {

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -19,7 +19,8 @@ const ArticleList = React.createClass({
 
   propTypes: {
     articles: React.PropTypes.array,
-    course: React.PropTypes.object
+    course: React.PropTypes.object,
+    current_user: React.PropTypes.object
   },
 
   render() {
@@ -34,6 +35,7 @@ const ArticleList = React.createClass({
           course={this.props.course}
           key={`${article.id}_drawer`}
           ref={`${article.id}_drawer`}
+          current_user={this.props.current_user}
         />
       );
     });

--- a/app/assets/javascripts/components/articles/salesforce_media_buttons.jsx
+++ b/app/assets/javascripts/components/articles/salesforce_media_buttons.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const SalesforceMediaButtons = React.createClass({
+  displayName: 'SalesforceMediaButtons',
+
+  propTypes: {
+    article: React.PropTypes.object,
+    course: React.PropTypes.object,
+    editors: React.PropTypes.array,
+    before_rev_id: React.PropTypes.number,
+    after_rev_id: React.PropTypes.number
+  },
+
+  render() {
+    const salesforceMediaUrlRoot = '/salesforce/create_media?';
+    const courseParam = `course_id=${this.props.course.id}`;
+    const articleParam = `&article_id=${this.props.article.id}`;
+    const diffParams = `&before_rev_id=${this.props.before_rev_id}&after_rev_id=${this.props.after_rev_id}`;
+    const urlWithoutUsername = salesforceMediaUrlRoot + courseParam + articleParam + diffParams;
+
+    const salesforceButtons = this.props.editors.map(username => {
+      const usernameParam = `&username=${username}`;
+      const completeUrl = urlWithoutUsername + usernameParam;
+      return (
+        <a href={completeUrl} className="button dark small" key={`salesforce-media-${username}`}>
+          {username}
+        </a>
+      );
+    });
+
+    return (
+      <div>
+        <p>
+          Create Salesforce media record for:
+        </p>
+        {salesforceButtons}
+      </div>
+    );
+  }
+});
+
+export default SalesforceMediaButtons;

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import OnClickOutside from 'react-onclickoutside';
+import SalesforceMediaButtons from '../articles/salesforce_media_buttons.jsx';
 
 const DiffViewer = React.createClass({
   displayName: 'DiffViewer',
@@ -14,7 +15,11 @@ const DiffViewer = React.createClass({
     first_revision: React.PropTypes.object,
     showButtonLabel: React.PropTypes.string,
     hideButtonLabel: React.PropTypes.string,
-    largeButton: React.PropTypes.bool
+    largeButton: React.PropTypes.bool,
+    editors: React.PropTypes.array,
+    showSalesforceButton: React.PropTypes.bool,
+    article: React.PropTypes.object,
+    course: React.PropTypes.object
   },
 
   getInitialState() {
@@ -190,6 +195,19 @@ const DiffViewer = React.createClass({
       editDate = <p className="diff-comment">({timeSpan})</p>;
     }
 
+    let salesforceButtons;
+    if (this.props.showSalesforceButton) {
+      salesforceButtons = (
+        <SalesforceMediaButtons
+          course={this.props.course}
+          article={this.props.article}
+          editors={this.props.editors}
+          before_rev_id={this.state.parentRevisionId}
+          after_rev_id={this.props.revision.mw_rev_id}
+        />
+      );
+    }
+
     return (
       <div>
         {button}
@@ -199,6 +217,7 @@ const DiffViewer = React.createClass({
             {button}
             <a className="pull-right button small" href="/feedback?subject=Diff Viewer" target="_blank">How did the diff viewer work for you?</a>
           </p>
+          {salesforceButtons}
           <table>
             <thead>
               <tr>

--- a/app/controllers/salesforce_controller.rb
+++ b/app/controllers/salesforce_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class SalesforceController < ApplicationController
-  respond_to :json
+  respond_to :json, only: [:link]
   before_action :require_admin_permissions
 
   def link
@@ -12,7 +12,21 @@ class SalesforceController < ApplicationController
     render json: { success: true, flags: @course.flags }
   end
 
+  def create_media
+    set_article_course_and_user
+    url = CreateSalesforceMediaRecord.new(article: @article, course: @course, user: @user,
+                                          before_rev_id: params[:before_rev_id],
+                                          after_rev_id: params[:after_rev_id]).url
+    redirect_to url
+  end
+
   private
+
+  def set_article_course_and_user
+    @article = Article.find(params[:article_id])
+    @course = Course.find(params[:course_id])
+    @user = User.find_by(username: params[:username])
+  end
 
   # Valid Salesforce IDs are either 15 or 18 characters.
   VALID_SALESFORCE_ID_SIZES = [15, 18].freeze

--- a/app/services/create_salesforce_media_record.rb
+++ b/app/services/create_salesforce_media_record.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#= Creates a new Media record in Salesforce, returning the URL of the new record
+class CreateSalesforceMediaRecord
+  include ArticleHelper
+
+  def initialize(article:, course:, user:, before_rev_id:, after_rev_id:)
+    return unless Features.wiki_ed?
+    @article, @course, @user = article, course, user
+    @before_rev_id, @after_rev_id = before_rev_id, after_rev_id
+    @salesforce_course_id = @course.flags[:salesforce_id]
+    @client = Restforce.new
+    create_salesforce_record
+  end
+
+  def url
+    ENV['SF_SERVER'] + @salesforce_media_id
+  end
+
+  private
+
+  def create_salesforce_record
+    # :create returns the Salesforce id of the new record
+    @salesforce_media_id = @client.create!('Media__c', salesforce_media_fields)
+  end
+
+  def salesforce_media_fields
+    {
+      Name: full_title(@article),
+      Format__c: 'Wiki Contribution',
+      Author_Wiki_Username_Optional__c: @user.username,
+      Primary_Course__c: @salesforce_course_id,
+      Link__c: article_url(@article),
+      Before_link__c: diff_link(@before_rev_id),
+      After_link__c: diff_link(@after_rev_id)
+    }
+  end
+
+  def diff_link(rev_id)
+    return nil if rev_id == '0'
+    article_url(@article) + "?oldid=#{rev_id}"
+  end
+end

--- a/app/services/push_course_to_salesforce.rb
+++ b/app/services/push_course_to_salesforce.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "#{Rails.root}/lib/word_count"
 
-#= Enables chat features for a course and adds all participants to course chat channel
+#= Pushes course data to Salesforce, either by creating a new record or updating an existing one
 class PushCourseToSalesforce
   attr_reader :result
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,8 +235,9 @@ Rails.application.routes.draw do
   end
 
   # Salesforce
-  if true # Features.wiki_ed?
+  if Features.wiki_ed?
     put '/salesforce/link/:course_id' => 'salesforce#link'
+    get '/salesforce/create_media' => 'salesforce#create_media'
   end
 
   resources :admin

--- a/spec/controllers/salesforce_controller_spec.rb
+++ b/spec/controllers/salesforce_controller_spec.rb
@@ -5,6 +5,7 @@ describe SalesforceController do
   let(:course) { create(:course) }
   let(:admin) { create(:admin) }
   let(:user) { create(:user) }
+  let(:article) { create(:article) }
 
   describe '#link' do
     context 'when user is an admin' do
@@ -26,6 +27,34 @@ describe SalesforceController do
       before { allow(controller).to receive(:current_user).and_return(user) }
       it 'does not allow the action' do
         put :link, params: { course_id: course.id, salesforce_id: 'a0f1a000001Wyar' }
+        expect(response.code).to eq('401')
+      end
+    end
+  end
+
+  describe '#create_media' do
+    context 'when user is an admin' do
+      before { allow(controller).to receive(:current_user).and_return(admin) }
+      let(:subject) do
+        put :create_media, params: {
+          course_id: course.id,
+          username: user.username,
+          article_id:  article.id,
+          before_rev_id: '0',
+          after_rev_id: 123456
+        }
+      end
+      it 'creates a media record and redirects to Salesforce' do
+        expect_any_instance_of(Restforce::Data::Client).to receive(:create!).and_return('12345')
+
+        expect(subject).to redirect_to(/12345/)
+      end
+    end
+
+    context 'when user it not an admin' do
+      before { allow(controller).to receive(:current_user).and_return(user) }
+      it 'does not allow the action' do
+        get :create_media
         expect(response.code).to eq('401')
       end
     end

--- a/spec/services/create_salesforce_media_record_spec.rb
+++ b/spec/services/create_salesforce_media_record_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe CreateSalesforceMediaRecord do
+  let(:course) { create(:course, flags: { salesforce_id: 'a2qQ0101015h4HF' }) }
+  let(:user) { create(:user) }
+  let(:article) { create(:article) }
+  let(:subject) do
+    described_class.new(
+      course: course,
+      user: user,
+      article: article,
+      before_rev_id: 1234,
+      after_rev_id: 3456
+    )
+  end
+
+  it 'calls #create! on the Restforce client and returns a url' do
+    expect_any_instance_of(Restforce::Data::Client).to receive(:create!)
+      .and_return('a2qQQ101015h4GG')
+    expect(subject.url).to include('a2qQQ101015h4GG')
+  end
+end

--- a/test/components/articles/salesforce_media_buttons.spec.jsx
+++ b/test/components/articles/salesforce_media_buttons.spec.jsx
@@ -1,0 +1,30 @@
+import '../../testHelper';
+
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import SalesforceMediaButtons from '../../../app/assets/javascripts/components/articles/salesforce_media_buttons.jsx';
+
+const course = {
+  id: 5,
+  home_wiki: { language: 'en', project: 'wikipedia' }
+};
+const editors = ['Ragesoss', 'Ragesock', 'Sage (Wiki Ed)'];
+const article = { id: 1234 };
+
+describe('SalesforceMediaButtons', () => {
+  it('renders a link for each editor', () => {
+    const TestButtons = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SalesforceMediaButtons
+          course={course}
+          article={article}
+          editors={editors}
+          before_rev_id={123}
+          after_rev_id={234}
+        />
+      </div>
+    );
+    expect(TestButtons.querySelectorAll('a').length).to.eq(3);
+  });
+});


### PR DESCRIPTION
For admins, this adds a set of links within the diff viewer to create a Salesforce media record for the article at hand.