### PR TITLE
Remove 'build your own' wizard option for returning instructors

### DIFF
--- a/app/controllers/wizard_controller.rb
+++ b/app/controllers/wizard_controller.rb
@@ -14,11 +14,8 @@ class WizardController < ApplicationController
   def wizard_index
     content_path = "#{Rails.root}/config/wizard/wizard_index.yml"
     all_content = YAML.safe_load(File.read(File.expand_path(content_path, __FILE__)))
-    if current_user&.returning_instructor?
-      extra_content_path = "#{Rails.root}/config/wizard/extra_timeline_options.yml"
-      extra_options = YAML.safe_load(File.read(File.expand_path(extra_content_path, __FILE__)))
-      all_content += extra_options
-    end
+    # Additional wizard options can be added conditionally to all_content, such as
+    # a 'from scratch' option that was previously enabled for returning instructors.
     respond_to do |format|
       format.json { render json: all_content.to_json }
     end

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -350,65 +350,6 @@ describe 'New course creation and editing', type: :feature do
       end
     end
   end
-
-  describe 'returning instructor creating a new course', js: true do
-    before do
-      create(:course, id: 1)
-      create(:courses_user,
-             course_id: 1,
-             user_id: 1,
-             role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
-      create(:campaigns_course, course_id: 1, campaign_id: Campaign.first.id)
-      create(:tag, tag: 'cloneable', course_id: 1)
-    end
-
-    it 'has the option of starting with no timeline' do
-      visit root_path
-
-      click_link 'Create Course'
-      click_button 'Create New Course'
-      fill_out_course_creator_form
-      sleep 1
-      go_through_course_dates_and_timeline_dates
-
-      # Last option for returning instructor is 'build your own'
-      find('button', text: 'Build your own timeline').click
-      click_button 'Next'
-      sleep 1
-
-      # Proceed to the summary
-      click_button 'Next'
-      sleep 1
-
-      # Finish the wizard
-      click_button 'Generate Timeline'
-      expect(page).to have_content 'Launch the Wizard' # 'no timeline' banner above the Timeline
-      expect(page).to have_content 'Add Assignment' # Button in the Timeline
-      sleep 1
-
-      # Add a week
-      within '.timeline__week-nav .panel' do
-        find('.week-nav__add-week').click
-      end
-      sleep 1
-      within '.timeline__weeks' do
-        expect(page).to have_content 'Week 1'
-        find('.week__add-block').click
-        find('input.title').set('block title')
-        within('.block__block-actions') do
-          click_button 'Save'
-        end
-        sleep 1
-      end
-      # is it still there after reloading?
-      visit current_path
-      expect(page).to have_content 'Week 1'
-      expect(page).to have_content 'block title'
-
-      # Add Assignment button should not appear once there is timeline content.
-      expect(page).not_to have_content 'Add Assignment'
-    end
-  end
 end
 
 describe 'timeline editing', js: true do


### PR DESCRIPTION
It will still be possible to create a timeline from scratch, but we don't want to guide people to do so as often by including an explicit option in the wizard.