### PR TITLE
Redirect when users visit /update_locale/:locale to change languages

### DIFF
--- a/app/controllers/users/locale_controller.rb
+++ b/app/controllers/users/locale_controller.rb
@@ -11,6 +11,7 @@ class Users::LocaleController < ApplicationController
     if request.method == 'POST'
       render json: { success: true }
     else
+      flash[:notice] = 'Locale preference updated!'
       redirect_to '/'
     end
   end

--- a/app/controllers/users/locale_controller.rb
+++ b/app/controllers/users/locale_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+class Users::LocaleController < ApplicationController
+  before_action :require_signed_in
+
+  def update_locale
+    @locale = params[:locale]
+    validate_locale { return }
+
+    save_user_locale
+
+    if request.method == 'POST'
+      render json: { success: true }
+    else
+      redirect_to '/'
+    end
+  end
+
+  private
+
+  def validate_locale
+    return if I18n.available_locales.include?(@locale.to_sym)
+
+    render json: { message: 'Invalid locale' }, status: :unprocessable_entity
+    yield
+  end
+
+  def save_user_locale
+    current_user.locale = @locale
+    current_user.save!
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,7 @@ class UsersController < ApplicationController
 
     current_user.locale = locale
     current_user.save!
-    if request.path_parameters[:format] == :json
+    if request.method == 'POST'
       render json: { success: true }
     else
       redirect_to '/'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,6 @@ class UsersController < ApplicationController
   respond_to :html, :json
 
   before_action :require_participating_user, only: [:enroll]
-  before_action :require_signed_in, only: [:update_locale]
   before_action :require_admin_permissions, only: [:index]
 
   layout 'admin', only: [:index]
@@ -21,23 +20,6 @@ class UsersController < ApplicationController
     else
       current_user.update_attributes(wiki_token: nil, wiki_secret: nil)
       redirect_to true_destroy_user_session_path
-    end
-  end
-
-  def update_locale
-    locale = params[:locale]
-
-    unless I18n.available_locales.include?(locale.to_sym)
-      render json: { message: 'Invalid locale' }, status: :unprocessable_entity
-      return
-    end
-
-    current_user.locale = locale
-    current_user.save!
-    if request.method == 'POST'
-      render json: { success: true }
-    else
-      redirect_to '/'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,11 @@ class UsersController < ApplicationController
 
     current_user.locale = locale
     current_user.save!
-    render json: { success: true }
+    if request.path_parameters[:format] == :json
+      render json: { success: true }
+    else
+      redirect_to '/'
+    end
   end
 
   #########################

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,10 @@ module ApplicationHelper
   end
 
   def language_switcher_enabled
-    Features.enable_language_switcher?.to_s
+    # If the language switcher is not enabled site-wide, show it anyway for users
+    # with a non-English browser-based locale and for users with an explicit locale set.
+    (Features.enable_language_switcher? || I18n.locale != :en || current_user&.locale&.present?)
+      .to_s
   end
 
   def logo_favicon_tag

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -314,8 +314,8 @@ Rails.application.routes.draw do
   put 'onboarding/supplementary' => 'onboarding#supplementary', as: :supplementary
 
   # Update Locale Preference
-  post '/update_locale/:locale' => 'users#update_locale', as: :update_locale
-  get '/update_locale/:locale' => 'users#update_locale'
+  post '/update_locale/:locale' => 'users/locale#update_locale', as: :update_locale
+  get '/update_locale/:locale' => 'users/locale#update_locale'
 
   # Route aliases for React frontend
   get '/course_creator(/*any)' => 'dashboard#index', as: :course_creator

--- a/spec/controllers/users/locale_controller_spec.rb
+++ b/spec/controllers/users/locale_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::LocaleController, type: :request do
+  describe '#update_locale' do
+    let(:user) { create(:user, locale: 'fr') }
+    let(:invalid_locale) { 'bad-locale' }
+    let(:valid_locale) { 'es' }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+
+    it 'returns a 422 if locale is invalid' do
+      post "/update_locale/#{invalid_locale}"
+      expect(response.status).to eq(422)
+      expect(user.locale).to eq('fr')
+    end
+
+    it 'updates user locale and returns a 200 or 302 if locale is valid' do
+      post "/update_locale/#{valid_locale}"
+      expect(response.status).to eq(200).or eq(302)
+      expect(user.locale).to eq('es')
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -202,9 +202,9 @@ describe UsersController, type: :request do
       expect(user.locale).to eq('fr')
     end
 
-    it 'updates user locale and returns a 200 if locale is valid' do
+    it 'updates user locale and returns a 200 or 302 if locale is valid' do
       post "/update_locale/#{valid_locale}"
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(200).or eq(302)
       expect(user.locale).to eq('es')
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -187,28 +187,6 @@ describe UsersController, type: :request do
     end
   end
 
-  describe '#update_locale' do
-    let(:user) { create(:user, locale: 'fr') }
-    let(:invalid_locale) { 'bad-locale' }
-    let(:valid_locale) { 'es' }
-
-    before do
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-    end
-
-    it 'returns a 422 if locale is invalid' do
-      post "/update_locale/#{invalid_locale}"
-      expect(response.status).to eq(422)
-      expect(user.locale).to eq('fr')
-    end
-
-    it 'updates user locale and returns a 200 or 302 if locale is valid' do
-      post "/update_locale/#{valid_locale}"
-      expect(response.status).to eq(200).or eq(302)
-      expect(user.locale).to eq('es')
-    end
-  end
-
   describe '#index' do
     context 'when user is NOT admin' do
       let(:user) { create(:user) }

--- a/spec/features/update_locale_spec.rb
+++ b/spec/features/update_locale_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'updating locale via URL', type: :feature do
+  let(:user) { create(:user) }
+
+  before { login_as(user) }
+
+  it 'updates the locale and redirects to the home page' do
+    expect(user.locale).to be_nil
+    visit '/update_locale/ar'
+    expect(user.reload.locale).to eq('ar')
+    expect(page).to have_content('مرحبا')
+  end
+end


### PR DESCRIPTION
This will save a bit of confusion when we direct users to update their locale via https://dashboard.wikiedu.org/update_locale/en