### PR TITLE
Add ability to delete cloned course

### DIFF
--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -14,6 +14,8 @@ const CourseClonedModal = createReactClass({
 
   propTypes: {
     course: PropTypes.object.isRequired,
+    initiateConfirm: PropTypes.func.isRequired,
+    deleteCourse: PropTypes.func.isRequired,
     updateCourse: PropTypes.func.isRequired,
     updateClonedCourse: PropTypes.func.isRequired,
     currentUser: PropTypes.object.isRequired,
@@ -56,6 +58,14 @@ const CourseClonedModal = createReactClass({
   },
 
   cloneCompletedStatus: 2,
+
+  cancelCloneCourse() {
+    const i18nPrefix = this.props.course.string_prefix;
+    const confirm = CourseUtils.i18n('creator.cancel_course_clone_confirm', i18nPrefix);
+    this.props.initiateConfirm(confirm, () => {
+      this.props.deleteCourse(this.state.course.slug);
+    });
+  },
 
   updateCourse(valueKey, value) {
     const updatedCourse = $.extend(true, {}, this.state.course);
@@ -350,6 +360,7 @@ const CourseClonedModal = createReactClass({
                 />
               </div>
               {rightColumn}
+              <button onClick={this.cancelCloneCourse} className="button light">{CourseUtils.i18n('creator.cancel_course_clone', i18nPrefix)}</button>
               <button onClick={this.saveCourse} disabled={saveDisabled} className={buttonClass}>{CourseUtils.i18n('creator.save_cloned_course', i18nPrefix)}</button>
             </div>
           </div>

--- a/app/assets/javascripts/components/overview/overview_handler.jsx
+++ b/app/assets/javascripts/components/overview/overview_handler.jsx
@@ -16,7 +16,8 @@ import SyllabusUpload from './syllabus-upload.jsx';
 import MyArticles from './my_articles.jsx';
 import Modal from '../common/modal.jsx';
 import StatisticsUpdateInfo from './statistics_update_info.jsx';
-import { updateCourse, resetCourse, persistCourse, nameHasChanged, updateClonedCourse, refetchCourse } from '../../actions/course_actions';
+import { initiateConfirm } from '../../actions/confirm_actions.js';
+import { deleteCourse, updateCourse, resetCourse, persistCourse, nameHasChanged, updateClonedCourse, refetchCourse } from '../../actions/course_actions';
 import { fetchOnboardingAlert } from '../../actions/course_alert_actions';
 import { fetchTags } from '../../actions/tag_actions';
 import { setValid, setInvalid, activateValidations } from '../../actions/validation_actions';
@@ -31,6 +32,8 @@ const Overview = createReactClass({
     course_id: PropTypes.string,
     location: PropTypes.object,
     students: PropTypes.array,
+    initiateConfirm: PropTypes.func.isRequired,
+    deleteCourse: PropTypes.func.isRequired,
     fetchTags: PropTypes.func.isRequired,
     fetchOnboardingAlert: PropTypes.func.isRequired,
     updateCourse: PropTypes.func.isRequired,
@@ -58,6 +61,8 @@ const Overview = createReactClass({
       return (
         <CourseClonedModal
           course={course}
+          initiateConfirm={this.props.initiateConfirm}
+          deleteCourse={this.props.deleteCourse}
           updateCourse={this.props.updateCourse}
           updateClonedCourse={this.props.updateClonedCourse}
           currentUser={this.props.current_user}
@@ -163,6 +168,8 @@ const mapStateToProps = state => ({
  });
 
 const mapDispatchToProps = {
+  initiateConfirm,
+  deleteCourse,
   updateCourse,
   resetCourse,
   persistCourse,

--- a/app/assets/stylesheets/modules/_wizard.styl
+++ b/app/assets/stylesheets/modules/_wizard.styl
@@ -371,6 +371,11 @@ p.red
     display block
     float right
     margin-top 2em
+  
+  .button.light
+    display block
+    float left
+    margin-top 2em
 
 .button.dark.working
   background url('../images/loader.gif') #fff 99% center no-repeat

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,6 +348,8 @@ en:
       assignment_end_placeholder: YYYY-MM-DD
       assignment_start: Assignment start
       assignment_start_placeholder: YYYY-MM-DD
+      cancel_course_clone: Cancel course clone
+      cancel_course_clone_confirm: Are you sure you want to stop cloning this course?
       checking_for_uniqueness: This course is being checked for uniqueness.
       choose_clone: Choose a course to clone.
       clone_previous: Clone Previous Course
@@ -663,6 +665,8 @@ en:
       assignment_end_placeholder: YYYY-MM-DD
       assignment_start: Event start
       assignment_start_placeholder: YYYY-MM-DD
+      cancel_course_clone: Cancel program clone
+      cancel_course_clone_confirm: Are you sure you want to stop cloning this program?
       checking_for_uniqueness: This program is being checked for uniqueness.
       choose_clone: Choose a program to clone.
       clone_previous: Clone Previous Program

--- a/test/components/overview/course_cloned_modal.spec.jsx
+++ b/test/components/overview/course_cloned_modal.spec.jsx
@@ -23,6 +23,8 @@ describe('CourseClonedModal', () => {
     <Provider store={reduxStore} >
       <CourseClonedModal
         course={course}
+        initiateConfirm={jest.fn()}
+        deleteCourse={jest.fn()}
         updateCourse={jest.fn()}
         updateClonedCourse={jest.fn()}
         currentUser={currentUser}
@@ -40,5 +42,18 @@ describe('CourseClonedModal', () => {
     TestModal.setState({ error_message: null });
     const warnings = TestModal.find('.warning');
     expect(warnings).to.have.length(0);
+  });
+
+  it('includes a Cancel and Save New Course button', () => {
+    const renderedModal = TestModal.find('.cloned-course');
+    expect(renderedModal).to.have.length(1);
+
+    const cancel = renderedModal.find('.button.light');
+    expect(cancel).to.have.length(1);
+    expect(cancel.prop('disabled')).to.be.undefined;
+
+    const create = renderedModal.find('.button.dark');
+    expect(create).to.have.length(1);
+    expect(create.prop('disabled')).to.equal('disabled');
   });
 });


### PR DESCRIPTION
Related to issue #395.

Adds a cancel button to the cloned course modal that will delete the course.
![image](https://user-images.githubusercontent.com/1316902/53979520-f3d27580-40c2-11e9-88f2-e60a1e674cde.png)

This spawned PR #2581. Merging that PR should be considered a dependency for this one.