### PR TITLE
No passcode at campaign creation

### DIFF
--- a/app/views/campaigns/_create_modal.html.haml
+++ b/app/views/campaigns/_create_modal.html.haml
@@ -17,7 +17,7 @@
               = label(:campaign, :default_passcode, t('campaign.default_passcode') + ':')
               = text_field(:campaign, :default_passcode, maxlength: 255)
               %label
-                = check_box_tag('campaign[default_passcode]', 'no-passcode', @campaign.default_passcode)
+                = check_box_tag('campaign[default_passcode]', 'no-passcode')
                 = t('campaign.no_passcode')
 
 

--- a/app/views/campaigns/_create_modal.html.haml
+++ b/app/views/campaigns/_create_modal.html.haml
@@ -16,6 +16,10 @@
             .form-group
               = label(:campaign, :default_passcode, t('campaign.default_passcode') + ':')
               = text_field(:campaign, :default_passcode, maxlength: 255)
+              %label
+                = check_box_tag('campaign[default_passcode]', 'no-passcode', @campaign.default_passcode)
+                = t('campaign.no_passcode')
+
 
             .form-group
               - use_dates = @campaign.start || @campaign.end
@@ -35,6 +39,7 @@
             .form-group
               = label(:campaign, :description, t('campaign.description') + ':')
               = text_area(:campaign, :description, maxlength: 65535)
+
             .form-group
               = label(:campaign, :default_course_type, t('campaign.default_course_type') + ':')
               = select(:campaign, :default_course_type, options_for_select(['BasicCourse', 'Editathon', 'ArticleScopedProgram']), include_blank: true)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
     default_passcode: Default Passcode
     description: Description
     delete_campaign: Delete this campaign
+    no_passcode: No passcode
     none: None
     organizers: Organizers
     organizer_added: '%{user} is now an organizer of the "%{title}" campaign'

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -80,9 +80,7 @@ class CourseCreationManager
   end
 
   def set_passcode
-    if @course_params[:passcode] == 'no-passcode'
-      @overrides[:passcode] = ''
-    end
+    @overrides[:passcode] = '' if @course_params[:passcode] == 'no-passcode'
     return if @course_params[:passcode].present?
     @overrides[:passcode] = Course.generate_passcode
   end

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -80,9 +80,9 @@ class CourseCreationManager
   end
 
   def set_passcode
-    if @course_params[:passcode] = 'no-passcode'
+    if @course_params[:passcode] == 'no-passcode'
       @overrides[:passcode] = ''
-    end  
+    end
     return if @course_params[:passcode].present?
     @overrides[:passcode] = Course.generate_passcode
   end

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -80,6 +80,9 @@ class CourseCreationManager
   end
 
   def set_passcode
+    if @course_params[:passcode] = 'no-passcode'
+      @overrides[:passcode] = ''
+    end  
     return if @course_params[:passcode].present?
     @overrides[:passcode] = Course.generate_passcode
   end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -142,6 +142,7 @@ describe CoursesController do
     context 'setting passcode' do
       let(:course) { create(:course) }
       before { course.update_attribute(:passcode, nil) }
+
       it 'sets if it is nil and not in params' do
         params = { id: course.slug, course: { title: 'foo' } }
         put :update, params: params, as: :json
@@ -222,7 +223,8 @@ describe CoursesController do
             term: 'Fall 2015',
             start: '2015-01-05',
             end: '2015-12-20',
-            role_description: role_description }
+            role_description: role_description,
+            passcode: 'passcode' }
         end
         it 'sets slug correctly' do
           post :create, params: { course: course_params }, as: :json
@@ -232,6 +234,29 @@ describe CoursesController do
         it 'sets instructor role description correctly' do
           post :create, params: { course: course_params }, as: :json
           expect(CoursesUsers.last.role_description).to eq(role_description)
+        end
+
+        it 'sets passcode correctly' do
+          post :create, params: { course: course_params }, as: :json
+          expect(Course.last.passcode).to eq('passcode')
+        end
+      end
+
+      context 'sets no passcode' do
+        let(:course_params) do
+          { school: 'Wiki University',
+            title: 'How to Wiki',
+            term: 'Fall 2015',
+            start: '2015-01-05',
+            end: '2015-12-20',
+            type: 'Editathon',
+            passcode: 'no-passcode'
+          }
+        end
+
+        it 'creates an empty passcode' do
+          post :create, params: { course: course_params }, as: :json
+          expect(Course.last.passcode).to eq('')
         end
       end
 
@@ -246,7 +271,7 @@ describe CoursesController do
         end
       end
 
-      context 'valid lanaguage and project present' do
+      context 'valid language and project present' do
         let(:course_params) do
           { school: 'Wiki University',
             title: 'How to Wiki',
@@ -269,7 +294,7 @@ describe CoursesController do
         end
       end
 
-      context 'invalid lanaguage and project present' do
+      context 'invalid language and project present' do
         let(:course_params) do
           { school: 'Wiki University',
             title: 'How to Wiki',

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -242,7 +242,7 @@ describe CoursesController do
         end
       end
 
-      context 'sets no passcode' do
+      context 'sets en empty passcode' do
         let(:course_params) do
           { school: 'Wiki University',
             title: 'How to Wiki',
@@ -250,8 +250,7 @@ describe CoursesController do
             start: '2015-01-05',
             end: '2015-12-20',
             type: 'Editathon',
-            passcode: 'no-passcode'
-          }
+            passcode: 'no-passcode' }
         end
 
         it 'creates an empty passcode' do


### PR DESCRIPTION
- Adds checkbox if the instructor wants to set the no passcode as default

- Overrides the course if the default_passcode is "no-passcode" as ''
- Adds locales for the translations