### PR TITLE
Tests and refactoring for Tickets code

### DIFF
--- a/app/helpers/tickets_helper.rb
+++ b/app/helpers/tickets_helper.rb
@@ -6,12 +6,12 @@ module TicketsHelper
     message.sender&.real_name || message.sender&.username || message.details[:sender_email]
   end
 
-  def successful_replies_in_reverse(_ticket, recipient)
-    successful_messages = @ticket.messages.reject do |message|
+  def successful_replies_in_reverse(ticket, recipient)
+    successful_messages = ticket.messages.reject do |message|
       message.details[:delivered].nil? && message.details[:delivery_failed]
     end
 
-    reversed_messages = successful_messages.reverse[1..-1]
+    reversed_messages = successful_messages.reverse
 
     reversed_messages.select do |message|
       recipient.admin? || message.reply?

--- a/app/views/ticket_notification_mailer/notify.html.haml
+++ b/app/views/ticket_notification_mailer/notify.html.haml
@@ -13,7 +13,7 @@
                 \-
                 =@sender_name
 
-              - successful_replies_in_reverse(@ticket, @recipient).each do |message|
+              - successful_replies_in_reverse(@ticket, @recipient)[1..-1].each do |message|
                 %div.blockquote
                   %p.sender= sender_for_message(message)
                   %p.date= message.created_at.in_time_zone('US/Pacific').strftime('%b %e, %l:%M %p %Z')

--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -62,13 +62,6 @@ class EmailProcessor
     @course ||= @sender.courses.last if @sender
   end
 
-  def from_signature(from)
-    ''"
-
-    From #{from[:full]}
-    "''
-  end
-
   def define_content_and_reference_id
     @content = @email.body
     reference = @email.raw_body.match('ref_(.*)_ref')

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -13,10 +13,14 @@ describe TicketsController, type: :request do
       sender_id: user.id
     )
   end
-  let(:message) { ticket.messages.first }
+  let(:message) { ticket.messages.last }
 
   before do
     login_as admin
+    TicketDispenser::Message.create(ticket: ticket, kind: TicketDispenser::Message::Kinds::NOTE,
+      content: 'this is a note')
+    TicketDispenser::Message.create(ticket: ticket, kind: TicketDispenser::Message::Kinds::REPLY,
+      content: 'this is a reply')
   end
 
   describe '#dashboard' do
@@ -40,6 +44,15 @@ describe TicketsController, type: :request do
       expect(response.status).to eq(200)
     end
 
+    it 'includes replies and excludes notes' do
+      expect(TicketNotificationMailer).to receive(:notify_of_message).and_call_original
+      post '/tickets/reply', params: { message_id: message.id, sender_id: admin.id }
+
+      delivery = ActionMailer::Base.deliveries.first
+      expect(delivery.text_part.body).not_to include('this is a note')
+      expect(delivery.text_part.body).to include('this is a reply')
+    end
+
     it 'triggers an email reply even if there is no sender' do
       message.update(sender: nil, details: { sender_email: user.email })
       expect(TicketNotificationMailer).to receive(:notify_of_message).and_call_original
@@ -49,17 +62,25 @@ describe TicketsController, type: :request do
   end
 
   describe '#notify_owner' do
-    it 'triggers an email reply' do
-      new_owner = create(:admin, username: 'otheradmin', email: 'otheradmin@email.com')
-      ticket.update(owner: new_owner)
+    let(:recipient) { create(:admin, username: 'otheradmin', email: 'otheradmin@email.com') }
+    let(:message) do
+      TicketDispenser::Message.create(ticket: ticket, kind: TicketDispenser::Message::Kinds::NOTE,
+                                      content: 'this is a note')
+    end
+
+    it 'includes notes and replies' do
+      ticket.update(owner: recipient)
+
       expect(TicketNotificationMailer).to receive(:notify_of_message).and_call_original
       params = { message_id: message.id, sender_id: admin.id }
       post '/tickets/notify_owner', params: params
       expect(response.status).to eq(200)
 
       delivery = ActionMailer::Base.deliveries.first
-      expect(delivery.to).to include(new_owner.email)
+      expect(delivery.to).to include(recipient.email)
       expect(delivery.from).to include(admin.email)
+      expect(delivery.html_part.body).to include('this is a note')
+      expect(delivery.text_part.body).to include('this is a reply')
     end
   end
 end

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -59,6 +59,16 @@ describe TicketsController, type: :request do
       post '/tickets/reply', params: { message_id: message.id, sender_id: admin.id }
       expect(response.status).to eq(200)
     end
+
+    it 'updates the message record when email delivery fails' do
+      allow(TicketNotificationMailer).to receive(:notify_of_message).and_raise('failed')
+
+      expect do
+        post '/tickets/reply', params: { message_id: message.id, sender_id: admin.id }
+      end.to raise_error('failed')
+
+      expect(message.reload.details[:delivery_failed]).not_to be_nil
+    end
   end
 
   describe '#notify_owner' do

--- a/spec/lib/email_processor_spec.rb
+++ b/spec/lib/email_processor_spec.rb
@@ -197,6 +197,7 @@ describe EmailProcessor do
         message = TicketDispenser::Message.first
         expect(ticket.owner).to eq(expert)
         expect(message.details[:sender_email]).to eq('jprof@edu.edu')
+        expect(message.content).to include('What went wrong with these pages?')
       end
     end
 


### PR DESCRIPTION
This adds coverage for the bits of the backend Tickets code that were not exercised in tests yet.

It removes the `EmailProcessor#from_signature` method, which appears not to have been used anywhere.

It turns `successful_replies_in_reverse` into a pure function, and moves the responsibility of excluding the first message over to the `notify.haml.html` email template.