### PR TITLE
Reworded 'full contribution history' text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -939,7 +939,7 @@ en:
     chars_added:
       Characters Added<br>(article | user | draft)
     contributions: User Contributions
-    contributions_history_full: View full contribution history on Wikipedia
+    contributions_history_full: View full contribution history
     contributions_more: View More Contributions
     contribution_statistics: Contribution Statistics
     course_passcode: 'Passcode: '


### PR DESCRIPTION
Fixes #2197.
"View full contribution history on Wikipedia" reworded to "View full contribution history" because it can link to projects other than Wikipedia.