### PR TITLE
Adds a default passcode to the campaigns

### DIFF
--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -28,7 +28,8 @@ export default function course(state = initialState, action) {
         initial_campaign_id: campaign.id,
         initial_campaign_title: campaign.title,
         description: campaign.template_description,
-        type: campaign.default_course_type
+        type: campaign.default_course_type,
+        passcode: campaign.default_passcode
       };
       return newState;
     }

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -215,6 +215,6 @@ class CampaignsController < ApplicationController
 
   def campaign_params
     params.require(:campaign)
-          .permit(:slug, :description, :template_description, :title, :start, :end, :default_course_type)
+          .permit(:slug, :description, :template_description, :title, :start, :end, :default_course_type, :default_passcode)
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -16,6 +16,7 @@ require 'csv'
 #  end                  :datetime
 #  template_description :text(65535)
 #  default_course_type  :string(255)
+#  default_passcode     :string(255)
 #
 
 #= Campaign model

--- a/app/views/campaigns/_create_modal.html.haml
+++ b/app/views/campaigns/_create_modal.html.haml
@@ -14,6 +14,10 @@
               = text_field(:campaign, :title, required: true)
 
             .form-group
+              = label(:campaign, :default_passcode, t('campaign.default_passcode') + ':')
+              = text_field(:campaign, :default_passcode, maxlength: 255)
+
+            .form-group
               - use_dates = @campaign.start || @campaign.end
               %label
                 = check_box_tag(:use_dates, '1', use_dates)
@@ -31,10 +35,11 @@
             .form-group
               = label(:campaign, :description, t('campaign.description') + ':')
               = text_area(:campaign, :description, maxlength: 65535)
-
             .form-group
               = label(:campaign, :default_course_type, t('campaign.default_course_type') + ':')
               = select(:campaign, :default_course_type, options_for_select(['BasicCourse', 'Editathon', 'ArticleScopedProgram']), include_blank: true)
+
+
 
 
         .wizard__panel__controls.wizard__form

--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -86,6 +86,14 @@
               %span.rails_editable-input
                 = select(:campaign, :default_course_type, options_for_select(['', 'BasicCourse', 'Editathon', 'ArticleScopedProgram'], @campaign.default_course_type))
 
+            .campaign-default_passcode.form-group.rails_editable-field
+              %label{for: 'default_passcode'}
+                = succeed ':' do
+                  = t('campaign.default_passcode')
+              %span.rails_editable-content
+                = @campaign.default_passcode
+              = text_field(:campaign, :default_passcode, required: false, class: 'rails_editable-input')
+
             .campaign-use-dates.form-group.rails_editable-field
               - use_dates = @campaign.start || @campaign.end
               %label

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -108,6 +108,12 @@
                 %span.rails_editable-content
                   = @campaign.default_course_type
 
+              .campaign-default_passcode.form-group.rails_editable-field
+                %label{for: 'default_passcode'}
+                  = succeed ':' do
+                    = t('campaign.default_passcode')
+                %span.rails_editable-content
+                  = @campaign.default_passcode
 
       - if @campaign.template_description.present?
         = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do

--- a/app/views/campaigns/show.json.jbuilder
+++ b/app/views/campaigns/show.json.jbuilder
@@ -8,5 +8,6 @@ if @campaign
     json.description @campaign.description
     json.template_description @campaign.template_description
     json.default_course_type @campaign.default_course_type
+    json.default_passcode @campaign.default_passcode
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,7 @@ en:
     create_campaign: Create a New Campaign
     create_my_campaign: Create my Campaign!
     default_course_type: Default Course Type
+    default_passcode: Default Passcode
     description: Description
     delete_campaign: Delete this campaign
     none: None

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -192,6 +192,7 @@ es:
     create_campaign: Crear una campaña nueva
     create_my_campaign: ¡Crear mi campaña!
     default_course_type: Tipo de curso predeterminado
+    default_passcode: Contraseña predeterminada
     description: Descripción
     delete_campaign: Eliminar esta campaña
     none: Ninguno

--- a/db/migrate/20180105134255_add_default_passcode_to_campaigns.rb
+++ b/db/migrate/20180105134255_add_default_passcode_to_campaigns.rb
@@ -1,0 +1,5 @@
+class AddDefaultPasscodeToCampaigns < ActiveRecord::Migration[5.1]
+  def change
+    add_column :campaigns, :default_passcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180102234119) do
+ActiveRecord::Schema.define(version: 20180105134255) do
 
   create_table "alerts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "course_id"
@@ -33,10 +33,10 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["user_id"], name: "index_alerts_on_user_id"
   end
 
-  create_table "articles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "articles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
-    t.datetime "updated_at"
     t.datetime "created_at"
+    t.datetime "updated_at"
     t.date "views_updated_at"
     t.integer "namespace"
     t.string "rating"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["namespace", "wiki_id", "title"], name: "index_articles_on_namespace_and_wiki_id_and_title"
   end
 
-  create_table "articles_courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "articles_courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "article_id"
@@ -72,18 +72,18 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["assignment_id"], name: "index_assignment_suggestions_on_assignment_id"
   end
 
-  create_table "assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "article_title"
     t.integer "user_id"
     t.integer "course_id"
     t.integer "article_id"
+    t.string "article_title"
     t.integer "role"
     t.integer "wiki_id"
   end
 
-  create_table "blocks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "blocks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "kind"
     t.text "content"
     t.integer "week_id"
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["week_id"], name: "index_blocks_on_week_id"
   end
 
-  create_table "campaigns", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "campaigns", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.string "slug"
     t.string "url"
@@ -108,9 +108,10 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.datetime "end"
     t.text "template_description"
     t.string "default_course_type"
+    t.string "default_passcode"
   end
 
-  create_table "campaigns_courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "campaigns_courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "campaign_id"
     t.integer "course_id"
     t.datetime "created_at"
@@ -158,7 +159,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["course_id"], name: "index_categories_courses_on_course_id"
   end
 
-  create_table "commons_uploads", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "commons_uploads", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.string "file_name", limit: 2000
     t.datetime "uploaded_at"
@@ -172,7 +173,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["user_id"], name: "index_commons_uploads_on_user_id"
   end
 
-  create_table "courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -217,7 +218,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 
-  create_table "courses_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "courses_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "course_id"
@@ -235,14 +236,14 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["user_id"], name: "index_courses_users_on_user_id"
   end
 
-  create_table "feedback_form_responses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "feedback_form_responses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "subject"
     t.text "body"
     t.integer "user_id"
     t.datetime "created_at"
   end
 
-  create_table "gradeables", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "gradeables", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.integer "points"
     t.integer "gradeable_item_id"
@@ -262,8 +263,8 @@ ActiveRecord::Schema.define(version: 20180102234119) do
 
   create_table "rapidfire_answer_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "question_group_id"
-    t.integer "user_id"
     t.string "user_type"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "course_id"
@@ -308,7 +309,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["question_group_id"], name: "index_rapidfire_questions_on_question_group_id"
   end
 
-  create_table "revisions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "revisions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "characters", default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -318,9 +319,9 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.datetime "date"
     t.boolean "new_article", default: false
     t.boolean "deleted", default: false
-    t.boolean "system", default: false
     t.float "wp10", limit: 24
     t.float "wp10_previous", limit: 24
+    t.boolean "system", default: false
     t.integer "ithenticate_id"
     t.integer "wiki_id"
     t.integer "mw_rev_id"
@@ -385,7 +386,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.text "optout"
   end
 
-  create_table "surveys_question_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "surveys_question_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "survey_id"
     t.integer "rapidfire_question_group_id"
     t.integer "position"
@@ -395,7 +396,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["survey_id"], name: "index_surveys_question_groups_on_survey_id"
   end
 
-  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "course_id"
     t.string "tag"
     t.string "key"
@@ -404,7 +405,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["course_id", "key"], name: "index_tags_on_course_id_and_key", unique: true
   end
 
-  create_table "training_modules_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "training_modules_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id"
     t.integer "training_module_id"
     t.string "last_slide_completed"
@@ -423,7 +424,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.string "institution"
   end
 
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "username"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -456,7 +457,7 @@ ActiveRecord::Schema.define(version: 20180102234119) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "weeks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "weeks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
     t.integer "course_id"
     t.datetime "created_at"

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -80,6 +80,7 @@ class CourseCreationManager
   end
 
   def set_passcode
+    return if @course_params[:passcode].present?
     @overrides[:passcode] = Course.generate_passcode
   end
 

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -18,6 +18,7 @@ describe 'open course creation', type: :feature, js: true do
            title: 'My Awesome Campaign',
            description: 'This is the best campaign',
            default_course_type: 'Editathon',
+           passcode: 'passcode',
            template_description: 'This is the template description')
   end
 
@@ -81,5 +82,6 @@ describe 'open course creation', type: :feature, js: true do
     expect(CampaignsCourses.last.course_id).to eq(Course.last.id)
     expect(Course.last.description).to eq(campaign.template_description)
     expect(Course.last.type).to eq('Editathon')
+    expect(Course.last.passcode).to eq('passcode')
   end
 end

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -18,7 +18,7 @@ describe 'open course creation', type: :feature, js: true do
            title: 'My Awesome Campaign',
            description: 'This is the best campaign',
            default_course_type: 'Editathon',
-           passcode: 'passcode',
+           default_passcode: 'passcode',
            template_description: 'This is the template description')
   end
 


### PR DESCRIPTION
- Generates a new migration which adds a new field to campaigns table default_passcode)

- Adds this default_passcode to the campaign permitted params
- Adds the default passcode to the course reducer in order to add it to the course created via a campaign
- Adds the default passcode to the show.json.jbuilder
- Adds text field to the campaign creator to add the default passcode you want to pass to the courses
- Adds also a text field to the campaign edit haml that allows the user to edit the passcode
- Adds Locales for default passcode
- Prevents the course creation manager to override the passode if its present in the params