### PR TITLE
[WIP] Permanently exempt rubocop rule: FormatStringToken

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,8 +77,6 @@ Style/RedundantReturn:
   Enabled: false # Sometimes a redundant return enhances clarity.
 Style/SymbolArray:
   Enabled: false # Rare syntax that is potentially confusing to newcomers.
-Style/FormatStringToken:
-  Enabled: false # Not very helpful, string interpolation used instead of Kernel::Format
 Naming/VariableNumber:
   Enabled: false # Not very helpful, and conflicts with wp10-related names
 Rails/Blank:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,8 @@ Style/RedundantReturn:
   Enabled: false # Sometimes a redundant return enhances clarity.
 Style/SymbolArray:
   Enabled: false # Rare syntax that is potentially confusing to newcomers.
+Style/FormatStringToken:
+  Enabled: false # Not very helpful, string interpolation used instead of Kernel::Format
 Naming/VariableNumber:
   Enabled: false # Not very helpful, and conflicts with wp10-related names
 Rails/Blank:
@@ -87,6 +89,7 @@ Naming/UncommunicativeMethodParamName:
   Enabled: false # This is too restrictive. Calling errors `e` is fine, for example.
 Layout/EmptyLineAfterGuardClause:
   Enabled: false # Not very helpful
+
 ########################
 # Temporary exceptions #
 ########################
@@ -95,8 +98,6 @@ Layout/EmptyLineAfterGuardClause:
 # or they should be moved to the 'Permanent' section
 # if we decide they shouldn't be fixed.
 
-Style/FormatStringToken:
-  Enabled: false
 Rails/FilePath:
   Enabled: false
 Rails/TimeZone:


### PR DESCRIPTION
Moves the `Style/FormatStringToken` in rubocop.yml to permanent exemptions; it's not applicable if only string interpolation (#{foo}) is used.

(from #2173)