### PR TITLE
Fix horizontal overflow on Popover components for issue #1205

### DIFF
--- a/app/assets/stylesheets/modules/_popover.styl
+++ b/app/assets/stylesheets/modules/_popover.styl
@@ -19,17 +19,19 @@
     // so we need to turn it off and add the -webkit- prefix explicitly to make
     // it work together with css-flipper.
     /* autoprefixer: off */
-    /*@replace: translateX(50%) translateY(-30px) scale(.7, .7)*/ transform translateX(-50%) translateY(-30px) scale(.7, .7)
-    /*@replace: translateX(50%) translateY(-30px) scale(.7, .7)*/ -webkit-transform translateX(-50%) translateY(-30px) scale(.7, .7)
+    /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ transform translateX(0px) translateY(0) scale(.7, .7)
+    /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ -webkit-transform translateX(0px) translateY(0) scale(.7, .7)
     /* autoprefixer: on */
     transition all .2s
     z-index 10
+    left auto
+    right 0
     &.open
       opacity 1
       pointer-events all
       /* autoprefixer: off */
-      /*@replace: translateX(50%) translateY(0) scale(1, 1)*/ transform translateX(-50%) translateY(0) scale(1, 1)
-      /*@replace: translateX(50%) translateY(0) scale(1, 1)*/ -webkit-transform translateX(-50%) translateY(0) scale(1, 1)
+      /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ transform translateX(0px) translateY(0) scale(1, 1)
+      /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ -webkit-transform translateX(0px) translateY(0) scale(1, 1)
       /* autoprefixer: on */
     &:before
       border-bottom 6px solid white
@@ -41,6 +43,11 @@
       margin-left -3px
       position absolute
       top -6px
+      left auto
+      right 5px
+    &.open:before
+      left auto
+      right 5px
     tr.edit
       border-bottom 1px solid $border_lt
     tr:last-child


### PR DESCRIPTION
<img width="316" alt="screen shot 2017-09-15 at 7 57 43 pm" src="https://user-images.githubusercontent.com/13757305/30507204-40e1e2fe-9a50-11e7-9d1e-a36c401ce97b.png">

I simply added the additional `plus-right-aligned` class to overwrite `right-aligned` on `<Popover />` components that have the `<button>` with class `plus`.