### PR TITLE
fix console warning for use of key in react iterable components

### DIFF
--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -116,7 +116,7 @@ const StudentList = createReactClass({
 
     let requestAccountsButton;
     if (this.props.course.flags.register_accounts === true && this.props.course.published) {
-      requestAccountsButton = <NewAccountButton course={this.props.course} passcode={this.props.course.passcode} currentUser={this.props.current_user} />;
+      requestAccountsButton = <NewAccountButton course={this.props.course} passcode={this.props.course.passcode} currentUser={this.props.current_user} key="request" />;
     }
 
     let notifyOverdue;


### PR DESCRIPTION
Remove console warning for iterable components from NewAccountButton in StudentList by adding a fixed key "request" to the NewAccountButton component.