### PR TITLE
Deletes one argument to the methods of UpdateLog

### DIFF
--- a/app/models/update_log.rb
+++ b/app/models/update_log.rb
@@ -7,8 +7,8 @@ class UpdateLog
   # We want to keep a maximum number of 10 updates, so the last key we want to save is the ninth
   MAX_UPDATES_KEY = 9
 
-  def self.log_updates(starttime, endtime)
-    add_new_log(starttime, endtime)
+  def self.log_updates(input_hash)
+    add_new_log(input_hash)
     delete_old_log
     log_delay
     save_setting
@@ -29,15 +29,12 @@ class UpdateLog
       @setting ||= Setting.find_or_create_by(key: 'metrics_update')
     end
 
-    def add_new_log(start_time, end_time)
+    def add_new_log(input_hash)
       setting_record.value['constant_update'] ||= {}
       @last_update = setting_record.value['constant_update'].keys.last
       this_update = @last_update ? @last_update + 1 : 0
 
-      setting_record.value['constant_update'][this_update] = {
-        'start_time' => start_time,
-        'end_time' => end_time
-      }
+      setting_record.value['constant_update'][this_update] = input_hash
     end
 
     def delete_old_log

--- a/app/models/update_log.rb
+++ b/app/models/update_log.rb
@@ -7,8 +7,8 @@ class UpdateLog
   # We want to keep a maximum number of 10 updates, so the last key we want to save is the ninth
   MAX_UPDATES_KEY = 9
 
-  def self.log_updates(input_hash)
-    add_new_log(input_hash)
+  def self.log_updates(times)
+    add_new_log(times)
     delete_old_log
     log_delay
     save_setting
@@ -29,12 +29,12 @@ class UpdateLog
       @setting ||= Setting.find_or_create_by(key: 'metrics_update')
     end
 
-    def add_new_log(input_hash)
+    def add_new_log(times)
       setting_record.value['constant_update'] ||= {}
       @last_update = setting_record.value['constant_update'].keys.last
       this_update = @last_update ? @last_update + 1 : 0
 
-      setting_record.value['constant_update'][this_update] = input_hash
+      setting_record.value['constant_update'][this_update] = times
     end
 
     def delete_old_log

--- a/lib/data_cycle/batch_update_logging.rb
+++ b/lib/data_cycle/batch_update_logging.rb
@@ -80,7 +80,7 @@ module BatchUpdateLogging
     log_message 'Update finished'
     total_time = distance_of_time_in_words(@start_time, @end_time)
     Rails.logger.info "#{message} Time: #{total_time}."
-    UpdateLog.log_updates(@start_time.to_datetime, @end_time.to_datetime) if self.class.to_s == 'ConstantUpdate'
+    UpdateLog.log_updates({"start_time" => @start_time.to_datetime, "end_time" => @end_time.to_datetime}) if self.class.to_s == 'ConstantUpdate'
     Raven.capture_message message,
                           level: 'info',
                           tags: { update_time: total_time },

--- a/spec/models/update_log_spec.rb
+++ b/spec/models/update_log_spec.rb
@@ -5,24 +5,23 @@ require 'rails_helper'
 describe UpdateLog do
   describe '.log_updates' do
     it 'adds the time of the metrics last update as a value to the settings table' do
-      UpdateLog.log_updates(Time.now, Time.now)
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
       setting = UpdateLog.setting_record
       expect(setting.value['constant_update'].values.last['end_time'])
         .to be_within(2.seconds).of(Time.now)
     end
 
     it 'adds a maximum of 10 records' do
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
-      UpdateLog.log_updates(Time.now, Time.now)
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
+      UpdateLog.log_updates({"start_time" => Time.now, "end_time" => Time.now})
       number_of_updates = UpdateLog.setting_record.value['constant_update'].keys.length
       expect(number_of_updates).to be(10)
     end
@@ -43,14 +42,14 @@ describe UpdateLog do
 
   describe '.log_delay' do
     it 'adds the average delay time to the settings table' do
-      UpdateLog.log_updates(Time.parse("2017-12-06 11:11:33 +0100"),
-                            Time.parse("2017-12-06 13:11:33 +0100"))
-      UpdateLog.log_updates(Time.parse("2017-12-06 13:13:33 +0100"),
-                            Time.parse("2017-12-06 15:13:33 +0100"))
-      UpdateLog.log_updates(Time.parse("2017-12-06 15:30:00 +0100"),
-                            Time.parse("2017-12-06 21:30:00 +0100"))
-      UpdateLog.log_updates(Time.parse("2017-12-06 21:45:00 +0100"),
-                            Time.parse("2017-12-06 22:45:00 +0100"))
+      UpdateLog.log_updates("start_time" => Time.parse("2017-12-06 11:11:33 +0100"),
+                            "end_time" => Time.parse("2017-12-06 13:11:33 +0100"))
+      UpdateLog.log_updates("start_time" => Time.parse("2017-12-06 13:13:33 +0100"),
+                            "end_time" => Time.parse("2017-12-06 15:13:33 +0100"))
+      UpdateLog.log_updates("start_time" => Time.parse("2017-12-06 15:30:00 +0100"),
+                            "end_time" => Time.parse("2017-12-06 21:30:00 +0100"))
+      UpdateLog.log_updates("start_time" => Time.parse("2017-12-06 21:45:00 +0100"),
+                            "end_time" => Time.parse("2017-12-06 22:45:00 +0100"))
       delay = UpdateLog.setting_record.value["average_delay"]
       expect(delay).to eq(11469)
     end
@@ -70,8 +69,8 @@ describe UpdateLog do
     end
 
     it 'returns nil if the there was only one update' do
-      UpdateLog.log_updates(Time.parse("2017-12-06 11:11:33 +0100"),
-                            Time.parse("2017-12-06 13:11:33 +0100"))
+      UpdateLog.log_updates("start_time" => Time.parse("2017-12-06 11:11:33 +0100"),
+                            "end_time" => Time.parse("2017-12-06 13:11:33 +0100"))
       delay = UpdateLog.average_delay
       expect(delay).to be(nil)
     end


### PR DESCRIPTION
- In order to be more stable, deletes one of the arguments that we were passing to log_updates and add_new_log
- These arguments is now a hash that should have the key values "start_update" and "end_update" included
- Changes also batch update logging to include the hash with the values needed.