### PR TITLE
Fixed uploader link in Uploads view

### DIFF
--- a/app/assets/javascripts/components/uploads/upload.jsx
+++ b/app/assets/javascripts/components/uploads/upload.jsx
@@ -63,7 +63,7 @@ const Upload = createReactClass({
     let uploader;
     if (this.props.linkUsername) {
       const profileLink = `/users/${encodeURIComponent(this.props.upload.uploader)}`;
-      uploader = <a href={profileLink} target="_blank">{this.props.upload.uploader}</a>;
+      uploader = <a href={profileLink} onClick={event => event.stopPropagation()} target="_blank">{this.props.upload.uploader}</a>;
     } else {
       uploader = this.props.upload.uploader;
     }


### PR DESCRIPTION
#2036 
Fixed uploader link by adding 
```js
event.stopPropagation()
``` 
to `app/assets/javascript/components/uploads/upload.jsx`

Now it only opens uploader profile in a new tab.