### PR TITLE
Create Syllabus controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,8 @@ Metrics/ModuleLength:
 
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
 Style/ColonMethodCall:
   Enabled: false
 Style/NumericLiterals:

--- a/app/controllers/courses/syllabuses_controller.rb
+++ b/app/controllers/courses/syllabuses_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class Courses::SyllabusesController < ApplicationController
+  before_action :require_permissions, only: :update
+
+  def update
+    @course = Course.find(params[:id])
+    handle_syllabus_params
+    if @course.save
+      render json: { success: true, url: @course.syllabus.url }
+    else
+      render json: { message: I18n.t('error.invalid_file_format') },
+             status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def handle_syllabus_params
+    syllabus = params['syllabus']
+    if syllabus == 'null'
+      @course.syllabus.destroy
+      @course.syllabus = nil
+    else
+      @course.syllabus = params['syllabus']
+    end
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -17,7 +17,6 @@ class CoursesController < ApplicationController
                                                update
                                                destroy
                                                notify_untrained
-                                               update_syllabus
                                                delete_all_weeks]
 
   ################
@@ -69,17 +68,6 @@ class CoursesController < ApplicationController
     respond_to do |format|
       format.html { render }
       format.json { render @endpoint }
-    end
-  end
-
-  def update_syllabus
-    @course = Course.find(params[:id])
-    handle_syllabus_params
-    if @course.save
-      render json: { success: true, url: @course.syllabus.url }
-    else
-      render json: { message: I18n.t('error.invalid_file_format') },
-             status: :unprocessable_entity
     end
   end
 
@@ -140,16 +128,6 @@ class CoursesController < ApplicationController
 
   def campaign_params
     params.require(:campaign).permit(:title)
-  end
-
-  def handle_syllabus_params
-    syllabus = params['syllabus']
-    if syllabus == 'null'
-      @course.syllabus.destroy
-      @course.syllabus = nil
-    else
-      @course.syllabus = params['syllabus']
-    end
   end
 
   def validate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,7 @@ Rails.application.routes.draw do
           titleterm: /[^\/]*/
         }
     post 'clone_course/:id' => 'course_clone#clone'
-    post 'courses/:id/update_syllabus' => 'courses#update_syllabus'
+    post 'courses/:id/update_syllabus' => 'courses/syllabuses#update'
     delete 'courses/:id/delete_all_weeks' => 'courses#delete_all_weeks',
       constraints: {
         id: /.*/

--- a/spec/controllers/courses/syllabuses_controller_spec.rb
+++ b/spec/controllers/courses/syllabuses_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Courses::SyllabusesController, type: :controller do
+  describe '#update' do
+    let(:course) { create(:course) }
+    let(:instructor) do
+      create(:user, id: 5)
+      create(:courses_user, user_id: 5,
+                            course_id: course.id,
+                            role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+      User.find(5)
+    end
+
+    before do
+      allow(controller).to receive(:current_user).and_return(instructor)
+    end
+
+    it 'saves a pdf' do
+      file = fixture_file_upload('syllabus.pdf', 'application/pdf')
+      post :update, params: { id: course.id, syllabus: file }
+      expect(response.status).to eq(200)
+      expect(course.syllabus).not_to be_nil
+    end
+
+    it 'deletes a saved file' do
+      file = fixture_file_upload('syllabus.pdf', 'application/pdf')
+      course.syllabus = file
+      course.save
+      expect(course.syllabus.exists?).to eq(true)
+      post :update, params: { id: course.id, syllabus: 'null' }
+      expect(course.syllabus.exists?).to eq(false)
+    end
+
+    it 'renders an error for disallowed file types' do
+      file = fixture_file_upload('syllabus.torrent', 'application/x-bittorrent')
+      post :update, params: { id: course.id, syllabus: file }
+      expect(response.status).to eq(422)
+    end
+  end
+end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -560,43 +560,6 @@ describe CoursesController do
     end
   end
 
-  describe '#update_syllabus' do
-    let(:course) { create(:course) }
-    let(:instructor) do
-      create(:user, id: 5)
-      create(:courses_user, user_id: 5,
-                            course_id: course.id,
-                            role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
-      User.find(5)
-    end
-
-    before do
-      allow(controller).to receive(:current_user).and_return(instructor)
-    end
-
-    it 'saves a pdf' do
-      file = fixture_file_upload('syllabus.pdf', 'application/pdf')
-      post :update_syllabus, params: { id: course.id, syllabus: file }
-      expect(response.status).to eq(200)
-      expect(course.syllabus).not_to be_nil
-    end
-
-    it 'deletes a saved file' do
-      file = fixture_file_upload('syllabus.pdf', 'application/pdf')
-      course.syllabus = file
-      course.save
-      expect(course.syllabus.exists?).to eq(true)
-      post :update_syllabus, params: { id: course.id, syllabus: 'null' }
-      expect(course.syllabus.exists?).to eq(false)
-    end
-
-    it 'renders an error for disallowed file types' do
-      file = fixture_file_upload('syllabus.torrent', 'application/x-bittorrent')
-      post :update_syllabus, params: { id: course.id, syllabus: file }
-      expect(response.status).to eq(422)
-    end
-  end
-
   describe '#delete_all_weeks' do
     let(:course) { create(:course) }
     let!(:user) { create(:admin) }


### PR DESCRIPTION
Moved syllabus controller and associated method to its own controller
file.

Moved specs for controller syllabus to its own file.

Updated syllabus controller route. Action name is now 'update'.
Routing endpoint remains the same.

This helps to keep controller's small and manageable.

This starts to address issues referenced in #1417 
