### PR TITLE
Adds tool tip for timeline toggle input field

### DIFF
--- a/app/assets/javascripts/components/overview/timeline_toggle.jsx
+++ b/app/assets/javascripts/components/overview/timeline_toggle.jsx
@@ -34,12 +34,23 @@ const TimelineToggle = createReactClass({
         <strong>{I18n.t("courses.timeline_enabled")}:</strong> {currentValue ? 'yes' : 'no'}
       </span>
     );
+    const tooltip = (
+      <div className="tooltip-trigger">
+        <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
+        <div className="tooltip large dark">
+          <p>
+            {I18n.t("courses.timeline_tooltip")}
+          </p>
+        </div>
+      </div>
+    );
     if (this.props.editable) {
       selector = (
         <div className="form-group">
           <span htmlFor={this.state.id}>
             <strong>{I18n.t("courses.timeline_enabled")}:</strong>
           </span>
+          {tooltip}
           <select
             id={this.state.id}
             name="timeline_enabled"

--- a/app/assets/stylesheets/modules/_modules.styl
+++ b/app/assets/stylesheets/modules/_modules.styl
@@ -48,7 +48,7 @@
   p
     margin 0
 
-  .submitted_selector
+  .submitted_selector, .timeline_toggle
     .tooltip-trigger
       display inline-block
       position relative

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,7 @@ en:
     timeline: Assignment Details
     timeline_enabled: Timeline enabled
     timeline_link: Timeline
+    timeline_tooltip: Timeline help you to keep track of your course by breaking the course duration in weeks which have proper agendas and tasks associated with them.
     time_zone_message: Start and end times are displayed in your local time zone.
     title: Title
     training_due:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,7 +538,7 @@ en:
     timeline: Assignment Details
     timeline_enabled: Timeline enabled
     timeline_link: Timeline
-    timeline_tooltip: Timeline help you to keep track of your course by breaking the course duration in weeks which have proper agendas and tasks associated with them.
+    timeline_tooltip: Enabling the Timeline will let you specify week-by-week activities and assign training modules. It is useful for Education Program courses and other long, highly structured programs.
     time_zone_message: Start and end times are displayed in your local time zone.
     title: Title
     training_due:

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -458,6 +458,7 @@ qqq:
     user_role: '{{Identical|Role}}'
     term: '{{Identical|Term}}'
     timeline_link: '{{Identical|Timeline}}'
+    timeline_tooltip: Message that explains what timeline is good for
     time_zone_message: Message explaining that times are shown to the user in their
       local time zone
     title: |-


### PR DESCRIPTION
Fixes #1765.
Adds a tooltip displaying a message about what the timeline is good for, uses I18n locales.
**Screenshot:**
![image](https://user-images.githubusercontent.com/23720731/37256370-af88aad4-257f-11e8-9081-8ca88c8098b9.png)
