### PR TITLE
fix links of article results from article finder

### DIFF
--- a/app/views/article_finder/_row.html.haml
+++ b/app/views/article_finder/_row.html.haml
@@ -1,4 +1,4 @@
-%tr{"data-link" => "%< article.url %>"}
+%tr{"data-link" => "#{article.url}"}
   %td= article.full_title
   %td= article.average_views
   %td= article.revisions.last.wp10


### PR DESCRIPTION
The links in article_finder view were broken because of mixed usage of Haml and ERB syntax. This changes the links to Haml syntax.