### PR TITLE
[WIP] Adding support for incubator.wikimedia.org

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -22,6 +22,7 @@ class Wiki < ActiveRecord::Base
   PROJECTS = %w(
     wikibooks
     wikidata
+    wikimedia
     wikinews
     wikipedia
     wikiquote
@@ -38,11 +39,11 @@ class Wiki < ActiveRecord::Base
     bug bxr ca cbk-zam cdo ce ceb ch cho chr chy ckb cmn co cr crh cs csb cu
     cv cy cz da de diq dk dsb dv dz ee egl el eml en eo epo es et eu ext fa
     ff fi fiu-vro fj fo fr frp frr fur fy ga gag gan gd gl glk gn gom got gsw
-    gu gv ha hak haw he hi hif ho hr hsb ht hu hy hz ia id ie ig ii ik ilo io
-    is it iu ja jbo jp jv ka kaa kab kbd kg ki kj kk kl km kn ko koi kr krc
-    ks ksh ku kv kw ky la lad lb lbe lez lg li lij lmo ln lo lrc lt ltg lv
-    lzh mai map-bms mdf mg mh mhr mi min minnan mk ml mn mo mr mrj ms mt mus
-    mwl my myv mzn na nah nan nap nb nds nds-nl ne new ng nl nn no nov nrm
+    gu gv ha hak haw he hi hif ho hr hsb ht hu hy hz ia id ie ig ii ik ilo
+    incubator io is it iu ja jbo jp jv ka kaa kab kbd kg ki kj kk kl km kn ko
+    koi kr krc ks ksh ku kv kw ky la lad lb lbe lez lg li lij lmo ln lo lrc lt
+    ltg lv lzh mai map-bms mdf mg mh mhr mi min minnan mk ml mn mo mr mrj ms mt
+    mus mwl my myv mzn na nah nan nap nb nds nds-nl ne new ng nl nn no nov nrm
     nso nv ny oc om or os pa pag pam pap pcd pdc pfl pi pih pl pms pnb pnt ps
     pt qu rm rmy rn ro roa-rup roa-tara ru rue rup rw sa sah sc scn sco sd se
     sg sgs sh si simple sk sl sm sn so sq sr srn ss st stq su sv sw szl ta te
@@ -75,6 +76,8 @@ class Wiki < ActiveRecord::Base
 
   def ensure_valid_project
 		# Multilingual projects must have language == nil.
+    # Doesn't apply to multilingual Wikimedia projects, subdomain is accepted
+    # as language there.
     # TODO: Validate the language/project combination by pinging it's API.
     case project
     when 'wikidata'
@@ -112,6 +115,8 @@ class Wiki < ActiveRecord::Base
       language = nil
     when 'wikisource'
       language = nil if language == 'www'
+    when 'wikimedia'
+      language = nil unless language == 'incubator'
     end
     language
   end

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -155,12 +155,15 @@ class Replica
     "#{base_url}#{endpoint}?#{language_and_project_params}&#{query}"
   end
 
-  # We must special-case Multilingual Wikisource because its labs database name
-  # does not follow the normal pattern; it is called 'sourceswiki', which is the
-  # same one we'd get if a Wikipedia's language was "sources".
+  # We must special-case Multilingual Wikisource/ Wikimedia Incubator because
+  # their labs database names do not follow the normal pattern; they are called
+  # 'sourceswiki' and 'incubatorwiki' respectively, which are the same as we'd
+  # get if a Wikipedia's language was "sources" or "incubator".
   def language_and_project_params
     if @wiki.project == 'wikisource' && @wiki.language.nil?
       'lang=sources&project=wikipedia'
+    elsif @wiki.project == 'wikimedia' && @wiki.language == 'incubator'
+      "lang=incubator&project=wikipedia"
     else
       "lang=#{@wiki.language}&project=#{@wiki.project}"
     end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -172,6 +172,30 @@ describe AssignmentsController do
         end
       end
 
+      context 'when the assignment is for Wikimedia incubator' do
+        let!(:wikimedia_incubator) { create(:wiki, language: 'incubator', project: 'wikimedia') }
+        let(:wikimedia_params) do
+          { user_id: user.id, course_id: course.slug, title: 'Wp/kiu/Heyder Cansa', role: 0,
+            language: 'incubator', project: 'wikimedia' }
+        end
+
+        before do
+          expect(Article.find_by(title: 'Wp/kiu/Heyder Cansa')).to be_nil
+        end
+
+        it 'imports the article' do
+          VCR.use_cassette 'assignment_import' do
+            expect_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
+            expect_any_instance_of(WikiCourseEdits).to receive(:update_course)
+            put :create, params: wikimedia_params
+            assignment = assigns(:assignment)
+            expect(assignment).to be_a_kind_of(Assignment)
+            expect(assignment.article.title).to eq('Wp/kiu/Heyder_Cansa')
+            expect(assignment.article.namespace).to eq(Article::Namespaces::MAINSPACE)
+          end
+        end
+      end
+
       context 'when the article exists' do
         before do
           create(:article, title: 'Pizza', namespace: Article::Namespaces::MAINSPACE)

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -82,4 +82,22 @@ describe 'multiwiki assignments', type: :feature, js: true do
       end
     end
   end
+
+  it 'will create a valid assignment for multilingual wikimedia incubator projects' do
+    VCR.use_cassette 'multiwiki_assignment' do
+      visit "/courses/#{course.slug}/students"
+      click_button 'Assign Articles'
+      click_button 'Assign an article'
+      within('#users') do
+        first('input').set('https://incubator.wikimedia.org/wiki/Wp/kiu/Heyder_Cansa')
+      end
+      click_button 'Assign'
+      click_button 'OK'
+      visit "/courses/#{course.slug}/students"
+
+      within('#users') do
+        expect(page).to have_content 'incubator:wikimedia:Wp/kiu/Heyder Cansa'
+      end
+    end
+  end
 end

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -178,6 +178,21 @@ describe Replica do
         expect(response.count).to eq(28)
       end
     end
+
+    it 'functions identically on wikimedia incubator' do
+      VCR.use_cassette 'replica/wikimedia_incubator_revisions' do
+        all_users = [
+          build(:user, username: 'Daad Ikram')
+        ]
+
+        rev_start = 2017_03_11_000000
+        rev_end = 2017_03_17_000000
+
+        incubator = Wiki.new(language: 'incubator', project: 'wikimedia')
+        response = Replica.new(incubator).get_revisions(all_users, rev_start, rev_end)
+        expect(response.count).to eq(1)
+      end
+    end
   end
 
   describe 'error handling' do

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -30,7 +30,7 @@ describe Wiki do
         expect(Wiki.last.language).to be_nil
       end
 
-      it 'allows nil for wikisource' do
+      it 'allows nil language for wikisource' do
         wiki = create(:wiki, language: nil, project: 'wikisource')
         expect(wiki).to be_valid
       end
@@ -69,6 +69,12 @@ describe Wiki do
         expect { create(:wiki, language: nil, project: 'wikisource') }
           .to raise_error(ActiveRecord::RecordInvalid)
       end
+
+      it "it does not allow duplicate wikimedia incubator projects" do
+        create(:wiki, language: 'incubator', project: 'wikimedia')
+        expect { create(:wiki, language: 'incubator', project: 'wikimedia') }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
   end
 
@@ -81,7 +87,7 @@ describe Wiki do
       end
 
       context 'when the wiki project does not have language support' do
-        it 'will ignore language but still return a record' do
+        it 'will ignore language but still return a record for wikidata' do
           new_wiki   = create(:wiki, language: nil, project: 'wikidata')
           found_wiki = Wiki.get_or_create(language: 'es', project: 'wikidata')
           expect(new_wiki).to eq(found_wiki), -> { "we did not find wikidata for language: 'es'" }
@@ -146,6 +152,11 @@ describe Wiki do
     it 'returns the correct url for wikidata' do
       wiki = Wiki.get_or_create(language: nil, project: 'wikidata')
       expect(wiki.base_url).to eq('https://www.wikidata.org')
+    end
+
+    it 'returns the correct url for wikimedia incubator' do
+      wiki = Wiki.get_or_create(language: 'incubator', project: 'wikimedia')
+      expect(wiki.base_url).to eq('https://incubator.wikimedia.org')
     end
   end
 end

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -102,6 +102,15 @@ describe('courseUtils.articleFromTitleInput', () => {
     expect(output.article_url).to.eq(input);
   });
 
+  it("correctly parses the wikimedia incubator url", () => {
+    const input = 'https://incubator.wikimedia.org/wiki/Wp/kiu/Heyder_Cansa';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).to.eq('Wp/kiu/Heyder Cansa');
+    expect(output.project).to.eq('wikimedia');
+    expect(output.language).to.eq('incubator');
+    expect(output.article_url).to.eq(input);
+  });
+
   it('handles url-encoded characters in Wikipedia urls', () => {
     const input = 'https://es.wikipedia.org/wiki/Jalape%C3%B1o';
     const output = courseUtils.articleFromTitleInput(input);


### PR DESCRIPTION
@ragesoss Please review.
Done with the assumption that the incubator project does not offer language support.
Also, name of the incubator project in the Wiki model has been kept as 'wikimedia'. Other options in mind were 'incubator_wikimedia' and 'wikimedia_incubator', but they exceeded number of allowed column characters in the DB, please suggest if it needs to be changed. 

Refers #1180