### PR TITLE
[WIP] Enable timezone-related rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,8 @@ Style/RedundantReturn:
   Enabled: false # Sometimes a redundant return enhances clarity.
 Style/SymbolArray:
   Enabled: false # Rare syntax that is potentially confusing to newcomers.
+Style/FormatStringToken:
+  Enabled: false # Not very helpful, string interpolation used instead of Kernel::Format
 Naming/VariableNumber:
   Enabled: false # Not very helpful, and conflicts with wp10-related names
 Rails/Blank:
@@ -87,6 +89,7 @@ Naming/UncommunicativeMethodParamName:
   Enabled: false # This is too restrictive. Calling errors `e` is fine, for example.
 Layout/EmptyLineAfterGuardClause:
   Enabled: false # Not very helpful
+
 ########################
 # Temporary exceptions #
 ########################
@@ -95,8 +98,6 @@ Layout/EmptyLineAfterGuardClause:
 # or they should be moved to the 'Permanent' section
 # if we decide they shouldn't be fixed.
 
-Style/FormatStringToken:
-  Enabled: false
 Rails/FilePath:
   Enabled: false
 Rails/TimeZone:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,8 +100,6 @@ Layout/EmptyLineAfterGuardClause:
 
 Rails/FilePath:
   Enabled: false
-Rails/Date:
-  Enabled: false
 Rails/SkipsModelValidations:
   Enabled: false
 Rails/OutputSafety:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,8 +100,6 @@ Layout/EmptyLineAfterGuardClause:
 
 Rails/FilePath:
   Enabled: false
-Rails/TimeZone:
-  Enabled: false
 Rails/Date:
   Enabled: false
 Rails/SkipsModelValidations:

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -49,7 +49,7 @@ class DashboardController < ApplicationController
     # This makes sure the combination of displayed courses includes all courses,
     # without leaving some stuck in between being past and current.
     if current_user.admin?
-      current_user.courses.where('end <= ?', Date.today).order(end: :desc)
+      current_user.courses.where('end <= ?', Time.zone.today).order(end: :desc)
     else
       current_user.courses.archived.order(end: :desc)
     end

--- a/app/mailers/overdue_training_alert_mailer.rb
+++ b/app/mailers/overdue_training_alert_mailer.rb
@@ -8,7 +8,7 @@ class OverdueTrainingAlertMailer < ApplicationMailer
     return if alert.user.email.blank?
 
     email(alert).deliver_now
-    alert.update(email_sent_at: Time.now)
+    alert.update(email_sent_at: Time.zone.now)
   end
 
   def email(alert)

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -97,7 +97,7 @@ class Alert < ApplicationRecord
     content_expert = course.nonstudents.find_by(greeter: true)
     return if content_expert.nil?
     AlertMailer.alert(self, content_expert).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def email_course_admins
@@ -106,14 +106,14 @@ class Alert < ApplicationRecord
     admins.each do |admin|
       AlertMailer.alert(self, admin).deliver_now
     end
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def email_target_user
     return if emails_disabled?
     return if target_user.nil?
     AlertMailer.alert(self, target_user).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   # Disable emails for specific alert types in application.yml, like so:

--- a/app/models/alert_types/first_enrolled_student_alert.rb
+++ b/app/models/alert_types/first_enrolled_student_alert.rb
@@ -33,7 +33,7 @@ class FirstEnrolledStudentAlert < Alert
   def send_email
     return if emails_disabled?
     FirstEnrolledStudentAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def from_user

--- a/app/models/alert_types/no_enrolled_students_alert.rb
+++ b/app/models/alert_types/no_enrolled_students_alert.rb
@@ -33,7 +33,7 @@ class NoEnrolledStudentsAlert < Alert
   def send_email
     return if emails_disabled?
     NoEnrolledStudentsAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def from_user

--- a/app/models/alert_types/untrained_students_alert.rb
+++ b/app/models/alert_types/untrained_students_alert.rb
@@ -33,7 +33,7 @@ class UntrainedStudentsAlert < Alert
   def send_email
     return if emails_disabled?
     UntrainedStudentsAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def from_user

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -115,7 +115,7 @@ class Campaign < ApplicationRecord
   # Intercept Rails typecasting and add error if given value cannot be parsed into a date.
   def validate_date_attribute(date_type)
     value = send("#{date_type}_before_type_cast")
-    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.parse(value)
+    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
   rescue ArgumentError, TypeError
     errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
   end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -115,7 +115,7 @@ class Campaign < ApplicationRecord
   # Intercept Rails typecasting and add error if given value cannot be parsed into a date.
   def validate_date_attribute(date_type)
     value = send("#{date_type}_before_type_cast")
-    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
+    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.parse(value)
   rescue ArgumentError, TypeError
     errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
   end

--- a/app/models/surveys/survey_notification.rb
+++ b/app/models/surveys/survey_notification.rb
@@ -47,7 +47,7 @@ class SurveyNotification < ApplicationRecord
     return if email_sent_at.present?
     return if user.email.nil?
     SurveyMailer.send_notification(self)
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   # This should return something falsey if no email was sent, and something
@@ -57,7 +57,7 @@ class SurveyNotification < ApplicationRecord
     return if user.email.nil?
     return unless ready_for_follow_up?
     SurveyMailer.send_follow_up(self)
-    update_attributes(last_follow_up_sent_at: Time.now,
+    update_attributes(last_follow_up_sent_at: Time.zone.now,
                       follow_up_count: follow_up_count + 1)
   end
 
@@ -82,7 +82,7 @@ class SurveyNotification < ApplicationRecord
   MAX_FOLLOW_UPS = 3
   def ready_for_follow_up?
     return false if email_sent_at.nil?
-    return false if Time.now < last_email_sent_at + time_before_another_email
+    return false if Time.zone.now < last_email_sent_at + time_before_another_email
     return false if follow_up_count >= MAX_FOLLOW_UPS
     true
   end

--- a/lib/alerts/unsubmitted_course_alert_manager.rb
+++ b/lib/alerts/unsubmitted_course_alert_manager.rb
@@ -18,7 +18,7 @@ class UnsubmittedCourseAlertManager
 
   DAYS_AGO_LIMIT = 30
   def unsubmitted_recently_started_courses
-    ClassroomProgramCourse.unsubmitted.where(start: DAYS_AGO_LIMIT.days.ago..Date.today)
+    ClassroomProgramCourse.unsubmitted.where(start: DAYS_AGO_LIMIT.days.ago..Time.zone.today)
   end
 
   # First time instructors work with the Outreach Manager.

--- a/lib/alerts/untrained_students_alert_manager.rb
+++ b/lib/alerts/untrained_students_alert_manager.rb
@@ -38,6 +38,6 @@ class UntrainedStudentsAlertManager
     # Courses without enough meeting dates to fit all Week records can have nil
     # assignment dates.
     assignment_dates.reject!(&:nil?)
-    assignment_dates.select { |date| date < Time.now }.sort
+    assignment_dates.select { |date| date < Time.zone.now }.sort
   end
 end

--- a/lib/analytics/histogram_plotter.rb
+++ b/lib/analytics/histogram_plotter.rb
@@ -35,7 +35,7 @@ class HistogramPlotter
   end
 
   def csv_filename
-    "#{slug_filename}-#{Date.today}.csv"
+    "#{slug_filename}-#{Time.zone.today}.csv"
   end
 
   def public_analytics_path

--- a/lib/experiments/fall2017_cmu_experiment.rb
+++ b/lib/experiments/fall2017_cmu_experiment.rb
@@ -64,9 +64,9 @@ class Fall2017CmuExperiment
 
   def update_status(new_status, email_just_sent: false, email_code: nil, reminder_just_sent: false)
     @course.flags[STATUS_KEY] = new_status
-    @course.flags[EMAIL_SENT_AT] = Time.now.to_s if email_just_sent
+    @course.flags[EMAIL_SENT_AT] = Time.zone.now.to_s if email_just_sent
     @course.flags[EMAIL_CODE] = email_code if email_code.present?
-    @course.flags[REMINDER_SENT_AT] = Time.now.to_s if reminder_just_sent
+    @course.flags[REMINDER_SENT_AT] = Time.zone.now.to_s if reminder_just_sent
     @course.save
     @status = new_status
   end
@@ -80,7 +80,7 @@ class Fall2017CmuExperiment
   end
 
   def invited_over_a_week_ago?
-    invited_at = Time.parse(@course.flags[EMAIL_SENT_AT])
+    invited_at = Time.zone.parse(@course.flags[EMAIL_SENT_AT])
     invited_at < 1.week.ago
   end
 

--- a/lib/experiments/spring2018_cmu_experiment.rb
+++ b/lib/experiments/spring2018_cmu_experiment.rb
@@ -65,9 +65,9 @@ class Spring2018CmuExperiment
 
   def update_status(new_status, email_just_sent: false, email_code: nil, reminder_just_sent: false)
     @course.flags[STATUS_KEY] = new_status
-    @course.flags[EMAIL_SENT_AT] = Time.now.to_s if email_just_sent
+    @course.flags[EMAIL_SENT_AT] = Time.zone.now.to_s if email_just_sent
     @course.flags[EMAIL_CODE] = email_code if email_code.present?
-    @course.flags[REMINDER_SENT_AT] = Time.now.to_s if reminder_just_sent
+    @course.flags[REMINDER_SENT_AT] = Time.zone.now.to_s if reminder_just_sent
     @course.save
     @status = new_status
   end
@@ -81,7 +81,7 @@ class Spring2018CmuExperiment
   end
 
   def invited_over_a_week_ago?
-    invited_at = Time.parse(@course.flags[EMAIL_SENT_AT])
+    invited_at = Time.zone.parse(@course.flags[EMAIL_SENT_AT])
     invited_at < 1.week.ago
   end
 

--- a/spec/controllers/training_status_controller_spec.rb
+++ b/spec/controllers/training_status_controller_spec.rb
@@ -24,7 +24,7 @@ describe TrainingStatusController do
     end
 
     context 'when the training is complete' do
-      let(:completion_date) { Time.now }
+      let(:completion_date) { Time.zone.now }
 
       before do
         create(:training_modules_users, training_module_id: 1,

--- a/spec/features/admin_role_spec.rb
+++ b/spec/features/admin_role_spec.rb
@@ -43,9 +43,9 @@ describe 'Admin users', type: :feature, js: true do
            role: 1)
 
     create(:campaign, id: 1, title: 'Fall 2015',
-                      created_at: Time.now + 2.minutes)
+                      created_at: Time.zone.now + 2.minutes)
     create(:campaign, id: 2, title: 'Spring 2016',
-                      created_at: Time.now + 4.minutes)
+                      created_at: Time.zone.now + 4.minutes)
 
     user = create(:admin,
                   id: 200,

--- a/spec/features/course_cloning_spec.rb
+++ b/spec/features/course_cloning_spec.rb
@@ -11,7 +11,7 @@ describe 'cloning a course', js: true do
   # and bugginess in the Capybara drivers. We want to avoid setting a date the
   # same as today's date.
 
-  if (11..12).cover? Date.today.day
+  if (11..12).cover? Time.zone.today.day
     let(:course_start) { '13' }
     let(:timeline_start) { '14' }
   else
@@ -19,7 +19,7 @@ describe 'cloning a course', js: true do
     let(:timeline_start) { '12' }
   end
 
-  if (27..28).cover? Date.today.day
+  if (27..28).cover? Time.zone.today.day
     let(:course_end) { '26' }
     let(:timeline_end) { '25' }
   else

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -110,7 +110,7 @@ describe 'New course creation and editing', type: :feature do
                   permissions: User::Permissions::INSTRUCTOR)
     create(:training_modules_users, user_id: user.id,
                                     training_module_id: 3,
-                                    completed_at: Time.now)
+                                    completed_at: Time.zone.now)
     login_as(user, scope: :user)
 
     visit root_path

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -39,7 +39,7 @@ describe 'dashboard', type: :feature, js: true do
         create(:training_modules_users,
                user_id: user.id,
                training_module_id: 3,
-               completed_at: Time.now)
+               completed_at: Time.zone.now)
         visit root_path
         expect(page).to have_content 'Click on Create Course to create your first course'
       end
@@ -134,8 +134,8 @@ describe 'dashboard', type: :feature, js: true do
              slug: 'University/Course2_(Term)',
              submitted: false,
              passcode: 'passcode',
-             start: Time.now,
-             end: Time.now + 100.days)
+             start: Time.zone.now,
+             end: Time.zone.now + 100.days)
       create(:courses_user,
              user_id: user.id,
              course_id: 10002,

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -81,7 +81,7 @@ describe 'Instructor users', type: :feature, js: true do
     let(:week) { create(:week, course_id: Course.first.id) }
     let(:tm) { TrainingModule.all.first }
     let!(:block) do
-      create(:block, week_id: week.id, training_module_ids: [tm.id], due_date: Date.today)
+      create(:block, week_id: week.id, training_module_ids: [tm.id], due_date: Time.zone.today)
     end
 
     before do

--- a/spec/lib/data_cycle/update_logger_spec.rb
+++ b/spec/lib/data_cycle/update_logger_spec.rb
@@ -6,15 +6,17 @@ require "#{Rails.root}/lib/data_cycle/update_logger"
 describe UpdateLogger do
   describe '.update_settings_record' do
     it 'adds the time of the metrics last update as a value to the settings table' do
-      described_class.update_settings_record('start_time' => Time.now, 'end_time' => Time.now)
+      described_class.update_settings_record('start_time' => Time.zone.now,
+                                             'end_time' => Time.zone.now)
       record = Setting.find_or_create_by(key: 'metrics_update')
       expect(record.value['constant_update'].values.last['end_time'])
-        .to be_within(2.seconds).of(Time.now)
+        .to be_within(2.seconds).of(Time.zone.now)
     end
 
     it 'adds a maximum of 10 records' do
       15.times do
-        described_class.update_settings_record('start_time' => Time.now, 'end_time' => Time.now)
+        described_class.update_settings_record('start_time' => Time.zone.now,
+                                               'end_time' => Time.zone.now)
       end
       record = Setting.find_or_create_by(key: 'metrics_update')
       number_of_updates = record.value['constant_update'].size

--- a/spec/lib/importers/view_importer_spec.rb
+++ b/spec/lib/importers/view_importer_spec.rb
@@ -18,8 +18,8 @@ describe ViewImporter do
         # Course and article-course are also needed.
         create(:course,
                id: 10001,
-               start: Date.today - 1.week,
-               end: Date.today + 1.week)
+               start: Time.zone.today - 1.week,
+               end: Time.zone.today + 1.week)
         create(:articles_course,
                id: 1,
                course_id: 10001,
@@ -34,8 +34,8 @@ describe ViewImporter do
   describe '.update_all_views' do
     let!(:course) do
       create(:course, id: 10001,
-                      start: Date.today - 1.week,
-                      end: Date.today + 1.week)
+                      start: Time.zone.today - 1.week,
+                      end: Time.zone.today + 1.week)
     end
     let!(:articles_course) { create(:articles_course, id: 1, course_id: 10001, article_id: 1) }
     let!(:revision) { create(:revision, article_id: 1) }
@@ -50,7 +50,7 @@ describe ViewImporter do
         # Add an article (which has a revision and is part of the course)
         create(:article, id: 1, title: 'Wikipedia', namespace: 0,
                          wiki_id: en_wiki.id,
-                         views_updated_at: Date.today - 2.days)
+                         views_updated_at: Time.zone.today - 2.days)
 
         # Update again with this article.
         allow(WikiPageviews).to receive(:new).and_call_original
@@ -66,7 +66,7 @@ describe ViewImporter do
 
       create(:article, id: 1, title: 'Wikipedia', namespace: 0,
                        wiki_id: es_wiki.id,
-                       views_updated_at: Date.today - 2.days)
+                       views_updated_at: Time.zone.today - 2.days)
       stub_request(:get, %r{.*pageviews/per-article/es.wikipedia.*})
         .to_return(
           status: 200,
@@ -91,8 +91,8 @@ describe ViewImporter do
         # Course, article-course, and revision are also needed.
         create(:course,
                id: 10001,
-               start: Date.today - 1.month,
-               end: Date.today + 1.month)
+               start: Time.zone.today - 1.month,
+               end: Time.zone.today + 1.month)
         create(:articles_course,
                id: 1,
                course_id: 10001,

--- a/spec/lib/student_greeting_checker_spec.rb
+++ b/spec/lib/student_greeting_checker_spec.rb
@@ -8,7 +8,7 @@ describe StudentGreetingChecker do
     subject { described_class.check_all_ungreeted_students }
 
     before do
-      create(:course, id: 1, start: 2.weeks.ago, end: Date.today + 2.weeks)
+      create(:course, id: 1, start: 2.weeks.ago, end: Time.zone.today + 2.weeks)
       create(:user, id: 1, username: 'Danny', greeter: true)
       create(:courses_user,
              id: 1,

--- a/spec/lib/training_module_due_date_manager_spec.rb
+++ b/spec/lib/training_module_due_date_manager_spec.rb
@@ -211,7 +211,7 @@ describe TrainingModuleDueDateManager do
       end
 
       context 'user belongs to two courses with the module assigned' do
-        let(:course2)   { create(:course, timeline_start: Date.today, slug: 'foo/2') }
+        let(:course2)   { create(:course, timeline_start: Time.zone.today, slug: 'foo/2') }
         let!(:cu2)      { create(:courses_user, user_id: user.id, course_id: course2.id) }
         let(:week2)     { create(:week, course_id: course2.id, order: 1) }
         let(:due_date2) { 1.week.ago.to_date }
@@ -224,7 +224,7 @@ describe TrainingModuleDueDateManager do
 
           it 'uses the earlier of the existent block due date '\
              'or the end of the week of the block without a date' do
-            expect(subject).to eq(Date.today.end_of_week(:sunday))
+            expect(subject).to eq(Time.zone.today.end_of_week(:sunday))
           end
         end
 

--- a/spec/lib/training_progress_manager_spec.rb
+++ b/spec/lib/training_progress_manager_spec.rb
@@ -137,7 +137,7 @@ describe TrainingProgressManager do
     end
 
     context 'completed_at is present for tmu' do
-      let(:completed_at) { Time.now }
+      let(:completed_at) { Time.zone.now }
 
       it 'returns true' do
         expect(subject.module_completed?).to eq(true)
@@ -159,7 +159,7 @@ describe TrainingProgressManager do
     end
 
     context 'module is completed' do
-      let(:completed_at) { Time.now }
+      let(:completed_at) { Time.zone.now }
 
       before do
         allow_any_instance_of(TrainingModuleDueDateManager)
@@ -184,7 +184,7 @@ describe TrainingProgressManager do
     end
 
     context 'completed' do
-      let(:completed_at) { Time.now }
+      let(:completed_at) { Time.zone.now }
       let(:last_slide_completed) { slides.last.slug }
 
       it 'returns "completed"' do

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -55,7 +55,7 @@ describe ArticleScopedProgram, type: :model do
     asp = create(:article_scoped_program,
                  id: 10001,
                  start: 1.year.ago,
-                 end: Date.today + 1.year)
+                 end: Time.zone.today + 1.year)
     editor = create(:user)
     create(:courses_user,
            user_id: editor.id,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -130,25 +130,25 @@ describe Course, type: :model do
 
   it 'updates start/end times when changing course type' do
     course = create(:basic_course,
-                    start: Time.new(2016, 1, 1, 12, 45, 0),
-                    end: Time.new(2016, 1, 10, 15, 30, 0),
+                    start: Time.zone.local(2016, 1, 1, 12, 45, 0),
+                    end: Time.zone.local(2016, 1, 10, 15, 30, 0),
                     title: 'History Class')
-    expect(course.end).to eq(Time.new(2016, 1, 10, 15, 30, 0))
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 15, 30, 0))
     course = course.becomes!(ClassroomProgramCourse)
     course.save!
-    expect(course.end).to eq(Time.new(2016, 1, 10, 23, 59, 59, '+00:00'))
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 23, 59, 59, '+00:00'))
     course = course.becomes!(BasicCourse)
     course.save!
-    expect(course.end).to eq(Time.new(2016, 1, 10, 23, 59, 59, '+00:00'))
-    course.end = Time.new(2016, 1, 10, 15, 30, 0)
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 23, 59, 59, '+00:00'))
+    course.end = Time.zone.local(2016, 1, 10, 15, 30, 0)
     course.save!
-    expect(course.end).to eq(Time.new(2016, 1, 10, 15, 30, 0))
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 15, 30, 0))
   end
 
   it 'updates end time to equal start time it the times are invalid' do
     course = build(:course,
-                   start: Time.now,
-                   end: Time.now - 2.months)
+                   start: Time.zone.now,
+                   end: Time.zone.now - 2.months)
     course.save
     expect(course.end).to eq(course.start)
   end

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -55,7 +55,7 @@ describe VisitingScholarship, type: :model do
     vs = create(:visiting_scholarship,
                 id: 10001,
                 start: 1.year.ago,
-                end: Date.today + 1.year)
+                end: Time.zone.today + 1.year)
     scholar = create(:user)
     create(:courses_user,
            user_id: scholar.id,

--- a/spec/support/rapidfire/answer_spec_helper.rb
+++ b/spec/support/rapidfire/answer_spec_helper.rb
@@ -15,7 +15,7 @@ module Rapidfire
       FactoryBot.create(:answer, question: @question_radio, answer_text: 'female')
 
       3.times do
-        FactoryBot.create(:answer, question: @question_date, answer_text: Date.today.to_s)
+        FactoryBot.create(:answer, question: @question_date, answer_text: Time.zone.today.to_s)
         FactoryBot.create(:answer, question: @question_long, answer_text: 'my bio goes on and on!')
         FactoryBot.create(:answer, question: @question_numeric, answer_text: 999)
         FactoryBot.create(:answer, question: @question_short, answer_text: 'this is cool')


### PR DESCRIPTION
1. move FormatStringToken rule to permanent exception; not applicable if only string interpolation (`#{foo}`) is used
2. enabled Rails/TimeZone and Rails/Date

There's one Rubocop violation in `app/models/campaign.rb`; the `validate_date_attribute` function there used `Time.parse`, which violates Rails/Timezone. Changing it to `Time.zone.parse()` conforms to Rubocop, but [broke the spec](https://travis-ci.org/kaine119/WikiEduDashboard/jobs/448672011#L5332) for date validation. I left it there as `Time.parse()` for now, but I'm not sure how to fix the Rubocop violation.
