### PR TITLE
Change admin courses table to anchor tags. Fixes #1577

### DIFF
--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -20,6 +20,17 @@
         &:last-child
           border-right 1px solid #ddd
 
+      // Table cell with links
+      .table-link-cell
+        padding 0px 0px
+        a
+          color #6a6a6a
+          display block
+          margin 0
+          text-decoration none
+          text-align left
+          padding 12px 24px
+
       &:first-child td
         border-top 1px solid #ddd
 

--- a/app/views/dashboard/_admin_course_row.html.haml
+++ b/app/views/dashboard/_admin_course_row.html.haml
@@ -1,27 +1,32 @@
-%tr{:class => "#{user ? date_highlight_class(course) : ''}", "data-link" => "#{course_slug_path(course.slug)}"}
-  %td.title{:role => "button", :tabindex => "0"}
-    = course.title
-    %span.creation-date.hidden
-      = course.created_at
-  %td.revisions
-    = course.recent_revision_count
-  %td
-    %span.characters-human
-      = number_to_human course.word_count
-    %span.characters.hidden
-      = course.word_count
-    %small.average-words-human
-      (#{t("metrics.per_user", number: number_to_human(course.average_word_count))})
-    %span.average-words.hidden
-      = course.average_word_count
-  %td
-    %span.views-human
-      = number_to_human course.view_sum
-    %span.views.hidden
-      = course.view_sum
-  %td
-    %span.students-human
-      = "#{course.user_count}/#{course.expected_students}"
-    %small.untrained= t("users.training_complete_count", count: course.trained_count)
-    %span.students.hidden
-      = course.user_count
+%tr{:class => "#{user ? date_highlight_class(course) : ''}"}
+  %td{:class => "title table-link-cell", :role => "button", :tabindex => "0"}
+    %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+      = course.title
+      %span.creation-date.hidden
+        = course.created_at
+  %td{:class => "revisions table-link-cell"}
+    %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+      = course.recent_revision_count
+  %td{:class => "table-link-cell"}
+    %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+      %span.characters-human
+        = number_to_human course.word_count
+      %span.characters.hidden
+        = course.word_count
+      %small.average-words-human
+        (#{t("metrics.per_user", number: number_to_human(course.average_word_count))})
+      %span.average-words.hidden
+        = course.average_word_count
+  %td{:class => "table-link-cell"}
+    %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+      %span.views-human
+        = number_to_human course.view_sum
+      %span.views.hidden
+        = course.view_sum
+  %td{:class => "table-link-cell"}
+    %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+      %span.students-human
+        = "#{course.user_count}/#{course.expected_students}"
+      %small.untrained= t("users.training_complete_count", count: course.trained_count)
+      %span.students.hidden
+        = course.user_count


### PR DESCRIPTION
Right now, tables are made clickable using jquery and data-link attributes which do not give proper link options.
This removes the data-link attribute and adds an anchor tag with proper styling in all the admin course table cells.