### PR TITLE
Add overflow: scroll to ArticleViewer author list

### DIFF
--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -5,7 +5,7 @@
   /*@noflip*/ left 50%
   width 100%
   max-width 1200px
-  max-height calc(95vh \- 70px)
+  max-height calc(95vh \- 55px)
   z-index 10
   border 1px solid mischka
   border-radius 3px
@@ -38,6 +38,8 @@
 .user-legend-wrap
   width 90%
   background white
+  height 110px
+  overflow scroll
 
 .user-legend
   margin 10px
@@ -99,7 +101,7 @@
   color bayoux
 
 .article-scrollbox
-  max-height calc(95vh \- 200px)
+  max-height calc(95vh \- 225px)
   overflow-y scroll
   overflow-x hidden
 


### PR DESCRIPTION
Prevents the author list from flowing off the page. Bug viewable on the following link:
https://dashboard.wikiedu.org/courses/Marshall_University/Principles_of_Cell_Biology_(Fall_2017)/articles

The rows after the first row are accessible by scrolling, but they are kinda hidden. I can increase the `height` of `.user-legend-wrap` to `60px` to show the top of the second row, but it didn't look good to me.

![screen shot 2017-11-09 at 9 17 31 pm](https://user-images.githubusercontent.com/13618860/32644202-ff24910c-c594-11e7-956c-5e5dd4ea31d4.png)


References #1487 