### PR TITLE
Add initial Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Dockerfile
+#
+# Build and Run:
+#   - docker build -t wiki-edu-dashboard .
+#   - docker run --net=host -it wiki-edu-dashboard
+
+FROM ruby:2.5
+
+WORKDIR /usr/src/app
+
+# Setup repos
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# Install deps
+RUN apt update
+RUN apt install -y nodejs r-base gnupg yarn pandoc redis-server mariadb-server libmariadbclient-dev
+
+# Install gems
+RUN bundle config --global frozen 1
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# App setup and configurations
+RUN yarn global add phantomjs-prebuilt
+COPY config/application.example.yml ./config/application.yml
+COPY config/database.example.yml ./config/database.yml
+COPY entrypoint.sh ./entrypoint.sh
+COPY . .
+RUN yarn && yarn global add gulp
+
+EXPOSE 3000
+
+# Setup and run
+CMD './entrypoint.sh'
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #   - docker build -t wiki-edu-dashboard .
 #   - docker run --net=host -it wiki-edu-dashboard
 
-FROM ruby:2.5
+FROM ruby:2.5.0
 
 WORKDIR /usr/src/app
 
@@ -27,8 +27,12 @@ RUN yarn global add phantomjs-prebuilt
 COPY config/application.example.yml ./config/application.yml
 COPY config/database.example.yml ./config/database.yml
 COPY entrypoint.sh ./entrypoint.sh
+COPY db_init.sh ./db_init.sh
 COPY . .
 RUN yarn && yarn global add gulp
+
+# Setup and initialize DBs
+RUN ./db_init.sh
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This project welcomes contributions, and we try to be as newbie-friendly as poss
 ### Setup
 - [Dashboard Setup](docs/setup.md)
 - [Using the Dashboard in development](docs/user_roles.md)
+- [Using Docker for development](docs/docker.md)
 - [OAuth Setup](docs/oauth.md)
 - [Troubleshooting](docs/troubleshooting.md)
 

--- a/db_init.sh
+++ b/db_init.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script initializes the DB by creating users, granting privileges
+# and migrating the dev and test DBs in order to persist the DB in the 
+# container image itself
+
+set -e
+set -x
+
+# Start mariadb server
+service mysql start
+sleep 5
+
+# Init DBs
+echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      exit" | mysql && printf "$\n[DATABSE CREATED]\n"
+
+echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
+      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
+      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
+      exit" | mysql > /dev/null && printf "\n[USER CREATED]\n"
+
+# Migrate dev and test DBs
+rake db:migrate
+rake db:migrate RAILS_ENV=test
+
+service mysql stop

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,57 @@
+# Docker Setup
+
+This document outlines how you can setup a containerized testing/development environment quickly using docker. Using a containerized dashboard image allows for a faster and reproducible test setup. We first have to build the Docker image and then run the container. 
+
+### TL;DR
+```sh
+$ docker build -t wiki-edu-dashboard .
+$ docker run --net=host -it -v /path/to/WikiEduDashboard:/usr/src/app wiki-edu-dashboard
+```
+
+## Build Docker Image
+
+Make sure the docker daemon is running. Else, `service docker status`. Then, from the root of your development directory (`WikiEduDashboard`), issue the build command:
+ ```sh
+ $ docker build -t wiki-edu-dashboard .
+ ```
+ This builds the `wiki-edu-dashboard` container image using the Dockerfile. The dashboard container image is based on the official `ruby:2.5.0` [base image](https://hub.docker.com/_/ruby/). The container image contains all the necessary dependencies as well as an initialized MariaDB database as required by the Wiki Edu Dashboard. 
+
+## Run
+The current docker image can be used for testing, local deploys or development purposes. `docker run` initializes the setup and spawns a container which starts serving the dashboard on `http://localhost:3000`. Do note that the following setup uses [Docker host networking](https://docs.docker.com/network/network-tutorial-host/) which is currently only supported on Linux. Also, this requires port `3000` to be open on the host.
+
+### Development Setup
+For a developer's ease of use, it is desirable to have the container auto update as the source code changes in the development directory. Therefore, we use Docker volumes to mount the local directory and have its real-time changes accessible inside the container. Run the container with the `-v` option as follows:
+ ```sh
+ $ docker run --net=host -it -v /path/to/WikiEduDashboard:/usr/src/app wiki-edu-dashboard
+```
+This starts the container with host networking and allows `/path/to/WikiEduDashboard` (developer's working directory) to be accessible from the `WORKDIR` of container. For WikiEduDashboard Docker image, the working directory has been set as `/usr/src/app`. Once the container starts, you should start expecting the following prompts and `gulp` to have started with its status messages waiting for live changes.
+```
+[ ok ] Starting MariaDB database server: mysqld ..
++ sleep 5
++ redis-server --daemonize yes
++ sleep 10
++ rails s -d
+=> Booting WEBrick
+=> Rails 5.1.6 application starting in development on http://localhost:3000
+=> Run `rails server -h` for more startup options
+..
+```
+At this point, developers can continue working in their local work directories and the changes would be reflected inside the container. Live changes are visible on `http://localhost:3000` from the host.
+
+### Testing Deployment
+The above container can also be spawned without the need of volumes, thus freezing the code in the container to be the same as latest image built using `docker build`. Developers can also tag multiple container image builds using `docker build -t name:tag .` To deploy a test build:
+
+```sh
+$ docker run --net=host -it wiki-edu-dashboard
+```
+
+Open a browser on the host at `http://localhost:3000` and start testing.
+
+## Monitoring the Dashboard Container
+Some useful commands and tools that can be used to monitor and administer the containers are:
+  * [`ctop`](https://github.com/bcicen/ctop)
+  * `docker images`
+  * `docker inspect <container id>`
+
+Further Reference: https://docs.docker.com/reference/
+

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,4 +1,14 @@
 [Back to README](../README.md)
+# Dockerized Setup
+We have a Dockerfile which allows building and running the application easily with minimal setup. Only requirements are a slight familiarity with Docker.
+Make sure the Docker daemon is up and running then proceed as follows:
+
+Build and run the dashboard:
+- `$ docker build -t wiki-edu-dashboard .`
+- `$ docker run --net=host -it wiki-edu-dashboard`
+
+Open a browser and the dashboard should be accessible now at http://localhost:3000
+
 # Script Setup
 We have a script to automate the process of setting up your developmental environment. Right now, it supports Debian-based systems(Debian, Ubuntu etc.) and MacOS.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,14 +1,4 @@
 [Back to README](../README.md)
-# Dockerized Setup
-We have a Dockerfile which allows building and running the application easily with minimal setup. Only requirements are a slight familiarity with Docker.
-Make sure the Docker daemon is up and running then proceed as follows:
-
-Build and run the dashboard:
-- `$ docker build -t wiki-edu-dashboard .`
-- `$ docker run --net=host -it wiki-edu-dashboard`
-
-Open a browser and the dashboard should be accessible now at http://localhost:3000
-
 # Script Setup
 We have a script to automate the process of setting up your developmental environment. Right now, it supports Debian-based systems(Debian, Ubuntu etc.) and MacOS.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,31 +1,15 @@
 #!/bin/bash
 
-# This is the entrypoint for the container which initializes the DB and starts
-# the dashbaord on 3000. Use docker host networking "--net=host" and access the 
-# application from host as http://localhost:3000
+# This is the entrypoint for the container which starts the dashbaord. 
+# Use docker host networking (--net=host) and access the application from 
+# host as http://localhost:3000
 
 set -e
 set -x
 
-# Start mariadb server
+# Start dashboard
 service mysql start
 sleep 5
-
-# Init DBs
-echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      exit" | mysql && printf "$\n[DATABSE CREATED]\n"
-
-echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
-      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
-      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
-      exit" | mysql > /dev/null && printf "\n[USER CREATED]\n"
-
-# Migrate dev and test DBs
-rake db:migrate
-rake db:migrate RAILS_ENV=test
-
-# Start dashboard
 redis-server --daemonize yes
 sleep 10
 rails s -d

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This is the entrypoint for the container which initializes the DB and starts
+# the dashbaord on 3000. Use docker host networking "--net=host" and access the 
+# application from host as http://localhost:3000
+
+set -e
+set -x
+
+# Start mariadb server
+service mysql start
+sleep 5
+
+# Init DBs
+echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      exit" | mysql && printf "$\n[DATABSE CREATED]\n"
+
+echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
+      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
+      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
+      exit" | mysql > /dev/null && printf "\n[USER CREATED]\n"
+
+# Migrate dev and test DBs
+rake db:migrate
+rake db:migrate RAILS_ENV=test
+
+# Start dashboard
+redis-server --daemonize yes
+sleep 10
+rails s -d
+sleep 10
+gulp


### PR DESCRIPTION
Fixes #1787

This sets ground for using a containerized image for build/test an deploy. Currently this is a single image containing the DB as well as the complete application, but there can be options to separate the logic for flexible deployments using `docker-composer`. Apart from Docker volumens could also be used eventually and if the maintainers wish, we could publish a prebuilt image to Docker Hub or Docker Store from the official WikiEduDashboard org! 

As a reference for now, a prebuilt working WikiEdu dashboard image is at my own repo : https://hub.docker.com/r/tuxology/wiki-edu-dashboard/

To test run the pre-built image, 
```
$ docker pull tuxology/wiki-edu-dashboard
$ docker run --net=host -it tuxology/wiki-edu-dashboard
```

To build and run your own image,

```
$ docker build -t wiki-edu-dashboard .
$ docker run --net=host -it wiki-edu-dashboard
```