### PR TITLE
remove deprecated homebrew/science, now part of core from MacOS setup

### DIFF
--- a/setup/osx-setup.sh
+++ b/setup/osx-setup.sh
@@ -62,7 +62,7 @@ echo '[*] Installing gulp...'
 sudo yarn global add gulp
 
 echo '[*] Installing R...'
-brew tap homebrew/science && brew install r
+brew install r
 
 echo '[*] Migrating databases...'
 rake db:migrate


### PR DESCRIPTION
The MacOS setup currently references to the deprecated homebrew/science but, since [this is now contained in the R core](https://stackoverflow.com/questions/20457290/installing-r-with-homebrew), I recommend just installing the core.