### PR TITLE
Corrected Text-Alignment for pageviews & revScore

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -70,7 +70,7 @@ const ArticleFinderRow = createReactClass({
       if (this.props.article.fetchState === 'PAGEASSESSMENT_RECEIVED' || this.props.article.fetchState === 'REVISION_RECEIVED') {
         revScore = (<td><div className="results-loading"> &nbsp; &nbsp; </div></td>);
       } else if (this.props.article.revScore) {
-        revScore = (<td>{Math.round(this.props.article.revScore)}</td>);
+        revScore = (<td className="revScore">{Math.round(this.props.article.revScore)}</td>);
       } else if (fetchStates[this.props.article.fetchState] >= fetchStates.REVISIONSCORE_RECEIVED) {
         revScore = (<td><div>Estimation Score not found!</div></td>);
       } else {
@@ -169,7 +169,7 @@ const ArticleFinderRow = createReactClass({
         </td>
         {grade}
         {revScore}
-        <td>
+        <td className="pageviews">
           {pageviews}
         </td>
         {button}

--- a/app/assets/stylesheets/modules/_article_finder.styl
+++ b/app/assets/stylesheets/modules/_article_finder.styl
@@ -11,6 +11,13 @@
 .fetch-more
   height 3rem
 
+.pageviews 
+  text-align justify
+  direction rtl
+
+.revScore 
+  text-align center
+
 .search-bar
   display flex
   flex-direction row


### PR DESCRIPTION
Fixes #2064 

This is how the alignment looks now.
![actual](https://user-images.githubusercontent.com/32068121/47450592-4762b780-d7e3-11e8-8f26-845dc07b12f1.png)
