### PR TITLE
Long page titles break the layout of UploadViewer #2099

### DIFF
--- a/app/assets/stylesheets/modules/_uploads.styl
+++ b/app/assets/stylesheets/modules/_uploads.styl
@@ -119,6 +119,9 @@
     grid-template-columns 1fr 1fr
     grid-column-gap 3rem
     padding 20px
+  
+  .modal-body a
+    word-break break-all
 
     h4
       margin 2rem 0 1rem 0


### PR DESCRIPTION
**What this PR does**
Fixed for hyperlink of Article Name column of 'File Usage on Other Wiki' table

**Screenshots**
**Before:**
![overflow_UploadViewer1](https://user-images.githubusercontent.com/23306376/54473919-381aef80-4800-11e9-9ec2-cab195798edd.png)

**After:**
![overflow_UploadViewer2](https://user-images.githubusercontent.com/23306376/54473924-46690b80-4800-11e9-8038-3f33440f0239.png)
