### PR TITLE
fix username links on did-you-know and possible-plagiarism tabs

### DIFF
--- a/app/views/revision_analytics/dyk_eligible.json.jbuilder
+++ b/app/views/revision_analytics/dyk_eligible.json.jbuilder
@@ -5,6 +5,7 @@ json.articles do
     revision = article.revisions.last
     json.key revision.id
     json.title article.full_title
+    json.base_url revision.wiki.base_url
     json.article_url article.url
     json.diff_url revision.url
     json.revision_score revision.wp10

--- a/app/views/revision_analytics/suspected_plagiarism.json.jbuilder
+++ b/app/views/revision_analytics/suspected_plagiarism.json.jbuilder
@@ -6,6 +6,7 @@ json.revisions do
     json.call(revision, :wiki, :mw_rev_id, :mw_page_id)
     json.key revision.id
     json.title article.full_title
+    json.base_url revision.wiki.base_url
     json.article_url article.url
     json.report_url revision.plagiarism_report_link
     json.diff_url revision.url


### PR DESCRIPTION
Fixes #1668 adds base_url field which is used to generate the URL for the username links which was present in recent edits but was missing from suspected plagiarism and did you know json builders.