### PR TITLE
Allow for forwarded emails to attempt to pull correct sender

### DIFF
--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -106,6 +106,9 @@
 # Default sender for emails
   SENDER_EMAIL_ADDRESS: 'test@example.com'
 
+# Email at which to receive forwarded ticket emails
+  TICKET_FORWARDING_EMAIL_ADDRESS: 'assign@dashboard.wikiedu.org'
+
 # Whitelisted test emails for staging and development
 # Except in production, the system will only send mail to these addresses.
   survey_test_email: 'developmer@yourdomain.me'

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -107,7 +107,7 @@
   SENDER_EMAIL_ADDRESS: 'test@example.com'
 
 # Email at which to receive forwarded ticket emails
-  TICKET_FORWARDING_EMAIL_ADDRESS: 'assign@dashboard.wikiedu.org'
+  TICKET_FORWARDING_DOMAIN: 'wikiedu.org'
 
 # Whitelisted test emails for staging and development
 # Except in production, the system will only send mail to these addresses.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,6 +27,7 @@ ENV['chat_server'] = 'https://dashboardchat.wmflabs.org'
 ENV['SF_SERVER'] = 'https://cs54.salesforce.com/'
 ENV['edit_en.wikipedia.org'] = 'true'
 ENV['dashboard_url'] = 'dashboard.wikiedu.org'
+ENV['TICKET_FORWARDING_DOMAIN'] = 'wikiedu.org'
 
 Rails.application.configure do
   # Settings specified here will take

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -3,24 +3,43 @@
 class EmailProcessor
   def initialize(email)
     @email = email
+    @content, @course, @from_address, @owner, @reference_id, @sender = nil
   end
 
   def process
-    recipient_emails = @email.to.pluck(:email)
-    @owner = User.find_by(greeter: true, email: recipient_emails)
-
-    @from_address = @email.from[:email]
-    @sender = User.find_by(email: @from_address) if @from_address
-    @course = @sender.courses.last if @sender
-
-    body, @reference_id = parse_body_and_reference_id
-    @content = body
-    @content += " #{from_signature(@email.from)}" if @sender.blank?
-
+    define_owner
+    define_sender
+    define_content_and_reference_id
     dispense_or_thread_ticket
   end
 
+  def email_addresses_from_email
+    raw_body = @email.raw_body
+    expression = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{0,63}\b/i
+    raw_body.scan(expression)
+  end
+
   private
+
+  def define_owner
+    recipient_emails = @email.to.pluck(:email)
+    @owner = User.find_by(greeter: true, email: recipient_emails)
+    @from_address = @email.from[:email]
+  end
+
+  def define_sender
+    recipient_emails = @email.cc ? @email.cc.pluck(:email) : []
+    if recipient_emails.include?(ENV['TICKET_FORWARDING_EMAIL_ADDRESS'])
+      addresses = email_addresses_from_email
+      @sender = User.find_by(greeter: false, email: addresses)
+    elsif @from_address
+      @sender = User.find_by(email: @from_address)
+    end
+  end
+
+  def define_course
+    @course = @sender.courses.last if @sender
+  end
 
   def from_signature(from)
     ''"
@@ -29,11 +48,10 @@ class EmailProcessor
     "''
   end
 
-  def parse_body_and_reference_id
+  def define_content_and_reference_id
+    @content = @email.body
     reference = @email.raw_body.match('ref_(.*)_ref')
-    reference_id = reference[1] if reference
-
-    return [@email.body, reference_id]
+    @reference_id = reference[1] if reference
   end
 
   def dispense_or_thread_ticket

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -15,8 +15,8 @@ class EmailProcessor
 
   def retrieve_forwarder_email
     raw_body = @email.raw_body
-    expression = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{0,63}\b/i
-    raw_body.scan(expression).first
+    expression = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
+    raw_body[expression]
   end
 
   private

--- a/spec/lib/email_processor_spec.rb
+++ b/spec/lib/email_processor_spec.rb
@@ -50,7 +50,6 @@ describe EmailProcessor do
 
       message = ticket.messages.first
       expect(message.sender).to eq(nil)
-      expect(message.content).to include('From other@email.com')
     end
 
     it 'does not set an owner if it is not addressed to a Wikipedia Expert' do
@@ -89,6 +88,44 @@ describe EmailProcessor do
       processor.process
 
       expect(ticket.messages.length).to eq(2)
+    end
+
+    it 'should assign forwarded emails to the original sender' do
+      student
+      body = <<~EXAMPLE
+        Example email test\r\n\r\n---------- Forwarded message ---------\r\nFrom:
+        Student <student@email.com>\r\nDate: Mon, Apr 8, 2019 at 3:42 PM\r\n
+        Subject: Help!\r\nTo: <staff@email.com>\r\n\r\n\r\nHelp message\r\n
+      EXAMPLE
+      email = create(:email,
+                     to: [{ email: expert.email }],
+                     cc: [{ email: ENV['TICKET_FORWARDING_EMAIL_ADDRESS'] }],
+                     from: { email: 'other@email.com' },
+                     raw_body: body)
+      processor = described_class.new(email)
+      processor.process
+
+      expect(TicketDispenser::Ticket.all.count).to eq(1)
+      expect(TicketDispenser::Message.all.count).to eq(1)
+
+      ticket = TicketDispenser::Ticket.first
+      message = TicketDispenser::Message.first
+      expect(ticket.owner).to eq(expert)
+      expect(message.sender).to eq(student)
+    end
+  end
+
+  describe '#email_addresses_from_email' do
+    it 'should return a list of all emails that appear in the email body' do
+      body = <<~EXAMPLE
+        Example email test\r\n\r\n---------- Forwarded message ---------\r\nFrom:
+        Person A <aaa@email.com>\r\nDate: Mon, Apr 8, 2019 at 3:42 PM\r\n
+        Subject: Help!\r\nTo: <bbb@email.com>\r\n\r\n\r\nHelp message\r\n
+      EXAMPLE
+      email = build(:email, raw_body: body)
+      expected_result = ['aaa@email.com', 'bbb@email.com']
+
+      expect(described_class.new(email).email_addresses_from_email).to match_array(expected_result)
     end
   end
 end

--- a/spec/lib/email_processor_spec.rb
+++ b/spec/lib/email_processor_spec.rb
@@ -97,10 +97,10 @@ describe EmailProcessor do
         Student <student@email.com>\r\nDate: Mon, Apr 8, 2019 at 3:42 PM\r\n
         Subject: Help!\r\nTo: <staff@email.com>\r\n\r\n\r\nHelp message\r\n
       EXAMPLE
+      domain = ENV['TICKET_FORWARDING_DOMAIN']
       email = create(:email,
                      to: [{ email: expert.email }],
-                     cc: [{ email: ENV['TICKET_FORWARDING_EMAIL_ADDRESS'] }],
-                     from: { email: 'other@email.com' },
+                     from: { email: "other-staff@#{domain}" },
                      raw_body: body)
       processor = described_class.new(email)
       processor.process
@@ -115,17 +115,17 @@ describe EmailProcessor do
     end
   end
 
-  describe '#email_addresses_from_email' do
-    it 'should return a list of all emails that appear in the email body' do
+  describe '#retrieve_forwarder_email' do
+    it 'should return the first email from a forwarded message' do
       body = <<~EXAMPLE
         Example email test\r\n\r\n---------- Forwarded message ---------\r\nFrom:
         Person A <aaa@email.com>\r\nDate: Mon, Apr 8, 2019 at 3:42 PM\r\n
         Subject: Help!\r\nTo: <bbb@email.com>\r\n\r\n\r\nHelp message\r\n
       EXAMPLE
       email = build(:email, raw_body: body)
-      expected_result = ['aaa@email.com', 'bbb@email.com']
+      expected_result = 'aaa@email.com'
 
-      expect(described_class.new(email).email_addresses_from_email).to match_array(expected_result)
+      expect(described_class.new(email).retrieve_forwarder_email).to eq(expected_result)
     end
   end
 end


### PR DESCRIPTION
If an email is sent and includes the specified forwarding email as a CC, attempt to search through the message to find the sender.