### PR TITLE
Fix horizontal overflow on issue 1205

### DIFF
--- a/app/assets/javascripts/components/common/popover.jsx
+++ b/app/assets/javascripts/components/common/popover.jsx
@@ -14,7 +14,9 @@ const Popover = React.createClass({
     if (this.props.is_open) {
       divClass += ' open';
     }
-
+    if (this.props.right_aligned) {
+      divClass += ' right-aligned';
+    }
     return (
       <div className={divClass}>
         <table>

--- a/app/assets/javascripts/components/common/popover.jsx
+++ b/app/assets/javascripts/components/common/popover.jsx
@@ -4,6 +4,7 @@ const Popover = React.createClass({
   displayName: 'Popover',
 
   propTypes: {
+    right_aligned: React.PropTypes.bool,
     is_open: React.PropTypes.bool,
     edit_row: React.PropTypes.node,
     rows: React.PropTypes.node

--- a/app/assets/javascripts/components/students/assign_button.jsx
+++ b/app/assets/javascripts/components/students/assign_button.jsx
@@ -26,6 +26,7 @@ const AssignButton = React.createClass({
     add_available: React.PropTypes.bool,
     assignments: React.PropTypes.array,
     open: React.PropTypes.func.isRequired,
+    right_aligned: React.PropTypes.bool,
     tooltip_message: React.PropTypes.string
   },
 
@@ -329,6 +330,7 @@ const AssignButton = React.createClass({
         {showButton}
         {editButton}
         <Popover
+          right_aligned={this.props.right_aligned}
           is_open={this.props.is_open}
           edit_row={editRow}
           rows={assignments}

--- a/app/assets/javascripts/components/students/assign_cell.jsx
+++ b/app/assets/javascripts/components/students/assign_cell.jsx
@@ -59,7 +59,7 @@ const AssignCell = React.createClass({
     return (
       <div>
         {link}
-        <AssignButton {...this.props} role={this.props.role} permitted={permitted} ref="button" />
+        <AssignButton {...this.props} right_aligned={true} role={this.props.role} permitted={permitted} ref="button" />
       </div>
     );
   }

--- a/app/assets/javascripts/components/students/enroll_button.jsx
+++ b/app/assets/javascripts/components/students/enroll_button.jsx
@@ -23,6 +23,7 @@ const EnrollButton = React.createClass({
     inline: React.PropTypes.bool,
     open: React.PropTypes.func,
     is_open: React.PropTypes.bool,
+    right_aligned: React.PropTypes.bool,
     current_user: React.PropTypes.object
   },
 
@@ -196,6 +197,7 @@ const EnrollButton = React.createClass({
         {confirmationDialog}
         {button}
         <Popover
+          right_aligned={this.props.right_aligned}
           is_open={this.props.is_open}
           edit_row={editRows}
           rows={users}

--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -91,7 +91,7 @@ const StudentList = React.createClass({
 
     let addStudent;
     if (this.props.course.published) {
-      addStudent = <EnrollButton {...this.props} role={0} key="add_student" allowed={false} />;
+      addStudent = <EnrollButton {...this.props} role={0} right_aligned={true} key="add_student" allowed={false} />;
     }
 
     let notifyOverdue;

--- a/app/assets/stylesheets/modules/_popover.styl
+++ b/app/assets/stylesheets/modules/_popover.styl
@@ -31,6 +31,13 @@
       /*@replace: translateX(50%) translateY(0) scale(1, 1)*/ transform translateX(-50%) translateY(0) scale(1, 1)
       /*@replace: translateX(50%) translateY(0) scale(1, 1)*/ -webkit-transform translateX(-50%) translateY(0) scale(1, 1)
       /* autoprefixer: on */
+    &.right-aligned
+      /* autoprefixer: off */
+      /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ transform translateX(0px) translateY(0) scale(1, 1)
+      /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ -webkit-transform translateX(0px) translateY(0) scale(1, 1)
+      /* autoprefixer: on */
+      left auto
+      right 0
     &:before
       border-bottom 6px solid white
       border-right 6px solid transparent
@@ -41,6 +48,9 @@
       margin-left -3px
       position absolute
       top -6px
+    &.right-aligned:before
+      left auto
+      right 50px
     tr.edit
       border-bottom 1px solid $border_lt
     tr:last-child


### PR DESCRIPTION
'Fixes issue #1205'

@ragesoss Updated PR

Heres the message from before: We were able to prevent the overflow by right aligning the popovers with the right side of the container. This affected the button in the issue at hand, but we also noticed this affected the enrollment button on the students page. We adjusted the placement of .pop.open ::before pseudoelement to a fixed offset of 50px from the right. Please let us know if this is an acceptable solution.

Thanks!

Authors: @buji405 @dstock48 @coleworsley
### Screenshot 1
![screen shot 2017-08-29 at 2 08 10 pm](https://user-images.githubusercontent.com/16696290/29841757-e4e49a3a-8cc3-11e7-9f66-78e67ccf37bf.png)

### Screenshot 2
![screen shot 2017-08-29 at 2 08 21 pm](https://user-images.githubusercontent.com/16696290/29841752-e119c95c-8cc3-11e7-8c93-ca9e6ac0947d.png)