### PR TITLE
Fixes #1942 added campaigns to course page

### DIFF
--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -65,6 +65,7 @@ class WikiCourseOutput
        | expected_students = #{@course.expected_students}
        | assignment_page = #{@course.wiki_title}
        | slug = #{@course.slug}
+       | campaigns = #{@course.campaigns.pluck(:title).join(", ")} 
        | #{@dashboard_url} = yes
       }}
     COURSE_DETAILS

--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -65,7 +65,7 @@ class WikiCourseOutput
        | expected_students = #{@course.expected_students}
        | assignment_page = #{@course.wiki_title}
        | slug = #{@course.slug}
-       | campaigns = #{@course.campaigns.pluck(:title).join(", ")} 
+       | campaigns = #{@course.campaigns.pluck(:title).join(', ')}
        | #{@dashboard_url} = yes
       }}
     COURSE_DETAILS

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -44,6 +44,22 @@ describe WikiCourseOutput do
                       timeline_start: '2016-01-11',
                       timeline_end: '2016-04-24',
                       weeks: [week1, week2])
+      campaign1 = create(:campaign,
+                         id: 1,
+                         title: 'Campaign Title 1',
+                         slug: 'Campaign Slug 1')
+      campaign2 = create(:campaign,
+                         id: 2,
+                         title: 'Campaign Title 2',
+                         slug: 'Campaign Slug 2')
+      create(:campaigns_course,
+             id: 1,
+             campaign: campaign1,
+             course: course)
+      create(:campaigns_course,
+             id: 2,
+             campaign: campaign2,
+             course: course)
       create(:courses_user,
              user: student,
              course: course,
@@ -71,6 +87,7 @@ describe WikiCourseOutput do
       expect(response).to include('[[Your article]]')
       expect(response).to include('{{start of course week|2016-01-11|2016-01-13|2016-01-15}}')
       expect(response).to include('Jacque')
+      expect(response).to include('Campaign Title 1, Campaign Title 2')
     end
 
     context 'when the course has no weeks or users or anything' do

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -45,19 +45,15 @@ describe WikiCourseOutput do
                       timeline_end: '2016-04-24',
                       weeks: [week1, week2])
       campaign1 = create(:campaign,
-                         id: 1,
                          title: 'Campaign Title 1',
                          slug: 'Campaign Slug 1')
       campaign2 = create(:campaign,
-                         id: 2,
                          title: 'Campaign Title 2',
                          slug: 'Campaign Slug 2')
       create(:campaigns_course,
-             id: 1,
              campaign: campaign1,
              course: course)
       create(:campaigns_course,
-             id: 2,
              campaign: campaign2,
              course: course)
       create(:courses_user,


### PR DESCRIPTION
I have added the names of all campaigns that a course is part of to be shown on courses page.