### PR TITLE
For course slugs, multiple internal spaces should be collapsed into one space

### DIFF
--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -14,7 +14,7 @@ const CourseUtils = class {
   }
   slugify(text) {
     if (typeof text !== 'undefined' && text !== null) {
-        return text.split(/\s+/).join('_');
+      return text.split(/\s+/).join('_');
     }
   }
 

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -29,9 +29,9 @@ const CourseUtils = class {
 
   cleanupCourseSlugComponents(course) {
     const cleanedCourse = course;
-    cleanedCourse.title = course.title.trim();
-    cleanedCourse.school = course.school.trim();
-    cleanedCourse.term = course.term.trim();
+    cleanedCourse.title = course.title.trim().split(/\s+/).join(' ');
+    cleanedCourse.school = course.school.trim().split(/\s+/).join(' ');
+    cleanedCourse.term = course.term.trim().split(/\s+/).join(' ');
     return cleanedCourse;
   }
 

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -14,7 +14,7 @@ const CourseUtils = class {
   }
   slugify(text) {
     if (typeof text !== 'undefined' && text !== null) {
-      return text.split(/\s/).join('_');
+        return text.split(/\s+/).join('_');
     }
   }
 

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -22,6 +22,16 @@ describe('courseUtils.generateTempId', () => {
     expect(slug).to.eq('University_of_Wikipedia/Introduction_to_Editing_(Fall_2015)');
   });
 
+  it('collapses multiple whiltespaces into one space', () => {
+    const course = {
+      term: 'Fall    2015',
+      school: ' University    of   Wikipedia            ',
+      title: '          Introduction     to         Editing          '
+    };
+    const slug = courseUtils.generateTempId(course);
+    expect(slug).to.eq('University_of_Wikipedia/Introduction_to_Editing_(Fall_2015)');
+  });
+
   it('creates a slug from title and school when term is empty', () => {
     const course = {
       school: ' University of Wikipedia',

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -56,11 +56,11 @@ describe('CourseUtils.courseSlugRegex', () => {
 });
 
 describe('courseUtils.cleanupCourseSlugComponents', () =>
-  it('trims whitespace from the slug-related fields of a course object', () => {
+  it('trims whitespace and collapses multispaces from the slug-related fields of a course object', () => {
     const course = {
-      term: ' Fall 2015',
-      school: '   University of Wikipedia ',
-      title: ' Introduction to Editing     '
+      term: ' Fall      2015',
+      school: '   University          of       Wikipedia ',
+      title: '   Introduction      to      Editing     '
     };
     courseUtils.cleanupCourseSlugComponents(course);
     expect(course.term).to.eq('Fall 2015');


### PR DESCRIPTION
made a few changes to `course.utils.js` , to collapse multiple whitespaces into one space for course slugs.