### PR TITLE
Private programs

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -142,6 +142,11 @@ const CourseCreator = createReactClass({
     CourseActions.updateCourse(updatedCourse);
   },
 
+  updateCoursePrivacy(e) {
+    const isPrivate = e.target.checked;
+    this.updateCourse('private', isPrivate);
+  },
+
   expectedStudentsIsValid() {
     if (this.state.course.expected_students === '0' && this.state.default_course_type === 'ClassroomProgramCourse') {
       ValidationActions.setInvalid('expected_students', I18n.t('application.field_required'));
@@ -291,6 +296,7 @@ const CourseCreator = createReactClass({
 
     let language;
     let project;
+    let privacyCheckbox;
     let campaign;
     if (this.state.default_course_type !== 'ClassroomProgramCourse') {
       language = (
@@ -314,6 +320,18 @@ const CourseCreator = createReactClass({
           label={I18n.t('courses.creator.course_project')}
           placeholder="wikipedia"
         />
+      );
+      privacyCheckbox = (
+        <div className="form-group">
+          <label htmlFor="course_private">{I18n.t('courses.creator.course_private')}:</label>
+          <input
+            id="course_private"
+            type="checkbox"
+            value={true}
+            onChange={this.updateCoursePrivacy}
+            checked={!!this.state.course.private}
+          />
+        </div>
       );
     }
     if (this.state.course.initial_campaign_title) {
@@ -387,6 +405,7 @@ const CourseCreator = createReactClass({
                   {expectedStudents}
                   {language}
                   {project}
+                  {privacyCheckbox}
                 </div>
                 <div className="column">
                   <DatePicker

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -55,6 +55,9 @@ class CampaignsController < ApplicationController
 
   def users
     set_presenter
+    @courses_users = CoursesUsers.where(
+      course: @campaign.courses.nonprivate, role: CoursesUsers::Roles::STUDENT_ROLE
+    ).includes(:user, :course).order(revision_count: :desc)
   end
 
   def edit

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -9,7 +9,7 @@ class UserProfilesController < ApplicationController
 
   def show
     if @user
-      @courses_users = @user.courses_users
+      @courses_users = @user.courses_users.includes(:course).where(courses: { private: false })
       @user_profile = UserProfile.new(user_id: @user.id)
     else
       flash[:notice] = 'User not found'
@@ -26,7 +26,7 @@ class UserProfilesController < ApplicationController
 
   def stats
     @individual_stats_presenter = IndividualStatisticsPresenter.new(user: @user)
-    @courses_list = @user.courses.where('courses_users.role = ?',
+    @courses_list = public_courses.where('courses_users.role = ?',
                                         CoursesUsers::Roles::INSTRUCTOR_ROLE)
     @courses_presenter = CoursesPresenter.new(current_user: current_user,
                                               courses_list: @courses_list)
@@ -34,13 +34,17 @@ class UserProfilesController < ApplicationController
 
   def stats_graphs
     @individual_stats_presenter = IndividualStatisticsPresenter.new(user: @user)
-    @courses_list = @user.courses.where('courses_users.role = ?',
+    @courses_list = public_courses.where('courses_users.role = ?',
                                         CoursesUsers::Roles::INSTRUCTOR_ROLE)
     @courses_presenter = CoursesPresenter.new(current_user: current_user,
                                               courses_list: @courses_list)
   end
 
   private
+
+  def public_courses
+    @user.courses.nonprivate
+  end
 
   def require_write_permissions
     return if current_user == @user

--- a/app/models/article_scoped_program.rb
+++ b/app/models/article_scoped_program.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 class ArticleScopedProgram < Course

--- a/app/models/basic_course.rb
+++ b/app/models/basic_course.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 class BasicCourse < Course

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -54,7 +54,7 @@ class Campaign < ActiveRecord::Base
 
   def users_to_csv(role, opts = {})
     csv_data = []
-    courses.each do |course|
+    courses.nonprivate.each do |course|
       users = course.send(role)
       users.each do |user|
         line = [user.username]

--- a/app/models/classroom_program_course.rb
+++ b/app/models/classroom_program_course.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 class ClassroomProgramCourse < Course

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 require "#{Rails.root}/lib/course_cache_manager"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -122,6 +122,7 @@ class Course < ActiveRecord::Base
   # Scopes #
   ##########
 
+  scope :nonprivate, -> { where(private: false) }
   # Legacy courses are ones that are imported from the EducationProgram
   # MediaWiki extension, not created within the dashboard via the wizard.
   scope :legacy, -> { where(type: 'LegacyCourse') }

--- a/app/models/editathon.rb
+++ b/app/models/editathon.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 class Editathon < Course

--- a/app/models/legacy_course.rb
+++ b/app/models/legacy_course.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 # Course type for courses imported from the MediaWiki EducationProgram extension

--- a/app/models/visiting_scholarship.rb
+++ b/app/models/visiting_scholarship.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 class VisitingScholarship < Course

--- a/app/views/campaigns/users.html.haml
+++ b/app/views/campaigns/users.html.haml
@@ -19,7 +19,7 @@
           %th= t('courses.edit_count')
           %th= t("#{@presenter.course_string_prefix}.course")
       %tbody.list
-        - CoursesUsers.where(course: @campaign.courses, role: CoursesUsers::Roles::STUDENT_ROLE).includes(:user, :course).order(revision_count: :desc).each do |cu|
+        - @courses_users.each do |cu|
           %tr
             %td
               = link_to cu.user.username, "/users/#{cu.user.username}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,7 @@ en:
         Please include enough detail to give other Wikipedia editors a sense of
         context for the contributions your students will be making.
       course_language: Home language
+      course_private: Private program (viewable only by admins and facilitators)
       course_project: Home project
       course_school: Course school
       course_subject: Course subject

--- a/db/migrate/20171205204605_add_private_to_course.rb
+++ b/db/migrate/20171205204605_add_private_to_course.rb
@@ -1,0 +1,5 @@
+class AddPrivateToCourse < ActiveRecord::Migration[5.1]
+  def change
+    add_column :courses, :private, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171204183016) do
+ActiveRecord::Schema.define(version: 20171205204605) do
 
   create_table "alerts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "course_id"
@@ -210,6 +210,7 @@ ActiveRecord::Schema.define(version: 20171204183016) do
     t.string "chatroom_id"
     t.text "flags"
     t.string "level"
+    t.boolean "private", default: false
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -12,6 +12,7 @@ class WikiCourseEdits
 
   def initialize(action:, course:, current_user:, **opts)
     return unless course.wiki_edits_enabled?
+    return if course.private # Never make edits for private courses.
     @course = course
     # Edits can only be made to the course's home wiki through WikiCourseEdits
     @home_wiki = course.home_wiki

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/features/private_courses_spec.rb
+++ b/spec/features/private_courses_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Private courses' do
+  let(:course) { create(:course, private: true) }
+  let(:user) { create(:user) }
+  before do
+    login_as user
+    stub_oauth_edit
+  end
+
+  context 'when the can edit the course the course' do
+    before do
+      JoinCourse.new(course: course, user: user, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    end
+
+    it 'renders the course normally' do
+      visit "/courses/#{course.slug}"
+      expect(page.status_code).to eq(200)
+    end
+  end
+  context 'when the user is not participating in the course' do
+    it 'raises a 404 error' do
+      expect { visit "/courses/#{course.slug}" }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -9,13 +9,12 @@ describe 'Student users', type: :feature, js: true do
     page.current_window.resize_to(1920, 1080)
   end
 
-  let(:user) { create(:user, id: 200, wiki_token: 'foo', wiki_secret: 'bar') }
-
-  before :each do
-    create(:campaign,
-           id: 1)
+  let(:user) { create(:user, wiki_token: 'foo', wiki_secret: 'bar') }
+  let!(:instructor) { create(:user, username: 'Professor Sage') }
+  let!(:classmate) { create(:user, username: 'Classmate')  }
+  let!(:campaign) { create(:campaign) }
+  let!(:course) do
     create(:course,
-           id: 10001,
            title: 'An Example Course',
            school: 'University',
            term: 'Term',
@@ -24,23 +23,19 @@ describe 'Student users', type: :feature, js: true do
            passcode: 'passcode',
            start: '2015-01-01'.to_date,
            end: '2020-01-01'.to_date)
-    create(:user,
-           id: 100,
-           username: 'Professor Sage')
+  end
+
+  before :each do
     create(:courses_user,
-           user_id: 100,
-           course_id: 10001,
+           user: instructor,
+           course: course,
            role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     create(:campaigns_course,
-           campaign_id: 1,
-           course_id: 10001)
-    create(:user,
-           id: 101,
-           username: 'Classmate')
+           campaign: campaign,
+           course: course)
     create(:courses_user,
-           id: 2,
-           user_id: 101,
-           course_id: 10001,
+           user: classmate,
+           course: course,
            role: CoursesUsers::Roles::STUDENT_ROLE)
     stub_add_user_to_channel_success
   end
@@ -234,8 +229,8 @@ describe 'Student users', type: :feature, js: true do
       stub_oauth_edit
       stub_info_query
       create(:courses_user,
-             course_id: 10001,
-             user_id: 200,
+             course: course,
+             user: user,
              role: CoursesUsers::Roles::STUDENT_ROLE)
       visit "/courses/#{Course.first.slug}/students"
       sleep 2
@@ -260,8 +255,8 @@ describe 'Student users', type: :feature, js: true do
       stub_oauth_edit
       stub_info_query
       create(:courses_user,
-             course_id: 10001,
-             user_id: 200,
+             course: course,
+             user: user,
              role: CoursesUsers::Roles::STUDENT_ROLE)
       visit "/courses/#{Course.first.slug}/students"
       sleep 3
@@ -284,13 +279,13 @@ describe 'Student users', type: :feature, js: true do
       stub_oauth_edit
       stub_info_query
       create(:courses_user,
-             course_id: 10001,
-             user_id: 200,
+             course: course,
+             user: user,
              role: CoursesUsers::Roles::STUDENT_ROLE)
       create(:assignment,
              article_title: 'Selfie',
-             course_id: 10001,
-             user_id: 200,
+             course: course,
+             user: user,
              article_id: nil,
              role: Assignment::Roles::ASSIGNED_ROLE)
       visit "/courses/#{Course.first.slug}/students"
@@ -316,8 +311,8 @@ describe 'Student users', type: :feature, js: true do
       login_as(user, scope: :user)
 
       create(:courses_user,
-             course_id: 10001,
-             user_id: 200,
+             course: course,
+             user: user,
              role: CoursesUsers::Roles::STUDENT_ROLE)
 
       visit root_path

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/editathon_spec.rb
+++ b/spec/models/editathon_spec.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -44,6 +44,7 @@
 #  chatroom_id           :string(255)
 #  flags                 :text(65535)
 #  level                 :string(255)
+#  private               :boolean          default(FALSE)
 #
 
 require 'rails_helper'


### PR DESCRIPTION
Adds rudimentary support for creating 'private' programs that can only be viewed by instructors/facilitators and by admins.

Also hides those courses from user profile pages and excludes the users from the campaign user list and downloadable CSV user lists.