### PR TITLE
add react-select in block_type_select without css

### DIFF
--- a/app/assets/javascripts/components/high_order/input_hoc.jsx
+++ b/app/assets/javascripts/components/high_order/input_hoc.jsx
@@ -55,9 +55,9 @@ const InputHOC = (Component) => {
 
     shouldComponentUpdate(nextProps, nextState) {
       if (this.state.value === nextState.value
-            && this.state.id === nextState.id
-            && this.state.invalid === nextState.invalid
-            && this.props.editable === nextProps.editable) {
+        && this.state.id === nextState.id
+        && this.state.invalid === nextState.invalid
+        && this.props.editable === nextProps.editable) {
         return false;
       }
       return true;

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -41,7 +41,11 @@ const Block = createReactClass({
   },
 
   deleteBlock() {
-    if (confirm('Are you sure you want to delete this block? This will delete the block and all of its content.\n\nThis cannot be undone.')) {
+    if (
+      confirm(
+        'Are you sure you want to delete this block? This will delete the block and all of its content.\n\nThis cannot be undone.'
+      )
+    ) {
       return this.props.deleteBlock(this.props.block.id);
     }
   },
@@ -80,8 +84,26 @@ const Block = createReactClass({
     if (isEditable) {
       blockActions = (
         <div className="float-container block__block-actions">
-          <button onClick={this.props.saveBlockChanges.bind(null, this.props.block.id)} className="button dark pull-right no-clear">Save</button>
-          <span role="button" tabIndex={0} onClick={this.props.cancelBlockEditable.bind(null, this.props.block.id)} className="span-link pull-right no-clear">Cancel</span>
+          <button
+            onClick={this.props.saveBlockChanges.bind(
+              null,
+              this.props.block.id
+            )}
+            className="button dark pull-right no-clear"
+          >
+            Save
+          </button>
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={this.props.cancelBlockEditable.bind(
+              null,
+              this.props.block.id
+            )}
+            className="span-link pull-right no-clear"
+          >
+            Cancel
+          </span>
         </div>
       );
     }
@@ -104,17 +126,31 @@ const Block = createReactClass({
     }
 
     if (!dueDateRead) {
-      dueDateRead = isGraded ? (<span className="block__default-due-date">{I18n.t('timeline.due_default')}</span>) : '';
+      dueDateRead = isGraded ? (
+        <span className="block__default-due-date">
+          {I18n.t('timeline.due_default')}
+        </span>
+      ) : (
+          ''
+        );
     }
 
     let deleteBlock;
     // let graded;
     if (isEditable) {
       if (!this.props.block.is_new) {
-        deleteBlock = (<div className="delete-block-container"><button className="danger" onClick={this.deleteBlock}>Delete Block</button></div>);
+        deleteBlock = (
+          <div className="delete-block-container">
+            <button className="danger" onClick={this.deleteBlock}>
+              Delete Block
+            </button>
+          </div>
+        );
       }
       className += ' editable';
-      if (this.props.isDragging) { className += ' dragging'; }
+      if (this.props.isDragging) {
+        className += ' dragging';
+      }
       // graded = (
       //   <Checkbox
       //     value={isGraded}
@@ -155,19 +191,27 @@ const Block = createReactClass({
           wysiwyg={true}
           className="block__block-content"
         />
-
       </div>
     );
 
     const dueDateSpacer = this.props.block.due_date ? (
       <span className="block__due-date-spacer"> - </span>
-    ) : undefined;
+    ) : (
+        undefined
+      );
 
     const editButton = this.props.editPermissions ? (
       <div className="block__edit-button-container">
-        <button className="pull-right button ghost-button block__edit-block" onClick={this._setEditable}>Edit</button>
+        <button
+          className="pull-right button ghost-button block__edit-block"
+          onClick={this._setEditable}
+        >
+          Edit
+        </button>
       </div>
-    ) : undefined;
+    ) : (
+        undefined
+      );
 
     let headerClass = 'block-title';
     if (isEditable) {
@@ -243,8 +287,6 @@ const Block = createReactClass({
       </li>
     );
   }
-}
-);
-
+});
 
 export default Block;

--- a/app/assets/javascripts/components/timeline/block_type_select.jsx
+++ b/app/assets/javascripts/components/timeline/block_type_select.jsx
@@ -3,6 +3,8 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Conditional from '../high_order/conditional.jsx';
 import InputHOC from '../high_order/input_hoc.jsx';
+import Select from 'react-select';
+import selectStyles from '../../styles/single_select';
 
 const BlockTypeSelect = createReactClass({
   displayName: 'BlockTypeSelect',
@@ -10,7 +12,18 @@ const BlockTypeSelect = createReactClass({
   propTypes: {
     value: PropTypes.any,
     options: PropTypes.array,
-    editable: PropTypes.bool,
+    editable: PropTypes.bool
+  },
+
+  getInitialState() {
+    const initialState = this.props.options[this.props.value];
+    return { selectedOption: { value: this.props.value, label: initialState } };
+  },
+
+  handleClick(selectedOption) {
+    this.setState({ selectedOption });
+    const e = { target: selectedOption };
+    this.props.onChange(e);
   },
 
   render() {
@@ -20,28 +33,31 @@ const BlockTypeSelect = createReactClass({
       <div className="tooltip dark">
         <p>{I18n.t('timeline.block_type')}</p>
       </div>
-          );
+    );
 
     const options = this.props.options.map((option, i) => {
-      return <option value={i} key={i}>{option}</option>;
+      return { value: i, label: option };
     });
 
     if (this.props.editable) {
       return (
         <div className="form-group">
-          <label htmlFor={this.props.id} className={labelClass}>{label}{tooltip}</label>
-          <select
+          <label htmlFor={this.props.id} className={labelClass}>
+            {label}
+            {tooltip}
+          </label>
+          <Select
             id={this.props.id}
-            value={this.props.value}
-            onChange={this.props.onChange}
-          >
-            {options}
-          </select>
-        </div>);
+            value={options.find(option => option.value === this.state.selectedOption.value)}
+            onChange={this.handleClick}
+            options={options}
+            styles={selectStyles}
+          />
+        </div>
+      );
     }
     return <span>{this.props.options[this.props.value]}</span>;
   }
-}
-);
+});
 
 export default Conditional(InputHOC(BlockTypeSelect));

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -136,6 +136,7 @@
   position relative
   -webkit-font-smoothing auto
   top 2px
+  min-width 125px
   &.editable
     margin-right 80px
   select


### PR DESCRIPTION
![block_type](https://user-images.githubusercontent.com/35252539/51792984-a3bce500-21df-11e9-8559-50ad90096dae.png)
This adds react-select in block_type_select but the css in not perfect. @ragesoss can you please give some suggestions how should it look as increasing the size of select component disrupts in the css of entire block.