### PR TITLE
Made article title in 'Article Finder' toggle 'Article Viewer' component

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -148,8 +148,8 @@ const ArticleFinderRow = createReactClass({
     };
     const articleViewer = (
       <ArticleViewer
+        title={this.props.article.title}
         article={article}
-        showButtonClass="pull-left"
         showArticleFinder={true}
       />
     );
@@ -161,10 +161,7 @@ const ArticleFinderRow = createReactClass({
         </td>
         <td>
           <div className="horizontal-flex">
-            <a href={`https://${this.props.course.home_wiki.language}.${this.props.course.home_wiki.project}.org/wiki/${this.props.article.title.replace(/ /g, '_')}`} className="inline" target="_blank">{this.props.title}</a>
-            <div>
-              {articleViewer}
-            </div>
+            {articleViewer}
           </div>
         </td>
         {grade}

--- a/app/assets/javascripts/components/common/article_viewer.jsx
+++ b/app/assets/javascripts/components/common/article_viewer.jsx
@@ -15,10 +15,11 @@ const ArticleViewer = createReactClass({
     article: PropTypes.object.isRequired,
     showButtonLabel: PropTypes.string,
     showButtonClass: PropTypes.string,
+    title: PropTypes.string,
     users: PropTypes.array,
     showOnMount: PropTypes.bool,
-    fetchArticleDetails: PropTypes.func,
     showArticleLegend: PropTypes.bool,
+    fetchArticleDetails: PropTypes.func,
   },
   getDefaultProps() {
     return {
@@ -263,6 +264,16 @@ const ArticleViewer = createReactClass({
 
   render() {
     if (!this.state.showArticle) {
+      if (this.props.title) {
+        return (
+          <div className={`tooltip-trigger ${this.props.showButtonClass || ''}`}>
+            <button onClick={this.showArticle}>{this.props.title}</button>
+            <div className="tooltip tooltip-title dark large">
+              <p>{this.showButtonLabel()}</p>
+            </div>
+          </div>
+        );
+      }
       return (
         <div className={`tooltip-trigger ${this.props.showButtonClass}`}>
           <button onClick={this.showArticle} className="icon icon-article-viewer" />

--- a/app/assets/stylesheets/modules/_tooltips.styl
+++ b/app/assets/stylesheets/modules/_tooltips.styl
@@ -32,6 +32,8 @@
     transition opacity .2s linear, top .2s linear
     white-space normal
     z-index 4
+    &.tooltip-title
+      left: +5px
     &.tooltip-center
       left -145%
       min-width 200px !important


### PR DESCRIPTION
#1984 

Modified [`article_finder_row.jsx`](https://github.com/WikiEducationFoundation/WikiEduDashboard/compare/master...takidelfin:feat/togglearticleviewer?expand=1#diff-5981c578681b5d1c3994490bf595bdbd) by adding additional `title` prop type to [`article_viewer.jsx`](https://github.com/WikiEducationFoundation/WikiEduDashboard/compare/master...takidelfin:feat/togglearticleviewer?expand=1#diff-9e15ebe7615e9d999c02c23eae19d00f). Also made `showBUttonClass` optional when `title` is provided.

GCI task