### PR TITLE
added i18n support for (history) and (article development) links in Articles tab. #1549

### DIFF
--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -45,7 +45,7 @@ const Article = createReactClass({
             <a href={this.props.article.url} target="_blank" className="inline">{formattedTitle} {(this.props.article.new_article ? ` ${I18n.t('articles.new')}` : '')}</a>
             <br />
             <small>
-              <a href={historyUrl} target="_blank" className="inline">(history)</a> | <ArticleGraphs article={this.props.article} />
+              <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a> | <ArticleGraphs article={this.props.article} />
             </small>
           </div>
         </td>

--- a/app/assets/javascripts/components/articles/article_graphs.jsx
+++ b/app/assets/javascripts/components/articles/article_graphs.jsx
@@ -145,7 +145,7 @@ const ArticleGraphs = createReactClass({
 
     return (
       <a onClick={this.showGraph} className="inline">
-        (article development)
+        {I18n.t('articles.article_development')}
         <div className={className}>
           <div className="radio-row">
             {radioInput}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
     label: Activity
 
   articles:
+    article_development: Article Development
     assigned: Assigned Articles
     available: Available Articles
     assigned_to: Assigned To
@@ -133,6 +134,7 @@ en:
     edited_by: 'Edited by:'
     edited_mobile: Articles
     hide: Hide
+    history: History
     label: Articles
     loading: Loading articles...
     new: (new)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
     label: Activity
 
   articles:
-    article_development: Article Development
+    article_development: (article development)
     assigned: Assigned Articles
     available: Available Articles
     assigned_to: Assigned To
@@ -134,7 +134,7 @@ en:
     edited_by: 'Edited by:'
     edited_mobile: Articles
     hide: Hide
-    history: History
+    history: (history)
     label: Articles
     loading: Loading articles...
     new: (new)

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -120,6 +120,7 @@ qqq:
       Short name for activities
       {{Identical|Activity}}
   articles:
+    article_development: Label for article deelopment link
     assigned: Label for a list of assigned articles
     available: Label for a list of articles not assigned to anyone
     assigned_to: Table header for the user who is assigned to work on an article
@@ -128,6 +129,7 @@ qqq:
     edited_by: Label for a list of users who edited an article
     edited_mobile: '{{Identical|Article}}'
     hide: '{{Identical|Hide}}'
+    history: Label for the history url
     label: |-
       Short name for articles
       {{Identical|Article}}

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -120,7 +120,7 @@ qqq:
       Short name for activities
       {{Identical|Activity}}
   articles:
-    article_development: Label for article deelopment link
+    article_development: Label for article development link
     assigned: Label for a list of assigned articles
     available: Label for a list of articles not assigned to anyone
     assigned_to: Table header for the user who is assigned to work on an article


### PR DESCRIPTION
These strings in article.jsx and article_graphs.jsx were hardcoded to English. Now, they are using I18n support.