### PR TITLE
[WP] Test that all actions don't modify passed state for course reducer

### DIFF
--- a/test/reducers/course.spec.js
+++ b/test/reducers/course.spec.js
@@ -1,12 +1,31 @@
 import deepFreeze from 'deep-freeze';
 import course from '../../app/assets/javascripts/reducers/course';
-import { UPDATE_COURSE } from '../../app/assets/javascripts/constants';
+import * as ACTION_TYPES from '../../app/assets/javascripts/constants/course';
 import '../testHelper';
 
 describe('course reducer', () => {
+  it("doesn't modify passed state", () => {
+    const initialState = {};
+    deepFreeze(initialState);
+
+    Object.values(ACTION_TYPES).forEach((actionType) => {
+      const action = { type: actionType };
+      const actionBlackHole = new Proxy(action, {
+        get: function (target, key) {
+          if (key === 'type') {
+            return target.type;
+          }
+
+          return actionBlackHole;
+        }
+      });
+      course(initialState, actionBlackHole);
+    });
+  });
+
   it('updates an attribute via UPDATE_COURSE', () => {
     const initialState = { title: 'old title', term: 'old term' };
-    const action = { type: UPDATE_COURSE, course: { title: 'new title' } };
+    const action = { type: ACTION_TYPES.UPDATE_COURSE, course: { title: 'new title' } };
     deepFreeze(initialState);
 
     const newState = course(initialState, action);


### PR DESCRIPTION
I expect `Proxy` might be better extracted somewhere.