### PR TITLE
Add real_name 'sanitization' to Onboarding controller

### DIFF
--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -15,7 +15,7 @@ class OnboardingController < ApplicationController
     validate_params
     @user = current_user
     set_new_permissions
-    @user.update_attributes(real_name: params[:real_name],
+    @user.update_attributes(real_name: sanitized_real_name,
                             email: params[:email],
                             permissions: @permissions,
                             onboarded: true)
@@ -39,5 +39,9 @@ class OnboardingController < ApplicationController
     [:real_name, :email, :instructor].each_with_object(params) do |key, obj|
       obj.require(key)
     end
+  end
+
+  def sanitized_real_name
+    params[:real_name].squish
   end
 end

--- a/spec/controllers/onboarding_controller_spec.rb
+++ b/spec/controllers/onboarding_controller_spec.rb
@@ -57,5 +57,11 @@ describe OnboardingController do
       expect(user.reload.onboarded).to eq(true)
       expect(user.permissions).to eq(User::Permissions::ADMIN)
     end
+
+    it "should strip name field of excessive whitespace" do
+      params = { real_name: " Name  \n Surname ", email: 'email@email.org', instructor: false }
+      put 'onboard', params: params
+      expect(user.real_name).to eq('Name Surname')
+    end
   end
 end


### PR DESCRIPTION
Minor fix to a minor bug https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1391

Private method in `OnboardingController` for `Real_name` sanitization.
