### PR TITLE
#1655 Account creation cleanup

### DIFF
--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -30,7 +30,7 @@ const NewAccountButton = React.createClass({
     if (!course.flags || !course.flags.register_accounts) {
       return (
         <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
-          <i className="icon icon-wiki-logo" />{I18n.t('application.create_account')}
+          <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
         </a>
       );
     }
@@ -42,7 +42,7 @@ const NewAccountButton = React.createClass({
     } else {
       buttonOrModal = (
         <button onClick={this.openModal} className="button auth signup border margin">
-          <i className="icon icon-wiki-logo" /> {I18n.t('application.create_account')}
+          <i className="icon icon-wiki-logo" /> {currentUser.role === INSTRUCTOR_ROLE ? I18n.t('application.create_accounts') : I18n.t('application.request_account')}
         </button>
       );
     }

--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -42,7 +42,7 @@ const NewAccountButton = React.createClass({
       buttonOrModal = <NewAccountModal course={course} passcode={this.props.passcode} closeModal={this.closeModal} currentUser={this.props.currentUser} />;
     } else {
       buttonOrModal = (
-        <button onClick={this.openModal} key="request_account" className="button auth signup border margin">
+        <button onClick={this.openModal} key="request_account" className="button auth signup border margin request_accounts">
           <i className="icon icon-wiki-logo" /> {currentUser.role === INSTRUCTOR_ROLE ? I18n.t('application.create_accounts') : I18n.t('application.request_account')}
         </button>
       );

--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -30,7 +30,7 @@ const NewAccountButton = React.createClass({
     if (!course.flags || !course.flags.register_accounts) {
       return (
         <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
-          <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
+          <i className="icon icon-wiki-logo" />{I18n.t('application.create_account')}
         </a>
       );
     }
@@ -42,7 +42,7 @@ const NewAccountButton = React.createClass({
     } else {
       buttonOrModal = (
         <button onClick={this.openModal} className="button auth signup border margin">
-          <i className="icon icon-wiki-logo" /> {I18n.t('application.sign_up_extended')}
+          <i className="icon icon-wiki-logo" /> {I18n.t('application.create_account')}
         </button>
       );
     }

--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -29,7 +29,7 @@ const NewAccountButton = React.createClass({
     // endpoint for the user to register an account on their own.
     if (!course.flags || !course.flags.register_accounts) {
       return (
-        <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border">
+        <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
           <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
         </a>
       );
@@ -41,7 +41,7 @@ const NewAccountButton = React.createClass({
       buttonOrModal = <NewAccountModal course={course} passcode={this.props.passcode} closeModal={this.closeModal} currentUser={this.props.currentUser} />;
     } else {
       buttonOrModal = (
-        <button onClick={this.openModal} className="button auth signup border">
+        <button onClick={this.openModal} className="button auth signup border margin">
           <i className="icon icon-wiki-logo" /> {I18n.t('application.sign_up_extended')}
         </button>
       );

--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import NewAccountModal from './new_account_modal.jsx';
+import { INSTRUCTOR_ROLE } from '../../constants';
 
 const NewAccountButton = React.createClass({
   displayName: 'NewAccountButton',
@@ -41,7 +42,7 @@ const NewAccountButton = React.createClass({
       buttonOrModal = <NewAccountModal course={course} passcode={this.props.passcode} closeModal={this.closeModal} currentUser={this.props.currentUser} />;
     } else {
       buttonOrModal = (
-        <button onClick={this.openModal} className="button auth signup border margin">
+        <button onClick={this.openModal} key="request_account" className="button auth signup border margin">
           <i className="icon icon-wiki-logo" /> {currentUser.role === INSTRUCTOR_ROLE ? I18n.t('application.create_accounts') : I18n.t('application.request_account')}
         </button>
       );

--- a/app/assets/javascripts/components/enroll/new_account_modal.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_modal.jsx
@@ -36,17 +36,17 @@ const NewAccountModal = ({ course, passcode, currentUser, closeModal, newAccount
   }
 
   let newAccountInfo;
+  let wikipediaAccountCreation;
   if (currentUser.role === INSTRUCTOR_ROLE) {
     newAccountInfo = <div><p>{I18n.t('courses.new_account_info_admin')}</p></div>;
   } else {
     newAccountInfo = <div><p>{I18n.t('courses.new_account_info')}</p></div>;
+    wikipediaAccountCreation = (
+      <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
+        <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
+      </a>
+    );
   }
-
-  const wikipediaAccountCreation = (
-    <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
-      <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
-    </a>
-  );
 
   return (
     <div className="basic-modal left">

--- a/app/assets/javascripts/components/enroll/new_account_modal.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_modal.jsx
@@ -42,6 +42,12 @@ const NewAccountModal = ({ course, passcode, currentUser, closeModal, newAccount
     newAccountInfo = <div><p>{I18n.t('courses.new_account_info')}</p></div>;
   }
 
+  const wikipediaAccountCreation = (
+    <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
+      <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
+    </a>
+  );
+
   return (
     <div className="basic-modal left">
       <button onClick={closeModal} className="pull-right article-viewer-button icon-close" />
@@ -73,6 +79,7 @@ const NewAccountModal = ({ course, passcode, currentUser, closeModal, newAccount
           {checkingSpinner}
         </div>
         <div className="right pull-right">
+          {wikipediaAccountCreation}
           {checkAvailabilityButton}
           {requestAccountButton}
         </div>

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -13,6 +13,7 @@ import SalesforceLink from './salesforce_link.jsx';
 import GreetStudentsButton from './greet_students_button.jsx';
 import CourseStatsDownloadModal from './course_stats_download_modal.jsx';
 import { enableAccountRequests } from '../../actions/new_account_actions.js';
+import CourseActions from '../../actions/course_actions.js';
 
 const getState = () => ({ course: CourseStore.getCourse() });
 
@@ -100,7 +101,8 @@ const AvailableActions = createReactClass({
     const course = this.state.course;
     const onConfirm = function () {
       enableRequests(course);
-      return alert(I18n.t('courses.accounts_generation_enabled'));
+      alert(I18n.t('courses.accounts_generation_enabled'));
+      return CourseActions.updateCourse(course);
     };
     const confirmMessage = 'Are you sure you want to enable the account requests?';
     this.props.initiateConfirm(confirmMessage, onConfirm);

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -64,10 +64,13 @@ const AvailableActions = createReactClass({
   },
 
   leave() {
-    if (confirm(I18n.t('courses.leave_confirmation'))) {
-      const userObject = { user_id: this.props.current_user.id, role: 0 };
-      return ServerActions.remove('user', this.state.course.slug, { user: userObject });
-    }
+    const course = this.state.course.slug;
+    const currentUserId = this.props.current_user.id;
+    const onConfirm = function () {
+      return ServerActions.remove('user', course, { user: { user_id: currentUserId, role: 0 } });
+    };
+    const confirmMessage = I18n.t('courses.leave_confirmation');
+    this.props.initiateConfirm(confirmMessage, onConfirm);
   },
 
   delete() {
@@ -84,16 +87,23 @@ const AvailableActions = createReactClass({
   },
 
   enableChat() {
-    if (confirm('Are you sure you want to enable chat?')) {
-      return ChatActions.enableForCourse(this.state.course.id);
-    }
+    const course = this.state.course.id;
+    const onConfirm = function () {
+      return ChatActions.enableForCourse(course);
+    };
+    const confirmMessage = 'Are you sure you want to enable chat?';
+    this.props.initiateConfirm(confirmMessage, onConfirm);
   },
 
   enableRequests() {
-    if (confirm('Are you sure you want to enable the account requests?')) {
-      this.props.enableAccountRequests(this.state.course);
+    const enableRequests = this.props.enableAccountRequests;
+    const course = this.state.course;
+    const onConfirm = function () {
+      enableRequests(course);
       return alert(I18n.t('courses.accounts_generation_enabled'));
-    }
+    };
+    const confirmMessage = 'Are you sure you want to enable the account requests?';
+    this.props.initiateConfirm(confirmMessage, onConfirm);
   },
 
   render() {

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -9,6 +9,7 @@ import CourseStore from '../../stores/course_store.js';
 import CourseUtils from '../../utils/course_utils.js';
 import CourseDateUtils from '../../utils/course_date_utils.js';
 import { initiateConfirm } from '../../actions/confirm_actions.js';
+import { addNotification } from '../../actions/notification_actions.js';
 import SalesforceLink from './salesforce_link.jsx';
 import GreetStudentsButton from './greet_students_button.jsx';
 import CourseStatsDownloadModal from './course_stats_download_modal.jsx';
@@ -98,13 +99,18 @@ const AvailableActions = createReactClass({
 
   enableRequests() {
     const enableRequests = this.props.enableAccountRequests;
+    const notify = this.props.addNotification;
     const course = this.state.course;
     const onConfirm = function () {
       enableRequests(course);
-      alert(I18n.t('courses.accounts_generation_enabled'));
-      return CourseActions.updateCourse(course);
+      CourseActions.updateCourse(course);
+      notify({
+        message: I18n.t('courses.accounts_generation_enabled'),
+        closable: true,
+        type: 'success'
+      });
     };
-    const confirmMessage = 'Are you sure you want to enable the account requests?';
+    const confirmMessage = I18n.t('courses.accounts_generation_confirm_message');
     this.props.initiateConfirm(confirmMessage, onConfirm);
   },
 
@@ -205,6 +211,6 @@ const AvailableActions = createReactClass({
 }
 );
 
-const mapDispatchToProps = { initiateConfirm, enableAccountRequests };
+const mapDispatchToProps = { initiateConfirm, addNotification, enableAccountRequests };
 
 export default connect(null, mapDispatchToProps)(AvailableActions);

--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -116,7 +116,7 @@ const StudentList = createReactClass({
 
     let requestAccountsButton;
     if (this.props.course.flags.register_accounts === true && this.props.course.published) {
-      requestAccountsButton = <NewAccountButton key="request_account" course={this.props.course} passcode={this.props.course.passcode} currentUser={this.props.current_user} />;
+      requestAccountsButton = <NewAccountButton course={this.props.course} passcode={this.props.course.passcode} currentUser={this.props.current_user} />;
     }
 
     let notifyOverdue;

--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -12,7 +12,7 @@ import List from '../common/list.jsx';
 import Student from './student.jsx';
 import StudentDrawer from './student_drawer.jsx';
 import EnrollButton from './enroll_button.jsx';
-import NewAccountModal from '../enroll/new_account_modal.jsx';
+import NewAccountButton from '../enroll/new_account_button.jsx';
 
 import AssignmentStore from '../../stores/assignment_store.js';
 import ServerActions from '../../actions/server_actions.js';
@@ -114,17 +114,9 @@ const StudentList = createReactClass({
       addStudent = <EnrollButton {...this.props} users={this.props.students} role={0} key="add_student" allowed={false} />;
     }
 
-    let requestAccountsModal;
+    let requestAccountsButton;
     if (this.props.course.flags.register_accounts === true && this.props.course.published) {
-      if (this.state.showModal) {
-        requestAccountsModal = <NewAccountModal course={this.props.course} key="request_account" currentUser={this.props.current_user} passcode={this.props.course.passcode} closeModal={this.closeModal} />;
-      } else {
-        requestAccountsModal = (
-          <button onClick={this.openModal} key="request_account_closed" className="request_accounts button auth signup border margin">
-            <i className="icon icon-wiki-logo" /> {I18n.t('application.create_accounts')}
-          </button>
-        );
-      }
+      requestAccountsButton = <NewAccountButton key="request_account" course={this.props.course} passcode={this.props.course.passcode} currentUser={this.props.current_user} />;
     }
 
     let notifyOverdue;
@@ -162,7 +154,7 @@ const StudentList = createReactClass({
     };
     return (
       <div className="list__wrapper">
-        {this.props.controls([addStudent, requestAccountsModal, notifyOverdue], this.props.students.length < 1)}
+        {this.props.controls([addStudent, requestAccountsButton, notifyOverdue], this.props.students.length < 1)}
         <List
           elements={elements}
           className="table--expandable table--hoverable"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,6 @@ en:
 
   application:
     cancel: Cancel
-    create_account: Create an account
     create_accounts: Create Wikipedia accounts
     dashboard: Wiki Ed Dashboard
     documentation: Documentation
@@ -58,6 +57,7 @@ en:
     my_dashboard: My Dashboard
     recent_activity: Recent Activity
     report_problem: Report a problem
+    request_account: Request an account
     search: ask a question
     search_results: "Results for: '%{search_terms}'"
     sign_up_extended: Sign up with Wikipedia

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
 
   application:
     cancel: Cancel
+    create_account: Create an account
     create_accounts: Create Wikipedia accounts
     dashboard: Wiki Ed Dashboard
     documentation: Documentation
@@ -60,6 +61,7 @@ en:
     search: ask a question
     search_results: "Results for: '%{search_terms}'"
     sign_up_extended: Sign up with Wikipedia
+
     # FIXME: deprecate lego message
     sign_up_log_in_extended: with Wikipedia
     sign_up: Sign up

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,7 @@ en:
 
   courses:
     accounts_generation_enabled: Accounts request generation enabled
+    accounts_generation_confirm_message: Are you sure you want to enable the account requests?
     activity: Activity
     active_courses: Active %{course_type}
     all_courses: All Courses

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Student users', type: :feature, js: true do
+describe 'Student users', type: :feature, js: true, focus: true do
   before do
     include type: :feature
     include Devise::TestHelpers
@@ -105,8 +105,9 @@ describe 'Student users', type: :feature, js: true do
 
       expect(page).to have_content 'An Example Course'
 
-      accept_confirm do
-        click_button 'Leave course'
+      click_button 'Leave course'
+      within('.confirm-modal') do
+        click_button 'OK'
       end
 
       sleep 3

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Student users', type: :feature, js: true, focus: true do
+describe 'Student users', type: :feature, js: true do
   before do
     include type: :feature
     include Devise::TestHelpers


### PR DESCRIPTION
- Substitutes confirm with initiateConfirm
- Includes new account button instead of new account modal in the student list
- Adds a button that enables the user to create the account directly on wikipedia in the modal
- Adds new label naming for the new account button -- that i think makes more sense for the usability