### PR TITLE
Adds a link instead of a button to register at Wikipedia

### DIFF
--- a/app/assets/javascripts/components/enroll/new_account_modal.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_modal.jsx
@@ -42,8 +42,8 @@ const NewAccountModal = ({ course, passcode, currentUser, closeModal, newAccount
   } else {
     newAccountInfo = <div><p>{I18n.t('courses.new_account_info')}</p></div>;
     wikipediaAccountCreation = (
-      <a href={`/users/auth/mediawiki_signup?origin=${window.location}`} className="button auth signup border margin">
-        <i className="icon icon-wiki-logo" />{I18n.t('application.sign_up_extended')}
+      <a href={`/users/auth/mediawiki_signup?origin=${window.location}`}>
+        {I18n.t('application.sign_up_wikipedia')}
       </a>
     );
   }
@@ -77,9 +77,9 @@ const NewAccountModal = ({ course, passcode, currentUser, closeModal, newAccount
         <div className = "left">
           <p className="red" dangerouslySetInnerHTML={{ __html: newAccount.error }} />
           {checkingSpinner}
+          {wikipediaAccountCreation}
         </div>
         <div className="right pull-right">
-          {wikipediaAccountCreation}
           {checkAvailabilityButton}
           {requestAccountButton}
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
     search: ask a question
     search_results: "Results for: '%{search_terms}'"
     sign_up_extended: Sign up with Wikipedia
-    sign_up_wikipedia: Or sign up at Wikipedia
+    sign_up_wikipedia: Or sign up on Wikipedia
 
     # FIXME: deprecate lego message
     sign_up_log_in_extended: with Wikipedia

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
     search: ask a question
     search_results: "Results for: '%{search_terms}'"
     sign_up_extended: Sign up with Wikipedia
+    sign_up_wikipedia: Or sign up at Wikipedia
 
     # FIXME: deprecate lego message
     sign_up_log_in_extended: with Wikipedia


### PR DESCRIPTION
We want to give some hierarchy to the new account modal, as we would prefer that users register through our new request account implementation (if available). Therefore we decided to offer the registration at wikipedia just as a button.
This PR includes:
- Implementation of a link that drives the user to the wikipedia account formular
- new locale for translations