### PR TITLE
fixes links to programs from campaigns editors view

### DIFF
--- a/app/views/campaigns/users.html.haml
+++ b/app/views/campaigns/users.html.haml
@@ -27,4 +27,4 @@
               = cu.revision_count
             %td
               %small
-                = link_to cu.course.title, course_path(cu.course)
+                = link_to cu.course.title, course_slug_path(cu.course.slug)


### PR DESCRIPTION
Fixes #1676.This fixes the broken links in the campaign editors view by using slug to generate the urls.