### PR TITLE
[WIP] Allow for backup account when creating requested accounts

### DIFF
--- a/app/assets/javascripts/components/settings/views/add_special_user_form.jsx
+++ b/app/assets/javascripts/components/settings/views/add_special_user_form.jsx
@@ -76,6 +76,7 @@ const AddSpecialUserForm = createReactClass({
               <option>outreach_manager</option>
               <option>technical_help_staff</option>
               <option>survey_alerts_recipient</option>
+              <option>backup_account_creator</option>
             </select>
             <button className={buttonClass} type="submit" value="Submit">{I18n.t('application.submit')}</button>
           </form>

--- a/app/presenters/special_users.rb
+++ b/app/presenters/special_users.rb
@@ -30,4 +30,8 @@ class SpecialUsers
   def self.survey_alerts_recipient
     User.find_by(username: special_users[:survey_alerts_recipient])
   end
+
+  def self.backup_account_creator
+    User.find_by(username: special_users[:backup_account_creator])
+  end
 end

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -126,9 +126,3 @@
   chat_server: 'https://your.rocket.chat'
   chat_admin_username: 'admin'
   chat_admin_password: 'passwiord'
-
-# If a course or program is set to allow for accounts to be requested from the
-# organizer, the following account will be used as a backup in case the
-# requested accounts fails upon creation. This is to help in cases where too
-# many account requests are coming from one user.
-  account_creation_backup_creator_id: "1"

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -126,3 +126,9 @@
   chat_server: 'https://your.rocket.chat'
   chat_admin_username: 'admin'
   chat_admin_password: 'passwiord'
+
+# If a course or program is set to allow for accounts to be requested from the
+# organizer, the following account will be used as a backup in case the
+# requested accounts fails upon creation. This is to help in cases where too
+# many account requests are coming from one user.
+  account_creation_backup_creator_id: "1"

--- a/spec/services/create_requested_account_spec.rb
+++ b/spec/services/create_requested_account_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe CreateRequestedAccount do
   let(:creator) { create(:admin) }
+  let(:super_admin) { create(:super_admin) }
   let(:course) { create(:course) }
   let(:user) { create(:user) }
   let(:requested_account) do
@@ -36,6 +37,13 @@ describe CreateRequestedAccount do
     expect(Raven).to receive(:capture_exception)
     stub_account_creation_failure_unexpected
     expect(subject.result[:failure]).not_to be_nil
+    expect(RequestedAccount.count).to eq(1)
+  end
+
+  it 'retries the account creation at least once if request fails' do
+    ENV['account_creation_backup_creator_id'] = super_admin.id.to_s
+    stub_account_creation_failure_unexpected
+    expect(subject.creator).to eq(super_admin)
     expect(RequestedAccount.count).to eq(1)
   end
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -98,6 +98,21 @@ module RequestHelpers
     stub_list_users_query
   end
 
+  def stub_account_creation_failure_throttle
+    # Stub out the creation of accounts at Wikipedia
+    # First the request for edit tokens for a user
+    stub_account_creation_token_request
+
+    # Then the account creation request itself
+    failure = '{"createaccount":{"status":"FAIL",
+                                 "messagecode":"acct_creation_throttle_hit"}}'
+    stub_request(:post, /.*wikipedia.*/)
+      .to_return(status: 200, body: failure, headers: {})
+
+    # After account creation, stub the query for user info for UserImporter
+    stub_list_users_query
+  end
+
   def stub_oauth_edit_failure
     stub_token_request
     # Then the edit request itself


### PR DESCRIPTION
Adds a new environment variable that specifies an ID for an account that will be used as a backup in the event a requested account creation fails. If the environment variable is not there, it will just default to the previous implementation.

After you've had a chance to take a look at the code, let's just chat on Slack about this. I'd like to just run by you what I'll do to be manually testing this.