### PR TITLE
Fallback to email in the event the original sender is not a user

### DIFF
--- a/app/assets/javascripts/components/tickets/reply.jsx
+++ b/app/assets/javascripts/components/tickets/reply.jsx
@@ -11,23 +11,25 @@ export const Reply = ({ message }) => {
   const failedTime = moment(message.details.delivery_failed).format('YYYY/MM/DD h:mm a');
   const failed = `Failed on ${failedTime}`;
 
+  const { sender, details } = message;
   let subject;
-  if (message.details.subject) {
+  if (details.subject) {
     subject = (
-      <h4>{ message.details.subject }</h4>
+      <h4>{ details.subject }</h4>
     );
   }
 
   let cc;
-  if (message.details.cc) {
+  if (details.cc) {
     cc = (
       <h6 className="cc">
         <span>CC: </span>
-        {message.details.cc.map(({ email }) => email)}
+        {details.cc.map(({ email }) => email)}
       </h6>
     );
   }
 
+  const from = sender.real_name || sender.username || details.sender_email;
   return (
     <React.Fragment>
       <section className="reply-header module mb0 mt0">
@@ -38,7 +40,7 @@ export const Reply = ({ message }) => {
       </section>
       <aside className="reply-details">
         <span>
-          <p>From: {message.sender.real_name || message.sender.username}</p>
+          <p>From: {from}</p>
         </span>
         <span>
           <p>Created: {moment(message.created_at).format('MMM DD, YYYY h:mm a')}</p>

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -10,10 +10,11 @@ class TicketsController < ApplicationController
 
   def notify
     message = TicketDispenser::Message.find(notification_params[:message_id])
-    sender = User.find(notification_params[:sender_id])
+    sender_email = message.details[:sender_email]
+    sender = User.find(notification_params[:sender_id]) || sender_email
     ticket = message.ticket
     course = ticket.project
-    recipient = ticket.reply_to
+    recipient = ticket.reply_to || User.new(email: sender_email)
 
     TicketNotificationMailer.notify_of_message(course, message, recipient, sender)
 

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -39,5 +39,12 @@ describe TicketsController, type: :request do
       post '/tickets/notify', params: { message_id: message.id, sender_id: admin.id }
       expect(response.status).to eq(200)
     end
+
+    it 'triggers an email reply even if there is no sender' do
+      message.update(sender: nil, details: { sender_email: user.email })
+      expect(TicketNotificationMailer).to receive(:notify_of_message).and_call_original
+      post '/tickets/notify', params: { message_id: message.id, sender_id: admin.id }
+      expect(response.status).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
If a recipient can't be found, fall back to using the sender email.