### PR TITLE
Retrieve course by slug if unable to find at first

### DIFF
--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -32,7 +32,7 @@ class EmailProcessor
   def email_can_be_ignored?
     @email.body.include?('ignore_creating_dashboard_ticket')
   end
-  
+
   # This regex helps look for a course slug inside of text
   # (?<=\/courses\/) - Starts with `/courses/`
   # [^?\/\s] - Any non-whitespace character excluding a slash or question mark
@@ -58,11 +58,8 @@ class EmailProcessor
   end
 
   def define_course
-    @course = @sender.courses.last if @sender
-    if @course.nil?
-      slug = retrieve_course_slug_by_url
-      @course = Course.find_by(slug: slug) if slug
-    end
+    @course = Course.find_by(slug: retrieve_course_slug_by_url)
+    @course ||= @sender.courses.last if @sender
   end
 
   def from_signature(from)

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -35,7 +35,7 @@ class EmailProcessor
   
   # This regex helps look for a course slug inside of text
   # (?<=\/courses\/) - Starts with `/courses/`
-  # [^?\/\s] - Any non-whitespace character excluding a slash
+  # [^?\/\s] - Any non-whitespace character excluding a slash or question mark
   # \/ - A slash
   # [^?\/\s] - Any non-whitespace character excluding a slash
   def course_slug_pattern

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -37,7 +37,7 @@ class EmailProcessor
   # (?<=\/courses\/) - Starts with `/courses/`
   # [^?\/\s] - Any non-whitespace character excluding a slash or question mark
   # \/ - A slash
-  # [^?\/\s] - Any non-whitespace character excluding a slash
+  # [^?\/\s] - Any non-whitespace character excluding a slash or question mark
   def course_slug_pattern
     %r{(?<=/courses/)[^?/\s]+/[^?/\s]+}i
   end

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -10,6 +10,7 @@ class EmailProcessor
     return false if email_can_be_ignored?
     define_owner
     define_sender
+    define_course
     define_content_and_reference_id
     dispense_or_thread_ticket
   end
@@ -18,6 +19,13 @@ class EmailProcessor
     raw_body = @email.raw_body
     expression = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
     raw_body[expression]
+  end
+
+  def retrieve_course_slug_by_url
+    raw_body = @email.raw_body
+    expression = %r{/courses/.*/\S*}i
+    match = raw_body[expression]
+    match ? match.gsub('/courses/', '') : nil
   end
 
   private
@@ -43,6 +51,10 @@ class EmailProcessor
 
   def define_course
     @course = @sender.courses.last if @sender
+    if @course.nil?
+      slug = retrieve_course_slug_by_url
+      @course = Course.find_by(slug: slug) if slug
+    end
   end
 
   def from_signature(from)

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -23,15 +23,23 @@ class EmailProcessor
 
   def retrieve_course_slug_by_url
     raw_body = @email.raw_body
-    expression = %r{/courses/.*/\S*}i
-    match = raw_body[expression]
-    match ? match.gsub('/courses/', '') : nil
+    expression = course_slug_pattern
+    raw_body[expression]
   end
 
   private
 
   def email_can_be_ignored?
     @email.body.include?('ignore_creating_dashboard_ticket')
+  end
+  
+  # This regex helps look for a course slug inside of text
+  # (?<=\/courses\/) - Starts with `/courses/`
+  # [^?\/\s] - Any non-whitespace character excluding a slash
+  # \/ - A slash
+  # [^?\/\s] - Any non-whitespace character excluding a slash
+  def course_slug_pattern
+    %r{(?<=/courses/)[^?/\s]+/[^?/\s]+}i
   end
 
   def define_owner

--- a/spec/lib/email_processor_spec.rb
+++ b/spec/lib/email_processor_spec.rb
@@ -204,9 +204,19 @@ describe EmailProcessor do
   end
 
   describe '#retrieve_course_by_url' do
-    it 'should return the first slug from a message' do
+    it 'should return a course slug from a URL' do
       body = <<~EXAMPLE
         Example email test\r\n\r\nhttps://example.org/courses/example/slug
+      EXAMPLE
+      email = build(:email, raw_body: body)
+      expected_result = 'example/slug'
+
+      expect(described_class.new(email).retrieve_course_slug_by_url).to eq(expected_result)
+    end
+
+    it 'should return a course slug from a complex URL' do
+      body = <<~EXAMPLE
+        Example email test\r\n\r\nhttps://example.org/courses/example/slug/articles/edited?showArticle=1
       EXAMPLE
       email = build(:email, raw_body: body)
       expected_result = 'example/slug'


### PR DESCRIPTION
If we're unable to assign the ticket to a course, try searching through the email for a course slug.