### PR TITLE
Add option to download a CSV of data for a single course, and calculate new editor count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_install:
 - export DISPLAY=:99.0
 - export SENDER_EMAIL_ADDRESS='sender@wikiedu.org'
 - sh -e /etc/init.d/xvfb start
-- nvm install stable
-- nvm use stable
 - node --version
 - npm --version
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
 - TEST_SUITE='~type:feature' AFTER_SUCCESS='./travis-deploy.sh'
 - TEST_SUITE='~type:foo' AFTER_SUCCESS='' # Run all tests in job 2
 language: ruby
+node_js: "7"
 rvm: 2.3.1
 sudo: required
 dist: trusty

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -135,7 +135,13 @@ const AvailableActions = React.createClass({
         <p key="join"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', this.state.course.string_prefix)}</button></p>
       ));
     }
-
+    // If the user an instructor or admin, and the course is published, show a stats download link
+    if ((user.role === 1 || user.admin) && this.state.course.published) {
+      const csvLink = `/course_csv?course=${this.state.course.slug}`;
+      controls.push((
+        <p key="stats_csv"><a href={csvLink} className="button">{I18n.t('courses.download_stats_data')}</a></p>
+      ));
+    }
     // If no controls are available
     if (controls.length === 0) {
       controls.push(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,6 +310,7 @@ en:
     delete_course_instructions: You may delete this page if all campaigns are removed first.
     dismiss_survey: Dismiss
     dismiss_survey_confirm: Are you sure you want to permanently dismiss this survey?
+    download_stats_data: Download stats
     duration: Course Duration
     edit_course_dates: Edit Course Dates
     enable_chat: Enable chat

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
   get 'analytics(/*any)' => 'analytics#index'
   post 'analytics(/*any)' => 'analytics#results'
   get 'ungreeted' => 'analytics#ungreeted'
+  get 'course_csv' => 'analytics#course_csv'
 
   # Campaigns
   resources :campaigns, param: :slug, except: :show do

--- a/db/migrate/20170530204233_add_registered_at_to_user.rb
+++ b/db/migrate/20170530204233_add_registered_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddRegisteredAtToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :registered_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170523190741) do
+ActiveRecord::Schema.define(version: 20170530204233) do
 
   create_table "alerts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "course_id"
@@ -397,6 +397,7 @@ ActiveRecord::Schema.define(version: 20170523190741) do
     t.string   "locale"
     t.string   "chat_password"
     t.string   "chat_id"
+    t.datetime "registered_at"
     t.index ["username"], name: "index_users_on_username", unique: true, using: :btree
   end
 

--- a/lib/analytics/campaign_csv_builder.rb
+++ b/lib/analytics/campaign_csv_builder.rb
@@ -1,61 +1,19 @@
 # frozen_string_literal: true
+
 require 'csv'
+require "#{Rails.root}/lib/analytics/course_csv_builder"
 
 class CampaignCsvBuilder
   def initialize(campaign)
     @campaign = campaign
   end
 
-  COURSE_CSV_HEADERS = %w(
-    course_slug
-    title
-    institution
-    new_or_returning
-    student_count
-    articles_edited
-    articles_created
-    bytes_added
-    edit_count
-    article_views
-    upload_count
-    training_completion_rate
-  ).freeze
   def courses_to_csv
-    csv_data = [COURSE_CSV_HEADERS]
+    csv_data = [CourseCsvBuilder::CSV_HEADERS]
     @campaign.courses.each do |course|
-      csv_data << course_row(course)
+      csv_data << CourseCsvBuilder.new(course).row
     end
 
     CSV.generate { |csv| csv_data.uniq.each { |line| csv << line } }
-  end
-
-  private
-
-  def course_row(course)
-    row = [course.slug]
-    row << course.title
-    row << course.school
-    row << new_or_returning_tag(course)
-    row << course.user_count
-    row << course.article_count
-    row << course.new_article_count
-    row << course.character_sum
-    row << course.revision_count
-    row << course.view_sum
-    row << course.upload_count
-    row << training_completion_rate(course)
-    row
-  end
-
-  def training_completion_rate(course)
-    return if course.user_count.zero?
-    course.trained_count.to_f / course.user_count
-  end
-
-  def new_or_returning_tag(course)
-    tags = course.tags.pluck(:tag)
-    return 'first_time_instructor' if tags.include?('first_time_instructor')
-    return 'returning_instructor' if tags.include?('returning_instructor')
-    return 'unknown'
   end
 end

--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+class CourseCsvBuilder
+  def initialize(course)
+    @course = course
+  end
+
+  CSV_HEADERS = %w[
+    course_slug
+    title
+    institution
+    term
+    editors
+    new_editors
+    articles_edited
+    articles_created
+    bytes_added
+    total_edits
+    mainspace_edits
+    article_talk_edits
+    userspace_edits
+    article_views
+    upload_count
+    uploads_used_in_articles
+    upload_usage_count_across_all_wikis
+    training_completion_rate
+  ].freeze
+  def generate_csv
+    csv_data = [CSV_HEADERS]
+    csv_data << course_row(@course)
+    CSV.generate { |csv| csv_data.each { |line| csv << line } }
+  end
+
+  private
+
+  def course_row(course)
+    row = [course.slug]
+    row << course.title
+    row << course.school
+    row << course.term
+    row << course.user_count
+    row << '' # new editors
+    row << course.article_count
+    row << course.new_article_count
+    row << course.character_sum
+    row << course.revision_count
+    row << revisions_by_namespace(Article::Namespaces::MAINSPACE)
+    row << revisions_by_namespace(Article::Namespaces::TALK)
+    row << revisions_by_namespace(Article::Namespaces::USER)
+    row << course.view_sum
+    row << course.upload_count
+    row << course.uploads_in_use_count
+    row << course.upload_usages_count
+    row << training_completion_rate
+    row
+  end
+
+  def revisions_by_namespace(namespace)
+    @course.revisions.joins(:article).where(articles: { namespace: namespace }).count
+  end
+
+  def training_completion_rate
+    return if @course.user_count.zero?
+    @course.trained_count.to_f / @course.user_count
+  end
+end

--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -68,7 +68,7 @@ class CourseCsvBuilder
 
   def new_editors_count
     # A user counts as a new editor if they registered during the course
-    @course.students.where(created_at: @course.start..@course.end).count
+    @course.students.where(registered_at: @course.start..@course.end).count
   end
 
   def revisions_by_namespace(namespace)

--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -12,6 +12,7 @@ class CourseCsvBuilder
     title
     institution
     term
+    new_or_returning
     editors
     new_editors
     articles_edited
@@ -27,34 +28,47 @@ class CourseCsvBuilder
     upload_usage_count_across_all_wikis
     training_completion_rate
   ].freeze
+  def row
+    row = [@course.slug]
+    row << @course.title
+    row << @course.school
+    row << @course.term
+    row << @new_or_returning
+    row << @course.user_count
+    row << new_editors_count
+    row << @course.article_count
+    row << @course.new_article_count
+    row << @course.character_sum
+    row << @course.revision_count
+    row << revisions_by_namespace(Article::Namespaces::MAINSPACE)
+    row << revisions_by_namespace(Article::Namespaces::TALK)
+    row << revisions_by_namespace(Article::Namespaces::USER)
+    row << @course.view_sum
+    row << @course.upload_count
+    row << @course.uploads_in_use_count
+    row << @course.upload_usages_count
+    row << training_completion_rate
+    row
+  end
+
   def generate_csv
     csv_data = [CSV_HEADERS]
-    csv_data << course_row(@course)
+    csv_data << row
     CSV.generate { |csv| csv_data.each { |line| csv << line } }
   end
 
   private
 
-  def course_row(course)
-    row = [course.slug]
-    row << course.title
-    row << course.school
-    row << course.term
-    row << course.user_count
-    row << '' # new editors
-    row << course.article_count
-    row << course.new_article_count
-    row << course.character_sum
-    row << course.revision_count
-    row << revisions_by_namespace(Article::Namespaces::MAINSPACE)
-    row << revisions_by_namespace(Article::Namespaces::TALK)
-    row << revisions_by_namespace(Article::Namespaces::USER)
-    row << course.view_sum
-    row << course.upload_count
-    row << course.uploads_in_use_count
-    row << course.upload_usages_count
-    row << training_completion_rate
-    row
+  def new_or_returning_tag
+    tags = @course.tags.pluck(:tag)
+    return 'first_time_instructor' if tags.include?('first_time_instructor')
+    return 'returning_instructor' if tags.include?('returning_instructor')
+    return 'unknown'
+  end
+
+  def new_editors_count
+    # A user counts as a new editor if they registered during the course
+    @course.students.where(created_at: @course.start..@course.end).count
   end
 
   def revisions_by_namespace(namespace)

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -58,7 +58,7 @@ class UserImporter
   end
 
   def self.update_users(users=nil)
-    users ||= User.all
+    users ||= User.where(registered_at: nil)
     users.each do |user|
       update_user_from_metawiki(user)
     end

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -98,7 +98,7 @@ class UserImporter
   def self.update_user_from_metawiki(user)
     user_data = WikiApi.new(MetaWiki.new).get_user_info(user.username)
     user.update!(username: user_data['name'],
-                 # registered_at: user_data['registration'],
+                 registered_at: user_data['registration'],
                  global_id: user_data['centralids']['CentralAuth'])
   end
 end

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -90,14 +90,8 @@ class Replica
   # API methods #
   ###############
 
-  # Given an endpoint (either 'users.php' or 'revisions.php') and a
+  # Given an endpoint ('articles.php' or 'revisions.php') and a
   # query appropriate to that endpoint, return the parsed json response.
-  #
-  # Example users.php query with 2 users:
-  #   http://tools.wmflabs.org/wikiedudashboard/users.php?user_ids[0]=012345&user_ids[1]=678910
-  # Example users.php parsed response with 2 users:
-  # [{"id"=>"123", "wiki_id"=>"User_A", "global_id"=>"8675309", trained: 1},
-  #  {"id"=>"6789", "wiki_id"=>"User_B", "global_id"=>"9035768", trained: 0}]
   #
   # Example revisions.php query:
   #   http://tools.wmflabs.org/wikiedudashboard/revisions.php?user_ids[0]=%27Example_User%27&user_ids[1]=%27Ragesoss%27&user_ids[2]=%27Sage%20(Wiki%20Ed)%27&start=20150105&end=20150108

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "#{Rails.root}/lib/revision_data_parser"
 
 #= Fetches wiki revision data from an endpoint that provides SQL query
@@ -21,7 +22,7 @@ class Replica
   ################
 
   # Given a list of users and a start and end date, return a nicely formatted
-  # array of revisions made by those users between those dates.
+  # hash of page_ids and revisions made by those users between those dates.
   def get_revisions(users, rev_start, rev_end)
     raw = get_revisions_raw(users, rev_start, rev_end)
     @data = {}
@@ -42,16 +43,6 @@ class Replica
     oauth_tags = oauth_tags.blank? ? oauth_tags : "&#{oauth_tags}"
     query = user_list + oauth_tags + "&start=#{rev_start}&end=#{rev_end}"
     api_get('revisions.php', query)
-  end
-
-  # Given a list of users, fetch their global_id and trained status. Completion
-  # of training is defined by the users.php endpoint as having made an edit
-  # to a specific page on Wikipedia:
-  # [[Wikipedia:Training/For students/Training feedback]]
-  def get_user_info(users)
-    query = compile_usernames_query(users)
-    query = "#{query}&training_page_id=#{ENV['training_page_id']}" if ENV['training_page_id']
-    api_get('users.php', query)
   end
 
   # Given a list of articles *or* hashes of the form { 'mw_page_id' => 1234 },
@@ -160,11 +151,11 @@ class Replica
   # project/language naming conventions
   def project_database_params
     if @wiki.project == 'wikidata'
-      "db=wikidatawiki"
+      'db=wikidatawiki'
     elsif @wiki.project == 'wikisource' && @wiki.language.nil?
-      "db=sourceswiki"
+      'db=sourceswiki'
     elsif @wiki.project == 'wikimedia' && @wiki.language == 'incubator'
-      "db=incubatorwiki"
+      'db=incubatorwiki'
     else
       "lang=#{@wiki.language}&project=#{@wiki.project}"
     end

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -25,12 +25,18 @@ class WikiApi
   end
 
   def get_user_id(username)
+    info = get_user_info(username)
+    return unless info
+    info['userid']
+  end
+
+  def get_user_info(username)
     user_query = { list: 'users',
-                   ususers: username }
+                   ususers: username,
+                   usprop: 'centralids|registration' }
     user_data = mediawiki('query', user_query)
     return unless user_data.data['users'].any?
-    user_id = user_data.data['users'][0]['userid']
-    user_id
+    user_data.data['users'][0]
   end
 
   def redirect?(page_title)

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -50,4 +50,12 @@ describe AnalyticsController do
       expect(response.body).to have_content(user.username)
     end
   end
+
+  describe '#course_csv' do
+    let(:course) { create(:course, slug: 'foo/bar_(baz)') }
+    it 'returns a CSV' do
+      get 'course_csv', params: { course: course.slug }
+      expect(response.body).to have_content(course.slug)
+    end
+  end
 end

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Instructor users', type: :feature, js: true do
@@ -78,7 +79,9 @@ describe 'Instructor users', type: :feature, js: true do
     end
 
     it 'should be able to add students' do
-      allow_any_instance_of(WikiApi).to receive(:get_user_id).and_return(123)
+      allow_any_instance_of(WikiApi).to receive(:get_user_info).and_return(
+        'name' => 'Risker', 'userid' => 123, 'centralids' => { 'CentralAuth' => 456 }
+      )
       visit "/courses/#{Course.first.slug}/students"
       sleep 1
       click_button 'Enrollment'

--- a/spec/lib/analytics/course_csv_builder_spec.rb
+++ b/spec/lib/analytics/course_csv_builder_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/course_csv_builder"
+
+describe CourseCsvBuilder do
+  let(:course) { create(:course) }
+  let(:subject) { described_class.new(course).generate_csv }
+
+  it 'creates a CSV with a header and a row of data' do
+    expect(subject.split("\n").count).to eq(2)
+  end
+end

--- a/spec/lib/importers/user_importer_spec.rb
+++ b/spec/lib/importers/user_importer_spec.rb
@@ -122,7 +122,7 @@ describe UserImporter do
   end
 
   describe '.update_users' do
-    it 'updates global ids' do
+    it 'updates global ids and MetaWiki registration date' do
       create(:user, username: 'Ragesoss', global_id: nil)
       create(:user, username: 'Ragesock', global_id: nil)
 
@@ -137,6 +137,8 @@ describe UserImporter do
       # expect(ragesoss.trained).to eq(true)
       expect(ragesoss.global_id).to eq(827)
       expect(ragesock.global_id).to eq(14093230)
+      expect(ragesoss.registered_at.to_date).to eq(Date.new(2006, 7, 14))
+      expect(ragesock.registered_at.to_date).to eq(Date.new(2012, 7, 11))
     end
   end
 end

--- a/spec/lib/importers/user_importer_spec.rb
+++ b/spec/lib/importers/user_importer_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require "#{Rails.root}/lib/importers/user_importer"
 
@@ -121,20 +122,21 @@ describe UserImporter do
   end
 
   describe '.update_users' do
-    it 'should update which users have completed training' do
-      # Create a new user, who by default is assumed not to have been trained.
-      ragesoss = create(:trained)
-      expect(ragesoss.trained).to eq(false)
+    it 'updates global ids' do
+      create(:user, username: 'Ragesoss', global_id: nil)
+      create(:user, username: 'Ragesock', global_id: nil)
 
       # Update trained users to see that user has really been trained
-      UserImporter.update_users
-      ragesoss = User.all.first
-      expect(ragesoss.trained).to eq(true)
-    end
-
-    it 'should handle exceptions for missing users' do
-      user = [build(:user)]
-      UserImporter.update_users(user)
+      VCR.use_cassette 'users/update_users' do
+        UserImporter.update_users
+      end
+      ragesoss = User.find_by(username: 'Ragesoss')
+      ragesock = User.find_by(username: 'Ragesock')
+      # Since on-wiki trainings are not used anymore, we no longer update "trained"
+      # status via UserImporter.
+      # expect(ragesoss.trained).to eq(true)
+      expect(ragesoss.global_id).to eq(827)
+      expect(ragesock.global_id).to eq(14093230)
     end
   end
 end


### PR DESCRIPTION
This set of changes adds a `registered_at` field for the User model, which records when the account was created on meta.wikimedia.org. For new Wikipedia accounts, the account on Meta will be automatically created at the time of registration.

This registration date is used to calculate the number of editors in a course who are newbies — that is, who have accounts that were registered during the course.

This data is accessible via a new 'Download stats' link from course pages (visible to instructors and admins), and is also included in the course-by-course data of the Campaign CSVs.

We may later want to add a field on Course to cache the new editor count, so that we don't have to run queries against registered_at for each row in a Campaign CSV.