### PR TITLE
bugfix: 1487 AritcleView no longer cuts off author list

### DIFF
--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -20,9 +20,10 @@
 .article-footer
   border-top 1px solid mischka !important
   font-size 90%
-  overflow: scroll
-  max-height: 92px
-  width: 100%
+  overflow-y auto
+  overflow-x hidden
+  max-height 92px
+  width 100%
   div
     float left
 

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -5,7 +5,6 @@
   /*@noflip*/ left 50%
   width 100%
   max-width 1200px
-  max-height calc(95vh \- 70px)
   z-index 10
   border 1px solid mischka
   border-radius 3px
@@ -20,9 +19,10 @@
 
 .article-footer
   border-top 1px solid mischka !important
-  margin-bottom 10px
   font-size 90%
-  height 100%
+  overflow: scroll
+  max-height: 92px
+  width: 100%
   div
     float left
 


### PR DESCRIPTION
In `ArticleView`, when a list of authors grows beyond 2 rows, the footer would formerly extend out of the `div`. 

This change adds an `overflow: scroll` to `.article-footer` and changes the height so that overflow only occurs when a 3rd row is added. Cases with 1 or 2 rows are aligned properly.

#1487