### PR TITLE
Clone Course for Programs & Events Dashboard

### DIFF
--- a/app/assets/javascripts/actions/course_creation_actions.js
+++ b/app/assets/javascripts/actions/course_creation_actions.js
@@ -29,8 +29,8 @@ export const submitCourse = (course, failureCallback) => (dispatch) => {
     });
 };
 
-export const cloneCourse = courseId => (dispatch) => {
-  return API.cloneCourse(courseId)
+export const cloneCourse = (courseId, campaign) => (dispatch) => {
+  return API.cloneCourse(courseId, campaign)
     .then(resp => dispatch({ type: RECEIVE_COURSE_CLONE, data: resp }))
     .catch(resp => dispatch({ type: API_FAIL, data: resp }));
 };

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -227,7 +227,7 @@ const CourseCreator = createReactClass({
   useThisClass() {
     const select = this.courseSelect;
     const courseId = select.options[select.selectedIndex].getAttribute('data-id-key');
-    this.props.cloneCourse(courseId);
+    this.props.cloneCourse(courseId, this.campaignParam());
     return this.setState({ isSubmitting: true, shouldRedirect: true });
   },
 
@@ -241,15 +241,8 @@ const CourseCreator = createReactClass({
     let showNewOrClone;
     let showWizardForm;
     let showCourseDates;
-    // If the creator was launched from a campaign, do not offer the cloning option.
-    if (this.campaignParam()) {
-      if (this.state.showCourseDates) {
-        showCourseDates = true;
-        showCourseForm = false;
-      } else {
-        showCourseForm = true;
-      }
-    } else if (this.state.showWizardForm) {
+
+    if (this.state.showWizardForm) {
       showWizardForm = true;
     } else if (this.state.showCourseDates) {
       showCourseDates = true;

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -191,7 +191,7 @@ const AvailableActions = createReactClass({
     }
 
     // If the user is an admin and the course is both published and a Wiki-Ed course.
-    if (user.admin && Features.wikiEd && course.published) {
+    if (user.admin && course.published) {
       controls.push((
         <div key="clone_course" className="available-action"><CloneCourseButton courseId={course.id}/></div>
       ));

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -202,11 +202,12 @@ const API = {
     );
   },
 
-  cloneCourse(id) {
+  cloneCourse(id, campaign) {
+    const campaignQueryParam = campaign ? `?campaign_slug=${campaign}` : ''
     return new Promise((res, rej) =>
       $.ajax({
         type: 'POST',
-        url: `/clone_course/${id}`,
+        url: `/clone_course/${id}${campaignQueryParam}`,
         success(data) {
           return res(data);
         }

--- a/app/controllers/course_clone_controller.rb
+++ b/app/controllers/course_clone_controller.rb
@@ -8,7 +8,9 @@ class CourseCloneController < ApplicationController
   def clone
     @course = Course.find(params[:id])
     check_permission
-    new_course = CourseCloneManager.new(@course, current_user).clone!
+
+    campaign_slug = clone_params[:campaign_slug]
+    new_course = CourseCloneManager.new(@course, current_user, campaign_slug).clone!
 
     respond_to do |format|
       format.json { render json: { course: new_course.as_json } }
@@ -22,5 +24,9 @@ class CourseCloneController < ApplicationController
     return if current_user.can_edit?(@course)
     exception = ActionController::InvalidAuthenticityToken.new('Unauthorized')
     raise exception
+  end
+
+  def clone_params
+    params.permit(:campaign_slug)
   end
 end

--- a/app/controllers/course_clone_controller.rb
+++ b/app/controllers/course_clone_controller.rb
@@ -9,7 +9,11 @@ class CourseCloneController < ApplicationController
     @course = Course.find(params[:id])
     check_permission
     new_course = CourseCloneManager.new(@course, current_user).clone!
-    render json: { course: new_course.as_json }
+
+    respond_to do |format|
+      format.json { render json: { course: new_course.as_json } }
+      format.html { redirect_to "/courses/#{new_course.slug}" }
+    end
   end
 
   private

--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -25,7 +25,11 @@ class CoursesPresenter
   end
 
   def can_remove_course?
-    @can_remove ||= current_user&.admin? || @campaign.organizers.include?(current_user)
+    @can_remove ||= current_user&.admin? || campaign_organizer?
+  end
+
+  def campaign_organizer?
+    @campaign.organizers.include?(current_user)
   end
 
   def campaigns

--- a/app/views/campaigns/_course_row.html.haml
+++ b/app/views/campaigns/_course_row.html.haml
@@ -38,10 +38,15 @@
       %span.students
         = course.user_count
       %small.untrained= t("users.training_complete_count", count: course.trained_count)
-  - if @presenter&.can_remove_course?
     %td{:class => "table-link-cell"}
-      %a.course-link{:href => "#{course_slug_path(course.slug)}"}
-        = form_for(@campaign, url: remove_course_campaign_path(@campaign.slug, course_id: course.id), method: :put, html: { class: 'remove-program-form' }) do
-          = hidden_field_tag('course_title', course.title)
-          %button.button.danger.remove-course{'data-id' => course.id, 'data-title' => course.title, 'data-campaign-title' => @campaign.title}
-            = t('assignments.remove')
+      - if @presenter&.campaign_organizer?
+        %a.course-link{:href => "#{course_slug_path(course.slug)}", style: "padding-bottom: 0;"}
+          = form_for(@campaign, url: course_clone_path(course.id), method: :post, html: { class: 'remove-program-form' }) do
+            %button.button.info
+              = t('assignments.clone')
+      - if @presenter&.can_remove_course?
+        %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+          = form_for(@campaign, url: remove_course_campaign_path(@campaign.slug, course_id: course.id), method: :put, html: { class: 'remove-program-form' }) do
+            = hidden_field_tag('course_title', course.title)
+            %button.button.danger.remove-course{'data-id' => course.id, 'data-title' => course.title, 'data-campaign-title' => @campaign.title}
+              = t('assignments.remove')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
     add_available_submit: Add articles
     assign_self: Assign myself an article
     assign_tooltip: An assigned article is one that you plan to create or improve.
+    clone: Clone
     confirm_add_available: Are you sure you want to add %{title}?
     confirm_addition: Are you sure you want to assign %{title} to %{username}?
     confirm_deletion: Are you sure you want to delete this article assignment?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
         titleterm: /[^\/]*/
     }
 
-    post 'clone_course/:id' => 'course_clone#clone'
+    post 'clone_course/:id' => 'course_clone#clone', as: 'course_clone'
     post 'courses/:id/update_syllabus' => 'courses/syllabuses#update'
     delete 'courses/:id/delete_all_weeks' => 'courses#delete_all_weeks',
       constraints: {

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -3,9 +3,10 @@ require_dependency "#{Rails.root}/lib/tag_manager"
 
 #= Procedures for creating a duplicate of an existing course for reuse
 class CourseCloneManager
-  def initialize(course, user)
+  def initialize(course, user, campaign_slug=nil)
     @course = course
     @user = user
+    @campaign = Campaign.find_by(slug: campaign_slug) if campaign_slug
   end
 
   def clone!
@@ -17,7 +18,13 @@ class CourseCloneManager
     clear_meeting_days_and_due_dates
     set_instructor
     tag_course
-    copy_campaigns if Features.open_course_creation?
+
+    if @campaign
+      @clone.campaigns << @campaign
+    elsif Features.open_course_creation?
+      copy_campaigns
+    end
+
     return @clone
   # If a course with the new slug already exists — an incomplete clone of the
   # same course — then return the previously-created clone.

--- a/spec/controllers/course_clone_controller_spec.rb
+++ b/spec/controllers/course_clone_controller_spec.rb
@@ -17,16 +17,25 @@ describe CourseCloneController, type: :request do
                               role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
       end
 
-      it 'clones the course' do
-        expect_any_instance_of(CourseCloneManager).to receive(:clone!)
-        post "/clone_course/#{course.id}", params: { id: course.id }
+      context 'json' do
+        it 'clones the course' do
+          expect_any_instance_of(CourseCloneManager).to receive(:clone!)
+          post "/clone_course/#{course.id}", params: { format: :json, id: course.id }
+        end
+      end
+
+      context 'html' do
+        it 'clones the course' do
+          expect_any_instance_of(CourseCloneManager).to receive(:clone!).and_return(course)
+          post "/clone_course/#{course.id}", params: { format: :html, id: course.id }
+        end
       end
     end
 
     context 'when the user is not the original instructor' do
       it 'returns a 401 error' do
         expect(CourseCloneManager).not_to receive(:new)
-        post "/clone_course/#{course.id}", params: { id: course.id }
+        post "/clone_course/#{course.id}", params: { format: :json, id: course.id }
         expect(response.status).to eq(401)
       end
     end

--- a/spec/features/open_course_creation_spec.rb
+++ b/spec/features/open_course_creation_spec.rb
@@ -91,6 +91,7 @@ describe 'open course creation', type: :feature, js: true do
 
   it 'creates a course belonging to a given campaign' do
     visit course_creator_path(campaign_slug: campaign.slug)
+    choose_course_type
     expect(page).to have_content campaign.title
     fill_out_open_course_creator_form
     click_button 'Next'

--- a/spec/lib/course_clone_manager_spec.rb
+++ b/spec/lib/course_clone_manager_spec.rb
@@ -140,4 +140,15 @@ describe CourseCloneManager do
       expect(clone.type).to eq('ClassroomProgramCourse')
     end
   end
+
+  context 'with a preset campaign' do
+    it 'allows for the campaign to be set' do
+      slug = 'new_campaign_slug'
+      new_campaign = create(:campaign, id: 2, title: 'New Campaign', slug: slug)
+      campaign_clone = described_class.new(Course.find(1), User.find(1), slug).clone!
+
+      expect(campaign_clone.campaigns.length).to eq(1)
+      expect(campaign_clone.campaigns).to include(new_campaign)
+    end
+  end
 end

--- a/test/components/overview/available_actions.spec.jsx
+++ b/test/components/overview/available_actions.spec.jsx
@@ -8,7 +8,7 @@ import AvailableActions from '../../../app/assets/javascripts/components/overvie
 const mockStore = configureMockStore()({});
 
 describe('AvailableActions', () => {
-  it('Displays no actions for ended course', () => {
+  it('displays no actions for ended course', () => {
     const endedCourse = {
       ended: true
     };
@@ -27,7 +27,7 @@ describe('AvailableActions', () => {
     expect(text).to.eq('No available actions');
   });
 
-  it('Displays administrative P&E actions if the user is an admin', () => {
+  it('displays administrative P&E actions if the user is an admin', () => {
     const course = {
       id: 999,
       ended: false,
@@ -49,7 +49,7 @@ describe('AvailableActions', () => {
     );
 
     const actions = TestAvailableActions.find('.available-action');
-    expect(actions.length).to.eq(4);
+    expect(actions.length).to.eq(5);
 
     const deleteButton = actions.at(0);
     expect(deleteButton.text()).to.eq('Delete course');
@@ -62,9 +62,12 @@ describe('AvailableActions', () => {
 
     const embedStatsButton = actions.at(3);
     expect(embedStatsButton.text()).to.eq('Embed Course Stats');
+
+    const cloneCourseButton = actions.at(4);
+    expect(cloneCourseButton.text()).to.eq('Clone This Course');
   });
 
-  it('Displays administrative WikiEd actions if the user is an admin', () => {
+  it('displays administrative WikiEd actions if the user is an admin', () => {
     global.Features.wikiEd = true;
     const course = {
       id: 999,


### PR DESCRIPTION
Adds additional places for a course to be cloned.

1. Clone the course from a course's page
  ![image](https://user-images.githubusercontent.com/1316902/57966979-4fd63780-7959-11e9-931a-8452fd7f7a99.png)

1. Clone the course from the campaign list
  ![image](https://user-images.githubusercontent.com/1316902/57966932-dcccc100-7958-11e9-9bb4-78b2e849f2cd.png)

1. From the campaign home page, allow for users to clone a course