### PR TITLE
Store onboarding alert information in serialized hash

### DIFF
--- a/lib/alerts/onboarding_alert_manager.rb
+++ b/lib/alerts/onboarding_alert_manager.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class OnboardingAlertManager
-  def create_alert(user_name, msg)
+  def create_alert(user_name, msg, details)
     user = User.find_by(username: user_name)
     alert = Alert.create(type: 'OnboardingAlert',
                          user: user,
                          message: msg,
+                         details: details,
                          target_user: SpecialUsers.outreach_manager)
     alert.email_target_user
   end

--- a/spec/controllers/onboarding_controller_spec.rb
+++ b/spec/controllers/onboarding_controller_spec.rb
@@ -90,5 +90,18 @@ describe OnboardingController, type: :request do
       alert = Alert.where(user_id: user.id, type: 'OnboardingAlert').first
       expect(alert.message).to include('Jeor Mormont')
     end
+
+    it 'stores information in the details field' do
+      params = {
+        user_name: user.username,
+        heardFrom: 'From Nights Watch',
+        referralDetails: 'Jeor Mormont'
+      }
+      put '/onboarding/supplementary', params: params
+      expect(response.status).to eq(204)
+      alert = Alert.where(user_id: user.id, type: 'OnboardingAlert').first
+      expect(alert.reload.details['heard_from']['answer']).to eq('From Nights Watch')
+      expect(alert.reload.details['heard_from']['additional']).to eq('Jeor Mormont')
+    end
   end
 end


### PR DESCRIPTION
This will store OnboardingAlert information as a hash in the `details` column. This will make it easier to present this information back on the frontend.