### PR TITLE
Added support for videos in Wiki slides

### DIFF
--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -12,6 +12,7 @@ class WikiSlideParser
     remove_translate_tags
     extract_quiz_template
     convert_image_template
+    convert_video_template
   end
 
   # The first translated line is the slide title
@@ -111,6 +112,13 @@ class WikiSlideParser
     @wikitext.gsub!('IMAGE_PLACEHOLDER', figure_markup)
   end
 
+  def convert_video_template
+    @wikitext.gsub!(/(?<video>{{Training module video.*\n}})/m, 'VIDEO_PLACEHOLDER')
+    @video_template = Regexp.last_match && Regexp.last_match['video']
+    return unless @video_template
+    @wikitext.gsub!('VIDEO_PLACEHOLDER', video_markup)
+  end
+
   def figure_markup
     <<-FIGURE
 <figure class="#{image_layout}"><img src="#{image_source}" />
@@ -119,6 +127,12 @@ class WikiSlideParser
 </figcaption>
 </figure>
     FIGURE
+  end
+
+  def video_markup
+    <<-VIDEO
+<iframe width="420" height="315" src="#{video_source}" frameborder="0" allowfullscreen></iframe>
+    VIDEO
   end
 
   def image_layout
@@ -135,5 +149,9 @@ class WikiSlideParser
 
   def image_credit
     template_parameter_value(@image_template, 'credit')
+  end
+
+  def video_source
+    template_parameter_value(@video_template, 'source')
   end
 end

--- a/spec/lib/training/wiki_slide_parser_spec.rb
+++ b/spec/lib/training/wiki_slide_parser_spec.rb
@@ -69,6 +69,21 @@ Wikipedia is the encyclopedia anyone can edit, but there's a lot of collaboratio
     WIKISLIDE
   end
 
+  let(:video_wikitext) do
+    <<-WIKISLIDE
+== Starting new programs ==
+
+If you are the host of a program or event, you need to be able to create events. There are two different ways to create a program: through creating a new one, or cloning an existing event.
+
+{{Training module video
+| video = File:How to Use the Dashboard (2 of 5).webm
+| source = https://upload.wikimedia.org/wikipedia/commons/7/79/How_to_Use_the_Dashboard_%282_of_5%29.webm
+| caption = How to Use the Dashboard (2 of 5)
+}}
+
+    WIKISLIDE
+  end
+
   describe '#title' do
     it 'extracts title from translation-enabled source wikitext' do
       output = WikiSlideParser.new(source_wikitext.dup).title
@@ -94,6 +109,10 @@ Wikipedia is the encyclopedia anyone can edit, but there's a lot of collaboratio
     it 'converts an image template into figure markup' do
       output = WikiSlideParser.new(image_wikitext.dup).content
       expect(output).to match(/Eryk Salvaggio/)
+    end
+    it 'converts a video template into iframe markup' do
+      output = WikiSlideParser.new(video_wikitext.dup).content
+      expect(output).to include("iframe>")
     end
     it 'includes a forced newline after figure markup' do
       # Markdown conversion outputs just one newline after figure markup, which


### PR DESCRIPTION
Right now, in order to embed a video in a slide generated from a Wiki page, you would have to enter the raw HTML, which would look good on the dashboard slide but wouldn't render correctly on Wiki.

This change adds support for a video template in the same way the image template works. The Wiki page would have a [template](https://meta.wikimedia.org/wiki/Template:Training_module_video) like this:

```
{{Training module video
| video = File:How to Use the Dashboard (2 of 5).webm
| source = https://upload.wikimedia.org/wikipedia/commons/7/79/How_to_Use_the_Dashboard_%282_of_5%29.webm
| caption = How to Use the Dashboard (2 of 5)
}}
```

On Wiki, this would embed the file normally (like `[[{{{video}}}|thumb|{{{caption}}}]]`). But on the dashboard it would insert an `<iframe>` tag. 

I've also added a test in the relevant spec file for it. 

This is my first contribution to a Ruby project so I welcome any advice/tips! 