### PR TITLE
Fix bug for sorting the timeline

### DIFF
--- a/app/assets/javascripts/reducers/timeline.js
+++ b/app/assets/javascripts/reducers/timeline.js
@@ -113,8 +113,8 @@ const updateBlockPosition = (movingBlock, newWeekId, targetIndex, blocks) => {
   });
 
   // Sort the unmoved blocks in the affected weeks by block order.
-  blocksInOldWeek.sort((a, b) => a.order > b.order);
-  blocksInNewWeek.sort((a, b) => a.order > b.order);
+  blocksInOldWeek.sort((a, b) => a.order - b.order);
+  blocksInNewWeek.sort((a, b) => a.order - b.order);
 
   // Insert the moved block into the desired position in the target week.
   blocksInNewWeek.splice(targetIndex, 0, movedBlock);


### PR DESCRIPTION
Firefox and Chrome use callback in the .sort() method slightly differently. This fix changes it so that the callback returns a number (the desired return value) as opposed to a boolean (which only works in Firefox).