### PR TITLE
Improve revision import behavior when there are unimported revisions before the first imported ones

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -150,7 +150,7 @@ class CoursesController < ApplicationController
 
   def manual_update
     @course = find_course_by_slug(params[:id])
-    UpdateCourseStats.new(@course) if user_signed_in?
+    UpdateCourseStats.new(@course, full: true) if user_signed_in?
     redirect_to "/courses/#{@course.slug}"
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -211,6 +211,7 @@ class Course < ApplicationRecord
   before_save :reorder_weeks
   before_save :set_default_times
   before_save :check_course_times
+  before_save :set_needs_update
 
   ####################
   # Instance methods #
@@ -436,5 +437,12 @@ class Course < ApplicationRecord
   # as that of the start time
   def check_course_times
     self.end = start if start > self.end
+  end
+
+  # If the start date changed, set needs_update to `true` so that
+  # the stats will be updated to reflect the new start date
+  # and the earlier revisions will be fetched.
+  def set_needs_update
+    self.needs_update = true if start_changed?
   end
 end

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -25,7 +25,7 @@ class UpdateCourseStats
 
   def fetch_data
     log_update_progress :start
-    CourseRevisionUpdater.import_new_revisions(@course)
+    CourseRevisionUpdater.import_revisions(@course)
     log_update_progress :revisions_imported
     CourseUploadImporter.new(@course).run
     log_update_progress :uploads_imported

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -8,7 +8,12 @@ require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
 
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats
-  def initialize(course)
+  def initialize(course, full: false)
+    # If the upate was explicitly requested by a user,
+    # it could be because the dates or other paramters were just changed.
+    # In that case, do a full update rather than just fetching the most
+    # recent revisions.
+    @full_update = full || @course.needs_update
     @course = course
     @start_time = Time.zone.now
     fetch_data
@@ -25,7 +30,7 @@ class UpdateCourseStats
 
   def fetch_data
     log_update_progress :start
-    CourseRevisionUpdater.import_revisions(@course)
+    CourseRevisionUpdater.import_revisions(@course, all_time: @full_update)
     log_update_progress :revisions_imported
     CourseUploadImporter.new(@course).run
     log_update_progress :uploads_imported

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -9,12 +9,13 @@ require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats
   def initialize(course, full: false)
+    @course = course
     # If the upate was explicitly requested by a user,
     # it could be because the dates or other paramters were just changed.
     # In that case, do a full update rather than just fetching the most
     # recent revisions.
     @full_update = full || @course.needs_update
-    @course = course
+
     @start_time = Time.zone.now
     fetch_data
     update_categories if @course.needs_update

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -25,7 +25,7 @@ class UpdateCourseStats
 
   def fetch_data
     log_update_progress :start
-    CourseRevisionUpdater.import_new_revisions([@course])
+    CourseRevisionUpdater.import_new_revisions(@course)
     log_update_progress :revisions_imported
     CourseUploadImporter.new(@course).run
     log_update_progress :uploads_imported

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -7,7 +7,7 @@ class CourseRevisionUpdater
   ###############
   # Entry point #
   ###############
-  def self.import_new_revisions(course)
+  def self.import_revisions(course)
     return if course.students.empty?
     new(course).update_revisions_for_relevant_wikis
     ArticlesCourses.update_from_course(course)

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -7,12 +7,10 @@ class CourseRevisionUpdater
   ###############
   # Entry point #
   ###############
-  def self.import_new_revisions(courses)
-    courses.each do |course|
-      next if course.students.empty?
-      new(course).update_revisions_for_relevant_wikis
-      ArticlesCourses.update_from_course(course)
-    end
+  def self.import_new_revisions(course)
+    return if course.students.empty?
+    new(course).update_revisions_for_relevant_wikis
+    ArticlesCourses.update_from_course(course)
   end
 
   def initialize(course)

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -7,20 +7,6 @@ class CourseRevisionUpdater
   ###############
   # Entry point #
   ###############
-
-  def self.import_new_revisions_concurrently(courses)
-    # Revision data is imported via Replica, and its capacity may be the
-    # bottleneck in this process.
-    concurrency = Replica::CONCURRENCY_LIMIT
-    course_groups = courses.to_a.in_groups(concurrency, false)
-    threads = course_groups.map.with_index do |course_group, i|
-      Thread.new(i) do
-        import_new_revisions(course_group)
-      end
-    end
-    threads.each(&:join)
-  end
-
   def self.import_new_revisions(courses)
     courses.each do |course|
       next if course.students.empty?

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -7,9 +7,9 @@ class CourseRevisionUpdater
   ###############
   # Entry point #
   ###############
-  def self.import_revisions(course)
+  def self.import_revisions(course, all_time:)
     return if course.students.empty?
-    new(course).update_revisions_for_relevant_wikis
+    new(course).update_revisions_for_relevant_wikis(all_time)
     ArticlesCourses.update_from_course(course)
   end
 
@@ -25,10 +25,11 @@ class CourseRevisionUpdater
     wiki_ids
   end
 
-  def update_revisions_for_relevant_wikis
+  def update_revisions_for_relevant_wikis(all_time)
     wiki_ids = @course.assignments.pluck(:wiki_id) + default_wiki_ids
     wiki_ids.uniq.each do |wiki_id|
-      RevisionImporter.new(Wiki.find(wiki_id), @course).import_new_revisions_for_course
+      RevisionImporter.new(Wiki.find(wiki_id), @course)
+                      .import_revisions_for_course(all_time: all_time)
     end
   end
 end

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -11,8 +11,12 @@ class RevisionImporter
     @course = course
   end
 
-  def import_new_revisions_for_course
-    import_revisions(new_revisions_for_course)
+  def import_revisions_for_course(all_time:)
+    if all_time
+      import_revisions(all_revisions_for_course)
+    else
+      import_revisions(new_revisions_for_course)
+    end
   end
 
   ###########
@@ -20,7 +24,10 @@ class RevisionImporter
   ###########
   private
 
-  # Given a Course, get new revisions for the users in that course.
+  def all_revisions_for_course
+    get_revisions(@course.students, course_start_date, end_of_update_period)
+  end
+
   def new_revisions_for_course
     results = []
 

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -403,7 +403,7 @@ describe 'the course page', type: :feature, js: true do
       login_as(user, scope: :user)
       stub_oauth_edit
 
-      expect(CourseRevisionUpdater).to receive(:import_new_revisions)
+      expect(CourseRevisionUpdater).to receive(:import_revisions)
       expect_any_instance_of(CourseUploadImporter).to receive(:run)
       visit "/courses/#{slug}/manual_update"
       js_visit "/courses/#{slug}"

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -14,7 +14,7 @@ describe CourseRevisionUpdater do
 
     let(:revision_import) do
       course && user && courses_user
-      Course.all.each { |course| described_class.import_revisions(course) }
+      Course.all.each { |course| described_class.import_revisions(course, all_time: true) }
     end
 
     it 'includes the correct article and revision data' do
@@ -56,7 +56,7 @@ describe CourseRevisionUpdater do
                               user: user,
                               role: CoursesUsers::Roles::STUDENT_ROLE)
 
-        described_class.import_revisions(course)
+        described_class.import_revisions(course, all_time: true)
 
         expect(course.reload.revisions.count).to eq(3)
         expect(course.reload.revisions.count).to eq(3)
@@ -70,7 +70,7 @@ describe CourseRevisionUpdater do
         create(:courses_user, course: course, user: user,
                               role: CoursesUsers::Roles::STUDENT_ROLE)
 
-        described_class.import_revisions(course)
+        described_class.import_revisions(course, all_time: false)
 
         expect(user.reload.revisions.count).to eq(3)
         expect(course.reload.revisions.count).to eq(0)
@@ -102,7 +102,7 @@ describe CourseRevisionUpdater do
                user_id: 5,
                role: 0)
         CoursesUsers.update_all_caches(CoursesUsers.all)
-        described_class.import_revisions(Course.find(1))
+        described_class.import_revisions(Course.find(1), all_time: true)
         expect(Revision.all.count > 1).to be true
       end
     end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -108,18 +108,6 @@ describe CourseRevisionUpdater do
     end
   end
 
-  describe '.import_new_revisions_concurrently' do
-    let!(:course) { create(:course) }
-
-    it 'calls import_new_revisions multiple times' do
-      VCR.use_cassette 'course_revision_updater' do
-        expect(described_class).to receive(:import_new_revisions)
-          .exactly(Replica::CONCURRENCY_LIMIT).times
-        described_class.import_new_revisions_concurrently(Course.all)
-      end
-    end
-  end
-
   describe '#default_wiki_ids' do
     it 'includes wikidata for Programs & Events Dashboard' do
       stub_wiki_validation

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -14,7 +14,7 @@ describe CourseRevisionUpdater do
 
     let(:revision_import) do
       course && user && courses_user
-      Course.all.each { |course| described_class.import_new_revisions(course) }
+      Course.all.each { |course| described_class.import_revisions(course) }
     end
 
     it 'includes the correct article and revision data' do
@@ -47,7 +47,7 @@ describe CourseRevisionUpdater do
     end
   end
 
-  describe '.import_new_revisions' do
+  describe '.import_revisions' do
     it 'includes revisions on the final day of a course up to the end time' do
       VCR.use_cassette 'course_revision_updater' do
         course = create(:course, start: '2016-03-20', end: '2016-03-31'.to_date.end_of_day)
@@ -56,7 +56,7 @@ describe CourseRevisionUpdater do
                               user: user,
                               role: CoursesUsers::Roles::STUDENT_ROLE)
 
-        described_class.import_new_revisions(course)
+        described_class.import_revisions(course)
 
         expect(course.reload.revisions.count).to eq(3)
         expect(course.reload.revisions.count).to eq(3)
@@ -70,7 +70,7 @@ describe CourseRevisionUpdater do
         create(:courses_user, course: course, user: user,
                               role: CoursesUsers::Roles::STUDENT_ROLE)
 
-        described_class.import_new_revisions(course)
+        described_class.import_revisions(course)
 
         expect(user.reload.revisions.count).to eq(3)
         expect(course.reload.revisions.count).to eq(0)
@@ -102,7 +102,7 @@ describe CourseRevisionUpdater do
                user_id: 5,
                role: 0)
         CoursesUsers.update_all_caches(CoursesUsers.all)
-        described_class.import_new_revisions(Course.find(1))
+        described_class.import_revisions(Course.find(1))
         expect(Revision.all.count > 1).to be true
       end
     end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -14,7 +14,7 @@ describe CourseRevisionUpdater do
 
     let(:revision_import) do
       course && user && courses_user
-      described_class.import_new_revisions(Course.all)
+      Course.all.each { |course| described_class.import_new_revisions(course) }
     end
 
     it 'includes the correct article and revision data' do
@@ -50,30 +50,30 @@ describe CourseRevisionUpdater do
   describe '.import_new_revisions' do
     it 'includes revisions on the final day of a course up to the end time' do
       VCR.use_cassette 'course_revision_updater' do
-        create(:course, id: 1, start: '2016-03-20', end: '2016-03-31'.to_date.end_of_day)
-        create(:user, id: 1, username: 'Tedholtby')
-        create(:courses_user, course_id: 1,
-                              user_id: 1,
+        course = create(:course, start: '2016-03-20', end: '2016-03-31'.to_date.end_of_day)
+        user = create(:user, username: 'Tedholtby')
+        create(:courses_user, course: course,
+                              user: user,
                               role: CoursesUsers::Roles::STUDENT_ROLE)
 
-        described_class.import_new_revisions(Course.all)
+        described_class.import_new_revisions(course)
 
-        expect(User.find(1).revisions.count).to eq(3)
-        expect(Course.find(1).revisions.count).to eq(3)
+        expect(course.reload.revisions.count).to eq(3)
+        expect(course.reload.revisions.count).to eq(3)
       end
     end
 
     it 'imports revisions soon after the final day of the course, but excludes them from metrics' do
       VCR.use_cassette 'course_revision_updater' do
-        create(:course, id: 1, start: '2016-03-20', end: '2016-03-30')
-        create(:user, id: 15, username: 'Tedholtby')
-        create(:courses_user, course_id: 1, user_id: 15,
+        course = create(:course, start: '2016-03-20', end: '2016-03-30')
+        user = create(:user, id: 15, username: 'Tedholtby')
+        create(:courses_user, course: course, user: user,
                               role: CoursesUsers::Roles::STUDENT_ROLE)
 
-        described_class.import_new_revisions(Course.all)
+        described_class.import_new_revisions(course)
 
-        expect(User.find(15).revisions.count).to eq(3)
-        expect(Course.find(1).revisions.count).to eq(0)
+        expect(user.reload.revisions.count).to eq(3)
+        expect(course.reload.revisions.count).to eq(0)
       end
     end
 
@@ -102,7 +102,7 @@ describe CourseRevisionUpdater do
                user_id: 5,
                role: 0)
         CoursesUsers.update_all_caches(CoursesUsers.all)
-        described_class.import_new_revisions(Course.all)
+        described_class.import_new_revisions(Course.find(1))
         expect(Revision.all.count > 1).to be true
       end
     end

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -23,9 +23,9 @@ describe ScheduleCourseUpdates do
     end
 
     it 'clears the needs_update flag from courses' do
-      expect(Course.where(needs_update: true).count).to eq(1)
+      expect(Course.where(needs_update: true).any?).to be(true)
       described_class.new
-      expect(Course.where(needs_update: true).count).to eq(0)
+      expect(Course.where(needs_update: true).any?).to be(false)
     end
 
     it 'reports logs to sentry even when it errors out' do

--- a/spec/lib/importers/revision_importer_spec.rb
+++ b/spec/lib/importers/revision_importer_spec.rb
@@ -37,10 +37,12 @@ describe RevisionImporter do
     end
   end
 
-  describe '#import_new_revisions_for_course' do
+  describe '#import_revisions_for_course' do
     let(:zh_wiki) { Wiki.new(language: 'zh', project: 'wikipedia', id: 999) }
     let(:course) { create(:course, start: '2018-05-26', end: '2018-05-27') }
-    let(:subject) { described_class.new(zh_wiki, course).import_new_revisions_for_course }
+    let(:subject) do
+      described_class.new(zh_wiki, course).import_revisions_for_course(all_time: false)
+    end
     let(:user) { create(:user, username: '-Zest') }
 
     before do

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -28,7 +28,7 @@ describe UpdateCourseStats do
     let(:flags) { { debug_updates: true } }
 
     it 'posts debug info to Sentry' do
-      expect(Raven).to receive(:capture_message).exactly(6).times.and_call_original
+      expect(Raven).to receive(:capture_message).at_least(6).times.and_call_original
       subject
     end
   end


### PR DESCRIPTION
RevisionImporter starts from the last already-imported revisions for each user, and only imports later revisions.

In cases where the start date of a course has changed, this could mean that early revision that are now within the course dates never get imported.

This modifies the behavior of `/manual_update` and the `needs_update` flag so that updates from either of those user-initiated update modes will (re-)fetch all revisions, not just ones later than the already-known revisions. It also automatically sets the `needs_update` flag for a course whenever the start date gets changed, so that updating the stats in such cases will happen automatically.