### PR TITLE
Update setup.md to display 'python 3.5 or newer'

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,7 +26,7 @@ We have a script to automate the process of setting up your developmental enviro
 ## Prerequisite
 There are some basic requirements for the script to work:
 - git (to clone the repository)
-- python 3
+- python 3.5 or newer
 - ruby 2.5.0
 - apt (debian) or homebrew (MacOS)
 - node v10 or lower


### PR DESCRIPTION
This PR references issue: #2584 

PR goes into setup.md and changes the prerequisite to ask for 'python 3.5 or newer' rather than python 3. This addresses the issue of running the setup.py with a python3 version below 3.5. 

**Before:**
![image](https://user-images.githubusercontent.com/36907562/54004036-15eee680-4109-11e9-918e-3fe299a82049.png)

**After:**
![image](https://user-images.githubusercontent.com/36907562/54004837-fd340000-410b-11e9-9216-ac07cf5aaa11.png)
