### PR TITLE
Update: homebrew/science now part of R core

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -83,7 +83,7 @@ If you know your way around Rails, here's the very short version. Some additiona
 
 - Install R:
   - Debian: `sudo apt install r-base`
-  - OS X: `brew tap homebrew/science && brew install r`
+  - OS X: `brew install r`
   - Also you can refer to this [install R](https://cran.r-project.org/)
 ## Initialize
 1. **Migrate the development and test databases**


### PR DESCRIPTION
The MacOS setup currently references to the deprecated homebrew/science but, since [this is now contained in the R core](https://stackoverflow.com/questions/20457290/installing-r-with-homebrew), I recommend just installing the core.