### PR TITLE
Fix diffviewer for wikidata #1347

### DIFF
--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -56,7 +56,6 @@ const DiffViewer = React.createClass({
     if (this.props.first_revision) {
       return this.findParentOfFirstRevision();
     }
-
     this.fetchDiff(this.diffUrl());
   },
 
@@ -137,11 +136,18 @@ const DiffViewer = React.createClass({
 
   render() {
     let button;
-    let showButtonStyle;
+    let showButtonStyle = '';
+
+    if (this.props.revision.wiki.project === 'wikidata') {
+      // the DiffViewer does not work for wikidata.org because it doesn't use the same diff format as other wikis,
+      // so we're hiding the button
+      showButtonStyle = ' hidden';
+    }
+
     if (this.props.largeButton) {
-      showButtonStyle = 'button dark';
+      showButtonStyle = `button dark${showButtonStyle}`;
     } else {
-      showButtonStyle = 'button dark small';
+      showButtonStyle = `button dark small${showButtonStyle}`;
     }
 
     if (this.state.showDiff) {

--- a/app/controllers/experiments/fall2017_cmu_experiment_controller.rb
+++ b/app/controllers/experiments/fall2017_cmu_experiment_controller.rb
@@ -9,7 +9,7 @@ module Experiments
 
     def opt_in
       Fall2017CmuExperiment.new(@course).opt_in
-      flash[:notice] = 'Thanks for opting in!'
+      flash[:notice] = 'Thank you for opting in. We will add the video sessions to the relevant assignments on the timeline for your WikiEd dashboard and send you an email about next steps.'
       redirect_to "/courses/#{@course.slug}"
     end
 

--- a/app/views/courses/_weeks.json.jbuilder
+++ b/app/views/courses/_weeks.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 course_meetings_manager = CourseMeetingsManager.new(course)
 
 json.weeks course.weeks.eager_load(blocks: [:gradeable]) do |week|
@@ -22,6 +23,10 @@ json.weeks course.weeks.eager_load(blocks: [:gradeable]) do |week|
     end
     if block.training_modules.any?
       json.training_modules block.training_modules do |tm|
+        # The available training modules may change over time, especially on
+        # Programs & Events Dashboard where wiki trainings are enabled.
+        # For modules that aren't found, simply skip sending info.
+        next unless tm
         progress_manager = TrainingProgressManager.new(current_user, tm)
         due_date_manager = TrainingModuleDueDateManager.new(
           course: course,


### PR DESCRIPTION
The code I added hides the button for wikidata items. However, I did notice when you're in the Articles section and open a drawer for an edited article for the first time you will briefly see the “Show Cumulative Changes” button.  