### PR TITLE
Resources tab

### DIFF
--- a/app/assets/javascripts/components/app.jsx
+++ b/app/assets/javascripts/components/app.jsx
@@ -16,7 +16,7 @@ import Nav from './nav/nav.jsx';
 // `nav_root` is present throughout the app, via the Rails view layouts.
 const navBar = document.getElementById('nav_root');
 if (navBar) {
-  ReactDOM.render((<Nav />), navBar);
+  ReactDOM.render((<Nav history={history} />), navBar);
 }
 
 // The main `react_root` is only present in some Rails views, corresponding

--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -48,6 +48,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
   const articlesLink = `${courseLink}/articles`;
   const uploadsLink = `${courseLink}/uploads`;
   const activityLink = `${courseLink}/activity`;
+  const resourcesLink = `${courseLink}/resources`;
 
   // ////////////
   // Chat link //
@@ -93,6 +94,9 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
         </div>
         <div className="nav__item" id="activity-link">
           <p><NavLink to={activityLink} activeClassName="active">{I18n.t('activity.label')}</NavLink></p>
+        </div>
+        <div className="nav__item" id="resources-link">
+          <p><NavLink to={resourcesLink} activeClassName="active">{I18n.t('resources.label')}</NavLink></p>
         </div>
         {chatNav}
         {getHelp}

--- a/app/assets/javascripts/components/course/course.jsx
+++ b/app/assets/javascripts/components/course/course.jsx
@@ -12,6 +12,7 @@ import RevisionsHandler from '../revisions/revisions_handler.jsx';
 import StudentsHandler from '../students/students_handler.jsx';
 import ArticlesHandler from '../articles/articles_handler.jsx';
 import UploadsHandler from '../uploads/uploads_handler.jsx';
+import Resources from '../resources/resources.jsx';
 import RocketChat from '../common/rocket_chat.jsx';
 import ArticleFinder from '../article_finder/article_finder.jsx';
 
@@ -139,6 +140,7 @@ export const Course = createReactClass({
             <Route exact path="/courses/:course_school/:course_title/chat" render={() => <RocketChat {...courseProps} />} />
             <Route exact path="/courses/:course_school/:course_title/article_finder" render={() => <ArticleFinder {...courseProps} />} />
             <Route path="/courses/:course_school/:course_title/timeline" render={() => <TimelineHandler {...courseProps} />} />
+            <Route path="/courses/:course_school/:course_title/resources" render={() => <Resources {...courseProps} />} />
           </Switch>
         </div>
       </div>

--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -143,6 +143,8 @@ const Nav = createReactClass({
           <CustomLink to={this.state.exploreUrl} name={this.state.exploreName} clickedElement="explore" />
         </li>
       );
+    }
+    if (!this.isCoursePage() || !Features.wikiEd) {
       training = (
         <li>
           <CustomLink to={this.state.trainingUrl} name={I18n.t('application.training')} clickedElement="training" />

--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -68,9 +68,14 @@ const Nav = createReactClass({
     event.preventDefault();
   },
 
+  isCoursePage() {
+    return !!this.props.history.location.pathname.match(/courses/);
+  },
+
   render() {
     let navBar;
     let navClass;
+    let explore;
     let myDashboard;
     let forAdmin;
     let notifications;
@@ -128,6 +133,13 @@ const Nav = createReactClass({
               &nbsp;{I18n.t('application.sign_up_log_in_extended')}
             </span>
           </a>
+        </li>
+      );
+    }
+    if (!this.isCoursePage()) {
+      explore = (
+        <li>
+          <CustomLink to={this.state.exploreUrl} name={this.state.exploreName} clickedElement="explore" />
         </li>
       );
     }
@@ -209,9 +221,7 @@ const Nav = createReactClass({
                 </a>
               </div>
               <ul className="top-nav__main-links">
-                <li>
-                  <CustomLink to={this.state.exploreUrl} name={this.state.exploreName} clickedElement="explore" />
-                </li>
+                {explore}
                 {myDashboard}
                 {forAdmin}
                 <li>

--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -78,6 +78,7 @@ const Nav = createReactClass({
     let explore;
     let myDashboard;
     let forAdmin;
+    let training;
     let notifications;
     let help;
     let Sandbox;
@@ -140,6 +141,11 @@ const Nav = createReactClass({
       explore = (
         <li>
           <CustomLink to={this.state.exploreUrl} name={this.state.exploreName} clickedElement="explore" />
+        </li>
+      );
+      training = (
+        <li>
+          <CustomLink to={this.state.trainingUrl} name={I18n.t('application.training')} clickedElement="training" />
         </li>
       );
     }
@@ -224,9 +230,7 @@ const Nav = createReactClass({
                 {explore}
                 {myDashboard}
                 {forAdmin}
-                <li>
-                  <CustomLink to={this.state.trainingUrl} name={I18n.t('application.training')} clickedElement="training" />
-                </li>
+                {training}
                 {Sandbox}
                 {help}
                 {wikiEd}

--- a/app/assets/javascripts/components/resources/handouts.jsx
+++ b/app/assets/javascripts/components/resources/handouts.jsx
@@ -7,13 +7,16 @@ const handouts = [
   { name: 'Illustrating Wikipedia', link: 'https://wikiedu.org/illustratingwikipedia' }
 ];
 
+const HANDOUTS_BLOCK_KIND = 4;
+
+
 const Handouts = ({ blocks, trainingLibrarySlug }) => {
   let topicGuides;
-  const topicGuidesBlock = blocks.find(block => block.title.match(/writing articles in your topic area/));
-  if (topicGuidesBlock) {
+  const topicGuidesBlocks = blocks.filter(block => block.kind === HANDOUTS_BLOCK_KIND);
+  if (topicGuidesBlocks) {
     topicGuides = (
       <>
-        <Block block={topicGuidesBlock} trainingLibrarySlug={trainingLibrarySlug} />
+        {topicGuidesBlocks.map(block => <Block key={block.id} block={block} trainingLibrarySlug={trainingLibrarySlug} />)}
         <a href="https://wikiedu.org/for-instructors/#subject-specific" className="button pull-right" target="_blank">Additional subject-specific guides</a>
       </>
     );

--- a/app/assets/javascripts/components/resources/handouts.jsx
+++ b/app/assets/javascripts/components/resources/handouts.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Block from '../timeline/block';
+
+const handouts = [
+  { name: 'Editing Wikipedia', link: 'https://wikiedu.org/editingwikipedia' },
+  { name: 'Evaluating Wikipedia', link: 'https://wikiedu.org/evaluatingwikipedia' },
+  { name: 'Illustrating Wikipedia', link: 'https://wikiedu.org/illustratingwikipedia' }
+];
+
+const Handouts = ({ blocks, trainingLibrarySlug }) => {
+  if (!Features.wikiEd) { return; }
+
+  let topicGuides;
+  const topicGuidesBlock = blocks.find(block => block.title.match(/writing articles in your topic area/));
+  if (topicGuidesBlock) {
+    topicGuides = (
+      <>
+        <Block block={topicGuidesBlock} trainingLibrarySlug={trainingLibrarySlug} />
+        <a href="https://wikiedu.org/for-instructors/#subject-specific" className="button pull-right" target="_blank">Additional subject-specific guides</a>
+      </>
+    );
+  }
+
+  const links = handouts.map((handout) => {
+    return (
+      <a key={handout.link} className="handout-link ml1" href={handout.link}>{handout.name}</a>
+    );
+  });
+
+  return (
+    <div id="handouts" className="list-unstyled container block__training-modules">
+      <h4>Handouts (PDF)</h4>
+      <li className="block">
+        <h3 className="block-title">General guides</h3>
+        {links}
+      </li>
+      {topicGuides}
+    </div>
+  );
+};
+
+export default Handouts;

--- a/app/assets/javascripts/components/resources/handouts.jsx
+++ b/app/assets/javascripts/components/resources/handouts.jsx
@@ -8,8 +8,6 @@ const handouts = [
 ];
 
 const Handouts = ({ blocks, trainingLibrarySlug }) => {
-  if (!Features.wikiEd) { return; }
-
   let topicGuides;
   const topicGuidesBlock = blocks.find(block => block.title.match(/writing articles in your topic area/));
   if (topicGuidesBlock) {

--- a/app/assets/javascripts/components/resources/resources.jsx
+++ b/app/assets/javascripts/components/resources/resources.jsx
@@ -1,0 +1,47 @@
+
+import React from 'react';
+import { connect } from 'react-redux';
+import _ from 'lodash';
+
+import CourseLink from '../common/course_link.jsx';
+import { getWeeksArray } from '../../selectors';
+
+
+const Resources = ({ weeks }) => {
+  const blocks = _.flatten(weeks.map(week => week.blocks));
+  const modules = _.flatten(blocks.map(block => block.training_modules));
+  const trainings = modules.map((module) => {
+    if (!module) { return; }
+    return (
+      <li key={`training-link-${module.id}`}><CourseLink to={`/training/students/${module.slug}`}>{module.name}</CourseLink></li>
+    );
+  });
+  return (
+    <div id="resources">
+      <div className="section-header">
+        <h3>{I18n.t('resources.header')}</h3>
+        <div id="training-modules">
+          <h4>Assigned training modules</h4>
+          <ul>
+            {trainings}
+          </ul>
+          <CourseLink to={'/training'} className="button dark">All student training modules</CourseLink>
+        </div>
+        <hr />
+        <div id="handouts">
+          <h4>Handouts</h4>
+          <ul>
+            {/* <li><CourseLink to={wizardUrl} className="button dark">Instructor orientation modules</CourseLink></li>
+            <li><CourseLink to={wizardUrl} className="button dark">Student training modules</CourseLink></li> */}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const mapStateToProps = state => ({
+  weeks: getWeeksArray(state)
+});
+
+export default connect(mapStateToProps)(Resources);

--- a/app/assets/javascripts/components/resources/resources.jsx
+++ b/app/assets/javascripts/components/resources/resources.jsx
@@ -9,6 +9,8 @@ import Block from '../timeline/block';
 import TrainingModules from '../timeline/training_modules';
 import Handouts from './handouts';
 
+const flattenAndCompact = _.flow([_.flatten, _.compact]);
+
 const Resources = ({ weeks, current_user, course }) => {
   const trainingLibrarySlug = course.training_library_slug;
   let instructorModulesLink;
@@ -16,7 +18,7 @@ const Resources = ({ weeks, current_user, course }) => {
     instructorModulesLink = <CourseLink to={'/training/instructors'} className="button pull-right">Instructor orientation modules</CourseLink>;
   }
   const blocks = _.flatten(weeks.map(week => week.blocks));
-  const modules = _.compact(_.flatten(blocks.map(block => block.training_modules)));
+  const modules = flattenAndCompact(blocks.map(block => block.training_modules));
 
   let additionalResources;
   const additionalResourcesBlock = blocks.find(block => block.title.match(/Additional Resources/));

--- a/app/assets/javascripts/components/resources/resources.jsx
+++ b/app/assets/javascripts/components/resources/resources.jsx
@@ -13,7 +13,7 @@ const Resources = ({ weeks, current_user, course }) => {
   const trainingLibrarySlug = course.training_library_slug;
   let instructorModulesLink;
   if (current_user.isInstructor && Features.wikiEd) {
-    instructorModulesLink = <CourseLink to={'/training/instructors'} className="button pull-right ml1">Instructor orientation modules</CourseLink>;
+    instructorModulesLink = <CourseLink to={'/training/instructors'} className="button pull-right">Instructor orientation modules</CourseLink>;
   }
   const blocks = _.flatten(weeks.map(week => week.blocks));
   const modules = _.compact(_.flatten(blocks.map(block => block.training_modules)));
@@ -27,19 +27,35 @@ const Resources = ({ weeks, current_user, course }) => {
       </div>
     );
   }
+  let assignedModules;
+  if (modules.length) {
+    assignedModules = (
+      <TrainingModules
+        block_modules={modules}
+        trainingLibrarySlug={trainingLibrarySlug}
+        header="Assigned trainings"
+      />
+    );
+  }
+  let additionalModules;
+  if (Features.wikiEd) {
+     additionalModules = (
+       <CourseLink to={`/training/${trainingLibrarySlug}`} className="button pull-right ml1">Additional training modules</CourseLink>
+    );
+  } else {
+    additionalModules = (
+      <CourseLink to={'/training'} className="button dark mb1">{I18n.t('training.training_library')}</CourseLink>
+    );
+  }
 
   return (
     <div id="resources" className="w75">
       <div className="section-header">
         <h3>{I18n.t('resources.header')}</h3>
         <div id="training-modules" className="container">
-          <TrainingModules
-            block_modules={modules}
-            trainingLibrarySlug={trainingLibrarySlug}
-            header="Assigned trainings"
-          />
+          {assignedModules}
+          {additionalModules}
           {instructorModulesLink}
-          <CourseLink to={`/training/${trainingLibrarySlug}`} className="button pull-right">Additional training modules</CourseLink>
         </div>
         {additionalResources}
         <Handouts trainingLibrarySlug={trainingLibrarySlug} blocks={blocks} />

--- a/app/assets/javascripts/components/resources/resources.jsx
+++ b/app/assets/javascripts/components/resources/resources.jsx
@@ -5,27 +5,44 @@ import _ from 'lodash';
 
 import CourseLink from '../common/course_link.jsx';
 import { getWeeksArray } from '../../selectors';
+import Block from '../timeline/block';
 import TrainingModules from '../timeline/training_modules';
+import Handouts from './handouts';
 
-const Resources = ({ weeks }) => {
+const Resources = ({ weeks, current_user, course }) => {
+  const trainingLibrarySlug = course.training_library_slug;
+  let instructorModulesLink;
+  if (current_user.isInstructor && Features.wikiEd) {
+    instructorModulesLink = <CourseLink to={'/training/instructors'} className="button pull-right ml1">Instructor orientation modules</CourseLink>;
+  }
   const blocks = _.flatten(weeks.map(week => week.blocks));
   const modules = _.compact(_.flatten(blocks.map(block => block.training_modules)));
+
+  let additionalResources;
+  const additionalResourcesBlock = blocks.find(block => block.title.match(/Additional Resources/));
+  if (additionalResourcesBlock) {
+    additionalResources = (
+      <div className="list-unstyled container mt2 mb2">
+        <Block block={additionalResourcesBlock} trainingLibrarySlug={trainingLibrarySlug} />
+      </div>
+    );
+  }
+
   return (
-    <div id="resources">
+    <div id="resources" className="w75">
       <div className="section-header">
         <h3>{I18n.t('resources.header')}</h3>
-        <div id="training-modules">
-          <TrainingModules block_modules={modules} trainingLibrarySlug="students" />
-          <CourseLink to={'/training/students'} className="button dark pull-right">All student training modules</CourseLink>
+        <div id="training-modules" className="container">
+          <TrainingModules
+            block_modules={modules}
+            trainingLibrarySlug={trainingLibrarySlug}
+            header="Assigned trainings"
+          />
+          {instructorModulesLink}
+          <CourseLink to={`/training/${trainingLibrarySlug}`} className="button pull-right">Additional training modules</CourseLink>
         </div>
-        <hr />
-        <div id="handouts">
-          <h4>Handouts</h4>
-          <ul>
-            {/* <li><CourseLink to={wizardUrl} className="button dark">Instructor orientation modules</CourseLink></li>
-            <li><CourseLink to={wizardUrl} className="button dark">Student training modules</CourseLink></li> */}
-          </ul>
-        </div>
+        {additionalResources}
+        <Handouts trainingLibrarySlug={trainingLibrarySlug} blocks={blocks} />
       </div>
     </div>
   );

--- a/app/assets/javascripts/components/resources/resources.jsx
+++ b/app/assets/javascripts/components/resources/resources.jsx
@@ -5,27 +5,18 @@ import _ from 'lodash';
 
 import CourseLink from '../common/course_link.jsx';
 import { getWeeksArray } from '../../selectors';
-
+import TrainingModules from '../timeline/training_modules';
 
 const Resources = ({ weeks }) => {
   const blocks = _.flatten(weeks.map(week => week.blocks));
-  const modules = _.flatten(blocks.map(block => block.training_modules));
-  const trainings = modules.map((module) => {
-    if (!module) { return; }
-    return (
-      <li key={`training-link-${module.id}`}><CourseLink to={`/training/students/${module.slug}`}>{module.name}</CourseLink></li>
-    );
-  });
+  const modules = _.compact(_.flatten(blocks.map(block => block.training_modules)));
   return (
     <div id="resources">
       <div className="section-header">
         <h3>{I18n.t('resources.header')}</h3>
         <div id="training-modules">
-          <h4>Assigned training modules</h4>
-          <ul>
-            {trainings}
-          </ul>
-          <CourseLink to={'/training'} className="button dark">All student training modules</CourseLink>
+          <TrainingModules block_modules={modules} trainingLibrarySlug="students" />
+          <CourseLink to={'/training/students'} className="button dark pull-right">All student training modules</CourseLink>
         </div>
         <hr />
         <div id="handouts">

--- a/app/assets/javascripts/components/resources/resources.jsx
+++ b/app/assets/javascripts/components/resources/resources.jsx
@@ -8,6 +8,7 @@ import { getWeeksArray } from '../../selectors';
 import Block from '../timeline/block';
 import TrainingModules from '../timeline/training_modules';
 import Handouts from './handouts';
+import { BLOCK_KIND_RESOURCES } from '../../constants/timeline';
 
 const flattenAndCompact = _.flow([_.flatten, _.compact]);
 
@@ -21,11 +22,11 @@ const Resources = ({ weeks, current_user, course }) => {
   const modules = flattenAndCompact(blocks.map(block => block.training_modules));
 
   let additionalResources;
-  const additionalResourcesBlock = blocks.find(block => block.title.match(/Additional Resources/));
-  if (additionalResourcesBlock) {
+  const additionalResourcesBlocks = blocks.filter(block => block.kind === BLOCK_KIND_RESOURCES);
+  if (additionalResourcesBlocks) {
     additionalResources = (
       <div className="list-unstyled container mt2 mb2">
-        <Block block={additionalResourcesBlock} trainingLibrarySlug={trainingLibrarySlug} />
+        {additionalResourcesBlocks.map(block => <Block key={block.id} block={block} trainingLibrarySlug={trainingLibrarySlug} />)}
       </div>
     );
   }

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -5,7 +5,6 @@ import TextInput from '../common/text_input.jsx';
 import DatePicker from '../common/date_picker.jsx';
 import TextAreaInput from '../common/text_area_input.jsx';
 import TrainingModules from './training_modules.jsx';
-// import Checkbox from '../common/checkbox.jsx';
 import BlockTypeSelect from './block_type_select.jsx';
 import { BLOCK_KIND_RESOURCES } from '../../constants/timeline';
 
@@ -125,16 +124,6 @@ const Block = createReactClass({
       }
       className += ' editable';
       if (this.props.isDragging) { className += ' dragging'; }
-      // graded = (
-      //   <Checkbox
-      //     value={isGraded}
-      //     onChange={this.updateGradeable}
-      //     value_key={'gradeable'}
-      //     editable={isEditable}
-      //     label="Graded"
-      //     container_class="graded"
-      //   />
-      // );
     }
 
     let modules;
@@ -245,7 +234,6 @@ const Block = createReactClass({
               onBlur={this.props.toggleFocused}
             />
           </div>
-          {/* {graded} */}
         </div>
         {content}
         {deleteBlock}

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -116,6 +116,11 @@ const Block = createReactClass({
       dueDateRead = isGraded ? (<span className="block__default-due-date">{I18n.t('timeline.due_default')}</span>) : '';
     }
 
+    let blockKindNote;
+    if (block.kind === BLOCK_KIND_RESOURCES && isEditable) {
+      blockKindNote = <small>This block will be included on the Resources tab. It will not appear on the Timeline for students.</small>;
+    }
+
     let deleteBlock;
     // let graded;
     if (isEditable) {
@@ -234,6 +239,7 @@ const Block = createReactClass({
               onBlur={this.props.toggleFocused}
             />
           </div>
+          {blockKindNote}
         </div>
         {content}
         {deleteBlock}

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -7,6 +7,7 @@ import TextAreaInput from '../common/text_area_input.jsx';
 import TrainingModules from './training_modules.jsx';
 // import Checkbox from '../common/checkbox.jsx';
 import BlockTypeSelect from './block_type_select.jsx';
+import { BLOCK_KIND_RESOURCES } from '../../constants/timeline';
 
 const DEFAULT_POINTS = 10;
 
@@ -57,6 +58,12 @@ const Block = createReactClass({
     return false;
   },
 
+  _hidden() {
+    // Resources blocks are hidden on the timeline, except for instructors and admins.
+    // They show up in the Resources tab instead, where there is no Week and so no weekStart.
+    return this.props.weekStart && !this.props.editPermissions && this.props.block.kind === BLOCK_KIND_RESOURCES;
+  },
+
   updateGradeable(_valueKey, value) {
     if (value) {
       this.updateBlock('points', DEFAULT_POINTS);
@@ -67,6 +74,8 @@ const Block = createReactClass({
 
   render() {
     const isEditable = this._isEditable();
+    if (this._hidden()) { return null; }
+
     const isGraded = !!this.props.block.points;
     let className = 'block';
     className += ` block-kind-${this.props.block.kind}`;
@@ -212,7 +221,6 @@ const Block = createReactClass({
               value={this.props.block.kind}
               value_key={'kind'}
               editable={isEditable}
-              options={['In Class', 'Assignment', 'Milestone', 'Custom']}
               show={this.props.block.kind < 3 || isEditable}
             />
             {dueDateSpacer}

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -73,12 +73,13 @@ const Block = createReactClass({
   },
 
   render() {
+    const block = this.props.block;
     const isEditable = this._isEditable();
     if (this._hidden()) { return null; }
 
-    const isGraded = !!this.props.block.points;
+    const isGraded = !!block.points;
     let className = 'block';
-    className += ` block-kind-${this.props.block.kind}`;
+    className += ` block-kind-${block.kind}`;
 
     let blockTypeClassName = 'block__block-type';
     if (this.props.editPermissions) {
@@ -89,22 +90,22 @@ const Block = createReactClass({
     if (isEditable) {
       blockActions = (
         <div className="float-container block__block-actions">
-          <button onClick={this.props.saveBlockChanges.bind(null, this.props.block.id)} className="button dark pull-right no-clear">Save</button>
-          <span role="button" tabIndex={0} onClick={this.props.cancelBlockEditable.bind(null, this.props.block.id)} className="span-link pull-right no-clear">Cancel</span>
+          <button onClick={this.props.saveBlockChanges.bind(null, block.id)} className="button dark pull-right no-clear">Save</button>
+          <span role="button" tabIndex={0} onClick={this.props.cancelBlockEditable.bind(null, block.id)} className="span-link pull-right no-clear">Cancel</span>
         </div>
       );
     }
 
     let dueDateRead;
-    if (this.props.block.due_date !== null && this.props.block.kind === 1) {
+    if (block.due_date !== null && block.kind === 1) {
       dueDateRead = (
         <TextInput
           onChange={this.updateBlock}
-          value={this.props.block.due_date}
+          value={block.due_date}
           value_key={'due_date'}
           editable={false}
           label="Due"
-          show={Boolean(this.props.block.due_date)}
+          show={Boolean(block.due_date)}
           onFocus={this.props.toggleFocused}
           onBlur={this.props.toggleFocused}
           p_tag_classname="block__read__due-date"
@@ -119,7 +120,7 @@ const Block = createReactClass({
     let deleteBlock;
     // let graded;
     if (isEditable) {
-      if (!this.props.block.is_new) {
+      if (!block.is_new) {
         deleteBlock = (<div className="delete-block-container"><button className="danger" onClick={this.deleteBlock}>Delete Block</button></div>);
       }
       className += ' editable';
@@ -137,14 +138,14 @@ const Block = createReactClass({
     }
 
     let modules;
-    if (this.props.block.training_modules || isEditable) {
+    if (block.training_modules || isEditable) {
       modules = (
         <TrainingModules
           onChange={this.passedUpdateBlock}
           all_modules={this.props.all_training_modules}
-          block_modules={this.props.block.training_modules}
+          block_modules={block.training_modules}
           editable={isEditable}
-          block={this.props.block}
+          block={block}
           trainingLibrarySlug={this.props.trainingLibrarySlug}
         />
       );
@@ -155,7 +156,7 @@ const Block = createReactClass({
         {modules}
         <TextAreaInput
           onChange={this.updateBlock}
-          value={this.props.block.content}
+          value={block.content}
           value_key="content"
           editable={isEditable}
           rows="4"
@@ -168,7 +169,7 @@ const Block = createReactClass({
       </div>
     );
 
-    const dueDateSpacer = this.props.block.due_date && this.props.block.kind === 1 ? (
+    const dueDateSpacer = block.due_date && block.kind === 1 ? (
       <span className="block__due-date-spacer"> - </span>
     ) : undefined;
 
@@ -191,11 +192,11 @@ const Block = createReactClass({
           <h3 className={headerClass}>
             <TextInput
               onChange={this.updateBlock}
-              value={this.props.block.title}
+              value={block.title}
               value_key="title"
               editable={isEditable}
               placeholder="Block title"
-              show={Boolean(this.props.block.title) && !isEditable}
+              show={Boolean(block.title) && !isEditable}
               className="title pull-left"
               spacer=""
               onFocus={this.props.toggleFocused}
@@ -203,7 +204,7 @@ const Block = createReactClass({
             />
             <TextInput
               onChange={this.updateBlock}
-              value={this.props.block.title}
+              value={block.title}
               value_key={'title'}
               editable={isEditable}
               placeholder="Block title"
@@ -218,10 +219,10 @@ const Block = createReactClass({
           <div className={blockTypeClassName}>
             <BlockTypeSelect
               onChange={this.updateBlock}
-              value={this.props.block.kind}
+              value={block.kind}
               value_key={'kind'}
               editable={isEditable}
-              show={this.props.block.kind < 3 || isEditable}
+              show={block.kind < 3 || isEditable}
             />
             {dueDateSpacer}
             {dueDateRead}
@@ -231,14 +232,14 @@ const Block = createReactClass({
           <div className="block__block-due-date">
             <DatePicker
               onChange={this.updateBlock}
-              value={this.props.block.due_date}
+              value={block.due_date}
               value_key="due_date"
               editable={isEditable}
               label="Due date"
               spacer=""
               placeholder="Due date"
               isClearable={true}
-              show={isEditable && parseInt(this.props.block.kind) === 1}
+              show={isEditable && parseInt(block.kind) === 1}
               date_props={{ minDate: this.props.weekStart }}
               onFocus={this.props.toggleFocused}
               onBlur={this.props.toggleFocused}

--- a/app/assets/javascripts/components/timeline/block_type_select.jsx
+++ b/app/assets/javascripts/components/timeline/block_type_select.jsx
@@ -6,12 +6,13 @@ import InputHOC from '../high_order/input_hoc.jsx';
 import Select from 'react-select';
 import selectStyles from '../../styles/single_select';
 
+const KINDS = ['In Class', 'Assignment', 'Milestone', 'Custom', 'Handouts', 'Resources'];
+
 const BlockTypeSelect = createReactClass({
   displayName: 'BlockTypeSelect',
 
   propTypes: {
     value: PropTypes.any,
-    options: PropTypes.array,
     editable: PropTypes.bool,
   },
 
@@ -29,7 +30,7 @@ const BlockTypeSelect = createReactClass({
       </div>
     );
 
-    const options = this.props.options.map((option, i) => {
+    const options = KINDS.map((option, i) => {
       return { value: i, label: option };
     });
 
@@ -52,7 +53,7 @@ const BlockTypeSelect = createReactClass({
         </div>
       );
     }
-    return <span>{this.props.options[this.props.value]}</span>;
+    return <span>{KINDS[this.props.value]}</span>;
   }
 });
 

--- a/app/assets/javascripts/components/timeline/training_modules.jsx
+++ b/app/assets/javascripts/components/timeline/training_modules.jsx
@@ -14,7 +14,8 @@ const TrainingModules = createReactClass({
     editable: PropTypes.bool,
     all_modules: PropTypes.array,
     onChange: PropTypes.func,
-    trainingLibrarySlug: PropTypes.string.isRequired
+    trainingLibrarySlug: PropTypes.string.isRequired,
+    header: PropTypes.string
   },
 
   getInitialState() {
@@ -120,7 +121,7 @@ const TrainingModules = createReactClass({
     return (
       <div className="block__training-modules">
         <div>
-          <h4>Training</h4>
+          <h4>{this.props.header || 'Training'}</h4>
           <table className="table table--small">
             <tbody>
               {modules}

--- a/app/assets/javascripts/constants/timeline.js
+++ b/app/assets/javascripts/constants/timeline.js
@@ -12,3 +12,5 @@ export const UPDATE_TITLE = 'UPDATE_TITLE';
 export const RESET_TITLES = 'RESET_TITLES';
 export const RESTORE_TIMELINE = 'RESTORE_TIMELINE';
 export const DELETE_ALL_WEEKS = 'DELETE_ALL_WEEKS';
+
+export const BLOCK_KIND_RESOURCES = 5;

--- a/app/models/course_data/block.rb
+++ b/app/models/course_data/block.rb
@@ -30,7 +30,8 @@ class Block < ApplicationRecord
     'assignment' => 1,
     'milestone'  => 2,
     'custom'     => 3,
-    'handouts'   => 4
+    'handouts'   => 4,
+    'resources'  => 5
   }.freeze
 
   DEFAULT_POINTS = 10

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -829,6 +829,10 @@ en:
     view_on_wiki: View diff on wiki
     see_more: See more
 
+  resources:
+    label: Resources
+    header: Resources and Training
+
   settings:
     admin_users:
       new:


### PR DESCRIPTION
Adds a Resources tab, and removes the Training link from the main nav when you're on a Wiki Education course page.

It will embed any Timeline block called 'Additional Resources' onto the Resources tab, and will also embed the wizard-generated block of subject-specific handouts (based on block title).

![once more](https://user-images.githubusercontent.com/848483/57733122-9d019300-7653-11e9-892d-8c10c64548ae.png)
