### PR TITLE
Do not assign a sender with nil email accidentally

### DIFF
--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -30,7 +30,7 @@ class EmailProcessor
     @from_address = @email.from[:email]
     if @from_address.end_with?(ENV['TICKET_FORWARDING_DOMAIN'])
       addresses = retrieve_forwarder_email
-      @sender = User.find_by(greeter: false, email: addresses)
+      @sender = User.find_by(greeter: false, email: addresses) unless addresses.nil?
     elsif @from_address
       @sender = User.find_by(email: @from_address)
     end


### PR DESCRIPTION
In the event we can't find an email when searching for forwarded emails, don't assign a user.