### PR TITLE
fix dependencies

### DIFF
--- a/lib/commons.rb
+++ b/lib/commons.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'mediawiki_api'
 require 'json'
+require_dependency "#{Rails.root}/lib/wiki_api"
 
 #= This class is for getting data directly from the Wikimedia Commons API.
 class Commons


### PR DESCRIPTION
Rails console showed `NameError: uninitialized constant Commons::WikiApi` while trying to fetch uploads from users through ` UploadImporter.import_all_uploads(User.where(username: <username>))
`