### PR TITLE
Remove zeus from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,6 @@ group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'
   gem 'rubocop', require: false
-  gem 'zeus', platforms: :ruby # zeus doesn't work on Windows
   gem 'timecop' # Test utility for setting the time
   gem 'poltergeist' # Capypara feature specs driven by PhantomJS
   gem 'factory_bot_rails' # Factory for creating ActiveRecord objects in tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,8 +468,6 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.0.0)
       nokogiri (~> 1.8)
-    zeus (0.15.14)
-      method_source (>= 0.6.7)
 
 PLATFORMS
   ruby
@@ -549,7 +547,6 @@ DEPENDENCIES
   vcr
   webmock
   whenever
-  zeus
 
 RUBY VERSION
    ruby 2.5.0p0


### PR DESCRIPTION
Zeus was used to boot the app faster but is not supported with ruby-2.5.0 and was not a necessary tool for development.