### PR TITLE
#1603 Allows the user to set different event/statistics updates

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -445,7 +445,7 @@ const CourseCreator = createReactClass({
                     value_key="timeline_start"
                     editable
                     label={CourseUtils.i18n('creator.start_event_date', this.state.course_string_prefix)}
-                    placeholder={I18n.t('courses.creator.start_date_placeholder')}
+                    placeholder={I18n.t('courses.creator.start_event_date_placeholder')}
                     blank
                     isClearable={false}
                     showTime={this.state.use_start_and_end_times}
@@ -457,7 +457,7 @@ const CourseCreator = createReactClass({
                     value_key="timeline_end"
                     editable
                     label={CourseUtils.i18n('creator.end_event_date', this.state.course_string_prefix)}
-                    placeholder={I18n.t('courses.creator.end_date_placeholder')}
+                    placeholder={I18n.t('courses.creator.end_event_date_placeholder')}
                     blank
                     date_props={dateProps.timeline_end}
                     enabled={!!this.props.course.timeline_start}

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -50,7 +50,7 @@ const CourseCreator = createReactClass({
       isSubmitting: false,
       showCourseForm: false,
       showCloneChooser: false,
-      showEventDates: false,
+      showEventDates: this.props.course.showEventDates,
       default_course_type: this.props.courseCreator.defaultCourseType,
       course_string_prefix: this.props.courseCreator.courseStringPrefix,
       use_start_and_end_times: this.props.courseCreator.useStartAndEndTimes

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -165,8 +165,10 @@ const CourseCreator = createReactClass({
   dateTimesAreValid() {
     const startDateTime = new Date(this.props.course.start);
     const endDateTime = new Date(this.props.course.end);
+    const startEventTime = new Date(this.props.timeline_start);
+    const endEventTime = new Date(this.props.timeline_end);
 
-    if (startDateTime >= endDateTime) {
+    if (startDateTime >= endDateTime || startEventTime >= endEventTime) {
       ValidationActions.setInvalid('end', I18n.t('application.field_invalid_date_time'));
       return false;
     }
@@ -385,7 +387,7 @@ const CourseCreator = createReactClass({
           label={CourseUtils.i18n('creator.start_event_date', this.state.course_string_prefix)}
           placeholder={I18n.t('courses.creator.start_event_date_placeholder')}
           blank
-          isClearable={false}
+          isClearable={true}
           showTime={this.state.use_start_and_end_times}
         />
     );
@@ -401,7 +403,7 @@ const CourseCreator = createReactClass({
           blank
           date_props={dateProps.timeline_end}
           enabled={!!this.props.course.timeline_start}
-          isClearable={false}
+          isClearable={true}
           showTime={this.state.use_start_and_end_times}
         />
     );

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -50,7 +50,7 @@ const CourseCreator = createReactClass({
       isSubmitting: false,
       showCourseForm: false,
       showCloneChooser: false,
-      showEventDates: this.props.course.showEventDates,
+      showEventDates: false,
       default_course_type: this.props.courseCreator.defaultCourseType,
       course_string_prefix: this.props.courseCreator.courseStringPrefix,
       use_start_and_end_times: this.props.courseCreator.useStartAndEndTimes

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -379,13 +379,13 @@ const CourseCreator = createReactClass({
     );
       timelineStart = (
         <DatePicker
-          id="course_event_start"
+          id="course_timeline_start"
           onChange={this.updateCourseDates}
           value={this.props.course.timeline_start}
           value_key="timeline_start"
           editable
-          label={CourseUtils.i18n('creator.start_event_date', this.state.course_string_prefix)}
-          placeholder={I18n.t('courses.creator.start_event_date_placeholder')}
+          label={CourseUtils.i18n('creator.assignment_start', this.state.course_string_prefix)}
+          placeholder={I18n.t('courses.creator.assignment_start_placeholder')}
           blank
           isClearable={true}
           showTime={this.state.use_start_and_end_times}
@@ -393,13 +393,13 @@ const CourseCreator = createReactClass({
     );
       timelineEnd = (
         <DatePicker
-          id="course_event_end"
+          id="course_timeline_end"
           onChange={this.updateCourseDates}
           value={this.props.course.timeline_end}
           value_key="timeline_end"
           editable
-          label={CourseUtils.i18n('creator.end_event_date', this.state.course_string_prefix)}
-          placeholder={I18n.t('courses.creator.end_event_date_placeholder')}
+          label={CourseUtils.i18n('creator.assignment_end', this.state.course_string_prefix)}
+          placeholder={I18n.t('courses.creator.assignment_end_placeholder')}
           blank
           date_props={dateProps.timeline_end}
           enabled={!!this.props.course.timeline_start}

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -132,6 +132,10 @@ const CourseCreator = createReactClass({
     }
   },
 
+  showEventDates() {
+    return this.setState({ showEventDates: !this.state.showEventDates });
+  },
+
   updateCourse(key, value) {
     this.props.updateCourse({ [key]: value });
     if (_.includes(['title', 'school', 'term'], key)) {
@@ -148,10 +152,6 @@ const CourseCreator = createReactClass({
     const isPrivate = e.target.checked;
     this.props.updateCourse({ private: isPrivate });
     this.updateCourse('private', isPrivate);
-  },
-
-  showEventDates() {
-    return this.setState({ showEventDates: !this.state.showEventDates });
   },
 
   expectedStudentsIsValid() {
@@ -236,8 +236,8 @@ const CourseCreator = createReactClass({
     const selectClass = showCloneChooser ? '' : ' hidden';
     const options = this.props.user_courses.map((course, i) => <option key={i} data-id-key={course.id}>{course.title}</option>);
     const selectClassName = `select-container ${selectClass}`;
-    const eventsFormClass = this.state.showEventDates ? '' : 'hidden';
-    const eventsClass = `${eventsFormClass}`;
+    const eventFormClass = this.state.showEventDates ? '' : 'hidden';
+    const eventClass = `${eventFormClass}`;
 
 
     let term;
@@ -496,7 +496,7 @@ const CourseCreator = createReactClass({
                     showTime={this.state.use_start_and_end_times}
                   />
                   {eventCheckbox}
-                  <span className={eventsClass}>
+                  <span className={eventClass}>
                     {timelineStart}
                     {timelineEnd}
                   </span>

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -438,6 +438,32 @@ const CourseCreator = createReactClass({
                     isClearable={false}
                     showTime={this.state.use_start_and_end_times}
                   />
+                  <DatePicker
+                    id="course_event_start"
+                    onChange={this.updateCourseDates}
+                    value={this.props.course.timeline_start}
+                    value_key="timeline_start"
+                    editable
+                    label={CourseUtils.i18n('creator.start_event_date', this.state.course_string_prefix)}
+                    placeholder={I18n.t('courses.creator.start_date_placeholder')}
+                    blank
+                    isClearable={false}
+                    showTime={this.state.use_start_and_end_times}
+                  />
+                  <DatePicker
+                    id="course_event_end"
+                    onChange={this.updateCourseDates}
+                    value={this.props.course.timeline_end}
+                    value_key="timeline_end"
+                    editable
+                    label={CourseUtils.i18n('creator.end_event_date', this.state.course_string_prefix)}
+                    placeholder={I18n.t('courses.creator.end_date_placeholder')}
+                    blank
+                    date_props={dateProps.timeline_end}
+                    enabled={!!this.props.course.timeline_start}
+                    isClearable={false}
+                    showTime={this.state.use_start_and_end_times}
+                  />
                   {this.state.use_start_and_end_times ? timeZoneMessage : null}
                   <span className="text-input-component__label"><strong>{CourseUtils.i18n('creator.course_description', this.state.course_string_prefix)}:</strong></span>
                   <TextAreaInput

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -50,6 +50,7 @@ const CourseCreator = createReactClass({
       isSubmitting: false,
       showCourseForm: false,
       showCloneChooser: false,
+      showEventDates: false,
       default_course_type: this.props.courseCreator.defaultCourseType,
       course_string_prefix: this.props.courseCreator.courseStringPrefix,
       use_start_and_end_times: this.props.courseCreator.useStartAndEndTimes
@@ -149,6 +150,10 @@ const CourseCreator = createReactClass({
     this.updateCourse('private', isPrivate);
   },
 
+  showEventDates() {
+    return this.setState({ showEventDates: !this.state.showEventDates });
+  },
+
   expectedStudentsIsValid() {
     if (this.props.course.expected_students === '0' && this.state.default_course_type === 'ClassroomProgramCourse') {
       ValidationActions.setInvalid('expected_students', I18n.t('application.field_required'));
@@ -229,6 +234,9 @@ const CourseCreator = createReactClass({
     const selectClass = showCloneChooser ? '' : ' hidden';
     const options = this.props.user_courses.map((course, i) => <option key={i} data-id-key={course.id}>{course.title}</option>);
     const selectClassName = `select-container ${selectClass}`;
+    const eventsFormClass = this.state.showEventDates ? '' : 'hidden';
+    const eventsClass = `${eventsFormClass}`;
+
 
     let term;
     let subject;
@@ -352,6 +360,53 @@ const CourseCreator = createReactClass({
         {I18n.t('courses.time_zone_message')}
       </p>
     );
+    let eventCheckbox;
+    let timelineStart;
+    let timelineEnd;
+    if (this.state.default_course_type !== 'ClassroomProgramCourse') {
+      eventCheckbox = (<div className="form-group">
+        <label htmlFor="course_event">{CourseUtils.i18n('creator.course_event', this.state.course_string_prefix)}:</label>
+        <input
+          id="course_event"
+          type="checkbox"
+          value={true}
+          onChange={this.showEventDates}
+          checked={!!this.state.showEventDates}
+        />
+      </div>
+    );
+      timelineStart = (
+        <DatePicker
+          id="course_event_start"
+          onChange={this.updateCourseDates}
+          value={this.props.course.timeline_start}
+          value_key="timeline_start"
+          editable
+          label={CourseUtils.i18n('creator.start_event_date', this.state.course_string_prefix)}
+          placeholder={I18n.t('courses.creator.start_event_date_placeholder')}
+          blank
+          isClearable={false}
+          showTime={this.state.use_start_and_end_times}
+        />
+    );
+      timelineEnd = (
+        <DatePicker
+          id="course_event_end"
+          onChange={this.updateCourseDates}
+          value={this.props.course.timeline_end}
+          value_key="timeline_end"
+          editable
+          label={CourseUtils.i18n('creator.end_event_date', this.state.course_string_prefix)}
+          placeholder={I18n.t('courses.creator.end_event_date_placeholder')}
+          blank
+          date_props={dateProps.timeline_end}
+          enabled={!!this.props.course.timeline_start}
+          isClearable={false}
+          showTime={this.state.use_start_and_end_times}
+        />
+    );
+  }
+
 
     return (
       <TransitionGroup
@@ -438,32 +493,11 @@ const CourseCreator = createReactClass({
                     isClearable={false}
                     showTime={this.state.use_start_and_end_times}
                   />
-                  <DatePicker
-                    id="course_event_start"
-                    onChange={this.updateCourseDates}
-                    value={this.props.course.timeline_start}
-                    value_key="timeline_start"
-                    editable
-                    label={CourseUtils.i18n('creator.start_event_date', this.state.course_string_prefix)}
-                    placeholder={I18n.t('courses.creator.start_event_date_placeholder')}
-                    blank
-                    isClearable={false}
-                    showTime={this.state.use_start_and_end_times}
-                  />
-                  <DatePicker
-                    id="course_event_end"
-                    onChange={this.updateCourseDates}
-                    value={this.props.course.timeline_end}
-                    value_key="timeline_end"
-                    editable
-                    label={CourseUtils.i18n('creator.end_event_date', this.state.course_string_prefix)}
-                    placeholder={I18n.t('courses.creator.end_event_date_placeholder')}
-                    blank
-                    date_props={dateProps.timeline_end}
-                    enabled={!!this.props.course.timeline_start}
-                    isClearable={false}
-                    showTime={this.state.use_start_and_end_times}
-                  />
+                  {eventCheckbox}
+                  <span className={eventsClass}>
+                    {timelineStart}
+                    {timelineEnd}
+                  </span>
                   {this.state.use_start_and_end_times ? timeZoneMessage : null}
                   <span className="text-input-component__label"><strong>{CourseUtils.i18n('creator.course_description', this.state.course_string_prefix)}:</strong></span>
                   <TextAreaInput

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -55,11 +55,7 @@ const Details = createReactClass({
   },
   mixins: [ValidationStore.mixin],
   getInitialState() {
-    const inits = {
-      showEventDates: this.props.course.showEventDates
-    };
-
-    return { ...inits, ...getState() };
+    return getState();
   },
 
   updateDetails(valueKey, value) {
@@ -80,13 +76,10 @@ const Details = createReactClass({
     return CourseActions.updateCourse(updatedCourse);
   },
 
-  showEventDates() {
-    return this.setState({ showEventDates: !this.state.showEventDates });
-  },
-
   storeDidChange() {
     return this.setState({ error_message: ValidationStore.firstMessage() });
   },
+
 
   canRename() {
     if (!this.props.editable) { return false; }
@@ -100,6 +93,7 @@ const Details = createReactClass({
   render() {
     const canRename = this.canRename();
     const isClassroomProgramType = this.props.course.type === 'ClassroomProgramCourse';
+    const timelineDatesDiffer = this.props.course.start !== this.props.course.timeline_start || this.props.course.end !== this.props.course.timeline_end;
     const instructors = <InlineUsers {...this.props} users={this.props.instructors} role={1} title={CourseUtils.i18n('instructors', this.props.course.string_prefix)} />;
     let online;
     let campus;
@@ -187,39 +181,23 @@ const Details = createReactClass({
         />
       );
     }
-    const eventFormClass = this.state.showEventDates ? '' : 'hidden';
-    const eventClass = `${eventFormClass}`;
+
     const dateProps = CourseDateUtils.dateProps(this.props.course);
     let timelineStart;
     let timelineEnd;
-    let eventCheckbox;
-    if (this.props.editable) {
-    eventCheckbox = (<div className="form-group">
-      <label htmlFor="course_event">{CourseUtils.i18n('creator.course_event', this.state.course.string_prefix)}</label>
-      <input
-        id="course_event"
-        type="checkbox"
-        value={true}
-        editable = {this.props.editable}
-        onChange={this.showEventDates}
-        checked={!!this.state.showEventDates}
-      />
-    </div>
-    );
-    }
-    if (this.state.showEventDates) {
-    timelineStart = (
-      <DatePicker
-        onChange={this.updateCourseDates}
-        value={this.props.course.timeline_start}
-        value_key="timeline_start"
-        editable={this.props.editable}
-        validation={CourseDateUtils.isDateValid}
-        label={CourseUtils.i18n('assignment_start', this.props.course.string_prefix)}
-        date_props={dateProps.timeline_start}
-        showTime={this.props.course.use_start_and_end_times}
-        required={true}
-      />
+    if (timelineDatesDiffer || this.props.editable) {
+      timelineStart = (
+        <DatePicker
+          onChange={this.updateCourseDates}
+          value={this.props.course.timeline_start}
+          value_key="timeline_start"
+          editable={this.props.editable}
+          validation={CourseDateUtils.isDateValid}
+          label={CourseUtils.i18n('assignment_start', this.props.course.string_prefix)}
+          date_props={dateProps.timeline_start}
+          showTime={this.props.course.use_start_and_end_times}
+          required={true}
+        />
       );
       timelineEnd = (
         <DatePicker
@@ -233,8 +211,8 @@ const Details = createReactClass({
           showTime={this.props.course.use_start_and_end_times}
           required={true}
         />
-        );
-      }
+      );
+    }
     const lastIndex = this.props.campaigns.length - 1;
     const campaigns = this.props.campaigns.length > 0 ?
       _.map(this.props.campaigns, (campaign, index) => {
@@ -334,7 +312,7 @@ const Details = createReactClass({
               value_key="start"
               validation={CourseDateUtils.isDateValid}
               editable={this.props.editable}
-              label={I18n.t('courses.start')}
+              label={CourseUtils.i18n('start', this.props.course.string_prefix)}
               showTime={this.props.course.use_start_and_end_times}
               required={true}
             />
@@ -344,17 +322,14 @@ const Details = createReactClass({
               value_key="end"
               editable={this.props.editable}
               validation={CourseDateUtils.isDateValid}
-              label={I18n.t('courses.end')}
+              label={CourseUtils.i18n('end', this.props.course.string_prefix)}
               date_props={dateProps.end}
               enabled={Boolean(this.props.course.start)}
               showTime={this.props.course.use_start_and_end_times}
               required={true}
             />
-            {eventCheckbox}
-            <span className={eventClass}>
-              {timelineStart}
-              {timelineEnd}
-            </span>
+            {timelineStart}
+            {timelineEnd}
           </form>
           <div>
             <span><strong>{CourseUtils.i18n('campaigns', this.props.course.string_prefix)} </strong>{campaigns}</span>

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -183,7 +183,7 @@ const Details = createReactClass({
     const dateProps = CourseDateUtils.dateProps(this.props.course);
     let timelineStart;
     let timelineEnd;
-    if (this.props.course.timeline_start && this.props.course.timeline_end) {
+    if (this.props.course.showEventDates) {
     timelineStart = (
       <DatePicker
         onChange={this.updateCourseDates}

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -326,6 +326,28 @@ const Details = createReactClass({
               showTime={this.props.course.use_start_and_end_times}
               required={true}
             />
+            <DatePicker
+              onChange={this.updateCourseDates}
+              value={this.props.course.timeline_start}
+              value_key="timeline_start"
+              validation={CourseDateUtils.isDateValid}
+              editable={this.props.editable}
+              label={I18n.t('courses.event_start')}
+              showTime={this.props.course.use_start_and_end_times}
+              required={true}
+            />
+            <DatePicker
+              onChange={this.updateCourseDates}
+              value={this.props.course.timeline_end}
+              value_key="timeline_end"
+              editable={this.props.editable}
+              validation={CourseDateUtils.isDateValid}
+              label={I18n.t('courses.event_end')}
+              date_props={dateProps.timeline_end}
+              enabled={Boolean(this.props.course.start)}
+              showTime={this.props.course.use_start_and_end_times}
+              required={true}
+            />
             {timelineStart}
             {timelineEnd}
           </form>

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -181,33 +181,31 @@ const Details = createReactClass({
     }
 
     const dateProps = CourseDateUtils.dateProps(this.props.course);
-    let timelineStart;
-    let timelineEnd;
-      timelineStart = (
+    const timelineStart = (
+      <DatePicker
+        onChange={this.updateCourseDates}
+        value={this.props.course.timeline_start}
+        value_key="timeline_start"
+        editable={this.props.editable}
+        validation={CourseDateUtils.isDateValid}
+        label={CourseUtils.i18n('assignment_start', this.props.course.string_prefix)}
+        date_props={dateProps.timeline_start}
+        showTime={this.props.course.use_start_and_end_times}
+        required={true}
+      />
+      );
+      const timelineEnd = (
         <DatePicker
           onChange={this.updateCourseDates}
-          value={this.props.course.timeline_start}
-          value_key="timeline_start"
+          value={this.props.course.timeline_end}
+          value_key="timeline_end"
           editable={this.props.editable}
           validation={CourseDateUtils.isDateValid}
-          label={CourseUtils.i18n('assignment_start', this.props.course.string_prefix)}
-          date_props={dateProps.timeline_start}
+          label={CourseUtils.i18n('assignment_end', this.props.course.string_prefix)}
+          date_props={dateProps.timeline_end}
           showTime={this.props.course.use_start_and_end_times}
           required={true}
         />
-      );
-        timelineEnd = (
-          <DatePicker
-            onChange={this.updateCourseDates}
-            value={this.props.course.timeline_end}
-            value_key="timeline_end"
-            editable={this.props.editable}
-            validation={CourseDateUtils.isDateValid}
-            label={CourseUtils.i18n('assignment_end', this.props.course.string_prefix)}
-            date_props={dateProps.timeline_end}
-            showTime={this.props.course.use_start_and_end_times}
-            required={true}
-          />
         );
     const lastIndex = this.props.campaigns.length - 1;
     const campaigns = this.props.campaigns.length > 0 ?

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -181,7 +181,10 @@ const Details = createReactClass({
     }
 
     const dateProps = CourseDateUtils.dateProps(this.props.course);
-    const timelineStart = (
+    let timelineStart;
+    let timelineEnd;
+    if (this.props.course.timeline_start && this.props.course.timeline_end) {
+    timelineStart = (
       <DatePicker
         onChange={this.updateCourseDates}
         value={this.props.course.timeline_start}
@@ -194,7 +197,7 @@ const Details = createReactClass({
         required={true}
       />
       );
-      const timelineEnd = (
+      timelineEnd = (
         <DatePicker
           onChange={this.updateCourseDates}
           value={this.props.course.timeline_end}
@@ -207,6 +210,7 @@ const Details = createReactClass({
           required={true}
         />
         );
+      }
     const lastIndex = this.props.campaigns.length - 1;
     const campaigns = this.props.campaigns.length > 0 ?
       _.map(this.props.campaigns, (campaign, index) => {

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -183,7 +183,6 @@ const Details = createReactClass({
     const dateProps = CourseDateUtils.dateProps(this.props.course);
     let timelineStart;
     let timelineEnd;
-    if (isClassroomProgramType) {
       timelineStart = (
         <DatePicker
           onChange={this.updateCourseDates}
@@ -197,20 +196,19 @@ const Details = createReactClass({
           required={true}
         />
       );
-      timelineEnd = (
-        <DatePicker
-          onChange={this.updateCourseDates}
-          value={this.props.course.timeline_end}
-          value_key="timeline_end"
-          editable={this.props.editable}
-          validation={CourseDateUtils.isDateValid}
-          label={CourseUtils.i18n('assignment_end', this.props.course.string_prefix)}
-          date_props={dateProps.timeline_end}
-          showTime={this.props.course.use_start_and_end_times}
-          required={true}
-        />
-      );
-    }
+        timelineEnd = (
+          <DatePicker
+            onChange={this.updateCourseDates}
+            value={this.props.course.timeline_end}
+            value_key="timeline_end"
+            editable={this.props.editable}
+            validation={CourseDateUtils.isDateValid}
+            label={CourseUtils.i18n('assignment_end', this.props.course.string_prefix)}
+            date_props={dateProps.timeline_end}
+            showTime={this.props.course.use_start_and_end_times}
+            required={true}
+          />
+        );
     const lastIndex = this.props.campaigns.length - 1;
     const campaigns = this.props.campaigns.length > 0 ?
       _.map(this.props.campaigns, (campaign, index) => {
@@ -322,28 +320,6 @@ const Details = createReactClass({
               validation={CourseDateUtils.isDateValid}
               label={I18n.t('courses.end')}
               date_props={dateProps.end}
-              enabled={Boolean(this.props.course.start)}
-              showTime={this.props.course.use_start_and_end_times}
-              required={true}
-            />
-            <DatePicker
-              onChange={this.updateCourseDates}
-              value={this.props.course.timeline_start}
-              value_key="timeline_start"
-              validation={CourseDateUtils.isDateValid}
-              editable={this.props.editable}
-              label={I18n.t('courses.event_start')}
-              showTime={this.props.course.use_start_and_end_times}
-              required={true}
-            />
-            <DatePicker
-              onChange={this.updateCourseDates}
-              value={this.props.course.timeline_end}
-              value_key="timeline_end"
-              editable={this.props.editable}
-              validation={CourseDateUtils.isDateValid}
-              label={I18n.t('courses.event_end')}
-              date_props={dateProps.timeline_end}
               enabled={Boolean(this.props.course.start)}
               showTime={this.props.course.use_start_and_end_times}
               required={true}

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -55,7 +55,11 @@ const Details = createReactClass({
   },
   mixins: [ValidationStore.mixin],
   getInitialState() {
-    return getState();
+    const inits = {
+      showEventDates: this.props.course.showEventDates
+    };
+
+    return { ...inits, ...getState() };
   },
 
   updateDetails(valueKey, value) {
@@ -74,6 +78,10 @@ const Details = createReactClass({
   updateCourseDates(valueKey, value) {
     const updatedCourse = CourseDateUtils.updateCourseDates(this.props.course, valueKey, value);
     return CourseActions.updateCourse(updatedCourse);
+  },
+
+  showEventDates() {
+    return this.setState({ showEventDates: !this.state.showEventDates });
   },
 
   storeDidChange() {
@@ -179,11 +187,27 @@ const Details = createReactClass({
         />
       );
     }
-
+    const eventFormClass = this.state.showEventDates ? '' : 'hidden';
+    const eventClass = `${eventFormClass}`;
     const dateProps = CourseDateUtils.dateProps(this.props.course);
     let timelineStart;
     let timelineEnd;
-    if (this.props.course.showEventDates) {
+    let eventCheckbox;
+    if (this.props.editable) {
+    eventCheckbox = (<div className="form-group">
+      <label htmlFor="course_event">{CourseUtils.i18n('creator.course_event', this.state.course.string_prefix)}</label>
+      <input
+        id="course_event"
+        type="checkbox"
+        value={true}
+        editable = {this.props.editable}
+        onChange={this.showEventDates}
+        checked={!!this.state.showEventDates}
+      />
+    </div>
+    );
+    }
+    if (this.state.showEventDates) {
     timelineStart = (
       <DatePicker
         onChange={this.updateCourseDates}
@@ -326,8 +350,11 @@ const Details = createReactClass({
               showTime={this.props.course.use_start_and_end_times}
               required={true}
             />
-            {timelineStart}
-            {timelineEnd}
+            {eventCheckbox}
+            <span className={eventClass}>
+              {timelineStart}
+              {timelineEnd}
+            </span>
           </form>
           <div>
             <span><strong>{CourseUtils.i18n('campaigns', this.props.course.string_prefix)} </strong>{campaigns}</span>

--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -14,8 +14,7 @@ const initialState = {
   timeline_end: null,
   day_exceptions: '',
   weekdays: '0000000',
-  editingSyllabus: false,
-  showEventDates: false
+  editingSyllabus: false
 };
 
 

--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -10,6 +10,8 @@ const initialState = {
   expected_students: '0',
   start: null,
   end: null,
+  timeline_start: null,
+  timeline_end: null,
   day_exceptions: '',
   weekdays: '0000000',
   editingSyllabus: false

--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -14,8 +14,10 @@ const initialState = {
   timeline_end: null,
   day_exceptions: '',
   weekdays: '0000000',
-  editingSyllabus: false
+  editingSyllabus: false,
+  showEventDates: false
 };
+
 
 export default function course(state = initialState, action) {
   switch (action.type) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,7 +328,8 @@ en:
       create_label: Create New Course
       create_new: Create a New Course
       create_short: Create Course
-      end_date: End date
+      end_date: Statistics end date
+      end_event_date: Event end date
       end_date_placeholder: End date (YYYY-MM-DD)
       expected_number: Expected number of students
       find: Find Your Course
@@ -348,8 +349,9 @@ en:
       role_description: Your role in the course
       role_description_placeholder: Instructor, teaching assistant, etc
       save_cloned_course: Save New Course
-      start_date: Start date
+      start_date: Statistics start date
       start_date_placeholder: Start date (YYYY-MM-DD)
+      start_event_date: Event start date
       subject: Subject
       update_scheduled: >
         Update scheduled. The data will be updated along with all current
@@ -384,10 +386,12 @@ en:
     edit_count: Edit Count
     edit_course_dates: Edit Course Dates
     enable_chat: Enable chat
-    end: End
+    end: Statistics end
     ended: The course has ended.
     enroll: Enroll
     enrollment: Enrollment
+    event_start: Event start
+    event_end: Event end
     courses_enrolled: Courses enrolled
     error:
       exists: That course already exists! Please try again with a different title, school, or term.
@@ -450,7 +454,7 @@ en:
     revisions_none: This course has no recent Wikipedia editing activity.
     school: School
     school_and_term: Institution/Term
-    start: Start
+    start: Statistics start
     start_typing: Start typing
     students: Students
     students_taught: Students Taught

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,10 +328,8 @@ en:
       create_label: Create New Course
       create_new: Create a New Course
       create_short: Create Course
-      end_date: Statistics end date
-      end_event_date: Event end date
+      end_date: End date
       end_date_placeholder: End date (YYYY-MM-DD)
-      end_event_date_placeholder: Event end (YYYY-MM-DD)
       expected_number: Expected number of students
       find: Find Your Course
       intro: >
@@ -350,7 +348,7 @@ en:
       role_description: Your role in the course
       role_description_placeholder: Instructor, teaching assistant, etc
       save_cloned_course: Save New Course
-      start_date: Statistics start date
+      start_date: Start date
       start_date_placeholder: Start date (YYYY-MM-DD)
       start_event_date: Event start date
       start_event_date_placeholder: Event start (YYYY-MM-DD)
@@ -388,7 +386,7 @@ en:
     edit_count: Edit Count
     edit_course_dates: Edit Course Dates
     enable_chat: Enable chat
-    end: Statistics end
+    end: End
     ended: The course has ended.
     enroll: Enroll
     enrollment: Enrollment
@@ -456,7 +454,7 @@ en:
     revisions_none: This course has no recent Wikipedia editing activity.
     school: School
     school_and_term: Institution/Term
-    start: Statistics start
+    start: Start
     start_typing: Start typing
     students: Students
     students_taught: Students Taught
@@ -534,6 +532,10 @@ en:
     campaigns: 'Campaigns: '
     campaign_courses: '%{title} Programs'
     creator:
+      assignment_end: Event end
+      assignment_end_placeholder: Event end (YYYY-MM-DD)
+      assignment_start: Event start
+      assignment_start_placeholder: Event start (YYYY-MM-DD)
       checking_for_uniqueness: This program is being checked for uniqueness.
       choose_clone: Choose a program to clone.
       clone_previous: Clone Previous Program
@@ -557,6 +559,7 @@ en:
       create_label: Create New Program
       create_new: Create an Independent Program
       create_short: Create Program
+      end_date: End of activity tracking
       find: Find a Program
       intro: >
         The program title and institution form the URL of the program. The home wiki
@@ -570,11 +573,13 @@ en:
         that you participated in.
       participate_in_campaign: Participate in a Campaign
       save_cloned_course: Save
+      start_date: Start of activity tracking
     delete_course: Delete program
     edit_course_dates: Edit Project Dates
-    explore: Find Programs
+    end: Activity tracking end
     enroll: Add Editor
     enrollment: Participation
+    explore: Find Programs
     courses_enrolled: Programs participated
     expected_students: Expected Editors
     instructors: Facilitators
@@ -586,6 +591,7 @@ en:
     revisions_none: This project has no recent editing activity.
     school: Institution
     school_and_term: Institution/When
+    start: Activity tracking start
     student_editors: Editors
     students: Editors
     students_taught: Total Editors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,6 +331,7 @@ en:
       end_date: Statistics end date
       end_event_date: Event end date
       end_date_placeholder: End date (YYYY-MM-DD)
+      end_event_date_placeholder: Event end (YYYY-MM-DD)
       expected_number: Expected number of students
       find: Find Your Course
       intro: >
@@ -352,6 +353,7 @@ en:
       start_date: Statistics start date
       start_date_placeholder: Start date (YYYY-MM-DD)
       start_event_date: Event start date
+      start_event_date_placeholder: Event start (YYYY-MM-DD)
       subject: Subject
       update_scheduled: >
         Update scheduled. The data will be updated along with all current

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,8 +350,6 @@ en:
       save_cloned_course: Save New Course
       start_date: Start date
       start_date_placeholder: Start date (YYYY-MM-DD)
-      start_event_date: Event start date
-      start_event_date_placeholder: Event start (YYYY-MM-DD)
       subject: Subject
       update_scheduled: >
         Update scheduled. The data will be updated along with all current
@@ -390,8 +388,6 @@ en:
     ended: The course has ended.
     enroll: Enroll
     enrollment: Enrollment
-    event_start: Event start
-    event_end: Event end
     courses_enrolled: Courses enrolled
     error:
       exists: That course already exists! Please try again with a different title, school, or term.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,9 +524,9 @@ en:
     all_courses: All Programs
     archived: Archived Programs
     articles_none: There are no edited articles for this project yet.
-    assignment_end: Timeline End
+    assignment_end: Event End
     assignments_none: This project has no assigned articles.
-    assignment_start: Timeline Start
+    assignment_start: Event Start
     cancel: Cancel
     course: Program
     courses: Programs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,6 +542,7 @@ en:
       clone_successful_details: >
         Your program has been cloned.
         Click 'Save' below to finalize it.
+      course_event: Do you want to add different event dates?
       course_when: Add something in the 'When' field (for example, the month and year) to differentiate it from the original.
       course_description: Program description
       course_description_placeholder: >

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -462,7 +462,6 @@ es:
     cancel: Cancelar
     course: Programa
     courses: Programas
-
     courses_taught: Programas impartidos
     campaigns: 'Campañas:'
     campaign_courses: Programa de «%{title}»

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -54,6 +54,8 @@ es:
     change: Cambiar
     details: Detalles
     confirm: Aceptar
+    opt_in: Sí
+    opt_out: "No"
   dashboard:
     create_note: Haz clic en Crear curso para crear tu primer curso.
     create_preparation_note: Asegúrate de tener tu calendario académico a mano antes
@@ -300,7 +302,7 @@ es:
       create_label: Crear curso nuevo
       create_new: Crear un curso nuevo
       create_short: Crear curso
-      end_date: Fecha de fin de estadísticas
+      end_date: Fecha de finalización
       end_date_placeholder: Fecha de fin (AAAA-MM-DD)
       expected_number: Número de estudiantes esperado
       find: Encuentra tu curso
@@ -310,7 +312,7 @@ es:
         tu tarea en Wikipedia.
       no_class_holidays: Yo no tengo vacaciones de clases
       save_cloned_course: Guardar curso nuevo
-      start_date: Fecha de inicio de estadísticas
+      start_date: Fecha de inicio
       start_date_placeholder: Fecha de inicio (AAAA-MM-DD)
       subject: Asunto
     current: Cursos actuales
@@ -331,7 +333,7 @@ es:
     edit_count: Recuento de ediciones
     edit_course_dates: Editar las fechas del curso
     enable_chat: Activar el chat
-    end: Fin de estadísticas
+    end: Fin
     ended: El curso ha terminado.
     enroll: Inscribirse
     enrollment: Inscripción
@@ -393,7 +395,7 @@ es:
     revisions_none: Este curso no tiene ediciones recientes en Wikipedia.
     school: Escuela
     school_and_term: Institución/Período
-    start: Inicio de estadísticas
+    start: Inicio
     start_typing: Empieza a escribir
     students: Estudiantes
     students_count: '# Estudiantes'
@@ -456,9 +458,9 @@ es:
     all_courses: Todos los programas
     archived: Programas archivados
     articles_none: No hay artículos editados para este proyecto aún.
-    assignment_end: Fin del evento
+    assignment_end: Final del cronograma
     assignments_none: Este proyecto no tiene artículos asignados.
-    assignment_start: Inicio del evento
+    assignment_start: Inicio del cronograma
     cancel: Cancelar
     course: Programa
     courses: Programas
@@ -474,7 +476,6 @@ es:
       clone_successful_details: Tu programa se ha clonado. Pulsa 'Guardar' más abajo
         para finalizarlo.
       course_description: Descripción del programa
-      course_event: ¿Quieres añadir otras fechas para el evento?
       course_school: Institución
       course_term: Cuándo
       course_term_placeholder: Cuándo
@@ -483,16 +484,12 @@ es:
       create_label: Crear programa nuevo
       create_new: Crear un programa independiente
       create_short: Crear programa
-      end_event_date: Fin del evento
-      end_event_date_placeholder: Fin de evento (AAAA-MM-DD)
       find: Encuentra un programa
       intro: El título del programa es necesario, todo lo demás puede completarse
         más tarde. Haz clic en "¡Crear mi programa!" para empezar a crear la página
         de tu programa wiki.
       participate_in_campaign: Participa en una campaña
       save_cloned_course: Guardar
-      start_event_date: Inicio del evento
-      start_event_date_placeholder: Inicio de evento (AAAA-MM-DD)
     delete_course: Eliminar programa
     edit_course_dates: Editar las fechas del proyecto
     explore: Encuentra programas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -302,8 +302,6 @@ es:
       create_short: Crear curso
       end_date: Fecha de fin de estadísticas
       end_date_placeholder: Fecha de fin (AAAA-MM-DD)
-      end_event_date: Fin del evento
-      end_event_date_placeholder: Fin de evento (AAAA-MM-DD)
       expected_number: Número de estudiantes esperado
       find: Encuentra tu curso
       intro: El título, la escuela y el plazo crean la dirección URL de la página
@@ -314,8 +312,6 @@ es:
       save_cloned_course: Guardar curso nuevo
       start_date: Fecha de inicio de estadísticas
       start_date_placeholder: Fecha de inicio (AAAA-MM-DD)
-      start_event_date: Inicio del evento
-      start_event_date_placeholder: Inicio de evento (AAAA-MM-DD)
       subject: Asunto
     current: Cursos actuales
     data_articles: Datos de artículos
@@ -466,7 +462,7 @@ es:
     cancel: Cancelar
     course: Programa
     courses: Programas
-    course_event: ¿Quieres añadir otras fechas para el evento?
+
     courses_taught: Programas impartidos
     campaigns: 'Campañas:'
     campaign_courses: Programa de «%{title}»
@@ -479,6 +475,7 @@ es:
       clone_successful_details: Tu programa se ha clonado. Pulsa 'Guardar' más abajo
         para finalizarlo.
       course_description: Descripción del programa
+      course_event: ¿Quieres añadir otras fechas para el evento?
       course_school: Institución
       course_term: Cuándo
       course_term_placeholder: Cuándo
@@ -487,12 +484,16 @@ es:
       create_label: Crear programa nuevo
       create_new: Crear un programa independiente
       create_short: Crear programa
+      end_event_date: Fin del evento
+      end_event_date_placeholder: Fin de evento (AAAA-MM-DD)
       find: Encuentra un programa
       intro: El título del programa es necesario, todo lo demás puede completarse
         más tarde. Haz clic en "¡Crear mi programa!" para empezar a crear la página
         de tu programa wiki.
       participate_in_campaign: Participa en una campaña
       save_cloned_course: Guardar
+      start_event_date: Inicio del evento
+      start_event_date_placeholder: Inicio de evento (AAAA-MM-DD)
     delete_course: Eliminar programa
     edit_course_dates: Editar las fechas del proyecto
     explore: Encuentra programas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -300,7 +300,7 @@ es:
       create_label: Crear curso nuevo
       create_new: Crear un curso nuevo
       create_short: Crear curso
-      end_date: Fecha de finalización
+      end_date: Fecha de fin de estadísticas
       end_date_placeholder: Fecha de fin (AAAA-MM-DD)
       expected_number: Número de estudiantes esperado
       find: Encuentra tu curso
@@ -310,7 +310,7 @@ es:
         tu tarea en Wikipedia.
       no_class_holidays: Yo no tengo vacaciones de clases
       save_cloned_course: Guardar curso nuevo
-      start_date: Fecha de inicio
+      start_date: Fecha de inicio de estadísticas
       start_date_placeholder: Fecha de inicio (AAAA-MM-DD)
       subject: Asunto
     current: Cursos actuales
@@ -331,7 +331,7 @@ es:
     edit_count: Recuento de ediciones
     edit_course_dates: Editar las fechas del curso
     enable_chat: Activar el chat
-    end: Fin
+    end: Fin de estadísticas
     ended: El curso ha terminado.
     enroll: Inscribirse
     enrollment: Inscripción
@@ -393,7 +393,7 @@ es:
     revisions_none: Este curso no tiene ediciones recientes en Wikipedia.
     school: Escuela
     school_and_term: Institución/Período
-    start: Inicio
+    start: Inicio de estadísticas
     start_typing: Empieza a escribir
     students: Estudiantes
     students_count: '# Estudiantes'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -302,6 +302,7 @@ es:
       create_short: Crear curso
       end_date: Fecha de fin de estadísticas
       end_date_placeholder: Fecha de fin (AAAA-MM-DD)
+      end_event_date: Fin del evento
       end_event_date_placeholder: Fin de evento (AAAA-MM-DD)
       expected_number: Número de estudiantes esperado
       find: Encuentra tu curso
@@ -313,6 +314,7 @@ es:
       save_cloned_course: Guardar curso nuevo
       start_date: Fecha de inicio de estadísticas
       start_date_placeholder: Fecha de inicio (AAAA-MM-DD)
+      start_event_date: Inicio del evento
       start_event_date_placeholder: Inicio de evento (AAAA-MM-DD)
       subject: Asunto
     current: Cursos actuales
@@ -458,9 +460,9 @@ es:
     all_courses: Todos los programas
     archived: Programas archivados
     articles_none: No hay artículos editados para este proyecto aún.
-    assignment_end: Final del cronograma
+    assignment_end: Fin del evento
     assignments_none: Este proyecto no tiene artículos asignados.
-    assignment_start: Inicio del cronograma
+    assignment_start: Inicio del evento
     cancel: Cancelar
     course: Programa
     courses: Programas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -302,6 +302,7 @@ es:
       create_short: Crear curso
       end_date: Fecha de fin de estadísticas
       end_date_placeholder: Fecha de fin (AAAA-MM-DD)
+      end_event_date_placeholder: Fin de evento (AAAA-MM-DD)
       expected_number: Número de estudiantes esperado
       find: Encuentra tu curso
       intro: El título, la escuela y el plazo crean la dirección URL de la página
@@ -312,6 +313,7 @@ es:
       save_cloned_course: Guardar curso nuevo
       start_date: Fecha de inicio de estadísticas
       start_date_placeholder: Fecha de inicio (AAAA-MM-DD)
+      start_event_date_placeholder: Inicio de evento (AAAA-MM-DD)
       subject: Asunto
     current: Cursos actuales
     data_articles: Datos de artículos

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -466,6 +466,7 @@ es:
     cancel: Cancelar
     course: Programa
     courses: Programas
+    course_event: ¿Quieres añadir otras fechas para el evento?
     courses_taught: Programas impartidos
     campaigns: 'Campañas:'
     campaign_courses: Programa de «%{title}»


### PR DESCRIPTION
- Adds different labelling for events dates and statistics dates
- Adds a checkbox to include different event dates or not
- Adds a datepicker for statistics dates different than event dates
- Adds the possibility to edit the statistics dates in the course overview page
- Enables the user to edit and add the event dates after creating the course
