### PR TITLE
Postioned diffViewer below Navbar to avoid overlapping

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -23,7 +23,6 @@ import Modal from '../common/modal.jsx';
 
 import Editable from '../high_order/editable.jsx';
 import TextInput from '../common/text_input.jsx';
-import Notifications from '../common/notifications.jsx';
 
 import DatePicker from '../common/date_picker.jsx';
 import CourseActions from '../../actions/course_actions.js';
@@ -417,7 +416,6 @@ const Details = createReactClass({
     return (
       <div className="modal-course-details">
         <Modal>
-          <Notifications />
           {shared}
         </Modal>
       </div>

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -1,7 +1,7 @@
 .article-viewer
   background-color white
   position fixed
-  top 70px
+  top 130px
   /*@noflip*/ left 50%
   width 100%
   max-width 1200px

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -6,6 +6,9 @@
     margin-bottom 0px
     margin-top 0px
 
+.course_main
+  z-index 0
+
 .course
   background #fff
   border 1px solid $border_lt


### PR DESCRIPTION
Positioned the top of the diff viewer below the nav bar so it doesn't hide beneath it

![screenshot from 2018-03-17 21-24-43](https://user-images.githubusercontent.com/22816171/37557443-c1e527c0-2a2a-11e8-8715-d205e8c1e6c3.png)

fix #1807
