### PR TITLE
Add sender_email, subject support to tickets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/WikiEducationFoundation/TicketDispenser.git
-  revision: 3143ad4cecf2e1d1e9a8fb5c68b63c16052b9165
+  revision: ef1b6b51b9e6d548689c79c97ee61a4be283d7a3
   specs:
     ticket_dispenser (0.1.0)
       active_model_serializers

--- a/app/assets/javascripts/components/tickets/reply.jsx
+++ b/app/assets/javascripts/components/tickets/reply.jsx
@@ -11,9 +11,20 @@ export const Reply = ({ message }) => {
   const failedTime = moment(message.details.delivery_failed).format('YYYY/MM/DD h:mm a');
   const failed = `Failed on ${failedTime}`;
 
+  let subject;
+  if (message.details.subject) {
+    subject = (
+      <React.Fragment>
+        <h4 className=".message-subject">{ message.details.subject }</h4>
+        <hr />
+      </React.Fragment>
+    );
+  }
+
   return (
     <React.Fragment>
       <section className="module mb0 mt0">
+        {subject}
         <div className="plaintext" dangerouslySetInnerHTML={{ __html: linkifyHtml(message.content) }} />
       </section>
       <aside className="reply-details">

--- a/app/assets/javascripts/components/tickets/ticket_show.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_show.jsx
@@ -16,7 +16,7 @@ export const TicketShow = ({
 
   return (
     <main className="container ticket-dashboard">
-      <h1 className="mt4">Ticket from {ticket.sender.real_name || ticket.sender.username}</h1>
+      <h1 className="mt4">Ticket from {ticket.sender.real_name || ticket.sender.username || ticket.sender_email }</h1>
       <hr/>
       <section className="messages">
         {replies}

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -26,6 +26,11 @@ export class TicketsHandler extends React.Component {
         desktop_only: false,
         sortable: true
       },
+      subject: {
+        label: 'Subject',
+        desktop_only: false,
+        sortable: true
+      },
       course_title: {
         label: 'Course',
         desktop_only: false,

--- a/app/assets/javascripts/components/tickets/tickets_table_row.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_table_row.jsx
@@ -7,10 +7,13 @@ import TicketOwnerHandler from './ticket_owner_handler';
 const TicketsTableRow = ({ ticket }) => {
   return (
     <tr className={ticket.status === 0 ? 'table-row--faded' : ''}>
-      <td className="w15">
-        {ticket.sender.real_name || ticket.sender.username || 'Unknown User Record' }
+      <td className="w10">
+        {ticket.sender.real_name || ticket.sender.username || ticket.sender_email || 'Unknown User Record' }
       </td>
-      <td className="w30">
+      <td className="w15">
+        {ticket.subject}
+      </td>
+      <td className="w25">
         {
           ticket.project.id
           ? <Link to={`/courses/${ticket.project.slug}`}>{ ticket.project.title }</Link>

--- a/app/assets/stylesheets/modules/_ticket_dashboard.styl
+++ b/app/assets/stylesheets/modules/_ticket_dashboard.styl
@@ -5,6 +5,8 @@
     span(3/4)
     p
       margin-bottom 0
+    h4
+      color $text
   .sidebar
     padding 0 2rem
     span(1/4)

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -42,7 +42,9 @@ class AlertsController < ApplicationController
       content: @alert.message,
       project_id: @alert.course_id,
       owner_id: @alert.target_user_id,
-      sender_id: @alert.user_id
+      sender_id: @alert.user_id,
+      subject: 'Need Help Alert',
+      sender_email: @alert.user.email
     )
   end
 

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -9,15 +9,15 @@ class EmailProcessor
     recipient_emails = @email.to.pluck(:email)
     owner = User.find_by(greeter: true, email: recipient_emails)
 
-    email = @email.from[:email]
-    sender = User.find_by(email: email) if email
-    course = sender.courses.last if sender
+    @from_address = @email.from[:email]
+    @sender = User.find_by(email: @from_address) if @from_address
+    course = @sender.courses.last if @sender
 
     body, reference_id = parse_body_and_reference_id
     content = body
-    content += " #{from_signature(@email.from)}" if sender.blank?
+    content += " #{from_signature(@email.from)}" if @sender.blank?
 
-    dispense_or_thread_ticket(content, course, owner, reference_id, sender)
+    dispense_or_thread_ticket(content, course, owner, reference_id)
   end
 
   private
@@ -36,20 +36,24 @@ class EmailProcessor
     return [@email.body, reference_id]
   end
 
-  def dispense_or_thread_ticket(content, course, owner, reference_id, sender)
+  def dispense_or_thread_ticket(content, course, owner, reference_id)
     raise unless reference_id
 
     TicketDispenser::Dispenser.thread(
       content: content,
       reference_id: reference_id,
-      sender_id: sender.id
+      sender_id: @sender&.id,
+      sender_email: @from_address,
+      subject: @email.subject
     )
   rescue StandardError
     TicketDispenser::Dispenser.call(
       content: content,
       owner_id: owner&.id,
       project_id: course&.id,
-      sender_id: sender&.id
+      sender_id: @sender&.id,
+      subject: @email.subject,
+      sender_email: @from_address
     )
   end
 end


### PR DESCRIPTION
This adds extra info to the `details` field of Ticket messages, and uses that in the Ticket Dashboard interface

![ticket email, subject](https://user-images.githubusercontent.com/848483/56171010-98848480-5f98-11e9-91f7-b7101128975b.png)

![ticket show email, subject](https://user-images.githubusercontent.com/848483/56171015-9b7f7500-5f98-11e9-8045-35759dffd71d.png)
