### PR TITLE
Add alerts for edits to Good or Featured articles

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -42,6 +42,7 @@ class Alert < ApplicationRecord
     DYKNominationAlert
     FirstEnrolledStudentAlert
     GANominationAlert
+    HighQualityArticleEditAlert
     NeedHelpAlert
     NoEnrolledStudentsAlert
     OnboardingAlert
@@ -59,6 +60,7 @@ class Alert < ApplicationRecord
     DiscretionarySanctionsEditAlert
     DYKNominationAlert
     GANominationAlert
+    HighQualityArticleEditAlert
   ].freeze
 
   PUBLIC_ALERT_TYPES = %w[
@@ -71,6 +73,7 @@ class Alert < ApplicationRecord
     DiscretionarySanctionsEditAlert
     DYKNominationAlert
     GANominationAlert
+    HighQualityArticleEditAlert
     NoEnrolledStudentsAlert
     ProductiveCourseAlert
     UnsubmittedCourseAlert

--- a/app/models/alert_types/high_quality_article_edit_alert.rb
+++ b/app/models/alert_types/high_quality_article_edit_alert.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id             :integer          not null, primary key
+#  course_id      :integer
+#  user_id        :integer
+#  article_id     :integer
+#  revision_id    :integer
+#  type           :string(255)
+#  email_sent_at  :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  message        :text(65535)
+#  target_user_id :integer
+#  subject_id     :integer
+#  resolved       :boolean          default(FALSE)
+#  details        :text(65535)
+#
+
+# Alert for when Good or Featured on Wikipedia has been edited
+class HighQualityArticleEditAlert < Alert
+  def main_subject
+    "#{article.title} — #{course&.slug}"
+  end
+
+  def url
+    article.url
+  end
+
+  def resolvable?
+    !resolved
+  end
+
+  def resolve_explanation
+    <<~EXPLANATION
+      Resolve this alert if you want to be alerted again for future edits to
+      the article. The Dashboard will issue a new alert only if there edits to
+      this article that happen after the resolved alert was generated.
+    EXPLANATION
+  end
+end

--- a/lib/alerts/high_quality_article_monitor.rb
+++ b/lib/alerts/high_quality_article_monitor.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/importers/category_importer"
+
+# This class identifies articles that are Good or Features
+# templates, and generates alerts for the articles that have been edited by
+# Dashboard participants.
+class HighQualityArticleMonitor
+  def self.create_alerts_for_course_articles
+    new.create_alerts_from_page_titles
+  end
+
+  def initialize
+    @wiki = Wiki.find_by(language: 'en', project: 'wikipedia')
+    find_good_and_featured_articles
+    normalize_titles
+  end
+
+  def create_alerts_from_page_titles
+    course_articles = ArticlesCourses.joins(:article)
+                                     .where(articles: { title: @page_titles, wiki_id: @wiki.id })
+    course_articles.each do |articles_course|
+      create_alert(articles_course)
+    end
+  end
+
+  private
+
+  FA_CATEGORY = 'Category:Featured articles'
+  GA_CATEGORY = 'Category:Good articles'
+  def find_good_and_featured_articles
+    @fa_titles = CategoryImporter.new(@wiki).page_titles_for_category(FA_CATEGORY)
+    @ga_titles = CategoryImporter.new(@wiki).page_titles_for_category(GA_CATEGORY)
+  end
+
+  def normalize_titles
+    @page_titles = (@fa_titles + @ga_titles).map do |title|
+      next if title.blank?
+      title.tr(' ', '_')
+    end
+    @page_titles.compact!
+    @page_titles.uniq!
+  end
+
+  def create_alert(articles_course)
+    return if unresolved_alert_already_exists?(articles_course)
+    revisions = articles_course.course.revisions.where(article_id: articles_course.article_id)
+    last_revision = revisions.last
+    return if resolved_alert_covers_latest_revision?(articles_course, last_revision)
+    first_revision = revisions.first
+    alert = Alert.create!(type: 'HighQualityArticleEditAlert',
+                          article_id: articles_course.article_id,
+                          user_id: first_revision&.user_id,
+                          course_id: articles_course.course_id,
+                          revision_id: first_revision&.id)
+    alert.email_content_expert
+  end
+
+  def unresolved_alert_already_exists?(articles_course)
+    HighQualityArticleEditAlert.exists?(article_id: articles_course.article_id,
+                                        course_id: articles_course.course_id,
+                                        resolved: false)
+  end
+
+  def resolved_alert_covers_latest_revision?(articles_course, last_revision)
+    return false if last_revision.nil?
+    last_resolved = HighQualityArticleEditAlert.where(article_id: articles_course.article_id,
+                                                      course_id: articles_course.course_id,
+                                                      resolved: true).last
+    return false unless last_resolved.present?
+    last_resolved.created_at > last_revision.date
+  end
+end

--- a/lib/data_cycle/update_cycle_alert_generator.rb
+++ b/lib/data_cycle/update_cycle_alert_generator.rb
@@ -6,6 +6,7 @@ require_dependency "#{Rails.root}/lib/alerts/ga_nomination_monitor"
 require_dependency "#{Rails.root}/lib/alerts/course_alert_manager"
 require_dependency "#{Rails.root}/lib/alerts/survey_response_alert_manager"
 require_dependency "#{Rails.root}/lib/alerts/discretionary_sanctions_monitor"
+require_dependency "#{Rails.root}/lib/alerts/high_quality_article_monitor"
 require_dependency "#{Rails.root}/lib/alerts/blocked_user_monitor"
 
 module UpdateCycleAlertGenerator
@@ -19,8 +20,11 @@ module UpdateCycleAlertGenerator
     log_message 'Generating DYK alerts'
     DYKNominationMonitor.create_alerts_for_course_articles
 
-    log_message 'Generating Good Article alerts'
+    log_message 'Generating Good Article nominationalerts'
     GANominationMonitor.create_alerts_for_course_articles
+
+    log_message 'Generating GA and FA edit alerts'
+    HighQualityArticleMonitor.create_alerts_for_course_articles
 
     log_message 'Generating course alerts'
     CourseAlertManager.generate_course_alerts

--- a/spec/lib/alerts/high_quality_article_monitor_spec.rb
+++ b/spec/lib/alerts/high_quality_article_monitor_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/alerts/high_quality_article_monitor"
+
+def mock_mailer
+  OpenStruct.new(deliver_now: true)
+end
+
+describe HighQualityArticleMonitor do
+  describe '.create_alerts_for_course_articles' do
+    let(:course) { create(:course) }
+    let(:student) { create(:user, username: 'student') }
+    let!(:courses_user) do
+      create(:courses_user, user_id: student.id,
+                            course_id: course.id,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
+    let(:content_expert) { create(:user, greeter: true) }
+
+    # Good article that hasn't been edited by students
+    let!(:article2) { create(:article, title: 'History_of_aspirin', namespace: 0) }
+
+    # Featured article edited by student
+    let(:article) { create(:article, title: 'Phan_Đình_Phùng', namespace: 0) }
+    let!(:revision) do
+      create(:revision, article_id: article.id,
+                        user_id: student.id,
+                        date: course.start + 1.day)
+    end
+    let!(:articles_course) do
+      create(:articles_course, article_id: article.id,
+                               course_id: course.id)
+    end
+
+    before do
+      allow_any_instance_of(CategoryImporter).to receive(:page_titles_for_category)
+        .with('Category:Good articles')
+        .and_return(['10 Hygiea',
+                     'History of aspirin',
+                     'Goshin'])
+      allow_any_instance_of(CategoryImporter).to receive(:page_titles_for_category)
+        .with('Category:Featured articles')
+        .and_return(["Petter's big-footed mouse",
+                     'Phan Đình Phùng',
+                     'The Phantom Tollbooth'])
+    end
+
+    it 'creates Alert records for edited Good articles' do
+      VCR.use_cassette 'high_quality' do
+        described_class.create_alerts_for_course_articles
+      end
+      expect(HighQualityArticleEditAlert.count).to eq(1)
+      alerted_article_ids = HighQualityArticleEditAlert.all.pluck(:article_id)
+      expect(alerted_article_ids).to include(article.id)
+    end
+
+    it 'emails a greeter' do
+      create(:courses_user, user_id: content_expert.id, course_id: course.id, role: 4)
+      allow_any_instance_of(AlertMailer).to receive(:alert).and_return(mock_mailer)
+      VCR.use_cassette 'high_quality' do
+        described_class.create_alerts_for_course_articles
+      end
+      expect(Alert.last.email_sent_at).not_to be_nil
+    end
+
+    it 'does not create a second Alert for the same articles, if the first is not resolved' do
+      Alert.create(type: 'HighQualityArticleEditAlert',
+                   article_id: article.id, course_id: course.id)
+      expect(HighQualityArticleEditAlert.count).to eq(1)
+      VCR.use_cassette 'high_quality' do
+        described_class.create_alerts_for_course_articles
+      end
+      expect(HighQualityArticleEditAlert.count).to eq(1)
+    end
+
+    it 'does not create second Alert if the first alert is resolved but there are no new edits' do
+      Alert.create(type: 'HighQualityArticleEditAlert', article_id: article.id,
+                   course_id: course.id, resolved: true, created_at: revision.date + 1.hour)
+      expect(Alert.count).to eq(1)
+      VCR.use_cassette 'high_quality' do
+        described_class.create_alerts_for_course_articles
+      end
+      expect(Alert.count).to eq(1)
+    end
+
+    it 'does create second Alert if the first alert is resolved and there are later edits' do
+      Alert.create(type: 'HighQualityArticleEditAlert', article_id: article.id,
+                   course_id: course.id, resolved: true, created_at: revision.date - 1.hour)
+      expect(Alert.count).to eq(1)
+      VCR.use_cassette 'high_quality' do
+        described_class.create_alerts_for_course_articles
+      end
+      expect(Alert.count).to eq(2)
+    end
+  end
+end

--- a/spec/lib/data_cycle/constant_update_spec.rb
+++ b/spec/lib/data_cycle/constant_update_spec.rb
@@ -17,6 +17,7 @@ describe ConstantUpdate do
       expect(StudentGreetingChecker).to receive(:check_all_ungreeted_students)
       expect(ArticlesForDeletionMonitor).to receive(:create_alerts_for_course_articles)
       expect(DiscretionarySanctionsMonitor).to receive(:create_alerts_for_course_articles)
+      expect(HighQualityArticleMonitor).to receive(:create_alerts_for_course_articles)
       expect(DYKNominationMonitor).to receive(:create_alerts_for_course_articles)
       expect(GANominationMonitor).to receive(:create_alerts_for_course_articles)
       expect(BlockedUserMonitor).to receive(:create_alerts_for_recently_blocked_users)


### PR DESCRIPTION
Add alerts for whenever students edit Good or Featured articles, using the same strategy as DiscretionarySanctionsMonitor. All Good and Featured articles are in the respective category, although there are about 30,000 GAs and over 5,000 FAs.

Using CategoryImporter for these large categories makes it take ~30 seconds, so it will lengthen the `ConstantUpdate` cycle by that much.

These particular alerts share a lot of logic with the discretionary sanctions ones in particular and with plenty of similarity to several other alert monitors, but there are just enough differences among these monitors that I don't think it quite makes sense to refactor out the common logic. They also have a good track record of not requiring any changes, and would be as likely as not to move in different directions if they did change, so I think this duplication is an okay strategy here.