### PR TITLE
add post methods for replica service to get articles by titles

### DIFF
--- a/lib/article_status_manager.rb
+++ b/lib/article_status_manager.rb
@@ -124,18 +124,6 @@ class ArticleStatusManager
     true
   end
 
-  # This is limited by the URI length of the combined titles. For most languages,
-  # 100 titles per query is no problem, but languages with unicode titles hit the
-  # URI length limit.
-  # TODO: move the chunking to Replica and set the size dynamically depending on the
-  # length of the URI.
-  LONG_URI_LANGUAGES = %w[he ar ml mk].freeze
-  HIGH_REPLICA_LIMIT = 80
-  LOW_REPLICA_LIMIT = 20
-  def articles_per_replica_query
-    LONG_URI_LANGUAGES.include?(@wiki.language) ? LOW_REPLICA_LIMIT : HIGH_REPLICA_LIMIT
-  end
-
   # Check whether any deleted pages still exist with a different article_id.
   # If so, update the Article to use the new id.
   def update_article_ids(deleted_page_ids)

--- a/lib/article_status_manager.rb
+++ b/lib/article_status_manager.rb
@@ -146,7 +146,7 @@ class ArticleStatusManager
     @failed_request_count += 1 if request_results.nil?
 
     # Update articles whose IDs have changed (keyed on title and namespace)
-    request_results.each do |stp|
+    request_results&.each do |stp|
       resolve_page_id(stp, deleted_page_ids)
     end
   end

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -52,11 +52,6 @@ class Replica
 
   # Given a list of articles *or* hashes of the form { 'title' => 'Something' },
   # see which ones have not been deleted.
-  def get_existing_articles_by_title(articles)
-    article_list = compile_article_titles_query(articles)
-    api_get('articles.php', article_list)
-  end
-
   def post_existing_articles_by_title(articles)
     article_list = articles.map { |article| article["title"] }
     api_post('articles.php', 'post_article_titles[]', article_list)

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -58,7 +58,8 @@ class Replica
   end
 
   def post_existing_articles_by_title(articles)
-    api_post('articles.php', 'post_article_titles', articles)
+    article_list = articles.map { |article| article["title"] }
+    api_post('articles.php', 'post_article_titles', article_list)
   end
 
   # Given a list of revisions, see which ones have not been deleted

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -59,7 +59,7 @@ class Replica
 
   def post_existing_articles_by_title(articles)
     article_list = articles.map { |article| article["title"] }
-    api_post('articles.php', 'post_article_titles', article_list)
+    api_post('articles.php', 'post_article_titles[]', article_list)
   end
 
   # Given a list of revisions, see which ones have not been deleted
@@ -136,8 +136,8 @@ class Replica
   def api_post(endpoint, key, data)
     tries ||= 3
     response = do_post(endpoint, key, data)
-    return if response.empty?
-    parsed = Oj.load(response.to_s)
+    return unless response.kind_of? Net::HTTPSuccess
+    parsed = Oj.load(response.body)
     return unless parsed['success']
     parsed['data']
   rescue StandardError => e
@@ -159,7 +159,7 @@ class Replica
                          'db' => database_params['db'],
                          'lang' => database_params['lang'],
                          'project' => database_params['project'],
-                         key => data)
+                          key => data)
   end
 
   # Query URL for the WikiEduDashboardTools repository
@@ -182,9 +182,7 @@ class Replica
   def project_database_params_post
     db = ''
     db = SPECIAL_DB_NAMES[@wiki.domain] if SPECIAL_DB_NAMES[@wiki.domain]
-    lang = @wiki.language
-    project = @wiki.project
-    { 'db' => db, 'lang' => lang, 'project' => project }
+    { 'db' => db, 'lang' => @wiki.language, 'project' => @wiki.project }
   end
 
   def compile_usernames_query(users)

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -131,7 +131,7 @@ class Replica
   def api_post(endpoint, key, data)
     tries ||= 3
     response = do_post(endpoint, key, data)
-    return unless response.is_a? Net::HTTPSuccess
+    return if response.body.empty?
     parsed = Oj.load(response.body)
     return unless parsed['success']
     parsed['data']

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -53,7 +53,7 @@ class Replica
   # Given a list of articles *or* hashes of the form { 'title' => 'Something' },
   # see which ones have not been deleted.
   def post_existing_articles_by_title(articles)
-    article_list = articles.map { |article| article["title"] }
+    article_list = articles.map { |article| article['title'] }
     api_post('articles.php', 'post_article_titles[]', article_list)
   end
 
@@ -131,7 +131,7 @@ class Replica
   def api_post(endpoint, key, data)
     tries ||= 3
     response = do_post(endpoint, key, data)
-    return unless response.kind_of? Net::HTTPSuccess
+    return unless response.is_a? Net::HTTPSuccess
     parsed = Oj.load(response.body)
     return unless parsed['success']
     parsed['data']
@@ -154,7 +154,7 @@ class Replica
                          'db' => database_params['db'],
                          'lang' => database_params['lang'],
                          'project' => database_params['project'],
-                          key => data)
+                         key => data)
   end
 
   # Query URL for the WikiEduDashboardTools repository
@@ -189,14 +189,6 @@ class Replica
     return '' if oauth_ids.nil?
     oauth_id_tags = oauth_ids.split(',').map { |id| "OAuth CID: #{id}" }
     { oauth_tags: oauth_id_tags }.to_query
-  end
-
-  # Compile an article list to send to the replica endpoint, which might look
-  # something like this:
-  # "article_ids[]='Artist'&article_ids[]='Microsoft_Research'"
-  def compile_article_titles_query(articles)
-    quoted_titles = articles.map { |article| "'#{CGI.escape(article['title'])}'" }
-    { article_titles: quoted_titles }.to_query
   end
 
   # Compile an article list to send to the replica endpoint, which might look

--- a/spec/lib/article_status_manager_spec.rb
+++ b/spec/lib/article_status_manager_spec.rb
@@ -183,7 +183,7 @@ describe ArticleStatusManager do
              namespace: 0)
       create(:revision, date: 1.day.ago, article_id: 1, user: user)
 
-      allow_any_instance_of(Replica).to receive(:get_existing_articles_by_title).and_return(nil)
+      allow_any_instance_of(Replica).to receive(:post_existing_articles_by_title).and_return(nil)
       described_class.update_article_status_for_course(course)
       expect(Article.find(848).deleted).to eq(false)
       expect(Article.find(1).deleted).to eq(false)

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -96,7 +96,7 @@ describe Replica do
           { 'title' => 'Mmilldev/sandbox' }, # exists in namespace 2
           { 'title' => 'THIS_ARTICLE_DOES_NOT_EXIST' }
         ]
-        response = Replica.new(en_wiki).get_existing_articles_by_title(article_titles)
+        response = Replica.new(en_wiki).post_existing_articles_by_title(article_titles)
         expect(response.size).to eq(15)
       end
     end

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -202,7 +202,7 @@ describe Replica do
 
   describe 'post request error handling' do
     article_titles = []
-    let(:result) { Replica.new(en_wiki).post_existing_articles_by_title(article_titles)}
+    let(:result) { Replica.new(en_wiki).post_existing_articles_by_title(article_titles) }
 
     it 'handles timeout errors' do
       stub_request(:any, %r{https://tools.wmflabs.org/.*})


### PR DESCRIPTION
Fixes #1575. This adds post methods in replica.rb to access the replica service with post methods and uses the said function in article_status_manager.rb to retrieve articles by titles without breaking the data into chunks.