### PR TITLE
'Credit' column data overflows in the Uploads table #2004

### DIFF
--- a/app/assets/stylesheets/modules/_uploads.styl
+++ b/app/assets/stylesheets/modules/_uploads.styl
@@ -144,3 +144,8 @@
 
     .upload-viewer-button
       margin 10px
+
+a.external.text {
+    word-break: break-word;
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
If provided with a link in 'Credit' column, it causes overflow. So I have reproduced this issue and fixed it by breaking this url(Table was already responsive) using css.

Signed-off-by: Sanjana suman <sumansanjna13@gmail.com>

## Before the Pull Request ##
* Test out your changes manually to confirm that it works and search for bugs.
* Run the Javascript tests locally (`yarn test`) and confirm that they are passing.
* Run the specs for any Ruby files you changes, along with the feature specs that are related to your changes. Optionally, you can run the entire test suite locally (`rake spec`). For feature specs, you will need to use the production build of the assets by running `gulp build` first.

## Opening the Pull Request ##

* Describe the changes included in the PR.
* Note the issue that the PR addresses. Include `Fixes #12345` if it will completely address the issue.
* If there are UI elements to the change, include a screenshot or animation to illustrate it.
* If the PR is not complete but you want feedback on it, include `[WIP]` in the title to indicate work-in-progress. Edit the title when it's ready.

## After the PR ##
* Check the continuous integration build, which usually takes about 20 minutes.
    * Fix any failures.
    * Add a comment to the PR if you are stuck. If the build is failing and you don't discuss it with anyone, we will assume that you've seen the failing specs and are working to fix them.
    * Occasionally, specs unrelated to the PR will fail. If you think that's the case, you can ping someone to restart the build, or close and reopen the PR to trigger a new build.
* If the build is passing, we will review it as soon as we can.
* If you are abandoning a PR, please close it to help us keep track of which PRs are still active.
