### PR TITLE
Fix course description bug where field resets to initial state

### DIFF
--- a/app/assets/javascripts/components/overview/course_stats.jsx
+++ b/app/assets/javascripts/components/overview/course_stats.jsx
@@ -16,14 +16,14 @@ const CourseStats = ({ course }) => {
   if (course.home_wiki.language === 'en') {
     contentCount = (
       <div className="stat-display__stat" id="word-count">
-        <div className={valueClass('wordCount')}>{course.word_count}</div>
+        <div className={valueClass('word_count')}>{course.word_count}</div>
         <small>{I18n.t('metrics.word_count')}</small>
       </div>
     );
   } else {
     contentCount = (
       <div className="stat-display__stat" id="bytes-added">
-        <div className={valueClass('wordCount')}>{course.character_sum_human}</div>
+        <div className={valueClass('word_count')}>{course.character_sum_human}</div>
         <small>{I18n.t('metrics.bytes_added')}</small>
       </div>
     );
@@ -40,7 +40,7 @@ const CourseStats = ({ course }) => {
     );
   } else {
     viewData = (
-      <div className={valueClass('viewCount')}>
+      <div className={valueClass('view_count')}>
         {course.view_count}
       </div>
     );
@@ -60,19 +60,19 @@ const CourseStats = ({ course }) => {
   return (
     <div className="stat-display">
       <div className="stat-display__stat" id="articles-created">
-        <div className={valueClass('createdCount')}>{course.created_count}</div>
+        <div className={valueClass('created_count')}>{course.created_count}</div>
         <small>{I18n.t('metrics.articles_created')}</small>
       </div>
       <div className="stat-display__stat" id="articles-edited">
-        <div className={valueClass('editedCount')}>{course.edited_count}</div>
+        <div className={valueClass('edited_count')}>{course.edited_count}</div>
         <small>{I18n.t('metrics.articles_edited')}</small>
       </div>
       <div className="stat-display__stat" id="total-edits">
-        <div className={valueClass('editCount')}>{course.edit_count}</div>
+        <div className={valueClass('edit_count')}>{course.edit_count}</div>
         <small>{I18n.t('metrics.edit_count_description')}</small>
       </div>
       <div className="stat-display__stat tooltip-trigger" id="student-editors">
-        <div className={valueClass('studentCount')}>
+        <div className={valueClass('student_count')}>
           {course.student_count}
           {infoImg}
         </div>
@@ -85,7 +85,7 @@ const CourseStats = ({ course }) => {
         <small>{I18n.t('metrics.view_count_description')}</small>
       </div>
       <div className="stat-display__stat tooltip-trigger" id="upload-count">
-        <div className={valueClass('uploadCount')}>
+        <div className={valueClass('upload_count')}>
           {course.upload_count}
           <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
         </div>

--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -40,8 +40,12 @@ export default function course(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_COURSE:
       return { ...action.data.course };
-    case RECEIVE_COURSE_UPDATE:
-      return { ...action.data.course, newStats: CourseUtils.newCourseStats(state, action.data.course) };
+    case RECEIVE_COURSE_UPDATE: {
+      const courseData = action.data.course;
+      const newStats = CourseUtils.newCourseStats(state, courseData);
+      const newKeys = CourseUtils.courseStatsToUpdate(courseData, newStats);
+      return { ...state, ...newKeys, newStats };
+    }
     case PERSISTED_COURSE:
       return { ...state, ...action.data.course };
     case UPDATE_COURSE:

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -178,14 +178,23 @@ const CourseUtils = class {
 
   newCourseStats(oldCourse, newCourse) {
     return {
-      createdCount: oldCourse.created_count !== newCourse.created_count,
-      editedCount: oldCourse.edited_count !== newCourse.edited_count,
-      editCount: oldCourse.edit_count !== newCourse.edit_count,
-      studentCount: oldCourse.student_count !== newCourse.student_count,
-      wordCount: oldCourse.character_sum_human !== newCourse.character_sum_human,
-      viewCount: oldCourse.view_count !== newCourse.view_count,
-      uploadCount: oldCourse.upload_count !== newCourse.upload_count
+      created_count: oldCourse.created_count !== newCourse.created_count,
+      edited_count: oldCourse.edited_count !== newCourse.edited_count,
+      edit_count: oldCourse.edit_count !== newCourse.edit_count,
+      student_count: oldCourse.student_count !== newCourse.student_count,
+      word_count: oldCourse.character_sum_human !== newCourse.character_sum_human,
+      view_count: oldCourse.view_count !== newCourse.view_count,
+      upload_count: oldCourse.upload_count !== newCourse.upload_count
     };
+  }
+
+  // Given a course and camelized stats from the above `newCourseStats`
+  // function, return only the key-value pairs of what needs to be updated
+  // in the course.
+  courseStatsToUpdate(course, newStats) {
+    return Object.entries(newStats)
+      .filter(([, val]) => val)
+      .reduce((acc, [key]) => ({ ...acc, [key]: course[key] }), {});
   }
 };
 

--- a/test/reducers/course.spec.js
+++ b/test/reducers/course.spec.js
@@ -39,16 +39,45 @@ describe('course reducer', () => {
   });
 
   it('keeps track of which stats have been updated with RECEIVE_COURSE_UPDATE', () => {
-    const initialState = { title: 'title', created_count: 0, edited_count: 0 };
+    const initialState = {
+      title: 'title',
+      created_count: 0,
+      edited_count: 0,
+      student_count: 3
+    };
     deepFreeze(initialState);
+
     const mockedAction = {
       type: RECEIVE_COURSE_UPDATE,
-      data: { course: { created_count: 1, edited_count: 0 } }
+      data: { course: { ...initialState, created_count: 1, student_count: 5 } }
     };
 
     const newState = course(initialState, mockedAction);
-    expect(newState.newStats.createdCount).to.eq(true);
-    expect(newState.newStats.editedCount).to.eq(false);
+    expect(newState.newStats.created_count).to.eq(true);
+    expect(newState.newStats.student_count).to.eq(true);
+    expect(newState.newStats.edited_count).to.eq(false);
+    expect(newState.created_count).to.eq(1);
+    expect(newState.student_count).to.eq(5);
+    expect(newState.edited_count).to.eq(0);
+  });
+
+  it('only updates stat information with RECEIVE_COURSE_UPDATE', () => {
+    const initialState = {
+      title: 'new title',
+      description: 'initial description',
+    };
+    deepFreeze(initialState);
+
+    const newState = course(initialState, {
+      type: UPDATE_COURSE,
+      course: { description: 'a new description' }
+    });
+
+    const finalState = course(newState, {
+      type: RECEIVE_COURSE_UPDATE,
+      data: { course: { ...initialState } }
+    });
+    expect(finalState.description).to.eq('a new description');
   });
 
   it('updates course with receive data via PERSITED_COURSE', () => {

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -306,4 +306,33 @@ describe('courseUtils.formattedArticleTitle', () => {
     article.formatted_title = courseUtils.formattedArticleTitle(article, defaultWiki);
     expect(article.formatted_title).to.eq('wikidata:Judith Butler');
   });
+
+  describe('courseUtils.courseStatsToUpdate', () => {
+    const course = {
+      title: 'My Course',
+      description: 'My Description',
+      student_count: 0,
+      upload_count: 0
+    };
+
+    const stats = {
+      student_count: false,
+      upload_count: false
+    };
+
+    it('should return an empty object if no stats should be updated', () => {
+      const actual = courseUtils.courseStatsToUpdate(course, stats);
+      const expected = {};
+      expect(actual).to.deep.equal(expected);
+    });
+
+    it('should return key-value pairs of what stats to update in a course', () => {
+      const courseData = { ...course, student_count: 99 };
+      const newStats = { ...stats, student_count: true };
+
+      const actual = courseUtils.courseStatsToUpdate(courseData, newStats);
+      const expected = { student_count: 99 };
+      expect(actual).to.deep.equal(expected);
+    });
+  });
 });


### PR DESCRIPTION
Ended up being a real simple change.  :)

This test also correctly fails with the previous code but now passes.