### PR TITLE
Alter the student List - Making Header stick to the top

### DIFF
--- a/app/assets/javascripts/components/common/list.jsx
+++ b/app/assets/javascripts/components/common/list.jsx
@@ -1,118 +1,162 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Loading from './loading.jsx';
 import UIActions from '../../actions/ui_actions.js';
 
-const List = ({
-  store,
-  keys,
-  sortable,
-  table_key,
-  className,
-  elements,
-  none_message,
-  loading,
-  sortBy
-}) => {
-  const sorting = store && store.getSorting();
-  const sortClass = (sorting && sorting.asc) ? 'asc' : 'desc';
-  const headers = [];
-  const iterable = Object.keys(keys);
+const List = createReactClass({
 
-  const sortByFunction = (tableKey, key) => {
-    if (sortBy) {
-      return () => {
-        sortBy(key);
-      };
+  propTypes: {
+    store: PropTypes.object,
+    keys: PropTypes.object,
+    sortable: PropTypes.bool,
+    table_key: PropTypes.string,
+    className: PropTypes.string,
+    elements: PropTypes.node,
+    none_message: PropTypes.string,
+    sortBy: PropTypes.func,
+    stickyHeader: PropTypes.bool
+  },
+
+  componentDidMount() {
+    if ($('.persist-area').length !== 0) {
+      let clonedHeaderRow;
+      $(".persist-area").each(function () {
+          clonedHeaderRow = $(".persist-header", this);
+          clonedHeaderRow
+            .before(clonedHeaderRow.clone())
+            .css("width", clonedHeaderRow.width())
+            .addClass("floatingHeader");
+      });
+      return window.addEventListener('scroll', this._UpdateTableHeaders);
     }
-    return UIActions.sort.bind(null, tableKey, key);
-  };
+  },
 
-  for (let i = 0; i < iterable.length; i++) {
-    const key = iterable[i];
-    const keyObj = keys[key];
-    let headerOnClick;
-    let headerClass = (sorting && sorting.key) === key ? sortClass : '';
-    let tooltip;
-    headerClass += keyObj.desktop_only ? ' desktop-only-tc' : '';
-    if ((sortable !== false) && (keyObj.sortable !== false)) {
-      headerClass += ' sortable';
-      headerOnClick = sortByFunction(table_key, key);
+  componentWillUnmount() {
+    if ($('.persist-area').length !== 0) {
+      return window.removeEventListener('scroll', this._UpdateTableHeaders);
     }
-    if (keyObj.info_key) {
-      headerClass += ' tooltip-trigger';
-      tooltip = [(
-        <div key="tt" className="tooltip dark">
-          <p>{I18n.t(keyObj.info_key)}</p>
-        </div>
-      ), (
-        <span key="ttindicator" className="tooltip-indicator" />
-      )];
-    }
-    headers.push((
-      <th onClick={headerOnClick} className={headerClass} key={key}>
-        <span dangerouslySetInnerHTML={{ __html: keyObj.label }} />
-        <span className="sortable-indicator" />
-        {tooltip}
-      </th>
-    ));
-  }
+  },
 
-  // eslint-disable-next-line
-  let defaultClassName = `${table_key} table `;
+  _UpdateTableHeaders() {
+   $(".persist-area").each(function () {
+     const el = $(this);
+     const offset = el.offset();
+     const scrollTop = $(window).scrollTop();
+     const floatingHeader = $(".floatingHeader", this);
 
-  if (className) { defaultClassName += className; }
+       if ((scrollTop > offset.top) && (scrollTop < offset.top + el.height())) {
+           floatingHeader.css({
+            visibility: "visible"
+           });
+       } else {
+           floatingHeader.css({
+            visibility: "hidden"
+           });
+       }
+   });
+},
 
-  if (sortable) { defaultClassName += ' table--sortable'; }
+  render() {
+    const { store, keys, sortable, table_key, className, none_message, sortBy, loading, stickyHeader } = this.props;
+    let { elements } = this.props;
+    const sorting = store && store.getSorting();
+    const sortClass = (sorting && sorting.asc) ? 'asc' : 'desc';
+    const headers = [];
+    const iterable = Object.keys(keys);
 
-  // Handle the case of no elements:
-  // Show a none message if data is already loaded, or
-  // show the Loading spinner if data is not yet loaded.
-  if (elements.length === 0) {
-    let emptyMessage;
-    if (store && store.isLoaded() || !loading) {
-      // eslint-disable-next-line
-      let noneMessage = none_message;
-      if (typeof noneMessage === 'undefined' || noneMessage === null) {
-        // eslint-disable-next-line
-        noneMessage = I18n.t(`${table_key}.none`);
+    const sortByFunction = (tableKey, key) => {
+      if (sortBy) {
+        return () => {
+          sortBy(key);
+        };
       }
-      emptyMessage = <span>{noneMessage}</span>;
-    } else {
-      emptyMessage = <Loading />;
+      return UIActions.sort.bind(null, tableKey, key);
+    };
+
+    for (let i = 0; i < iterable.length; i++) {
+      const key = iterable[i];
+      const keyObj = keys[key];
+      let headerOnClick;
+      let headerClass = (sorting && sorting.key) === key ? sortClass : '';
+      let tooltip;
+      headerClass += keyObj.desktop_only ? ' desktop-only-tc' : '';
+      if ((sortable !== false) && (keyObj.sortable !== false)) {
+        headerClass += ' sortable';
+        headerOnClick = sortByFunction(table_key, key);
+      }
+      if (keyObj.info_key) {
+        headerClass += ' tooltip-trigger';
+        tooltip = [(
+          <div key="tt" className="tooltip dark">
+            <p>{I18n.t(keyObj.info_key)}</p>
+          </div>
+        ), (
+          <span key="ttindicator" className="tooltip-indicator" />
+        )];
+      }
+      headers.push((
+        <th onClick={headerOnClick} className={headerClass} key={key}>
+          <span dangerouslySetInnerHTML={{ __html: keyObj.label }} />
+          <span className="sortable-indicator" />
+          {tooltip}
+        </th>
+      ));
     }
-    elements = (
-      <tr className="disabled">
-        <td colSpan={headers.length + 1} className="text-center">
-          {emptyMessage}
-        </td>
-      </tr>
+
+    // eslint-disable-next-line
+    let defaultClassName = `${table_key} table `;
+
+    if (className) { defaultClassName += className; }
+
+    if (sortable) { defaultClassName += ' table--sortable'; }
+
+    // Handle the case of no elements:
+    // Show a none message if data is already loaded, or
+    // show the Loading spinner if data is not yet loaded.
+    if (elements.length === 0) {
+      let emptyMessage;
+      if (store && store.isLoaded() || !loading) {
+        // eslint-disable-next-line
+        let noneMessage = none_message;
+        if (typeof noneMessage === 'undefined' || noneMessage === null) {
+          // eslint-disable-next-line
+          noneMessage = I18n.t(`${table_key}.none`);
+        }
+        emptyMessage = <span>{noneMessage}</span>;
+      } else {
+        emptyMessage = <Loading />;
+      }
+      elements = (
+        <tr className="disabled">
+          <td colSpan={headers.length + 1} className="text-center">
+            {emptyMessage}
+          </td>
+        </tr>
+      );
+    }
+    let fixedArea;
+    let fixedHeader;
+    if (stickyHeader) {
+      fixedArea = "persist-area";
+      fixedHeader = "persist-header";
+    }
+    return (
+      <div className={fixedArea}>
+        <table className={defaultClassName}>
+          <thead className={fixedHeader}>
+            <tr>
+              {headers}
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {elements}
+          </tbody>
+        </table>
+      </div>
     );
   }
-
-  return (
-    <table className={defaultClassName}>
-      <thead>
-        <tr>
-          {headers}
-          <th />
-        </tr>
-      </thead>
-      <tbody>
-        {elements}
-      </tbody>
-    </table>
-  );
-};
-
-List.propTypes = {
-  store: PropTypes.object,
-  keys: PropTypes.object,
-  sortable: PropTypes.bool,
-  table_key: PropTypes.string,
-  className: PropTypes.string,
-  elements: PropTypes.node,
-  none_message: PropTypes.string
-};
+});
 
 export default List;

--- a/app/assets/javascripts/components/common/list.jsx
+++ b/app/assets/javascripts/components/common/list.jsx
@@ -47,7 +47,7 @@ const List = createReactClass({
         }
         const offset = persistAreaElement.offsetTop;
         const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
-        if (!fixHeader && scrollTop > offset && scrollTop < offset + persistAreaElement.clientHeight) {
+        if (!fixHeader && scrollTop >= offset && scrollTop < offset + persistAreaElement.clientHeight) {
           this.setState({ fixHeader: true });
         }
         if (fixHeader && scrollTop >= offset && scrollTop > offset + persistAreaElement.clientHeight) {

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -54,6 +54,7 @@ const DiffViewer = createReactClass({
 
   showDiff() {
     this.setState({ showDiff: true });
+    $('.floatingHeader').css({ opacity: 0 });
     if (!this.props.editors) {
       this.props.fetchArticleDetails();
     } else if (!this.state.fetched) {
@@ -63,6 +64,7 @@ const DiffViewer = createReactClass({
 
   hideDiff() {
     this.setState({ showDiff: false });
+    $('.floatingHeader').css({ opacity: 1 });
   },
 
   handleClickOutside() {

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -54,7 +54,6 @@ const DiffViewer = createReactClass({
 
   showDiff() {
     this.setState({ showDiff: true });
-    $('.floatingHeader').css({ opacity: 0 });
     if (!this.props.editors) {
       this.props.fetchArticleDetails();
     } else if (!this.state.fetched) {
@@ -64,7 +63,6 @@ const DiffViewer = createReactClass({
 
   hideDiff() {
     this.setState({ showDiff: false });
-    $('.floatingHeader').css({ opacity: 1 });
   },
 
   handleClickOutside() {

--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -163,6 +163,7 @@ const StudentList = createReactClass({
           none_message={CourseUtils.i18n('students_none', this.props.course.string_prefix)}
           editable={this.props.editable}
           sortBy={this.props.sortUsers}
+          stickyHeader={true}
         />
       </div>
     );

--- a/app/assets/stylesheets/modules/_diff_viewer.styl
+++ b/app/assets/stylesheets/modules/_diff_viewer.styl
@@ -2,7 +2,7 @@
   background-color white
   padding 0 10px
   position fixed
-  top 70px
+  top 160px
   /*@noflip*/ left 50%
   width 100%
   max-width 1200px

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -1,3 +1,32 @@
+.floatingHeader
+  position fixed
+  top 50px
+  visibility hidden
+  background-color white
+  z-index 2
+  border-bottom 1px solid lightgray
+
+  tr
+    width inherit
+
+    th
+      width inherit
+
+      &:first-child
+        span:first-of-type
+          padding-right 95px
+
+      &:nth-child(3)
+        padding-right 0px
+        padding-left 19px
+
+      &:nth-child(4)
+        padding-right 0px
+
+      &:last-child
+        padding unset
+
+
 .table
   width 100%
   border-collapse separate

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -1,7 +1,6 @@
 .floatingHeader
   position fixed
   top 50px
-  visibility hidden
   background-color white
   z-index 2
   border-bottom 1px solid lightgray

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -1,30 +1,21 @@
-.floatingHeader
-  position fixed
-  top 50px
-  background-color white
-  z-index 2
-  border-bottom 1px solid lightgray
+.persist-area
+  tbody
+    tr
+      td
+        width 20%
 
-  tr
-    width inherit
+  .floatingHeader
+    position fixed
+    top 50px
+    background-color white
+    z-index 2
+    border-bottom 1px solid lightgray
 
-    th
+    tr
       width inherit
 
-      &:first-child
-        span:first-of-type
-          padding-right 75px
-
-      &:nth-child(3)
-        padding-right 0px
-        padding-left 19px
-
-      &:nth-child(4)
-        padding-right 0px
-
-      &:last-child
-        padding unset
-
+      th
+        width 20%
 
 .table
   width 100%

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -14,7 +14,7 @@
 
       &:first-child
         span:first-of-type
-          padding-right 95px
+          padding-right 75px
 
       &:nth-child(3)
         padding-right 0px

--- a/test/components/settings/admin_user_list.spec.jsx
+++ b/test/components/settings/admin_user_list.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import { render } from 'enzyme';
 
 import '../../testHelper';
 import AdminUserList from '../../../app/assets/javascripts/components/settings/admin_users_list.jsx';
@@ -7,30 +8,12 @@ import AdminUserList from '../../../app/assets/javascripts/components/settings/a
 describe('AdminUserList', () => {
   it('renders a List component with correct elements', () => {
     const expectedAdminUsers = [{ id: 1, username: 'testUser', real_name: 'real name', permissions: 3 }];
-    const wrapper = shallow(<AdminUserList adminUsers={expectedAdminUsers} />);
+    const renderedList = render(
+      <Provider store={reduxStore}>
+        <AdminUserList adminUsers={expectedAdminUsers} />
+      </Provider>
+    );
 
-    const renderedUsers = wrapper
-      .find('List')
-      .first()
-      .props()
-      .elements.map((elem) => {
-      return elem.props.user;
-    });
-
-    expect(renderedUsers).to.eql(expectedAdminUsers);
-  });
-
-  it('renders the correct empty message', () => {
-    const expectedAdminUsers = [];
-    const wrapper = shallow(<AdminUserList adminUsers={expectedAdminUsers} />);
-    const list = wrapper.find('List').first();
-    const renderedUsers = list
-      .props()
-      .elements.map((elem) => {
-        return elem.props.user;
-      });
-
-    expect(renderedUsers).to.eql([]);
-    expect(list.props().none_message).to.equal('no admin users');
+    expect(renderedList.find('td.user__username').text()).to.eq('testUser');
   });
 });


### PR DESCRIPTION
The header of the page sticks to the top when the user scrolls down -- to help them understand the information being displayed. Fixes #1469

- Added a StickyHeader bool PropType to List Component which can be set to true if this functionality is required.

[
![stickyheader](https://user-images.githubusercontent.com/14351471/37730937-e5e78cd2-2d66-11e8-89a5-6694302f82ca.png)
](url)