### PR TITLE
[WIP] Enforce rubocop Rails/Timezone rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,8 +99,6 @@ Style/FormatStringToken:
   Enabled: false
 Rails/FilePath:
   Enabled: false
-Rails/TimeZone:
-  Enabled: false
 Rails/SkipsModelValidations:
   Enabled: false
 Rails/OutputSafety:

--- a/app/mailers/overdue_training_alert_mailer.rb
+++ b/app/mailers/overdue_training_alert_mailer.rb
@@ -8,7 +8,7 @@ class OverdueTrainingAlertMailer < ApplicationMailer
     return if alert.user.email.blank?
 
     email(alert).deliver_now
-    alert.update(email_sent_at: Time.now)
+    alert.update(email_sent_at: Time.zone.now)
   end
 
   def email(alert)

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -97,7 +97,7 @@ class Alert < ApplicationRecord
     content_expert = course.nonstudents.find_by(greeter: true)
     return if content_expert.nil?
     AlertMailer.alert(self, content_expert).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def email_course_admins
@@ -106,14 +106,14 @@ class Alert < ApplicationRecord
     admins.each do |admin|
       AlertMailer.alert(self, admin).deliver_now
     end
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def email_target_user
     return if emails_disabled?
     return if target_user.nil?
     AlertMailer.alert(self, target_user).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   # Disable emails for specific alert types in application.yml, like so:

--- a/app/models/alert_types/first_enrolled_student_alert.rb
+++ b/app/models/alert_types/first_enrolled_student_alert.rb
@@ -33,7 +33,7 @@ class FirstEnrolledStudentAlert < Alert
   def send_email
     return if emails_disabled?
     FirstEnrolledStudentAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def from_user

--- a/app/models/alert_types/no_enrolled_students_alert.rb
+++ b/app/models/alert_types/no_enrolled_students_alert.rb
@@ -33,7 +33,7 @@ class NoEnrolledStudentsAlert < Alert
   def send_email
     return if emails_disabled?
     NoEnrolledStudentsAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def from_user

--- a/app/models/alert_types/untrained_students_alert.rb
+++ b/app/models/alert_types/untrained_students_alert.rb
@@ -33,7 +33,7 @@ class UntrainedStudentsAlert < Alert
   def send_email
     return if emails_disabled?
     UntrainedStudentsAlertMailer.email(self).deliver_now
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   def from_user

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -115,7 +115,7 @@ class Campaign < ApplicationRecord
   # Intercept Rails typecasting and add error if given value cannot be parsed into a date.
   def validate_date_attribute(date_type)
     value = send("#{date_type}_before_type_cast")
-    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.parse(value)
+    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
   rescue ArgumentError, TypeError
     errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
   end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -115,7 +115,9 @@ class Campaign < ApplicationRecord
   # Intercept Rails typecasting and add error if given value cannot be parsed into a date.
   def validate_date_attribute(date_type)
     value = send("#{date_type}_before_type_cast")
-    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
+    # rubocop:disable Rails/TimeZone
+    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.parse(value)
+    # rubocop:enable Rails/TimeZone
   rescue ArgumentError, TypeError
     errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
   end

--- a/app/models/surveys/survey_notification.rb
+++ b/app/models/surveys/survey_notification.rb
@@ -47,7 +47,7 @@ class SurveyNotification < ApplicationRecord
     return if email_sent_at.present?
     return if user.email.nil?
     SurveyMailer.send_notification(self)
-    update_attribute(:email_sent_at, Time.now)
+    update_attribute(:email_sent_at, Time.zone.now)
   end
 
   # This should return something falsey if no email was sent, and something
@@ -57,7 +57,7 @@ class SurveyNotification < ApplicationRecord
     return if user.email.nil?
     return unless ready_for_follow_up?
     SurveyMailer.send_follow_up(self)
-    update_attributes(last_follow_up_sent_at: Time.now,
+    update_attributes(last_follow_up_sent_at: Time.zone.now,
                       follow_up_count: follow_up_count + 1)
   end
 
@@ -82,7 +82,7 @@ class SurveyNotification < ApplicationRecord
   MAX_FOLLOW_UPS = 3
   def ready_for_follow_up?
     return false if email_sent_at.nil?
-    return false if Time.now < last_email_sent_at + time_before_another_email
+    return false if Time.zone.now < last_email_sent_at + time_before_another_email
     return false if follow_up_count >= MAX_FOLLOW_UPS
     true
   end

--- a/lib/alerts/untrained_students_alert_manager.rb
+++ b/lib/alerts/untrained_students_alert_manager.rb
@@ -38,6 +38,6 @@ class UntrainedStudentsAlertManager
     # Courses without enough meeting dates to fit all Week records can have nil
     # assignment dates.
     assignment_dates.reject!(&:nil?)
-    assignment_dates.select { |date| date < Time.now }.sort
+    assignment_dates.select { |date| date < Time.zone.now }.sort
   end
 end

--- a/lib/experiments/fall2017_cmu_experiment.rb
+++ b/lib/experiments/fall2017_cmu_experiment.rb
@@ -64,9 +64,9 @@ class Fall2017CmuExperiment
 
   def update_status(new_status, email_just_sent: false, email_code: nil, reminder_just_sent: false)
     @course.flags[STATUS_KEY] = new_status
-    @course.flags[EMAIL_SENT_AT] = Time.now.to_s if email_just_sent
+    @course.flags[EMAIL_SENT_AT] = Time.zone.now.to_s if email_just_sent
     @course.flags[EMAIL_CODE] = email_code if email_code.present?
-    @course.flags[REMINDER_SENT_AT] = Time.now.to_s if reminder_just_sent
+    @course.flags[REMINDER_SENT_AT] = Time.zone.now.to_s if reminder_just_sent
     @course.save
     @status = new_status
   end
@@ -80,7 +80,7 @@ class Fall2017CmuExperiment
   end
 
   def invited_over_a_week_ago?
-    invited_at = Time.parse(@course.flags[EMAIL_SENT_AT])
+    invited_at = Time.zone.parse(@course.flags[EMAIL_SENT_AT])
     invited_at < 1.week.ago
   end
 

--- a/lib/experiments/spring2018_cmu_experiment.rb
+++ b/lib/experiments/spring2018_cmu_experiment.rb
@@ -65,9 +65,9 @@ class Spring2018CmuExperiment
 
   def update_status(new_status, email_just_sent: false, email_code: nil, reminder_just_sent: false)
     @course.flags[STATUS_KEY] = new_status
-    @course.flags[EMAIL_SENT_AT] = Time.now.to_s if email_just_sent
+    @course.flags[EMAIL_SENT_AT] = Time.zone.now.to_s if email_just_sent
     @course.flags[EMAIL_CODE] = email_code if email_code.present?
-    @course.flags[REMINDER_SENT_AT] = Time.now.to_s if reminder_just_sent
+    @course.flags[REMINDER_SENT_AT] = Time.zone.now.to_s if reminder_just_sent
     @course.save
     @status = new_status
   end
@@ -81,7 +81,7 @@ class Spring2018CmuExperiment
   end
 
   def invited_over_a_week_ago?
-    invited_at = Time.parse(@course.flags[EMAIL_SENT_AT])
+    invited_at = Time.zone.parse(@course.flags[EMAIL_SENT_AT])
     invited_at < 1.week.ago
   end
 

--- a/spec/controllers/training_status_controller_spec.rb
+++ b/spec/controllers/training_status_controller_spec.rb
@@ -24,7 +24,7 @@ describe TrainingStatusController do
     end
 
     context 'when the training is complete' do
-      let(:completion_date) { Time.now }
+      let(:completion_date) { Time.zone.now }
 
       before do
         create(:training_modules_users, training_module_id: 1,

--- a/spec/features/admin_role_spec.rb
+++ b/spec/features/admin_role_spec.rb
@@ -43,9 +43,9 @@ describe 'Admin users', type: :feature, js: true do
            role: 1)
 
     create(:campaign, id: 1, title: 'Fall 2015',
-                      created_at: Time.now + 2.minutes)
+                      created_at: Time.zone.now + 2.minutes)
     create(:campaign, id: 2, title: 'Spring 2016',
-                      created_at: Time.now + 4.minutes)
+                      created_at: Time.zone.now + 4.minutes)
 
     user = create(:admin,
                   id: 200,

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -110,7 +110,7 @@ describe 'New course creation and editing', type: :feature do
                   permissions: User::Permissions::INSTRUCTOR)
     create(:training_modules_users, user_id: user.id,
                                     training_module_id: 3,
-                                    completed_at: Time.now)
+                                    completed_at: Time.zone.now)
     login_as(user, scope: :user)
 
     visit root_path

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -39,7 +39,7 @@ describe 'dashboard', type: :feature, js: true do
         create(:training_modules_users,
                user_id: user.id,
                training_module_id: 3,
-               completed_at: Time.now)
+               completed_at: Time.zone.now)
         visit root_path
         expect(page).to have_content 'Click on Create Course to create your first course'
       end
@@ -134,8 +134,8 @@ describe 'dashboard', type: :feature, js: true do
              slug: 'University/Course2_(Term)',
              submitted: false,
              passcode: 'passcode',
-             start: Time.now,
-             end: Time.now + 100.days)
+             start: Time.zone.now,
+             end: Time.zone.now + 100.days)
       create(:courses_user,
              user_id: user.id,
              course_id: 10002,

--- a/spec/lib/data_cycle/update_logger_spec.rb
+++ b/spec/lib/data_cycle/update_logger_spec.rb
@@ -6,15 +6,17 @@ require "#{Rails.root}/lib/data_cycle/update_logger"
 describe UpdateLogger do
   describe '.update_settings_record' do
     it 'adds the time of the metrics last update as a value to the settings table' do
-      described_class.update_settings_record('start_time' => Time.now, 'end_time' => Time.now)
+      described_class.update_settings_record('start_time' => Time.zone.now,
+                                             'end_time' => Time.zone.now)
       record = Setting.find_or_create_by(key: 'metrics_update')
       expect(record.value['constant_update'].values.last['end_time'])
-        .to be_within(2.seconds).of(Time.now)
+        .to be_within(2.seconds).of(Time.zone.now)
     end
 
     it 'adds a maximum of 10 records' do
       15.times do
-        described_class.update_settings_record('start_time' => Time.now, 'end_time' => Time.now)
+        described_class.update_settings_record('start_time' => Time.zone.now,
+                                               'end_time' => Time.zone.now)
       end
       record = Setting.find_or_create_by(key: 'metrics_update')
       number_of_updates = record.value['constant_update'].size

--- a/spec/lib/training_progress_manager_spec.rb
+++ b/spec/lib/training_progress_manager_spec.rb
@@ -137,7 +137,7 @@ describe TrainingProgressManager do
     end
 
     context 'completed_at is present for tmu' do
-      let(:completed_at) { Time.now }
+      let(:completed_at) { Time.zone.now }
 
       it 'returns true' do
         expect(subject.module_completed?).to eq(true)
@@ -159,7 +159,7 @@ describe TrainingProgressManager do
     end
 
     context 'module is completed' do
-      let(:completed_at) { Time.now }
+      let(:completed_at) { Time.zone.now }
 
       before do
         allow_any_instance_of(TrainingModuleDueDateManager)
@@ -184,7 +184,7 @@ describe TrainingProgressManager do
     end
 
     context 'completed' do
-      let(:completed_at) { Time.now }
+      let(:completed_at) { Time.zone.now }
       let(:last_slide_completed) { slides.last.slug }
 
       it 'returns "completed"' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -130,25 +130,25 @@ describe Course, type: :model do
 
   it 'updates start/end times when changing course type' do
     course = create(:basic_course,
-                    start: Time.new(2016, 1, 1, 12, 45, 0),
-                    end: Time.new(2016, 1, 10, 15, 30, 0),
+                    start: Time.zone.local(2016, 1, 1, 12, 45, 0),
+                    end: Time.zone.local(2016, 1, 10, 15, 30, 0),
                     title: 'History Class')
-    expect(course.end).to eq(Time.new(2016, 1, 10, 15, 30, 0))
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 15, 30, 0))
     course = course.becomes!(ClassroomProgramCourse)
     course.save!
-    expect(course.end).to eq(Time.new(2016, 1, 10, 23, 59, 59, '+00:00'))
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 23, 59, 59, '+00:00'))
     course = course.becomes!(BasicCourse)
     course.save!
-    expect(course.end).to eq(Time.new(2016, 1, 10, 23, 59, 59, '+00:00'))
-    course.end = Time.new(2016, 1, 10, 15, 30, 0)
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 23, 59, 59, '+00:00'))
+    course.end = Time.zone.local(2016, 1, 10, 15, 30, 0)
     course.save!
-    expect(course.end).to eq(Time.new(2016, 1, 10, 15, 30, 0))
+    expect(course.end).to eq(Time.zone.local(2016, 1, 10, 15, 30, 0))
   end
 
   it 'updates end time to equal start time it the times are invalid' do
     course = build(:course,
-                   start: Time.now,
-                   end: Time.now - 2.months)
+                   start: Time.zone.now,
+                   end: Time.zone.now - 2.months)
     course.save
     expect(course.end).to eq(course.start)
   end


### PR DESCRIPTION
Enable the Rubocop `Rails/Timezone` rule.

This rule breaks date validation in `app/models/campaign.rb`, so for now I've ignored the problem line

(from #2173)