### PR TITLE
changed 'ruby 2.3.1' to 'ruby >= 2.3.1' in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '>=2.3.1'
 gem 'rails', '5.1.3'
 gem 'jbuilder', '~> 2.0'
 gem 'haml-rails'


### PR DESCRIPTION
changed 'ruby 2.3.1' to 'ruby >= 2.3.1' in Gemfile to make it compatible with higher versions of ruby.