### PR TITLE
replace pageviews api with more powerful mediawiki pageviews API

### DIFF
--- a/app/assets/javascripts/reducers/article_finder.js
+++ b/app/assets/javascripts/reducers/article_finder.js
@@ -29,7 +29,13 @@ export default function articleFinder(state = initialState, action) {
       return newState;
     }
     case SORT_ARTICLE_FINDER: {
-      const newArticles = sortByKey(Object.values(state.articles), action.key, state.sortKey);
+      let newArticles;
+      if (action.initial) {
+        newArticles = sortByKey(Object.values(state.articles), action.key, null, true);
+      }
+      else {
+        newArticles = sortByKey(Object.values(state.articles), action.key, state.sortKey);
+      }
       const newArticlesObject = {};
       newArticles.newModels.forEach((article) => {
         newArticlesObject[article.title] = article;
@@ -102,11 +108,11 @@ export default function articleFinder(state = initialState, action) {
     }
     case RECEIVE_ARTICLE_PAGEVIEWS: {
       const newStateArticles = _.cloneDeep(state.articles);
-      const title = action.data[0].article.replace(/_/g, ' ');
-      const averagePageviews = Math.round((_.sumBy(action.data, (o) => { return o.views; }) / action.data.length) * 100) / 100;
-
-      newStateArticles[title].pageviews = averagePageviews;
-      newStateArticles[title].fetchState = "PAGEVIEWS_RECEIVED";
+      _.forEach(action.data, (article) => {
+        const averagePageviews = Math.round((_.reduce(article.pageviews, (result, value) => { return result + value; }, 0) / Object.values(article.pageviews).length) * 100) / 100;
+        newStateArticles[article.title].pageviews = averagePageviews;
+        newStateArticles[article.title].fetchState = "PAGEVIEWS_RECEIVED";
+      });
 
       return {
         ...state,

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -85,33 +85,6 @@ export const getFilteredAlerts = createSelector(
   }
 );
 
-export const getFilteredArticleFinderByQuality = createSelector(
-  [getArticleFinderState], (articleFinder) => {
-    return _.pickBy(articleFinder.articles, (article) => {
-      let quality = article.revScore;
-      if (article.grade) {
-        quality = Math.max(article.revScore, WP10Weights[article.grade]);
-      }
-      const qualityFilter = articleFinder.article_quality;
-      if (article.fetchState === "REVISIONSCORE_RECEIVED" && quality <= qualityFilter) {
-        return true;
-      }
-      return false;
-    });
-  }
-);
-
-export const getFilteredArticleFinderByViews = createSelector(
-  [getArticleFinderState], (articleFinder) => {
-    return _.pickBy(articleFinder.articles, (article) => {
-      if (article.fetchState === "PAGEVIEWS_RECEIVED" && article.pageviews >= articleFinder.min_views) {
-        return true;
-      }
-      return false;
-    });
-  }
-);
-
 export const getFilteredArticleFinder = createSelector(
   [getArticleFinderState], (articleFinder) => {
     return _.pickBy(articleFinder.articles, (article) => {

--- a/app/assets/javascripts/utils/article_finder_utils.js
+++ b/app/assets/javascripts/utils/article_finder_utils.js
@@ -1,7 +1,5 @@
 import logErrorMessage from './log_error_message';
 
-const pageviewBaseUrl = 'https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/';
-
 export const queryUrl = (url, query = {}, dataType = 'jsonp') => {
   return new Promise((res, rej) => {
     return $.ajax({
@@ -72,25 +70,11 @@ export const keywordQueryGenerator = (keyword, offset) => {
   };
 };
 
-const formatDate = (date) => {
-  const year = date.getUTCFullYear();
-  let month = date.getUTCMonth() + 1;
-  if (month < 10) {
-    month = `0${month}`;
-  }
-  let day = date.getUTCDate();
-  if (day < 10) {
-    day = `0${day}`;
-  }
-  return `${year}${month}${day}`;
-};
-
-export const pageviewQueryGenerator = (title) => {
-  const startDateString = formatDate(new Date(new Date() - 50 * 24 * 60 * 60 * 1000));
-  const endDateString = formatDate(new Date(new Date() - 1 * 24 * 60 * 60 * 1000));
-  title = title.replace(/ /g, '_');
-  const queryParams = `${title}/daily/${startDateString}00/${endDateString}00`;
-  return pageviewBaseUrl + queryParams;
+export const pageviewQueryGenerator = (pageids) => {
+  return {
+    prop: 'pageviews',
+    pageids: multipleQueryGenerator(pageids)
+  };
 };
 
 export const extractClassGrade = (pageAssessments) => {


### PR DESCRIPTION
- Replace the Pageviews API
- Add default sorting via action in batches of 50
- remove intermediate selectors which are no longer required