### PR TITLE
#fixes 1459 ,wiki-course page shows first instructor and real name fetched from CourseUsers

### DIFF
--- a/app/views/dashboard/_course_row.html.haml
+++ b/app/views/dashboard/_course_row.html.haml
@@ -8,8 +8,8 @@
       .course-details_title
         = course_i18n('instructors', course)
       .course-details_value
-        - course.instructors.each do |user|
-          = user.username
+        - course.instructors.first(1).each do |courses_users|
+          = courses_users.username
     .col
       .course-details_title
         = course_i18n('school', course)


### PR DESCRIPTION
On Wiki course pages, only first instructor is listed.He is the first enrolled.
The real name is fetched from the CoursesUsers record.