### PR TITLE
Improves win-setup.bat to work smoothly #1709

### DIFF
--- a/setup/win-setup.bat
+++ b/setup/win-setup.bat
@@ -5,7 +5,7 @@ echo [*] Installing chocolatey...
 @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 echo [*] Installing ruby...
-choco install ruby2.devkit -y
+choco install ruby2.devkit --version 4.7.2.2013022403 -y
 
 echo [*] Installing Node.js...
 choco install nodejs-lts -y
@@ -15,7 +15,8 @@ call gem install bundler
 call bundle install
 
 echo [*] Installing Yarn...
-choco install yarn -y
+choco install yarn -y 
+SET "PATH=%PATH%;%ProgramFiles(x86)%\Yarn\bin"
 
 echo [*] Installing node modules...
 call yarn
@@ -35,14 +36,21 @@ choco install bitnami-xampp -y
 start C:\xampp\mysql\bin\mysqld
 
 echo [*] Setting up database...
-echo CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;exit| C:\xampp\mysql\bin\mysql -u root
+echo CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; exit| C:\xampp\mysql\bin\mysql -u root
+
+echo [*] Creating User for Mysql...
+echo CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';exit| C:\xampp\mysql\bin\mysql -u root
+
 
 echo [*] Installing Redis...
 msiexec /i https://github.com/MicrosoftArchive/redis/releases/download/win-3.0.504/Redis-x64-3.0.504.msi
 
-echo [*] Installing Gulp...
-yarn global add gulp
-
 echo [*] Migrating databases...
-rake db:migrate
-rake db:migrate RAILS_ENV=test
+call rake db:migrate
+call rake db:migrate RAILS_ENV=test
+
+echo [*] Installing Gulp...
+call yarn global add gulp
+SET "PATH=%PATH%;%LOCALAPPDATA%\Yarn\bin"
+
+echo Your developmental environment setup is complete. If you there are any errors, please refer to the docs for manual installation, or ask for help.

--- a/setup/win-setup.bat
+++ b/setup/win-setup.bat
@@ -45,12 +45,12 @@ echo CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';GRANT ALL PRIVILEGES
 echo [*] Installing Redis...
 msiexec /i https://github.com/MicrosoftArchive/redis/releases/download/win-3.0.504/Redis-x64-3.0.504.msi
 
-echo [*] Migrating databases...
-call rake db:migrate
-call rake db:migrate RAILS_ENV=test
-
 echo [*] Installing Gulp...
 call yarn global add gulp
 SET "PATH=%PATH%;%LOCALAPPDATA%\Yarn\bin"
+
+echo [*] Migrating databases...
+call rake db:migrate
+call rake db:migrate RAILS_ENV=test
 
 echo Your developmental environment setup is complete. If you there are any errors, please refer to the docs for manual installation, or ask for help.

--- a/setup/win-setup.bat
+++ b/setup/win-setup.bat
@@ -3,54 +3,69 @@ echo Setting up your developmental environment. This may take a while.
 
 echo [*] Installing chocolatey...
 @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+echo [+] Chco installed!
 
-echo [*] Installing ruby...
+echo [*] Installing ruby+devkit...
 choco install ruby2.devkit --version 4.7.2.2013022403 -y
+echo [+] Ruby+devkit installed!
 
 echo [*] Installing Node.js...
 choco install nodejs-lts -y
+echo [+] Node.js installed!
 
 echo [*] Installing Gems...
 call gem install bundler
 call bundle install
+echo [+] Gems installed!
 
 echo [*] Installing Yarn...
 choco install yarn -y 
 SET "PATH=%PATH%;%ProgramFiles(x86)%\Yarn\bin"
+echo [+] Yarn installed!
 
 echo [*] Installing node modules...
 call yarn
+echo [+] Node modules installed!
 
 echo [*] Installing PhantomJs...
 call yarn global add phantomjs-prebuilt
+echo [+] PhantomJs installed!
 
 echo [*] Installing Pandoc...
 choco install pandoc -y
+echo [+] Pandoc installed!
 
 echo [*] Creating configuration files...
 copy config\application.example.yml config\application.yml
 copy config\database.example.yml config\database.yml
+echo [+] Configuration files created!
 
 echo [*] Installing XAMPP...
 choco install bitnami-xampp -y
 start C:\xampp\mysql\bin\mysqld
+echo [+] XAMPP install complete!
 
-echo [*] Setting up database...
+echo [*] Creating databases...
 echo CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; exit| C:\xampp\mysql\bin\mysql -u root
+echo [+] Databases created!
 
 echo [*] Creating User for Mysql...
 echo CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';exit| C:\xampp\mysql\bin\mysql -u root
+echo [+] Database user created!
 
 
 echo [*] Installing Redis...
 msiexec /i https://github.com/MicrosoftArchive/redis/releases/download/win-3.0.504/Redis-x64-3.0.504.msi
+echo [+] Redis installed!
 
 echo [*] Installing Gulp...
 call yarn global add gulp
 SET "PATH=%PATH%;%LOCALAPPDATA%\Yarn\bin"
+echo [+] Gulp install complete!
 
 echo [*] Migrating databases...
 call rake db:migrate
 call rake db:migrate RAILS_ENV=test
+echo [+] Database migration complete!
 
 echo Your developmental environment setup is complete. If you there are any errors, please refer to the docs for manual installation, or ask for help.


### PR DESCRIPTION
This fixes several issues with the win-setup.bat file (issue #1709)

1) Adds a fix to ruby devkit not installing from choco - still unclear as to why this occurs, but trying the fix as discussed [here](https://github.com/chocolatey/choco/issues/846) seemed to work, so the version is explicitly stated
2) Added the path to yarn directories to PATH in two places to make sure the installer can use yarn properly as it previously would crash as it could not find yarn
3) Created a user "wiki" for the database as otherwise migration would not work (this copied from the debian setup file)
4) Switched all instances of `rake` and `yarn` to `call rake` and `call yarn` to stop the batch process hanging
5) Added a message to let the user know the batch has in fact completed!

These fixes are all down to my own personal experience of a broken batch file whilst installing. On a fresh install, the new batch works with no tweaking to the script!

(This is part of a Google Code-In task)