### PR TITLE
Bug fix to allow classes to be scheduled on Saturdays

### DIFF
--- a/lib/course_meetings_manager.rb
+++ b/lib/course_meetings_manager.rb
@@ -97,7 +97,8 @@ class CourseMeetingsManager
     meetings = []
     @timeline_week_count.times do |wk|
       week_start = @beginning_of_first_week + wk.weeks
-      week_end = week_start.end_of_week(:saturday)
+      # This excludes Sunday, putting the end of the week at Saturday.
+      week_end = week_start.end_of_week(:sunday)
       week_mtgs = []
       @meeting_dates.each do |meeting|
         next if (meeting < @course.timeline_start) || (@course.timeline_end < meeting)


### PR DESCRIPTION
Fixes issue #2089.

`.end_of_week(:<day>)` is exclusive. For example:

```ruby
> '2019-01-15'.to_date.end_of_week(:saturday)
=> Fri, 18 Jan 2019
```