### PR TITLE
Allow to join a course without a passcode #1380

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -35,13 +35,23 @@ const AvailableActions = createReactClass({
   },
 
   join() {
-    const EnrollURL = this.state.course.enroll_url;
-    const onConfirm = function (passcode) {
+    console.log(this.state.course.passcode_required)
+    if (this.state.course.passcode_required) {
+      const EnrollURL = this.state.course.enroll_url;
+      const onConfirm = function (passcode) {
       return window.location = EnrollURL + passcode;
-    };
-    const confirmMessage = I18n.t('courses.passcode_prompt');
-    const joinDescription = CourseUtils.i18n('join_details', this.state.course.string_prefix);
-    this.props.initiateConfirm(confirmMessage, onConfirm, true, joinDescription);
+      };
+      const confirmMessage = I18n.t('courses.passcode_prompt');
+      const joinDescription = CourseUtils.i18n('join_details', this.state.course.string_prefix);
+      this.props.initiateConfirm(confirmMessage, onConfirm, true, joinDescription);
+    } else {
+      const EnrollURL = this.state.course.enroll_url;
+      const onConfirm = function() {
+        return window.location = EnrollURL;
+      };
+      const confirmMessage = CourseUtils.i18n('join_no_passcode');
+      this.props.initiateConfirm(confirmMessage, onConfirm);
+    }
   },
 
   updateStats() {

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -35,8 +35,14 @@ const AvailableActions = createReactClass({
   },
 
   join() {
-    console.log(this.state.course.passcode_required)
-    if (this.state.course.passcode_required) {
+    if (this.state.course.allow_no_passcode) {
+      const EnrollURL = this.state.course.enroll_url;
+      const onConfirm = function() {
+        return window.location = EnrollURL;
+      };
+      const confirmMessage = CourseUtils.i18n('join_no_passcode');
+      this.props.initiateConfirm(confirmMessage, onConfirm);
+    } else {
       const EnrollURL = this.state.course.enroll_url;
       const onConfirm = function (passcode) {
       return window.location = EnrollURL + passcode;
@@ -44,13 +50,6 @@ const AvailableActions = createReactClass({
       const confirmMessage = I18n.t('courses.passcode_prompt');
       const joinDescription = CourseUtils.i18n('join_details', this.state.course.string_prefix);
       this.props.initiateConfirm(confirmMessage, onConfirm, true, joinDescription);
-    } else {
-      const EnrollURL = this.state.course.enroll_url;
-      const onConfirm = function() {
-        return window.location = EnrollURL;
-      };
-      const confirmMessage = CourseUtils.i18n('join_no_passcode');
-      this.props.initiateConfirm(confirmMessage, onConfirm);
     }
   },
 

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -37,7 +37,7 @@ const AvailableActions = createReactClass({
   join() {
     if (this.state.course.allow_no_passcode) {
       const EnrollURL = this.state.course.enroll_url;
-      const onConfirm = function() {
+      const onConfirm = function () {
         return window.location = EnrollURL;
       };
       const confirmMessage = CourseUtils.i18n('join_no_passcode');

--- a/app/controllers/self_enrollment_controller.rb
+++ b/app/controllers/self_enrollment_controller.rb
@@ -90,17 +90,12 @@ class SelfEnrollmentController < ApplicationController
   end
 
   def allow_no_passcode_if_not_required
-    return if allow_no_passcode?
+    return unless @course.allow_no_passcode?
     add_student_to_course
     set_mediawiki_preferences
     make_enrollment_edits
     redirect_to course_slug_path(@course.slug)
     yield
-  end
-
-  def allow_no_passcode?
-    # If course doesn't require a passcode, allow the user to join without one
-    return true if @course.passcode_required?
   end
 
   def add_student_to_course

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -222,6 +222,11 @@ class Course < ActiveRecord::Base
     true
   end
 
+  # If course doesn't require a passcode and the course passcode is blank, allow the user to join without one
+  def allow_no_passcode?
+    return true if self.passcode_required? === false && self.passcode.blank?
+  end
+
   def current?
     start < Time.zone.now && self.end > Time.zone.now - UPDATE_LENGTH
   end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -26,6 +26,7 @@ json.course do
   json.view_count number_to_human @course.view_sum
   json.syllabus @course.syllabus.url if @course.syllabus.file?
   json.last_update UpdateLog.last_update
+  json.passcode_required @course.passcode_required?
 
   if user_role.zero? # student role
     ctpm = CourseTrainingProgressManager.new(current_user, @course)

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -26,7 +26,7 @@ json.course do
   json.view_count number_to_human @course.view_sum
   json.syllabus @course.syllabus.url if @course.syllabus.file?
   json.last_update UpdateLog.last_update
-  json.passcode_required @course.passcode_required?
+  json.allow_no_passcode @course.allow_no_passcode?
 
   if user_role.zero? # student role
     ctpm = CourseTrainingProgressManager.new(current_user, @course)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,6 +415,7 @@ en:
       cannot_join_twice: Users may not join the same course twice.
       not_yet_approved: This course has not yet been approved for enrollment.
     join_details: To join this course, you need to get the passcode — or an enrollment link that includes the passcode — from the instructor. If you haven't received this, contact your instructor.
+    join_no_passcode: Are you sure you want to join this course?
     leave_confirmation: Are you sure you want to leave this course?
     leave_course: Leave course
     loading: Loading…

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -135,7 +135,7 @@ describe 'Student users', type: :feature, js: true do
 
       expect(page).to have_content 'An Example Editathon'
 
-      click_button 'Join course'
+      click_button 'Join program'
       within('.confirm-modal') do
         click_button 'OK'
       end

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -36,18 +36,6 @@ describe 'Student users', type: :feature, js: true do
            end: '2020-01-01'.to_date)
   end
 
-  let!(:second_editathon) do
-    create(:editathon,
-           title: 'Second Example Editathon',
-           school: 'University',
-           term: 'Term',
-           slug: 'University/Second_Example_Editathon_(Term)',
-           submitted: true,
-           passcode: 'passcode',
-           start: '2015-01-01'.to_date,
-           end: '2020-01-01'.to_date)
-  end
-
   before :each do
     create(:courses_user,
            user: instructor,
@@ -138,12 +126,12 @@ describe 'Student users', type: :feature, js: true do
       sleep 5
     end
 
-    it 'joins and leaves an editathon without a passcode' do
+    it 'joins an Editathon without a passcode' do
       login_as(user, scope: :user)
       stub_oauth_edit
 
       # click enroll button, enter passcode in alert popup to enroll
-      visit "/courses/University/An_Example_Editathon_(Term)"
+      visit "/courses/#{Editathon.first.slug}"
 
       expect(page).to have_content 'An Example Editathon'
 
@@ -154,35 +142,8 @@ describe 'Student users', type: :feature, js: true do
 
       sleep 3
 
-      visit "/courses/University/An_Example_Editathon_(Term)/students"
+      visit "/courses/#{Editathon.first.slug}/students"
       expect(find('tbody', match: :first)).to have_content User.last.username
-
-      # now unenroll
-      visit "/courses/University/An_Example_Editathon_(Term)"
-
-      expect(page).to have_content 'An Example Editathon'
-
-      accept_confirm do
-        click_button 'Leave course'
-      end
-
-      sleep 3
-
-      visit "/courses/University/An_Example_Editathon_(Term)/students"
-      expect(find('tbody', match: :first)).not_to have_content User.last.username
-    end
-
-    it 'redirects to an error page if passcode is incorrect in Editathons' do
-      login_as(user, scope: :user)
-      visit "/courses/University/Second_Example_Editathon_(Term)"
-      sleep 1
-      click_button 'Join course'
-      within('.confirm-modal') do
-        find('input').set('')
-        click_button 'OK'
-      end
-      expect(page).to have_content 'Incorrect passcode'
-      sleep 5
     end
   end
 

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -24,6 +24,29 @@ describe 'Student users', type: :feature, js: true do
            start: '2015-01-01'.to_date,
            end: '2020-01-01'.to_date)
   end
+  let!(:editathon) do
+    create(:editathon,
+           title: 'An Example Editathon',
+           school: 'University',
+           term: 'Term',
+           slug: 'University/An_Example_Editathon_(Term)',
+           submitted: true,
+           passcode: '',
+           start: '2015-01-01'.to_date,
+           end: '2020-01-01'.to_date)
+  end
+
+  let!(:second_editathon) do
+    create(:editathon,
+           title: 'Second Example Editathon',
+           school: 'University',
+           term: 'Term',
+           slug: 'University/Second_Example_Editathon_(Term)',
+           submitted: true,
+           passcode: 'passcode',
+           start: '2015-01-01'.to_date,
+           end: '2020-01-01'.to_date)
+  end
 
   before :each do
     create(:courses_user,
@@ -109,6 +132,53 @@ describe 'Student users', type: :feature, js: true do
       click_button 'Join course'
       within('.confirm-modal') do
         find('input').set('wrong_passcode')
+        click_button 'OK'
+      end
+      expect(page).to have_content 'Incorrect passcode'
+      sleep 5
+    end
+
+    it 'joins and leaves an editathon without a passcode' do
+      login_as(user, scope: :user)
+      stub_oauth_edit
+
+      # click enroll button, enter passcode in alert popup to enroll
+      visit "/courses/University/An_Example_Editathon_(Term)"
+
+      expect(page).to have_content 'An Example Editathon'
+
+      click_button 'Join course'
+      within('.confirm-modal') do
+        click_button 'OK'
+      end
+
+      sleep 3
+
+      visit "/courses/University/An_Example_Editathon_(Term)/students"
+      expect(find('tbody', match: :first)).to have_content User.last.username
+
+      # now unenroll
+      visit "/courses/University/An_Example_Editathon_(Term)"
+
+      expect(page).to have_content 'An Example Editathon'
+
+      accept_confirm do
+        click_button 'Leave course'
+      end
+
+      sleep 3
+
+      visit "/courses/University/An_Example_Editathon_(Term)/students"
+      expect(find('tbody', match: :first)).not_to have_content User.last.username
+    end
+
+    it 'redirects to an error page if passcode is incorrect in Editathons' do
+      login_as(user, scope: :user)
+      visit "/courses/University/Second_Example_Editathon_(Term)"
+      sleep 1
+      click_button 'Join course'
+      within('.confirm-modal') do
+        find('input').set('')
         click_button 'OK'
       end
       expect(page).to have_content 'Incorrect passcode'


### PR DESCRIPTION
For those cases where we want to allow the users to join a program without having a passcode, we will display a different kind of button that doesn't require to fill out a passcode input.
This PR: 
- Adds a new method to the Course model that checks if the course requires a passcode and if this passcode is blank. Will return true only if the passcode IS blank and IS NOT required
- Adds a new functionality to available_actions displaying a different kind of button if the course allows registration without a passcode
- Includes a new method in the SelfEnrollment Controller that will allow the user indeed to register in this course they don't provide the passcode. 
- Adds an English translation for the Modal Prompt.