### PR TITLE
Add ticket filtering by status, set default filters

### DIFF
--- a/app/assets/javascripts/actions/tickets_actions.js
+++ b/app/assets/javascripts/actions/tickets_actions.js
@@ -130,4 +130,5 @@ export const deleteTicket = id => async (dispatch) => {
   dispatch({ type: DELETE_TICKET, id });
 };
 
-export const setTicketFilters = filters => ({ type: FILTER_TICKETS, filters });
+export const setTicketOwnersFilter = filters => ({ type: FILTER_TICKETS, filters: { owners: filters } });
+export const setTicketStatusesFilter = filters => ({ type: FILTER_TICKETS, filters: { statuses: filters } });

--- a/app/assets/javascripts/actions/tickets_actions.js
+++ b/app/assets/javascripts/actions/tickets_actions.js
@@ -7,8 +7,10 @@ import {
   SELECT_TICKET,
   SET_MESSAGES_TO_READ,
   SORT_TICKETS,
+  TICKET_STATUS_OPEN,
   UPDATE_TICKET
 } from '../constants/tickets';
+import { STATUSES } from '../components/tickets/util';
 import { API_FAIL } from '../constants/api';
 import fetch from 'cross-fetch';
 
@@ -132,3 +134,17 @@ export const deleteTicket = id => async (dispatch) => {
 
 export const setTicketOwnersFilter = filters => ({ type: FILTER_TICKETS, filters: { owners: filters } });
 export const setTicketStatusesFilter = filters => ({ type: FILTER_TICKETS, filters: { statuses: filters } });
+
+export const setInitialTicketFilters = () => (dispatch, getState) => {
+  // Open tickets only
+  dispatch(setTicketStatusesFilter([{ value: TICKET_STATUS_OPEN, label: STATUSES[TICKET_STATUS_OPEN] }]));
+
+  // Owned by current user, or no one
+  const state = getState();
+  const currentUserId = state.currentUserFromHtml.id;
+  const currentUser = state.admins.find(admin => admin[1] === currentUserId);
+  const currentUserOption = { label: currentUser[0], value: currentUser[1] };
+  const unassignedOption = { label: 'unassigned', value: null };
+  dispatch(setTicketOwnersFilter([currentUserOption, unassignedOption]));
+};
+

--- a/app/assets/javascripts/components/tickets/ticket_owners_filter.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_owners_filter.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import MultiSelectField from '../common/multi_select_field.jsx';
 
-import { setTicketFilters } from '../../actions/tickets_actions';
+import { setTicketOwnersFilter } from '../../actions/tickets_actions';
 
-export const TicketFilters = ({ admins, setFilters, filters }) => {
+export const TicketOwnersFilter = ({ admins, setOwnersFilter, ownerFilters }) => {
   const options = admins.map(([username, id]) => ({ label: username, value: id }));
   options.push({ label: 'unassigned', value: null });
 
@@ -12,20 +12,20 @@ export const TicketFilters = ({ admins, setFilters, filters }) => {
     <MultiSelectField
       options={options}
       label="Filter by owner"
-      selected={filters}
-      setSelectedFilters={setFilters}
+      selected={ownerFilters}
+      setSelectedFilters={setOwnersFilter}
     />
   );
 };
 
 const mapStateToProps = ({ admins, tickets }) => ({
   admins,
-  filters: tickets.filters
+  ownerFilters: tickets.filters.owners
 });
 
 const mapDispatchToProps = {
-  setFilters: setTicketFilters
+  setOwnersFilter: setTicketOwnersFilter
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
-export default connector(TicketFilters);
+export default connector(TicketOwnersFilter);

--- a/app/assets/javascripts/components/tickets/ticket_statuses_filter.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_statuses_filter.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import MultiSelectField from '../common/multi_select_field.jsx';
+
+import { setTicketStatusesFilter } from '../../actions/tickets_actions';
+import { STATUSES } from './util';
+
+const options = Object.entries(STATUSES).map(([value, label]) => ({ label, value }));
+
+export const TicketStatusesFilter = ({ setStatusesFilter, statusesFilter }) => {
+  return (
+    <MultiSelectField
+      options={options}
+      label="Filter by status"
+      selected={statusesFilter}
+      setSelectedFilters={setStatusesFilter}
+    />
+  );
+};
+
+const mapStateToProps = ({ admins, tickets }) => ({
+  admins,
+  statusesFilter: tickets.filters.owners
+});
+
+const mapDispatchToProps = {
+  setStatusesFilter: setTicketStatusesFilter
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+export default connector(TicketStatusesFilter);

--- a/app/assets/javascripts/components/tickets/ticket_statuses_filter.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_statuses_filter.jsx
@@ -20,7 +20,7 @@ export const TicketStatusesFilter = ({ setStatusesFilter, statusesFilter }) => {
 
 const mapStateToProps = ({ admins, tickets }) => ({
   admins,
-  statusesFilter: tickets.filters.owners
+  statusesFilter: tickets.filters.statuses
 });
 
 const mapDispatchToProps = {

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -6,7 +6,7 @@ import Loading from '../common/loading';
 import List from '../common/list.jsx';
 import TicketOwnersFilter from './ticket_owners_filter';
 import TicketStatusesFilter from './ticket_statuses_filter';
-import { fetchTickets, sortTickets } from '../../actions/tickets_actions';
+import { fetchTickets, sortTickets, setInitialTicketFilters } from '../../actions/tickets_actions';
 import { getFilteredTickets } from '../../selectors';
 
 export class TicketsHandler extends React.Component {
@@ -14,6 +14,7 @@ export class TicketsHandler extends React.Component {
     if (!this.props.tickets.all.length) {
       this.props.fetchTickets();
     }
+    this.props.setInitialTicketFilters();
   }
 
   render() {
@@ -88,7 +89,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   fetchTickets,
-  sortTickets
+  sortTickets,
+  setInitialTicketFilters
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -4,8 +4,8 @@ import { connect } from 'react-redux';
 import Row from './tickets_table_row';
 import Loading from '../common/loading';
 import List from '../common/list.jsx';
-import TicketFilters from './ticket_filters';
-
+import TicketOwnersFilter from './ticket_owners_filter';
+import TicketStatusesFilter from './ticket_statuses_filter';
 import { fetchTickets, sortTickets } from '../../actions/tickets_actions';
 import { getFilteredTickets } from '../../selectors';
 
@@ -61,8 +61,13 @@ export class TicketsHandler extends React.Component {
     return (
       <main className="container ticket-dashboard">
         <h1 className="mt4">Ticketing Dashboard</h1>
+        <div>
+          <span className="pull-left w10">Status: </span>
+          <TicketStatusesFilter />
+          <span className="pull-left w10">Owner: </span>
+          <TicketOwnersFilter />
+        </div>
         <hr/>
-        <TicketFilters />
         <List
           className="table--expandable table--hoverable"
           elements={elements}

--- a/app/assets/javascripts/reducers/tickets.js
+++ b/app/assets/javascripts/reducers/tickets.js
@@ -13,7 +13,10 @@ import { sortByKey } from '../utils/model_utils';
 const initialState = {
   all: [],
   selected: {},
-  filters: [],
+  filters: {
+    owners: [],
+    statuses: []
+  },
   loading: true,
   sort: {
     sortKey: null,
@@ -61,8 +64,10 @@ export default function (state = initialState, action) {
     }
     case FETCH_TICKETS:
       return { ...state, loading: true };
-    case FILTER_TICKETS:
-      return { ...state, filters: action.filters };
+    case FILTER_TICKETS: {
+      const newFilters = { ...state.filters, ...action.filters };
+      return { ...state, filters: newFilters };
+    }
     case RECEIVE_TICKETS: {
       return {
         ...state,

--- a/app/assets/javascripts/reducers/tickets.js
+++ b/app/assets/javascripts/reducers/tickets.js
@@ -6,8 +6,10 @@ import {
   SELECT_TICKET,
   SET_MESSAGES_TO_READ,
   SORT_TICKETS,
+  TICKET_STATUS_OPEN,
   UPDATE_TICKET
 } from '../constants/tickets';
+import { STATUSES } from '../components/tickets/util';
 import { sortByKey } from '../utils/model_utils';
 
 const initialState = {
@@ -15,7 +17,7 @@ const initialState = {
   selected: {},
   filters: {
     owners: [],
-    statuses: []
+    statuses: [{ value: TICKET_STATUS_OPEN, label: STATUSES[TICKET_STATUS_OPEN] }]
   },
   loading: true,
   sort: {

--- a/app/assets/javascripts/reducers/tickets.js
+++ b/app/assets/javascripts/reducers/tickets.js
@@ -6,10 +6,8 @@ import {
   SELECT_TICKET,
   SET_MESSAGES_TO_READ,
   SORT_TICKETS,
-  TICKET_STATUS_OPEN,
   UPDATE_TICKET
 } from '../constants/tickets';
-import { STATUSES } from '../components/tickets/util';
 import { sortByKey } from '../utils/model_utils';
 
 const initialState = {
@@ -17,7 +15,7 @@ const initialState = {
   selected: {},
   filters: {
     owners: [],
-    statuses: [{ value: TICKET_STATUS_OPEN, label: STATUSES[TICKET_STATUS_OPEN] }]
+    statuses: []
   },
   loading: true,
   sort: {

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -226,9 +226,21 @@ export const editPermissions = createSelector(
 
 export const getFilteredTickets = createSelector(
   [getTickets], (tickets) => {
-    const ownerIds = tickets.filters.map(filter => filter.value);
-    if (!ownerIds.length) { return tickets.all; }
-    return tickets.all.filter(ticket => ownerIds.includes(ticket.owner.id));
+    const ownerIds = tickets.filters.owners.map(filter => filter.value);
+    const statuses = tickets.filters.statuses.map(filter => parseInt(filter.value));
+
+    let ownerFilter = ticket => ticket;
+    let statusFilter = ticket => ticket;
+    if (ownerIds.length) {
+      ownerFilter = ticket => ownerIds.includes(ticket.owner.id);
+    }
+    if (statuses.length) {
+      statusFilter = ticket => statuses.includes(ticket.status);
+    }
+
+    return tickets.all
+      .filter(ownerFilter)
+      .filter(statusFilter);
   }
 );
 

--- a/app/assets/stylesheets/_utils.styl
+++ b/app/assets/stylesheets/_utils.styl
@@ -168,6 +168,9 @@ show-over(breakpoint, display)
 .w25
   width 25%
 
+.w10
+  width 10%
+
 .hidden
   display none !important
 


### PR DESCRIPTION
This adds a second selector for filtering by ticket status, and sets the default filters we want, on the same criteria that would make the bell ring: open tickets that are either owned by you or unassigned.

![Filters!](https://user-images.githubusercontent.com/848483/56154355-31050f80-5f6d-11e9-984e-c087ff6bb524.png)
