### PR TITLE
Send emails to students to who are overdue on trainings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,8 @@ Style/ParallelAssignment:
   Enabled: false # We generally use this only to initialize empty variables.
 Style/RedundantReturn:
   Enabled: false # Sometimes a redundant return enhances clarity.
+Style/SymbolArray:
+  Enabled: false # Rare syntax that is potentially confusing to newcomers.
 Naming/VariableNumber:
   Enabled: false # Not very helpful, and conflicts with wp10-related names
 Rails/Blank:
@@ -85,7 +87,9 @@ Naming/UncommunicativeMethodParamName:
 # Temporary exceptions #
 ########################
 
-# These should be enabled once violations are fixed.
+# These should be enabled once violations are fixed,
+# or they should be moved to the 'Permanent' section
+# if we decide they shouldn't be fixed.
 
 Style/FormatStringToken:
   Enabled: false

--- a/app/mailers/overdue_training_alert_mailer.rb
+++ b/app/mailers/overdue_training_alert_mailer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/training_module"
+
+class OverdueTrainingAlertMailer < ApplicationMailer
+  def email(alert)
+    return unless Features.email?
+    @alert = alert
+    user_email = @alert.user.email
+    return if user_email.blank?
+
+    params = { to: user_email,
+               subject: @alert.main_subject }
+    params[:reply_to] = @alert.reply_to unless @alert.reply_to.nil?
+    mail(params)
+  end
+end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -44,6 +44,7 @@ class Alert < ApplicationRecord
     NeedHelpAlert
     NoEnrolledStudentsAlert
     OnboardingAlert
+    OverdueTrainingAlert
     ProductiveCourseAlert
     SurveyResponseAlert
     UnsubmittedCourseAlert
@@ -141,6 +142,10 @@ class Alert < ApplicationRecord
 
   def resolvable?
     false
+  end
+
+  def opt_out_link
+    nil
   end
 
   def resolve_explanation

--- a/app/models/article_scoped_program.rb
+++ b/app/models/article_scoped_program.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/models/articles_courses.rb
+++ b/app/models/articles_courses.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: articles_courses
@@ -9,7 +8,7 @@
 #  updated_at    :datetime
 #  article_id    :integer
 #  course_id     :integer
-#  view_count    :integer          default(0)
+#  view_count    :bigint(8)        default(0)
 #  character_sum :integer          default(0)
 #  new_article   :boolean          default(FALSE)
 #

--- a/app/models/assignment_suggestion.rb
+++ b/app/models/assignment_suggestion.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: assignment_suggestions
 #
-#  id            :integer          not null, primary key
+#  id            :bigint(8)        not null, primary key
 #  text          :text(65535)
-#  assignment_id :integer
+#  assignment_id :bigint(8)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  user_id       :integer

--- a/app/models/basic_course.rb
+++ b/app/models/basic_course.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -17,6 +17,7 @@ require 'csv'
 #  template_description :text(65535)
 #  default_course_type  :string(255)
 #  default_passcode     :string(255)
+#  register_accounts    :boolean          default(FALSE)
 #
 
 #= Campaign model

--- a/app/models/categories_courses.rb
+++ b/app/models/categories_courses.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: categories_courses
 #
-#  id          :integer          not null, primary key
+#  id          :bigint(8)        not null, primary key
 #  category_id :integer
 #  course_id   :integer
 #  created_at  :datetime         not null

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,7 +3,7 @@
 #
 # Table name: categories
 #
-#  id             :integer          not null, primary key
+#  id             :bigint(8)        not null, primary key
 #  wiki_id        :integer
 #  article_titles :text(16777215)
 #  name           :string(255)

--- a/app/models/classroom_program_course.rb
+++ b/app/models/classroom_program_course.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/models/editathon.rb
+++ b/app/models/editathon.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/models/legacy_course.rb
+++ b/app/models/legacy_course.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/models/overdue_training_alert.rb
+++ b/app/models/overdue_training_alert.rb
@@ -22,6 +22,8 @@
 
 # Alert for when a student has an assigned training that is overdue
 class OverdueTrainingAlert < Alert
+  MINIMUM_DAYS_BETWEEN_ALERTS = 10
+
   def main_subject
     "Overdue training module for #{course.slug}"
   end
@@ -37,8 +39,7 @@ class OverdueTrainingAlert < Alert
   def send_email
     return if emails_disabled?
     return if opted_out?
-    OverdueTrainingAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    OverdueTrainingAlertMailer.send_email(self)
   end
 
   private

--- a/app/models/overdue_training_alert.rb
+++ b/app/models/overdue_training_alert.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id             :integer          not null, primary key
+#  course_id      :integer
+#  user_id        :integer
+#  article_id     :integer
+#  revision_id    :integer
+#  type           :string(255)
+#  email_sent_at  :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  message        :text(65535)
+#  target_user_id :integer
+#  subject_id     :integer
+#  resolved       :boolean          default(FALSE)
+#  details        :text(65535)
+#
+
+# Alert for when a student has an assigned training that is overdue
+class OverdueTrainingAlert < Alert
+  def main_subject
+    "#{user.username} / #{course.slug}"
+  end
+
+  def url
+    "https://#{ENV['dashboard_url']}/training/students/#{training_module_slug}"
+  end
+
+  def opt_out_link
+    "https://#{ENV['dashboard_url']}/update_email_preferences/#{user.username}#{opt_out_params}"
+  end
+
+  def send_email
+    return if emails_disabled?
+    return if opted_out?
+    # send
+  end
+
+  private
+
+  def opted_out?
+    user_profile.email_allowed?('OverdueTrainingAlert')
+  end
+
+  def opt_out_params
+    "?type=OverdueTrainingAlert&token=#{user_profile.email_preferences_token}"
+  end
+
+  def user_profile
+    user.user_profile || user.create_user_profile
+  end
+
+  def training_module_slug
+    details[:training_module_slug]
+  end
+end

--- a/app/models/overdue_training_alert.rb
+++ b/app/models/overdue_training_alert.rb
@@ -23,11 +23,11 @@
 # Alert for when a student has an assigned training that is overdue
 class OverdueTrainingAlert < Alert
   def main_subject
-    "#{user.username} / #{course.slug}"
+    "Overdue training module for #{course.slug}"
   end
 
   def url
-    "https://#{ENV['dashboard_url']}/training/students/#{training_module_slug}"
+    "https://#{ENV['dashboard_url']}/courses/#{course.slug}"
   end
 
   def opt_out_link
@@ -37,24 +37,21 @@ class OverdueTrainingAlert < Alert
   def send_email
     return if emails_disabled?
     return if opted_out?
-    # send
+    OverdueTrainingAlertMailer.email(self).deliver_now
+    update_attribute(:email_sent_at, Time.now)
   end
 
   private
 
   def opted_out?
-    user_profile.email_allowed?('OverdueTrainingAlert')
+    !user_profile.email_allowed?('OverdueTrainingAlert')
   end
 
   def opt_out_params
-    "?type=OverdueTrainingAlert&token=#{user_profile.email_preferences_token}"
+    "?type=OverdueTrainingAlert&token=#{user.email_preferences_token}"
   end
 
   def user_profile
     user.user_profile || user.create_user_profile
-  end
-
-  def training_module_slug
-    details[:training_module_slug]
   end
 end

--- a/app/models/requested_account.rb
+++ b/app/models/requested_account.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: requested_accounts
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  course_id  :integer
 #  username   :string(255)
 #  email      :string(255)

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: revisions
@@ -10,13 +9,13 @@
 #  updated_at     :datetime
 #  user_id        :integer
 #  article_id     :integer
-#  views          :integer          default(0)
+#  views          :bigint(8)        default(0)
 #  date           :datetime
 #  new_article    :boolean          default(FALSE)
 #  deleted        :boolean          default(FALSE)
+#  system         :boolean          default(FALSE)
 #  wp10           :float(24)
 #  wp10_previous  :float(24)
-#  system         :boolean          default(FALSE)
 #  ithenticate_id :integer
 #  wiki_id        :integer
 #  mw_rev_id      :integer

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: settings
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  key        :string(255)
 #  value      :text(65535)
 #  created_at :datetime         not null

--- a/app/models/training_slide.rb
+++ b/app/models/training_slide.rb
@@ -3,7 +3,7 @@
 #
 # Table name: training_slides
 #
-#  id           :integer          not null, primary key
+#  id           :bigint(8)        not null, primary key
 #  title        :string(255)
 #  title_prefix :string(255)
 #  summary      :string(255)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,6 +184,10 @@ class User < ApplicationRecord
     REAL_NAME_ROLES.include? role(course)
   end
 
+  def email_preferences_token
+    (user_profile || create_user_profile).email_preferences_token
+  end
+
   # Exclude tokens/secrets from json output
   def to_json(options={})
     options[:except] ||= %i[wiki_token wiki_secret remember_token]

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: user_profiles
@@ -13,6 +12,7 @@
 #  image_updated_at   :datetime
 #  location           :string(255)
 #  institution        :string(255)
+#  email_preferences  :text(65535)
 #
 
 class UserProfile < ApplicationRecord

--- a/app/models/visiting_scholarship.rb
+++ b/app/models/visiting_scholarship.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/app/views/overdue_training_alert_mailer/email.html.haml
+++ b/app/views/overdue_training_alert_mailer/email.html.haml
@@ -8,7 +8,9 @@
             %td.main-content
               %p.paragraph
                 = "Hi #{@alert.user.username}."
-                Here are all the assigned training modules, with your status for each one:
+                Here are all the assigned training modules for&nbsp;
+                %a.link{href: @course_url}> your course
+                , with your status for each one:
             %td.expander
           %tr
             %td
@@ -31,7 +33,9 @@
             %td.main-content
               %p.paragraph
               %p.paragraph
-                We'll send you another reminder in about 10 days if you still have overdue training modules.
+                We'll send you another reminder in about
+                = @days_until_next_alert
+                days if you still have overdue training modules.
                 If you don't want to receive any more training reminders,
                 %a{href: @alert.opt_out_link} click here
                 to opt out.

--- a/app/views/overdue_training_alert_mailer/email.html.haml
+++ b/app/views/overdue_training_alert_mailer/email.html.haml
@@ -1,0 +1,39 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Hi #{@alert.user.username}."
+                It looks like you're overdue for completing some training for your Wikipedia assignment.
+              %p.paragraph
+                Here's where you're at with the assigned training modules:
+            %td.expander
+          %tr
+            %td
+              %table
+                %tr
+                  %th.trainings-table Module
+                  %th.trainings-table Status
+                  %th.trainings-table Due Date
+                - @alert.details.each do |slug, module_details|
+                  - training = TrainingModule.find_by(slug: slug)
+                  %tr
+                    %td.trainings-table-cell
+                      %a.link.training{href: "https://#{ENV['dashboard_url']}/training/students/#{slug}"}
+                        = training.name
+                    %td{class: "trainings-table-cell #{module_details[:status]}"}= module_details[:status]
+                    %td.trainings-table-cell= module_details[:due_date]
+
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+              %p.paragraph
+                We'll send you another reminder in about 10 days if you still have overdue training modules.
+                If you don't want to receive any more training reminders,
+                %a{href: @alert.opt_out_link} click here
+                opt out.

--- a/app/views/overdue_training_alert_mailer/email.html.haml
+++ b/app/views/overdue_training_alert_mailer/email.html.haml
@@ -8,9 +8,7 @@
             %td.main-content
               %p.paragraph
                 = "Hi #{@alert.user.username}."
-                It looks like you're overdue for completing some training for your Wikipedia assignment.
-              %p.paragraph
-                Here's where you're at with the assigned training modules:
+                Here are all the assigned training modules, with your status for each one:
             %td.expander
           %tr
             %td
@@ -36,4 +34,4 @@
                 We'll send you another reminder in about 10 days if you still have overdue training modules.
                 If you don't want to receive any more training reminders,
                 %a{href: @alert.opt_out_link} click here
-                opt out.
+                to opt out.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     get 'users/:username' => 'user_profiles#show' , constraints: { username: /.*/ }
     get 'user_stats' => 'user_profiles#stats'
     get 'stats_graphs' => 'user_profiles#stats_graphs'
+    get 'update_email_preferences/:username' => 'user_profiles#update_email_preferences'
     post 'users/update/:username' => 'user_profiles#update'
   end
 

--- a/db/migrate/20180604211453_add_email_preferences_to_user_profile.rb
+++ b/db/migrate/20180604211453_add_email_preferences_to_user_profile.rb
@@ -1,0 +1,5 @@
+class AddEmailPreferencesToUserProfile < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_profiles, :email_preferences, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180410150621) do
+ActiveRecord::Schema.define(version: 2018_06_04_211453) do
 
-  create_table "alerts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
     t.integer "article_id"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["user_id"], name: "index_alerts_on_user_id"
   end
 
-  create_table "articles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.datetime "updated_at"
     t.datetime "created_at"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.datetime "rating_updated_at"
     t.boolean "deleted", default: false
     t.string "language", limit: 10
-    t.float "average_views", limit: 24
+    t.float "average_views"
     t.date "average_views_updated_at"
     t.integer "wiki_id"
     t.integer "mw_page_id"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["namespace", "wiki_id", "title"], name: "index_articles_on_namespace_and_wiki_id_and_title"
   end
 
-  create_table "articles_courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "articles_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "article_id"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["course_id"], name: "index_articles_courses_on_course_id"
   end
 
-  create_table "assignment_suggestions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "assignment_suggestions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "text"
     t.bigint "assignment_id"
     t.datetime "created_at", null: false
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["assignment_id"], name: "index_assignment_suggestions_on_assignment_id"
   end
 
-  create_table "assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "article_title"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
-  create_table "blocks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "kind"
     t.text "content"
     t.integer "week_id"
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["week_id"], name: "index_blocks_on_week_id"
   end
 
-  create_table "campaigns", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "campaigns", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "slug"
     t.string "url"
@@ -114,7 +114,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.boolean "register_accounts", default: false
   end
 
-  create_table "campaigns_courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "campaigns_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "campaign_id"
     t.integer "course_id"
     t.datetime "created_at"
@@ -122,14 +122,14 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["course_id", "campaign_id"], name: "index_campaigns_courses_on_course_id_and_campaign_id", unique: true
   end
 
-  create_table "campaigns_survey_assignments", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "campaigns_survey_assignments", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "survey_assignment_id"
     t.integer "campaign_id"
     t.index ["campaign_id"], name: "index_campaigns_survey_assignments_on_campaign_id"
     t.index ["survey_assignment_id"], name: "index_campaigns_survey_assignments_on_survey_assignment_id"
   end
 
-  create_table "campaigns_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "campaigns_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "campaign_id"
     t.integer "user_id"
     t.integer "role", default: 0
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["user_id"], name: "index_campaigns_users_on_user_id"
   end
 
-  create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "wiki_id"
     t.text "article_titles", limit: 16777215
     t.string "name"
@@ -152,7 +152,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["wiki_id"], name: "index_categories_on_wiki_id"
   end
 
-  create_table "categories_courses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "categories_courses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "category_id"
     t.integer "course_id"
     t.datetime "created_at", null: false
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["course_id"], name: "index_categories_courses_on_course_id"
   end
 
-  create_table "commons_uploads", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "commons_uploads", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "file_name", limit: 2000
     t.datetime "uploaded_at"
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["user_id"], name: "index_commons_uploads_on_user_id"
   end
 
-  create_table "courses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -222,7 +222,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 
-  create_table "courses_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "courses_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "course_id"
@@ -241,14 +241,14 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["user_id"], name: "index_courses_users_on_user_id"
   end
 
-  create_table "feedback_form_responses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "feedback_form_responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "subject"
     t.text "body"
     t.integer "user_id"
     t.datetime "created_at"
   end
 
-  create_table "gradeables", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "gradeables", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.integer "points"
     t.integer "gradeable_item_id"
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.string "gradeable_item_type"
   end
 
-  create_table "question_group_conditionals", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "question_group_conditionals", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "rapidfire_question_group_id"
     t.integer "campaign_id"
     t.datetime "created_at", null: false
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["rapidfire_question_group_id"], name: "index_question_group_conditionals_on_rapidfire_question_group_id"
   end
 
-  create_table "rapidfire_answer_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "rapidfire_answer_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "question_group_id"
     t.integer "user_id"
     t.string "user_type"
@@ -277,7 +277,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["user_id", "user_type"], name: "index_rapidfire_answer_groups_on_user_id_and_user_type"
   end
 
-  create_table "rapidfire_answers", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "rapidfire_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "answer_group_id"
     t.integer "question_id"
     t.text "answer_text"
@@ -288,14 +288,14 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["question_id"], name: "index_rapidfire_answers_on_question_id"
   end
 
-  create_table "rapidfire_question_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "rapidfire_question_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "tags"
   end
 
-  create_table "rapidfire_questions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "rapidfire_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "question_group_id"
     t.string "type"
     t.text "question_text"
@@ -314,7 +314,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["question_group_id"], name: "index_rapidfire_questions_on_question_group_id"
   end
 
-  create_table "requested_accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "requested_accounts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
     t.string "username"
     t.string "email"
@@ -322,7 +322,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "revisions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "revisions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "characters", default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -333,8 +333,8 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.boolean "new_article", default: false
     t.boolean "deleted", default: false
     t.boolean "system", default: false
-    t.float "wp10", limit: 24
-    t.float "wp10_previous", limit: 24
+    t.float "wp10"
+    t.float "wp10_previous"
     t.integer "ithenticate_id"
     t.integer "wiki_id"
     t.integer "mw_rev_id"
@@ -346,7 +346,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["wiki_id", "mw_rev_id"], name: "index_revisions_on_wiki_id_and_mw_rev_id", unique: true
   end
 
-  create_table "settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "settings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "key"
     t.text "value"
     t.datetime "created_at", null: false
@@ -354,7 +354,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["key"], name: "index_settings_on_key", unique: true
   end
 
-  create_table "survey_assignments", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "survey_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "courses_user_role"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -371,7 +371,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["survey_id"], name: "index_survey_assignments_on_survey_id"
   end
 
-  create_table "survey_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "survey_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "courses_users_id"
     t.integer "course_id"
     t.integer "survey_assignment_id"
@@ -387,7 +387,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["survey_assignment_id"], name: "index_survey_notifications_on_survey_assignment_id"
   end
 
-  create_table "surveys", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -399,7 +399,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.text "optout"
   end
 
-  create_table "surveys_question_groups", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "surveys_question_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "survey_id"
     t.integer "rapidfire_question_group_id"
     t.integer "position"
@@ -409,7 +409,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["survey_id"], name: "index_surveys_question_groups_on_survey_id"
   end
 
-  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "tag"
     t.string "key"
@@ -418,7 +418,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["course_id", "key"], name: "index_tags_on_course_id_and_key", unique: true
   end
 
-  create_table "training_modules_users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "training_modules_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "training_module_id"
     t.string "last_slide_completed"
@@ -428,7 +428,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["user_id", "training_module_id"], name: "index_training_modules_users_on_user_id_and_training_module_id"
   end
 
-  create_table "training_slides", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "training_slides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "title_prefix"
     t.string "summary"
@@ -443,7 +443,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["slug"], name: "index_training_slides_on_slug", unique: true
   end
 
-  create_table "user_profiles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "bio"
     t.integer "user_id"
     t.string "image_file_name"
@@ -452,9 +452,10 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.datetime "image_updated_at"
     t.string "location"
     t.string "institution"
+    t.text "email_preferences"
   end
 
-  create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "username"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -478,7 +479,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "versions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
@@ -488,7 +489,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "weeks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "weeks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.integer "course_id"
     t.datetime "created_at"
@@ -497,7 +498,7 @@ ActiveRecord::Schema.define(version: 20180410150621) do
     t.index ["course_id"], name: "index_weeks_on_course_id"
   end
 
-  create_table "wikis", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "wikis", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "language", limit: 16
     t.string "project", limit: 16
     t.index ["language", "project"], name: "index_wikis_on_language_and_project", unique: true

--- a/lib/alerts/overdue_training_alert_manager.rb
+++ b/lib/alerts/overdue_training_alert_manager.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# In contrast to UntrainedStudentsAlertManager, this creates alerts for individual students
+# who have overdue trainings, and emails them to remind them to complete the trainings.
+class OverdueTrainingAlertManager
+  # TODO: Call this as part of the DailyUpdate, for strictly current courses
+  def initialize(courses)
+    @courses = courses
+  end
+
+  def create_alerts
+    @courses.each do |course|
+      next unless course.type == 'ClassroomProgramCourse'
+      course.students.each { |student| manage_alert(course, student) }
+    end
+  end
+
+  private
+
+  def manage_alert(course, student)
+    # TODO: Return instead if last alert was less that 10? days ago.
+    return if Alert.exists?(course: course, user: student, type: 'OverdueTrainingAlert')
+    status = {}
+    overdue = false
+    course.training_modules.each do |training_module|
+      due_date_manager = TrainingModuleDueDateManager.new(course: course,
+                                                          user: student,
+                                                          training_module: training_module)
+      overdue = true if due_date_manager.overdue?
+      status[training_module.slug] = { due_date: due_date_manager.computed_due_date,
+                                       status: due_date_manager.deadline_status,
+                                       progress: due_date_manager.module_progress }
+    end
+
+    return unless overdue
+    alert = Alert.create(type: 'OverdueTrainingAlert', user: student,
+                         course: course, details: status)
+    # OverdueTrainingAlert will not send the email if user has opted out of this email type
+    alert.send_email
+  end
+end

--- a/lib/alerts/overdue_training_alert_manager.rb
+++ b/lib/alerts/overdue_training_alert_manager.rb
@@ -7,9 +7,14 @@ class OverdueTrainingAlertManager
     @courses = courses
   end
 
+  # To avoid flooding students in nearly-over courses with alert emails,
+  # we'll only send them for course that start near the launch date
+  # of this feature, or later.
+  START_DATE = '2018-06-01'.to_date
   def create_alerts
     @courses.each do |course|
       next unless course.type == 'ClassroomProgramCourse'
+      next unless course.start > START_DATE
       course.students.each { |student| manage_alert(course, student) }
     end
   end

--- a/lib/alerts/overdue_training_alert_manager.rb
+++ b/lib/alerts/overdue_training_alert_manager.rb
@@ -41,6 +41,6 @@ class OverdueTrainingAlertManager
   def any_recent_alerts?(course, student)
     earliest_date = OverdueTrainingAlert::MINIMUM_DAYS_BETWEEN_ALERTS.days.ago
     Alert.where(course: course, user: student, type: 'OverdueTrainingAlert')
-         .where('created_at < ?', earliest_date).exists?
+         .where('created_at > ?', earliest_date).exists?
   end
 end

--- a/lib/training/training_loader.rb
+++ b/lib/training/training_loader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/training/wiki_slide_parser"
+require_dependency "#{Rails.root}/lib/wiki_api"
 
 # Loads any of the three types of training content:
 # TrainingLibrary, TrainingModule, TrainingSlide

--- a/public/mailer.css
+++ b/public/mailer.css
@@ -60,3 +60,29 @@
   text-align:left;
   font-weight: 300;
 }
+
+.trainings-table-cell {
+  border: 1px solid #999999;
+  padding: 10px;
+}
+
+th.trainings-table, td.trainings-table {
+  padding: 10px;
+  color: #666666;
+}
+
+td.overdue {
+  background: #F2D2D2 !important;
+}
+
+td.complete {
+  background: #75dfc0 !important;
+}
+
+td.trainings-table {
+  background: #eeeeee;
+}
+
+a.training {
+  font-weight: bolder;
+}

--- a/spec/factories/alerts.rb
+++ b/spec/factories/alerts.rb
@@ -26,4 +26,6 @@ FactoryBot.define do
   factory :active_course_alert, class: 'ActiveCourseAlert'
 
   factory :continued_course_activity_alert, class: 'ContinuedCourseActivityAlert'
+
+  factory :overdue_training_alert, class: 'OverdueTrainingAlert'
 end

--- a/spec/factories/articles_courses.rb
+++ b/spec/factories/articles_courses.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: articles_courses
@@ -9,7 +8,7 @@
 #  updated_at    :datetime
 #  article_id    :integer
 #  course_id     :integer
-#  view_count    :integer          default(0)
+#  view_count    :bigint(8)        default(0)
 #  character_sum :integer          default(0)
 #  new_article   :boolean          default(FALSE)
 #

--- a/spec/factories/assignment_suggestions.rb
+++ b/spec/factories/assignment_suggestions.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: assignment_suggestions
 #
-#  id            :integer          not null, primary key
+#  id            :bigint(8)        not null, primary key
 #  text          :text(65535)
-#  assignment_id :integer
+#  assignment_id :bigint(8)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  user_id       :integer

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -15,6 +15,7 @@
 #  template_description :text(65535)
 #  default_course_type  :string(255)
 #  default_passcode     :string(255)
+#  register_accounts    :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -3,7 +3,7 @@
 #
 # Table name: categories
 #
-#  id             :integer          not null, primary key
+#  id             :bigint(8)        not null, primary key
 #  wiki_id        :integer
 #  article_titles :text(16777215)
 #  name           :string(255)

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/spec/factories/requested_accounts.rb
+++ b/spec/factories/requested_accounts.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: requested_accounts
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  course_id  :integer
 #  username   :string(255)
 #  email      :string(255)

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: revisions
@@ -10,13 +9,13 @@
 #  updated_at     :datetime
 #  user_id        :integer
 #  article_id     :integer
-#  views          :integer          default(0)
+#  views          :bigint(8)        default(0)
 #  date           :datetime
 #  new_article    :boolean          default(FALSE)
 #  deleted        :boolean          default(FALSE)
+#  system         :boolean          default(FALSE)
 #  wp10           :float(24)
 #  wp10_previous  :float(24)
-#  system         :boolean          default(FALSE)
 #  ithenticate_id :integer
 #  wiki_id        :integer
 #  mw_rev_id      :integer

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: settings
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  key        :string(255)
 #  value      :text(65535)
 #  created_at :datetime         not null

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: user_profiles
@@ -13,6 +12,7 @@
 #  image_updated_at   :datetime
 #  location           :string(255)
 #  institution        :string(255)
+#  email_preferences  :text(65535)
 #
 
 FactoryBot.define do

--- a/spec/features/email_opt_out_spec.rb
+++ b/spec/features/email_opt_out_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'email preferences opt out', type: :feature, js: true do
+  let(:user) { create(:user) }
+  let(:token) { user.email_preferences_token }
+
+  it 'returns a 401 if token is incorrect' do
+    visit "/update_email_preferences/#{user.username}?type=OverdueTrainingAlert&token=wrong_token"
+    expect(user.user_profile.reload.email_preferences['OverdueTrainingAlert']).to be_nil
+    expect(page.status_code).to eq(401)
+  end
+
+  it 'updates the preferences if token is correct' do
+    visit "/update_email_preferences/#{user.username}?type=OverdueTrainingAlert&token=#{token}"
+    expect(user.user_profile.reload.email_preferences['OverdueTrainingAlert']).to eq(false)
+  end
+end

--- a/spec/fixtures/campaigns.yml
+++ b/spec/fixtures/campaigns.yml
@@ -14,6 +14,7 @@
 #  template_description :text(65535)
 #  default_course_type  :string(255)
 #  default_passcode     :string(255)
+#  register_accounts    :boolean          default(FALSE)
 #
 
 default:

--- a/spec/fixtures/training_slides.yml
+++ b/spec/fixtures/training_slides.yml
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: training_slides
+#
+#  id           :bigint(8)        not null, primary key
+#  title        :string(255)
+#  title_prefix :string(255)
+#  summary      :string(255)
+#  button_text  :string(255)
+#  wiki_page    :string(255)
+#  assessment   :text(65535)
+#  content      :text(65535)
+#  translations :text(16777215)
+#  slug         :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
 editing_1:
   id: 201
   title: 'Welcome Students'

--- a/spec/lib/alerts/overdue_training_alert_manager_spec.rb
+++ b/spec/lib/alerts/overdue_training_alert_manager_spec.rb
@@ -5,7 +5,8 @@ require "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
 describe OverdueTrainingAlertManager do
   let(:subject) { OverdueTrainingAlertManager.new([course]).create_alerts }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, start: start_date) }
+  let(:start_date) { '2018-06-07'.to_date }
   let(:week) { create(:week) }
   let(:block) { create(:block, training_module_ids: [1, 2, 3], due_date: due_date) }
   let(:due_date) { nil }
@@ -17,7 +18,7 @@ describe OverdueTrainingAlertManager do
     week.blocks << block
   end
 
-  describe 'when training is overdue' do
+  context 'when training is overdue' do
     let(:due_date) { 1.day.ago }
     it 'creates an alert' do
       expect(OverdueTrainingAlert.count).to eq(0)
@@ -26,7 +27,7 @@ describe OverdueTrainingAlertManager do
     end
   end
 
-  describe 'when training is not yet due' do
+  context 'when training is not yet due' do
     let(:due_date) { 1.day.from_now }
     it 'does not create an alert' do
       expect(OverdueTrainingAlert.count).to eq(0)
@@ -35,7 +36,7 @@ describe OverdueTrainingAlertManager do
     end
   end
 
-  describe 'when training is overdue but a recent alert exists' do
+  context 'when training is overdue but a recent alert exists' do
     let(:due_date) { 5.days.ago }
     it 'does not create a new alert' do
       create(:overdue_training_alert, user: user, course: course, created_at: 5.days.ago)
@@ -45,13 +46,23 @@ describe OverdueTrainingAlertManager do
     end
   end
 
-  describe 'when training is overdue and an 10-plus day old alert exists' do
-    let(:due_date) { 11.day.ago }
+  context 'when training is overdue and an 10-plus day old alert exists' do
+    let(:due_date) { 11.days.ago }
     it 'creates another alert' do
       create(:overdue_training_alert, user: user, course: course, created_at: 11.days.ago)
       expect(OverdueTrainingAlert.count).to eq(1)
       subject
       expect(OverdueTrainingAlert.count).to eq(2)
+    end
+  end
+
+  context 'when the course was already underway before this feature launched' do
+    let(:start_date) { '2018-05-01'.to_date }
+    let(:due_date) { 1.day.ago }
+    it 'does not create an alert' do
+      expect(OverdueTrainingAlert.count).to eq(0)
+      subject
+      expect(OverdueTrainingAlert.count).to eq(0)
     end
   end
 end

--- a/spec/lib/alerts/overdue_training_alert_manager_spec.rb
+++ b/spec/lib/alerts/overdue_training_alert_manager_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
+
+describe OverdueTrainingAlertManager do
+  let(:subject) { OverdueTrainingAlertManager.new([course]).create_alerts }
+  let(:course) { create(:course) }
+  let(:week) { create(:week) }
+  let(:block) { create(:block, training_module_ids: [1, 2, 3], due_date: due_date) }
+  let(:due_date) { nil }
+  let(:user) { create(:user, email: 'student@example.edu') }
+
+  before do
+    create(:courses_user, user: user, course: course)
+    course.weeks << week
+    week.blocks << block
+  end
+
+  describe 'when training is overdue' do
+    let(:due_date) { 1.day.ago }
+    it 'creates an alert' do
+      expect(OverdueTrainingAlert.count).to eq(0)
+      subject
+      expect(OverdueTrainingAlert.count).to eq(1)
+    end
+  end
+
+  describe 'when training is not yet due' do
+    let(:due_date) { 1.day.from_now }
+    it 'does not create an alert' do
+      expect(OverdueTrainingAlert.count).to eq(0)
+      subject
+      expect(OverdueTrainingAlert.count).to eq(0)
+    end
+  end
+end

--- a/spec/lib/alerts/overdue_training_alert_manager_spec.rb
+++ b/spec/lib/alerts/overdue_training_alert_manager_spec.rb
@@ -34,4 +34,24 @@ describe OverdueTrainingAlertManager do
       expect(OverdueTrainingAlert.count).to eq(0)
     end
   end
+
+  describe 'when training is overdue but a recent alert exists' do
+    let(:due_date) { 5.days.ago }
+    it 'does not create a new alert' do
+      create(:overdue_training_alert, user: user, course: course, created_at: 5.days.ago)
+      expect(OverdueTrainingAlert.count).to eq(1)
+      subject
+      expect(OverdueTrainingAlert.count).to eq(1)
+    end
+  end
+
+  describe 'when training is overdue and an 10-plus day old alert exists' do
+    let(:due_date) { 11.day.ago }
+    it 'creates another alert' do
+      create(:overdue_training_alert, user: user, course: course, created_at: 11.days.ago)
+      expect(OverdueTrainingAlert.count).to eq(1)
+      subject
+      expect(OverdueTrainingAlert.count).to eq(2)
+    end
+  end
 end

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -18,6 +18,7 @@ describe DailyUpdate do
       expect(ArticleStatusManager).to receive(:update_article_status)
       expect(OresScoresBeforeAndAfterImporter).to receive(:import_all)
       expect(UploadImporter).to receive(:find_deleted_files)
+      expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
       expect(PushCourseToSalesforce).to receive(:new)
       expect(Raven).to receive(:capture_message).and_call_original
       update = DailyUpdate.new

--- a/spec/mailers/previews/overdue_training_alert_mailer_preview.rb
+++ b/spec/mailers/previews/overdue_training_alert_mailer_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class OverdueTrainingAlertMailerPreview < ActionMailer::Preview
+  def message_to_student
+    OverdueTrainingAlertMailer.email(OverdueTrainingAlert.last)
+  end
+end

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: articles_courses
@@ -9,7 +8,7 @@
 #  updated_at    :datetime
 #  article_id    :integer
 #  course_id     :integer
-#  view_count    :integer          default(0)
+#  view_count    :bigint(8)        default(0)
 #  character_sum :integer          default(0)
 #  new_article   :boolean          default(FALSE)
 #

--- a/spec/models/assignment_suggestion_spec.rb
+++ b/spec/models/assignment_suggestion_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: assignment_suggestions
 #
-#  id            :integer          not null, primary key
+#  id            :bigint(8)        not null, primary key
 #  text          :text(65535)
-#  assignment_id :integer
+#  assignment_id :bigint(8)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  user_id       :integer

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -15,6 +15,7 @@
 #  template_description :text(65535)
 #  default_course_type  :string(255)
 #  default_passcode     :string(255)
+#  register_accounts    :boolean          default(FALSE)
 #
 
 require 'rails_helper'

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: categories
 #
-#  id             :integer          not null, primary key
+#  id             :bigint(8)        not null, primary key
 #  wiki_id        :integer
 #  article_titles :text(16777215)
 #  name           :string(255)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/spec/models/editathon_spec.rb
+++ b/spec/models/editathon_spec.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)

--- a/spec/models/overdue_training_alert_spec.rb
+++ b/spec/models/overdue_training_alert_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id             :integer          not null, primary key
+#  course_id      :integer
+#  user_id        :integer
+#  article_id     :integer
+#  revision_id    :integer
+#  type           :string(255)
+#  email_sent_at  :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  message        :text(65535)
+#  target_user_id :integer
+#  subject_id     :integer
+#  resolved       :boolean          default(FALSE)
+#  details        :text(65535)
+#
+
+require 'rails_helper'
+
+describe OverdueTrainingAlert do
+  let(:course) { create(:course) }
+  let(:student) { create(:user, email: 'student@example.edu') }
+  before do
+    create(:user_profile, user: student, email_preferences: email_preferences)
+  end
+  let(:alert) do
+    create(:overdue_training_alert,
+           user: student, course: course,
+           details: { 'plagiarism' => { due_date: 1.day.ago,
+                                        status: 'overdue',
+                                        progress: '85% Complete' } })
+  end
+  describe '#send_email' do
+    let(:subject) { alert.send_email }
+
+    context 'when the user has not opted out' do
+      let(:email_preferences) { {} }
+      it 'sends an email' do
+        expect(alert.email_sent_at).to be_nil
+        subject
+        expect(alert.reload.email_sent_at).not_to be_nil
+      end
+    end
+
+    context 'when the user has opted out' do
+      let(:email_preferences) { { 'OverdueTrainingAlert' => false } }
+      it 'does not send an email' do
+        expect(OverdueTrainingAlertMailer).not_to receive(:send_email)
+        subject
+      end
+    end
+  end
+end

--- a/spec/models/requested_account_spec.rb
+++ b/spec/models/requested_account_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: requested_accounts
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  course_id  :integer
 #  username   :string(255)
 #  email      :string(255)

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: revisions
@@ -10,13 +9,13 @@
 #  updated_at     :datetime
 #  user_id        :integer
 #  article_id     :integer
-#  views          :integer          default(0)
+#  views          :bigint(8)        default(0)
 #  date           :datetime
 #  new_article    :boolean          default(FALSE)
 #  deleted        :boolean          default(FALSE)
+#  system         :boolean          default(FALSE)
 #  wp10           :float(24)
 #  wp10_previous  :float(24)
-#  system         :boolean          default(FALSE)
 #  ithenticate_id :integer
 #  wiki_id        :integer
 #  mw_rev_id      :integer

--- a/spec/models/training_slide_spec.rb
+++ b/spec/models/training_slide_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: training_slides
 #
-#  id           :integer          not null, primary key
+#  id           :bigint(8)        not null, primary key
 #  title        :string(255)
 #  title_prefix :string(255)
 #  summary      :string(255)

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_profiles
+#
+#  id                 :integer          not null, primary key
+#  bio                :text(65535)
+#  user_id            :integer
+#  image_file_name    :string(255)
+#  image_content_type :string(255)
+#  image_file_size    :integer
+#  image_updated_at   :datetime
+#  location           :string(255)
+#  institution        :string(255)
+#  email_preferences  :text(65535)
+#
+require 'rails_helper'
+
+describe UserProfile do
+  let(:user_profile) { create(:user_profile) }
+  describe '#email_opt_out' do
+    let(:subject) { user_profile.email_opt_out('InvalidType') }
+    it 'raises an error if the type is invalid' do
+      expect { subject }.to raise_error(UserProfile::InvalidEmailPreferencesType)
+    end
+  end
+end

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -12,7 +12,7 @@
 #  school                :string(255)
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
-#  view_sum              :integer          default(0)
+#  view_sum              :bigint(8)        default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)


### PR DESCRIPTION
This adds email reminders for students in the Wiki Education Classroom Program.

![email training](https://user-images.githubusercontent.com/848483/41128829-54e5c8e4-6a64-11e8-86b5-7ab1cd6c31cc.png)

Emails will only be sent for courses starting after today.

Along with these emails and the new OverdueTrainingAlert type to track them, this PR also introduces a system for handling email preferences, storing a hash of email preference data on UserProfile records. The emails include an opt-out link that will prevent further training emails from being sent. The same opt-out flow will be usable for other email types if needed.