### PR TITLE
sending DYK alerts to instructors

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -118,6 +118,17 @@ class Alert < ApplicationRecord
     update_attribute(:email_sent_at, Time.zone.now)
   end
 
+  def email_course_instructor
+    return if emails_disabled?
+    return if course.nil?
+    course_creators = course.instructors
+    return if course_creators.empty?
+    course_creators.each do |course_creator|
+      AlertMailer.alert(self, course_creator).deliver_now
+    end
+    update_attribute(:email_sent_at, Time.zone.now)
+  end
+
   # Disable emails for specific alert types in application.yml, like so:
   #   ProductiveCourseAlert_email_disabled: 'true'
   def emails_disabled?

--- a/lib/alerts/dyk_nomination_monitor.rb
+++ b/lib/alerts/dyk_nomination_monitor.rb
@@ -58,6 +58,7 @@ class DYKNominationMonitor
                           course_id: articles_course.course_id,
                           revision_id: first_revision&.id)
     alert.email_content_expert
+    alert.email_course_instructor
   end
 
   def alert_already_exists?(articles_course)

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
   },
   "devDependencies": {
     "webpack-cli": "^3.3.0",
-    "@babel/plugin-transform-runtime": "^7.3.4"
+    "@babel/plugin-transform-runtime": "^7.4.0"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"

--- a/spec/lib/alerts/dyk_nomination_monitor_spec.rb
+++ b/spec/lib/alerts/dyk_nomination_monitor_spec.rb
@@ -16,11 +16,16 @@ describe DYKNominationMonitor do
                             course_id: course.id,
                             role: CoursesUsers::Roles::STUDENT_ROLE)
     end
+    let(:course_creator) do
+      create(:courses_user, user_id: student.id,
+                            course_id: course.id,
+                            role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    end
     let(:content_expert) { create(:user, greeter: true) }
 
     # Article that hasn't been edited by students
     let!(:article2) { create(:article, title: '17776', namespace: 0) }
-
+    
     # DYK article
     let(:article) { create(:article, title: 'Venus_and_Adonis_(Titian)', namespace: 0) }
     let(:revision) do
@@ -52,6 +57,13 @@ describe DYKNominationMonitor do
 
     it 'emails a greeter' do
       create(:courses_user, user_id: content_expert.id, course_id: course.id, role: 4)
+      allow_any_instance_of(AlertMailer).to receive(:alert).and_return(mock_mailer)
+      described_class.create_alerts_for_course_articles
+      expect(Alert.last.email_sent_at).not_to be_nil
+    end
+
+    it 'emails course creator' do
+      create(:courses_user, user_id: course_creator.id, course_id: course.id, role: 1)
       allow_any_instance_of(AlertMailer).to receive(:alert).and_return(mock_mailer)
       described_class.create_alerts_for_course_articles
       expect(Alert.last.email_sent_at).not_to be_nil

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,10 @@
   dependencies:
     regenerator-transform "^0.13.4"
 
-"@babel/plugin-transform-runtime@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.3.4.tgz#57805ac8c1798d102ecd75c03b024a5b3ea9b431"
-  integrity sha512-PaoARuztAdd5MgeVjAxnIDAIUet5KpogqaefQvPOmPYCxYoaPhautxDh3aO8a4xHsKgT/b9gSxR0BKK1MIewPA==
+"@babel/plugin-transform-runtime@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz#b4d8c925ed957471bc57e0b9da53408ebb1ed457"
+  integrity sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
It addresses isssue number 2635, DYK alerts now being send to creator of the course/program inaddition to content experts associated with a course.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
How can i test if DYK alerts are being send to both instructors and content experts in my local machine