### PR TITLE
Corrected "Science communcation" handout link to "Science communication"

### DIFF
--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -139,7 +139,7 @@ class WizardTimelineManager
     'medicine_handout' => ['Medicine', 'https://wikiedu.org/medicine'],
     'political_science_handout' => ['Political Science', 'https://wikiedu.org/political_science'],
     'psychology_handout' => ['Psychology', 'https://wikiedu.org/psychology'],
-    'science_communication_handout' => ['Science Communcation', 'https://wikiedu.org/science_communication'],
+    'science_communication_handout' => ['Science Communication', 'https://wikiedu.org/science_communication'],
     'sociology_handout' => ['Sociology', 'https://wikiedu.org/sociology'],
     'species_handout' => ['Species', 'https://wikiedu.org/species'],
     'womens_studies_handout' => ["Women's Studies", 'https://wikiedu.org/womens_studies']


### PR DESCRIPTION
Corrected typo in subject-specific brochure links on Timeline