### PR TITLE
Add concept of 'closed' course

### DIFF
--- a/app/assets/javascripts/components/high_order/editable_redux.jsx
+++ b/app/assets/javascripts/components/high_order/editable_redux.jsx
@@ -5,9 +5,10 @@ import { connect } from 'react-redux';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { resetValidations } from '../../actions/validation_actions';
-import { isValid } from '../../selectors';
+import { isValid, editPermissions } from '../../selectors';
 
 const mapStateToProps = state => ({
+  editPermissions: editPermissions(state),
   isValid: isValid(state)
 });
 
@@ -63,8 +64,7 @@ const EditableRedux = (Component, Label) => {
     },
 
     controls() {
-      const permissions = this.props.current_user.isNonstudent;
-      if (!permissions) { return null; }
+      if (!this.props.editPermissions) { return null; }
 
       if (this.state.editable) {
         return (
@@ -73,7 +73,7 @@ const EditableRedux = (Component, Label) => {
             <button onClick={this.saveChanges} className="dark button">{I18n.t('editable.save')}</button>
           </div>
         );
-      } else if (permissions && (this.props.editable === undefined || this.props.editable)) {
+      } else if (this.props.editable === undefined || this.props.editable) {
         return (
           <div className="controls">
             <button onClick={this.toggleEditable} className="dark button">{Label}</button>

--- a/app/assets/javascripts/components/students/student_list.jsx
+++ b/app/assets/javascripts/components/students/student_list.jsx
@@ -6,7 +6,7 @@ import _ from 'lodash';
 
 import { toggleUI, resetUI } from '../../actions';
 import { notifyOverdue } from '../../actions/course_actions';
-import { getStudentUsers } from '../../selectors';
+import { getStudentUsers, editPermissions } from '../../selectors';
 
 import List from '../common/list.jsx';
 import Student from './student.jsx';
@@ -30,7 +30,8 @@ const StudentList = createReactClass({
     sortUsers: PropTypes.func,
     userRevisions: PropTypes.object.isRequired,
     trainingStatus: PropTypes.object.isRequired,
-    notifyOverdue: PropTypes.func.isRequired
+    notifyOverdue: PropTypes.func.isRequired,
+    editPermissions: PropTypes.bool.isRequired
   },
 
   getInitialState() {
@@ -103,7 +104,7 @@ const StudentList = createReactClass({
     });
     const elements = _.flatten(_.zip(students, drawers));
     let controls;
-    if (this.props.current_user.isNonstudent) {
+    if (this.props.editPermissions) {
       let assignArticlesButton;
       if (this.props.students.length > 0) {
         const assignLabel = this.state.editAssignments ? I18n.t('users.assign_articles_done') : I18n.t('users.assign_articles');
@@ -199,7 +200,8 @@ const mapStateToProps = state => ({
   assignments: state.assignments.assignments,
   sort: state.users.sort,
   userRevisions: state.userRevisions,
-  trainingStatus: state.trainingStatus
+  trainingStatus: state.trainingStatus,
+  editPermissions: editPermissions(state)
 });
 
 const mapDispatchToProps = {

--- a/app/assets/javascripts/components/timeline/timeline_handler.jsx
+++ b/app/assets/javascripts/components/timeline/timeline_handler.jsx
@@ -12,7 +12,7 @@ import { fetchAllTrainingModules } from '../../actions/training_actions';
 
 import { addWeek, deleteWeek, persistTimeline, setBlockEditable, cancelBlockEditable,
   updateBlock, addBlock, deleteBlock, insertBlock, restoreTimeline, deleteAllWeeks } from '../../actions/timeline_actions';
-import { getWeeksArray, getAvailableTrainingModules } from '../../selectors';
+import { getWeeksArray, getAvailableTrainingModules, editPermissions } from '../../selectors';
 
 const TimelineHandler = createReactClass({
   displayName: 'TimelineHandler',
@@ -27,7 +27,8 @@ const TimelineHandler = createReactClass({
     loading: PropTypes.bool,
     editableBlockIds: PropTypes.array,
     all_training_modules: PropTypes.array,
-    fetchAllTrainingModules: PropTypes.func.isRequired
+    fetchAllTrainingModules: PropTypes.func.isRequired,
+    editPermissions: PropTypes.bool.isRequired
   },
 
   getInitialState() {
@@ -129,7 +130,7 @@ const TimelineHandler = createReactClass({
           setBlockEditable={this.props.setBlockEditable}
           resetState={() => {}}
           nameHasChanged={() => false}
-          edit_permissions={this.props.current_user.admin || this.props.current_user.role > 0}
+          edit_permissions={this.props.editPermissions}
         />
         {grading}
       </div>
@@ -141,7 +142,8 @@ const mapStateToProps = state => ({
   weeks: getWeeksArray(state),
   loading: state.timeline.loading,
   editableBlockIds: state.timeline.editableBlockIds,
-  availableTrainingModules: getAvailableTrainingModules(state)
+  availableTrainingModules: getAvailableTrainingModules(state),
+  editPermissions: editPermissions(state)
 });
 
 const mapDispatchToProps = {

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -26,6 +26,7 @@ const getCourseType = state => state.course.type;
 const getTraining = state => state.training;
 const getValidations = state => state.validations.validations;
 const getValidationErrors = state => state.validations.errorQueue;
+const getCourse = state => state.course;
 
 export const getInstructorUsers = createSelector(
   [getUsers], users => _.sortBy(getFiltered(users, { role: INSTRUCTOR_ROLE }), 'enrolled_at')
@@ -211,5 +212,12 @@ export const firstValidationErrorMessage = createSelector(
       return validations[validationErrors[0]].message;
     }
     return null;
+  }
+);
+
+export const editPermissions = createSelector(
+  [getCourse, getCurrentUser], (course, user) => {
+    if (!user.isNonstudent) { return false; }
+    return user.isAdmin || !course.closed;
   }
 );

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -236,6 +236,10 @@ class Course < ApplicationRecord
     campaigns.any? && !withdrawn
   end
 
+  def closed?
+    flags[:closed_date].present?
+  end
+
   def tag?(query_tag)
     tags.pluck(:tag).include? query_tag
   end

--- a/app/services/update_course_from_salesforce.rb
+++ b/app/services/update_course_from_salesforce.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/word_count"
+
+#= Pulls course-related data from Salesforce
+class UpdateCourseFromSalesforce
+  def initialize(course)
+    return unless Features.wiki_ed?
+    @course = course
+    @salesforce_id = @course.flags[:salesforce_id]
+    return unless @salesforce_id
+    @client = Restforce.new
+    update
+  rescue StandardError => e
+    Raven.capture_exception e
+  end
+
+  private
+
+  def salesforce_record
+    @salesforce_record ||= @client.find('Course__c', @salesforce_id)
+  end
+
+  def update
+    @course.flags[:closed_date] = salesforce_record['Course_Closed_Date__c']
+    @course.save
+  end
+end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -8,7 +8,8 @@ json.course do
             :timeline_end, :day_exceptions, :weekdays, :no_day_exceptions,
             :updated_at, :string_prefix, :use_start_and_end_times, :type,
             :home_wiki, :character_sum, :upload_count, :uploads_in_use_count,
-            :upload_usages_count, :cloned_status, :flags, :level, :private, :training_library_slug)
+            :upload_usages_count, :cloned_status, :flags, :level, :private, :closed?,
+            :training_library_slug)
 
   json.timeline_enabled @course.timeline_enabled?
   json.home_wiki_edits_enabled @course.home_wiki.edits_enabled?
@@ -18,6 +19,7 @@ json.course do
   json.legacy @course.legacy?
   json.ended @course.end < Time.zone.now
   json.published CampaignsCourses.exists?(course_id: @course.id)
+  json.closed @course.closed?
   json.enroll_url "#{request.base_url}#{course_slug_path(@course.slug)}/enroll/"
 
   json.created_count number_to_human @course.new_article_count

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -90,7 +90,9 @@ class DailyUpdate
   def push_course_data_to_salesforce
     log_message 'Pushing course data to Salesforce'
     Course.current.each do |course|
-      PushCourseToSalesforce.new(course) if course.flags[:salesforce_id]
+      next unless course.flags[:salesforce_id]
+      PushCourseToSalesforce.new(course)
+      UpdateCourseFromSalesforce.new(course)
     end
   end
 end

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -20,6 +20,7 @@ describe DailyUpdate do
       expect(UploadImporter).to receive(:find_deleted_files)
       expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
       expect(PushCourseToSalesforce).to receive(:new)
+      expect(UpdateCourseFromSalesforce).to receive(:new)
       expect(Raven).to receive(:capture_message).and_call_original
       update = described_class.new
       sentry_logs = update.instance_variable_get(:@sentry_logs)

--- a/spec/services/update_course_from_salesforce_spec.rb
+++ b/spec/services/update_course_from_salesforce_spec.rb
@@ -18,6 +18,12 @@ describe UpdateCourseFromSalesforce do
       subject
       expect(course.reload.flags[:closed_date]).to eq('2018-06-07')
     end
+
+    it 'handles Salesforce API downtime gracefully' do
+      expect_any_instance_of(Restforce::Data::Client).to receive(:find)
+        .and_raise(Faraday::ParsingError.new('Salesforce is down'))
+      subject
+    end
   end
 
   context 'when a course does not have a Salesforce record' do

--- a/spec/services/update_course_from_salesforce_spec.rb
+++ b/spec/services/update_course_from_salesforce_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/app/services/update_course_from_salesforce"
+
+describe UpdateCourseFromSalesforce do
+  let(:course) { create(:course, flags: flags) }
+  let(:salesforce_id) { 'a2qQ0101015h4HF' }
+  let(:mock_salesforce_record) { { 'Course_Closed_Date__c' => '2018-06-07' } }
+  let(:subject) { described_class.new(course) }
+
+  context 'when a course has a Salesforce record' do
+    let(:flags) { { salesforce_id: salesforce_id } }
+
+    it 'updates the record with the closed date' do
+      expect_any_instance_of(Restforce::Data::Client).to receive(:find)
+        .and_return(mock_salesforce_record)
+      subject
+      expect(course.reload.flags[:closed_date]).to eq('2018-06-07')
+    end
+  end
+
+  context 'when a course does not have a Salesforce record' do
+    let(:flags) { {} }
+
+    it 'returns without error' do
+      subject
+      expect(course.reload.flags[:closed_date]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This adds a routine to check Salesforce to find out which courses have been closed out, and prevents changes except by admins for those course, so that instructors do not mistakenly edit the dates and users of a previous term's course instead of creating a new course.