### PR TITLE
Trimmed 'Category:' and added a link in UploadViewer component

### DIFF
--- a/app/assets/javascripts/components/uploads/upload_viewer.jsx
+++ b/app/assets/javascripts/components/uploads/upload_viewer.jsx
@@ -102,11 +102,14 @@ const UploadViewer = createReactClass({
         </div>
       );
     }
-    let categoriesList = '';
+    let categoriesList = [];
     let categories;
-    _.forEach(_.get(metadata, 'categories', []), category => categoriesList = `${categoriesList} | ${category.title}`);
+    _.forEach(_.get(metadata, 'categories', []), (category) => {
+      categoriesList.push(<span> | </span>);
+      categoriesList.push(<a href={`https://commons.wikimedia.org/wiki/${category.title}`} target="_blank">{category.title.slice('Category:'.length)}</a>);
+    });
     if (categoriesList.length > 0) {
-      categoriesList = categoriesList.slice(2);
+      categoriesList = categoriesList.splice(1);
       categories = (
         <div>
           <h4>Categories</h4>


### PR DESCRIPTION
#2019 

Modified lodash `forEach` loop ([`app/assets/javascripts/components/uploads/upload_viewer.jsx:107`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/app/assets/javascripts/components/uploads/upload_viewer.jsx#L107)) by adding JSX components into it.

![screenshot_20181027_124601](https://user-images.githubusercontent.com/24775963/47613330-7308ca80-da8d-11e8-94cd-b72332b7dcde.png)

GCI task