### PR TITLE
Fix Timezone Failing Tests

### DIFF
--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -214,7 +214,7 @@ const DatePicker = createReactClass({
   },
 
   moment(...args) {
-    return this.props.showTime ? moment(...args) : moment(...args).utc();
+    return this.props.showTime ? moment.parseZone(...args) : moment.utc(...args);
   },
 
   showCurrentDate() {

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -118,13 +118,12 @@ class Campaign < ApplicationRecord
     # rubocop:disable Rails/TimeZone
     self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
     # rubocop:enable Rails/TimeZone
-  rescue ArgumentError, TypeError
-    errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
+    errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize)) if self[date_type].nil?
   end
 
   # Start must not be after end.
   def valid_start_and_end_dates?
-    return false unless start && self.end
+    return false unless start.present? && self.end.present?
     start <= self.end
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -116,7 +116,7 @@ class Campaign < ApplicationRecord
   def validate_date_attribute(date_type)
     value = send("#{date_type}_before_type_cast")
     # rubocop:disable Rails/TimeZone
-    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.parse(value)
+    self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
     # rubocop:enable Rails/TimeZone
   rescue ArgumentError, TypeError
     errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -119,6 +119,8 @@ class Campaign < ApplicationRecord
     if self[date_type].nil?
       errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
     end
+  rescue ArgumentError, TypeError
+    errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
   end
 
   # Start must not be after end.

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -115,10 +115,10 @@ class Campaign < ApplicationRecord
   # Intercept Rails typecasting and add error if given value cannot be parsed into a date.
   def validate_date_attribute(date_type)
     value = send("#{date_type}_before_type_cast")
-    # rubocop:disable Rails/TimeZone
     self[date_type] = value.is_a?(Date) || value.is_a?(Time) ? value : Time.zone.parse(value)
-    # rubocop:enable Rails/TimeZone
-    errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize)) if self[date_type].nil?
+    if self[date_type].nil?
+      errors.add(date_type, I18n.t('error.invalid_date', key: date_type.capitalize))
+    end
   end
 
   # Start must not be after end.

--- a/spec/features/campaign_overview_spec.rb
+++ b/spec/features/campaign_overview_spec.rb
@@ -209,8 +209,8 @@ describe 'campaign overview page', type: :feature, js: true do
           fill_in('campaign_start', with: '2016-01-10'.to_date)
           fill_in('campaign_end', with: '2016-02-10'.to_date)
           find('.campaign-details .rails_editable-save').click
-          expect(campaign.reload.start).to eq(Time.new(2016, 1, 10, 0, 0, 0, 0))
-          expect(campaign.end).to eq(Time.new(2016, 2, 10, 23, 59, 59, 0))
+          expect(campaign.reload.start).to eq(Time.zone.parse('2016-01-10 00:00:00'))
+          expect(campaign.end).to eq(Time.zone.parse('2016-02-10 23:59:59'))
           click_button 'Edit'
           find('.campaign-details .rails_editable-edit').click
           find('#use_dates').click # uncheck

--- a/spec/features/campaigns_spec.rb
+++ b/spec/features/campaigns_spec.rb
@@ -74,8 +74,8 @@ describe 'campaigns page', type: :feature, js: true do
       find('.wizard__form .button__submit').click
       expect(Campaign.last.title).to eq(title)
       expect(Campaign.last.description).to eq(description)
-      expect(Campaign.last.start).to eq(Time.new(2016, 1, 10, 0, 0, 0, '+00:00'))
-      expect(Campaign.last.end).to eq(Time.new(2016, 2, 10, 23, 59, 59, '+00:00'))
+      expect(Campaign.last.start).to eq(Time.zone.parse('2016-1-10 00:00:00'))
+      expect(Campaign.last.end).to eq(Time.zone.parse('2016-02-10 23:59:59'))
     end
 
     it 'can be reached from the explore page' do


### PR DESCRIPTION
#### What this PR does
Fixes issue  #2032 

#### Context
Some tests were failing on East African Time (EAT). I tracked this down to [this line](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/bb81026d3a1a0797c89c4a0e806ab56a98b83b8b/app/models/campaign.rb#L119).

The bug was that `Time.parse` uses system time to parse time. Since time is stored in `UTC` on the DB, this causes some inconsistencies. My approach was to prefer `Time.zone.parse` which uses the configured application timezone.

The side effect of this was that `Time.zone.parse(invalid string)` returns `nil`, rather than raise an exception like `Time.parse`. Also, this fix means that we will always default to `UTC`

Not sure if this is okay for now? I imagine that a long term viable support for timezone would be allowing users to configure their timezone on setup, which would require some backend changes to allow for this.