### PR TITLE
Ignore untrained student alert emails

### DIFF
--- a/app/views/untrained_students_alert_mailer/email.html.haml
+++ b/app/views/untrained_students_alert_mailer/email.html.haml
@@ -28,3 +28,6 @@
                 %br
                 %em
                   = @alert.from_user&.real_name || 'Wiki Ed'
+.hidden
+  %p -- DO NOT DELETE ANYTHING BELOW THIS LINE --
+  %p ignore_creating_dashboard_ticket


### PR DESCRIPTION
Ignore untrained student alert emails in the ticket dashboard.