### PR TITLE
Avoid loading scripts and assets from other domains on P&E Dashboard

### DIFF
--- a/app/assets/javascripts/tinymce.js
+++ b/app/assets/javascripts/tinymce.js
@@ -1,0 +1,10 @@
+// Import TinyMCE
+import 'tinymce/tinymce';
+
+// A theme is also required
+import 'tinymce/themes/modern/theme';
+
+// Any plugins you want to use has to be imported
+import 'tinymce/plugins/code';
+import 'tinymce/plugins/link';
+import 'tinymce/plugins/lists';

--- a/app/assets/stylesheets/_variables.styl
+++ b/app/assets/stylesheets/_variables.styl
@@ -1,8 +1,8 @@
 // Fonts
-body-font = 'Open Sans', sans-serif
+body-font = 'Open Sans', arial, sans-serif
 body-color = #6a6a6a
 
-$header-font = 'Source Sans Pro', sans-serif
+$header-font = 'Source Sans Pro', arial, sans-serif
 
 // Colors
 warning = #D95757

--- a/app/assets/stylesheets/home.styl
+++ b/app/assets/stylesheets/home.styl
@@ -3,9 +3,9 @@
 $brand-primary = #676EB4
 $body-color-dark = #2C2C2C
 $body_color = #6A6A6A
-$body_font = "Open Sans", "Source Sans Pro", sans-serif
+$body_font = "Open Sans", "Source Sans Pro", arial, sans-serif
 $heading_font = $body_font
-$h1_font = "Source Sans Pro", "Open Sans", sans-serif
+$h1_font = "Source Sans Pro", "Open Sans", arial, sans-serif
 
 body.home
   color $body_color

--- a/app/assets/stylesheets/modules/_tiny_mce.styl
+++ b/app/assets/stylesheets/modules/_tiny_mce.styl
@@ -1,26 +1,3 @@
-@import "../../../node_modules/tinymce/skins/lightgray/skin.min.css"
-
-@font-face {
-  font-family: "tinymce";
-  src: url('../tinymce-skins/lightgray/fonts/tinymce.eot');
-  src: url('../tinymce-skins/lightgray/fonts/tinymce.eot?#iefix') format('eot'),
-    url('../tinymce-skins/lightgray/fonts/tinymce.woff') format('woff'),
-    url('../tinymce-skins/lightgray/fonts/tinymce.ttf') format('truetype'),
-    url('../tinymce-skins/lightgray/fonts/tinymce.svg#icons') format('svg');
-  font-weight: normal;
-  font-style: normal;
-}
-
-.mce-ico:before {
-  display: inline-block;
-  font-family: "tinymce";
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 .mce-content-body
   padding 5px
   border solid 1px $brand_primary

--- a/app/assets/stylesheets/modules/_tiny_mce.styl
+++ b/app/assets/stylesheets/modules/_tiny_mce.styl
@@ -1,3 +1,26 @@
+@import "../../../node_modules/tinymce/skins/lightgray/skin.min.css"
+
+@font-face {
+  font-family: "tinymce";
+  src: url('../tinymce-skins/lightgray/fonts/tinymce.eot');
+  src: url('../tinymce-skins/lightgray/fonts/tinymce.eot?#iefix') format('eot'),
+    url('../tinymce-skins/lightgray/fonts/tinymce.woff') format('woff'),
+    url('../tinymce-skins/lightgray/fonts/tinymce.ttf') format('truetype'),
+    url('../tinymce-skins/lightgray/fonts/tinymce.svg#icons') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+
+.mce-ico:before {
+  display: inline-block;
+  font-family: "tinymce";
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 .mce-content-body
   padding 5px
   border solid 1px $brand_primary

--- a/app/views/shared/_foot.html.haml
+++ b/app/views/shared/_foot.html.haml
@@ -2,4 +2,3 @@
   = render :partial => 'shared/wiki_ed_footer'
 - else
   = render :partial => 'shared/footer'
-= piwik_tracking_tag

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -43,6 +43,6 @@
     Raven.setExtraContext(currentUser);
 
 = javascript_include_tag '/assets/javascripts/jquery-uls.js'
-%script{src: "//cdn.tinymce.com/4/tinymce.min.js"}
+= hot_javascript_tag("tinymce")
 = content_for :javascripts
 = csrf_meta_tags

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -4,8 +4,9 @@
 %title= raw "#{before}#{ENV['dashboard_title']}#{after}"
 = logo_favicon_tag
 %meta{content: ENV['meta_description'] || 'Wiki Dashboard', name: "description"}
-= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600', media: 'all'
-= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700', media: 'all'
+- if Features.wiki_ed?
+  = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600', media: 'all'
+  = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700', media: 'all'
 
 = content_for :head
 

--- a/app/views/shared/_wiki_ed_footer.html.haml
+++ b/app/views/shared/_wiki_ed_footer.html.haml
@@ -9,3 +9,4 @@
     = '. All content is'
     = link_to 'CC-BY-SA', 'https://creativecommons.org/licenses/by-sa/3.0/'
     = '.'
+= piwik_tracking_tag

--- a/gulp/tasks/copy-static.js
+++ b/gulp/tasks/copy-static.js
@@ -20,6 +20,11 @@ gulp.task('copy-fonts', () => {
     .pipe(gulp.dest(`${config.outputPath}/${config.fontsDirectory}`));
 });
 
+gulp.task('copy-tinymce-skins', () => {
+  return gulp.src('./node_modules/tinymce/skins/**/*')
+    .pipe(gulp.dest(`${config.outputPath}/tinymce-skins`));
+});
+
 gulp.task('copy-static', (cb) => {
-  return runSequence(['copy-images', 'copy-fonts'], cb);
+  return runSequence(['copy-images', 'copy-fonts', 'copy-tinymce-skins'], cb);
 });

--- a/gulp/tasks/copy-static.js
+++ b/gulp/tasks/copy-static.js
@@ -22,7 +22,7 @@ gulp.task('copy-fonts', () => {
 
 gulp.task('copy-tinymce-skins', () => {
   return gulp.src('./node_modules/tinymce/skins/**/*')
-    .pipe(gulp.dest(`${config.outputPath}/tinymce-skins`));
+    .pipe(gulp.dest(`${config.outputPath}/${config.jsDirectory}/skins`));
 });
 
 gulp.task('copy-static', (cb) => {

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -20,7 +20,8 @@ gulp.task('webpack', ['jquery-uls'], (cb) => {
     survey_admin: [`${jsSource}/surveys/survey-admin.js`],
     survey_results: [`${jsSource}/surveys/survey-results.jsx`],
     campaigns: [`${jsSource}/campaigns.js`],
-    charts: [`${jsSource}/charts.js`]
+    charts: [`${jsSource}/charts.js`],
+    tinymce: [`${jsSource}/tinymce.js`],
   };
 
   // Set up plugins based on dev/prod mode

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "slick-carousel": "git+https://github.com/cfoehrdes/slick.git#a4d85536c42951933e1d887bcc013615e25b03e7",
     "striptags": "^3.1.1",
     "stylus": "0.54.5",
+    "tinymce": "^4.9.0",
     "uuid": "^3.3.2",
     "velocity-animate": "^1.5.1",
     "vinyl-buffer": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13850,6 +13850,11 @@ tiny-lr@^1.1.1:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
+tinymce@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.9.0.tgz#29589a368c463db6deb5e3981f71e48e88753f7f"
+  integrity sha512-hrPeCLXY/sVCo3i64CTW8P5xbDiEI8Uii/vWpcmQWAMhex6GWWd2U+L8WIMj5tKKGdfcIQAJfpfQthc/92bcKw==
+
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
Since P&E Dashboard is subject to the Wikimedia Cloud Services terms of use, we can't serve anything from third-party domains.

This switches to serving TinyMCE locally, removes piwik.js from P&E Dashboard, and skips loading the 'Open Sans' and 'Source Sans Pro' fonts from fonts.googleapis.com for P&E Dashboard (falling back instead to arial, which is pretty close).

See https://phabricator.wikimedia.org/T210946