### PR TITLE
details.jsx: made course details edit mode into a modal

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -197,7 +197,7 @@ const AvailableActions = createReactClass({
     }
 
     return (
-      <div className="module">
+      <div className="module actions">
         <div className="section-header">
           <h3>{I18n.t('courses.actions')}</h3>
         </div>

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -19,6 +19,7 @@ import TimelineToggle from './timeline_toggle.jsx';
 import CourseLevelSelector from '../course_creator/course_level_selector.jsx';
 import HomeWikiProjectSelector from './home_wiki_project_selector.jsx';
 import HomeWikiLanguageSelector from './home_wiki_language_selector.jsx';
+import Modal from '../common/modal.jsx';
 
 import Editable from '../high_order/editable.jsx';
 import TextInput from '../common/text_input.jsx';
@@ -314,7 +315,7 @@ const Details = createReactClass({
       );
     }
 
-    return (
+    const shared = (
       <div className="module course-details">
         <div className="section-header">
           <h3>{I18n.t('application.details')}</h3>
@@ -322,53 +323,75 @@ const Details = createReactClass({
         </div>
         <div className="module__data extra-line-height">
           <Instructors {...this.props} />
-          {online}
-          {campus}
-          {staff}
-          <div><p className="red">{this.state.error_message}</p></div>
-          {school}
-          {title}
-          {term}
-          <form>
-            {passcode}
-            {expectedStudents}
-            <DatePicker
-              onChange={this.updateCourseDates}
-              value={this.props.course.start}
-              value_key="start"
-              validation={CourseDateUtils.isDateValid}
-              editable={this.props.editable}
-              label={CourseUtils.i18n('start', this.props.course.string_prefix)}
-              showTime={this.props.course.use_start_and_end_times}
-              required={true}
-            />
-            <DatePicker
-              onChange={this.updateCourseDates}
-              value={this.props.course.end}
-              value_key="end"
-              editable={this.props.editable}
-              validation={CourseDateUtils.isDateValid}
-              label={CourseUtils.i18n('end', this.props.course.string_prefix)}
-              date_props={dateProps.end}
-              enabled={Boolean(this.props.course.start)}
-              showTime={this.props.course.use_start_and_end_times}
-              required={true}
-            />
-            {timelineStart}
-            {timelineEnd}
-          </form>
+          <div className="details-form">
+            <div className="group-left">
+              {online}
+              {campus}
+              {staff}
+              <div><p className="red">{this.state.error_message}</p></div>
+              {school}
+              {title}
+              {term}
+              <form>
+                {passcode}
+                {expectedStudents}
+                <DatePicker
+                  onChange={this.updateCourseDates}
+                  value={this.props.course.start}
+                  value_key="start"
+                  validation={CourseDateUtils.isDateValid}
+                  editable={this.props.editable}
+                  label={CourseUtils.i18n('start', this.props.course.string_prefix)}
+                  showTime={this.props.course.use_start_and_end_times}
+                  required={true}
+                />
+                <DatePicker
+                  onChange={this.updateCourseDates}
+                  value={this.props.course.end}
+                  value_key="end"
+                  editable={this.props.editable}
+                  validation={CourseDateUtils.isDateValid}
+                  label={CourseUtils.i18n('end', this.props.course.string_prefix)}
+                  date_props={dateProps.end}
+                  enabled={Boolean(this.props.course.start)}
+                  showTime={this.props.course.use_start_and_end_times}
+                  required={true}
+                />
+              </form>
+            </div>
+            <div className="group-right">
+              {timelineStart}
+              {timelineEnd}
+              {subject}
+              {courseLevelSelector}
+              {tags}
+              {courseTypeSelector}
+              {submittedSelector}
+              {privacySelector}
+              {timelineToggle}
+              {withdrawnSelector}
+              {projectSelector}
+              {languageSelector}
+            </div>
+          </div>
           {campaigns}
-          {subject}
-          {courseLevelSelector}
-          {tags}
-          {courseTypeSelector}
-          {submittedSelector}
-          {privacySelector}
-          {timelineToggle}
-          {withdrawnSelector}
-          {projectSelector}
-          {languageSelector}
         </div>
+      </div>
+    );
+
+    if (!this.props.editable) {
+      return (
+        <div>
+          {shared}
+        </div>
+      );
+    }
+
+    return (
+      <div className="modal-course-details">
+        <Modal>
+          {shared}
+        </Modal>
       </div>
     );
   }

--- a/app/assets/stylesheets/modules/_confirm_modal.styl
+++ b/app/assets/stylesheets/modules/_confirm_modal.styl
@@ -14,6 +14,7 @@
 
 .confirm-modal-overlay
   background-color rgba(smoke, .4) !important
+  z-index 100 !important
 
 .confirm-explanation
   text-align left

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -6,6 +6,9 @@
     margin-bottom 0px
     margin-top 0px
 
+.course_main 
+  z-index 0
+  
 .course
   background #fff
   border 1px solid $border_lt
@@ -152,6 +155,25 @@ rating(color)
   &.list
     rating(#656E92)
 
+.modal-course-details
+  display inline-block
+
+  .wizard
+    z-index 1
+
+  .course-details
+    width 50%
+    top 60px
+
+  .group-left,
+  .group-right
+    width 50%
+    margin 20px
+    text-align left
+
+  .details-form
+    display flex
+
 @media only screen and (max-width: 920px)
   .course_main,
   .campaign_main
@@ -174,3 +196,17 @@ rating(color)
         padding-right 5px
       .course-details_value
         font-size 15px
+
+  .modal-course-details
+    top 100px
+
+    .course-details
+      width 90%
+
+    .group-left,
+    .group-right
+      width 90%
+      margin 10px
+
+    .details-form
+      display block

--- a/app/assets/stylesheets/modules/_modules.styl
+++ b/app/assets/stylesheets/modules/_modules.styl
@@ -44,6 +44,9 @@
     top 20px
     right 20px
 
+.module.actions
+  z-index 0
+
 .module.course-details
   p
     margin 0


### PR DESCRIPTION
Converted the edit Details mode to a modal so that all the editable fields can be seen on one screen and doesn't stretch below the fold.
![out-5](https://user-images.githubusercontent.com/22816171/37299973-d09cd922-264a-11e8-96e4-cd25287dc571.gif)
![screenshot from 2018-03-12 23-09-05](https://user-images.githubusercontent.com/22816171/37299994-dfd0c124-264a-11e8-8f76-d757bbe8259b.png)
