### PR TITLE
Wiki Slide Parsing Multiple Images & Remove Categories tag

### DIFF
--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -10,6 +10,7 @@ class WikiSlideParser
     remove_noinclude
     remove_translation_markers
     remove_translate_tags
+    remove_category
     extract_quiz_template
     convert_image_template
     convert_video_template
@@ -48,6 +49,12 @@ class WikiSlideParser
 
   def remove_noinclude
     @wikitext.gsub!(%r{<noinclude>.*?</noinclude>\n*}m, '')
+  end
+
+  # Category tags are useful for categorizing pages, but we don't want them to show up in the slides
+  # Example: [[Category:Programs & Events Dashboard]]
+  def remove_category
+    @wikitext.gsub!(%r{\[\[Category:.*?\]\]\n*}m, '')
   end
 
   def remove_translation_markers

--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -121,17 +121,18 @@ class WikiSlideParser
   end
 
   def convert_video_template
-    @wikitext.gsub!(/(?<video>{{Training module video.*?\n}})/m, 'VIDEO_PLACEHOLDER')
-    @video_template = Regexp.last_match && Regexp.last_match['video']
-    return unless @video_template
-    @wikitext.gsub!('VIDEO_PLACEHOLDER', video_markup)
+    # Get all the video templates on the page to allow for multiple videos in the same slide
+    video_templates =  @wikitext.scan(/(?<video>{{Training module video.*?\n}})/m)
+    return unless video_templates
+    # Replace each one with the correct figure markup
+    video_templates.each { |template| @wikitext.sub! template[0], video_markup_from_template(template[0])  }
   end
 
   def figure_markup_from_template(template)
-    image_layout = image_layout_from(template,'layout')
-    image_source = image_source_from(template,'source')
-    image_filename = image_filename_from(template, 'image')
-    image_credit = image_credit_from(template,'credit')
+    image_layout = image_layout_from(template)
+    image_source = image_source_from(template)
+    image_filename = image_filename_from(template)
+    image_credit = image_credit_from(template)
     <<-FIGURE
 <figure class="#{image_layout}"><img src="#{image_source}" />
 <figcaption class="image-credit">
@@ -142,6 +143,7 @@ class WikiSlideParser
   end
 
   def video_markup_from_template(template)
+    video_source = video_source_from(template)
     <<-VIDEO
 <iframe width="420" height="315" src="#{video_source}" frameborder="0" allowfullscreen></iframe>
     VIDEO
@@ -163,7 +165,7 @@ class WikiSlideParser
     template_parameter_value(template, 'credit')
   end
 
-  def video_source
-    template_parameter_value(@video_template, 'source')
+  def video_source_from(template)
+    template_parameter_value(template, 'source')
   end
 end

--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -113,10 +113,11 @@ class WikiSlideParser
   end
 
   def convert_image_template
-    @wikitext.gsub!(/(?<image>{{Training module image.*?\n}})/m, 'IMAGE_PLACEHOLDER')
-    @image_template = Regexp.last_match && Regexp.last_match['image']
-    return unless @image_template
-    @wikitext.gsub!('IMAGE_PLACEHOLDER', figure_markup)
+    # Get all the image templates on the page to allow for multiple images in the same slide
+    image_templates =  @wikitext.scan(/(?<image>{{Training module image.*?\n}})/m)
+    return unless image_templates
+    # Replace each one with the correct figure markup
+    image_templates.each { |template| @wikitext.sub! template[0], figure_markup_from_template(template[0])  }
   end
 
   def convert_video_template
@@ -126,7 +127,11 @@ class WikiSlideParser
     @wikitext.gsub!('VIDEO_PLACEHOLDER', video_markup)
   end
 
-  def figure_markup
+  def figure_markup_from_template(template)
+    image_layout = image_layout_from(template,'layout')
+    image_source = image_source_from(template,'source')
+    image_filename = image_filename_from(template, 'image')
+    image_credit = image_credit_from(template,'credit')
     <<-FIGURE
 <figure class="#{image_layout}"><img src="#{image_source}" />
 <figcaption class="image-credit">
@@ -136,26 +141,26 @@ class WikiSlideParser
     FIGURE
   end
 
-  def video_markup
+  def video_markup_from_template(template)
     <<-VIDEO
 <iframe width="420" height="315" src="#{video_source}" frameborder="0" allowfullscreen></iframe>
     VIDEO
   end
 
-  def image_layout
-    template_parameter_value(@image_template, 'layout')
+  def image_layout_from(template)
+    template_parameter_value(template, 'layout')
   end
 
-  def image_source
-    template_parameter_value(@image_template, 'source')
+  def image_source_from(template)
+    template_parameter_value(template, 'source')
   end
 
-  def image_filename
-    template_parameter_value(@image_template, 'image')
+  def image_filename_from(template)
+    template_parameter_value(template, 'image')
   end
 
-  def image_credit
-    template_parameter_value(@image_template, 'credit')
+  def image_credit_from(template)
+    template_parameter_value(template, 'credit')
   end
 
   def video_source

--- a/spec/lib/training/wiki_slide_parser_spec.rb
+++ b/spec/lib/training/wiki_slide_parser_spec.rb
@@ -69,6 +69,28 @@ Wikipedia is the encyclopedia anyone can edit, but there's a lot of collaboratio
     WIKISLIDE
   end
 
+  let(:multi_image_wikitext) do
+    <<-WIKISLIDE
+== Five Pillars: The core rules of Wikipedia ==
+
+{{Training module image
+| image = File:Palace_of_Fine_Arts%2C_five_pillars.jpg
+| source = https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Palace_of_Fine_Arts%2C_five_pillars.jpg/640px-Palace_of_Fine_Arts%2C_five_pillars.jpg
+| layout = alt-layout-40-right
+| credit = Photo by Eryk Salvaggio
+}}
+
+{{Training module image
+| image = File:Find_a_program.png
+| source = https://upload.wikimedia.org/wikipedia/commons/4/48/Find_a_program.png
+| layout = alt-layout-40-right 
+| credit = In the top right of the interface, next to the Log-out and User-name buttons, you can find the language switcher
+}}
+
+Wikipedia is the encyclopedia anyone can edit, but there's a lot of collaboration behind every article. You'll work with many people to build Wikipedia.
+    WIKISLIDE
+  end
+
   let(:video_wikitext) do
     <<-WIKISLIDE
 == Starting new programs ==
@@ -116,6 +138,11 @@ If you are the host of a program or event, you need to be able to create events.
     it 'converts an image template into figure markup' do
       output = WikiSlideParser.new(image_wikitext.dup).content
       expect(output).to match(/Eryk Salvaggio/)
+    end
+    it 'converts multiple image templates into distinct figure markups' do
+      output = WikiSlideParser.new(multi_image_wikitext.dup).content
+      expect(output).to include("five_pillars.jpg")
+      expect(output).to include("Find_a_program.png")
     end
     it 'converts a video template into iframe markup' do
       output = WikiSlideParser.new(video_wikitext.dup).content


### PR DESCRIPTION
This PR mainly:

- Removes the category tag (ex: `[[Category:Programs & Events Dashboard]]`) which is useful to have on Wiki pages but should not show up on the slides
- Refactors the image parsing to allow for parsing multiple images correctly. Right now if there are multiple image templates, the parser will replace them all with the last match. 
- Does the same thing for videos as well. 

This is needed so that the [Using the dashboard](https://outreachdashboard.wmflabs.org/training/learning-and-evaluation/using-the-dashboard) module works correctly. There is at least one slide with multiple images, and all the slides have the category tag. 