### PR TITLE
Fixed interwiki prefixes, added shorthands and tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,6 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 16 # We should bring this down, ideally to the default of 10
   Exclude:
-    - 'lib/wikitext.rb'
     - 'spec/**/*' # not a big deal in spec helper methods
 Metrics/ModuleLength:
   Exclude:
@@ -96,10 +95,6 @@ Layout/EmptyLineAfterGuardClause:
 # or they should be moved to the 'Permanent' section
 # if we decide they shouldn't be fixed.
 
-Metrics/CyclomaticComplexity:
-  Enabled: true
-  Exclude:
-  - 'lib/wikitext.rb' # case for interwiki shorthands
 Style/FormatStringToken:
   Enabled: false
 Rails/FilePath:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 16 # We should bring this down, ideally to the default of 10
   Exclude:
+    - 'lib/wikitext.rb'
     - 'spec/**/*' # not a big deal in spec helper methods
 Metrics/ModuleLength:
   Exclude:
@@ -95,6 +96,10 @@ Layout/EmptyLineAfterGuardClause:
 # or they should be moved to the 'Permanent' section
 # if we decide they shouldn't be fixed.
 
+Metrics/CyclomaticComplexity:
+  Enabled: true
+  Exclude:
+  - 'lib/wikitext.rb' # case for interwiki shorthands
 Style/FormatStringToken:
   Enabled: false
 Rails/FilePath:

--- a/lib/wikitext.rb
+++ b/lib/wikitext.rb
@@ -65,11 +65,51 @@ class Wikitext
     language = assignment.wiki.language
 
     # For other wikis a language prefix is required, except for wikidata where the language is nil
-    language_prefix = language ? ":#{language}:" : ''
+    language_prefix = language ? ":#{language}" : ''
     # If the project is different, a project prefix is also necessary.
-    project_prefix = project == home_wiki.project ? '' : "#{project}:"
+    project_prefix = project == home_wiki.project ? '' : ":#{project}"
 
-    language_prefix + project_prefix + title
+    # Interwiki shorthands, source: https://en.wikipedia.org/wiki/Help:Interwiki_linking#Project_titles_and_shortcuts
+
+    case project_prefix
+    when ':wikipedia'
+      project_prefix = ':w'
+    when ':wiktionary'
+      project_prefix = ':wikt'
+    when ':wikinews'
+      project_prefix = ':n'
+    when ':wikibooks'
+      project_prefix = ':b'
+    when ':wikiquote'
+      project_prefix = ':q'
+    when ':wikisource'
+      project_prefix = ':s'
+    when ':wikiversity'
+      project_prefix = ':v'
+    when ':wikivoyage'
+      project_prefix = ':voy'
+      # # Disabled due to Invalid Project:
+      # (`raise InvalidWikiError unless PROJECTS.include?(project)`) in app/models/wiki.rb
+      #
+      # when ':commons'
+      #   project_prefix = ':c'
+      # when ':metawikipedia'
+      #   project_prefix = ':m'
+      # when ':meta'
+      #   project_prefix = ':m'
+      # when ':wikispecies'
+      #   project_prefix = ':species'
+      # when ':wikimedia'
+      #   project_prefix = ':wmf'
+      # when ':foundation'
+      #   project_prefix = ':wmf'
+      # when ':mediawikiwiki'
+      #   project_prefix = ':mw'
+      # when ':phabricator'
+      #   project_prefix = ':phab'
+    end
+
+    project_prefix + language_prefix + ':' + title
   end
 
   # converts page title to a format suitable for on-wiki use

--- a/lib/wikitext.rb
+++ b/lib/wikitext.rb
@@ -2,6 +2,27 @@
 
 require 'pandoc-ruby'
 
+# Interwiki shorthands, source: https://en.wikipedia.org/wiki/Help:Interwiki_linking#Project_titles_and_shortcuts
+INTERWIKI_PREFIXES = {
+  ':wikipedia' => ':w',
+  ':wiktionary' => ':wikt',
+  ':wikinews' => ':n',
+  ':wikibooks' => ':b',
+  ':wikiquote' => ':q',
+  ':wikisource' => ':s',
+  ':wikiversity' => ':v',
+  ':wikivoyage' => ':voy',
+  # ':commons' => ':c',
+  # ':wikimedia' => ':wmf',
+  # ':foundation' => ':wmf'
+  # # Disabled due to Invalid Project:
+  # ':metawikipedia' => ':m',
+  # ':meta' => ':m',
+  # ':wikispecies' => ':species',
+  # ':mediawikiwiki' => ':mw',
+  # ':phabricator' => ':phab'
+}.freeze
+
 #= Utilities to create and manipulate mediawiki wikitext
 class Wikitext
   ################################
@@ -64,52 +85,14 @@ class Wikitext
     project = assignment.wiki.project
     language = assignment.wiki.language
 
+    return ":c:#{title}" if language == 'commons'
+
     # For other wikis a language prefix is required, except for wikidata where the language is nil
     language_prefix = language ? ":#{language}" : ''
     # If the project is different, a project prefix is also necessary.
     project_prefix = project == home_wiki.project ? '' : ":#{project}"
 
-    # Interwiki shorthands, source: https://en.wikipedia.org/wiki/Help:Interwiki_linking#Project_titles_and_shortcuts
-
-    case project_prefix
-    when ':wikipedia'
-      project_prefix = ':w'
-    when ':wiktionary'
-      project_prefix = ':wikt'
-    when ':wikinews'
-      project_prefix = ':n'
-    when ':wikibooks'
-      project_prefix = ':b'
-    when ':wikiquote'
-      project_prefix = ':q'
-    when ':wikisource'
-      project_prefix = ':s'
-    when ':wikiversity'
-      project_prefix = ':v'
-    when ':wikivoyage'
-      project_prefix = ':voy'
-      # # Disabled due to Invalid Project:
-      # (`raise InvalidWikiError unless PROJECTS.include?(project)`) in app/models/wiki.rb
-      #
-      # when ':commons'
-      #   project_prefix = ':c'
-      # when ':metawikipedia'
-      #   project_prefix = ':m'
-      # when ':meta'
-      #   project_prefix = ':m'
-      # when ':wikispecies'
-      #   project_prefix = ':species'
-      # when ':wikimedia'
-      #   project_prefix = ':wmf'
-      # when ':foundation'
-      #   project_prefix = ':wmf'
-      # when ':mediawikiwiki'
-      #   project_prefix = ':mw'
-      # when ':phabricator'
-      #   project_prefix = ':phab'
-    end
-
-    project_prefix + language_prefix + ':' + title
+    (INTERWIKI_PREFIXES[project_prefix] || project_prefix) + language_prefix + ':' + title
   end
 
   # converts page title to a format suitable for on-wiki use

--- a/spec/lib/wikitext_spec.rb
+++ b/spec/lib/wikitext_spec.rb
@@ -84,7 +84,20 @@ My list:
     let(:en_wiki) { Wiki.find_by(language: 'en', project: 'wikipedia') }
     let(:es_wiki) { create(:wiki, language: 'es', project: 'wikipedia') }
     let(:es_wiktionary) { create(:wiki, language: 'es', project: 'wiktionary') }
+    let(:en_wikinews) { create(:wiki, language: 'en', project: 'wikinews') }
+    let(:en_wikibooks) { create(:wiki, language: 'en', project: 'wikibooks') }
+    let(:pl_wikiquote) { create(:wiki, language: 'pl', project: 'wikiquote') }
+    let(:es_wikisource) { create(:wiki, language: 'es', project: 'wikisource') }
     let(:wikidata) { create(:wiki, project: 'wikidata') }
+    let(:de_wikiversity) { create(:wiki, language: 'de', project: 'wikiversity') }
+    let(:en_wikivoyage) { create(:wiki, language: 'en', project: 'wikivoyage') }
+    # Disabled due to Invalid Project:
+    # (`raise InvalidWikiError unless PROJECTS.include?(project)`) in app/models/wiki.rb
+    # let(:metawikipedia) { create(:wiki, language: 'en', project: 'metawikipedia') }
+    # let(:meta) { create(:wiki, language: 'en', project: 'meta') }
+    # let(:commons) { create(:wiki, language: 'en', project: 'commons') }
+    # let(:wikispecies) { create(:wiki, project: 'wikispecies') }
+
     let(:assignments) do
       [
         create(:assignment, article_title: 'Selfie'),
@@ -92,7 +105,25 @@ My list:
         create(:assignment, article_title: 'Bishnu Priya'),
         create(:assignment, article_title: 'Blanca de Beaulieu', wiki: es_wiki),
         create(:assignment, article_title: 'agrazarías', wiki: es_wiktionary),
-        create(:assignment, article_title: 'Q60', wiki: wikidata)
+        create(
+          :assignment,
+          article_title: 'Manned Soyuz space mission aborts during launch',
+          wiki: en_wikinews
+        ),
+        create(:assignment, article_title: 'Q60', wiki: wikidata),
+        create(:assignment, article_title: 'Mastering the Kitchen', wiki: en_wikibooks),
+        create(:assignment, article_title: 'Theodore Roosevelt', wiki: pl_wikiquote),
+        create(:assignment, article_title: 'Novelas y fantasías', wiki: es_wikisource),
+        create(:assignment, article_title: 'Mathematik', wiki: de_wikiversity),
+        create(:assignment, article_title: 'Previous Featured travel topics', wiki: en_wikivoyage),
+        # Disabled due to Invalid Project:
+        # (`raise InvalidWikiError unless PROJECTS.include?(project)`) in app/models/wiki.rb
+        # create(:assignment, article_title: 'Hardware donation program', wiki: meta)
+        # create(:assignment, article_title: 'Wiki4MediaFreedom contest - II edition', wiki: metawik
+        # ipedia),
+        # create(:assignment, article_title: 'Sitta europaea caesia', wiki: wikispecies),
+        # create(:assignment, article_title: 'File:Black-headed lapwing (Vanellus tectus tectus).jpg
+        # ', wiki: commons),
       ]
     end
 
@@ -104,8 +135,19 @@ My list:
       expect(output).to include('[[:Category:Photography]]')
       expect(output).to include('[[Bishnu Priya]]')
       expect(output).to include('[[:es:Blanca de Beaulieu]]')
-      expect(output).to include('[[:es:wiktionary:agrazarías]]')
-      expect(output).to include('[[wikidata:Q60]]')
+      expect(output).to include('[[:wikt:es:agrazarías]]')
+      expect(output).to include('[[:wikidata:Q60]]')
+      expect(output).to include('[[:n:en:Manned Soyuz space mission aborts during launch]]')
+      expect(output).to include('[[:b:en:Mastering the Kitchen]]')
+      expect(output).to include('[[:q:pl:Theodore Roosevelt]]')
+      expect(output).to include('[[:s:es:Novelas y fantasías')
+      expect(output).to include('[[:v:de:Mathematik]]')
+      expect(output).to include('[[:voy:en:Previous Featured travel topics]]')
+      # expect(output).to include('[[:m:en:Wiki4MediaFreedom contest - II edition]]')
+      # expect(output).to include('[[:n:en:Hardware donation program]]')
+      # expect(output).to include('[[:species:Sitta europaea caesia]]')
+      # expect(output).to include('[[:c:en:File:Black-headed lapwing (Vanellus tectus tectus).jpg]
+      # ]')
     end
   end
 end

--- a/spec/lib/wikitext_spec.rb
+++ b/spec/lib/wikitext_spec.rb
@@ -91,11 +91,11 @@ My list:
     let(:wikidata) { create(:wiki, project: 'wikidata') }
     let(:de_wikiversity) { create(:wiki, language: 'de', project: 'wikiversity') }
     let(:en_wikivoyage) { create(:wiki, language: 'en', project: 'wikivoyage') }
+    let(:commons) { create(:wiki, language: 'commons', project: 'wikimedia') }
     # Disabled due to Invalid Project:
     # (`raise InvalidWikiError unless PROJECTS.include?(project)`) in app/models/wiki.rb
     # let(:metawikipedia) { create(:wiki, language: 'en', project: 'metawikipedia') }
     # let(:meta) { create(:wiki, language: 'en', project: 'meta') }
-    # let(:commons) { create(:wiki, language: 'en', project: 'commons') }
     # let(:wikispecies) { create(:wiki, project: 'wikispecies') }
 
     let(:assignments) do
@@ -116,14 +116,15 @@ My list:
         create(:assignment, article_title: 'Novelas y fantasías', wiki: es_wikisource),
         create(:assignment, article_title: 'Mathematik', wiki: de_wikiversity),
         create(:assignment, article_title: 'Previous Featured travel topics', wiki: en_wikivoyage),
+        create(:assignment,
+               article_title: 'File:Black-headed lapwing (Vanellus tectus tectus).jpg',
+               wiki: commons),
         # Disabled due to Invalid Project:
         # (`raise InvalidWikiError unless PROJECTS.include?(project)`) in app/models/wiki.rb
         # create(:assignment, article_title: 'Hardware donation program', wiki: meta)
         # create(:assignment, article_title: 'Wiki4MediaFreedom contest - II edition', wiki: metawik
         # ipedia),
         # create(:assignment, article_title: 'Sitta europaea caesia', wiki: wikispecies),
-        # create(:assignment, article_title: 'File:Black-headed lapwing (Vanellus tectus tectus).jpg
-        # ', wiki: commons),
       ]
     end
 
@@ -143,11 +144,10 @@ My list:
       expect(output).to include('[[:s:es:Novelas y fantasías')
       expect(output).to include('[[:v:de:Mathematik]]')
       expect(output).to include('[[:voy:en:Previous Featured travel topics]]')
+      expect(output).to include('[[:c:File:Black-headed lapwing (Vanellus tectus tectus).jpg]]')
       # expect(output).to include('[[:m:en:Wiki4MediaFreedom contest - II edition]]')
       # expect(output).to include('[[:n:en:Hardware donation program]]')
       # expect(output).to include('[[:species:Sitta europaea caesia]]')
-      # expect(output).to include('[[:c:en:File:Black-headed lapwing (Vanellus tectus tectus).jpg]
-      # ]')
     end
   end
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -236,7 +236,8 @@ module RequestHelpers
       'www.wikidata.org',
       'en.wikinews.org',
       'pl.wikiquote.org',
-      'de.wikiversity.org'
+      'de.wikiversity.org',
+      'commons.wikimedia.org'
     ]
 
     wikis.each do |wiki|

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -214,16 +214,8 @@ module RequestHelpers
   def stub_wiki_validation
     wikis = [
       'incubator.wikimedia.org',
-      'en.wiktionary.org',
-      'es.wiktionary.org',
       'es.wikipedia.org',
       'pt.wikipedia.org',
-      'ta.wiktionary.org',
-      'es.wikibooks.org',
-      'ar.wikibooks.org',
-      'en.wikivoyage.org',
-      'wikisource.org',
-      'www.wikidata.org',
       'zh.wikipedia.org',
       'mr.wikipedia.org',
       'eu.wikipedia.org',
@@ -231,7 +223,20 @@ module RequestHelpers
       'fr.wikipedia.org',
       'ru.wikipedia.org',
       'simple.wikipedia.org',
-      'tr.wikipedia.org'
+      'tr.wikipedia.org',
+      'en.wiktionary.org',
+      'es.wiktionary.org',
+      'ta.wiktionary.org',
+      'es.wikibooks.org',
+      'en.wikibooks.org',
+      'ar.wikibooks.org',
+      'en.wikivoyage.org',
+      'wikisource.org',
+      'es.wikisource.org',
+      'www.wikidata.org',
+      'en.wikinews.org',
+      'pl.wikiquote.org',
+      'de.wikiversity.org'
     ]
 
     wikis.each do |wiki|


### PR DESCRIPTION
#2128

Fixed interwiki prefixes by reordering them (as stated in issue), added shorthands from [en.wikipedia.org/wiki/Help:Interwiki_linking](https://en.wikipedia.org/wiki/Help:Interwiki_linking#Project_titles_and_shortcuts). I also wrote tests for `lib/wikitext.rb`

GCI Task