### PR TITLE
partial fixes for issue 1395

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,31 +44,27 @@ class ApplicationController < ActionController::Base
   end
 
   def require_signed_in
-    return if user_signed_in?
-    exception = NotSignedInError.new
-    raise exception
+    raise NotSignedInError unless user_signed_in?
   end
 
   def require_permissions
+    require_signed_in
     course = Course.find_by_slug(params[:id])
-    return if user_signed_in? && current_user.can_edit?(course)
-    exception = NotPermittedError.new
-    raise exception
+    raise NotPermittedError unless current_user.can_edit? course
   end
 
   def require_admin_permissions
-    return if user_signed_in? && current_user.admin?
-    exception = NotAdminError.new
-    raise exception
+    require_signed_in
+    raise NotAdminError unless current_user.admin?
   end
 
   def require_participating_user
+    require_signed_in
     course = Course.find_by_slug(params[:id])
     # Course roles for non-students are greater than STUDENT_ROLE.
     # Non-participating users have the VISITOR_ROLE, which is below STUDENT_ROLE.
     return if user_signed_in? && current_user.role(course) >= CoursesUsers::Roles::STUDENT_ROLE
-    exception = ParticipatingUserError.new
-    raise exception
+    raise ParticipatingUserError
   end
 
   def check_for_expired_oauth_credentials

--- a/lib/errors/authentication_errors.rb
+++ b/lib/errors/authentication_errors.rb
@@ -21,7 +21,7 @@ module Errors
     end # NotAdmitError
 
     class ParticipatingUserError < StandardError
-      def initialize(msg='Only administrators may do that.')
+      def initialize(msg='Only participants of this course may do that.')
         super
       end
     end # ParticipatingUserError

--- a/lib/errors/authentication_errors.rb
+++ b/lib/errors/authentication_errors.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Errors
+  module AuthenticationErrors
+    class NotSignedInError < StandardError
+      def initialize(msg='Please sign in.')
+        super
+      end
+    end # NotSignedInError
+
+    class NotPermittedError < StandardError
+      def initialize(msg='You are not permitted to do that.')
+        super
+      end
+    end # NotPermittedError
+
+    class NotAdminError < StandardError
+      def initialize(msg='Only administrators may do that.')
+        super
+      end
+    end # NotAdmitError
+
+    class ParticipatingUserError < StandardError
+      def initialize(msg='Only administrators may do that.')
+        super
+      end
+    end # ParticipatingUserError
+
+  end # AuthenticationErrors
+end # Errors

--- a/lib/errors/rescue_errors.rb
+++ b/lib/errors/rescue_errors.rb
@@ -30,8 +30,9 @@ module Errors
     def self.rescue_not_signed_in(base)
       base.rescue_from AuthenticationErrors::NotSignedInError do |e|
         respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unprocessable_entity }
-          format.html {} # TODO
+          format.json { render json: { message: e.message }, status: :unauthorized }
+          # TODO: need more user friendly error handling for html
+          format.html { render plain: e.message, status: :unauthorized } 
         end
       end
     end # rescue_not_signed_in
@@ -39,8 +40,9 @@ module Errors
     def self.rescue_not_permitted(base)
       base.rescue_from AuthenticationErrors::NotPermittedError do |e|
         respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unprocessable_entity }
-          format.html {} # TODO
+          format.json { render json: { message: e.message }, status: :unauthorized }
+          # TODO: need more user friendly error handling for html
+          format.html { render plain: e.message , status: :unauthorized }
         end
       end
     end # rescue_not_permitted
@@ -48,8 +50,9 @@ module Errors
     def self.rescue_not_admin(base)
       base.rescue_from AuthenticationErrors::NotAdminError do |e|
         respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unprocessable_entity }
-          format.html {} # TODO
+          format.json { render json: { message: e.message }, status: :unauthorized }
+          # TODO: need more user friendly error handling for html
+          format.html { render plain: e.message, status: :unauthorized }
         end
       end
     end # rescue_not_admin
@@ -57,8 +60,9 @@ module Errors
     def self.rescue_participating_user(base)
       base.rescue_from AuthenticationErrors::ParticipatingUserError do |e|
         respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unprocessable_entity }
-          format.html {} # TODO
+          format.json { render json: { message: e.message }, status: :unauthorized }
+          # TODO: need more user friendly error handling for html
+          format.html { render plain: e.message, status: :unauthorized }
         end
       end
     end # rescue_participating_user

--- a/lib/errors/rescue_errors.rb
+++ b/lib/errors/rescue_errors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Errors
+  module RescueErrors
+    def self.included(base)
+      rescue_invalid_token(base)
+      rescue_unknown_format(base)
+    end # self.included
+
+    def self.rescue_invalid_token(base)
+      base.rescue_from ActionController::InvalidAuthenticityToken do
+        render plain: t('error_401.explanation'), status: :unauthorized
+      end
+    end # self.rescue_invalid_token
+
+    def self.rescue_unknown_format(base)
+      # Stop index.php routes from causing the kinds of errors that get reported
+      # to Sentry.
+      base.rescue_from ActionController::UnknownFormat do
+        render plain: t('error_404.explanation'), status: 404
+      end
+    end # self.rescue_unknown_format
+
+  end # RescueErrors
+end
+

--- a/lib/errors/rescue_errors.rb
+++ b/lib/errors/rescue_errors.rb
@@ -15,9 +15,10 @@ module Errors
 
     def self.rescue_invalid_token(base)
       base.rescue_from ActionController::InvalidAuthenticityToken do
-        respond_to do |format|
-          format.html { render plain: t('error_401.explanation'), status: :unauthorized }
-          format.json { render json: { message: 'Please sign in' }, status: :unauthorized }
+        if json?(request)
+          render json: { message: 'Please sign in' }, status: :unauthorized
+        else
+          render plain: t('error_401.explanation'), status: :unauthorized
         end
       end
     end # self.rescue_invalid_token
@@ -32,42 +33,52 @@ module Errors
 
     def self.rescue_not_signed_in(base)
       base.rescue_from AuthenticationErrors::NotSignedInError do |e|
-        respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unauthorized }
+        if json?(request)
+          render json: { message: e.message }, status: :unauthorized
+        else
           # TODO: need more user friendly error handling for html
-          format.html { render plain: e.message, status: :unauthorized }
+          render plain: e.message, status: :unauthorized
         end
       end
     end # rescue_not_signed_in
 
     def self.rescue_not_permitted(base)
       base.rescue_from AuthenticationErrors::NotPermittedError do |e|
-        respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unauthorized }
+        if json?(request)
+          render json: { message: e.message }, status: :unauthorized
+        else
           # TODO: need more user friendly error handling for html
-          format.html { render plain: e.message, status: :unauthorized }
+          render plain: e.message, status: :unauthorized
         end
       end
     end # rescue_not_permitted
 
     def self.rescue_not_admin(base)
       base.rescue_from AuthenticationErrors::NotAdminError do |e|
-        respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unauthorized }
+        if json?(request)
+          render json: { message: e.message }, status: :unauthorized
+        else
           # TODO: need more user friendly error handling for html
-          format.html { render plain: e.message, status: :unauthorized }
+          render plain: e.message, status: :unauthorized
         end
       end
     end # rescue_not_admin
 
     def self.rescue_participating_user(base)
       base.rescue_from AuthenticationErrors::ParticipatingUserError do |e|
-        respond_to do |format|
-          format.json { render json: { message: e.message }, status: :unauthorized }
+        if json?(request)
+          render json: { message: e.message }, status: :unauthorized
+        else
           # TODO: need more user friendly error handling for html
-          format.html { render plain: e.message, status: :unauthorized }
+          render plain: e.message, status: :unauthorized
         end
       end
     end # rescue_participating_user
+
+    private
+
+    def json?(request)
+      request.media_type.include? 'json'
+    end
   end # RescueErrors
 end

--- a/lib/errors/rescue_errors.rb
+++ b/lib/errors/rescue_errors.rb
@@ -2,9 +2,17 @@
 
 module Errors
   module RescueErrors
+    AUTHENTICATION_ERRORS = %i[not_signed_in not_permitted not_admin participating_user].freeze
+
     def self.included(base)
       rescue_invalid_token(base)
       rescue_unknown_format(base)
+
+      ##
+      # dynamically include each rescue method
+      AUTHENTICATION_ERRORS.each do |err|
+        send("rescue_#{err}", base)
+      end
     end # self.included
 
     def self.rescue_invalid_token(base)
@@ -20,6 +28,26 @@ module Errors
         render plain: t('error_404.explanation'), status: 404
       end
     end # self.rescue_unknown_format
+
+    ##
+    # dynamically define each rescue in terms of the exception it will catch
+    AUTHENTICATION_ERRORS.each do |err|
+      send(:define_singleton_method, "rescue_#{err}") do |base|
+        base.rescue_from "Errors::AuthenticationErrors::#{err.to_s.camelcase}Error".constantize do |e|
+          respond_to do |format|
+            format.json { render_json e.message }
+            # format.html {} what happens here?
+          end
+        end # rescue_from
+      end # send
+    end # loop
+
+    private
+
+    def render_json msg
+      render json: { message: msg },
+             status: :unprocessable_entity
+    end
 
   end # RescueErrors
 end

--- a/lib/errors/rescue_errors.rb
+++ b/lib/errors/rescue_errors.rb
@@ -15,7 +15,10 @@ module Errors
 
     def self.rescue_invalid_token(base)
       base.rescue_from ActionController::InvalidAuthenticityToken do
-        render plain: t('error_401.explanation'), status: :unauthorized
+        respond_to do |format|
+          format.html { render plain: t('error_401.explanation'), status: :unauthorized }
+          format.json { render json: { message: 'Please sign in' }, status: :unauthorized }
+        end
       end
     end # self.rescue_invalid_token
 
@@ -32,7 +35,7 @@ module Errors
         respond_to do |format|
           format.json { render json: { message: e.message }, status: :unauthorized }
           # TODO: need more user friendly error handling for html
-          format.html { render plain: e.message, status: :unauthorized } 
+          format.html { render plain: e.message, status: :unauthorized }
         end
       end
     end # rescue_not_signed_in
@@ -42,7 +45,7 @@ module Errors
         respond_to do |format|
           format.json { render json: { message: e.message }, status: :unauthorized }
           # TODO: need more user friendly error handling for html
-          format.html { render plain: e.message , status: :unauthorized }
+          format.html { render plain: e.message, status: :unauthorized }
         end
       end
     end # rescue_not_permitted

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -199,7 +199,7 @@ describe UsersController do
 
       it 'should not authorize' do
         get :index
-        expect(response.body).to have_content('You are not authorized')
+        expect(response.body).to have_content('Only administrators may do that.')
       end
     end
 


### PR DESCRIPTION
move application controller rescues to their own module (errors/rescue_errors)
respond with useful error messages for various errors in application controller

I still have two questions:

 1. I'm not sure how to handle point 1: "redirect /404 and /500 to the prettier error pages." AFAIK, rails first tries to fulfill a request by looking for static assets in `public/`. `routes.rb` is only consulted if they are not found. Since we don't want to remove `public/404.html` I'm not sure how to have the router handle requests for `/404` or `/500`
2. How specifically do you want to handle errors in the application controller when responding to html? Do you want to redirect somewhere for example?