### PR TITLE
Feature/ignore tickets with code

### DIFF
--- a/app/views/overdue_training_alert_mailer/email.html.haml
+++ b/app/views/overdue_training_alert_mailer/email.html.haml
@@ -41,4 +41,4 @@
                 to opt out.
 .hidden
   %p -- DO NOT DELETE ANYTHING BELOW THIS LINE --
-  %p= ENV['TICKET_IGNORE_CODE']
+  %p ignore_creating_dashboard_ticket

--- a/app/views/overdue_training_alert_mailer/email.html.haml
+++ b/app/views/overdue_training_alert_mailer/email.html.haml
@@ -39,3 +39,6 @@
                 If you don't want to receive any more training reminders,
                 %a{href: @alert.opt_out_link} click here
                 to opt out.
+.hidden
+  %p -- DO NOT DELETE ANYTHING BELOW THIS LINE --
+  %p= ENV['TICKET_IGNORE_CODE']

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -106,8 +106,11 @@
 # Default sender for emails
   SENDER_EMAIL_ADDRESS: 'test@example.com'
 
+# ==== Ticketing System Environment Variables
 # Email at which to receive forwarded ticket emails
   TICKET_FORWARDING_DOMAIN: 'wikiedu.org'
+# Code to include if emails should be ignored
+  TICKET_IGNORE_CODE: 'ticket_ignore_code'
 
 # Whitelisted test emails for staging and development
 # Except in production, the system will only send mail to these addresses.

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -109,8 +109,6 @@
 # ==== Ticketing System Environment Variables
 # Email at which to receive forwarded ticket emails
   TICKET_FORWARDING_DOMAIN: 'wikiedu.org'
-# Code to include if emails should be ignored
-  TICKET_IGNORE_CODE: 'ticket_ignore_code'
 
 # Whitelisted test emails for staging and development
 # Except in production, the system will only send mail to these addresses.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,6 @@ ENV['SF_SERVER'] = 'https://cs54.salesforce.com/'
 ENV['edit_en.wikipedia.org'] = 'true'
 ENV['dashboard_url'] = 'dashboard.wikiedu.org'
 ENV['TICKET_FORWARDING_DOMAIN'] = 'wikiedu.org'
-ENV['TICKET_IGNORE_CODE'] = 'ignore_code'
 
 Rails.application.configure do
   # Settings specified here will take

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,7 @@ ENV['SF_SERVER'] = 'https://cs54.salesforce.com/'
 ENV['edit_en.wikipedia.org'] = 'true'
 ENV['dashboard_url'] = 'dashboard.wikiedu.org'
 ENV['TICKET_FORWARDING_DOMAIN'] = 'wikiedu.org'
+ENV['TICKET_IGNORE_CODE'] = 'ignore_code'
 
 Rails.application.configure do
   # Settings specified here will take

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -7,6 +7,7 @@ class EmailProcessor
   end
 
   def process
+    return false if email_can_be_ignored?
     define_owner
     define_sender
     define_content_and_reference_id
@@ -20,6 +21,10 @@ class EmailProcessor
   end
 
   private
+
+  def email_can_be_ignored?
+    @email.body.include?(ENV['TICKET_IGNORE_CODE'])
+  end
 
   def define_owner
     recipient_emails = @email.to.pluck(:email)

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -23,7 +23,7 @@ class EmailProcessor
   private
 
   def email_can_be_ignored?
-    @email.body.include?(ENV['TICKET_IGNORE_CODE'])
+    @email.body.include?('ignore_creating_dashboard_ticket')
   end
 
   def define_owner

--- a/spec/lib/email_processor_spec.rb
+++ b/spec/lib/email_processor_spec.rb
@@ -17,7 +17,7 @@ describe EmailProcessor do
 
     it 'will ignore emails with the specified code' do
       body = <<~EXAMPLE
-        This is an automated email\r\n\r\n#{ENV['TICKET_IGNORE_CODE']}
+        This is an automated email\r\n\r\nignore_creating_dashboard_ticket
       EXAMPLE
       email = create(:email,
                      to: [{ email: expert.email }],

--- a/spec/lib/email_processor_spec.rb
+++ b/spec/lib/email_processor_spec.rb
@@ -15,6 +15,21 @@ describe EmailProcessor do
       create(:courses_user, user: expert, course: course, role: 4)
     end
 
+    it 'will ignore emails with the specified code' do
+      body = <<~EXAMPLE
+        This is an automated email\r\n\r\n#{ENV['TICKET_IGNORE_CODE']}
+      EXAMPLE
+      email = create(:email,
+                     to: [{ email: expert.email }],
+      from: { email: student.email },
+      body: body)
+      processor = described_class.new(email)
+      processor.process
+
+      expect(TicketDispenser::Ticket.all.count).to eq(0)
+      expect(TicketDispenser::Message.all.count).to eq(0)
+    end
+
     it 'creates an associated Ticket and Message' do
       expect(TicketDispenser::Ticket.all.count).to eq(0)
       expect(TicketDispenser::Message.all.count).to eq(0)


### PR DESCRIPTION
Skip over emails that include the `TICKET_IGNORE_CODE`. Only looks at `@email.body` which means only the most recent email should be affected.