### PR TITLE
add setup scripts. Fixes #1467

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import platform,subprocess
+
+def deb_setup():
+  print ("Your system is found to be debian-based.")
+  subprocess.run("sudo chmod 777 setup/deb-setup.sh && setup/deb-setup.sh",shell=True,check=True)
+
+def win_setup():
+  print ("Your system is found to be Windows")
+
+def osx_setup():
+  print ("Your system is found to be OSX")
+
+if platform.platform().lower().find('ubuntu') != -1 or platform.platform.lower().find('debian') != -1:
+  deb_setup()
+elif platform.platform().lower().find('osx') != -1:
+  osx_setup()
+elif platform.platform().lower().find('windows') != -1:
+  win_setup()
+else:
+  print ("Sorry! Your operating is not supported by this script. Please refer https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/docs/setup.md for manual setup instructions.")

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,15 @@ import platform,subprocess
 
 def deb_setup():
   print ("Your system is found to be debian-based.")
-  subprocess.run("sudo chmod 777 setup/deb-setup.sh && setup/deb-setup.sh",shell=True,check=True)
+  subprocess.run("sudo chmod 775 setup/deb-setup.sh && setup/deb-setup.sh",shell=True,check=True)
 
 def win_setup():
   print ("Your system is found to be Windows")
+  subprocess.run("runas /user:Administrator \"setup\win-setup.bat\"",shell=True,check=True)
 
 def osx_setup():
   print ("Your system is found to be OSX")
+  subprocess.run("sudo chmod 775 setup/deb-setup.sh && setup/deb-setup.sh",shell=True,check=True)
 
 if platform.platform().lower().find('ubuntu') != -1 or platform.platform.lower().find('debian') != -1:
   deb_setup()

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,33 @@
 #!/usr/bin/env python3
-import platform,subprocess
+import platform
+import subprocess
+
 
 def deb_setup():
-  print ("Your system is found to be debian-based.")
-  subprocess.run("sudo chmod 775 setup/deb-setup.sh && setup/deb-setup.sh",shell=True,check=True)
+    print ("Your system is found to be debian-based.")
+    subprocess.run("sudo chmod 775 setup/deb-setup.sh && setup/deb-setup.sh",
+                   shell=True, check=True)
+
 
 def win_setup():
-  print ("Your system is found to be Windows")
-  subprocess.run("runas /user:Administrator \"setup\win-setup.bat\"",shell=True,check=True)
+    print ("Your system is found to be Windows")
+    subprocess.run("runas /user:Administrator \"setup\win-setup.bat\"",
+                   shell=True, check=True)
+
 
 def osx_setup():
-  print ("Your system is found to be OSX")
-  subprocess.run("sudo chmod 775 setup/deb-setup.sh && setup/deb-setup.sh",shell=True,check=True)
+    print ("Your system is found to be OSX")
+    subprocess.run("sudo chmod 775 setup/deb-setup.sh && setup/deb-setup.sh",
+                   shell=True, check=True)
 
-if platform.platform().lower().find('ubuntu') != -1 or platform.platform.lower().find('debian') != -1:
-  deb_setup()
+if platform.platform().lower().find('ubuntu') != -1 \
+        or platform.platform.lower().find('debian') != -1:
+    deb_setup()
 elif platform.platform().lower().find('osx') != -1:
-  osx_setup()
+    osx_setup()
 elif platform.platform().lower().find('windows') != -1:
-  win_setup()
+    win_setup()
 else:
-  print ("Sorry! Your operating is not supported by this script. Please refer https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/docs/setup.md for manual setup instructions.")
+    print ("Sorry! Your operating is not supported by this script. Please refer \
+https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/ \
+docs/setup.md for manual setup instructions.")

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -46,10 +46,8 @@ echo '[*] Installing pandoc...'
 sudo apt-get install pandoc
 
 echo '[*] Creating configuration files...'
-cd config
-cp application.example.yml application.yml
-cp database.example.yml database.yml
-cd ..
+cp config/application.example.yml config/application.yml
+cp config/database.example.yml config/database.yml
 
 echo '[*] Installing Mysql-server...'
 sudo apt-get install mysql-server

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+echo 'Setting up your developmental environment. This may take a while.'
+
+echo '[*] Adding keys...'
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt-get update
+
+echo '[*] Installing GNUpg...'
+sudo apt-get install gnupg
+
+echo '[*] Adding Keys for rvm...'
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && echo '[*] Installing rvm...' && \curl -sSL https://get.rvm.io | bash -s stable
+
+echo '[*] Installing Ruby-2.5.0...'
+sudo rvm install ruby-2.5.0
+
+echo '[*] Install node.js...'
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+echo '[*] Installing bundler...'
+gem install bundler
+
+echo '[*] Installing Gems and dependencies...'
+sudo apt-get install libmysqlclient-dev libpq-dev libqtwebkit-dev
+bundle install
+
+echo '[*] Installing yarn...'
+sudo apt-get install yarn
+
+echo '[*] Installing node_modules...'
+yarn
+
+echo '[*] Installing phantomjs-prebuilt...'
+sudo yarn global add phantomjs-prebuilt
+
+echo '[*] Installing bower...'
+sudo yarn global add bower
+
+echo '[*] Installing bower modules...'
+bower install
+
+echo '[*] Installing pandoc...'
+sudo apt-get install pandoc
+
+echo '[*] Creating configuration files...'
+cd config
+cp application.example.yml application.yml
+cp database.example.yml database.yml
+cd ..
+
+echo '[*] Installing Mysql-server...'
+sudo apt-get install mysql-server
+
+echo '[*] Creating databases...'
+echo 'Enter password for Mysql root user'
+echo 'CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      exit' | sudo mysql -p
+
+echo '[*] Installing redis-server...'
+sudo apt install redis-server
+
+echo '[*] Installing gulp...'
+sudo yarn global add gulp
+
+echo '[*] Installing R...'
+sudo apt install r-base
+
+echo '[*] Migrating databases...'
+rake db:migrate
+rake db:migrate RAILS_ENV=test

--- a/setup/osx-setup.sh
+++ b/setup/osx-setup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+echo 'Setting up your developmental environment. This may take a while.'
+
+echo '[*] Installing GNUpg...'
+brew install gnupg
+
+echo '[*] Adding Keys for rvm...'
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+
+echo '[*] Installing rvm...'
+\curl -sSL https://get.rvm.io | bash -s stable
+
+echo '[*] Installing Ruby-2.5.0...'
+sudo rvm install ruby-2.5.0
+
+echo '[*] Install node.js...'
+brew install node
+
+echo '[*] Installing bundler...'
+gem install bundler
+
+echo '[*] Installing Gems and dependencies...'
+bundle install
+
+echo '[*] Installing yarn...'
+brew install yarn
+
+echo '[*] Installing node_modules...'
+yarn
+
+echo '[*] Installing phantomjs-prebuilt...'
+sudo yarn global add phantomjs-prebuilt
+
+echo '[*] Installing bower...'
+sudo yarn global add bower
+
+echo '[*] Installing bower modules...'
+bower install
+
+echo '[*] Installing pandoc...'
+brew install pandoc
+
+echo '[*] Creating configuration files...'
+cd config
+cp application.example.yml application.yml
+cp database.example.yml database.yml
+cd ..
+
+echo '[*] Installing Mysql-server...'
+brew install mysql
+mysql.server start
+
+echo '[*] Creating databases...'
+echo 'Enter password for Mysql root user'
+echo 'CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      exit' | sudo mysql -p
+
+echo '[*] Installing redis-server...'
+brew install redis
+
+echo '[*] Installing gulp...'
+sudo yarn global add gulp
+
+echo '[*] Installing R...'
+brew tap homebrew/science && brew install r
+
+echo '[*] Migrating databases...'
+rake db:migrate
+rake db:migrate RAILS_ENV=test

--- a/setup/osx-setup.sh
+++ b/setup/osx-setup.sh
@@ -42,10 +42,8 @@ echo '[*] Installing pandoc...'
 brew install pandoc
 
 echo '[*] Creating configuration files...'
-cd config
-cp application.example.yml application.yml
-cp database.example.yml database.yml
-cd ..
+cp config/application.example.yml config/application.yml
+cp config/database.example.yml config/database.yml
 
 echo '[*] Installing Mysql-server...'
 brew install mysql

--- a/setup/win-setup.bat
+++ b/setup/win-setup.bat
@@ -1,0 +1,57 @@
+echo OFF
+echo Setting up your developmental environment. This may take a while.
+
+echo [*] Installing chocolatey...
+@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+echo [*] Installing ruby...
+choco install ruby2.devkit -y
+
+echo [*] Installing Node.js...
+choco install nodejs-lts -y
+
+echo [*] Installing Gems...
+call gem install bundler
+call bundle install
+
+echo [*] Installing Yarn...
+choco install yarn -y
+
+echo [*] Installing node modules...
+call yarn
+
+echo [*] Installing PhantomJs...
+call yarn global add phantomjs-prebuilt
+
+echo [*] Installing Bower...
+call yarn global add Bower
+
+echo [*] Installing Bower modules...
+call bower install
+
+echo [*] Installing Pandoc...
+choco install pandoc -y
+
+echo [*] Creating configuration files...
+copy config\application.example.yml config\application.yml
+copy config\database.example.yml config\database.yml
+
+echo [*] Installing XAMPP...
+choco install bitnami-xampp -y
+start C:\xampp\mysql\bin\mysqld
+
+echo [*] Setting up database...
+echo CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;exit| C:\xampp\mysql\bin\mysql -u root
+
+echo [*] Installing Redis...
+msiexec /i https://github.com/MicrosoftArchive/redis/releases/download/win-3.0.504/Redis-x64-3.0.504.msi
+
+echo [*] Installing Gulp...
+yarn global add gulp
+
+echo [*] Installing R...
+choco install r.project -y
+
+echo [*] Migrating databases...
+rake db:migrate
+rake db:migrate RAILS_ENV=test


### PR DESCRIPTION
Fixes #1467. This adds the setup scripts for the repo. The main setup.py looks for the operating system of the user and executes the corresponding script. Right now, the script supports Debian based systems, OSX and Windows systems.