### PR TITLE
Remove reference to talk page from evaluate assignment

### DIFF
--- a/config/wizard/researchwrite/wizard.yml
+++ b/config/wizard/researchwrite/wizard.yml
@@ -46,7 +46,7 @@
     -
       title: Evaluate an article (required)
       required: true # cannot be unselected
-      blurb: Students critically evaluate a Wikipedia article related to their class, and leave suggestions for improving it on that article's talk page.
+      blurb: Students critically evaluate a Wikipedia article related to their class.
       # description:
       logic: critique
       selected: true # selected by default


### PR DESCRIPTION
Remove reference to talk page from the Evaluate assignment as it's no longer part of the assignment.