### PR TITLE
Articles tab show's more detail about each article

### DIFF
--- a/app/assets/javascripts/campaigns.js
+++ b/app/assets/javascripts/campaigns.js
@@ -84,10 +84,22 @@ $(() => {
     });
   }
 
+  // Article sorting
+  // only sort if there are tables to sort
+  let articlesList;
+  if ($('#articles table').length) {
+    articlesList = new List('articles', {
+      valueNames: [
+        'title', 'views', 'char_added'
+      ]
+    });
+  }
+
   return $('select.sorts').on('change', function () {
     const list = (() => {
       switch ($(this).attr('rel')) {
         case 'campaigns': return campaignList;
+        case 'articles': return articlesList;
         default: break;
       } })();
     if (list) {

--- a/app/assets/javascripts/campaigns.js
+++ b/app/assets/javascripts/campaigns.js
@@ -90,7 +90,7 @@ $(() => {
   if ($('#articles table').length) {
     articlesList = new List('articles', {
       valueNames: [
-        'title', 'views', 'char_added'
+        'title', 'views', 'char_added', 'lang_project'
       ]
     });
   }

--- a/app/assets/javascripts/utils/course.js
+++ b/app/assets/javascripts/utils/course.js
@@ -45,7 +45,7 @@ $(() => {
     articlesList = new List('articles', {
       page: 500,
       valueNames: [
-        'title', 'views', 'char_added'
+        'title', 'views', 'char_added', 'lang_project'
       ]
     });
   }

--- a/app/assets/javascripts/utils/course.js
+++ b/app/assets/javascripts/utils/course.js
@@ -38,6 +38,18 @@ $(() => {
     });
   }
 
+  // Article sorting
+  // only sort if there are tables to sort
+  let articlesList;
+  if ($('#articles table').length) {
+    articlesList = new List('articles', {
+      page: 500,
+      valueNames: [
+        'title', 'views', 'char_added'
+      ]
+    });
+  }
+
   // for use on campaign/programs page
   $('.remove-course').on('click', e => {
     const confirmed = window.confirm(I18n.t('campaign.confirm_course_removal', {
@@ -54,6 +66,7 @@ $(() => {
       switch ($(this).attr('rel')) {
         case 'courses': return courseList;
         case 'campaigns': return campaignList;
+        case 'articles': return articlesList;
         default: break;
       } })();
     if (list) {

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -21,6 +21,7 @@ class Campaign < ActiveRecord::Base
   has_many :campaigns_courses, class_name: 'CampaignsCourses', dependent: :destroy
   has_many :campaigns_users, class_name: 'CampaignsUsers', dependent: :destroy
   has_many :courses, through: :campaigns_courses
+  has_many :articles_courses, through: :courses
   has_many :articles, -> { distinct }, through: :courses
   has_many :students, -> { distinct }, through: :courses
   has_many :instructors, -> { distinct }, through: :courses

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -1,0 +1,10 @@
+%tr
+  %td.title
+    = link_to full_title(article), article_url(article)
+  %td.char_added
+    = article_course.character_sum
+  %td.views
+    = article_course.view_count
+  %td
+    %small
+      = "#{article.wiki.language}.#{article.wiki.project}"

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -5,6 +5,6 @@
     = article_course.character_sum
   %td.views
     = article_course.view_count
-  %td
+  %td.lang_project
     %small
       = "#{article.wiki.language}.#{article.wiki.project}"

--- a/app/views/campaigns/articles.html.haml
+++ b/app/views/campaigns/articles.html.haml
@@ -19,8 +19,10 @@
             = t("metrics.char_added")
           %option{rel: 'desc', value: 'views'}
             = t("metrics.view")
+          %option{rel: 'asc', value: 'lang_project'}
+            = t("articles.wiki")
 
-    %table.table.table--hoverable.table--expandable.table--sortable
+    %table.table.table--hoverable.table--sortable
       %thead
         %tr
           %th.sort.sortable.asc{'data-default-order' => 'asc', 'data-sort' => 'title'}
@@ -40,6 +42,9 @@
               %span.tooltip-indicator
               .tooltip.dark
                 %p= t('articles.view_doc')
+          %th.sort.sortable{'data-sort' => 'lang_project'}
+            = t('articles.wiki')
+            %span.sortable-indicator
 
       - articles = @campaign.articles_courses.includes(article: :wiki).order('articles.title')
 

--- a/app/views/campaigns/articles.html.haml
+++ b/app/views/campaigns/articles.html.haml
@@ -11,13 +11,43 @@
     .section-header
       %h3
         = t('courses.articles_edited', title: @campaign.title)
+      .sort-select
+        %select.sorts{rel: 'articles'}
+          %option{rel: 'asc', value: 'title'}
+            = t("articles.title")
+          %option{rel: 'desc', value: 'char_added'}
+            = t("metrics.char_added")
+          %option{rel: 'desc', value: 'views'}
+            = t("metrics.view")
 
-    %table.table.table--hoverable.table--sortable
+    %table.table.table--hoverable.table--expandable.table--sortable
+      %thead
+        %tr
+          %th.sort.sortable.asc{'data-default-order' => 'asc', 'data-sort' => 'title'}
+            = t('articles.title')
+            %span.sortable-indicator
+          %th.sort.sortable{'data-default-order' => 'desc', 'data-sort' => 'char_added'}
+            .tooltip-trigger
+              = t('metrics.char_added')
+              %span.sortable-indicator
+              %span.tooltip-indicator
+              .tooltip.dark
+                %p= t('articles.character_doc')
+          %th.sort.sortable{'data-default-order' => 'desc', 'data-sort' => 'views'}
+            .tooltip-trigger
+              = t('metrics.view')
+              %span.sortable-indicator
+              %span.tooltip-indicator
+              .tooltip.dark
+                %p= t('articles.view_doc')
+
+      - articles = @campaign.articles_courses.includes(article: :wiki).order('articles.title')
+
       %tbody.list
-        - @campaign.articles.includes(:wiki).order(:title).each do |article|
-          %tr
-            %td.title
-              = link_to full_title(article), article_url(article)
-            %td
-              %small
-                = "#{article.wiki.language}.#{article.wiki.project}"
+        - if articles.empty?
+          %tr.disabled
+            %td{:class => "text-center", :colSpan => 3}
+              %span= I18n.t('articles.none')
+        - else
+          - articles.each do |ac|
+            = render 'campaigns/article_row', article: ac.article, article_course: ac

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,7 @@ en:
     # This is a maintence script message
     views_added: "Added %{count} new views for %{title}"
     edit_size: Edit Size
+    wiki: Wiki
     wp10: Structural Completeness
     wp10_doc: >
       The 'Structural Completeness' score represents how closely an article fits

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -46,6 +46,7 @@ describe Campaign do
     it { should have_many(:campaigns_users) }
     it { should have_many(:question_group_conditionals) }
     it { should have_many(:rapidfire_question_groups).through(:question_group_conditionals) }
+    it { should have_many(:articles_courses) }
   end
 
   describe 'active campaign' do


### PR DESCRIPTION
Changes for enhancement https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1360

Campaign.articles_courses relation is added
campaigns/articles view changed to show table header row and two additional info columns
Sorting articles option is added to javascript