### PR TITLE
add VCR cassette support for all the replica endpoints

### DIFF
--- a/spec/lib/article_status_manager_spec.rb
+++ b/spec/lib/article_status_manager_spec.rb
@@ -11,194 +11,216 @@ describe ArticleStatusManager do
 
   describe '.update_article_status' do
     it 'runs without error' do
-      described_class.update_article_status
+      VCR.use_cassette 'article_status_manager/main' do
+        described_class.update_article_status
+      end
     end
   end
 
   describe '.update_article_status_for_course' do
     it 'marks deleted articles as "deleted"' do
-      create(:article,
-             id: 1,
-             mw_page_id: 1,
-             title: 'Noarticle',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 1, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        create(:article,
+               id: 1,
+               mw_page_id: 1,
+               title: 'Noarticle',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 1, user: user)
 
-      described_class.update_article_status_for_course(course)
-      expect(Article.find(1).deleted).to be true
+        described_class.update_article_status_for_course(course)
+        expect(Article.find(1).deleted).to be true
+      end
     end
 
     it 'updates the mw_page_ids of articles' do
-      # en.wikipedia - article 100 does not exist
-      create(:article,
-             id: 100,
-             mw_page_id: 100,
-             title: 'Audi',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 100, user: user)
+      VCR.use_cassette 'article_status_manager/mw_page_ids' do
+        # en.wikipedia - article 100 does not exist
+        create(:article,
+               id: 100,
+               mw_page_id: 100,
+               title: 'Audi',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 100, user: user)
 
-      # es.wikipedia
-      create(:wiki, id: 2, language: 'es', project: 'wikipedia')
-      create(:article,
-             id: 100000001,
-             mw_page_id: 100000001,
-             title: 'Audi',
-             namespace: 0,
-             wiki_id: 2)
-      create(:revision, date: 1.day.ago, article_id: 100000001, user: user)
+        # es.wikipedia
+        create(:wiki, id: 2, language: 'es', project: 'wikipedia')
+        create(:article,
+               id: 100000001,
+               mw_page_id: 100000001,
+               title: 'Audi',
+               namespace: 0,
+               wiki_id: 2)
+        create(:revision, date: 1.day.ago, article_id: 100000001, user: user)
 
-      described_class.update_article_status_for_course(course)
+        described_class.update_article_status_for_course(course)
 
-      expect(Article.find_by(title: 'Audi', wiki_id: 1).mw_page_id).to eq(848)
-      expect(Article.find_by(title: 'Audi', wiki_id: 2).mw_page_id).to eq(4976786)
+        expect(Article.find_by(title: 'Audi', wiki_id: 1).mw_page_id).to eq(848)
+        expect(Article.find_by(title: 'Audi', wiki_id: 2).mw_page_id).to eq(4976786)
+      end
     end
 
     it 'deletes articles when id changed but new one already exists' do
-      create(:article,
-             id: 100,
-             mw_page_id: 100,
-             title: 'Audi',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 100, user: user)
-      create(:article,
-             id: 848,
-             mw_page_id: 848,
-             title: 'Audi',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 848, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        create(:article,
+               id: 100,
+               mw_page_id: 100,
+               title: 'Audi',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 100, user: user)
+        create(:article,
+               id: 848,
+               mw_page_id: 848,
+               title: 'Audi',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 848, user: user)
 
-      described_class.update_article_status_for_course(course)
-      expect(Article.find_by(mw_page_id: 100).deleted).to eq(true)
+        described_class.update_article_status_for_course(course)
+        expect(Article.find_by(mw_page_id: 100).deleted).to eq(true)
+      end
     end
 
     it 'updates the namespace and titles when articles are moved' do
-      create(:article,
-             id: 848,
-             mw_page_id: 848,
-             title: 'Audi_Cars', # 'Audi' is the actual title
-             namespace: 2)
-      create(:revision, date: 1.day.ago, article_id: 848, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        create(:article,
+               id: 848,
+               mw_page_id: 848,
+               title: 'Audi_Cars', # 'Audi' is the actual title
+               namespace: 2)
+        create(:revision, date: 1.day.ago, article_id: 848, user: user)
 
-      described_class.update_article_status_for_course(course)
-      expect(Article.find(848).namespace).to eq(0)
-      expect(Article.find(848).title).to eq('Audi')
+        described_class.update_article_status_for_course(course)
+        expect(Article.find(848).namespace).to eq(0)
+        expect(Article.find(848).title).to eq('Audi')
+      end
     end
 
     it 'handles cases of space vs. underscore' do
-      # This page was first moved from a sandbox to "Yōji Sakate", then
-      # moved again to "Yōji Sakate (playwright)". It ended up in our database
-      # like this.
-      create(:article,
-             id: 46745170,
-             mw_page_id: 46745170,
-             # Currently this is a redirect to the other title.
-             title: 'Yōji Sakate',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 46745170, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        # This page was first moved from a sandbox to "Yōji Sakate", then
+        # moved again to "Yōji Sakate (playwright)". It ended up in our database
+        # like this.
+        create(:article,
+               id: 46745170,
+               mw_page_id: 46745170,
+               # Currently this is a redirect to the other title.
+               title: 'Yōji Sakate',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 46745170, user: user)
 
-      create(:article,
-             id: 46364485,
-             mw_page_id: 46364485,
-             # Current title is "Yōji Sakate" as of 2016-07-06.
-             title: 'Yōji_Sakate',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 46364485, user: user)
+        create(:article,
+               id: 46364485,
+               mw_page_id: 46364485,
+               # Current title is "Yōji Sakate" as of 2016-07-06.
+               title: 'Yōji_Sakate',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 46364485, user: user)
 
-      described_class.update_article_status_for_course(course)
+        described_class.update_article_status_for_course(course)
+      end
     end
 
     it 'handles case-variant titles' do
-      article1 = create(:article,
-                        id: 3914927,
-                        mw_page_id: 3914927,
-                        title: 'Cyber-ethnography',
-                        deleted: true,
-                        namespace: 1)
-      create(:revision, date: 1.day.ago, article_id: 3914927, user: user)
-      article2 = create(:article,
-                        id: 46394760,
-                        mw_page_id: 46394760,
-                        title: 'Cyber-Ethnography',
-                        deleted: false,
-                        namespace: 1)
-      create(:revision, date: 1.day.ago, article_id: 46394760, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        article1 = create(:article,
+                          id: 3914927,
+                          mw_page_id: 3914927,
+                          title: 'Cyber-ethnography',
+                          deleted: true,
+                          namespace: 1)
+        create(:revision, date: 1.day.ago, article_id: 3914927, user: user)
+        article2 = create(:article,
+                          id: 46394760,
+                          mw_page_id: 46394760,
+                          title: 'Cyber-Ethnography',
+                          deleted: false,
+                          namespace: 1)
+        create(:revision, date: 1.day.ago, article_id: 46394760, user: user)
 
-      described_class.update_article_status_for_course(course)
-      expect(article1.id).to eq(3914927)
-      expect(article2.id).to eq(46394760)
+        described_class.update_article_status_for_course(course)
+        expect(article1.id).to eq(3914927)
+        expect(article2.id).to eq(46394760)
+      end
     end
 
     it 'updates the mw_rev_id for revisions when article record changes' do
-      create(:article,
-             id: 2262715,
-             mw_page_id: 2262715,
-             title: 'Kostanay',
-             namespace: 0)
-      create(:revision,
-             date: 1.day.ago,
-             user: user,
-             article_id: 2262715,
-             mw_page_id: 2262715,
-             mw_rev_id: 648515801)
-      described_class.update_article_status_for_course(course)
+      VCR.use_cassette 'article_status_manager/update_for_revisions  ' do
+        create(:article,
+               id: 2262715,
+               mw_page_id: 2262715,
+               title: 'Kostanay',
+               namespace: 0)
+        create(:revision,
+               date: 1.day.ago,
+               user: user,
+               article_id: 2262715,
+               mw_page_id: 2262715,
+               mw_rev_id: 648515801)
+        described_class.update_article_status_for_course(course)
 
-      new_article = Article.find_by(title: 'Kostanay')
-      expect(new_article.mw_page_id).to eq(46349871)
-      expect(new_article.revisions.count).to eq(1)
-      expect(Revision.find_by(mw_rev_id: 648515801).article_id).to eq(new_article.id)
-      expect(Revision.find_by(mw_rev_id: 648515801).mw_page_id).to eq(new_article.mw_page_id)
+        new_article = Article.find_by(title: 'Kostanay')
+        expect(new_article.mw_page_id).to eq(46349871)
+        expect(new_article.revisions.count).to eq(1)
+        expect(Revision.find_by(mw_rev_id: 648515801).article_id).to eq(new_article.id)
+        expect(Revision.find_by(mw_rev_id: 648515801).mw_page_id).to eq(new_article.mw_page_id)
+      end
     end
 
     it 'does not delete articles by mistake if Replica is down' do
-      create(:article,
-             id: 848,
-             mw_page_id: 848,
-             title: 'Audi',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 848, user: user)
-      create(:article,
-             id: 1,
-             mw_page_id: 1,
-             title: 'Noarticle',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 1, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        create(:article,
+               id: 848,
+               mw_page_id: 848,
+               title: 'Audi',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 848, user: user)
+        create(:article,
+               id: 1,
+               mw_page_id: 1,
+               title: 'Noarticle',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 1, user: user)
 
-      allow_any_instance_of(Replica).to receive(:get_existing_articles_by_id).and_return(nil)
-      described_class.update_article_status_for_course(course)
-      expect(Article.find(848).deleted).to eq(false)
-      expect(Article.find(1).deleted).to eq(false)
+        allow_any_instance_of(Replica).to receive(:get_existing_articles_by_id).and_return(nil)
+        described_class.update_article_status_for_course(course)
+        expect(Article.find(848).deleted).to eq(false)
+        expect(Article.find(1).deleted).to eq(false)
+      end
     end
 
     it 'does not delete articles by mistake if Replica goes right before trying to fetch titles' do
-      create(:article,
-             id: 848,
-             mw_page_id: 848,
-             title: 'Audi',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 848, user: user)
-      create(:article,
-             id: 1,
-             mw_page_id: 1,
-             title: 'Noarticle',
-             namespace: 0)
-      create(:revision, date: 1.day.ago, article_id: 1, user: user)
+      VCR.use_cassette 'article_status_manager/main' do
+        create(:article,
+               id: 848,
+               mw_page_id: 848,
+               title: 'Audi',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 848, user: user)
+        create(:article,
+               id: 1,
+               mw_page_id: 1,
+               title: 'Noarticle',
+               namespace: 0)
+        create(:revision, date: 1.day.ago, article_id: 1, user: user)
 
-      allow_any_instance_of(Replica).to receive(:post_existing_articles_by_title).and_return(nil)
-      described_class.update_article_status_for_course(course)
-      expect(Article.find(848).deleted).to eq(false)
-      expect(Article.find(1).deleted).to eq(false)
+        allow_any_instance_of(Replica).to receive(:post_existing_articles_by_title).and_return(nil)
+        described_class.update_article_status_for_course(course)
+        expect(Article.find(848).deleted).to eq(false)
+        expect(Article.find(1).deleted).to eq(false)
+      end
     end
 
     it 'marks an undeleted article as not deleted' do
-      create(:article,
-             id: 50661367,
-             mw_page_id: 52228477,
-             title: 'Antiochis_of_Tlos',
-             namespace: 0,
-             deleted: true)
-      create(:revision, date: 1.day.ago, article_id: 50661367, user: user)
-      described_class.update_article_status_for_course(course)
-      expect(Article.find(50661367).deleted).to eq(false)
+      VCR.use_cassette 'article_status_manager/main' do
+        create(:article,
+               id: 50661367,
+               mw_page_id: 52228477,
+               title: 'Antiochis_of_Tlos',
+               namespace: 0,
+               deleted: true)
+        create(:revision, date: 1.day.ago, article_id: 50661367, user: user)
+        described_class.update_article_status_for_course(course)
+        expect(Article.find(50661367).deleted).to eq(false)
+      end
     end
   end
 end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -18,55 +18,63 @@ describe CourseRevisionUpdater do
     end
 
     it 'includes the correct article and revision data' do
-      revision_import
-      expected_article = Article.find_by(wiki_id: 1,
-                                         title: '1978_Revelation_on_Priesthood',
-                                         mw_page_id: 15124285,
-                                         namespace: 0)
-
-      expected_revision = Revision.find_by(mw_rev_id: 712907095,
-                                           user_id: user.id,
-                                           wiki_id: 1,
+      VCR.use_cassette 'course_revision_updater' do
+        revision_import
+        expected_article = Article.find_by(wiki_id: 1,
+                                           title: '1978_Revelation_on_Priesthood',
                                            mw_page_id: 15124285,
-                                           characters: 579,
-                                           article_id: expected_article.id)
-      expect(expected_revision).to be_a(Revision)
+                                           namespace: 0)
+
+        expected_revision = Revision.find_by(mw_rev_id: 712907095,
+                                             user_id: user.id,
+                                             wiki_id: 1,
+                                             mw_page_id: 15124285,
+                                             characters: 579,
+                                             article_id: expected_article.id)
+        expect(expected_revision).to be_a(Revision)
+      end
     end
 
     it 'updates article title if it does not match existing article record' do
-      create(:article, id: 15124285, mw_page_id: 15124285, wiki_id: 1, title: 'foo')
+      VCR.use_cassette 'course_revision_updater' do
+        create(:article, id: 15124285, mw_page_id: 15124285, wiki_id: 1, title: 'foo')
 
-      revision_import
+        revision_import
 
-      expect(Article.find_by(mw_page_id: 15124285).title).to eq('1978_Revelation_on_Priesthood')
-      expect(Article.where(mw_page_id: 15124285).count).to eq(1)
+        expect(Article.find_by(mw_page_id: 15124285).title).to eq('1978_Revelation_on_Priesthood')
+        expect(Article.where(mw_page_id: 15124285).count).to eq(1)
+      end
     end
   end
 
   describe '.import_new_revisions' do
     it 'includes revisions on the final day of a course up to the end time' do
-      create(:course, id: 1, start: '2016-03-20', end: '2016-03-31'.to_date.end_of_day)
-      create(:user, id: 1, username: 'Tedholtby')
-      create(:courses_user, course_id: 1,
-                            user_id: 1,
-                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      VCR.use_cassette 'course_revision_updater' do
+        create(:course, id: 1, start: '2016-03-20', end: '2016-03-31'.to_date.end_of_day)
+        create(:user, id: 1, username: 'Tedholtby')
+        create(:courses_user, course_id: 1,
+                              user_id: 1,
+                              role: CoursesUsers::Roles::STUDENT_ROLE)
 
-      CourseRevisionUpdater.import_new_revisions(Course.all)
+        CourseRevisionUpdater.import_new_revisions(Course.all)
 
-      expect(User.find(1).revisions.count).to eq(3)
-      expect(Course.find(1).revisions.count).to eq(3)
+        expect(User.find(1).revisions.count).to eq(3)
+        expect(Course.find(1).revisions.count).to eq(3)
+      end
     end
 
     it 'imports revisions soon after the final day of the course, but excludes them from metrics' do
-      create(:course, id: 1, start: '2016-03-20', end: '2016-03-30')
-      create(:user, id: 15, username: 'Tedholtby')
-      create(:courses_user, course_id: 1, user_id: 15,
-                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      VCR.use_cassette 'course_revision_updater' do
+        create(:course, id: 1, start: '2016-03-20', end: '2016-03-30')
+        create(:user, id: 15, username: 'Tedholtby')
+        create(:courses_user, course_id: 1, user_id: 15,
+                              role: CoursesUsers::Roles::STUDENT_ROLE)
 
-      CourseRevisionUpdater.import_new_revisions(Course.all)
+        CourseRevisionUpdater.import_new_revisions(Course.all)
 
-      expect(User.find(15).revisions.count).to eq(3)
-      expect(Course.find(1).revisions.count).to eq(0)
+        expect(User.find(15).revisions.count).to eq(3)
+        expect(Course.find(1).revisions.count).to eq(0)
+      end
     end
 
     it 'handles returning users with earlier revisions' do
@@ -103,9 +111,11 @@ describe CourseRevisionUpdater do
   describe '.import_new_revisions_concurrently' do
     let!(:course) { create(:course) }
     it 'calls import_new_revisions multiple times' do
-      expect(CourseRevisionUpdater).to receive(:import_new_revisions)
-        .exactly(Replica::CONCURRENCY_LIMIT).times
-      CourseRevisionUpdater.import_new_revisions_concurrently(Course.all)
+      VCR.use_cassette 'course_revision_updater' do
+        expect(CourseRevisionUpdater).to receive(:import_new_revisions)
+          .exactly(Replica::CONCURRENCY_LIMIT).times
+        CourseRevisionUpdater.import_new_revisions_concurrently(Course.all)
+      end
     end
   end
 
@@ -113,9 +123,11 @@ describe CourseRevisionUpdater do
     it 'includes wikidata for Programs & Events Dashboard' do
       stub_wiki_validation
       wiki_data = Wiki.get_or_create(language: nil, project: 'wikidata')
-      allow(Features).to receive(:wiki_ed?).and_return(false)
-      ids = CourseRevisionUpdater.new(create(:course)).default_wiki_ids
-      expect(ids).to include(wiki_data.id)
+      VCR.use_cassette 'course_revision_updater' do
+        allow(Features).to receive(:wiki_ed?).and_return(false)
+        ids = CourseRevisionUpdater.new(create(:course)).default_wiki_ids
+        expect(ids).to include(wiki_data.id)
+      end
     end
   end
 end

--- a/spec/lib/importers/article_importer_spec.rb
+++ b/spec/lib/importers/article_importer_spec.rb
@@ -10,15 +10,19 @@ describe ArticleImporter do
 
   describe '.import_articles' do
     it 'creates an Article from a English Wikipedia page_id' do
-      ArticleImporter.new(en_wiki).import_articles [46349871]
-      article = Article.find_by(mw_page_id: 46349871)
-      expect(article.title).to eq('Kostanay')
+      VCR.use_cassette 'article_importer/article_importer' do
+        ArticleImporter.new(en_wiki).import_articles [46349871]
+        article = Article.find_by(mw_page_id: 46349871)
+        expect(article.title).to eq('Kostanay')
+      end
     end
 
     it 'works for a language besides the default' do
-      ArticleImporter.new(es_wiki).import_articles [100]
-      article = Article.find_by(mw_page_id: 100)
-      expect(article.title).to eq('Alnus')
+      VCR.use_cassette 'article_importer/article_importer' do
+        ArticleImporter.new(es_wiki).import_articles [100]
+        article = Article.find_by(mw_page_id: 100)
+        expect(article.title).to eq('Alnus')
+      end
     end
   end
 

--- a/spec/lib/modified_revisions_manager_spec.rb
+++ b/spec/lib/modified_revisions_manager_spec.rb
@@ -6,16 +6,18 @@ require "#{Rails.root}/lib/modified_revisions_manager"
 describe ModifiedRevisionsManager do
   describe '.move_or_delete_revisions' do
     it 'updates the article_id for a moved revision' do
-      # https://en.wikipedia.org/w/index.php?title=Selfie&oldid=547645475
-      create(:revision,
-             mw_rev_id: 547645475,
-             mw_page_id: 1,
-             article_id: 1) # Not the actual article_id
-      revision = Revision.all
-      described_class.new(Wiki.default_wiki).move_or_delete_revisions(revision)
-      article = Revision.find_by(mw_rev_id: 547645475).article
-      expect(article.mw_page_id).to eq(38956275)
-      expect(Article.exists?(mw_page_id: 38956275)).to be true
+      VCR.use_cassette 'modified_revisions_manager' do
+        # https://en.wikipedia.org/w/index.php?title=Selfie&oldid=547645475
+        create(:revision,
+               mw_rev_id: 547645475,
+               mw_page_id: 1,
+               article_id: 1) # Not the actual article_id
+        revision = Revision.all
+        described_class.new(Wiki.default_wiki).move_or_delete_revisions(revision)
+        article = Revision.find_by(mw_rev_id: 547645475).article
+        expect(article.mw_page_id).to eq(38956275)
+        expect(Article.exists?(mw_page_id: 38956275)).to be true
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -132,7 +132,7 @@ VCR.configure do |c|
   c.default_cassette_options = { record: :new_episodes }
   c.configure_rspec_metadata!
   # Allows RSPEC to test the availability of the Wikimedia Tools
-  c.ignore_hosts 'tools.wmflabs.org', '127.0.0.1'
+  c.ignore_hosts '127.0.0.1'
   # c.allow_http_connections_when_no_cassette = true
   c.ignore_hosts 'codeclimate.com'
   # for controller test


### PR DESCRIPTION
Fixes #1618.
Adds VCR cassette support for all the below-mentioned replica endpoint using specs:
- article_status_manager_spec
- course_revision_updater_spec
- article_importer_spec
- category_importer_spec
- modified_revisions_manager_spec
- replica_spec
