### PR TITLE
added new UI action to reset the drawer state/close it on the unmount hook

### DIFF
--- a/app/assets/javascripts/actions/index.js
+++ b/app/assets/javascripts/actions/index.js
@@ -1,3 +1,4 @@
 import * as types from '../constants';
 
 export const toggleUI = key => ({ type: types.TOGGLE_UI, key });
+export const resetUI = key => ({ type: types.RESET_UI, key });

--- a/app/assets/javascripts/components/students/student_drawer.jsx
+++ b/app/assets/javascripts/components/students/student_drawer.jsx
@@ -12,7 +12,8 @@ const StudentDrawer = React.createClass({
 
   propTypes: {
     student: React.PropTypes.object,
-    isOpen: React.PropTypes.bool
+    isOpen: React.PropTypes.bool,
+    closeDrawer: React.PropTypes.func
   },
 
   mixins: [RevisionStore.mixin, TrainingStatusStore.mixin],
@@ -22,6 +23,10 @@ const StudentDrawer = React.createClass({
       revisions: getRevisions(this.props.student.id),
       trainingModules: getTrainingStatus()
     };
+  },
+
+  componentWillUnmount() {
+    this.props.closeDrawer();  
   },
 
   storeDidChange() {

--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import * as UIActions from '../../actions';
+import * as FrontendActions from '../../actions';
 
 import Editable from '../high_order/editable.jsx';
 import List from '../common/list.jsx';
@@ -49,6 +49,7 @@ const StudentList = React.createClass({
 
   render() {
     const toggleDrawer = this.props.actions.toggleUI;
+    const closeDrawer = this.props.actions.resetUI;
     const users = this.props.users.map(student => {
       const assignOptions = { user_id: student.id, role: 0 };
       const reviewOptions = { user_id: student.id, role: 1 };
@@ -85,6 +86,7 @@ const StudentList = React.createClass({
           key={drawerKey}
           ref={drawerKey}
           isOpen={isOpen}
+          closeDrawer={closeDrawer}
         />
       );
     });
@@ -152,7 +154,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(UIActions, dispatch)
+  actions: bindActionCreators(FrontendActions, dispatch)
 });
 
 export default Editable(

--- a/app/assets/javascripts/constants/ui.js
+++ b/app/assets/javascripts/constants/ui.js
@@ -1,1 +1,2 @@
 export const TOGGLE_UI = 'TOGGLE_UI';
+export const RESET_UI = 'RESET_UI';

--- a/app/assets/javascripts/reducers/ui.js
+++ b/app/assets/javascripts/reducers/ui.js
@@ -1,4 +1,4 @@
-import { TOGGLE_UI } from '../constants';
+import { TOGGLE_UI, RESET_UI } from '../constants';
 
 const initialState = { openKey: null };
 
@@ -9,6 +9,8 @@ export default function ui(state = initialState, action) {
         return { ...state, openKey: null };
       }
       return { ...state, openKey: action.key };
+    case RESET_UI:
+      return { ...state, openKey: null };
     default:
       return state;
   }


### PR DESCRIPTION
- added RESET_UI constant & corresponding action
- edited the ui.js reducer to account for new action type
- imported actions as FrontendActions (previously UIActions) @ragesoss i thought about importing it as just Actions but decided against it since we already have actions in the StudentList file.
- added unmount hook to StudentDrawer file that uses the new action