### PR TITLE
Minor changes to ticket response email

### DIFF
--- a/app/views/ticket_notification_mailer/notify.html.haml
+++ b/app/views/ticket_notification_mailer/notify.html.haml
@@ -1,7 +1,5 @@
 %link{rel: 'stylesheet', href:'/mailer.css'}
 .hidden
-  %p -- DO NOT DELETE ANYTHING BELOW THIS LINE --
-  %p= "ref_#{@ticket.reference_id}_ref"
   %p -- REPLY ABOVE THIS LINE --
 %table.row
   %tbody
@@ -32,3 +30,6 @@
                     %td.main-content.link-cell
                       %a.button_link.small{:href => @ticket_dashboard_link}
                         Go to Ticket Dashboard
+.hidden
+  %p -- DO NOT DELETE ANYTHING BELOW THIS LINE --
+  %p= "ref_#{@ticket.reference_id}_ref"

--- a/public/mailer.css
+++ b/public/mailer.css
@@ -112,5 +112,5 @@ a.training {
 
 .hidden p {
   color: white;
-  visibility: hidden;
+  font-size: 10px;
 }


### PR DESCRIPTION
Minor change to an email that goes out when an admin responds to a ticket. Removes the `visibility: hidden;` CSS in favor of just changing the text to white. Also reorients some of the hidden text.