### PR TITLE
Adding Vikidia to wikis [WIP]

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -33,6 +33,7 @@ class Wiki < ApplicationRecord
     wikiversity
     wikivoyage
     wiktionary
+    vikidia
   ].freeze
   validates_inclusion_of :project, in: PROJECTS
 


### PR DESCRIPTION
Vikidia (vikidia.org) is a growing wiki dedicated to childrens. It's doing many project with school and the dashboard would be very useful for them, so why don't add vikidia to wikis to help them managing projects.