### PR TITLE
Fix "Log in with Wikipedia" button vertical align

### DIFF
--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -100,6 +100,7 @@ nav.top-nav
 .top-nav__login-links
   display flex
   justify-content flex-end
+  align-items: center
   margin-left auto
   b
     +below(desktop)


### PR DESCRIPTION
## What this PR does
Fixes "Log in with Wikimedia" button placement by adding
```css
align-items: center;
```
to `.top-nav__login-links` in [_nav.styl](https://github.com/WikiEducationFoundation/WikiEduDashboard/tree/master/app/assets/stylesheets/modules/_nav.styl)

## Screenshots
Before:
![2019-05-17-160839_1580x796_scrot](https://user-images.githubusercontent.com/24775963/57933718-477cee80-78be-11e9-8426-7443b32fbba3.png)


After:
![2019-05-17-160907_1582x798_scrot](https://user-images.githubusercontent.com/24775963/57933729-4e0b6600-78be-11e9-8a87-ea2658c7d65e.png)

## Open questions and concerns
(Maybe it was intentional)
