### PR TITLE
fixes create campaign passcode behaviour 

### DIFF
--- a/app/assets/javascripts/campaigns.js
+++ b/app/assets/javascripts/campaigns.js
@@ -51,9 +51,9 @@ $(() => {
     }
   });
 
-  $('#campaign_default_passcode_custom').on('change', e => {
-    $('.customized_passcode').toggleClass('hidden', !e.target.checked);
-    if (!e.target.checked) {
+  $('.campaign_passcode').on('change', () => {
+    $('.customized_passcode').toggleClass('hidden', !$('#campaign_default_passcode_custom')[0].checked);
+    if (!$('#campaign_default_passcode_custom')[0].checked) {
       $('#campaign_default_passcode').val('');
     }
   });

--- a/app/views/campaigns/_create_modal.html.haml
+++ b/app/views/campaigns/_create_modal.html.haml
@@ -19,16 +19,16 @@
               .form-group
                 - customize_passcode = @campaign.default_passcode
                 %span
-                  = radio_button_tag('campaign[default_passcode]', 'no-passcode', true)
+                  = radio_button_tag('campaign[default_passcode]', 'no-passcode', true,:class => "campaign_passcode")
                   %label
                     = t('campaign.no_passcode')
                 %span
-                  = radio_button_tag('campaign[default_passcode]', '', @campaign.default_passcode)
+                  = radio_button_tag('campaign[default_passcode]', '', @campaign.default_passcode,:class => "campaign_passcode")
                   %label
                     = t('campaign.random_passcode')
 
                 %span
-                  = radio_button_tag('campaign[default_passcode]', 'custom', customize_passcode)
+                  = radio_button_tag('campaign[default_passcode]', 'custom', customize_passcode,:class => "campaign_passcode")
                   %label
                     = t('campaign.customize_passcode')
 


### PR DESCRIPTION
Fixes #1613.
The issue was because the onchange function is not called when other radio buttons were selected.
Solution: Added a common class to all the radio buttons and applied the onchange function to this class and check with the custom radio buttons value.