### PR TITLE
Timelines for outreach

### DIFF
--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -34,7 +34,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
   // Timeline link /
   // ///////////////
   let timeline;
-  if (course.type === 'ClassroomProgramCourse') {
+  if (course.timeline_enabled) {
     const timelineLink = `${courseLink}/timeline`;
     timeline = (
       <div className="nav__item" id="timeline-link">

--- a/app/assets/javascripts/components/timeline/empty_week.jsx
+++ b/app/assets/javascripts/components/timeline/empty_week.jsx
@@ -27,20 +27,18 @@ const EmptyWeek = React.createClass({
     // 1. If timeline is empty and user can edit it, show info and links to get started.
     if (this.props.emptyTimeline && this.props.edit_permissions) {
       let wizardLink;
+      let wizardLinkTransition;
       if (this.props.course.type === 'ClassroomProgramCourse') {
         const wizardUrl = `/courses/${this.props.course.slug}/timeline/wizard`;
-        wizardLink = (
-          <div>
-            {I18n.t('timeline.empty_week_3')}&nbsp;
-            <CourseLink to={wizardUrl} className="empty-week-clickable">{I18n.t('timeline.empty_week_4')}</CourseLink>
-          </div>
-        );
+        wizardLinkTransition = I18n.t('timeline.empty_week_3');
+        wizardLink = <CourseLink to={wizardUrl} className="empty-week-clickable">{I18n.t('timeline.empty_week_4')}</CourseLink>;
       }
 
       week = (
         <p className="week__no-activity__get-started">
           {I18n.t('timeline.empty_week_1')}&nbsp;
           <span className="empty-week-clickable" onClick={this.addWeek}>{I18n.t('timeline.empty_week_2')}</span>&nbsp;
+          {wizardLinkTransition}&nbsp;
           {wizardLink}
         </p>);
 

--- a/app/assets/javascripts/components/timeline/empty_week.jsx
+++ b/app/assets/javascripts/components/timeline/empty_week.jsx
@@ -26,13 +26,22 @@ const EmptyWeek = React.createClass({
 
     // 1. If timeline is empty and user can edit it, show info and links to get started.
     if (this.props.emptyTimeline && this.props.edit_permissions) {
-      const wizardLink = `/courses/${this.props.course.slug}/timeline/wizard`;
+      let wizardLink;
+      if (this.props.course.type === 'ClassroomProgramCourse') {
+        const wizardUrl = `/courses/${this.props.course.slug}/timeline/wizard`;
+        wizardLink = (
+          <div>
+            {I18n.t('timeline.empty_week_3')}&nbsp;
+            <CourseLink to={wizardUrl} className="empty-week-clickable">{I18n.t('timeline.empty_week_4')}</CourseLink>
+          </div>
+        );
+      }
+
       week = (
         <p className="week__no-activity__get-started">
           {I18n.t('timeline.empty_week_1')}&nbsp;
           <span className="empty-week-clickable" onClick={this.addWeek}>{I18n.t('timeline.empty_week_2')}</span>&nbsp;
-          {I18n.t('timeline.empty_week_3')}&nbsp;
-          <CourseLink to={wizardLink} className="empty-week-clickable">{I18n.t('timeline.empty_week_4')}</CourseLink>
+          {wizardLink}
         </p>);
 
     // 2. If timeline is empty but user cannot edit, just note that timeline is empty.
@@ -57,7 +66,7 @@ const EmptyWeek = React.createClass({
           <span className="week__week-dates pull-right">
             {dateCalc.start()} - {dateCalc.end()}
           </span>
-          <p className="week-index">{I18n.t('timeline.week_number', { number: weekNumber })}</p>
+          <p className="week-index">{I18n.t('timeline.week_number', { number: weekNumber || 1 })}</p>
         </div>
         <div className="week__no-activity">
           {week}

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -257,7 +257,7 @@ const Timeline = React.createClass({
     }
 
     let wizardLink;
-    if (weekComponents.length <= 0 && this.props.edit_permissions) {
+    if (weekComponents.length <= 0 && this.props.edit_permissions && this.props.course.type === 'ClassroomProgramCourse') {
       const wizardUrl = `/courses/${this.props.course.slug}/timeline/wizard`;
       wizardLink = <CourseLink to={wizardUrl} className="button dark button--block timeline__add-assignment">Add Assignment</CourseLink>;
     }

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -4,11 +4,9 @@ require "#{Rails.root}/app/workers/update_course_worker"
 #= Controller for timeline functionality
 class TimelineController < ApplicationController
   respond_to :html, :json
-  before_action :require_permissions,
-                only: [:update_timeline]
+  before_action [:require_permissions, :set_course]
 
   def update_timeline
-    @course = Course.find_by_slug(params[:course_id])
     Array.wrap(timeline_params['weeks']).each do |week|
       update_week week
     end
@@ -16,7 +14,23 @@ class TimelineController < ApplicationController
     render 'timeline'
   end
 
+  def enable_timeline
+    @course.flags[:timeline_enabled] = true
+    @course.save!
+    render :json, success: true
+  end
+
+  def disable_timeline
+    @course.flags[:timeline_enabled] = false
+    @course.save!
+    render :json, success: true
+  end
+
   private
+
+  def set_course
+    @course = Course.find_by_slug(params[:course_id])
+  end
 
   ########################
   # Week + Block Methods #

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 require "#{Rails.root}/app/workers/update_course_worker"
 
 #= Controller for timeline functionality
 class TimelineController < ApplicationController
   respond_to :html, :json
-  before_action [:require_permissions, :set_course]
+  before_action :require_permissions, :set_course
 
   def update_timeline
     Array.wrap(timeline_params['weeks']).each do |week|

--- a/app/models/classroom_program_course.rb
+++ b/app/models/classroom_program_course.rb
@@ -78,4 +78,8 @@ class ClassroomProgramCourse < Course
   def multiple_roles_allowed?
     false
   end
+
+  def timeline_enabled?
+    true
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -268,6 +268,11 @@ class Course < ActiveRecord::Base
     wiki_edits_enabled?
   end
 
+  # Overidden by ClassroomProgramCourse
+  def timeline_enabled?
+    flags[:timeline_enabled].present?
+  end
+
   #################
   # Cache methods #
   #################
@@ -339,8 +344,6 @@ class Course < ActiveRecord::Base
   # Check if course times are invalid and if yes, set the end time to be the same
   # as that of the start time
   def check_course_times
-    if start > self.end
-      self.end = start
-    end
+    self.end = start if start > self.end
   end
 end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 json.course do
   user_role = current_user&.role(@course) || CoursesUsers::Roles::VISITOR_ROLE
 
@@ -9,6 +10,7 @@ json.course do
             :home_wiki, :upload_count, :uploads_in_use_count, :upload_usages_count,
             :cloned_status, :flags)
 
+  json.timeline_enabled @course.timeline_enabled?
   json.term @course.cloned_status == 1 ? '' : @course.term
   json.legacy @course.legacy?
   json.ended !current?(@course) && @course.start < Time.zone.now

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,10 @@ Rails.application.routes.draw do
   resources :gradeables, collection: { update_multiple: :put }
   post 'courses/:course_id/timeline' => 'timeline#update_timeline',
        constraints: { course_id: /.*/ }
+  post 'courses/:course_id/enable_timeline' => 'timeline#enable_timeline',
+       constraints: { course_id: /.*/ }
+  post 'courses/:course_id/disable_timeline' => 'timeline#disable_timeline',
+       constraints: { course_id: /.*/ }
 
   get 'revisions' => 'revisions#index'
 

--- a/test/components/common/course_navbar.spec.jsx
+++ b/test/components/common/course_navbar.spec.jsx
@@ -11,6 +11,7 @@ describe('CourseNavbar', () => {
   describe('for ClassroomProgramCourse', () => {
     const course = {
       type: 'ClassroomProgramCourse',
+      timeline_enabled: true,
       flags: { enable_chat: true }, // adds Chat link
       title: 'bar',
       url: 'https://example.com'
@@ -31,9 +32,10 @@ describe('CourseNavbar', () => {
     });
   });
 
-  describe('for BasicCourse', () => {
+  describe('for BasicCourse without timeline enabled', () => {
     const course = {
-      type: 'BasicCourse'
+      type: 'BasicCourse',
+      timeline_enabled: false
     };
     const component = (
       <CourseNavbar

--- a/test/components/timeline/empty_week.spec.jsx
+++ b/test/components/timeline/empty_week.spec.jsx
@@ -8,7 +8,7 @@ import EmptyWeek from '../../../app/assets/javascripts/components/timeline/empty
 const makeSpacesUniform = (str) => { return str.replace(/\s{1,}/g, ' '); };
 
 describe('EmptyWeek', () => {
-  const course = { slug: 'my_course' };
+  const course = { slug: 'my_course', type: 'ClassroomProgramCourse' };
 
   describe('empty state', () => {
     const TestEmptyWeek = ReactTestUtils.renderIntoDocument(


### PR DESCRIPTION
This allow timelines for any course type, and limits the wizard to ClassroomProgramCourse type.

Next step is to make CPC unavailable from Outreach Dashboard and enable timeline for all the current ones there that are CPC.