### PR TITLE
Fix create class warning and PropTypes warning

### DIFF
--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import NewAccountModal from './new_account_modal.jsx';
 import { INSTRUCTOR_ROLE } from '../../constants';
 
@@ -7,8 +8,8 @@ const NewAccountButton = createReactClass({
   displayName: 'NewAccountButton',
 
   propTypes: {
-    course: React.PropTypes.object.isRequired,
-    passcode: React.PropTypes.string
+    course: PropTypes.object.isRequired,
+    passcode: PropTypes.string
   },
 
   getInitialState() {

--- a/app/assets/javascripts/components/enroll/new_account_button.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_button.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import NewAccountModal from './new_account_modal.jsx';
 import { INSTRUCTOR_ROLE } from '../../constants';
 
-const NewAccountButton = React.createClass({
+const NewAccountButton = createReactClass({
   displayName: 'NewAccountButton',
 
   propTypes: {

--- a/app/assets/javascripts/components/enroll/new_account_modal.jsx
+++ b/app/assets/javascripts/components/enroll/new_account_modal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import { INSTRUCTOR_ROLE } from '../../constants';
 
 import * as NewAccountActions from '../../actions/new_account_actions.js';
@@ -89,11 +90,11 @@ const NewAccountModal = ({ course, passcode, currentUser, closeModal, newAccount
 };
 
 NewAccountModal.propTypes = {
-  course: React.PropTypes.object,
-  passcode: React.PropTypes.string,
-  newAccount: React.PropTypes.object,
-  closeModal: React.PropTypes.func,
-  actions: React.PropTypes.object
+  course: PropTypes.object,
+  passcode: PropTypes.string,
+  newAccount: PropTypes.object,
+  closeModal: PropTypes.func,
+  actions: PropTypes.object
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Replace the use of prop types and createClass through react package with their corresponding packages to remove console warnings.