### PR TITLE
Fixes #2350 added strip course params in set_slug

### DIFF
--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -56,9 +56,9 @@ class CourseCreationManager
   end
 
   def set_slug
-    slug =  @course_params[:school].presence || ''
-    slug += "/#{@course_params[:title]}" if @course_params[:title].present?
-    slug += "_(#{@course_params[:term]})" if @course_params[:term].present?
+    slug =  @course_params[:school].strip.presence || ''
+    slug += "/#{@course_params[:title].strip}" if @course_params[:title].present?
+    slug += "_(#{@course_params[:term].strip})" if @course_params[:term].present?
     @slug = slug.tr(' ', '_')
     @overrides[:slug] = @slug
   end


### PR DESCRIPTION
I have the striped the various the params which make up the slug on course creation.This is my first contribution to this project.Please point any mistakes or points I didn't notice.