### PR TITLE
Upgrade Ruby to 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
 # Run all tests in job 2
 - TEST_SUITE='~type:foo' AFTER_SUCCESS='' CC_TEST_REPORTER_ID=f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
 language: ruby
-rvm: 2.5.0
+rvm: 2.5.1
 sudo: required
 dist: trusty
 cache:
@@ -19,7 +19,7 @@ addons:
 services:
   - redis-server
 before_install:
-- rvm --default use 2.5.0
+- rvm --default use 2.5.1
 - export PATH=$PATH:`yarn global bin`
 - export DB=test
 - export SENDER_EMAIL_ADDRESS='sender@wikiedu.org'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #   - docker build -t wiki-edu-dashboard .
 #   - docker run -p 3000:3000 -it wiki-edu-dashboard
 
-FROM ruby:2.5.0
+FROM ruby:2.5.1
 
 WORKDIR /usr/src/app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.0'
+ruby '2.5.1'
 
 ### Basic Framework
 gem 'rails', '5.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -587,7 +587,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.5.0p0
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
 # Docker Setup
 
-This document outlines how you can setup a containerized testing/development environment quickly using docker. Using a containerized dashboard image allows for a faster and reproducible test setup. We first have to build the Docker image and then run the container. 
+This document outlines how you can setup a containerized testing/development environment quickly using docker. Using a containerized dashboard image allows for a faster and reproducible test setup. We first have to build the Docker image and then run the container.
 
 ### TL;DR
 ```sh
@@ -14,7 +14,7 @@ Make sure the docker daemon is running. Else, `service docker status`. Then, fro
  ```sh
  $ docker build -t wiki-edu-dashboard .
  ```
- This builds the `wiki-edu-dashboard` container image using the Dockerfile. The dashboard container image is based on the official `ruby:2.5.0` [base image](https://hub.docker.com/_/ruby/). The container image contains all the necessary dependencies as well as an initialized MariaDB database as required by the Wiki Edu Dashboard. 
+ This builds the `wiki-edu-dashboard` container image using the Dockerfile. The dashboard container image is based on the official `ruby:2.5.1` [base image](https://hub.docker.com/_/ruby/). The container image contains all the necessary dependencies as well as an initialized MariaDB database as required by the Wiki Edu Dashboard.
 
 ## Run
 The current docker image can be used for testing, local deploys or development purposes. `docker run` initializes the setup and spawns a container which starts serving the dashboard on `http://localhost:3000`. Also, this requires port `3000` to be open on the host.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,7 +10,7 @@ We have a script to automate the process of setting up your developmental enviro
 There are some basic requirements for the script to work:
 - git(to clone the repository)
 - python 3
-- ruby-2.5.0
+- ruby-2.5.1
 - apt(debian)/homebrew(MacOS)
 
 ## Instructions
@@ -46,7 +46,7 @@ If you know your way around Rails, here's the very short version. Some additiona
 * copy `config/application.example.yml` to `config/application.yml`
 * copy `config/database.example.yml` to `config/database.yml`
 * create a MySQL database, `dashboard`
-* install ruby 2.5.0 and nodejs
+* install ruby 2.5.1 and nodejs
 * install R
 * `bundle install`
 * `rake db:migrate`
@@ -69,10 +69,10 @@ If you know your way around Rails, here's the very short version. Some additiona
 - Fork this repo, so that you can make changes and push them freely to GitHub.
 - Clone the new WikiEduDashboard repo and enter that directory.
 - On OSX/Debian, make sure you are in the "sudo" group.
-- Install Ruby 2.5.0 (RVM is documented here; rbenv also works fine.)
+- Install Ruby 2.5.1 (RVM is documented here; rbenv also works fine.)
     - OSX/Debian:
        - From the WikiEduDashboard directory, run the curl script from [rvm.io](https://rvm.io/)
-       - `rvm install ruby-2.5.0`
+       - `rvm install ruby-2.5.1`
     - Windows:
        - Use [RailsInstaller](http://railsinstaller.org/en)
        - Install [Ruby DevKit](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit)

--- a/docs/upgrade_dependencies.md
+++ b/docs/upgrade_dependencies.md
@@ -27,10 +27,10 @@ On the server where the dashboard is already running, in `/var/www/dashboard/cur
 Passenger should now be ready. Copy the output for updating the apache config.
 It will be something like this:
 ```
-LoadModule passenger_module /usr/local/rvm/gems/ruby-2.5.0/gems/passenger-5.1.12/buildout/apache2/mod_passenger.so
+LoadModule passenger_module /usr/local/rvm/gems/ruby-2.5.1/gems/passenger-5.1.12/buildout/apache2/mod_passenger.so
 <IfModule mod_passenger.c>
-  PassengerRoot /usr/local/rvm/gems/ruby-2.5.0/gems/passenger-5.1.12
-  PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.5.0/wrappers/ruby
+  PassengerRoot /usr/local/rvm/gems/ruby-2.5.1/gems/passenger-5.1.12
+  PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.5.1/wrappers/ruby
 </IfModule>
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ print ("WARNING! This is a work in progress script. It has been tested to work f
   The logs can be found in the setup directory. If you can help improve this script, \
   We would love your contributions.")
 
-print ("Please install ruby-2.5.0 before running this script.")
+print ("Please install ruby-2.5.1 before running this script.")
 
 def deb_setup():
     print ("Your system is found to be debian-based.")

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -35,12 +35,12 @@ echo '[+] Creating log file...'
 touch setup/log.txt
 echo '[+] Log File created'
 
-printf '[*] Checking for Ruby-2.5.0...\n'
-if ruby -v | grep "ruby 2.5.0" >/dev/null; then
+printf '[*] Checking for Ruby-2.5.1...\n'
+if ruby -v | grep "ruby 2.5.1" >/dev/null; then
   printf "${CLEAR_LINE}Ruby already installed\n"
 else
-  echo "Ruby-2.5.0 not found. Please install ruby-2.5.0 and run this script again."
-  echo "One way to install ruby-2.5.0 is through RVM, Visit: https://rvm.io/"
+  echo "Ruby-2.5.1 not found. Please install ruby-2.5.1 and run this script again."
+  echo "One way to install ruby-2.5.1 is through RVM, Visit: https://rvm.io/"
   exit 0;
 fi
 

--- a/setup/dnf-setup.sh
+++ b/setup/dnf-setup.sh
@@ -35,12 +35,12 @@ echo '[+] Creating log file...'
 touch setup/log.txt
 echo '[+] Log File created'
 
-printf '[*] Checking for Ruby-2.5.0...\n'
-if ruby -v | grep "ruby 2.5.0" >/dev/null; then
+printf '[*] Checking for Ruby-2.5.1...\n'
+if ruby -v | grep "ruby 2.5.1" >/dev/null; then
   printf "${CLEAR_LINE}Ruby already installed\n"
 else
-  echo "Ruby-2.5.0 not found. Please install ruby-2.5.0 and run this script again."
-  echo "One way to install ruby-2.5.0 is through RVM, Visit: https://rvm.io/"
+  echo "Ruby-2.5.1 not found. Please install ruby-2.5.1 and run this script again."
+  echo "One way to install ruby-2.5.1 is through RVM, Visit: https://rvm.io/"
   exit 0;
 fi
 

--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -35,12 +35,12 @@ echo '[+] Creating log file...'
 touch setup/log.txt
 echo '[+] Log File created'
 
-printf '[*] Checking for Ruby-2.5.0...\n'
-if ruby -v | grep "ruby 2.5.0" >/dev/null; then
+printf '[*] Checking for Ruby-2.5.1...\n'
+if ruby -v | grep "ruby 2.5.1" >/dev/null; then
   printf "${CLEAR_LINE}Ruby already installed\n"
 else
-  echo "Ruby-2.5.0 not found. Please install ruby-2.5.0 and run this script again."
-  echo "One way to install ruby-2.5.0 is through RVM, Visit: https://rvm.io/"
+  echo "Ruby-2.5.1 not found. Please install ruby-2.5.1 and run this script again."
+  echo "One way to install ruby-2.5.1 is through RVM, Visit: https://rvm.io/"
   exit 0;
 fi
 


### PR DESCRIPTION
I'm pretty sure the only reason 2.5.0 is used is [this comment](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/1844#issuecomment-378012713). Since Ruby 2.5.1 has now been out for some time, and since all Ruby requirements now specify 3 digits, I'm pretty sure upgrading to 2.5.1 will be fine.