### PR TITLE
Fix #1856 Campaign Alert Table Not Showing under Mobile Layout

### DIFF
--- a/app/assets/javascripts/components/alerts/alert.jsx
+++ b/app/assets/javascripts/components/alerts/alert.jsx
@@ -6,7 +6,7 @@ const Alert = ({ alert }) => {
   return (
     <tr className="alert">
       <td className="desktop-only-tc date">{moment(alert.created_at).format('YYYY-MM-DD   h:mm A')}</td>
-      <td className="desktop-only-tc">{alert.type}</td>
+      <td className="alert-type">{alert.type}</td>
       <td className="desktop-only-tc"><a target="_blank" href={`/courses/${alert.course_slug}`}>{alert.course}</a></td>
       <td className="desktop-only-tc"><a target="_blank" href={`/users/${alert.user}`}>{alert.user}</a></td>
       <td><a target="_blank" href={alert.article_url}>{alert.article}</a></td>

--- a/app/assets/javascripts/components/alerts/alert.jsx
+++ b/app/assets/javascripts/components/alerts/alert.jsx
@@ -9,7 +9,7 @@ const Alert = ({ alert }) => {
       <td className="desktop-only-tc">{alert.type}</td>
       <td className="desktop-only-tc"><a target="_blank" href={`/courses/${alert.course_slug}`}>{alert.course}</a></td>
       <td className="desktop-only-tc"><a target="_blank" href={`/users/${alert.user}`}>{alert.user}</a></td>
-      <td className="desktop-only-tc"><a target="_blank" href={alert.article_url}>{alert.article}</a></td>
+      <td><a target="_blank" href={alert.article_url}>{alert.article}</a></td>
     </tr>
   );
 };

--- a/app/assets/javascripts/components/alerts/alerts_list.jsx
+++ b/app/assets/javascripts/components/alerts/alerts_list.jsx
@@ -15,7 +15,6 @@ const AlertsList = ({ alerts, sortBy }) => {
     },
     type: {
       label: I18n.t('campaign.alert_type'),
-      desktop_only: true
     },
     course: {
       label: I18n.t('campaign.course'),

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -39,6 +39,10 @@
         &:last-child
           border-right 1px solid #ddd
 
+        @media only screen and (max-width: 919px)
+          &.alert-type
+            border-left 1px solid #ddd
+
       // Table cell with links
       .table-link-cell
         padding 0px 0px


### PR DESCRIPTION
Fix [#1856](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1856)

**The bug**

The article column in alert table has a `desktop-only-tc` class, which hides the whole column under mobile layout.

Since article column should be the only thing alert tables shows under mobile layout, that class makes the table looks like 'totally disappeared' when switches to mobile layout.

**What I did**

* Remove the problematic `desktop-only-tc` class of article column.
* Also add right border to that column under mobile layout.

**Result of fix (viewport width < 920px)**

<img width="1280" alt="screen shot 2018-04-24 at 9 53 28 pm" src="https://user-images.githubusercontent.com/13805499/39191671-0611279e-480a-11e8-9661-bd30f1094706.png">

Let me know if there is any problem with this PR. Thanks for reviewing!
