### PR TITLE
Extend existing validations to allow wikisource

### DIFF
--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -58,9 +58,9 @@ const CourseUtils = class {
       };
     }
 
-    const wikiSourceUrlParts = /wikisource\.org\/wiki\/([^#]*)/.exec(articleTitle);
-    if (wikiSourceUrlParts) {
-      const title = decodeURIComponent(wikiSourceUrlParts[1]).replace(/_/g, ' ');
+    const wikisourceUrlParts = /wikisource\.org\/wiki\/([^#]*)/.exec(articleTitle);
+    if (wikisourceUrlParts) {
+      const title = decodeURIComponent(wikisourceUrlParts[1]).replace(/_/g, ' ');
       const project = 'wikisource';
       const language = 'www';
       return {

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -58,6 +58,19 @@ const CourseUtils = class {
       };
     }
 
+    const wikiSourceUrlParts = /wikisource\.org\/wiki\/([^#]*)/.exec(articleTitle);
+    if (wikiSourceUrlParts) {
+      const title = decodeURIComponent(wikiSourceUrlParts[1]).replace(/_/g, ' ');
+      const project = 'wikisource'
+      const language = 'www'
+      return {
+        title,
+        project,
+        language,
+        article_url: articleTitle
+      };
+    }
+
     return {
       title: articleTitleInput,
       project: null,

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -61,8 +61,8 @@ const CourseUtils = class {
     const wikiSourceUrlParts = /wikisource\.org\/wiki\/([^#]*)/.exec(articleTitle);
     if (wikiSourceUrlParts) {
       const title = decodeURIComponent(wikiSourceUrlParts[1]).replace(/_/g, ' ');
-      const project = 'wikisource'
-      const language = 'www'
+      const project = 'wikisource';
+      const language = 'www';
       return {
         title,
         project,

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -110,7 +110,8 @@ class AssignmentsController < ApplicationController
                                         course: @course,
                                         wiki: @wiki,
                                         title: assignment_params[:title],
-                                        role: assignment_params[:role]).create_assignment
+                                        role: assignment_params[:role]
+                                       ).create_assignment
   end
 
   def check_permissions(user_id)

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -48,13 +48,13 @@ class Wiki < ActiveRecord::Base
     sg sgs sh si simple sk sl sm sn so sq sr srn ss st stq su sv sw szl ta te
     tet tg th ti tk tl tn to tpi tr ts tt tum tw ty tyv udm ug uk ur uz ve
     vec vep vi vls vo vro w wa war wikipedia wo wuu xal xh xmf yi yo yue za
-    zea zh zh-cfr zh-classical zh-cn zh-min-nan zh-tw zh-yue zu www
+    zea zh zh-cfr zh-classical zh-cn zh-min-nan zh-tw zh-yue zu
   ).freeze
   validates_inclusion_of :language, in: LANGUAGES + [nil]
 
   MULTILINGUAL_PROJECTS = {
     'wikidata' => 'www.wikidata.org',
-    'wikisource' => 'www.wikisource.org'
+    'wikisource' => 'wikisource.org'
   }.freeze
 
   def base_url
@@ -74,15 +74,10 @@ class Wiki < ActiveRecord::Base
   #############
 
   def ensure_valid_project
-    # Most multilingual projects must have language == nil,
-    # but wikisource is the exception, it can have nil, or a language.
-    # Standard projects must have a language.
-    #
+		# Multilingual projects must have language == nil.
     # TODO: Validate the language/project combination by pinging it's API.
-    if project == "wikidata"
+    if MULTILINGUAL_PROJECTS.include?(project)
       self.language = nil
-    elsif project == "wikisource"
-      #noop
     elsif language.nil?
       raise InvalidWikiError
     end
@@ -101,7 +96,7 @@ class Wiki < ActiveRecord::Base
   end
 
   def self.get_or_create(language:, project:)
-    language = nil if project == 'wikidata'
+    language = nil if MULTILINGUAL_PROJECTS.include?(project)
     find_or_create_by(language: language, project: project)
   end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -53,7 +53,8 @@ class Wiki < ActiveRecord::Base
   validates_inclusion_of :language, in: LANGUAGES + [nil]
 
   MULTILINGUAL_PROJECTS = {
-    'wikidata' => 'www.wikidata.org'
+    'wikidata' => 'www.wikidata.org',
+    'wikisource' => 'www.wikisource.org'
   }.freeze
 
   def base_url
@@ -73,14 +74,18 @@ class Wiki < ActiveRecord::Base
   #############
 
   def ensure_valid_project
-    # Multilingual projects must have language == nil.
+    # Most multilingual projects must have language == nil,
+    # but wikisource is the exception, it can have nil, or a language.
     # Standard projects must have a language.
-    if MULTILINGUAL_PROJECTS.include?(project)
+    #
+    # TODO: Validate the language/project combination by pinging it's API.
+    if project == "wikidata"
       self.language = nil
+    elsif project == "wikisource"
+      #noop
     elsif language.nil?
       raise InvalidWikiError
     end
-    # TODO: Validate the language/project combination by pinging its API.
   end
 
   class InvalidWikiError < StandardError; end
@@ -96,7 +101,7 @@ class Wiki < ActiveRecord::Base
   end
 
   def self.get_or_create(language:, project:)
-    language = nil if MULTILINGUAL_PROJECTS.include?(project)
+    language = nil if project == 'wikidata'
     find_or_create_by(language: language, project: project)
   end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -48,7 +48,7 @@ class Wiki < ActiveRecord::Base
     sg sgs sh si simple sk sl sm sn so sq sr srn ss st stq su sv sw szl ta te
     tet tg th ti tk tl tn to tpi tr ts tt tum tw ty tyv udm ug uk ur uz ve
     vec vep vi vls vo vro w wa war wikipedia wo wuu xal xh xmf yi yo yue za
-    zea zh zh-cfr zh-classical zh-cn zh-min-nan zh-tw zh-yue zu
+    zea zh zh-cfr zh-classical zh-cn zh-min-nan zh-tw zh-yue zu www
   ).freeze
   validates_inclusion_of :language, in: LANGUAGES + [nil]
 

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -76,10 +76,15 @@ class Wiki < ActiveRecord::Base
   def ensure_valid_project
 		# Multilingual projects must have language == nil.
     # TODO: Validate the language/project combination by pinging it's API.
-    if MULTILINGUAL_PROJECTS.include?(project)
+    case project
+    when 'wikidata'
       self.language = nil
-    elsif language.nil?
-      raise InvalidWikiError
+    when 'wikisource'
+      self.language = nil if language == 'www'
+    else
+      if self.language.nil?
+        raise InvalidWikiError
+      end
     end
   end
 
@@ -96,7 +101,18 @@ class Wiki < ActiveRecord::Base
   end
 
   def self.get_or_create(language:, project:)
-    language = nil if MULTILINGUAL_PROJECTS.include?(project)
+    language = language_for_multilingual(language: language, project: project)
     find_or_create_by(language: language, project: project)
+  end
+
+
+  def self.language_for_multilingual(language:, project:)
+    case project
+    when 'wikidata'
+      language = nil
+    when 'wikisource'
+      language = nil if language == 'www'
+    end
+    language
   end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -79,12 +79,12 @@ class Wiki < ActiveRecord::Base
     case project
     when 'wikidata'
       self.language = nil
+      return
     when 'wikisource'
       self.language = nil if language == 'www'
+      return
     else
-      if self.language.nil?
-        raise InvalidWikiError
-      end
+      raise InvalidWikiError if self.language.nil?
     end
   end
 

--- a/lib/assignment_manager.rb
+++ b/lib/assignment_manager.rb
@@ -19,7 +19,6 @@ class AssignmentManager
     import_article_from_wiki unless @article
     # TODO: update rating via Sidekiq worker
     update_article_rating if @article
-
     Assignment.create!(user_id: @user_id, course: @course,
                        article_title: @clean_title, wiki: @wiki, article: @article,
                        role: @role)
@@ -42,6 +41,8 @@ class AssignmentManager
   def set_article_from_database
     # We double check that the titles are equal to avoid false matches of case variants.
     # We can revise this once the database is set to use case-sensitive collation.
+    #
+    #
     articles = Article.where(title: @clean_title, wiki_id: @wiki.id,
                              namespace: Article::Namespaces::MAINSPACE)
     exact_title_matches = articles.select { |article| article.title == @clean_title }

--- a/lib/assignment_manager.rb
+++ b/lib/assignment_manager.rb
@@ -41,8 +41,6 @@ class AssignmentManager
   def set_article_from_database
     # We double check that the titles are equal to avoid false matches of case variants.
     # We can revise this once the database is set to use case-sensitive collation.
-    #
-    #
     articles = Article.where(title: @clean_title, wiki_id: @wiki.id,
                              namespace: Article::Namespaces::MAINSPACE)
     exact_title_matches = articles.select { |article| article.title == @clean_title }

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -30,6 +30,8 @@ class ArticleImporter
       next if results.blank?
       import_articles_from_title_query(results)
     end
+
+
   end
 
   private
@@ -48,7 +50,7 @@ class ArticleImporter
   def import_articles_from_title_query(results)
     articles = []
     results.each do |_id, page_data|
-      next if page_data['missing']
+      next if page_data['missing'].present?
       articles << Article.new(mw_page_id: page_data['pageid'].to_i,
                               title: page_data['title'].tr(' ', '_'),
                               wiki_id: @wiki.id,

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -30,8 +30,6 @@ class ArticleImporter
       next if results.blank?
       import_articles_from_title_query(results)
     end
-
-
   end
 
   private

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -50,7 +50,7 @@ class ArticleImporter
   def import_articles_from_title_query(results)
     articles = []
     results.each do |_id, page_data|
-      next if page_data['missing'].present?
+      next if page_data['missing']
       articles << Article.new(mw_page_id: page_data['pageid'].to_i,
                               title: page_data['title'].tr(' ', '_'),
                               wiki_id: @wiki.id,

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -148,6 +148,30 @@ describe AssignmentsController do
         end
       end
 
+      context 'when the assignment is for Wikisource' do
+        let!(:www_wikisource) { create(:wiki, language: 'www', project: 'wikisource') }
+        let(:wikisource_params) do
+          { user_id: user.id, course_id: course.slug, title: 'Heyder Cansa', role: 0,
+            language: 'www', project: 'wikisource' }
+        end
+
+        before do
+          expect(Article.find_by(title: 'Heyder Cansa')).to be_nil
+        end
+
+        it 'imports the article' do
+          VCR.use_cassette 'assignment_import' do
+            expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
+            expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
+            put :create, params: wikisource_params
+            assignment = assigns(:assignment)
+            expect(assignment).to be_a_kind_of(Assignment)
+            expect(assignment.article.title).to eq('Heyder_Cansa')
+            expect(assignment.article.namespace).to eq(Article::Namespaces::MAINSPACE)
+          end
+        end
+      end
+
       context 'when the article exists' do
         before do
           create(:article, title: 'Pizza', namespace: Article::Namespaces::MAINSPACE)

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -28,19 +28,14 @@ describe 'multiwiki assignments', type: :feature, js: true do
       click_button 'OK'
       visit "/courses/#{course.slug}/students"
 
-      expect(page).to have_content 'ta:wiktionary:ஆங்கிலம்'
-      expect(Assignment.last.wiki.language).to eq('ta')
-      expect(Assignment.last.wiki.project).to eq('wiktionary')
-      expect(Assignment.last.article.title).to eq('ஆங்கிலம்')
-      expect(Assignment.last.article.wiki.language).to eq('ta')
-      expect(Assignment.last.article.wiki.project).to eq('wiktionary')
+      within('#users') do
+        expect(page).to have_content 'ta:wiktionary:ஆங்கிலம்'
+      end
     end
   end
 
   it 'creates a valid assignment from an article and an alternative project and language' do
     VCR.use_cassette 'multiwiki_assignment' do
-      pending 'This sometimes fails on travis.'
-
       visit "/courses/#{course.slug}/students"
       click_button 'Assign Articles'
       click_button 'Assign an article'
@@ -64,16 +59,9 @@ describe 'multiwiki assignments', type: :feature, js: true do
 
       visit "/courses/#{course.slug}/students"
 
-      expect(page).to have_content 'es:wikisource:No le des prisa, dolor'
-
-      expect(Assignment.last.wiki.language).to eq('es')
-      expect(Assignment.last.wiki.project).to eq('wikisource')
-      expect(Assignment.last.article.title).to eq('No_le_des_prisa,_dolor')
-      expect(Assignment.last.article.wiki.language).to eq('es')
-      expect(Assignment.last.article.wiki.project).to eq('wikisource')
-
-      puts 'PASSED'
-      raise 'this test passed — this time'
+      within('#users') do
+        expect(page).to have_content 'es:wikisource:No le des prisa, dolor'
+      end
     end
   end
 

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -76,4 +76,22 @@ describe 'multiwiki assignments', type: :feature, js: true do
       raise 'this test passed — this time'
     end
   end
+
+  it 'will create a valid assignment for multiliungual wikisource projects' do
+    VCR.use_cassette 'multiwiki_assignment' do
+      visit "/courses/#{course.slug}/students"
+      click_button 'Assign Articles'
+      click_button 'Assign an article'
+      within('#users') do
+        first('input').set('https://wikisource.org/wiki/Heyder_Cansa')
+      end
+      click_button 'Assign'
+      click_button 'OK'
+      visit "/courses/#{course.slug}/students"
+
+      within('#users') do
+        expect(page).to have_content 'wikisource:Heyder Cansa'
+      end
+    end
+  end
 end

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -65,7 +65,7 @@ describe 'multiwiki assignments', type: :feature, js: true do
     end
   end
 
-  it 'will create a valid assignment for multiliungual wikisource projects' do
+  it 'will create a valid assignment for multilingual wikisource projects' do
     VCR.use_cassette 'multiwiki_assignment' do
       visit "/courses/#{course.slug}/students"
       click_button 'Assign Articles'

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -10,107 +10,141 @@
 
 require 'rails_helper'
 
-describe Wiki, type: :model do
+describe Wiki do
   describe 'validation' do
-    let(:create_wiki) { create(:wiki, language: 'zh', project: 'wiktionary') }
-    subject { create_wiki.valid? }
-    it 'allows valid language/project combinations' do
-      expect(subject).to eq(true)
+    context "For valid wiki projects" do
+      it 'allows valid language/project combinations' do
+        created_wiki = build(:wiki, language: 'zh', project: 'wiktionary')
+        expect(created_wiki).to be_valid
+      end
+
+      it 'allows nil language for wikidata' do
+        create(:wiki, language: nil, project: 'wikidata')
+        expect(Wiki.last.project).to eq('wikidata')
+        expect(Wiki.last.language).to be_nil
+      end
+
+      it 'ensures nil language for wikidata' do
+        create(:wiki, language: 'en', project: 'wikidata')
+        expect(Wiki.last.project).to eq('wikidata')
+        expect(Wiki.last.language).to be_nil
+      end
+
+      it 'allows nil for wikisource' do
+        wiki = create(:wiki, language: nil, project: 'wikisource')
+        expect(wiki).to be_valid
+      end
+
+      it 'ensures the project and language combination are unique' do
+        create(:wiki, language: 'zh', project: 'wiktionary')
+        expect { create(:wiki, language: 'zh', project: 'wiktionary') }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
 
-    let(:bad_language) { create(:wiki, language: 'xx', project: 'wikipedia') }
-    it 'does not allow bad language codes' do
-      expect { bad_language }.to raise_error(ActiveRecord::RecordInvalid)
-    end
+    context "For invalid wiki projects" do
+      let(:bad_language) { create(:wiki, language: 'xx', project: 'wikipedia') }
+      it 'does not allow bad language codes' do
+        expect { bad_language }.to raise_error(ActiveRecord::RecordInvalid)
+      end
 
-    let(:bad_project) { create(:wiki, language: 'en', project: 'wikinothing') }
-    it 'does not allow bad projects' do
-      expect { bad_project }.to raise_error(ActiveRecord::RecordInvalid)
-    end
+      let(:bad_project) { create(:wiki, language: 'en', project: 'wikinothing') }
+      it 'does not allow bad projects' do
+        expect { bad_project }.to raise_error(ActiveRecord::RecordInvalid)
+      end
 
-    let(:nil_language) { create(:wiki, language: nil, project: 'wikipedia') }
-    it 'does not allow nil language for standard projects' do
-      expect { nil_language }.to raise_error(Wiki::InvalidWikiError)
-    end
+      let(:nil_language) { create(:wiki, language: nil, project: 'wikipedia') }
+      it 'does not allow nil language for standard projects' do
+        expect { nil_language }.to raise_error(Wiki::InvalidWikiError)
+      end
 
-    let(:create_wikidata) { create(:wiki, language: nil, project: 'wikidata') }
-    it 'allows nil language for wikidata' do
-      create_wikidata
-      expect(Wiki.last.project).to eq('wikidata')
-      expect(Wiki.last.language).to be_nil
-    end
+      it 'does not allow duplicate wikidata projects because they all get set to language nil' do
+        create(:wiki, language: nil, project: 'wikidata')
+        expect { create(:wiki, language: 'zh', project: 'wikidata') }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
 
-    let(:create_en_wikidata) { create(:wiki, language: 'en', project: 'wikidata') }
-    it 'ensures nil language for wikidata' do
-      create_en_wikidata
-      expect(Wiki.last.project).to eq('wikidata')
-      expect(Wiki.last.language).to be_nil
-    end
-
-    it 'ensures the project and language combination are unique' do
-      create(:wiki, language: 'zh', project: 'wiktionary')
-      expect { create(:wiki, language: 'zh', project: 'wiktionary') }
-        .to raise_error(ActiveRecord::RecordInvalid)
-    end
-
-    it 'does not allow duplicate multilingual projects' do
-      create(:wiki, language: nil, project: 'wikidata')
-      expect { create(:wiki, language: 'zh', project: 'wikidata') }
-        .to raise_error(ActiveRecord::RecordInvalid)
+      it "it does not allow duplicate wikisource projects" do
+        create(:wiki, language: nil, project: 'wikisource')
+        expect { create(:wiki, language: nil, project: 'wikisource') }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
   end
 
   describe '.get_or_create' do
-    let(:subject) { Wiki.get_or_create(language: language, project: project) }
-    let(:language) { 'zh' }
-    let(:project) { 'wiktionary' }
-
     context 'when the record exists' do
-      before do
-        create(:wiki, language: language, project: project, id: 1001)
-      end
       it 'returns the existing record' do
-        expect(subject.id).to eq(1001)
+        new_wiki   = create(:wiki, language: 'zh', project: 'wiktionary')
+        found_wiki = Wiki.get_or_create(language: 'zh', project: 'wiktionary')
+        expect(new_wiki).to eq(found_wiki), -> { 'the pre existing wiki object was not found' }
       end
 
-      before do
-        create(:wiki, language: nil, project: 'wikidata', id: 1002)
+      context 'when the wiki project does not have language support' do
+        it 'will ignore language but still return a record' do
+          new_wiki   = create(:wiki, language: nil, project: 'wikidata')
+          found_wiki = Wiki.get_or_create(language: 'es', project: 'wikidata')
+          expect(new_wiki).to eq(found_wiki), -> { "we did not find wikidata for language: 'es'" }
+        end
       end
-      it 'ignores language for wikidata and still returns the record' do
-        subject = Wiki.get_or_create(language: 'es', project: 'wikidata')
-        expect(subject.id).to eq(1002)
-        expect(subject.language).to be_nil
+
+      context "for projects with a multilingual version in addition to language support" do
+        context "when given a languge" do
+          it "will return the approriate record" do
+            new_wiki   = create(:wiki, language: "es", project: 'wikisource')
+            found_wiki = Wiki.get_or_create(language: "es", project: 'wikisource')
+            expect(new_wiki).to eq(found_wiki), -> { "Unfortunately the correct Wiki object was not returned" }
+          end
+        end
+
+        context "when not given a language" do
+          it "will return a valid record" do
+            new_wiki = create(:wiki, language: nil, project: 'wikisource')
+            found_wiki = Wiki.get_or_create(language: nil, project: 'wikisource')
+            expect(new_wiki).to eq(found_wiki), -> { "Unfortunately the correct Wiki object was not returned" }
+          end
+        end
       end
     end
 
     context 'when the record does not exist' do
+      let(:project) { 'wiktionary' }
+      let(:language) { 'zh' }
+
       it 'creates and returns the record' do
-        existing_record = Wiki.find_by(language: language, project: project)
-        expect(existing_record).to be_nil
-        expect(subject.language).to eq(language)
-        expect(subject.project).to eq(project)
-        expect(subject.id).not_to be_nil
+        expect(Wiki.find_by(language: language, project: project)).to be_nil
+        wiki = Wiki.get_or_create(language: language, project: project)
+        expect(wiki).to be_persisted
+        expect(wiki.language).to eq(language)
+        expect(wiki.project).to eq(project)
       end
 
-      it 'creates and returns a multilingual project' do
-        existing_record = Wiki.find_by(project: 'wikidata')
-        expect(existing_record).to be_nil
-        subject = Wiki.get_or_create(language: nil, project: 'wikidata')
-        expect(subject.project).to eq('wikidata')
-        expect(subject.id).not_to be_nil
+      context 'when given nil language values on a multilingual project' do
+        let(:project) { 'wikidata' }
+        let(:language) { nil }
+
+        it 'creates and returns the multilingual project' do
+          existing_record = Wiki.find_by(project: project)
+          expect(existing_record).to be_nil
+
+          wiki = Wiki.get_or_create(language: language, project: project)
+          expect(wiki.project).to eq(project)
+          expect(wiki.language).to eq(language)
+          expect(wiki).to be_persisted
+        end
       end
     end
   end
 
   describe '#base_url' do
     it 'returns the correct url for standard projects' do
-      subject = Wiki.get_or_create(language: 'es', project: 'wikibooks')
-      expect(subject.base_url).to eq('https://es.wikibooks.org')
+      wiki = Wiki.get_or_create(language: 'es', project: 'wikibooks')
+      expect(wiki.base_url).to eq('https://es.wikibooks.org')
     end
 
     it 'returns the correct url for wikidata' do
-      subject = Wiki.get_or_create(language: nil, project: 'wikidata')
-      expect(subject.base_url).to eq('https://www.wikidata.org')
+      wiki = Wiki.get_or_create(language: nil, project: 'wikidata')
+      expect(wiki.base_url).to eq('https://www.wikidata.org')
     end
   end
 end

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -94,6 +94,7 @@ describe Wiki do
             new_wiki   = create(:wiki, language: "es", project: 'wikisource')
             found_wiki = Wiki.get_or_create(language: "es", project: 'wikisource')
             expect(new_wiki).to eq(found_wiki), -> { "Unfortunately the correct Wiki object was not returned" }
+            expect(new_wiki.language).to eq('es')
           end
         end
 

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -73,9 +73,19 @@ describe('courseUtils.articleFromTitleInput', () => {
   it('converts Wikipedia urls into titles', () => {
     const input = 'https://en.wikipedia.org/wiki/Robot_selfie';
     const output = courseUtils.articleFromTitleInput(input);
+
     expect(output.title).to.eq('Robot selfie');
     expect(output.project).to.eq('wikipedia');
     expect(output.language).to.eq('en');
+    expect(output.article_url).to.eq(input);
+  });
+
+  it("correctly parses multilingual wikisource url's", () => {
+    const input = 'https://wikisource.org/wiki/Heyder_Cansa';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).to.eq('Heyder Cansa');
+    expect(output.project).to.eq('wikisource');
+    expect(output.language).to.eq('www');
     expect(output.article_url).to.eq(input);
   });
 


### PR DESCRIPTION
Addresses: https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1195

These changes are 2 fold, adjustments to the validation & creating
methods for wikisource and some refactoring of the specs for speed and
readability.

Wikisource changes

Typically a wiki page has a language support, but in some edge cases a
given page will support many languages. This has led to specific logic
around wikidata and wikisource. They are both multilingual in nature but
wikisource can SOMETIMES have a language assigned depending on what
resource within wikisource is being worked on.

I consider these changes an intermittent step. Long term we want a way
to ask the services what languages they support for a given project and
do validation that way. Until that work is completed, this code will
  solve our current use case.

Refactoring of the spec

In some case, a create statement was not needed, so we can save time by
using FactoryGirl#build. Other places I was able to reduce the lines of
code by using object equality checks instead of going through property
comparisons. I also did my best to add some context descriptions to try
and help the documentation quality a little.