### PR TITLE
ArticleViewer replaces state of history only if necessary

### DIFF
--- a/app/assets/javascripts/components/common/article_viewer.jsx
+++ b/app/assets/javascripts/components/common/article_viewer.jsx
@@ -79,7 +79,9 @@ const ArticleViewer = createReactClass({
     if (this.props.showArticleFinder) { return; }
     const viewer = document.getElementsByClassName('article-viewer')[0];
     if (!viewer || event) {
-      window.history.replaceState(null, null, window.location.pathname);
+      if (window.location.search) {
+        window.history.replaceState(null, null, window.location.pathname);
+      }
     }
   },
 


### PR DESCRIPTION
This should stop the errors from surfacing that are mentioned in Issue #2186. Clicking off of the Articles page is still a bit slow though -- I believe this is happening due to the [react-onclickoutside](https://github.com/Pomax/react-onclickoutside) package. I can follow up on this issue in a subsequent PR.