### PR TITLE
Fixed overflow of article table #1883

### DIFF
--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -57,6 +57,12 @@
       &:first-child td
         border-top 1px solid #ddd
 
+.course_title
+  word-break break-word
+  max-width 450px
+
+
+
   // Transparent header
   thead
     tr

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -61,7 +61,9 @@
   word-break break-word
   max-width 450px
 
-
+.title 
+  word-break break-word
+  max-width 450px
 
   // Transparent header
   thead


### PR DESCRIPTION
Fixes #1883  
Fixed Program and Title column in the Article table.(https://dashboard.wikiedu.org/campaigns/spring_2018/articles)
![Screenshot after the CSS changes](https://user-images.githubusercontent.com/35132729/46062298-fc736700-c186-11e8-9bed-7844bf673a47.png)
