### PR TITLE
Add tests for reducer alerts

### DIFF
--- a/test/reducers/alerts.spec.js
+++ b/test/reducers/alerts.spec.js
@@ -1,0 +1,42 @@
+import deepFreeze from 'deep-freeze';
+import alerts from '../../app/assets/javascripts/reducers/alerts';
+import {
+  RECEIVE_ALERTS,
+  SORT_ALERTS,
+  FILTER_ALERTS
+} from '../../app/assets/javascripts/constants';
+import '../testHelper';
+
+describe('course reducer', () => {
+  it('assigns alerts to passed alerts and sorts them via RECEIVE_ALERTS', () => {
+    const initialState = { alerts: [] };
+    const action = { type: RECEIVE_ALERTS,
+      data: { alerts: [{ created_at: 1 }, { created_at: 2 }] }
+    };
+    const expectedSortedAlerts = [{ created_at: 2 }, { created_at: 1 }];
+    deepFreeze(initialState);
+
+    const newState = alerts(initialState, action);
+    expect(newState.alerts).to.deep.eq(expectedSortedAlerts);
+  });
+
+  it('sorts existing alerts via SORT_ALERTS', () => {
+    const initialState = { alerts: [{ custom_key: 2 }, { custom_key: 1 }] };
+    const action = { type: SORT_ALERTS, key: 'custom_key' };
+    const expectedSortedAlerts = [{ custom_key: 1 }, { custom_key: 2 }];
+    deepFreeze(initialState);
+
+    const newState = alerts(initialState, action);
+    expect(newState.alerts).to.deep.eq(expectedSortedAlerts);
+    expect(newState.sortKey).to.eq('custom_key');
+  });
+
+  it('assigns selectedFilters via FILTER_ALERTS', () => {
+    const initialState = { alerts: [] };
+    const action = { type: FILTER_ALERTS, selectedFilters: 'foo' };
+    deepFreeze(initialState);
+
+    const newState = alerts(initialState, action);
+    expect(newState.selectedFilters).to.eq('foo');
+  });
+});

--- a/test/reducers/alerts.spec.js
+++ b/test/reducers/alerts.spec.js
@@ -10,11 +10,11 @@ import '../testHelper';
 describe('course reducer', () => {
   it('assigns alerts to passed alerts and sorts them via RECEIVE_ALERTS', () => {
     const initialState = { alerts: [] };
+    deepFreeze(initialState);
     const action = { type: RECEIVE_ALERTS,
       data: { alerts: [{ created_at: 1 }, { created_at: 2 }] }
     };
     const expectedSortedAlerts = [{ created_at: 2 }, { created_at: 1 }];
-    deepFreeze(initialState);
 
     const newState = alerts(initialState, action);
     expect(newState.alerts).to.deep.eq(expectedSortedAlerts);
@@ -22,9 +22,9 @@ describe('course reducer', () => {
 
   it('sorts existing alerts via SORT_ALERTS', () => {
     const initialState = { alerts: [{ custom_key: 2 }, { custom_key: 1 }] };
+    deepFreeze(initialState);
     const action = { type: SORT_ALERTS, key: 'custom_key' };
     const expectedSortedAlerts = [{ custom_key: 1 }, { custom_key: 2 }];
-    deepFreeze(initialState);
 
     const newState = alerts(initialState, action);
     expect(newState.alerts).to.deep.eq(expectedSortedAlerts);
@@ -33,8 +33,8 @@ describe('course reducer', () => {
 
   it('assigns selectedFilters via FILTER_ALERTS', () => {
     const initialState = { alerts: [] };
-    const action = { type: FILTER_ALERTS, selectedFilters: 'foo' };
     deepFreeze(initialState);
+    const action = { type: FILTER_ALERTS, selectedFilters: 'foo' };
 
     const newState = alerts(initialState, action);
     expect(newState.selectedFilters).to.eq('foo');


### PR DESCRIPTION
I personally think that `deepFreeze` should go right after the `initialState` declaration as it's easy to forget. Otherwise, the PR is ready.

#2082