### PR TITLE
#1517 - Adds Manual Update Button for Edit-a-thons

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -44,6 +44,13 @@ const AvailableActions = createReactClass({
     this.props.initiateConfirm(confirmMessage, onConfirm, true, joinDescription);
   },
 
+  updateStats() {
+    const UpdateUrl = `${window.location.origin}/courses/${this.state.course.id}/manual_update`;
+    if (confirm('Are you sure you want to run a manual update?')) {
+      return window.location = UpdateUrl;
+    };
+  },
+
   leave() {
     if (confirm(I18n.t('courses.leave_confirmation'))) {
       const userObject = { user_id: this.props.current_user.id, role: 0 };
@@ -114,6 +121,13 @@ const AvailableActions = createReactClass({
         <p key="join"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', this.state.course.string_prefix)}</button></p>
       ));
     }
+    // If the user is an instructor or admin, and the course is published, show a manual stats update button
+    if ((user.role === 1 || user.admin || !Features.wikiEd) && this.state.course.published) {
+      controls.push((
+        <p key="updateStats"><button className="button" onClick={this.updateStats}>{I18n.t('courses.update_stats')}</button></p>
+      ));
+    }
+
     // If the user is an instructor or admin, and the course is published, show a stats download button
     // Always show the stats download for published non-Wiki Ed courses.
     if ((user.role === 1 || user.admin || !Features.wikiEd) && this.state.course.published) {

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -265,6 +265,7 @@ ca:
     training_nav: Anar a la formació
     unsubmitted: Cursos no enviats
     untrained: No entrenat
+    update_stats: Actualitza les estadístiques
     uploads_none: Aquesta classe encara no ha contribuït amb cap imatge o algun altre
       tipus de fitxer a Wikimedia Commons.
     view: Vegeu el curs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -482,6 +482,7 @@ en:
       The training module "%{title}" is assigned for this course, and was due on %{date}.
     unsubmitted: Unsubmitted Courses
     untrained: Untrained
+    update_stats: Update statistics
     uploads_none: This class has not contributed any images or other media files to Wikimedia Commons.
     user_suggestions: 'User Suggestions:'
     user_suggestions_prompt: 'Your suggestions for the editors of the article'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -378,6 +378,7 @@ es:
     suggestions_sending: Enviando comentarios...
     suggestions_sent: Comentarios enviados. Gracias por tu interes.
     suggestions_failed: No se pudieron mandar los comentarios. Intenta luego.
+    update_stats: Actualiza las estadísticas
     user_role: Oficio
     course_details: Detalles del curso
     subject: Asignatura


### PR DESCRIPTION
 - Adds a button to generate a manual update of the statistics only available to Admins and Instructors in case the Course is published and inside the P&E Program 
- After the button is clicked a modal is generated asking for confirmation 
- After confirmation a GET request is sent to /courses/ID/manual_update 
- The user is also sent to this url. Note: Is this the desired behaviour? 
- Adds locales and translations. Key: update_stats