### PR TITLE
Fixing Datepicker time zone problem during course creation

### DIFF
--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -222,7 +222,7 @@ const DatePicker = React.createClass({
   },
 
   moment(...args) {
-    return this.props.showTime ? moment(...args) : moment(...args).utc();
+    return moment(...args);
   },
 
   showCurrentDate() {


### PR DESCRIPTION
@ragesoss The bug could be reproduced only for positive timezones, it behaved in the same manner for all positive timezones, and could not be reproduced for any negative timezone. I have thoroughly tested this across all positive and negative timezones and the change here appears to be a valid fix. Could you please review.
Also, I could not find an appropriate file to add related tests. Please help.