### PR TITLE
remove tool table header when the course_id prop not found in article finder

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -195,6 +195,10 @@ const ArticleFinder = createReactClass({
       delete keys.grade;
     }
 
+    if (!this.props.course_id) {
+      delete keys.tools;
+    }
+
     let list;
     if (this.state.isSubmitted && !this.props.loading) {
       const elements = _.map(this.props.articles, (article, title) => {


### PR DESCRIPTION
It removes the tools table header in the case when article finder is accessed as a stand-alone tool without association to a course.