### PR TITLE
Make multiple requests to load tickets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/WikiEducationFoundation/TicketDispenser.git
-  revision: eb2335793b1c5af7ab816f416f64973420e97726
+  revision: 14fd2d65c30243433966122412fcac3f04157991
   specs:
     ticket_dispenser (0.1.0)
       active_model_serializers

--- a/app/assets/javascripts/components/tickets/pagination.jsx
+++ b/app/assets/javascripts/components/tickets/pagination.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default ({ currentPage, goToPage, length }) => {
+  const pages = Array.from({ length }).map((_el, i) => {
+    const className = currentPage === i ? 'selected' : null;
+    return (
+      <li key={i}>
+        <button
+          className={className}
+          onClick={() => goToPage(i)}
+        >
+          {i + 1}
+        </button>
+      </li>
+    );
+  });
+
+  return (
+    <ul className="tickets-pagination">
+      { pages }
+    </ul>
+  );
+};

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -67,10 +67,10 @@ export class TicketsHandler extends React.Component {
 
     const TICKETS_PER_PAGE = 10;
 
+    const pagesLength = Math.floor((this.props.filteredTickets.length - 1) / TICKETS_PER_PAGE) + 1;
     const elements = this.props.filteredTickets.map(ticket => (
       <Row key={ticket.id} ticket={ticket} />
-    )).slice(this.state.page, this.state.page + TICKETS_PER_PAGE);
-    const pagesLength = Math.floor(elements.length / TICKETS_PER_PAGE) + 1;
+    )).slice(this.state.page * TICKETS_PER_PAGE, this.state.page * TICKETS_PER_PAGE + TICKETS_PER_PAGE);
 
     // Since this is used multiple places (student_list.jsx), we should
     // refactor this a bit.

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Row from './tickets_table_row';
+import Pagination from './pagination';
 import Loading from '../common/loading';
 import List from '../common/list.jsx';
 import TicketOwnersFilter from './ticket_owners_filter';
@@ -10,11 +11,22 @@ import { fetchTickets, sortTickets, setInitialTicketFilters } from '../../action
 import { getFilteredTickets } from '../../selectors';
 
 export class TicketsHandler extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      page: 0
+    };
+  }
+
   componentDidMount() {
     if (!this.props.tickets.all.length) {
       this.props.fetchTickets();
       this.props.setInitialTicketFilters();
     }
+  }
+
+  goToPage(page) {
+    this.setState({ page });
   }
 
   render() {
@@ -53,9 +65,12 @@ export class TicketsHandler extends React.Component {
       }
     };
 
+    const TICKETS_PER_PAGE = 10;
+
     const elements = this.props.filteredTickets.map(ticket => (
       <Row key={ticket.id} ticket={ticket} />
-    ));
+    )).slice(this.state.page, this.state.page + TICKETS_PER_PAGE);
+    const pagesLength = Math.floor(elements.length / TICKETS_PER_PAGE) + 1;
 
     // Since this is used multiple places (student_list.jsx), we should
     // refactor this a bit.
@@ -81,6 +96,11 @@ export class TicketsHandler extends React.Component {
           sortBy={this.props.sortTickets}
           sortable={true}
           table_key="tickets"
+        />
+        <Pagination
+          currentPage={this.state.page}
+          goToPage={this.goToPage.bind(this)}
+          length={pagesLength}
         />
       </main>
     );

--- a/app/assets/javascripts/reducers/tickets.js
+++ b/app/assets/javascripts/reducers/tickets.js
@@ -63,7 +63,7 @@ export default function (state = initialState, action) {
       };
     }
     case FETCH_TICKETS:
-      return { ...state, loading: true };
+      return { ...state, all: [], loading: true };
     case FILTER_TICKETS: {
       const newFilters = { ...state.filters, ...action.filters };
       return { ...state, filters: newFilters };
@@ -71,7 +71,7 @@ export default function (state = initialState, action) {
     case RECEIVE_TICKETS: {
       return {
         ...state,
-        all: action.data,
+        all: state.all.concat(action.data),
         loading: false
       };
     }

--- a/app/assets/stylesheets/modules/_ticket_dashboard.styl
+++ b/app/assets/stylesheets/modules/_ticket_dashboard.styl
@@ -91,3 +91,16 @@
       background lighten(blue-violet, 10)
       border-color blue-violet
       color white
+  .tickets-pagination
+    margin 1rem 0
+    text-align center
+    li
+      color blue-violet
+      display inline-block
+      font-weight bold
+      margin-left 7px
+      button
+        padding 3px
+        &.selected
+          color dove
+          border-bottom 2px solid dove

--- a/test/actions/tickets_actions.spec.js
+++ b/test/actions/tickets_actions.spec.js
@@ -1,0 +1,14 @@
+import '../testHelper';
+import moment from 'moment';
+import { dateSegments } from '../../app/assets/javascripts/actions/tickets_actions';
+
+describe('Ticket Actions', () => {
+  describe('#dateSegments', () => {
+    it('creates four dates evenly spaced apart', () => {
+      const date = moment('06-30-2000', 'MM-DD-YYYY');
+      const actual = dateSegments(date);
+      const expected = ['06-30-2000', '06-15-2000', '05-31-2000', '05-16-2000'];
+      expect(actual).to.deep.eq(expected);
+    });
+  });
+});

--- a/test/actions/tickets_actions.spec.js
+++ b/test/actions/tickets_actions.spec.js
@@ -7,7 +7,7 @@ describe('Ticket Actions', () => {
     it('creates four dates evenly spaced apart', () => {
       const date = moment('06-30-2000', 'MM-DD-YYYY');
       const actual = dateSegments(date);
-      const expected = ['06-30-2000', '06-15-2000', '05-31-2000', '05-16-2000'];
+      const expected = ['2000-06-30', '2000-06-15', '2000-05-31', '2000-05-16', '2000-05-01'];
       expect(actual).to.deep.eq(expected);
     });
   });


### PR DESCRIPTION
This PR separates a single call to the API for all tickets to segmented calls to the API. In total, four calls are made for tickets within 15 days of each other each.

This PR includes pagination.

![pagination](https://user-images.githubusercontent.com/1316902/57031828-94de3800-6bfd-11e9-9b99-1fe6f67db29e.gif)

This PR will need [this PR from TicketDispenser](https://github.com/WikiEducationFoundation/TicketDispenser/pull/7) to work correctly.