### PR TITLE
Campaigntemplate#1080

### DIFF
--- a/app/assets/stylesheets/_base.styl
+++ b/app/assets/stylesheets/_base.styl
@@ -54,6 +54,10 @@ h5
 
 p
   margin-bottom 16px
+  -webkit-hyphens auto
+  -moz-hyphens auto
+  -ms-hyphens auto
+  hyphens auto
 
 small
   font-size 0.8em


### PR DESCRIPTION
Correct the little bug where campaign template content can extend beyond its box (e.g. long string). Content will now be auto hyphenated.