### PR TITLE
enable Rubocop Rails Filepath rule, found no violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,9 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*' # not a big deal in spec helper module
 
+Rails/FilePath:
+  Enabled: true
+
 ########################
 # Permanent exceptions #
 ########################
@@ -80,8 +83,6 @@ Rails/Blank:
 Metrics/LineLength:
   Enabled: false
 Style/FormatStringToken:
-  Enabled: false
-Rails/FilePath:
   Enabled: false
 Style/DateTime:
   Enabled: false


### PR DESCRIPTION
Enables Rubocop Rails/Filepath rule. No violations were found.