### PR TITLE
Fix horizontal overflow on issue 1205

### DIFF
--- a/app/assets/stylesheets/modules/_popover.styl
+++ b/app/assets/stylesheets/modules/_popover.styl
@@ -9,7 +9,7 @@
     border 1px solid mischka
     border-radius 3px
     box-shadow 0 0 15px 0 rgba(0, 0, 0, .2)
-    left 50%
+    right 0
     opacity 0
     pointer-events none
     position absolute
@@ -19,8 +19,8 @@
     // so we need to turn it off and add the -webkit- prefix explicitly to make
     // it work together with css-flipper.
     /* autoprefixer: off */
-    /*@replace: translateX(50%) translateY(-30px) scale(.7, .7)*/ transform translateX(-50%) translateY(-30px) scale(.7, .7)
-    /*@replace: translateX(50%) translateY(-30px) scale(.7, .7)*/ -webkit-transform translateX(-50%) translateY(-30px) scale(.7, .7)
+    /*@replace: translateX(50px) translateY(-30px) scale(.7, .7)*/ transform translateX(50px) translateY(-30px) scale(.7, .7)
+    /*@replace: translateX(50px) translateY(-30px) scale(.7, .7)*/ -webkit-transform translateX(50px) translateY(-30px) scale(.7, .7)
     /* autoprefixer: on */
     transition all .2s
     z-index 10
@@ -28,8 +28,8 @@
       opacity 1
       pointer-events all
       /* autoprefixer: off */
-      /*@replace: translateX(50%) translateY(0) scale(1, 1)*/ transform translateX(-50%) translateY(0) scale(1, 1)
-      /*@replace: translateX(50%) translateY(0) scale(1, 1)*/ -webkit-transform translateX(-50%) translateY(0) scale(1, 1)
+      /*@replace: translateX(0%) translateY(0) scale(1, 1)*/ transform translateX(-0%) translateY(0) scale(1, 1)
+      /*@replace: translateX(0%) translateY(0) scale(1, 1)*/ -webkit-transform translateX(-0%) translateY(0) scale(1, 1)
       /* autoprefixer: on */
     &:before
       border-bottom 6px solid white
@@ -37,7 +37,7 @@
       border-left 6px solid transparent
       content ''
       display block
-      left 50%
+      right 50px
       margin-left -3px
       position absolute
       top -6px

--- a/app/views/courses/_weeks.json.jbuilder
+++ b/app/views/courses/_weeks.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 course_meetings_manager = CourseMeetingsManager.new(course)
 
 json.weeks course.weeks.eager_load(blocks: [:gradeable]) do |week|
@@ -22,6 +23,10 @@ json.weeks course.weeks.eager_load(blocks: [:gradeable]) do |week|
     end
     if block.training_modules.any?
       json.training_modules block.training_modules do |tm|
+        # The available training modules may change over time, especially on
+        # Programs & Events Dashboard where wiki trainings are enabled.
+        # For modules that aren't found, simply skip sending info.
+        next unless tm
         progress_manager = TrainingProgressManager.new(current_user, tm)
         due_date_manager = TrainingModuleDueDateManager.new(
           course: course,


### PR DESCRIPTION
'Fixes issue #1205'

@ragesoss We were able to prevent the overflow by right aligning the popovers with the right side of the container. This affected the button in the issue at hand, but we also noticed this affected the enrollment button on the students page. We adjusted the placement of .pop.open ::before pseudoelement to a fixed offset of 50px from the right. Please let us know if this is an acceptable solution.

Thanks!

Authors: @buji405 @dstock48 @coleworsley
### Screenshot 1
![screen shot 2017-08-29 at 2 08 10 pm](https://user-images.githubusercontent.com/16696290/29841757-e4e49a3a-8cc3-11e7-9f66-78e67ccf37bf.png)

### Screenshot 2
![screen shot 2017-08-29 at 2 08 21 pm](https://user-images.githubusercontent.com/16696290/29841752-e119c95c-8cc3-11e7-8c93-ca9e6ac0947d.png)