### PR TITLE
Enabled and fixed 4 eslint rules (Issue #1408)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,7 +65,6 @@
     "prefer-destructuring": 0,
     "react/prop-types": 0,
     "semi-style": 0,
-    "operator-linebreak": 0,
     "react/jsx-tag-spacing": 0,
     "implicit-arrow-linebreak": 0,
     "react/destructuring-assignment": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "react/jsx-no-bind": 0,
     "no-alert": 0,
     "new-cap": [2, { "capIsNew": false }],
+    "no-else-return": [2, { "allowElseIf": true }],
     "no-use-before-define": 0,
     # App is using html from an outside source (Wikipedia, eg. for training slides, articles), so
     # it's going to be 'dangerous' in the sense of injecting whatever html comes from Wikipedia, but that's what is needed
@@ -72,7 +73,6 @@
     "react/destructuring-assignment": 0,
     "react/jsx-one-expression-per-line": 0,
     "react/button-has-type": 0,
-    "no-else-return": 0,
     "no-multiple-empty-lines": 0,
     "lines-between-class-members": 0,
     "import/order": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -50,7 +50,6 @@
     "class-methods-use-this": 0,
     "no-prototype-builtins": 0,
     "no-restricted-syntax": 0,
-    "space-unary-ops": 0,
     "global-require": 0,
     "no-restricted-globals": 0,
     "indent": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -49,7 +49,6 @@
     "newline-per-chained-call": 0,
     "class-methods-use-this": 0,
     "no-prototype-builtins": 0,
-    "no-restricted-syntax": 0,
     "global-require": 0,
     "no-restricted-globals": 0,
     "indent": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -78,7 +78,6 @@
     "import/order": 0,
     "react/jsx-wrap-multilines": 0,
     "react/no-access-state-in-setstate": 0,
-    "comma-style": 0,
     "import/no-useless-path-segments": 0,
     "react/no-this-in-sfc": 0,
     "react/jsx-props-no-multi-spaces": 0

--- a/app/assets/javascripts/components/common/weekday_picker.jsx
+++ b/app/assets/javascripts/components/common/weekday_picker.jsx
@@ -51,14 +51,12 @@ const WeekdayPicker = createReactClass({
   getModifiersForDay(weekday, modifierFunctions) {
     const modifiers = [];
     if (modifierFunctions) {
-      for (const modifier in modifierFunctions) {
-        if (Object.prototype.hasOwnProperty.call(modifierFunctions, modifier)) {
-          const func = modifierFunctions[modifier];
-          if (func(weekday)) {
-            modifiers.push(modifier);
-          }
+      Object.keys(modifierFunctions).forEach((modifier) => {
+        const func = modifierFunctions[modifier];
+        if (func(weekday)) {
+          modifiers.push(modifier);
         }
-      }
+      });
     }
     return modifiers;
   },

--- a/app/assets/javascripts/components/high_order/input_hoc.jsx
+++ b/app/assets/javascripts/components/high_order/input_hoc.jsx
@@ -25,8 +25,7 @@ const InputHOC = (Component) => {
         {
           value: props.value,
           id: props.id || this.state.id || uuid.v4() // create a UUID if no id prop
-        }
-        , function () {
+        }, function () {
           const valid = ValidationStore.getValidation(this.props.value_key);
           if (valid && this.props.required && (!props.value || props.value === null || props.value.length === 0)) {
             return ValidationActions.initialize(this.props.value_key, I18n.t('application.field_required'));

--- a/app/assets/javascripts/components/high_order/input_hoc.jsx
+++ b/app/assets/javascripts/components/high_order/input_hoc.jsx
@@ -65,7 +65,7 @@ const InputHOC = (Component) => {
         let charcheck;
         if (this.props.validation instanceof RegExp) {
           charcheck = (new RegExp(this.props.validation)).test(this.state.value);
-        } else if (typeof(this.props.validation) === 'function') {
+        } else if (typeof (this.props.validation) === 'function') {
           charcheck = this.props.validation(this.state.value);
         }
         if (this.props.required && !filled) {

--- a/app/assets/javascripts/components/onboarding/finished.jsx
+++ b/app/assets/javascripts/components/onboarding/finished.jsx
@@ -19,8 +19,7 @@ const Finished = createReactClass({
     return this.state.timeout = setTimeout(() => {
       const returnTo = this.props.returnToParam;
       return window.location = decodeURIComponent(returnTo);
-    }
-    , 750);
+    }, 750);
   },
 
   // clear the timeout just to be safe

--- a/app/assets/javascripts/components/overview/campaign_list.jsx
+++ b/app/assets/javascripts/components/overview/campaign_list.jsx
@@ -6,8 +6,8 @@ import CourseUtils from '../../utils/course_utils.js';
 
 const CampaignList = ({ campaigns, course }) => {
   const lastIndex = campaigns.length - 1;
-  campaigns = (campaigns.length > 0 ?
-    _.map(campaigns, (campaign, index) => {
+  campaigns = (campaigns.length > 0
+    ? _.map(campaigns, (campaign, index) => {
       let comma = '';
       const url = `/campaigns/${campaign.slug}/overview`;
       if (index !== lastIndex) { comma = ', '; }

--- a/app/assets/javascripts/components/overview/tag_list.jsx
+++ b/app/assets/javascripts/components/overview/tag_list.jsx
@@ -6,8 +6,8 @@ import CourseUtils from '../../utils/course_utils.js';
 
 const TagList = ({ tags, course }) => {
   const lastIndex = tags.length - 1;
-  const renderedTags = (tags.length > 0 ?
-    _.map(tags, (tag, index) => {
+  const renderedTags = (tags.length > 0
+    ? _.map(tags, (tag, index) => {
       const comma = (index !== lastIndex) ? ', ' : '';
       return <span key={`${tag.tag}${tag.id}`}>{tag.tag}{comma}</span>;
     })

--- a/app/assets/javascripts/components/settings/views/admin_user.jsx
+++ b/app/assets/javascripts/components/settings/views/admin_user.jsx
@@ -52,9 +52,9 @@ const AdminUser = createReactClass({
 
   render() {
     const { user } = this.props;
-    const adminLevel = user.permissions === 3 ?
-      'Super Admin' :
-      'Admin';
+    const adminLevel = user.permissions === 3
+      ? 'Super Admin'
+      : 'Admin';
 
     let buttonText;
     let buttonClass = 'button';

--- a/app/assets/javascripts/components/students/student.jsx
+++ b/app/assets/javascripts/components/students/student.jsx
@@ -67,8 +67,7 @@ const Student = createReactClass({
         </a>)
       </span>
       )
-      :
-      (
+      : (
         <span>
           <a onClick={this.stop} href={this.props.student.contribution_url} target="_blank">
             {trunc(this.props.student.username)}

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -163,8 +163,7 @@ const Timeline = createReactClass({
       }
     }
     );
-  }
-  , 150),
+  }, 150),
 
   tooManyWeeks() {
     const nonEmptyWeeks = this.props.week_meetings.filter(week => week !== '()');

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -159,8 +159,8 @@ const Week = createReactClass({
     ) : undefined;
 
     const weekContent = (
-      this.props.reorderable ?
-        (style = {
+      this.props.reorderable
+        ? (style = {
           position: 'relative',
           height: blocks.length * 75,
           transition: 'height 500ms ease-in-out'
@@ -169,8 +169,7 @@ const Week = createReactClass({
             {blocks}
           </ReactCSSTG>
         )
-        :
-        (
+        : (
           <ul className="week__block-list list-unstyled">
             {blocks}
           </ul>

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -53,10 +53,9 @@ const FormPanel = createReactClass({
   render() {
     const dateProps = CourseDateUtils.dateProps(this.props.course);
 
-    const step1 = this.props.shouldShowSteps ?
-      <h2><span>1.</span><small> Confirm the course’s start and end dates.</small></h2>
-    :
-      <p>Confirm the course’s start and end dates.</p>;
+    const step1 = this.props.shouldShowSteps
+      ? <h2><span>1.</span><small> Confirm the course’s start and end dates.</small></h2>
+      : <p>Confirm the course’s start and end dates.</p>;
 
     const rawOptions = (
       <div>

--- a/app/assets/javascripts/reducers/notifications.js
+++ b/app/assets/javascripts/reducers/notifications.js
@@ -6,12 +6,12 @@ const initialState = [];
 const saveTimelineFailedNotification = {
   closable: true,
   type: 'error',
-  message: 'The changes you just submitted were not saved. ' +
-           'This may happen if the timeline has been changed — ' +
-           'by someone else, or by you in another browser ' +
-           'window — since the page was loaded. The latest ' +
-           'course data has been reloaded, and is ready for ' +
-           'you to edit further.'
+  message: 'The changes you just submitted were not saved. '
+           + 'This may happen if the timeline has been changed — '
+           + 'by someone else, or by you in another browser '
+           + 'window — since the page was loaded. The latest '
+           + 'course data has been reloaded, and is ready for '
+           + 'you to edit further.'
 };
 
 const handleErrorNotification = function (data) {

--- a/app/assets/javascripts/reducers/training.js
+++ b/app/assets/javascripts/reducers/training.js
@@ -82,9 +82,8 @@ export default function training(state = initialState, action) {
       };
       if (newState.valid) {
         return update(setCurrentSlide(newState, data.slide));
-      } else {
-        return { ...newState, loading: false };
       }
+      return { ...newState, loading: false };
     }
     case MENU_TOGGLE:
       return { ...state, menuIsOpen: !data.currently };

--- a/app/assets/javascripts/stores/validation_store.js
+++ b/app/assets/javascripts/stores/validation_store.js
@@ -57,8 +57,7 @@ const ValidationStore = Flux.createStore(
       _errorQueue = [];
       return ValidationStore.emitChange();
     }
-  }
-  , (payload) => {
+  }, (payload) => {
     const { data } = payload;
     switch (payload.actionType) {
       case 'INITIALIZE':

--- a/app/assets/javascripts/styleguide/styleguide.jsx
+++ b/app/assets/javascripts/styleguide/styleguide.jsx
@@ -113,9 +113,7 @@ const StyleguideExamples = {
 };
 
 $(() => {
-  for (const example in StyleguideExamples) {
-    if (StyleguideExamples.hasOwnProperty(example)) {
+  Object.keys(StyleguideExamples).forEach((example) => {
       StyleguideExamples[example]();
-    }
-  }
+  });
 });

--- a/app/assets/javascripts/surveys/components/TextResults.jsx
+++ b/app/assets/javascripts/surveys/components/TextResults.jsx
@@ -88,8 +88,8 @@ export default class TextResults extends Component {
     const { limit, buttonText } = this.state;
     const answers = this.props.answers_data;
     const followUpAnswers = this.followUpAnswers;
-    if ((followUpOnly && followUpAnswers.length < limit) ||
-        (!followUpOnly && answers.length < limit)) {
+    if ((followUpOnly && followUpAnswers.length < limit)
+       || (!followUpOnly && answers.length < limit)) {
       return null;
     }
     const button = this.showButton ? <button type="button" className="link-button" onClick={this.toggleShowMore}>{`Show ${buttonText}`}</button> : null;

--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -356,8 +356,8 @@ const Survey = {
     }
 
     // Validate Checkbox
-    if ($block.find('[data-required-checkbox]').length &&
-        $block.find('input[type="checkbox"]:checked').length === 0) {
+    if ($block.find('[data-required-checkbox]').length
+        && $block.find('input[type="checkbox"]:checked').length === 0) {
       validation = false;
     }
 
@@ -647,8 +647,8 @@ const Survey = {
       });
       // Check if value matches a conditional question
       value.forEach((v) => {
-        if (conditionalGroup[v] !== undefined &&
-            currentAnswers.indexOf(v) === -1) {
+        if (conditionalGroup[v] !== undefined
+            && currentAnswers.indexOf(v) === -1) {
           conditional = conditionalGroup[v];
           currentAnswers.push(v);
           conditionalGroup.currentAnswers = currentAnswers;

--- a/app/assets/javascripts/surveys/modules/SurveyAssignmentAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAssignmentAdmin.js
@@ -12,8 +12,9 @@ const SurveyAssignmentAdmin = {
 
   sortableTables() {
     return $('[data-sortable-courses]').each((i, sortableCourses) => {
-      const options =
-        { valueNames: ['title', 'id'] };
+      const options = {
+        valueNames: ['title', 'id']
+      };
 
       return new List(sortableCourses, options);
     });

--- a/test/components/settings/admin_user.spec.jsx
+++ b/test/components/settings/admin_user.spec.jsx
@@ -45,9 +45,9 @@ describe('AdminUser', () => {
       const expectedCellValues = [
         expectedUser.username,
         expectedUser.real_name,
-        expectedUser.permissions === 3 ?
-          'Super Admin' :
-          'Admin',
+        expectedUser.permissions === 3
+          ? 'Super Admin'
+          : 'Admin',
       ];
 
       expectedCellValues.forEach((expectedValue, idx) => {


### PR DESCRIPTION
Enalbled and fixed 4 eslint rules (as requested [here](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1408)):

1. `comma-status`
2. `space-unary-ops`
3. `no-restricted-syntax`
4. I also enabled `no-else-return` but with `allowElseIf` - this is the default, but has been overriden somewhere outside of WikiEduDashbooard's .eslintrc, and allowing else if blocks does make the code more readable than multiple disjointed if statements

This is for a GCI task