### PR TITLE
[WIP] Allow for blocks to be uneditable or undeletable

### DIFF
--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -111,7 +111,13 @@ const Block = createReactClass({
     // let graded;
     if (isEditable) {
       if (!this.props.block.is_new) {
-        deleteBlock = (<div className="delete-block-container"><button className="danger" onClick={this.deleteBlock}>Delete Block</button></div>);
+        const button = this.props.block.is_deletable ? (
+          <button className="danger" onClick={this.deleteBlock}>Delete Block</button>
+        ) : (
+          <button disabled={true}>You may not delete this block</button>
+        );
+
+        deleteBlock = (<div className="delete-block-container">{ button }</div>);
       }
       className += ' editable';
       if (this.props.isDragging) { className += ' dragging'; }
@@ -163,7 +169,7 @@ const Block = createReactClass({
       <span className="block__due-date-spacer"> - </span>
     ) : undefined;
 
-    const editButton = this.props.editPermissions ? (
+    const editButton = this.props.editPermissions && this.props.block.is_editable ? (
       <div className="block__edit-button-container">
         <button className="pull-right button ghost-button block__edit-block" onClick={this._setEditable}>Edit</button>
       </div>

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -112,9 +112,9 @@ const Block = createReactClass({
     if (isEditable) {
       if (!this.props.block.is_new) {
         const button = this.props.block.is_deletable ? (
-          <button className="danger" onClick={this.deleteBlock}>Delete Block</button>
+          <button className="danger" onClick={this.deleteBlock}>{I18n.t('timeline.delete_block')}</button>
         ) : (
-          <button disabled={true}>You may not delete this block</button>
+          <button disabled={true}>{I18n.t('timeline.delete_block_not_allowed')}</button>
         );
 
         deleteBlock = (<div className="delete-block-container">{ button }</div>);

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -74,9 +74,16 @@ const Timeline = createReactClass({
   },
 
   deleteWeek(weekId) {
+    const isDeletable = this._isDeletableWeek(weekId);
+    if (!isDeletable) return confirm('You are not allowed to delete this week.');
     if (confirm(I18n.t('timeline.delete_week_confirmation'))) {
       return this.props.deleteWeek(weekId);
     }
+  },
+
+  _isDeletableWeek(weekId) {
+    const week = this.props.weeks.find(({ id }) => id === weekId);
+    return week.blocks.every(block => block.is_deletable);
   },
 
   deleteAllWeeks() {

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -411,6 +411,9 @@ h4.timeline-exercise
     color $warning_text
     background url("../images/trash-red.svg") left center no-repeat
     padding-left 25px
+    &:disabled
+      color body-color
+      background none
 
 .editable .block__default-due-date
   display none

--- a/app/models/course_data/block.rb
+++ b/app/models/course_data/block.rb
@@ -14,6 +14,8 @@
 #  due_date            :date
 #  training_module_ids :text(65535)
 #  points              :integer
+#  is_deletable        :boolean          default(TRUE)
+#  is_editable         :boolean          default(TRUE)
 #
 
 require_dependency "#{Rails.root}/lib/block_date_manager"
@@ -23,6 +25,8 @@ class Block < ApplicationRecord
   belongs_to :week
   has_one :course, through: :week
   serialize :training_module_ids, Array
+  before_update :editable?, if: :content_fields_changed?
+  before_destroy :deletable?
   default_scope { includes(:week, :course) }
 
   KINDS = {
@@ -49,5 +53,19 @@ class Block < ApplicationRecord
 
   def calculated_due_date
     date_manager.due_date
+  end
+
+  private
+
+  def editable?
+    throw :abort unless is_editable
+  end
+
+  def content_fields_changed?
+    content_changed? || title_changed? || training_module_ids_changed?
+  end
+
+  def deletable?
+    throw :abort unless is_deletable
   end
 end

--- a/app/models/course_data/block.rb
+++ b/app/models/course_data/block.rb
@@ -25,8 +25,6 @@ class Block < ApplicationRecord
   belongs_to :week
   has_one :course, through: :week
   serialize :training_module_ids, Array
-  before_update :editable?, if: :content_fields_changed?
-  before_destroy :deletable?
   default_scope { includes(:week, :course) }
 
   KINDS = {
@@ -53,19 +51,5 @@ class Block < ApplicationRecord
 
   def calculated_due_date
     date_manager.due_date
-  end
-
-  private
-
-  def editable?
-    throw :abort unless is_editable
-  end
-
-  def content_fields_changed?
-    content_changed? || title_changed? || training_module_ids_changed?
-  end
-
-  def deletable?
-    throw :abort unless is_deletable
   end
 end

--- a/app/views/courses/_weeks.json.jbuilder
+++ b/app/views/courses/_weeks.json.jbuilder
@@ -13,7 +13,8 @@ json.weeks course.weeks.eager_load(:blocks) do |week|
   json.end_date start_date.present? ? start_date.end_of_week(:sunday).strftime('%m/%d') : nil
   json.blocks week.blocks do |block|
     json.call(block, :id, :kind, :content, :week_id, :title,
-              :order, :due_date, :training_module_ids, :points)
+              :order, :due_date, :training_module_ids, :points,
+              :is_editable, :is_deletable)
     if block.training_modules.any?
       json.training_modules block.training_modules do |tm|
         # The available training modules may change over time, especially on

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -909,6 +909,8 @@ en:
     delete_weeks_confirmation: "Are you sure you want to delete this entire timeline and start over? \n\nThis cannot be undone."
     discard_all_changes: Discard All Changes
     delete_timeline_and_start_over: Delete Timeline
+    delete_block: Delete Block
+    delete_block_not_allowed: You may not delete this block
     due_default: Due next week
     # FIXME: lego message. This one is hard to work around because it has inline components.
     empty_week_1: 'To get started, '

--- a/db/migrate/20190221212222_add_is_deletable_and_is_editable_to_blocks.rb
+++ b/db/migrate/20190221212222_add_is_deletable_and_is_editable_to_blocks.rb
@@ -1,0 +1,6 @@
+class AddIsDeletableAndIsEditableToBlocks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :blocks, :is_deletable, :boolean, default: true
+    add_column :blocks, :is_editable, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_30_061337) do
+ActiveRecord::Schema.define(version: 2019_02_21_212222) do
 
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
@@ -96,6 +96,8 @@ ActiveRecord::Schema.define(version: 2018_12_30_061337) do
     t.date "due_date"
     t.text "training_module_ids"
     t.integer "points"
+    t.boolean "is_deletable", default: true
+    t.boolean "is_editable", default: true
     t.index ["week_id"], name: "index_blocks_on_week_id"
   end
 

--- a/spec/controllers/blocks_controller_spec.rb
+++ b/spec/controllers/blocks_controller_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 describe BlocksController, type: :request do
   describe '#destroy' do
-    let!(:block) { create(:block) }
     let(:admin) { create(:admin, id: 2) }
 
     before do
@@ -12,9 +11,17 @@ describe BlocksController, type: :request do
     end
 
     it 'destroys the block' do
+      id = create(:block).id
       expect(Block.count).to eq(1)
-      delete "/blocks/#{block.id}", params: { id: block.id, format: :json }
+      delete "/blocks/#{id}", params: { id: id, format: :json }
       expect(Block.count).to eq(0)
+    end
+
+    it 'does not destroy the block if it cannot be deleted' do
+      id = create(:block, is_deletable: false).id
+      expect(Block.count).to eq(1)
+      delete "/blocks/#{id}", params: { id: id, format: :json }
+      expect(Block.count).to eq(1)
     end
   end
 end

--- a/spec/controllers/blocks_controller_spec.rb
+++ b/spec/controllers/blocks_controller_spec.rb
@@ -16,12 +16,5 @@ describe BlocksController, type: :request do
       delete "/blocks/#{id}", params: { id: id, format: :json }
       expect(Block.count).to eq(0)
     end
-
-    it 'does not destroy the block if it cannot be deleted' do
-      id = create(:block, is_deletable: false).id
-      expect(Block.count).to eq(1)
-      delete "/blocks/#{id}", params: { id: id, format: :json }
-      expect(Block.count).to eq(1)
-    end
   end
 end

--- a/spec/controllers/timeline_controller_spec.rb
+++ b/spec/controllers/timeline_controller_spec.rb
@@ -33,6 +33,71 @@ describe TimelineController, type: :request do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
     end
 
+    describe 'modifying blocks' do
+      it 'updates the block content and title' do
+        title = 'My New Title'
+        content = 'My New Content'
+        weeks = [{
+          id: week.id,
+          blocks: [{
+            id: block.id,
+            title: title,
+            content: content
+          }]
+        }]
+
+        params = post_params.merge(weeks: weeks)
+        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
+
+        block.reload
+        expect(block.title).to eq(title)
+        expect(block.content).to eq(content)
+      end
+
+      it 'does not update the block content or title if not allowed' do
+        uneditable_block = create(:block,
+                                  is_editable: false,
+                                  week_id: week.id,
+                                  training_module_ids: first_ids)
+
+        title = 'My New Title'
+        content = 'My New Content'
+        weeks = [{
+          id: week.id,
+          blocks: [{
+            id: uneditable_block.id,
+            title: title,
+            content: content
+          }]
+        }]
+        params = post_params.merge(weeks: weeks)
+        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
+
+        uneditable_block.reload
+        expect(uneditable_block.title).not_to eq(title)
+        expect(uneditable_block.content).not_to eq(content)
+      end
+
+      it 'can still edit other fields if block.is_uneditable is false' do
+        uneditable_block = create(:block,
+                                  is_editable: false,
+                                  week_id: week.id,
+                                  training_module_ids: first_ids)
+
+        order = 3
+        weeks = [{
+          id: week.id,
+          blocks: [{
+            id: uneditable_block.id,
+            order: order
+          }]
+        }]
+        params = post_params.merge(weeks: weeks)
+        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
+        expect(uneditable_block.reload.order).to eq(order)
+      end
+    end
+
     describe 'setting training_module_ids' do
       it 'sets the training_module_ids to value provided' do
         # FIXME: Remove workaround after Rails 5.0.1
@@ -40,6 +105,26 @@ describe TimelineController, type: :request do
         headers = { 'HTTP_ACCEPT' => 'application/json' }
         post "/courses/#{course.slug}/timeline", params: post_params, headers: headers, as: :json
         expect(block.reload.training_module_ids).to eq(ids)
+      end
+      it 'does not set the training_module_ids if not allowed' do
+        uneditable_block = create(:block,
+                                  is_editable: false,
+                                  week_id: week.id,
+                                  training_module_ids: first_ids)
+
+        training_module_ids = [1, 2, 3]
+        weeks = [{
+          id: week.id,
+          blocks: [{
+            id: uneditable_block.id,
+            training_module_ids: training_module_ids
+          }]
+        }]
+        params = post_params.merge(weeks: weeks)
+        headers = { 'HTTP_ACCEPT' => 'application/json' }
+
+        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
+        expect(uneditable_block.reload.training_module_ids).not_to eq(training_module_ids)
       end
       context 'sending nil as training_module_ids param' do
         # When this gets set to [], ActiveRecord doesn't convert it to nil

--- a/spec/controllers/timeline_controller_spec.rb
+++ b/spec/controllers/timeline_controller_spec.rb
@@ -53,49 +53,6 @@ describe TimelineController, type: :request do
         expect(block.title).to eq(title)
         expect(block.content).to eq(content)
       end
-
-      it 'does not update the block content or title if not allowed' do
-        uneditable_block = create(:block,
-                                  is_editable: false,
-                                  week_id: week.id,
-                                  training_module_ids: first_ids)
-
-        title = 'My New Title'
-        content = 'My New Content'
-        weeks = [{
-          id: week.id,
-          blocks: [{
-            id: uneditable_block.id,
-            title: title,
-            content: content
-          }]
-        }]
-        params = post_params.merge(weeks: weeks)
-        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
-
-        uneditable_block.reload
-        expect(uneditable_block.title).not_to eq(title)
-        expect(uneditable_block.content).not_to eq(content)
-      end
-
-      it 'can still edit other fields if block.is_uneditable is false' do
-        uneditable_block = create(:block,
-                                  is_editable: false,
-                                  week_id: week.id,
-                                  training_module_ids: first_ids)
-
-        order = 3
-        weeks = [{
-          id: week.id,
-          blocks: [{
-            id: uneditable_block.id,
-            order: order
-          }]
-        }]
-        params = post_params.merge(weeks: weeks)
-        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
-        expect(uneditable_block.reload.order).to eq(order)
-      end
     end
 
     describe 'setting training_module_ids' do
@@ -105,26 +62,6 @@ describe TimelineController, type: :request do
         headers = { 'HTTP_ACCEPT' => 'application/json' }
         post "/courses/#{course.slug}/timeline", params: post_params, headers: headers, as: :json
         expect(block.reload.training_module_ids).to eq(ids)
-      end
-      it 'does not set the training_module_ids if not allowed' do
-        uneditable_block = create(:block,
-                                  is_editable: false,
-                                  week_id: week.id,
-                                  training_module_ids: first_ids)
-
-        training_module_ids = [1, 2, 3]
-        weeks = [{
-          id: week.id,
-          blocks: [{
-            id: uneditable_block.id,
-            training_module_ids: training_module_ids
-          }]
-        }]
-        params = post_params.merge(weeks: weeks)
-        headers = { 'HTTP_ACCEPT' => 'application/json' }
-
-        post "/courses/#{course.slug}/timeline", params: params, headers: headers, as: :json
-        expect(uneditable_block.reload.training_module_ids).not_to eq(training_module_ids)
       end
       context 'sending nil as training_module_ids param' do
         # When this gets set to [], ActiveRecord doesn't convert it to nil

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -14,6 +14,8 @@
 #  due_date            :date
 #  training_module_ids :text(65535)
 #  points              :integer
+#  is_deletable        :boolean          default(TRUE)
+#  is_editable         :boolean          default(TRUE)
 #
 
 FactoryBot.define do

--- a/spec/lib/wizard_timeline_manager_spec.rb
+++ b/spec/lib/wizard_timeline_manager_spec.rb
@@ -45,6 +45,32 @@ describe WizardTimelineManager do
       subject
       expect(course.weeks.count).to eq(expected_week_count)
     end
+
+    it 'assigns correct default values to the blocks' do
+      subject
+      expect(course.blocks.first.is_deletable).to be(true)
+      expect(course.blocks.first.is_editable).to be(true)
+    end
+
+    it 'makes the block undeletable if specified' do
+      content_path = "#{Rails.root}/config/wizard/#{wizard_id}/content.yml"
+      content = YAML.load_file(content_path)
+      content['essentials'].first['blocks'].first['is_deletable'] = false
+      allow(YAML).to receive(:load_file).and_return(content)
+
+      subject
+      expect(course.blocks.first.is_deletable).to be(false)
+    end
+
+    it 'makes the block uneditable if specified' do
+      content_path = "#{Rails.root}/config/wizard/#{wizard_id}/content.yml"
+      content = YAML.load_file(content_path)
+      content['essentials'].first['blocks'].first['is_editable'] = false
+      allow(YAML).to receive(:load_file).and_return(content)
+
+      subject
+      expect(course.blocks.first.is_editable).to be(false)
+    end
   end
 
   describe '#add_tags' do

--- a/test/components/timeline/block.spec.jsx
+++ b/test/components/timeline/block.spec.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import '../../testHelper';
+import Block from '../../../app/assets/javascripts/components/timeline/block.jsx';
+
+describe('Block', () => {
+  const content = '<p>Welcome to Wikipedia</p>';
+  const title = 'Welcome';
+  const block = {
+    id: 1,
+    is_deletable: true,
+    is_editable: true,
+    content,
+    title
+  };
+  it('should display the given block information and content', () => {
+    const component = shallow(
+      <Block block={block} trainingLibrarySlug="students" />
+    );
+    expect(component.find('.title').props().value).to.equal(title);
+    expect(component.find('.block__block-content').props().value).to.equal(content);
+  });
+  it('should have an edit button if it is editable', () => {
+    const component = shallow(
+      <Block block={block} editPermissions={true} trainingLibrarySlug="students" />
+    );
+    expect(component.find('.block__edit-block').length).to.equal(1);
+  });
+  it('should not have an edit button if the user is not allowed', () => {
+    const component = shallow(
+      <Block block={block} editPermissions={false} trainingLibrarySlug="students" />
+    );
+    expect(component.find('.block__edit-block').length).to.equal(0);
+  });
+  it('should not have an edit button if the block cannot be edited', () => {
+    const uneditableBlock = { ...block, is_editable: false };
+    const component = shallow(
+      <Block block={uneditableBlock} editPermissions={true} trainingLibrarySlug="students" />
+    );
+    expect(component.find('.block__edit-block').length).to.equal(0);
+  });
+  describe('editing block', () => {
+    const props = {
+      editableBlockIds: [block.id],
+      saveBlockChanges: jest.fn(),
+      cancelBlockEditable: jest.fn(),
+      editPermissions: true,
+      trainingLibrarySlug: 'students'
+    };
+    it('should show the edit fields', () => {
+      const component = shallow(
+        <Block block={block} {...props} />
+      );
+      expect(component.find('.title').props().editable).to.be.true;
+    });
+    it('should show the delete block button', () => {
+      const component = shallow(
+        <Block block={block} {...props} />
+      );
+      expect(component.find('.delete-block-container .danger').length).to.equal(1);
+    });
+    it('should not show the delete block button if the block is undeletable', () => {
+      const undeletableBlock = { ...block, is_deletable: false };
+      const component = shallow(
+        <Block block={undeletableBlock} {...props} />
+      );
+      expect(component.find('.delete-block-container .danger').length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
Pull Request to solve Issue #2503.

![image](https://user-images.githubusercontent.com/1316902/53358865-4b642a80-38e6-11e9-97c5-42cb32581e88.png)

Any other fields we shouldn't be allowing edits too? The only other one I can see is Block Type but that actually seems like it might be useful for instructors to always be able to modify.