### PR TITLE
Use dates set to appropriate time zone

### DIFF
--- a/lib/training_module_due_date_manager.rb
+++ b/lib/training_module_due_date_manager.rb
@@ -22,7 +22,7 @@ class TrainingModuleDueDateManager
   end
 
   def overdue?
-    !module_completed? && Date.today > computed_due_date
+    !module_completed? && Time.zone.now.to_date > computed_due_date
   end
 
   def deadline_status

--- a/spec/lib/training_module_due_date_manager_spec.rb
+++ b/spec/lib/training_module_due_date_manager_spec.rb
@@ -91,7 +91,7 @@ describe TrainingModuleDueDateManager do
         end
       end
       context "today's date is computed_due_date" do
-        let(:due_date) { Date.today }
+        let(:due_date) { Time.zone.now.to_date }
         it 'returns false' do
           expect(subject).to eq(false)
         end


### PR DESCRIPTION
Updated to use dates adjusted for the current time zone.

This was causing one test failure when UTC date did not match the dev's
local timezone date.

Fixes #1918 
