### PR TITLE
Issue 1611

### DIFF
--- a/app/assets/javascripts/actions/timeline_actions.js
+++ b/app/assets/javascripts/actions/timeline_actions.js
@@ -7,6 +7,8 @@ import {
   ADD_BLOCK,
   DELETE_BLOCK,
   INSERT_BLOCK,
+  UPDATE_TITLE,
+  RESET_TITLES,
   ADD_WEEK,
   DELETE_WEEK,
   API_FAIL,
@@ -93,6 +95,14 @@ export const addBlock = (weekId) => {
 
 export const insertBlock = (block, newWeekId, afterBlock) => {
   return { type: INSERT_BLOCK, block, newWeekId, afterBlock };
+};
+
+export const updateTitle = (weekId, title) => {
+  return { type: UPDATE_TITLE, weekId, title };
+};
+
+export const resetTitles = () => {
+  return { type: RESET_TITLES };
 };
 
 export const restoreTimeline = () => {

--- a/app/assets/javascripts/components/timeline/empty_week.jsx
+++ b/app/assets/javascripts/components/timeline/empty_week.jsx
@@ -10,6 +10,7 @@ const EmptyWeek = createReactClass({
   propTypes: {
     emptyTimeline: PropTypes.bool,
     edit_permissions: PropTypes.bool,
+    usingCustomTitles: PropTypes.bool,
     course: PropTypes.object,
     timeline_start: PropTypes.string,
     timeline_end: PropTypes.string,
@@ -56,14 +57,32 @@ const EmptyWeek = createReactClass({
 
     const weekNumber = this.props.index + this.props.weeksBeforeTimeline;
 
+    let header;
+    const datesStr = `${dateCalc.start()} - ${dateCalc.end()}`;
+    if (this.props.usingCustomTitles) {
+      header = (
+        <div className="week__week-header">
+          <p className="week-index">
+            {I18n.t('timeline.week_number', { number: datesStr })}
+          </p>
+        </div>
+      );
+    } else {
+      header = (
+        <div className="week__week-header">
+          <p className="week-index">
+            {I18n.t('timeline.week_number', { number: weekNumber || 1 })}
+          </p>
+          <span className="week__week-dates">
+            {datesStr}
+          </span>
+        </div>
+      );
+    }
+
     return (
       <li className={`week week-${this.props.index}`}>
-        <div className="week__week-header">
-          <span className="week__week-dates pull-right">
-            {dateCalc.start()} - {dateCalc.end()}
-          </span>
-          <p className="week-index">{I18n.t('timeline.week_number', { number: weekNumber || 1 })}</p>
-        </div>
+        {header}
         <div className="week__no-activity">
           {week}
         </div>

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -65,7 +65,7 @@ const Timeline = createReactClass({
   },
 
   usingCustomTitles() {
-    return this.props.weeks.find(week => week.title) !== undefined;
+    return this.props.weeks.some(week => week.title);
   },
 
   hasTimeline() {
@@ -316,14 +316,14 @@ const Timeline = createReactClass({
         {saveChangesButton}
         {cancelChangesButton}
       </div>
-    ) : undefined;
+    ) : null;
     const titlesActionButtons = this.props.editableTitles ? (
       <div>
         {saveChangesButton}
         {cancelChangesButton}
         {resetTitlesButton}
       </div>
-    ) : undefined;
+    ) : null;
 
     let reorderableControls;
     let editWeekTitles;

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -35,12 +35,16 @@ const Timeline = createReactClass({
     deleteAllWeeks: PropTypes.func.isRequired,
     saveGlobalChanges: PropTypes.func,
     cancelGlobalChanges: PropTypes.func,
+    updateTitle: PropTypes.func,
+    resetTitles: PropTypes.func,
     saveBlockChanges: PropTypes.func,
     cancelBlockEditable: PropTypes.func,
     all_training_modules: PropTypes.array,
     edit_permissions: PropTypes.bool,
     reorderable: PropTypes.bool,
-    enableReorderable: PropTypes.func
+    editableTitles: PropTypes.bool,
+    enableReorderable: PropTypes.func,
+    enableEditTitles: PropTypes.func
   },
 
   getInitialState() {
@@ -58,6 +62,10 @@ const Timeline = createReactClass({
   getBlocksInWeek(weekId) {
     const week = this.props.weeks.find(thisWeek => thisWeek.id === weekId);
     return week.blocks;
+  },
+
+  usingCustomTitles() {
+    return this.props.weeks.find(week => week.title) !== undefined;
   },
 
   hasTimeline() {
@@ -177,6 +185,8 @@ const Timeline = createReactClass({
 
     const weekComponents = [];
     const weeksBeforeTimeline = CourseDateUtils.weeksBeforeTimeline(this.props.course);
+    const usingCustomTitles = this.usingCustomTitles();
+    const weekNavInfo = [];
     let i = 0;
 
     this.props.weeks.sort((a, b) => a.order - b.order);
@@ -201,6 +211,7 @@ const Timeline = createReactClass({
       while (this.props.week_meetings[i] === '()') {
         const emptyWeekKey = `empty-week-${i}`;
         const weekAnchorName = `week-${i + 1 + weeksBeforeTimeline}`;
+        weekNavInfo.push({ emptyWeek: true, title: undefined });
         weekComponents.push((
           <div key={emptyWeekKey}>
             <a className="timeline__anchor" name={weekAnchorName} />
@@ -208,6 +219,7 @@ const Timeline = createReactClass({
               course={this.props.course}
               edit_permissions={this.props.edit_permissions}
               index={i + 1}
+              usingCustomTitles={usingCustomTitles}
               timeline_start={this.props.course.timeline_start}
               timeline_end={this.props.course.timeline_end}
               weeksBeforeTimeline={weeksBeforeTimeline}
@@ -220,6 +232,7 @@ const Timeline = createReactClass({
       }
 
       const weekAnchorName = `week-${i + 1 + weeksBeforeTimeline}`;
+      weekNavInfo.push({ emptyWeek: false, title: week.title });
       weekComponents.push((
         <div key={week.id}>
           <a className="timeline__anchor" name={weekAnchorName} />
@@ -227,6 +240,9 @@ const Timeline = createReactClass({
             week={week}
             index={i + 1}
             reorderable={this.props.reorderable}
+            editableTitles={this.props.editableTitles}
+            usingCustomTitles={usingCustomTitles}
+            updateTitle={this.props.updateTitle}
             blocks={week.blocks}
             deleteWeek={this.deleteWeek.bind(this, week.id)}
             meetings={this.props.week_meetings[i]}
@@ -280,18 +296,37 @@ const Timeline = createReactClass({
       wizardLink = <CourseLink to={wizardUrl} className="button dark button--block timeline__add-assignment">Add Assignment</CourseLink>;
     }
 
-    const controls = this.props.reorderable || __guard__(this.props, x => x.editableBlockIds.length) > 1 ? (
+    const saveChangesButton = (
+      <button className="button dark button--block" onClick={this.props.saveGlobalChanges}>
+        {I18n.t('timeline.save_all_changes')}
+      </button>
+    );
+    const cancelChangesButton = (
+      <button className="button button--clear button--block" onClick={this.props.cancelGlobalChanges}>
+        {I18n.t('timeline.discard_all_changes')}
+      </button>
+    );
+    const resetTitlesButton = (
+      <button className="button button--clear button--block" onClick={this.props.resetTitles}>
+        {I18n.t('timeline.reset_titles')}
+      </button>
+    );
+    const reorderActionButtons = this.props.reorderable || __guard__(this.props, x => x.editableBlockIds.length) > 1 ? (
       <div>
-        <button className="button dark button--block" onClick={this.props.saveGlobalChanges}>
-          {I18n.t('timeline.save_all_changes')}
-        </button>
-        <button className="button button--clear button--block" onClick={this.props.cancelGlobalChanges}>
-          {I18n.t('timeline.discard_all_changes')}
-        </button>
+        {saveChangesButton}
+        {cancelChangesButton}
+      </div>
+    ) : undefined;
+    const titlesActionButtons = this.props.editableTitles ? (
+      <div>
+        {saveChangesButton}
+        {cancelChangesButton}
+        {resetTitlesButton}
       </div>
     ) : undefined;
 
     let reorderableControls;
+    let editWeekTitles;
     let editCourseDates;
     let addWeekLink;
     if (this.props.edit_permissions) {
@@ -305,7 +340,23 @@ const Timeline = createReactClass({
       } else if (this.props.editableBlockIds.length === 0) {
         reorderableControls = (
           <div className="reorderable-controls">
-            <button className="button border button--block" onClick={this.props.enableReorderable}>Arrange Timeline</button>
+            <button className="button border button--block" onClick={this.props.enableReorderable}>{I18n.t('timeline.arrange_timeline')}</button>
+          </div>
+        );
+      }
+
+      // if currently editing titles show info, otherwise show button
+      if (this.props.editableTitles) {
+        editWeekTitles = (
+          <div className="edit-week-titles">
+            <h5>{I18n.t('timeline.edit_titles')}</h5>
+            <p className="muted">{I18n.t('timeline.edit_titles_info')}</p>
+          </div>
+        );
+      } else {
+        editWeekTitles = (
+          <div className="edit-week-titles">
+            <button className="button border button--block" onClick={this.props.enableEditTitles}>{I18n.t('timeline.edit_titles')}</button>
           </div>
         );
       }
@@ -334,7 +385,7 @@ const Timeline = createReactClass({
       );
     }
 
-    const weekNav = weekComponents.map((week, navIndex) => {
+    const weekNav = weekNavInfo.map((weekInfo, navIndex) => {
       let navClassName = 'week-nav__item';
       if (navIndex === 0) {
         navClassName += ' is-current';
@@ -343,12 +394,32 @@ const Timeline = createReactClass({
       const dateCalc = new DateCalculator(this.props.course.timeline_start, this.props.course.timeline_end, navIndex, { zeroIndexed: true });
       const navWeekKey = `week-${navIndex}`;
       const navWeekLink = `#week-${navIndex + 1 + weeksBeforeTimeline}`;
-      return (
-        <li className={navClassName} key={navWeekKey}>
-          <a href={navWeekLink}>{week.title || I18n.t('timeline.week_number', { number: navIndex + 1 + weeksBeforeTimeline })}</a>
-          <span className="pull-right">{dateCalc.start()} - {dateCalc.end()}</span>
-        </li>
-      );
+
+      // if using custom titles, show only titles, otherwise, show default titles and dates
+      let navItem;
+      if (usingCustomTitles) {
+        let navTitle = '';
+        if (weekInfo.emptyWeek) {
+          const datesStr = `${dateCalc.start()} - ${dateCalc.end()}`;
+          navTitle = I18n.t('timeline.week_number', { number: datesStr });
+        } else {
+          navTitle = weekInfo.title ? weekInfo.title : I18n.t('timeline.week_number', { number: navIndex + 1 + weeksBeforeTimeline });
+        }
+        navItem = (
+          <li className={navClassName} key={navWeekKey}>
+            <a className="no-nav-dates" href={navWeekLink}>{navTitle}</a>
+          </li>
+        );
+      } else {
+        navItem = (
+          <li className={navClassName} key={navWeekKey}>
+            <a href={navWeekLink}>{I18n.t('timeline.week_number', { number: navIndex + 1 + weeksBeforeTimeline })}</a>
+            <span className="pull-right">{dateCalc.start()} - {dateCalc.end()}</span>
+          </li>
+        );
+      }
+
+      return navItem;
     });
 
     let restartTimeline;
@@ -368,7 +439,11 @@ const Timeline = createReactClass({
           <section className="timeline-ctas float-container">
             <span>{wizardLink}</span>
             {reorderableControls}
-            {controls}
+            {reorderActionButtons}
+          </section>
+          <section className="timeline-ctas float-container">
+            {editWeekTitles}
+            {titlesActionButtons}
           </section>
           <section className="timeline-ctas float-container">
             {restartTimeline}

--- a/app/assets/javascripts/components/timeline/timeline_handler.jsx
+++ b/app/assets/javascripts/components/timeline/timeline_handler.jsx
@@ -14,7 +14,7 @@ import Meetings from './meetings.jsx';
 import { fetchAllTrainingModules } from '../../actions/training_actions';
 
 import { addWeek, deleteWeek, persistTimeline, setBlockEditable, cancelBlockEditable,
-  updateBlock, addBlock, deleteBlock, insertBlock, restoreTimeline, deleteAllWeeks } from '../../actions/timeline_actions';
+  updateBlock, addBlock, deleteBlock, insertBlock, updateTitle, resetTitles, restoreTimeline, deleteAllWeeks } from '../../actions/timeline_actions';
 import { getWeeksArray, getAvailableTrainingModules, editPermissions } from '../../selectors';
 
 const TimelineHandler = createReactClass({
@@ -35,7 +35,10 @@ const TimelineHandler = createReactClass({
   },
 
   getInitialState() {
-    return { reorderable: false };
+    return {
+      reorderable: false,
+      editableTitles: false
+    };
   },
 
   componentDidMount() {
@@ -49,6 +52,7 @@ const TimelineHandler = createReactClass({
 
   _cancelGlobalChanges() {
     this.setState({ reorderable: false });
+    this.setState({ editableTitles: false });
     this.props.restoreTimeline();
   },
 
@@ -56,8 +60,20 @@ const TimelineHandler = createReactClass({
     return this.setState({ reorderable: true });
   },
 
+  _enableEditTitles() {
+    return this.setState({ editableTitles: true });
+  },
+
+  _resetTitles() {
+    if (confirm(I18n.t('timeline.reset_titles_confirmation'))) {
+      this.props.resetTitles();
+      this.saveTimeline();
+    }
+  },
+
   saveTimeline() {
     this.setState({ reorderable: false });
+    this.setState({ editableTitles: false });
     const toSave = { weeks: this.props.weeks };
     this.props.persistTimeline(toSave, this.props.course_id);
   },
@@ -113,14 +129,18 @@ const TimelineHandler = createReactClass({
           week_meetings={weekMeetings}
           editableBlockIds={this.props.editableBlockIds}
           reorderable={this.state.reorderable}
+          editableTitles={this.state.editableTitles}
           controls={this.props.controls}
           persistCourse={this.props.persistTimeline}
           saveGlobalChanges={this.saveTimeline}
           saveBlockChanges={this.saveTimeline}
           cancelBlockEditable={this._cancelBlockEditable}
           cancelGlobalChanges={this._cancelGlobalChanges}
+          updateTitle={this.props.updateTitle}
+          resetTitles={this._resetTitles}
           updateBlock={this.props.updateBlock}
           enableReorderable={this._enableReorderable}
+          enableEditTitles={this._enableEditTitles}
           all_training_modules={this.props.availableTrainingModules}
           addWeek={this.props.addWeek}
           addBlock={this.props.addBlock}
@@ -157,6 +177,8 @@ const mapDispatchToProps = {
   cancelBlockEditable,
   updateBlock,
   insertBlock,
+  updateTitle,
+  resetTitles,
   restoreTimeline,
   deleteAllWeeks,
   fetchAllTrainingModules

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -20,9 +20,12 @@ const Week = createReactClass({
     edit_permissions: PropTypes.bool,
     editableBlockIds: PropTypes.array,
     reorderable: PropTypes.bool,
+    editableTitles: PropTypes.bool,
     onBlockDrag: PropTypes.func,
     onMoveBlockUp: PropTypes.func,
     onMoveBlockDown: PropTypes.func,
+    usingCustomTitles: PropTypes.bool,
+    updateTitle: PropTypes.func,
     canBlockMoveUp: PropTypes.func,
     canBlockMoveDown: PropTypes.func,
     saveBlockChanges: PropTypes.func,
@@ -68,21 +71,35 @@ const Week = createReactClass({
     let style;
     const dateCalc = new DateCalculator(this.props.timeline_start, this.props.timeline_end, this.props.index, { zeroIndexed: false });
 
-    let weekDates;
+    let weekDatesContent;
     if (this.props.meetings) {
-      weekDates = (
-        <span className="week__week-dates pull-right">
-          {dateCalc.start()} - {dateCalc.end()} {this.props.meetings}
-        </span>
-      );
+      weekDatesContent = `${dateCalc.start()} - ${dateCalc.end()} ${this.props.meetings}`;
     } else {
-      weekDates = (
-        <span className="week__week-dates pull-right">
-          Week of {dateCalc.start()} — AFTER TIMELINE END DATE!
-        </span>
-      );
+      weekDatesContent = `Week of ${dateCalc.start()} — AFTER TIMELINE END DATE!`;
     }
+    const weekDates = (
+      <div className="week__week-dates">
+        {weekDatesContent}
+      </div>
+    );
 
+    let weekTitleContent;
+    if (this.props.week.title) {
+      weekTitleContent = this.props.week.title;
+    } else {
+      weekTitleContent = I18n.t('timeline.week_number', { number: this.weekNumber() });
+    }
+    const weekId = this.props.week.id;
+    const weekTitle = this.props.editableTitles ? (
+      <input
+        className="week-index week-title-input"
+        defaultValue={weekTitleContent}
+        maxLength={20}
+        onChange={text => this.props.updateTitle(weekId, event.target.value, text)}
+      />
+    ) : (
+      <p className="week-index">{weekTitleContent}</p>
+    );
 
     const blocks = this.props.blocks.map((block, i) => {
       // If in reorderable mode
@@ -192,8 +209,8 @@ const Week = createReactClass({
       <li className={weekClassName}>
         <div className="week__week-header">
           {weekAddDelete}
+          {weekTitle}
           {weekDates}
-          <p className="week-index">{I18n.t('timeline.week_number', { number: this.weekNumber() })}</p>
         </div>
         {weekContent}
       </li>

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -95,7 +95,7 @@ const Week = createReactClass({
         className="week-index week-title-input"
         defaultValue={weekTitleContent}
         maxLength={20}
-        onChange={text => this.props.updateTitle(weekId, event.target.value, text)}
+        onChange={event => this.props.updateTitle(weekId, event.target.value)}
       />
     ) : (
       <p className="week-index">{weekTitleContent}</p>

--- a/app/assets/javascripts/constants/timeline.js
+++ b/app/assets/javascripts/constants/timeline.js
@@ -8,5 +8,7 @@ export const UPDATE_BLOCK = 'UPDATE_BLOCK';
 export const ADD_BLOCK = 'ADD_BLOCK';
 export const DELETE_BLOCK = 'DELETE_BLOCK';
 export const INSERT_BLOCK = 'INSERT_BLOCK';
+export const UPDATE_TITLE = 'UPDATE_TITLE';
+export const RESET_TITLES = 'RESET_TITLES';
 export const RESTORE_TIMELINE = 'RESTORE_TIMELINE';
 export const DELETE_ALL_WEEKS = 'DELETE_ALL_WEEKS';

--- a/app/assets/javascripts/reducers/timeline.js
+++ b/app/assets/javascripts/reducers/timeline.js
@@ -42,10 +42,16 @@ const blocksInWeek = (blocks, weekId) => {
 };
 
 const validateTitle = (title) => {
-  if ((typeof title === 'string' || title instanceof String) && title.length <= 20) {
-    return true;
-  }
-  return false;
+  return title.length <= 20;
+};
+
+const deepCopyWeeks = (weeks) => {
+  const weeksCopy = {};
+  const weekIds = Object.keys(weeks);
+  weekIds.forEach((id) => {
+    weeksCopy[id] = { ...weeks[id] };
+  });
+  return weeksCopy;
 };
 
 const newBlock = (tempId, weekId, state) => {
@@ -214,7 +220,7 @@ export default function timeline(state = initialState, action) {
       return { ...state, weeks };
     }
     case RESTORE_TIMELINE: {
-      return { ...state, blocks: { ...state.blocksPersisted }, weeks: { ...state.weeksPersisted }, editableBlockIds: [] };
+      return { ...state, blocks: { ...state.blocksPersisted }, weeks: deepCopyWeeks(state.weeksPersisted), editableBlockIds: [] };
     }
     default:
       return state;

--- a/app/assets/javascripts/reducers/timeline.js
+++ b/app/assets/javascripts/reducers/timeline.js
@@ -9,6 +9,8 @@ import {
   ADD_BLOCK,
   DELETE_BLOCK,
   INSERT_BLOCK,
+  UPDATE_TITLE,
+  RESET_TITLES,
   RESTORE_TIMELINE
 } from '../constants';
 
@@ -37,6 +39,13 @@ const blocksInWeek = (blocks, weekId) => {
     }
   });
   return count;
+};
+
+const validateTitle = (title) => {
+  if ((typeof title === 'string' || title instanceof String) && title.length <= 20) {
+    return true;
+  }
+  return false;
 };
 
 const newBlock = (tempId, weekId, state) => {
@@ -189,6 +198,20 @@ export default function timeline(state = initialState, action) {
     case INSERT_BLOCK: {
       const blocks = updateBlockPosition(action.block, action.newWeekId, action.afterBlock, state.blocks);
       return { ...state, blocks };
+    }
+    case UPDATE_TITLE: {
+      const weeks = { ...state.weeks };
+      if (validateTitle(action.title)) {
+        weeks[action.weekId].title = action.title;
+      }
+      return { ...state, weeks };
+    }
+    case RESET_TITLES: {
+      const weeks = { ...state.weeks };
+      Object.keys(weeks).forEach((weekId) => {
+        weeks[weekId].title = '';
+      });
+      return { ...state, weeks };
     }
     case RESTORE_TIMELINE: {
       return { ...state, blocks: { ...state.blocksPersisted }, weeks: { ...state.weeksPersisted }, editableBlockIds: [] };

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -191,7 +191,7 @@ button.week__add-block
 
 .week__week-dates
   position relative
-  top 16px
+  top -12px
   color $text_med
 
 .week__no-activity
@@ -224,6 +224,8 @@ button.week__add-block
   font-size 34px
   font-weight 300
   -webkit-font-smoothing auto
+  &.week-title-input
+    margin-bottom 12px
 
 .week__week-header .text-input-component__value:hover
   background url("../images/pencil.svg") right center no-repeat
@@ -359,6 +361,8 @@ h4.timeline-exercise
     white-space nowrap
     text-overflow ellipsis
     display inline-block
+    &.no-nav-dates
+      width 200px
   span
     color $text_med
 

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -191,7 +191,7 @@ button.week__add-block
 
 .week__week-dates
   position relative
-  top -12px
+  margin-bottom 12px
   color $text_med
 
 .week__no-activity
@@ -224,6 +224,7 @@ button.week__add-block
   font-size 34px
   font-weight 300
   -webkit-font-smoothing auto
+  margin-bottom 0px
   &.week-title-input
     margin-bottom 12px
 

--- a/app/views/courses/_weeks.json.jbuilder
+++ b/app/views/courses/_weeks.json.jbuilder
@@ -11,6 +11,7 @@ json.weeks course.weeks.eager_load(:blocks) do |week|
   json.end_date_raw start_date.present? ? start_date.end_of_week(:sunday) : nil
   json.start_date start_date.present? ? start_date.strftime('%m/%d') : nil
   json.end_date start_date.present? ? start_date.end_of_week(:sunday).strftime('%m/%d') : nil
+  json.title week.title
   json.blocks week.blocks do |block|
     json.call(block, :id, :kind, :content, :week_id, :title,
               :order, :due_date, :training_module_ids, :points)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -910,6 +910,8 @@ en:
     discard_all_changes: Discard All Changes
     delete_timeline_and_start_over: Delete Timeline
     due_default: Due next week
+    edit_titles: Edit Titles
+    edit_titles_info: Edit titles in timeline. Only weeks with scheduled meetings can be given custom titles. If any custom titles are used, weeks with no meetings will be dated instead of numbered.
     # FIXME: lego message. This one is hard to work around because it has inline components.
     empty_week_1: 'To get started, '
     empty_week_2: start editing this week
@@ -925,6 +927,8 @@ en:
     no_timeline: This course has no timeline.
     no_activity_this_week: No scheduled meetings this week
     nothing_this_week: There is nothing on the schedule for this week.
+    reset_titles: Reset to Default
+    reset_titles_confirmation: Are you sure you want to reset all week titles? This cannot be undone.
     save_all_changes: Save All
     this_week_title_default: This Week
     title: Timeline

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -910,8 +910,8 @@ en:
     discard_all_changes: Discard All Changes
     delete_timeline_and_start_over: Delete Timeline
     due_default: Due next week
-    edit_titles: Edit Titles
-    edit_titles_info: Edit titles in timeline. Only weeks with scheduled meetings can be given custom titles. If any custom titles are used, weeks with no meetings will be dated instead of numbered.
+    edit_titles: Edit Week Titles
+    edit_titles_info: Edit week titles in timeline. Only weeks with scheduled meetings can be given custom titles. If any custom titles are used, weeks with no meetings will be dated instead of numbered.
     # FIXME: lego message. This one is hard to work around because it has inline components.
     empty_week_1: 'To get started, '
     empty_week_2: start editing this week

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -658,10 +658,14 @@ qqq:
     block_assignment: '{{Identical|Assignment}}'
     block_custom: '{{Identical|Custom}}'
     block_milestone: '{{Identical|Milestone}}'
+    edit_titles: Edit Titles button label
+    edit_titles_info: Information message about editing titles
     empty_week_3: '{{Identical|Or}}'
     gradeable_value: '{{Identical|Value}}'
     grading_header: Header for Grading section of course timeline. 'total' is a number,
       the sum of all the values for graded assignments.
+    reset_titles: Reset Titles button label
+    reset_titles_confirmation: Confirmation message upon clicking reset button
     title: '{{Identical|Timeline}}'
     week_number: '{{Identical|Week}}'
   training:

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -658,8 +658,8 @@ qqq:
     block_assignment: '{{Identical|Assignment}}'
     block_custom: '{{Identical|Custom}}'
     block_milestone: '{{Identical|Milestone}}'
-    edit_titles: Edit Titles button label
-    edit_titles_info: Information message about editing titles
+    edit_titles: Edit Week Titles button label
+    edit_titles_info: Information message about editing week titles
     empty_week_3: '{{Identical|Or}}'
     gradeable_value: '{{Identical|Value}}'
     grading_header: Header for Grading section of course timeline. 'total' is a number,

--- a/spec/features/timeline_editing_spec.rb
+++ b/spec/features/timeline_editing_spec.rb
@@ -82,6 +82,27 @@ describe 'timeline editing', type: :feature, js: true do
     sleep 1
   end
 
+  it 'lets users rename and reset week titles' do
+    visit "/courses/#{course_with_timeline.slug}/timeline"
+    expect(page).not_to have_content 'Intro and Icebreaker'
+    expect(page).to have_content 'Week 1'
+    # Add new title
+    click_button 'Edit Titles'
+    find('input.week-title-input').native.clear
+    find('input.week-title-input').set 'Intro and Icebreaker'
+    # Save new title
+    click_button 'Save All'
+    expect(page).to have_content 'Intro and Icebreaker'
+    expect(page).not_to have_content 'Week 1'
+    # Reset to default titles
+    click_button 'Edit Titles'
+    accept_confirm { click_button 'Reset to Default' }
+
+    expect(page).not_to have_content 'Intro and Icebreaker'
+    expect(page).to have_content 'Week 1'
+    sleep 1
+  end
+
   it 'lets users delete a block' do
     visit "/courses/#{course_with_timeline.slug}/timeline"
     expect(page).to have_content 'Block Title'

--- a/spec/features/timeline_editing_spec.rb
+++ b/spec/features/timeline_editing_spec.rb
@@ -87,7 +87,7 @@ describe 'timeline editing', type: :feature, js: true do
     expect(page).not_to have_content 'Intro and Icebreaker'
     expect(page).to have_content 'Week 1'
     # Add new title
-    click_button 'Edit Titles'
+    click_button 'Edit Week Titles'
     find('input.week-title-input').native.clear
     find('input.week-title-input').set 'Intro and Icebreaker'
     # Save new title
@@ -95,7 +95,7 @@ describe 'timeline editing', type: :feature, js: true do
     expect(page).to have_content 'Intro and Icebreaker'
     expect(page).not_to have_content 'Week 1'
     # Reset to default titles
-    click_button 'Edit Titles'
+    click_button 'Edit Week Titles'
     accept_confirm { click_button 'Reset to Default' }
 
     expect(page).not_to have_content 'Intro and Icebreaker'


### PR DESCRIPTION
## What this PR does
This addressed the feature request from issue 1611. It adds a button to the Timeline page to edit week titles, and a button to reset to default titles. I also moved dates to be below the titles to accommodate the change.

## Screenshots
Before:
![Screenshot from 2019-03-18 19-50-23](https://user-images.githubusercontent.com/18557983/54572852-e91bb880-49bf-11e9-8c82-6601a1654308.png)

After:
![Screenshot from 2019-03-18 19-49-49](https://user-images.githubusercontent.com/18557983/54572855-f173f380-49bf-11e9-8bb4-239f7305156a.png)
