### PR TITLE
Display number of students left to be greeted on home page

### DIFF
--- a/app/assets/javascripts/utils/course.js
+++ b/app/assets/javascripts/utils/course.js
@@ -21,7 +21,8 @@ $(() => {
     courseList = new List('courses', {
       page: 500,
       valueNames: [
-        'title', 'school', 'revisions', 'characters', 'average-words', 'views', 'students', 'creation-date', 'untrained'
+        'title', 'school', 'revisions', 'characters', 'average-words', 'views',
+        'students', 'creation-date', 'ungreeted', 'untrained'
       ]
     });
   }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -35,11 +35,11 @@ class DashboardController < ApplicationController
 
     return unless current_user.admin?
     @submitted = Course.submitted_but_unapproved
-    @strictly_current = current_user.courses.strictly_current
+    @strictly_current = current_user.courses.strictly_current.includes(:students)
   end
 
   def current_courses
-    current_user.courses.current_and_future.includes(:students)
+    current_user.courses.current_and_future
   end
 
   def past_courses

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -39,7 +39,7 @@ class DashboardController < ApplicationController
   end
 
   def current_courses
-    current_user.courses.current_and_future
+    current_user.courses.current_and_future.includes(:students)
   end
 
   def past_courses

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -33,7 +33,7 @@ class DashboardPresenter
   end
 
   def ungreeted_students(course)
-    course.students.ungreeted.length
+    course.students.to_a.reject(&:greeted).length
   end
 
   # Show the 'Your Courses' label if there are current, submitted courses

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -32,6 +32,10 @@ class DashboardPresenter
     current_user.campaigns
   end
 
+  def ungreeted_students(course)
+    course.students.ungreeted.length
+  end
+
   # Show the 'Your Courses' label if there are current, submitted courses
   # OR you're an instructor with existing courses but you still haven't completed orientation
   def show_your_courses_label?

--- a/app/views/dashboard/_admin_course_row.html.haml
+++ b/app/views/dashboard/_admin_course_row.html.haml
@@ -32,3 +32,8 @@
       %small.untrained= t("users.training_complete_count", count: course.trained_count)
       %span.students.hidden
         = course.user_count
+  - if Features.wiki_ed?
+    %td{:class => "table-link-cell"}
+      %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+        %span.ungreeted
+          = @pres.ungreeted_students(course)

--- a/app/views/dashboard/_admin_courses.html.haml
+++ b/app/views/dashboard/_admin_courses.html.haml
@@ -26,6 +26,11 @@
         %th.sort.sortable{"data-sort" => "students", :style => "width: 200px;"}
           = t("users.editors")
           %span.sortable-indicator
+        - if Features.wiki_ed?
+          %th.sort.sortable{"data-sort" => "ungreeted", :style => "width: 150px;"}
+            = t("users.ungreeted")
+            %span.sortable-indicator
+
     %tbody.list
       - if @pres.strictly_current.empty?
         %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1032,6 +1032,7 @@ en:
     user_no_training_status: This user has not completed any training modules.
     up_to_date_with_training: 'up-to-date with training'
     uploads_doc: 'Number of file uploads to Wikimedia Commons'
+    ungreeted: Ungreeted
     username: Username
     username_placeholder: Username
     useremail_placeholder: Email

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -77,6 +77,41 @@ describe 'dashboard', type: :feature, js: true do
         expect(page).to have_content 'Create Course'
       end
     end
+
+    context 'as a Wiki Education Foundation admin' do
+      let(:permissions) { User::Permissions::SUPER_ADMIN }
+
+      before do
+        allow(Features).to receive(:wiki_ed?).and_return(true)
+        login_as(user, scope: :user)
+      end
+
+      it 'displays overview information for upcoming courses' do
+        create(:course,
+               id: 10001,
+               title: 'Title',
+               school: 'University',
+               term: 'Term',
+               slug: 'University/Course_(Term)',
+               submitted: false,
+               passcode: 'passcode',
+               start: 1.day.from_now,
+               end: 60.days.from_now,
+               timeline_start: 20.days.from_now,
+               timeline_end: 60.days.from_now)
+        create(:courses_user,
+               user_id: user.id,
+               course_id: 10001,
+               role: 4)
+        visit root_path
+        expect(page).to have_content 'Courses'
+        expect(page).to have_content 'Recent Edits'
+        expect(page).to have_content 'Words Added'
+        expect(page).to have_content 'Views'
+        expect(page).to have_content 'Editors'
+        expect(page).to have_content 'Ungreeted'
+      end
+    end
   end
 
   context 'archived courses' do


### PR DESCRIPTION
Issue #2473 
- Adds a sortable list to the home page for how many students are
  left to be greeted
- Should display for Wiki Edu admins only

If you'd rather not add another feature test, I will understand.  :)