### PR TITLE
Set dashboard_url ENV VAR for test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,6 +26,7 @@ ENV['chat_admin_password'] = 'password'
 ENV['chat_server'] = 'https://dashboardchat.wmflabs.org'
 ENV['SF_SERVER'] = 'https://cs54.salesforce.com/'
 ENV['edit_en.wikipedia.org'] = 'true'
+ENV['dashboard_url'] = 'dashboard.wikiedu.org'
 
 Rails.application.configure do
   # Settings specified here will take


### PR DESCRIPTION
Added the dashboard_url ENV VAR to the test environment config file.

Some tests were failing as the test environment is expecting a different
endpoint than what is set in application.yml. All environment variables
that tests rely on are consolidated to the config file as the
application.yml and the test config file may diverge.