### PR TITLE
Add Course Clone button to Course Overview for admins

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -12,6 +12,7 @@ import SalesforceLink from './salesforce_link.jsx';
 import GreetStudentsButton from './greet_students_button.jsx';
 import CourseStatsDownloadModal from './course_stats_download_modal.jsx';
 import EmbedStatsButton from './embed_stats_button.jsx';
+import CloneCourseButton from './clone_course_button.jsx';
 import { enableAccountRequests } from '../../actions/new_account_actions.js';
 import { needsUpdate, linkToSalesforce, updateSalesforceRecord, deleteCourse, greetStudents } from '../../actions/course_actions';
 import { removeUser } from '../../actions/user_actions';
@@ -186,6 +187,13 @@ const AvailableActions = createReactClass({
       ));
       controls.push((
         <p key="embed_course_stats"><EmbedStatsButton title={course.title} /></p>
+      ));
+    }
+
+    // If the user is an admin and the course is both published and a Wiki-Ed course.
+    if (user.admin && Features.wikiEd && course.published) {
+      controls.push((
+        <p key="clone_course"><CloneCourseButton courseId={course.id}/></p>
       ));
     }
 

--- a/app/assets/javascripts/components/overview/clone_course_button.jsx
+++ b/app/assets/javascripts/components/overview/clone_course_button.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { cloneCourse } from '../../actions/course_creation_actions.js';
+import { initiateConfirm } from '../../actions/confirm_actions.js';
+import { updateCourse } from '../../actions/course_actions.js';
+
+CloneCourseButton.propTypes = {
+  courseId: PropTypes.number.isRequired,
+  cloneCourse: PropTypes.func.isRequired,
+  initiateConfirm: PropTypes.func.isRequired,
+  updateCourse: PropTypes.func.isRequired
+};
+
+export function CloneCourseButton(props) {
+  return (
+    <a onClick={onClickConfirmation(props)} className="button">
+      {I18n.t('courses.creator.clone_this')}
+    </a>
+  );
+}
+
+function onClickConfirmation(props) {
+  return () => {
+    const clone = () => {
+      props.cloneCourse(props.courseId).then(({ data }) => {
+        const course = data.course;
+        props.updateCourse(course);
+        window.location = `/courses/${course.slug}`;
+      });
+    };
+    props.initiateConfirm('Are you sure you want to clone this course?', clone);
+  };
+}
+
+const mapDispatchToProps = {
+  cloneCourse,
+  initiateConfirm,
+  updateCourse
+};
+
+const connectorFn = connect(null, mapDispatchToProps);
+export default connectorFn(CloneCourseButton);

--- a/test/components/overview/available_actions.spec.jsx
+++ b/test/components/overview/available_actions.spec.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
 import '../../testHelper';
 import AvailableActions from '../../../app/assets/javascripts/components/overview/available_actions.jsx';
+
+const mockStore = configureMockStore()({});
 
 describe('AvailableActions', () => {
   it('Displays no actions for ended course', () => {
@@ -10,15 +14,94 @@ describe('AvailableActions', () => {
     };
 
     const TestAvailableActions = mount(
-      <AvailableActions
-        store={reduxStore}
-        course={endedCourse}
-        current_user={{}}
-        updateCourse={sinon.spy()}
-      />
+      <Provider store={mockStore}>
+        <AvailableActions
+          course={endedCourse}
+          current_user={{}}
+          updateCourse={sinon.spy()}
+        />
+      </Provider>
     );
 
     const text = TestAvailableActions.find('p').text();
     expect(text).to.eq('No available actions');
+  });
+
+  it('Displays administrative P&E actions if the user is an admin', () => {
+    const course = {
+      id: 999,
+      ended: false,
+      published: true,
+      submitted: true
+    };
+    const user = {
+      admin: true
+    };
+
+    const TestAvailableActions = mount(
+      <Provider store={mockStore}>
+        <AvailableActions
+          course={course}
+          current_user={user}
+          updateCourse={sinon.spy()}
+        />
+      </Provider>
+    );
+
+    const actions = TestAvailableActions.find('p');
+    expect(actions.length).to.eq(4);
+
+    const deleteButton = actions.at(0);
+    expect(deleteButton.text()).to.eq('Delete course');
+
+    const enableAccountRequestsButton = actions.at(1);
+    expect(enableAccountRequestsButton.text()).to.eq('Enable account requests');
+
+    const downloadStatsButton = actions.at(2);
+    expect(downloadStatsButton.text()).to.eq('Download stats');
+
+    const embedStatsButton = actions.at(3);
+    expect(embedStatsButton.text()).to.eq('Embed Course Stats');
+  });
+
+  it('Displays administrative WikiEd actions if the user is an admin', () => {
+    global.Features.wikiEd = true;
+    const course = {
+      id: 999,
+      ended: false,
+      published: true,
+      submitted: true
+    };
+    const user = {
+      admin: true
+    };
+
+    const TestAvailableActions = mount(
+      <Provider store={mockStore}>
+        <AvailableActions
+          course={course}
+          current_user={user}
+          updateCourse={sinon.spy()}
+        />
+      </Provider>
+    );
+
+    const actions = TestAvailableActions.find('p');
+    expect(actions.length).to.eq(5);
+
+    const deleteButton = actions.at(0);
+    expect(deleteButton.text()).to.eq('Greet students');
+
+    const enableAccountRequestsButton = actions.at(1);
+    expect(enableAccountRequestsButton.text()).to.eq('Enable account requests');
+
+    const downloadStatsButton = actions.at(2);
+    expect(downloadStatsButton.text()).to.eq('Download stats');
+
+    const embedStatsButton = actions.at(3);
+    expect(embedStatsButton.text()).to.eq('Embed Course Stats');
+
+    const cloneCourseButton = actions.at(4);
+    expect(cloneCourseButton.text()).to.eq('Clone This Course');
   });
 });


### PR DESCRIPTION
Solves issue #2497.

- Adds a course clone button for admins on WikiEd
- Adds AvailableActions component testing for both dashboards