### PR TITLE
issue #1445: Edited webpack.js so JS errors include source file line numbers in stack trace

### DIFF
--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -84,7 +84,7 @@ gulp.task('webpack', ['bower'], (cb) => {
       'i18n-js': 'I18n'
     },
     plugins: wpPlugins,
-    devtool: config.development ? 'cheap-module-eval-source-map' : 'source-map'
+    devtool: config.development ? 'cheap-module-source-map' : 'source-map'
   };
 
   const wp = webpack(wpConf);


### PR DESCRIPTION
After doing some research ([devtool config](https://webpack.js.org/configuration/devtool/)) it seems like cheap-module-eval-source-map is the best option, but for some reason it's not working correctly. None of the devtool options that contain `eval` in them appear to work correctly. I'm not sure if it's due to the webpack version the project is set up on or some other reason. Using the `cheap-module-source-map` will give us what we want. 

![screen shot 2017-10-19 at 7 12 52 pm](https://user-images.githubusercontent.com/1688676/31802405-ede56198-b502-11e7-98af-1038a450d885.png)

The documentation says the `cheap-source-map` option results in a slightly faster build & rebuild performance but I thought it could be a little confusing looking at transformed code if you're viewing the sources within the dev console. Let me know if you think we should go about this some other way. 


