### PR TITLE
Send UnsubmittedCourseAlerts to instructors before course starts

### DIFF
--- a/app/mailers/unsubmitted_course_alert_mailer.rb
+++ b/app/mailers/unsubmitted_course_alert_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class UnsubmittedCourseAlertMailer < ApplicationMailer
+  def self.send_email(alert)
+    return if !alert.user || alert.user.email.blank?
+    email(alert).deliver_now
+  end
+
+  def email(alert)
+    @instructor = alert.user
+    @name = @instructor.real_name || @instructor.username
+    @course_url = "https://#{ENV['dashboard_url']}/courses/#{alert.course.slug}"
+    @classroom_program_manager = SpecialUsers.classroom_program_manager
+    subject = 'Reminder: Submit your Wiki Education course page'
+    mail(to: @instructor.email,
+         reply_to: @classroom_program_manager.email,
+         subject: subject)
+  end
+end

--- a/app/models/alert_types/unsubmitted_course_alert.rb
+++ b/app/models/alert_types/unsubmitted_course_alert.rb
@@ -34,4 +34,9 @@ class UnsubmittedCourseAlert < Alert
   def reply_to
     user&.email
   end
+
+  def send_email
+    return if emails_disabled?
+    UnsubmittedCourseAlertMailer.send_email(self)
+  end
 end

--- a/app/models/alert_types/unsubmitted_course_alert.rb
+++ b/app/models/alert_types/unsubmitted_course_alert.rb
@@ -31,10 +31,6 @@ class UnsubmittedCourseAlert < Alert
     course_url
   end
 
-  def reply_to
-    user&.email
-  end
-
   def send_email
     return if emails_disabled?
     UnsubmittedCourseAlertMailer.send_email(self)

--- a/app/views/unsubmitted_course_alert_mailer/email.html.haml
+++ b/app/views/unsubmitted_course_alert_mailer/email.html.haml
@@ -1,0 +1,25 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@name},"
+              %p.paragraph
+                Just a quick reminder that you still need to hit "submit"
+                on your Wiki Education
+                %a{ href: @course_url } course page.
+              %p.paragraph
+                After you hit submit, we'll review your Wikipedia assignment 
+                and make it live on our system. Your students cannot begin their 
+                Wikipedia projects until you've submitted your page for review.
+              %p.paragraph
+                Thank you, and we look forward to working with you!
+              %p.paragraph
+                Best,
+                %br
+                %em
+                  =@classroom_program_manager.username

--- a/lib/alerts/unsubmitted_course_alert_manager.rb
+++ b/lib/alerts/unsubmitted_course_alert_manager.rb
@@ -9,7 +9,7 @@ class UnsubmittedCourseAlertManager
       alert = Alert.create(type: 'UnsubmittedCourseAlert',
                            course: course,
                            user: course.instructors.first)
-      alert.email_target_user
+      alert.send_email
     end
   end
 

--- a/lib/alerts/unsubmitted_course_alert_manager.rb
+++ b/lib/alerts/unsubmitted_course_alert_manager.rb
@@ -8,26 +8,17 @@ class UnsubmittedCourseAlertManager
 
       alert = Alert.create(type: 'UnsubmittedCourseAlert',
                            course: course,
-                           user: course.instructors.first,
-                           target_user: alert_recipient(course))
+                           user: course.instructors.first)
       alert.email_target_user
     end
   end
 
   private
 
-  DAYS_AGO_LIMIT = 30
+  TIME_WINDOW = 3
   def unsubmitted_recently_started_courses
-    ClassroomProgramCourse.unsubmitted.where(start: DAYS_AGO_LIMIT.days.ago..Time.zone.today)
-  end
-
-  # First time instructors work with the Outreach Manager.
-  # Returning instructors work with the Classroom Program Manager.
-  def alert_recipient(course)
-    if course.tag? 'first_time_instructor'
-      SpecialUsers.outreach_manager
-    else # 'returning_instructor', and fallback just in case a course has neither tag.
-      SpecialUsers.classroom_program_manager
-    end
+    ClassroomProgramCourse.unsubmitted
+                          .where('courses.created_at <= ?', TIME_WINDOW.days.ago)
+                          .where('courses.start <= ?', TIME_WINDOW.days.from_now)
   end
 end

--- a/lib/alerts/unsubmitted_course_alert_manager.rb
+++ b/lib/alerts/unsubmitted_course_alert_manager.rb
@@ -15,10 +15,10 @@ class UnsubmittedCourseAlertManager
 
   private
 
-  TIME_WINDOW = 3
+  TIME_WINDOW = 3.days
   def unsubmitted_recently_started_courses
     ClassroomProgramCourse.unsubmitted
-                          .where('courses.created_at <= ?', TIME_WINDOW.days.ago)
-                          .where('courses.start <= ?', TIME_WINDOW.days.from_now)
+                          .where('courses.created_at <= ?', TIME_WINDOW.ago)
+                          .where(start: TIME_WINDOW.ago...TIME_WINDOW.from_now)
   end
 end

--- a/spec/factories/alerts.rb
+++ b/spec/factories/alerts.rb
@@ -30,4 +30,6 @@ FactoryBot.define do
   factory :overdue_training_alert, class: 'OverdueTrainingAlert'
 
   factory :onboarding_alert, class: 'OnboardingAlert'
+
+  factory :unsubmitted_course_alert, class: 'UnsubmittedCourseAlert'
 end

--- a/spec/lib/alerts/unsubmitted_course_alert_manager_spec.rb
+++ b/spec/lib/alerts/unsubmitted_course_alert_manager_spec.rb
@@ -5,25 +5,54 @@ require "#{Rails.root}/lib/alerts/unsubmitted_course_alert_manager"
 
 describe UnsubmittedCourseAlertManager do
   let(:subject) { described_class.new }
-  let(:classroom_program_manager) { create(:user, username: 'CPM', email: 'cpm@wikiedu.org') }
-  let(:outreach_manager) { create(:user, username: 'OM', email: 'om@wikiedu.org') }
 
   before do
-    users = Setting.find_or_create_by(key: 'special_users')
-    users.update value: { classroom_program_manager: classroom_program_manager.username,
-                          outreach_manager: outreach_manager.username }
+    new_instructor = create(:instructor,
+                            id: 99,
+                            username: 'new',
+                            email: 'new@wikiedu.org')
+    returning_instructor = create(:instructor,
+                                  id: 88,
+                                  username: 'returning',
+                                  email: 'returning@wikiedu.org')
 
-    @first_course = create(:course, submitted: false, start: 1.week.ago)
+    @first_course = create(:course,
+                           instructors: [new_instructor],
+                           submitted: false,
+                           start: 3.days.from_now,
+                           created_at: 3.days.ago)
     @first_course.tags << Tag.new(tag: 'first_time_instructor')
+    create(:courses_user, course: @first_course, user: new_instructor, role: 1)
 
-    @returing_course = create(:course, submitted: false, slug: 'returning', start: 1.week.ago)
-    @returing_course.tags << Tag.new(tag: 'returning_instructor')
+    @returning_course = create(:course,
+                               instructors: [returning_instructor],
+                               submitted: false,
+                               slug: 'returning',
+                               start: 3.days.from_now,
+                               created_at: 3.days.ago)
+    @returning_course.tags << Tag.new(tag: 'returning_instructor')
+    create(:courses_user, course: @returning_course, user: returning_instructor, role: 1)
 
-    create(:course, submitted: false, start: 1.week.from_now, slug: 'not_started')
+    create(:course, submitted: false, start: 1.week.ago, slug: 'already_started')
+    create(:course, submitted: false, start: 1.week.from_now, slug: 'not_yet_started')
   end
 
   context 'when the alerts do not exist' do
-    it 'creates alerts for started courses and sends emails' do
+    it 'creates alerts for courses that start in 3 days and were created at least 3 days ago' do
+      subject.create_alerts
+      expect(Alert.count).to eq(2)
+    end
+    it 'sends the alert to the instructor on the course' do
+      subject.create_alerts
+      expect([Alert.first.user_id, Alert.last.user_id]).to include(99, 88)
+      expect([Alert.first.target_user, Alert.last.target_user]).to include(nil)
+    end
+    it 'does not create alerts for courses that were created too recently' do
+      create(:course,
+             submitted: false,
+             slug: 'last_minute_course',
+             start: 3.days.from_now,
+             created_at: 2.days.ago)
       subject.create_alerts
       expect(Alert.count).to eq(2)
     end
@@ -32,7 +61,7 @@ describe UnsubmittedCourseAlertManager do
   context 'when alerts already exist' do
     before { create(:alert, type: 'UnsubmittedCourseAlert', course: @first_course) }
 
-    before { create(:alert, type: 'UnsubmittedCourseAlert', course: @returing_course) }
+    before { create(:alert, type: 'UnsubmittedCourseAlert', course: @returning_course) }
 
     it 'does not create new ones' do
       expect(Alert.count).to eq(2)

--- a/spec/lib/alerts/unsubmitted_course_alert_manager_spec.rb
+++ b/spec/lib/alerts/unsubmitted_course_alert_manager_spec.rb
@@ -7,6 +7,11 @@ describe UnsubmittedCourseAlertManager do
   let(:subject) { described_class.new }
 
   before do
+    # CPM must be created for email to be sent
+    classroom_program_manager = create(:user, username: 'CPM', email: 'cpm@wikiedu.org')
+    users = Setting.find_or_create_by(key: 'special_users')
+    users.update value: { classroom_program_manager: classroom_program_manager.username }
+
     new_instructor = create(:instructor,
                             id: 99,
                             username: 'new',
@@ -45,7 +50,6 @@ describe UnsubmittedCourseAlertManager do
     it 'sends the alert to the instructor on the course' do
       subject.create_alerts
       expect([Alert.first.user_id, Alert.last.user_id]).to include(99, 88)
-      expect([Alert.first.target_user, Alert.last.target_user]).to include(nil)
     end
     it 'does not create alerts for courses that were created too recently' do
       create(:course,

--- a/spec/mailers/previews/unsubmitted_course_alert_mailer_preview.rb
+++ b/spec/mailers/previews/unsubmitted_course_alert_mailer_preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UnsubmittedCourseAlertMailerPreview < ActionMailer::Preview
+  def message_to_instructor
+    UnsubmittedCourseAlertMailer.email(alert)
+  end
+
+  private
+
+  def alert
+    user = User.first
+    Alert.new(type: 'UnsubmittedCourseAlert',
+              course: Course.new(slug: 'Example_University/Example_Course_(term)'),
+              user: user,
+              target_user: user)
+  end
+end

--- a/spec/mailers/unsubmitted_course_alert_mailer_spec.rb
+++ b/spec/mailers/unsubmitted_course_alert_mailer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UnsubmittedCourseAlertMailer do
+  describe '#send_email' do
+    let(:classroom_program_manager) { create(:user, username: 'CPM', email: 'cpm@wikiedu.org') }
+    let(:course) { create(:course) }
+    let(:alert) { create(:unsubmitted_course_alert, user: instructor, course: course) }
+    let(:mail) { described_class.send_email(alert) }
+
+    before do
+      users = Setting.find_or_create_by(key: 'special_users')
+      users.update value: { classroom_program_manager: classroom_program_manager.username }
+    end
+
+    context 'user with a real name' do
+      let(:instructor) { create(:instructor, real_name: 'Ada L.', email: 'ada@gmail.com') }
+
+      it 'sends an email to the course instructor' do
+        subject = 'Reminder: Submit your Wiki Education course page'
+        expect(mail.subject).to eq(subject)
+        expect(mail.to).to eq([instructor.email])
+        expect(mail.html_part.body).to include(instructor.real_name)
+      end
+    end
+
+    context 'user with only a username' do
+      let(:instructor) { create(:instructor, email: 'ada@gmail.com') }
+
+      it 'sends an email to the course instructor' do
+        subject = 'Reminder: Submit your Wiki Education course page'
+        expect(mail.subject).to eq(subject)
+        expect(mail.to).to eq([instructor.email])
+        expect(mail.html_part.body).to include(instructor.username)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should switch emails to go out to the instructor for a course 3 days before the start of a course, assuming they created the course at least 3 days before that. Created to solve Issue #2435.