### PR TITLE
Link username to profile page, with separate contributions link

### DIFF
--- a/app/assets/javascripts/components/students/student.jsx
+++ b/app/assets/javascripts/components/students/student.jsx
@@ -62,7 +62,7 @@ const Student = createReactClass({
         <strong>{trunc(this.props.student.real_name)}</strong>
         &nbsp;
         (
-        <a onClick={this.stop} href={this.props.student.contribution_url} target="_blank">
+        <a href={`/users/${this.props.student.username}`}>
           {trunc(this.props.student.username)}
         </a>)
       </span>
@@ -118,7 +118,11 @@ const Student = createReactClass({
             {userName}
           </div>
           {trainingProgress}
-          <div className="sandbox-link"><a onClick={this.stop} href={this.props.student.sandbox_url} target="_blank">(sandboxes)</a></div>
+          <div className="sandbox-link">
+            <a onClick={this.stop} href={this.props.student.sandbox_url} target="_blank">{I18n.t('users.sandboxes')}</a>
+            &nbsp;
+            <a onClick={this.stop} href={this.props.student.contribution_url} target="_blank">{I18n.t('users.edits')}</a>
+          </div>
         </td>
         <td className="desktop-only-tc">
           {assignButton}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1006,6 +1006,7 @@ en:
     contribution_statistics: Contribution Statistics
     course_passcode: 'Passcode: '
     editors: Editors
+    edits: edits
     edits_by: 'Edits by: '
     enroll_confirmation: Are you sure you want to add %{username}?
     enroll_url: 'Users may join by visiting this URL:'
@@ -1033,6 +1034,7 @@ en:
     revisions_doc: The number of edits made by this editor in the past 7 days
     reviewers: Reviewer(s)
     reviewing: Reviewing
+    sandboxes: sandboxes
     total_uploads: "Total Uploads"
     training_complete:
       one: "is up-to-date with training"


### PR DESCRIPTION
## What this PR does
Replaces the link on each username in the Students tab, pointing to the Dashboard profile page rather than the on-wiki contributions page. Adds an explicit link to the contributions page instead.

## Screenshots
Before:
![editors](https://user-images.githubusercontent.com/848483/57966564-8d5ea480-7908-11e9-84c8-732363a95007.png)


After:
![editors after](https://user-images.githubusercontent.com/848483/57966565-93ed1c00-7908-11e9-8284-24423711fd8c.png)
