### PR TITLE
Removed Peer Review module from Student training library page

### DIFF
--- a/training_content/wiki_ed/libraries/students.yml
+++ b/training_content/wiki_ed/libraries/students.yml
@@ -56,9 +56,6 @@ categories:
       - slug: moving-to-mainspace-group
         name: Moving work out of the sandbox (as a group)
         description: How to move a draft into Wikipedia proper as a group
-      - slug: peer-review
-        name: Peer review
-        description: Tips for getting the most out of the peer review process
       - slug: plagiarism
         name: Plagiarism and copyright violation
         description: A detailed review of plagiarism and how to avoid it


### PR DESCRIPTION
Removed Peer Review module from Student training library page. Helaine & Samantha agree that it is more of an exercise than a training, and therefore should only be visible through the Timeline.