### PR TITLE
Allow home_wiki of a course to be updated

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -17,6 +17,8 @@ import PrivacySelector from './privacy_selector.jsx';
 import WithdrawnSelector from './withdrawn_selector.jsx';
 import TimelineToggle from './timeline_toggle.jsx';
 import CourseLevelSelector from '../course_creator/course_level_selector.jsx';
+import HomeWikiProjectSelector from './home_wiki_project_selector.jsx';
+import HomeWikiLanguageSelector from './home_wiki_language_selector.jsx';
 
 import Editable from '../high_order/editable.jsx';
 import TextInput from '../common/text_input.jsx';
@@ -222,6 +224,8 @@ const Details = createReactClass({
     let courseLevelSelector;
     let timelineToggle;
     let withdrawnSelector;
+    let projectSelector;
+    let languageSelector;
     if (this.props.current_user.admin) {
       const tagsList = this.props.tags.length > 0 ?
         _.map(this.props.tags, 'tag').join(', ')
@@ -295,6 +299,22 @@ const Details = createReactClass({
       );
     }
 
+    if (this.props.editable) {
+      projectSelector = (
+        <HomeWikiProjectSelector
+          course={this.props.course}
+        />
+      );
+    }
+
+    if (this.props.editable) {
+      languageSelector = (
+        <HomeWikiLanguageSelector
+          course={this.props.course}
+        />
+      );
+    }
+
     return (
       <div className="module course-details">
         <div className="section-header">
@@ -347,6 +367,8 @@ const Details = createReactClass({
           {privacySelector}
           {timelineToggle}
           {withdrawnSelector}
+          {projectSelector}
+          {languageSelector}
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -299,15 +299,12 @@ const Details = createReactClass({
       );
     }
 
-    if (this.props.editable) {
+    if (this.props.editable && !Features.wikiEd) {
       projectSelector = (
         <HomeWikiProjectSelector
           course={this.props.course}
         />
       );
-    }
-
-    if (this.props.editable) {
       languageSelector = (
         <HomeWikiLanguageSelector
           course={this.props.course}

--- a/app/assets/javascripts/components/overview/home_wiki_language_selector.jsx
+++ b/app/assets/javascripts/components/overview/home_wiki_language_selector.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import uuid from 'uuid';
+import CourseActions from '../../actions/course_actions.js';
+
+const HomeWikiLanguageSelector = createReactClass({
+  propTypes: {
+    homeWiki: PropTypes.object
+  },
+
+  componentWillMount() {
+    this.setState({
+      id: uuid.v4()
+    });
+  },
+
+  _handleChange(e) {
+    const course = this.props.course;
+    const homeWikiLanguage = e.target.value;
+    course.home_wiki.language = homeWikiLanguage;
+    CourseActions.updateCourse(course);
+  },
+
+  render() {
+    const options = JSON.parse(WikiLanguages).map((language, index) => {
+      return (<option value={language} key={index}>{language}</option>);
+    });
+
+    const selector = (
+      <div className="form-group">
+        <label htmlFor={this.state.id}>Home Wiki Language:</label>
+        <select
+          id={this.state.id}
+          name="home_wiki_Language"
+          value={this.props.course.home_wiki.language}
+          onChange={this._handleChange}
+        >
+          {options}
+        </select>
+      </div>
+    );
+
+    return (
+      <div className="home_wiki_language_selector">
+        {selector}
+      </div>
+    );
+  }
+});
+
+export default HomeWikiLanguageSelector;

--- a/app/assets/javascripts/components/overview/home_wiki_language_selector.jsx
+++ b/app/assets/javascripts/components/overview/home_wiki_language_selector.jsx
@@ -29,7 +29,7 @@ const HomeWikiLanguageSelector = createReactClass({
 
     const selector = (
       <div className="form-group">
-        <label htmlFor={this.state.id}>Home Wiki Language:</label>
+        <label htmlFor={this.state.id}>{I18n.t('courses.home_wiki_language')}:</label>
         <select
           id={this.state.id}
           name="home_wiki_Language"

--- a/app/assets/javascripts/components/overview/home_wiki_project_selector.jsx
+++ b/app/assets/javascripts/components/overview/home_wiki_project_selector.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import uuid from 'uuid';
+import CourseActions from '../../actions/course_actions.js';
+
+const HomeWikiProjectSelector = createReactClass({
+  propTypes: {
+    course: PropTypes.object
+  },
+
+  componentWillMount() {
+    this.setState({
+      id: uuid.v4()
+    });
+  },
+
+  _handleChange(e) {
+    const course = this.props.course;
+    const homeWikiProject = e.target.value;
+    course.home_wiki.project = homeWikiProject;
+    CourseActions.updateCourse(course);
+  },
+
+  render() {
+    const options = JSON.parse(WikiProjects).map((project, index) => {
+      return (<option value={project} key={index}>{project}</option>);
+    });
+
+    const selector = (
+      <div className="form-group">
+        <label htmlFor={this.state.id}>Home Wiki Project:</label>
+        <select
+          id={this.state.id}
+          name="home_wiki_project"
+          value={this.props.course.home_wiki.project}
+          onChange={this._handleChange}
+        >
+          {options}
+        </select>
+      </div>
+    );
+
+    return (
+      <div className="home_wiki_project_selector">
+        {selector}
+      </div>
+    );
+  }
+});
+
+export default HomeWikiProjectSelector;

--- a/app/assets/javascripts/components/overview/home_wiki_project_selector.jsx
+++ b/app/assets/javascripts/components/overview/home_wiki_project_selector.jsx
@@ -29,7 +29,7 @@ const HomeWikiProjectSelector = createReactClass({
 
     const selector = (
       <div className="form-group">
-        <label htmlFor={this.state.id}>Home Wiki Project:</label>
+        <label htmlFor={this.state.id}>{I18n.t('courses.home_wiki_project')}:</label>
         <select
           id={this.state.id}
           name="home_wiki_project"

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -41,15 +41,6 @@ class CoursesController < ApplicationController
     validate
     handle_course_announcement(@course.instructors.first)
     slug_from_params if should_set_slug?
-
-    if params[:course].key?(:home_wiki)
-      home_wiki = Wiki.get_or_create language: params.dig(:course, :home_wiki, :language),
-                                     project: params.dig(:course, :home_wiki, :project)
-      update_params = course_params.merge(home_wiki_id: home_wiki[:id])
-    else
-      update_params = course_params
-    end
-
     @course.update update_params
     set_timeline_enabled
     ensure_passcode_set
@@ -224,6 +215,16 @@ class CoursesController < ApplicationController
               :expected_students, :start, :end, :submitted, :passcode,
               :timeline_start, :timeline_end, :day_exceptions, :weekdays,
               :no_day_exceptions, :cloned_status, :type, :level, :private)
+  end
+
+  def update_params
+    if params[:course].key?(:home_wiki)
+      home_wiki = Wiki.get_or_create language: params.dig(:course, :home_wiki, :language),
+                                     project: params.dig(:course, :home_wiki, :project)
+      course_params.merge!(home_wiki_id: home_wiki[:id])
+    else
+      course_params
+    end
   end
 
   def instructor_role_description

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -41,7 +41,16 @@ class CoursesController < ApplicationController
     validate
     handle_course_announcement(@course.instructors.first)
     slug_from_params if should_set_slug?
-    @course.update course_params
+
+    if params[:course].key?(:home_wiki)
+      home_wiki = Wiki.get_or_create language: params.dig(:course, :home_wiki, :language),
+                                     project: params.dig(:course, :home_wiki, :project)
+      update_params = course_params.merge(home_wiki_id: home_wiki[:id])
+    else
+      update_params = course_params
+    end
+
+    @course.update update_params
     set_timeline_enabled
     ensure_passcode_set
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,8 @@ en:
     feedback: Feedback
     feedback_loading: Please wait while suggestions are Loading...
     gradeables_none: This course has no gradeable assignments.
+    home_wiki_language: Home Wiki Language
+    home_wiki_project: Home Wiki Project
     instructor:
       one: Instructor
       other: Instructors

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -383,6 +383,8 @@ qqq:
     feedback: '{{Identical|Feedback}}'
     gradeables_none: Message indicating that the course has no gradeable items in
       the timeline (Wiki Ed only)
+    home_wiki_language: Label for Home Wiki Language Selector
+    home_wiki_project: Lable for Home Wiki Project Selector
     instructor:
       one: |-
         Label for a single instructor of a course (Wiki Ed only)

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -116,7 +116,8 @@ describe CoursesController do
         submitted: submitted_2,
         day_exceptions: '',
         weekdays: '0001000',
-        no_day_exceptions: true }
+        no_day_exceptions: true,
+        home_wiki_id: 1 }
     end
     before do
       allow(controller).to receive(:current_user).and_return(user)

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -29,6 +29,7 @@ course_end = '2015-12-31'
 
 describe 'the course page', type: :feature, js: true do
   let(:es_wiktionary) { create(:wiki, language: 'es', project: 'wiktionary') }
+  let(:en_wikipedia) { create(:wiki, language: 'en', project: 'wikipedia') }
   before do
     stub_wiki_validation
     page.current_window.resize_to(1920, 1080)
@@ -43,6 +44,7 @@ describe 'the course page', type: :feature, js: true do
                     timeline_end: course_end.to_date,
                     school: 'This university.foo',
                     term: 'term 2015',
+                    home_wiki_id: es_wiktionary.id,
                     description: 'This is a great course')
     campaign = create(:campaign)
     course.campaigns << campaign
@@ -223,6 +225,19 @@ describe 'the course page', type: :feature, js: true do
         click_button 'Save'
       end
       expect(Course.last.passcode).to eq(previous_passcode)
+    end
+
+    it 'allows edit in home_wiki_id' do
+      admin = create(:admin, id: User.last.id + 1)
+      login_as(admin)
+      js_visit "/courses/#{slug}"
+      within '.sidebar' do
+        click_button 'Edit Details'
+        find('div.home_wiki_language_selector').find('select').set 'en'
+        find('div.home_wiki_project_selector').find('select').set 'wikipedia'
+        click_button 'Save'
+      end
+      expect(course.home_wiki_id).to eq(en_wikipedia.id)
     end
   end
 


### PR DESCRIPTION
Fixes #1741.
It allows the home_wiki of a course to changed by the user. Provides `HomeWikiLanguageSelector` and `HomeWikiProjectSelector` components in editable course details component. Further, modifies `course_controller#update` to allow update of home_wiki_id for a course.