### PR TITLE
Better handling of plagiarism emails for Scholars & Scientists

### DIFF
--- a/spec/mailers/suspected_plagiarism_mailer_spec.rb
+++ b/spec/mailers/suspected_plagiarism_mailer_spec.rb
@@ -17,6 +17,7 @@ describe SuspectedPlagiarismMailer do
                           role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     create(:courses_user, course_id: course.id, user_id: content_expert.id,
                           role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+    SpecialUsers.set_user('wikipedia_experts', content_expert.username)
   end
 
   let(:article) { create(:article) }


### PR DESCRIPTION
Bug fix for when instructor and Wikipedia Expert are both staff and both have greeter: true. Also adds support for multiple Wikipedia Experts in the same course.