### PR TITLE
Add Program Id to Media Records on Salesforce

### DIFF
--- a/app/helpers/salesforce_helper.rb
+++ b/app/helpers/salesforce_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SalesforceHelper
+  def program_id(course)
+    case course.type
+    when 'ClassroomProgramCourse', 'LegacyCourse'
+      ENV['SF_CLASSROOM_PROGRAM_ID']
+    when 'VisitingScholarship'
+      ENV['SF_VISITING_SCHOLARS_PROGRAM_ID']
+    when 'FellowsCohort'
+      ENV['SF_WIKIPEDIA_FELLOWS_PROGRAM_ID']
+    end
+  end
+end

--- a/app/services/create_salesforce_media_record.rb
+++ b/app/services/create_salesforce_media_record.rb
@@ -4,6 +4,7 @@
 #= Creates a new Media record in Salesforce, returning the URL of the new record
 class CreateSalesforceMediaRecord
   include ArticleHelper
+  include SalesforceHelper
 
   def initialize(article:, course:, user:, before_rev_id:, after_rev_id:)
     return unless Features.wiki_ed?
@@ -34,6 +35,7 @@ class CreateSalesforceMediaRecord
       Engagement_Type__c: 'Wiki contribution',
       Author_Wiki_Username_Optional__c: @user.username,
       Primary_Course__c: @salesforce_course_id,
+      Program__c: program_id(@course),
       Link__c: @article.url,
       Before_link__c: diff_link(@before_rev_id),
       After_link__c: diff_link(@after_rev_id)

--- a/app/services/push_course_to_salesforce.rb
+++ b/app/services/push_course_to_salesforce.rb
@@ -4,6 +4,7 @@ require_dependency "#{Rails.root}/lib/word_count"
 
 #= Pushes course data to Salesforce, either by creating a new record or updating an existing one
 class PushCourseToSalesforce
+  include SalesforceHelper
   attr_reader :result
 
   def initialize(course)
@@ -57,7 +58,7 @@ class PushCourseToSalesforce
       Course_Page__c: @course.url,
       Course_End_Date__c: @course.end.strftime('%Y-%m-%d'),
       Course_Dashboard__c: "https://#{ENV['dashboard_url']}/courses/#{@course.slug}",
-      Program__c: program_id,
+      Program__c: program_id(@course),
       Estimated_No_of_Participants__c: @course.expected_students,
       Articles_edited__c: @course.article_count,
       Total_edits__c: @course.revision_count,
@@ -76,17 +77,6 @@ class PushCourseToSalesforce
     }
   end
   # rubocop:enable Metrics/MethodLength
-
-  def program_id
-    case @course.type
-    when 'ClassroomProgramCourse', 'LegacyCourse'
-      ENV['SF_CLASSROOM_PROGRAM_ID']
-    when 'VisitingScholarship'
-      ENV['SF_VISITING_SCHOLARS_PROGRAM_ID']
-    when 'FellowsCohort'
-      ENV['SF_WIKIPEDIA_FELLOWS_PROGRAM_ID']
-    end
-  end
 
   def words_added_in_thousands
     WordCount.from_characters(@course.character_sum).to_f / 1000


### PR DESCRIPTION
For issue #2544 

Adds the Program ID to Salesforce media records in addition to separating out the `program_id` method to a module.