### PR TITLE
[WIP] Add spinner animation to course overview dashboard

### DIFF
--- a/app/assets/javascripts/components/overview/course_stats.jsx
+++ b/app/assets/javascripts/components/overview/course_stats.jsx
@@ -6,20 +6,28 @@ const CourseStats = ({ course }) => {
   let viewData;
   let infoImg;
   let trainedTooltip;
-
   let contentCount;
+
   if (course.home_wiki.language === 'en') {
     contentCount = (
       <div className="stat-display__stat" id="word-count">
-        <div className="stat-display__value">{course.word_count}</div>
+        <div className="stat-display__value" id="word-count__value">{course.word_count}</div>
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
+        </div>
         <small>{I18n.t('metrics.word_count')}</small>
       </div>
     );
   } else {
     contentCount = (
       <div className="stat-display__stat" id="bytes-added">
-        <div className="stat-display__value">{course.character_sum}</div>
-        <small>{I18n.t('metrics.bytes_added')}</small>
+        <div className="stat-display__value hide" id="bytes-added__value">{course.character_sum}</div>
+        <div className="spinner">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
+        </div>
+        <small className="hide">{I18n.t('metrics.bytes_added')}</small>
       </div>
     );
   }
@@ -27,6 +35,7 @@ const CourseStats = ({ course }) => {
   if (course.upload_usages_count === undefined) {
     return <div className="stat-display" />;
   }
+
   if (course.view_count === '0' && course.edited_count !== '0') {
     viewData = (
       <div className="stat-display__data">
@@ -35,11 +44,12 @@ const CourseStats = ({ course }) => {
     );
   } else {
     viewData = (
-      <div className="stat-display__value">
+      <div className="stat-display__value" id="view-data__value">
         {course.view_count}
       </div>
     );
   }
+
   if (course.timeline_enabled) {
     infoImg = (
       <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
@@ -54,35 +64,66 @@ const CourseStats = ({ course }) => {
 
   return (
     <div className="stat-display">
+
       <div className="stat-display__stat" id="articles-created">
-        <div className="stat-display__value">{course.created_count}</div>
+        <div className="stat-display__value" id="articles-created__value">{course.created_count}</div>
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
+        </div>
         <small>{I18n.t('metrics.articles_created')}</small>
       </div>
+
       <div className="stat-display__stat" id="articles-edited">
-        <div className="stat-display__value">{course.edited_count}</div>
-        <small>{I18n.t('metrics.articles_edited')}</small>
+        <div className="stat-display__value" id="articles-edited__value">{course.edited_count}</div>
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
+        </div>
+        <small>{I18n.t('metrics.articles_created')}</small>
       </div>
+
       <div className="stat-display__stat" id="total-edits">
-        <div className="stat-display__value">{course.edit_count}</div>
-        <small>{I18n.t('metrics.edit_count_description')}</small>
+        <div className="stat-display__value" id="total-edits__value">{course.edit_count}</div>
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
+        </div>
+        <small>{I18n.t('metrics.articles_created')}</small>
       </div>
+
       <div className="stat-display__stat tooltip-trigger" id="student-editors">
-        <div className="stat-display__value">
+        <div className="stat-display__value" id="student-editors__value">
           {course.student_count}
           {infoImg}
+        </div>
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
         </div>
         <small>{CourseUtils.i18n('student_editors', course.string_prefix)}</small>
         {trainedTooltip}
       </div>
+
       {contentCount}
+
       <div className="stat-display__stat" id="view-count">
         {viewData}
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
+        </div>
         <small>{I18n.t('metrics.view_count_description')}</small>
       </div>
+
       <div className="stat-display__stat tooltip-trigger" id="upload-count">
-        <div className="stat-display__value">
+        <div className="stat-display__value" id="upload-count__value">
           {course.upload_count}
           <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
+        </div>
+        <div className="spinner hide">
+          <div className="double-bounce1"><p /></div>
+          <div className="double-bounce2"><p /></div>
         </div>
         <small>{I18n.t('metrics.upload_count')}</small>
         <div className="tooltip dark" id="upload-usage">
@@ -92,6 +133,7 @@ const CourseStats = ({ course }) => {
           <p>{I18n.t('metrics.upload_usages_count', { count: course.upload_usages_count })}</p>
         </div>
       </div>
+
     </div>
   );
 };

--- a/app/assets/javascripts/statsUpdate.js
+++ b/app/assets/javascripts/statsUpdate.js
@@ -1,0 +1,21 @@
+
+//watch data change on stats overview
+//load spineer for 2 sec before showing data
+$('.stat-display__value').each(function () {
+    target = this;
+
+    observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        const id = mutation.target.id;
+        const parent = $(`#${id}`).closest('.stat-display__stat').attr('id');
+        $(`#${id}`).addClass('hide');
+        $(`#${parent} .spinner`).removeClass('hide');
+        setTimeout(() => {
+          $(`#${id}`).removeClass('hide');
+          $(`#${parent} .spinner`).addClass('hide');
+        }, 2000);
+      });
+    });
+
+    observer.observe(target, { childList: true, characterData: true, subtree: true });
+  });

--- a/app/assets/stylesheets/modules/_stats.styl
+++ b/app/assets/stylesheets/modules/_stats.styl
@@ -15,6 +15,8 @@
     margin 0 20px 20px 20px
     text-align center
     width calc(50% - 40px)
+    display flex
+    flex-direction column
 
     +above(desktop)
       margin 0 0 20px 0
@@ -44,6 +46,8 @@
       color #666
       font-size 1em
       line-height 1
+      align-self flex-end
+      margin auto
 
   .tooltip
     left -15%
@@ -64,6 +68,47 @@
 
       .stat-display__stat
         margin 0 20px 0 20px
+
+.hide
+  display none
+
+.spinner
+  margin auto
+  width 50px
+  height 50px
+  position relative
+
+.double-bounce1, .double-bounce2
+  width 100%
+  height 100%
+  border-radius 50%
+  background-color rgba(107, 102, 182, 0.8)
+  opacity 0.6
+  position absolute
+  top 0
+  left 0
+  -webkit-animation sk-bounce 2.0s infinite ease-in-out
+  animation sk-bounce 2.0s infinite ease-in-out
+
+.double-bounce2
+  -webkit-animation-delay -1.0s
+  animation-delay -1.0s
+
+@-webkit-keyframes sk-bounce {
+  0%, 100% { -webkit-transform: scale(0.0) }
+  50% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes sk-bounce {
+  0%, 100% {
+    transform: scale(0.0);
+    -webkit-transform: scale(0.0);
+  } 50% {
+    transform: scale(1.0);
+    -webkit-transform: scale(1.0);
+  }
+}
+
 
 @media only screen and (max-width: 910px)
   .stat-display


### PR DESCRIPTION
Fixes for #1853

The animation is added to the course dashboard. To watch the data change on the DOM, `statsUpdate.js` file needs to add to the template. Not sure how to do it yet, looks like a gulp + webpack task, any pointer is appreciated.

The same feature can be added to the campaign dashboard too once it's done on the course page. 