### PR TITLE
Add automatic insertion of Intertwine training modules upon opt-in

### DIFF
--- a/lib/experiments/spring2018_cmu_experiment.rb
+++ b/lib/experiments/spring2018_cmu_experiment.rb
@@ -40,6 +40,7 @@ class Spring2018CmuExperiment
 
   def opt_in
     update_status 'opted_in'
+    add_trainings_to_default_blocks
   end
 
   def opt_out
@@ -91,5 +92,19 @@ class Spring2018CmuExperiment
                                                   reminder: true)
     update_status('reminder_sent', reminder_just_sent: true)
     sleep 2 unless Rails.env == 'test' # pause to avoid email rate-limiting
+  end
+
+  TRAINING_MAP = {
+    18 => /Get started on Wikipedia/, # get started
+    19 => /Add to an article/, # evaluate and improve an article
+    20 => /Peer review and copy edit/ # peer review
+  }.freeze
+  def add_trainings_to_default_blocks
+    TRAINING_MAP.each do |training_module_id, block_matcher|
+      block = @course.blocks.detect { |b| b.title =~ block_matcher }
+      next if block.nil?
+      block.training_module_ids |= [training_module_id]
+      block.save
+    end
   end
 end

--- a/spec/lib/experiments/spring2018_cmu_experiment_spec.rb
+++ b/spec/lib/experiments/spring2018_cmu_experiment_spec.rb
@@ -46,11 +46,14 @@ describe Spring2018CmuExperiment do
   end
 
   let(:course) { create(:course, flags: { Spring2018CmuExperiment::STATUS_KEY => 'email_sent' }) }
-
+  let(:week) { create(:week, course: course) }
+  let(:block) { create(:block, week: week, title: 'Get started on Wikipedia', training_module_ids: [1, 2]) }
   describe '#opt_in and #opt_out' do
-    it 'updates the experiment status of a course to opted_in' do
+    it 'updates the experiment status of a course to opted_in and adds trainings to timeline' do
+      expect(block.training_module_ids).not_to include(18)
       Spring2018CmuExperiment.new(course).opt_in
       expect(course.flags[Spring2018CmuExperiment::STATUS_KEY]).to eq('opted_in')
+      expect(block.reload.training_module_ids).to include(18)
     end
   end
 


### PR DESCRIPTION
@zhengyaocmu This patch will automate the insertion of training modules whenever someone opts in. It will only work on the default timeline block titles (per the TRAINING_MAP), so your team may still need to check courses to make sure the ones with customized timelines are set up correctly.

If this sounds/looks good to you, I can merge and deploy it.