### PR TITLE
Add visible CSS property to popups on student page

### DIFF
--- a/app/assets/stylesheets/modules/_popover.styl
+++ b/app/assets/stylesheets/modules/_popover.styl
@@ -11,6 +11,7 @@
     box-shadow 0 0 15px 0 rgba(0, 0, 0, .2)
     left 50%
     opacity 0
+    visibility hidden
     pointer-events none
     position absolute
     top calc(100% + 14px)
@@ -25,6 +26,7 @@
       left 0
     &.open
       opacity 1
+      visibility visible
       pointer-events all
       /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ transform translateX(0px) translateY(0) scale(1, 1)
       /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ -webkit-transform translateX(0px) translateY(0) scale(1, 1)


### PR DESCRIPTION
Issue #2502 

It [seems like](https://webaim.org/techniques/css/invisiblecontent/) visibility should work to make this popup not be read while still maintain the rest of the code.