### PR TITLE
[WIP] remove clone links

### DIFF
--- a/app/views/rapidfire/question_groups/_question_group.html.haml
+++ b/app/views/rapidfire/question_groups/_question_group.html.haml
@@ -19,6 +19,8 @@
   .survey__admin-row__col.survey__admin-row__col--actions
     .course-list__col
       = link_to "Edit", edit_question_group_path(question_group)
+    .course-list__col
+      = link_to "Clone", "/surveys/question_group/clone/#{question_group.id}", method: :post
     -# .course-list__col
     -#   = link_to "Add Question", new_question_group_question_path(question_group)
     - if question_group.questions.length > 0

--- a/app/views/rapidfire/question_groups/_question_group.html.haml
+++ b/app/views/rapidfire/question_groups/_question_group.html.haml
@@ -19,8 +19,6 @@
   .survey__admin-row__col.survey__admin-row__col--actions
     .course-list__col
       = link_to "Edit", edit_question_group_path(question_group)
-    .course-list__col
-      = link_to "Clone", "/surveys/question_group/clone/#{question_group.id}", method: :post
     -# .course-list__col
     -#   = link_to "Add Question", new_question_group_question_path(question_group)
     - if question_group.questions.length > 0

--- a/app/views/surveys/_survey.html.haml
+++ b/app/views/surveys/_survey.html.haml
@@ -18,7 +18,6 @@
     %span= survey.updated_at.strftime("%B %d, %Y")
   .survey__admin-row__col.survey__admin-row__col--actions
     = link_to 'Edit', edit_survey_path(survey)
-    = link_to "Clone Survey", "/surveys/clone/#{survey.id}", method: :post
     - if survey.rapidfire_question_groups.length > 0
       = link_to 'Preview', "#{survey_url(survey)}?preview"
     = link_to 'Results', survey_results_path(survey)

--- a/spec/features/survey_admin_spec.rb
+++ b/spec/features/survey_admin_spec.rb
@@ -107,10 +107,6 @@ describe 'Survey Administration', type: :feature, js: true do
       drag_target = find('#survey_intro')
       drag_source.drag_to(drag_target)
 
-      # Clone a Survey
-      visit '/surveys'
-      click_link 'Clone Survey'
-
       # Clone a Question Group
       click_link 'Question Groups'
       within 'li#question_group_2' do


### PR DESCRIPTION
removed 'clone' links from:

/views/survey_assignments/_survey.html.haml

and

/views/rapidfire/question_groups/_question_group.html.haml

Todos:

update routes.rb
survey_controller.rb
any other code associated with cloning