### PR TITLE
Fix yarn test warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,7 @@
     "import/extensions": 0,
     "import/prefer-default-export": 0,
     "import/no-extraneous-dependencies": 0,
+    "import/no-named-as-default": 0,
     "no-underscore-dangle": 0,
     "no-empty-pattern": 0,
     "object-shorthand": 0,

--- a/app/assets/javascripts/components/articles/articles_handler.jsx
+++ b/app/assets/javascripts/components/articles/articles_handler.jsx
@@ -12,7 +12,7 @@ import { fetchArticles, sortArticles, filterArticles, filterNewness } from '../.
 import { fetchAssignments } from '../../actions/assignment_actions';
 import { getArticlesByNewness } from '../../selectors';
 
-const ArticlesHandler = createReactClass({
+export const ArticlesHandler = createReactClass({
   displayName: 'ArticlesHandler',
 
   propTypes: {

--- a/app/assets/javascripts/components/course/course.jsx
+++ b/app/assets/javascripts/components/course/course.jsx
@@ -28,7 +28,7 @@ import Notifications from '../common/notifications.jsx';
 import CourseAlerts from './course_alerts';
 import { getStudentCount, getCurrentUser, getWeeksArray } from '../../selectors';
 
-const Course = createReactClass({
+export const Course = createReactClass({
   displayName: 'Course',
 
   propTypes: {

--- a/app/assets/javascripts/components/overview/my_articles.jsx
+++ b/app/assets/javascripts/components/overview/my_articles.jsx
@@ -8,7 +8,7 @@ import MyAssignment from './my_assignment.jsx';
 import { fetchAssignments } from '../../actions/assignment_actions';
 import { getFiltered } from '../../utils/model_utils';
 
-const MyArticles = createReactClass({
+export const MyArticles = createReactClass({
   displayName: 'MyArticles',
 
   propTypes: {

--- a/test/components/articles/articles_handler.spec.jsx
+++ b/test/components/articles/articles_handler.spec.jsx
@@ -1,17 +1,27 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
 
+import { ArticlesHandler } from '../../../app/assets/javascripts/components/articles/articles_handler.jsx';
 import '../../testHelper';
-
-import ArticlesHandler from '../../../app/assets/javascripts/components/articles/articles_handler.jsx';
 
 describe('ArticlesHandler', () => {
   it('renders', () => {
-    const TestDom = ReactTestUtils.renderIntoDocument(
-      <div>
-        <ArticlesHandler course={{ home_wiki: {} }} store={reduxStore} current_user={{}} />
-      </div>
+    const props = {
+      course: {
+        school: 'My School',
+        home_wiki: {
+          id: 1,
+          language: 'en',
+          project: 'wikipedia'
+        }
+      },
+      wikis: []
+    };
+    const component = shallow(
+      <ArticlesHandler {...props} />
     );
-    expect(TestDom.querySelector('h3')).to.exist;
+
+    expect(component.find('h3')).to.exist;
+    expect(component.text()).to.contain('Articles Edited');
   });
 });

--- a/test/components/overview/my_articles.spec.jsx
+++ b/test/components/overview/my_articles.spec.jsx
@@ -1,33 +1,18 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import { MemoryRouter } from 'react-router-dom';
-import history from '../../../app/assets/javascripts/components/util/history';
+import { shallow } from 'enzyme';
 
+import { MyArticles } from '../../../app/assets/javascripts/components/overview/my_articles.jsx';
 import '../../testHelper';
-import MyArticles from '../../../app/assets/javascripts/components/overview/my_articles.jsx';
 
 describe('MyArticles', () => {
-  const course = {};
-  const currentUser = { id: 1, admin: false, role: 0 };
-  const courseId = 'institution/title_(term)';
-
-  MyArticles.__Rewire__(
-    'AssignCell',
-    () => <div />
-  );
-
   it('renders the My Articles header', () => {
-    const TestMyArticles = ReactTestUtils.renderIntoDocument(
-      <MemoryRouter history={history}>
-        <MyArticles
-          store={reduxStore}
-          course={course}
-          course_id={courseId}
-          current_user={currentUser}
-        />
-      </MemoryRouter>
-    );
-    const module = ReactTestUtils.findRenderedDOMComponentWithTag(TestMyArticles, 'h3');
-    expect(module.textContent).to.eq('My Articles');
+    const props = {
+      course: {},
+      courseId: 'institution/title_(term)',
+      current_user: { id: 1, admin: false, role: 0 },
+      assignments: []
+    };
+    const component = shallow(<MyArticles {...props} />);
+    expect(component.find('h3').text()).to.eq('My Articles');
   });
 });

--- a/test/components/timeline/empty_week.spec.jsx
+++ b/test/components/timeline/empty_week.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { MemoryRouter } from 'react-router';
-import history from '../../../app/assets/javascripts/components/util/history';
 
 import '../../testHelper';
 import EmptyWeek from '../../../app/assets/javascripts/components/timeline/empty_week.jsx';
@@ -26,7 +25,7 @@ describe('EmptyWeek', () => {
 
   describe('timeline is empty, edit permissions', () => {
     const TestEmptyWeek = mount(
-      <MemoryRouter history={history}>
+      <MemoryRouter>
         <EmptyWeek
           emptyTimeline
           edit_permissions
@@ -45,7 +44,7 @@ describe('EmptyWeek', () => {
 
   describe('timeline is empty, no edit permissions', () => {
     const TestEmptyWeek = mount(
-      <MemoryRouter history={history}>
+      <MemoryRouter>
         <EmptyWeek
           emptyTimeline
           addWeek={jest.fn()}

--- a/test/components/training/slide_link.spec.jsx
+++ b/test/components/training/slide_link.spec.jsx
@@ -8,7 +8,11 @@ import '../../testHelper';
 import SlideLink from '../../../app/assets/javascripts/training/components/slide_link.jsx';
 import TrainingSlideHandler from '../../../app/assets/javascripts/training/components/training_slide_handler.jsx';
 
-jest.mock('../../../app/assets/javascripts/components/common/notifications.jsx', () => 'Notifications');
+jest.mock('../../../app/assets/javascripts/components/common/notifications.jsx', () => {
+  return function Notifications() {
+    return 'Notifications';
+  };
+});
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 describe('SlideLink', () => {
@@ -27,7 +31,7 @@ describe('SlideLink', () => {
         <Route
           exact
           path="/training/:library_id/:module_id/:slide_id"
-          render={() => (
+          render={({ match }) => (
             <TrainingSlideHandler
               loading={false}
             >
@@ -37,6 +41,7 @@ describe('SlideLink', () => {
                 disabled={false}
                 button={true}
                 onClick={jest.fn()}
+                params={match.params}
               />
             </TrainingSlideHandler>
           )}

--- a/test/components/training/slide_menu.spec.jsx
+++ b/test/components/training/slide_menu.spec.jsx
@@ -8,7 +8,11 @@ import '../../testHelper';
 import TrainingSlideHandler from '../../../app/assets/javascripts/training/components/training_slide_handler.jsx';
 import SlideMenu from '../../../app/assets/javascripts/training/components/slide_menu.jsx';
 
-jest.mock('../../../app/assets/javascripts/components/common/notifications.jsx', () => 'Notifications');
+jest.mock('../../../app/assets/javascripts/components/common/notifications.jsx', () => {
+  return function Notifications() {
+    return 'Notifications';
+  };
+});
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 

--- a/test/main/smoketest.spec.jsx
+++ b/test/main/smoketest.spec.jsx
@@ -1,37 +1,48 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import ReactTestUtils from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import { MemoryRouter, Route } from 'react-router-dom';
 import '../testHelper';
 
-import Course from '../../app/assets/javascripts/components/course/course.jsx';
-import OverviewHandler from '../../app/assets/javascripts/components/overview/overview_handler.jsx';
+import { Course } from '../../app/assets/javascripts/components/course/course.jsx';
 
 describe('top-level course component', () => {
-  document.body.innerHTML = "<div data-current_user='{ \"admin\": false, \"id\": null }' id='react_root'></div>";
-
   it('loads without an error', () => {
-    const courseProps = {
-      location: {
-        query: { enroll: 'passcode' },
-        pathname: '/courses/this_school/this_course'
-      },
-      params: { course_school: 'this_school', course_title: 'this_course' }
+    global.Features = { enableGetHelpButton: true };
+    const course = {
+      title: 'this_course',
+      description: '',
+      school: 'this_school'
     };
-    const currentUser = {
+    const user = {
       role: 0,
       username: 'Ragesoss',
       admin: true
     };
-    global.Features = { enableGetHelpButton: true };
-    const testCourse = ReactTestUtils.renderIntoDocument(
-      <Provider store={reduxStore}>
-        <MemoryRouter>
-          <Course {...courseProps}>
-            <OverviewHandler {...courseProps} current_user={currentUser} />
-          </Course>
-        </MemoryRouter>
-      </Provider>
+    const props = {
+      course, current_user: user
+    };
+    const fns = {
+      fetchCourse: sinon.stub(),
+      fetchUsers: sinon.stub(),
+      fetchTimeline: sinon.stub(),
+      fetchCampaigns: sinon.stub(),
+      persistCourse: sinon.stub(),
+      updateCourse: sinon.stub()
+    };
+    const testCourse = mount(
+      <MemoryRouter initialEntries={['/courses/this_school/this_course']}>
+        <Route
+          exact
+          path="/courses/:course_school/:course_title"
+          render={location => (
+            <Course
+              {...location}
+              {...props}
+              {...fns}
+            />
+          )}
+        />
+      </MemoryRouter>
     );
     expect(testCourse).to.exist;
   });


### PR DESCRIPTION
I noticed a number of warnings and or errors arise while running `yarn test` even though all the tests are passing. A couple of these came from the React Router refactor but others seemed unrelated. The following changes have fixed and or removed all these warnings so that the tests can just run.

A couple of the important changes:
* IMO the [import/no-named-as-default](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md) is not super important and being able to export multiple things from files (particularly for testing) with similar names seems more valuable. But, happy to change this one around.
* Where possible I just removed some of the references to `Provider` and `MemoryRouter` as it doesn't seem like the tests truly needed them. It also seemed like some of the tests were using them but were actually failing, for example the `smoketest.spec.js`.
* The mocked out `Notifications` component was complaining about improper casing. This fixes the problem and does indeed render just a string.