### PR TITLE
URI encode username of a user for contribution stats

### DIFF
--- a/app/assets/javascripts/components/user_profiles/contribution_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/contribution_stats.jsx
@@ -31,12 +31,12 @@ const ContributionStats = createReactClass({
   },
 
   componentDidMount() {
-    this.props.fetchStats(this.props.params.username);
+    this.props.fetchStats(encodeURIComponent(this.props.params.username));
     this.getData();
   },
 
   getData() {
-    const username = this.props.params.username;
+    const username = encodeURIComponent(this.props.params.username);
     const statsdataUrl = `/stats_graphs.json?username=${username}`;
     $.ajax(
       {


### PR DESCRIPTION
Fixes #1828.
It URI encode the username of a user using `encodeURIComponents` method allowing the username to have URI reserved characters which earlier caused issued with the user stats queries.