### PR TITLE
Remove unused variables from two files and update .eslintrc (Issue #1408)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,6 @@
     "jsx-a11y/no-autofocus": 0,
     "react/default-props-match-prop-types": 0,
     "prefer-destructuring": 0,
-    "no-unused-vars": 0,
     "react/prop-types": 0,
     "semi-style": 0,
   },

--- a/app/assets/javascripts/components/articles/article_graphs.jsx
+++ b/app/assets/javascripts/components/articles/article_graphs.jsx
@@ -1,4 +1,3 @@
-/* global vg */
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';

--- a/app/assets/javascripts/surveys/components/BarGraph.jsx
+++ b/app/assets/javascripts/surveys/components/BarGraph.jsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { answerTotals } from './utils';
 


### PR DESCRIPTION
This pull requests references issue [#1408](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1408).

Removed no-unused-vars rule from .eslintc and made the following changes to conform to newest set of linter rules:

* app/assets/javascripts/components/articles/article_graphs.jsx - removed commented out code `global vg` that was throwing a linter error.
* app/assets/javascripts/surveys/components/BarGraph.jsx - removed no longer used `{ Component }`.

<img width="753" alt="screen shot 2017-12-05 at 2 59 50 pm" src="https://user-images.githubusercontent.com/26471447/33634810-bcfbc2e4-d9d2-11e7-8068-a2a929a0a842.png">

Contributions by @bbp5280 @adammescher @nicktu12