### PR TITLE
[WIP] remove findDOMNode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
     "new-cap": [2, { "capIsNew": false }],
     "no-use-before-define": 0,
     # Rules below here should be enabled once violations are fixed.
-    "react/no-find-dom-node": 0,
+    "react/no-find-dom-node": 2,
     "react/forbid-prop-types": 0,
     "react/no-danger": 0,
     "react/no-children-prop": 0,

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { Link } from 'react-router';
@@ -176,7 +175,7 @@ const CourseCreator = createReactClass({
   },
 
   useThisClass() {
-    const select = ReactDOM.findDOMNode(this.refs.courseSelect);
+    const select = this.courseSelect;
     const courseId = select.options[select.selectedIndex].getAttribute('data-id-key');
     ServerActions.cloneCourse(courseId);
     return this.setState({ isSubmitting: true, shouldRedirect: true });

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 import Modal from '../common/modal.jsx';
 import CourseStore from '../../stores/course_store.js';
 import ValidationStore from '../../stores/validation_store.js';
@@ -39,7 +38,7 @@ const CourseClonedModal = createReactClass({
   },
 
   setNoBlackoutDatesChecked() {
-    const { checked } = ReactDOM.findDOMNode(this.refs.noDates);
+    const { checked } = this.noDates;
     return this.updateCourse('no_day_exceptions', checked);
   },
 

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 import Panel from './panel.jsx';
 import DatePicker from '../common/date_picker.jsx';
 import Calendar from '../common/calendar.jsx';
@@ -25,7 +24,7 @@ const FormPanel = createReactClass({
     return this.setState({ blackoutDatesSelected: bool });
   },
   setNoBlackoutDatesChecked() {
-    const { checked } = ReactDOM.findDOMNode(this.refs.noDates);
+    const { checked } = this.noDates;
     const toPass = this.props.course;
     toPass.no_day_exceptions = checked;
     return CourseActions.updateCourse(toPass);

--- a/app/assets/javascripts/components/wizard/option.jsx
+++ b/app/assets/javascripts/components/wizard/option.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 const md = require('../../utils/markdown_it.js').default();
 import WizardActions from '../../actions/wizard_actions.js';
 
@@ -21,7 +20,7 @@ const Option = createReactClass({
   },
 
   expand() {
-    $(ReactDOM.findDOMNode(this.refs.expandable)).slideToggle();
+    $(this.expandable).slideToggle();
     return WizardActions.toggleOptionExpanded(this.props.panel_index, this.props.index);
   },
 

--- a/test/components/common/modal.spec.jsx
+++ b/test/components/common/modal.spec.jsx
@@ -1,21 +1,18 @@
 import '../../testHelper';
 import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-dom/test-utils';
 import Modal from '../../../app/assets/javascripts/components/common/modal.jsx';
+import { mount } from 'enzyme';
 
 describe('Modal', () => {
-  const TestModal = ReactTestUtils.renderIntoDocument(
+  const wrapper = mount(
     <Modal modalClass="foo">
       <h3>bar</h3>
     </Modal>
-  );
+    );
 
   it('renders its children with the modalClass', () => {
-    const modalContent = ReactTestUtils.findRenderedDOMComponentWithTag(TestModal, 'div');
-    const content = ReactDOM.findDOMNode(modalContent);
-    expect(content.textContent).to.eq('bar');
-    expect(content.className).to.eq('wizard active foo');
+    expect(wrapper.text()).to.equal('bar');
+    expect(wrapper.find('div.wizard.active.foo')).to.have.length(1);
   });
 
   it('adds modal-open class to the body', () => {
@@ -23,7 +20,7 @@ describe('Modal', () => {
   });
 
   it('removes the modal-open when it unmounts', () => {
-    TestModal.componentWillUnmount();
+    wrapper.unmount();
     expect(document.body.className).to.eq('');
   });
 });

--- a/test/components/course_creator/course_creator.spec.jsx
+++ b/test/components/course_creator/course_creator.spec.jsx
@@ -1,93 +1,103 @@
 import '../../testHelper';
 import sinon from 'sinon';
-import _ from 'lodash';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactTestUtils, { Simulate } from 'react-dom/test-utils';
+import ReactTestUtils, { Simulate } from 'react-addons-test-utils';
 import CourseCreator from '../../../app/assets/javascripts/components/course_creator/course_creator.jsx';
 
 import CourseActions from '../../../app/assets/javascripts/actions/course_actions.js';
 import ValidationActions from '../../../app/assets/javascripts/actions/validation_actions.js';
 import ServerActions from '../../../app/assets/javascripts/actions/server_actions.js';
+import { mount } from 'enzyme';
 
 CourseCreator.__Rewire__('ValidationStore', {
   isValid() { return true; },
   firstMessage() { }
 });
 
-describe('CourseCreator', () => {
-  describe('render', () => {
-    const TestCourseCreator = ReactTestUtils.renderIntoDocument(
-      <CourseCreator fetchCoursesForUser={() => {}} user_courses={["some_course"]} />
-    );
+/**
+* returns the style attribute applied to a given node.
+  params:
+    node (enzyme node) the node you would like to inspect
+  returns empty string if no styles are found
+**/
 
+const getStyle = (node) => {
+  const rootTag = node.html().match(/(<.*?>)/)[1]; // grab the top tag
+  const styleMatch = rootTag.match(/style="([^"]*)"/i);
+  return styleMatch ? styleMatch[1] : '';
+};
+
+describe('CourseCreator', () => {
+  const TestCourseCreator = mount(<CourseCreator />);
+  describe('render', () => {
     it('renders a title', () => {
-      const headline = ReactTestUtils.findRenderedDOMComponentWithTag(TestCourseCreator, 'h3');
-      const h3 = ReactDOM.findDOMNode(headline);
-      expect(h3.textContent).to.eq('Create a New Course');
+      expect(TestCourseCreator.find('h3').first().text()).to.eq('Create a New Course');
     });
     describe('user courses-to-clone dropdown', () => {
       describe('state not updated', () => {
         it('does not show', () => {
-          const select = ReactTestUtils.findRenderedDOMComponentWithClass(TestCourseCreator, 'select-container');
-          expect(select.classList.contains('hidden')).to.eq(true);
+          expect(
+            TestCourseCreator
+              .find('select-container')
+              .first()
+              .hasClass('hidden')
+          ).to.eq(true);
         });
       });
       describe('state updated to show (and user has courses)', () => {
         it('shows', () => {
           TestCourseCreator.setState({ showCloneChooser: true });
-          const select = ReactTestUtils.findRenderedDOMComponentWithClass(TestCourseCreator, 'select-container');
-          expect(select.classList.contains('hidden')).to.eq(false);
+          TestCourseCreator.setState({ user_courses: ['some_course'] });
+          expect(
+            TestCourseCreator
+              .find('select-container')
+              .first()
+              .hasClass('hidden')
+            ).to.eq(false);
         });
       });
     });
     describe('formStyle', () => {
       describe('not submitting', () => {
         it('is empty', () => {
-          const form = ReactTestUtils.findRenderedDOMComponentWithClass(TestCourseCreator, 'wizard__panel');
-          expect(form.style.cssText).to.be.empty;
+          expect(getStyle(TestCourseCreator)).to.eq('');
         });
       });
       describe('submitting', () => {
         it('includes pointerEvents and opacity', () => {
           TestCourseCreator.setState({ isSubmitting: true });
-          const form = ReactTestUtils.findRenderedDOMComponentWithClass(TestCourseCreator, 'wizard__panel');
-          expect(form.style.cssText).to.eq('pointer-events: none; opacity: 0.5;');
+          const wizardPanel = TestCourseCreator.find('.wizard__panel').first();
+          expect(getStyle(wizardPanel)).to.eq('pointer-events: none; opacity: 0.5;');
           TestCourseCreator.setState({ isSubmitting: false });
         });
       });
     });
-    describe('text inputs', () => {
+    describe.only('text inputs', () => {
       TestCourseCreator.setState({ default_course_type: 'ClassroomProgramCourse' });
-      const updateCourse = sinon.spy(CourseActions, 'updateCourse');
-      const setValid = sinon.spy(ValidationActions, 'setValid');
-      const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(TestCourseCreator, 'input');
+      const updateCourseSpy = sinon.spy(CourseActions, 'updateCourse');
+      const setValidSpy = sinon.spy(ValidationActions, 'setValid');
+
       describe('subject', () => {
-        it('updates courseActions', (done) => {
-          const input = _.find(inputs, (ipt) => ipt.getAttribute('id') === 'course_subject');
-          const inputNode = ReactDOM.findDOMNode(input);
-          inputNode.value = 'foobar';
-          Simulate.change(inputNode);
-          setImmediate(() => {
-            expect(updateCourse).to.have.been.called;
-            expect(setValid).not.to.have.been.called;
-            done();
-          });
+        it('updates courseActions', () => {
+          const courseSubject = TestCourseCreator
+            .find({ id: 'course_subject' })
+            .first();
+          courseSubject.simulate('change');
+          expect(updateCourseSpy).to.have.been.called;
+          expect(setValidSpy).not.to.have.been.called;
         });
       });
       describe('term', () => {
-        it('updates courseActions and validationActions', (done) => {
+        it('updates courseActions and validationActions', () => {
           TestCourseCreator.setState({ default_course_type: 'ClassroomProgramCourse' });
-          const input = _.find(inputs, (ipt) => ipt.getAttribute('id') === 'course_term');
-          const inputNode = ReactDOM.findDOMNode(input);
-          inputNode.value = 'foobar';
-          Simulate.change(inputNode);
-          setImmediate(() => {
-            expect(updateCourse).to.have.been.called;
-            expect(setValid).to.have.been.called;
-            done();
-          });
+          const courseTerm = TestCourseCreator
+            .find({ id: 'course_term' })
+            .first();
+
+          courseTerm.simulate('change');
+          expect(updateCourseSpy).to.have.been.called;
+          expect(setValidSpy).to.have.been.called;
         });
       });
     });
@@ -98,8 +108,7 @@ describe('CourseCreator', () => {
       const setInvalid = sinon.spy(ValidationActions, 'setInvalid');
       it('calls the appropriate methods on the actions', () => {
         const button = ReactTestUtils.findRenderedDOMComponentWithClass(TestCourseCreator, 'button__submit');
-        const buttonNode = ReactDOM.findDOMNode(button);
-        Simulate.click(buttonNode);
+        Simulate.click(button);
         expect(checkCourse).to.have.been.called;
         expect(setInvalid).to.have.been.called;
       });

--- a/test/components/course_creator/course_creator.spec.jsx
+++ b/test/components/course_creator/course_creator.spec.jsx
@@ -2,7 +2,6 @@ import '../../testHelper';
 import sinon from 'sinon';
 
 import React from 'react';
-import ReactTestUtils, { Simulate } from 'react-addons-test-utils';
 import CourseCreator from '../../../app/assets/javascripts/components/course_creator/course_creator.jsx';
 
 import CourseActions from '../../../app/assets/javascripts/actions/course_actions.js';
@@ -10,10 +9,12 @@ import ValidationActions from '../../../app/assets/javascripts/actions/validatio
 import ServerActions from '../../../app/assets/javascripts/actions/server_actions.js';
 import { mount } from 'enzyme';
 
+
 CourseCreator.__Rewire__('ValidationStore', {
   isValid() { return true; },
   firstMessage() { }
 });
+
 
 /**
 * returns the style attribute applied to a given node.
@@ -21,7 +22,6 @@ CourseCreator.__Rewire__('ValidationStore', {
     node (enzyme node) the node you would like to inspect
   returns empty string if no styles are found
 **/
-
 const getStyle = (node) => {
   const rootTag = node.html().match(/(<.*?>)/)[1]; // grab the top tag
   const styleMatch = rootTag.match(/style="([^"]*)"/i);
@@ -29,8 +29,8 @@ const getStyle = (node) => {
 };
 
 describe('CourseCreator', () => {
-  const TestCourseCreator = mount(<CourseCreator />);
   describe('render', () => {
+    const TestCourseCreator = mount(<CourseCreator />);
     it('renders a title', () => {
       expect(TestCourseCreator.find('h3').first().text()).to.eq('Create a New Course');
     });
@@ -39,7 +39,7 @@ describe('CourseCreator', () => {
         it('does not show', () => {
           expect(
             TestCourseCreator
-              .find('select-container')
+              .find('.select-container')
               .first()
               .hasClass('hidden')
           ).to.eq(true);
@@ -51,7 +51,7 @@ describe('CourseCreator', () => {
           TestCourseCreator.setState({ user_courses: ['some_course'] });
           expect(
             TestCourseCreator
-              .find('select-container')
+              .find('.select-container')
               .first()
               .hasClass('hidden')
             ).to.eq(false);
@@ -73,7 +73,7 @@ describe('CourseCreator', () => {
         });
       });
     });
-    describe.only('text inputs', () => {
+    describe('text inputs', () => {
       TestCourseCreator.setState({ default_course_type: 'ClassroomProgramCourse' });
       const updateCourseSpy = sinon.spy(CourseActions, 'updateCourse');
       const setValidSpy = sinon.spy(ValidationActions, 'setValid');
@@ -83,7 +83,13 @@ describe('CourseCreator', () => {
           const courseSubject = TestCourseCreator
             .find({ id: 'course_subject' })
             .first();
-          courseSubject.simulate('change');
+          courseSubject.simulate(
+            'change',
+            { target: {
+              name: 'course_subject',
+              value: 'some course'
+            }
+            });
           expect(updateCourseSpy).to.have.been.called;
           expect(setValidSpy).not.to.have.been.called;
         });
@@ -95,20 +101,33 @@ describe('CourseCreator', () => {
             .find({ id: 'course_term' })
             .first();
 
-          courseTerm.simulate('change');
+          courseTerm.simulate(
+            'change',
+            { target: {
+              name: 'course_term',
+              value: 'some term'
+            }
+            });
           expect(updateCourseSpy).to.have.been.called;
           expect(setValidSpy).to.have.been.called;
         });
       });
     });
     describe('save course', () => {
-      sinon.stub(TestCourseCreator, 'expectedStudentsIsValid').callsFake(() => true);
-      sinon.stub(TestCourseCreator, 'dateTimesAreValid').callsFake(() => true);
       const checkCourse = sinon.spy(ServerActions, 'checkCourse');
       const setInvalid = sinon.spy(ValidationActions, 'setInvalid');
+      const stubedCourseCreator = mount(<CourseCreator />);
+      sinon.stub(stubedCourseCreator.instance(), 'dateTimesAreValid').returns(true);
+
       it('calls the appropriate methods on the actions', () => {
-        const button = ReactTestUtils.findRenderedDOMComponentWithClass(TestCourseCreator, 'button__submit');
-        Simulate.click(button);
+        const button = stubedCourseCreator.find('.button__submit').first();
+        button.simulate(
+          'click',
+          { target: {
+            name: 'submit',
+            value: 'submit'
+          }
+          });
         expect(checkCourse).to.have.been.called;
         expect(setInvalid).to.have.been.called;
       });

--- a/test/components/course_creator/course_creator.spec.jsx
+++ b/test/components/course_creator/course_creator.spec.jsx
@@ -30,7 +30,8 @@ const getStyle = (node) => {
 
 describe('CourseCreator', () => {
   describe('render', () => {
-    const TestCourseCreator = mount(<CourseCreator />);
+    const TestCourseCreator = mount(<CourseCreator fetchCoursesForUser={() => {}} user_courses={["some_course"]} />);
+
     it('renders a title', () => {
       expect(TestCourseCreator.find('h3').first().text()).to.eq('Create a New Course');
     });
@@ -80,9 +81,12 @@ describe('CourseCreator', () => {
 
       describe('subject', () => {
         it('updates courseActions', () => {
+
           const courseSubject = TestCourseCreator
             .find({ id: 'course_subject' })
             .first();
+
+          // i want to know that: change event -> calls this.updateCourse -> calls CourseActions.updateCourse
           courseSubject.simulate(
             'change',
             { target: {

--- a/test/components/overview/course_cloned_modal.spec.jsx
+++ b/test/components/overview/course_cloned_modal.spec.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import ReactDOM from 'react-dom';
 import '../../testHelper';
 import CourseClonedModal from '../../../app/assets/javascripts/components/overview/course_cloned_modal.jsx';
-
+import { mount } from 'enzyme';
 describe('CourseClonedModal', () => {
   const course = {
     slug: 'foo/bar_(baz)',
@@ -12,31 +10,24 @@ describe('CourseClonedModal', () => {
     title: 'bar',
     expected_students: 0
   };
-
-  it('renders a Modal', () => {
-    const TestModal = ReactTestUtils.renderIntoDocument(
-      <CourseClonedModal
-        course={course}
-      />
+  const TestModal = mount(
+    <CourseClonedModal
+      course={course}
+    />
     );
 
-    const renderedModal = ReactTestUtils.findRenderedDOMComponentWithClass(TestModal, 'cloned-course');
-    expect(renderedModal).not.to.be.empty;
+  it('renders a Modal', () => {
+    const renderedModal = TestModal.find('.cloned-course');
+    expect(renderedModal).to.have.length(1);
     TestModal.setState({ error_message: null });
-    const warnings = ReactTestUtils.scryRenderedDOMComponentsWithClass(TestModal, 'warning');
-    expect(warnings).to.be.empty;
+    const warnings = TestModal.find('.warning');
+    expect(warnings).to.have.length(0);
   });
 
   it('renders an error message if state includes one', () => {
-    const TestModal = ReactTestUtils.renderIntoDocument(
-      <CourseClonedModal
-        course={course}
-      />
-    );
     TestModal.setState({ error_message: 'test error message' });
-
-    const warnings = ReactTestUtils.scryRenderedDOMComponentsWithClass(TestModal, 'warning');
+    const warnings = TestModal.find('.warning');
     expect(warnings).not.to.be.empty;
-    expect(ReactDOM.findDOMNode(warnings[0]).textContent).to.eq('test error message');
+    expect(warnings.first().text()).to.eq('test error message');
   });
 });

--- a/test/components/timeline/empty_week.spec.jsx
+++ b/test/components/timeline/empty_week.spec.jsx
@@ -1,28 +1,25 @@
 import '../../testHelper';
 
 import React from 'react';
-import { findDOMNode } from 'react-dom';
-import ReactTestUtils from 'react-dom/test-utils';
 import EmptyWeek from '../../../app/assets/javascripts/components/timeline/empty_week.jsx';
-
+import { mount } from 'enzyme';
 const makeSpacesUniform = (str) => { return str.replace(/\s{1,}/g, ' '); };
 
 describe('EmptyWeek', () => {
   const course = { slug: 'my_course', type: 'ClassroomProgramCourse' };
 
   describe('empty state', () => {
-    const TestEmptyWeek = ReactTestUtils.renderIntoDocument(
+    const TestEmptyWeek = mount(
       <EmptyWeek />
     );
     it('gives the empty text if timeline and edit permissions are empty', () => {
-      const headline = ReactTestUtils.findRenderedDOMComponentWithTag(TestEmptyWeek, 'h1');
-      const h1 = ReactDOM.findDOMNode(headline);
-      expect(h1.textContent).to.eq(I18n.t('timeline.no_activity_this_week'));
+      const headline = TestEmptyWeek.find('h1');
+      expect(headline.text()).to.eq(I18n.t('timeline.no_activity_this_week'));
     });
   });
 
   describe('timeline is empty, edit permissions', () => {
-    const TestEmptyWeek = ReactTestUtils.renderIntoDocument(
+    const TestEmptyWeek = mount(
       <EmptyWeek
         emptyTimeline
         edit_permissions
@@ -30,22 +27,24 @@ describe('EmptyWeek', () => {
       />
     );
     it('suggests editing the week', () => {
-      const pTag = ReactTestUtils.findRenderedDOMComponentWithClass(TestEmptyWeek, 'week__no-activity__get-started');
-      expect(makeSpacesUniform(pTag.textContent)).to.eq(
+      const pTag = TestEmptyWeek.find('.week__no-activity__get-started');
+      expect(makeSpacesUniform(pTag.text())).to.eq(
         makeSpacesUniform('To get started, start editing this week or use the assignment wizard to create a timeline.')
       );
     });
   });
 
   describe('timeline is empty, no edit permissions', () => {
-    const TestEmptyWeek = ReactTestUtils.renderIntoDocument(
+    const TestEmptyWeek = mount(
       <EmptyWeek
         emptyTimeline
       />
     );
     it('says course has no timeline', () => {
-      const week = findDOMNode(TestEmptyWeek);
-      expect(week.innerHTML).to.contain('This course has no timeline.');
+      const pTag = TestEmptyWeek.find('.week__no-activity__get-started');
+      expect(makeSpacesUniform(pTag.text())).to.eq(
+        makeSpacesUniform('This course has no timeline.')
+      );
     });
   });
 });

--- a/test/components/training/slide_link.spec.jsx
+++ b/test/components/training/slide_link.spec.jsx
@@ -1,15 +1,13 @@
 import '../../testHelper';
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import ReactDOM from 'react-dom';
-
+import { mount } from 'enzyme';
 import SlideLink from '../../../app/assets/javascripts/training/components/slide_link.jsx';
 import TrainingSlideHandler from '../../../app/assets/javascripts/training/components/training_slide_handler.jsx';
 import ServerActions from '../../../app/assets/javascripts/actions/server_actions.js';
 global.sinon.stub(ServerActions, 'fetchTrainingModule');
 
 describe('SlideLink', () => {
-  const TestLink = ReactTestUtils.renderIntoDocument(
+  const TestLink = mount(
     <TrainingSlideHandler
       loading={false}
       params={{ library_id: 'foo', module_id: 'bar', slide_id: 'foobar' }}
@@ -24,33 +22,30 @@ describe('SlideLink', () => {
     </TrainingSlideHandler>
   );
 
-  global.beforeEach(() =>
+  let domBtn;
+  global.beforeEach(() => {
     TestLink.setState({
       loading: false,
       currentSlide: { content: 'hello', id: 1 },
       slides: ['a'],
       enabledSlides: [],
       nextSlide: { slug: 'foobar' }
-    })
-  );
+    });
+
+    domBtn = TestLink.find('.slide-nav');
+  });
 
   it('renders a button', () => {
-    const button = ReactTestUtils.scryRenderedComponentsWithType(TestLink, SlideLink)[0];
-    const domBtn = ReactDOM.findDOMNode(button);
-    expect(domBtn.className).to.eq('slide-nav btn btn-primary icon icon-rt_arrow');
+    expect(domBtn.prop('className')).to.eq('slide-nav btn btn-primary icon icon-rt_arrow');
   });
 
   it('renders correct text', () => {
-    const button = ReactTestUtils.scryRenderedComponentsWithType(TestLink, SlideLink)[0];
-    const domBtn = ReactDOM.findDOMNode(button);
-    expect(domBtn.textContent).to.eq('Next Page');
+    expect(domBtn.text()).to.eq('Next Page');
   });
 
   it('renders correct link', () => {
-    const button = ReactTestUtils.scryRenderedComponentsWithType(TestLink, SlideLink)[0];
-    const domBtn = ReactDOM.findDOMNode(button);
     const expected = '/training/foo/bar/foobar';
     // mocha won't render the link with an actual href for some reason…
-    expect(domBtn.getAttribute('data-href')).to.eq(expected);
+    expect(domBtn.prop('data-href')).to.eq(expected);
   });
 });

--- a/test/components/training/slide_link.spec.jsx
+++ b/test/components/training/slide_link.spec.jsx
@@ -32,7 +32,7 @@ describe('SlideLink', () => {
       nextSlide: { slug: 'foobar' }
     });
 
-    domBtn = TestLink.find('.slide-nav');
+    domBtn = TestLink.find('.slide-nav').first();
   });
 
   it('renders a button', () => {

--- a/test/components/training/slide_menu.spec.jsx
+++ b/test/components/training/slide_menu.spec.jsx
@@ -2,14 +2,13 @@ import '../../testHelper';
 import TrainingSlideHandler from '../../../app/assets/javascripts/training/components/training_slide_handler.jsx';
 import SlideMenu from '../../../app/assets/javascripts/training/components/slide_menu.jsx';
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import ReactDOM from 'react-dom';
+import { mount } from 'enzyme';
 
 describe('SlideMenu', () => {
   const emptyFunction = function () { };
   const params = { library_id: 'foo', module_id: 'bar', slide_id: 'kittens' };
   const slide = { id: 1, enabled: true, title: 'How to Kitten', slug: 'kittens' };
-  const TestMenu = ReactTestUtils.renderIntoDocument(
+  const TestMenu = mount(
     <TrainingSlideHandler
       loading={false}
       params={params}
@@ -25,19 +24,17 @@ describe('SlideMenu', () => {
       slides: [slide],
       enabledSlides: [slide],
       nextSlide: { slug: 'foobar' }
-    }
-    )
+    })
   );
 
   it('renders an ol', () => {
-    const menu = ReactTestUtils.scryRenderedComponentsWithType(TestMenu, SlideMenu)[0];
-    const menuNode = ReactDOM.findDOMNode(menu);
-    expect($(menuNode).find('ol').length).to.eq(1);
+    const list = TestMenu.find('ol').first();
+    expect(list.children().length).to.eq(1);
   });
 
   it('links to a slide', () => {
-    const menu = ReactTestUtils.scryRenderedComponentsWithType(TestMenu, SlideMenu)[0];
-    const menuNode = ReactDOM.findDOMNode(menu);
-    expect($(menuNode).find('a').attr('href')).to.eq('/training/foo/bar/kittens');
+    const menu = TestMenu.find(SlideMenu).first();
+    const aTag = menu.find('a');
+    expect(aTag.prop('href')).to.eq('/training/foo/bar/kittens');
   });
 });


### PR DESCRIPTION
 I removed `findDOMNode` from the project. Also, refactored many tests to use enzyme.

Some tests are still failing (see `course_creator.spec.jsx:86`). For reasons I don't understand, when I `simulate('change') on a `TextInput` component, I expect the method `updateCourse` to be called, but it isn't. Any ideas on how to fix this?