### PR TITLE
upgrade lodash version

### DIFF
--- a/app/assets/javascripts/components/activity/activity_table.jsx
+++ b/app/assets/javascripts/components/activity/activity_table.jsx
@@ -49,7 +49,7 @@ const ActivityTable = createReactClass({
     e.target.classList.add(nextSortOrder);
 
     const key = e.target.getAttribute('data-sort-key');
-    let activities = _.sortByOrder(this.state.activity, [key]);
+    let activities = _.orderBy(this.state.activity, [key]);
     if (nextSortOrder === 'desc') {
       activities = activities.reverse();
     }

--- a/app/assets/javascripts/components/timeline/grading.jsx
+++ b/app/assets/javascripts/components/timeline/grading.jsx
@@ -16,7 +16,7 @@ const Grading = createReactClass({
   },
 
   render() {
-    const total = _.sum(this.props.gradeables, 'points');
+    const total = _.sumBy(this.props.gradeables, 'points');
     const gradeables = this.props.gradeables.map((gradeable) => {
       const block = BlockStore.getBlock(gradeable.gradeable_item_id);
       return (

--- a/app/assets/javascripts/stores/course_store.js
+++ b/app/assets/javascripts/stores/course_store.js
@@ -51,7 +51,7 @@ const addCourse = () =>
 const _dismissNotification = function (payload) {
   const notifications = _course.survey_notifications;
   const { id } = payload.data;
-  const index = _.indexOf(notifications, _.where(notifications, { id })[0]);
+  const index = _.indexOf(notifications, _.filter(notifications, { id })[0]);
   delete _course.survey_notifications[index];
   return CourseStore.emitChange();
 };

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "json-loader": "^0.5.4",
     "jsx-require-extension": "^0.2.0",
     "location-origin": "^1.1.4",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.4",
     "lodash.map": "^4.6.0",
     "lodash.reject": "^4.6.0",
     "lodash.sorteduniqby": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5878,7 +5878,7 @@ lodash@3.7.x:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^3.1.0, lodash@^3.10.1:
+lodash@^3.1.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 


### PR DESCRIPTION
Fixes #1599 
It upgrades Lodash version to the latest ie. 4.17.4 and replaces the utilities with their updates names.