### PR TITLE
Self-enrollment as online volunteer

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -267,7 +267,7 @@ const ArticleFinder = createReactClass({
       const elements = _.map(this.props.articles, (article, title) => {
         let assignment;
         if (this.props.course_id) {
-          if (this.props.current_user.isNonstudent) {
+          if (this.props.current_user.isAdvancedRole) {
             assignment = _.find(this.props.assignments, { article_title: title, user_id: null });
           } else if (this.props.current_user.role === STUDENT_ROLE) {
             assignment = _.find(this.props.assignments, { article_title: title, user_id: this.props.current_user.id });

--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -106,7 +106,7 @@ const ArticleFinderRow = createReactClass({
       }
     }
     let button;
-    if (this.props.courseSlug && this.props.current_user.isNonstudent) {
+    if (this.props.courseSlug && this.props.current_user.isAdvancedRole) {
       if (this.props.assignment) {
         const className = `button small add-available-article ${this.state.isLoading ? 'disabled' : ''}`;
         button = (

--- a/app/assets/javascripts/components/articles/articles_handler.jsx
+++ b/app/assets/javascripts/components/articles/articles_handler.jsx
@@ -56,7 +56,7 @@ export const ArticlesHandler = createReactClass({
     const user = this.props.current_user;
     const assignments = this.props.assignments;
     const noAssignments = !assignments.filter(assignment => !assignment.user_id).length;
-    const isAdminOrInstructor = user.admin || user.isNonstudent;
+    const isAdminOrInstructor = user.admin || user.isAdvancedRole;
 
     return noAssignments && !isAdminOrInstructor;
   },

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -68,7 +68,7 @@ export const AvailableArticle = createReactClass({
       );
     }
 
-    if (this.props.current_user.isNonstudent) {
+    if (this.props.current_user.isAdvancedRole) {
       actionRemove = (
         <button className="button dark" onClick={this.onRemoveHandler}>{I18n.t('assignments.remove')}</button>
       );

--- a/app/assets/javascripts/components/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/articles/available_articles.jsx
@@ -24,7 +24,7 @@ const AvailableArticles = createReactClass({
     let availableArticles;
     let elements = [];
     let findingArticlesTraining;
-    if (Features.wikiEd && this.props.current_user.isNonstudent) {
+    if (Features.wikiEd && this.props.current_user.isAdvancedRole) {
       findingArticlesTraining = (
         <a href="/training/instructors/finding-articles" target="_blank" className="button ghost-button small">
           How to find articles
@@ -63,7 +63,7 @@ const AvailableArticles = createReactClass({
       );
     }
 
-    const showAvailableArticles = elements.length > 0 || this.props.current_user.isNonstudent;
+    const showAvailableArticles = elements.length > 0 || this.props.current_user.isAdvancedRole;
 
     if (showAvailableArticles) {
       availableArticles = (

--- a/app/assets/javascripts/components/categories/category_handler.jsx
+++ b/app/assets/javascripts/components/categories/category_handler.jsx
@@ -20,7 +20,7 @@ const CategoryHandler = createReactClass({
   },
 
   render() {
-    const editable = this.props.current_user.isNonstudent;
+    const editable = this.props.current_user.isAdvancedRole;
     return (
       <CategoryList
         course={this.props.course}

--- a/app/assets/javascripts/components/common/get_help_button.jsx
+++ b/app/assets/javascripts/components/common/get_help_button.jsx
@@ -117,7 +117,7 @@ const GetHelpButton = createReactClass({
       );
 
       // Show the program help button only to instructors and other non-students.
-      if (this.props.currentUser.isNonstudent) {
+      if (this.props.currentUser.isAdvancedRole) {
         const programHelpUser = this.programHelpUser();
         programHelpButton = (
           <span className="contact-program-help" key={`${programHelpUser.username}-program-help`}>
@@ -187,7 +187,7 @@ const GetHelpButton = createReactClass({
         </div>
       );
     } else {
-      if (this.props.currentUser.isNonstudent) {
+      if (this.props.currentUser.isAdvancedRole) {
         faqLink = (
           <a className="button dark stacked" href="https://ask.wikiedu.org/questions/scope:all/sort:activity-desc/tags:instructorfaq/page:1/" target="blank">Instructor FAQ</a>
         );

--- a/app/assets/javascripts/components/course/course_alerts.jsx
+++ b/app/assets/javascripts/components/course/course_alerts.jsx
@@ -46,7 +46,7 @@ const CourseAlerts = createReactClass({
     // Admin / Instructor notifications /
     // //////////////////////////////////
     // For unpublished courses, when viewed by an instructor or admin
-    if (userRoles.isNonstudent && !course.legacy && !course.published) {
+    if (userRoles.isAdvancedRole && !course.legacy && !course.published) {
       // If it's an unsubmitted ClassroomProgramCourse
       const isUnsubmittedClassroomProgramCourse = !course.submitted && course.type === 'ClassroomProgramCourse';
       if (isUnsubmittedClassroomProgramCourse) {
@@ -85,7 +85,7 @@ const CourseAlerts = createReactClass({
     }
     // Shows an alert for how many accounts have been requested
     if (course.requestedAccounts) {
-      if ((!Features.wikiEd && userRoles.isNonstudent) || userRoles.isAdmin) {
+      if ((!Features.wikiEd && userRoles.isAdvancedRole) || userRoles.isAdmin) {
         const message = I18n.t('courses.requested_accounts_alert', { count: course.requestedAccounts });
         const actionMessage = I18n.t('courses.requested_accounts_alert_view');
         const url = `/requested_accounts/${course.slug}`;
@@ -95,7 +95,7 @@ const CourseAlerts = createReactClass({
 
     // For published courses with no students, highlight the enroll link
     const hasNoStudents = this.props.usersLoaded && this.props.studentCount === 0;
-    if (userRoles.isNonstudent && course.published && hasNoStudents && !course.legacy) {
+    if (userRoles.isAdvancedRole && course.published && hasNoStudents && !course.legacy) {
       const enrollEquals = '?enroll=';
       const url = window.location.origin + this.props.courseLinkParams + enrollEquals + course.passcode;
       alerts.push((

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -15,6 +15,7 @@ import EmbedStatsButton from './embed_stats_button.jsx';
 import CloneCourseButton from './clone_course_button.jsx';
 import { enableAccountRequests } from '../../actions/new_account_actions.js';
 import { needsUpdate, linkToSalesforce, updateSalesforceRecord, deleteCourse, greetStudents } from '../../actions/course_actions';
+import { STUDENT_ROLE, ONLINE_VOLUNTEER_ROLE } from '../../constants/user_roles';
 import { removeUser } from '../../actions/user_actions';
 
 const AvailableActions = createReactClass({
@@ -63,7 +64,8 @@ const AvailableActions = createReactClass({
 
   leave() {
     const courseSlug = this.props.course.slug;
-    const userRecord = { user: { user_id: this.props.current_user.id, role: 0 } };
+    const role = this.props.current_user.isOnlineVolunteer ? ONLINE_VOLUNTEER_ROLE : STUDENT_ROLE;
+    const userRecord = { user: { user_id: this.props.current_user.id, role: role } };
     const leaveCourse = this.props.removeUser;
     const onConfirm = function () {
       return leaveCourse(courseSlug, userRecord);
@@ -125,7 +127,7 @@ const AvailableActions = createReactClass({
     // If user has a role in the course or is an admin
     if ((user.isEnrolled) || user.admin) {
       // If user is a student, show the 'leave' button.
-      if (user.isStudent) {
+      if (user.isStudent || user.isOnlineVolunteer) {
         controls.push((
           <div key="leave" className="available-action"><button onClick={this.leave} className="button">{CourseUtils.i18n('leave_course', course.string_prefix)}</button></div>
         ));

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -34,18 +34,17 @@ const AvailableActions = createReactClass({
     removeUser: PropTypes.func.isRequired
   },
 
-  join() {
+  join(role = null) {
+    const enrollURL = this.props.course.enroll_url;
     if (this.props.course.passcode === '') {
-      const EnrollURL = this.props.course.enroll_url;
       const onConfirm = function () {
-        return window.location = EnrollURL;
+        return window.location = `${enrollURL}?role=${role}`;
       };
       const confirmMessage = CourseUtils.i18n('join_no_passcode');
       this.props.initiateConfirm(confirmMessage, onConfirm);
     } else {
-      const EnrollURL = this.props.course.enroll_url;
       const onConfirm = function (passcode) {
-      return window.location = EnrollURL + passcode;
+        return window.location = `${enrollURL}${passcode}?role=${role}`;
       };
       const confirmMessage = I18n.t('courses.passcode_prompt');
       const joinDescription = CourseUtils.i18n('join_details', this.props.course.string_prefix);
@@ -157,9 +156,15 @@ const AvailableActions = createReactClass({
       }
     // If user has no role or is logged out
     } else if (!course.ended) {
-      controls.push((
+      controls.push(
         <div key="join" className="available-action"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', course.string_prefix)}</button></div>
-      ));
+      );
+      // On P&E Dashboard, offer option to join as online volunteer
+      if (!Features.wikiEd) {
+        controls.push(
+          <div key="volunteer" className="available-action"><button onClick={() => this.join('online_volunteer')} className="button">{CourseUtils.i18n('join_course_as_volunteer', course.string_prefix)}</button></div>
+        );
+      }
     }
     // If the user is enrolled in the course or admin, and the course type is editathon and not finished, show a manual stats update button
     if ((user.isEnrolled || user.isAdmin) && (course.type === 'Editathon' && !course.ended)) {

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -133,7 +133,7 @@ const AvailableActions = createReactClass({
       // If course is not published, show the 'delete' button to instructors and admins.
       // Show a disabled version of it on P&E Dashboard even if a course is published,
       // so that users can see the instructions for how to enable deletion.
-      if ((user.isNonstudent || user.admin) && (!course.published || !Features.wikiEd)) {
+      if ((user.isAdvancedRole || user.admin) && (!course.published || !Features.wikiEd)) {
         controls.push((
           <div title={I18n.t('courses.delete_course_instructions')} key="delete" className="available-action">
             <button className="button danger" onClick={this.delete}>
@@ -175,7 +175,7 @@ const AvailableActions = createReactClass({
 
     // Requested accounts
     // These are enabled for instructors on P&E Dashboard, but only for admins on Wiki Education Dashboard.
-    if ((user.isNonstudent && !Features.wikiEd) || user.admin) {
+    if ((user.isAdvancedRole && !Features.wikiEd) || user.admin) {
       // Enable account requests if allowed
       if (!course.account_requests_enabled) {
         controls.push((
@@ -186,7 +186,7 @@ const AvailableActions = createReactClass({
 
     // If the user is an instructor or admin, and the course is published, show a stats download button
     // Always show the stats download for published non-Wiki Ed courses.
-    if ((user.isNonstudent || user.admin || !Features.wikiEd) && course.published) {
+    if ((user.isAdvancedRole || user.admin || !Features.wikiEd) && course.published) {
       controls.push((
         <div key="download_course_stats" className="available-action"><CourseStatsDownloadModal course={course} /></div>
       ));

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -162,7 +162,7 @@ const AvailableActions = createReactClass({
         <div key="join" className="available-action"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', course.string_prefix)}</button></div>
       );
       // On P&E Dashboard, offer option to join as online volunteer
-      if (!Features.wikiEd) {
+      if (!Features.wikiEd && course.online_volunteers_enabled) {
         controls.push(
           <div key="volunteer" className="available-action"><button onClick={() => this.join('online_volunteer')} className="button">{CourseUtils.i18n('join_course_as_volunteer', course.string_prefix)}</button></div>
         );

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -116,7 +116,7 @@ const CourseClonedModal = createReactClass({
   saveEnabled() {
     // You must be logged in and have permission to edit the course.
     // This will be the case if you created it (and are therefore the instructor) or if you are an admin.
-    if (!this.props.currentUser.isNonstudent) { return false; }
+    if (!this.props.currentUser.isAdvancedRole) { return false; }
     // ClassroomProgramCourse conditions
     if (this.props.course.type === 'ClassroomProgramCourse') {
       if (!this.state.valuesUpdated || !this.state.dateValuesUpdated) { return false; }
@@ -140,7 +140,7 @@ const CourseClonedModal = createReactClass({
       errorMessage = <div className="warning">{this.props.firstErrorMessage}</div>;
     } else if (!this.props.currentUser.id) {
       errorMessage = <div className="warning">{I18n.t('courses.please_log_in')}</div>;
-    } else if (!this.props.currentUser.isNonstudent) {
+    } else if (!this.props.currentUser.isAdvancedRole) {
       errorMessage = <div className="warning">{CourseUtils.i18n('not_permitted', i18nPrefix)}</div>;
     }
 

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -16,6 +16,8 @@ import SubmittedSelector from './submitted_selector.jsx';
 import PrivacySelector from './privacy_selector.jsx';
 import WithdrawnSelector from './withdrawn_selector.jsx';
 import TimelineToggle from './timeline_toggle.jsx';
+import OnlineVolunteersToggle from './online_volunteers_toggle.jsx';
+
 import WikiEditsToggle from './wiki_edits_toggle';
 import EditSettingsToggle from './edit_settings_toggle';
 import CourseLevelSelector from '../course_creator/course_level_selector.jsx';
@@ -105,7 +107,10 @@ const Details = createReactClass({
       staff = <WikiEdStaff {...this.props} />;
       campus = <CampusVolunteers {...this.props} />;
     }
-    const online = <OnlineVolunteers {...this.props} />;
+    let online;
+    if (Features.wikiEd || this.props.course.online_volunteers_enabled) {
+      online = <OnlineVolunteers {...this.props} />;
+    }
 
     if (this.props.course.school || canRename) {
       school = (
@@ -232,6 +237,7 @@ const Details = createReactClass({
     let privacySelector;
     let courseLevelSelector;
     let timelineToggle;
+    let onlineVolunteersToggle;
     let wikiEditsToggle;
     let editSettingsToggle;
     let withdrawnSelector;
@@ -306,6 +312,17 @@ const Details = createReactClass({
     if (canRename && !isClassroomProgramType) {
       timelineToggle = (
         <TimelineToggle
+          course={this.props.course}
+          editable={this.props.editable}
+          updateCourse={this.props.updateCourse}
+        />
+      );
+    }
+
+    // Users who can rename a course can enable Online Volunteers to join
+    if (canRename && !Features.wikiEd) {
+      onlineVolunteersToggle = (
+        <OnlineVolunteersToggle
           course={this.props.course}
           editable={this.props.editable}
           updateCourse={this.props.updateCourse}
@@ -404,6 +421,7 @@ const Details = createReactClass({
               {submittedSelector}
               {privacySelector}
               {timelineToggle}
+              {onlineVolunteersToggle}
               {wikiEditsToggle}
               {editSettingsToggle}
               {withdrawnSelector}

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -98,15 +98,14 @@ const Details = createReactClass({
     const canRename = this.canRename();
     const isClassroomProgramType = this.props.course.type === 'ClassroomProgramCourse';
     const timelineDatesDiffer = this.props.course.start !== this.props.course.timeline_start || this.props.course.end !== this.props.course.timeline_end;
-    let online;
     let campus;
     let staff;
     let school;
     if (Features.wikiEd) {
       staff = <WikiEdStaff {...this.props} />;
-      online = <OnlineVolunteers {...this.props} />;
       campus = <CampusVolunteers {...this.props} />;
     }
+    const online = <OnlineVolunteers {...this.props} />;
 
     if (this.props.course.school || canRename) {
       school = (

--- a/app/assets/javascripts/components/overview/online_volunteers_toggle.jsx
+++ b/app/assets/javascripts/components/overview/online_volunteers_toggle.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import YesNoSelector from './yes_no_selector';
+
+const OnlineVolunteersToggle = ({ course, editable, updateCourse }) => {
+  return (
+    <YesNoSelector
+      courseProperty="online_volunteers_enabled"
+      label={I18n.t('courses.online_volunteers_enabled')}
+      tooltip={I18n.t('courses.online_volunteers_tooltip')}
+      course={course}
+      editable={editable}
+      updateCourse={updateCourse}
+    />
+  );
+};
+
+export default OnlineVolunteersToggle;

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -219,7 +219,7 @@ export const firstValidationErrorMessage = createSelector(
 
 export const editPermissions = createSelector(
   [getCourse, getCurrentUser], (course, user) => {
-    if (!user.isNonstudent) { return false; }
+    if (!user.isAdvancedRole) { return false; }
     return user.isAdmin || !course.closed;
   }
 );

--- a/app/assets/javascripts/utils/user_utils.js
+++ b/app/assets/javascripts/utils/user_utils.js
@@ -37,6 +37,9 @@ const UserUtils = class {
       roles.isAdmin = true;
       roles.isNonstudent = true;
     }
+    if (currentUser.campaign_organizer) {
+      roles.isNonstudent = true;
+    }
     return roles;
   }
 

--- a/app/assets/javascripts/utils/user_utils.js
+++ b/app/assets/javascripts/utils/user_utils.js
@@ -17,12 +17,10 @@ const UserUtils = class {
     }
     if (getFiltered(users, { id: currentUser.id, role: CAMPUS_VOLUNTEER_ROLE })[0]) {
       roles.isCampusVolunteer = true;
-      roles.isAdvancedRole = true;
       roles.isEnrolled = true;
     }
     if (getFiltered(users, { id: currentUser.id, role: ONLINE_VOLUNTEER_ROLE })[0]) {
       roles.isOnlineVolunteer = true;
-      roles.isAdvancedRole = true;
       roles.isEnrolled = true;
     }
     if (getFiltered(users, { id: currentUser.id, role: STAFF_ROLE })[0]) {

--- a/app/assets/javascripts/utils/user_utils.js
+++ b/app/assets/javascripts/utils/user_utils.js
@@ -12,22 +12,22 @@ const UserUtils = class {
     }
     if (getFiltered(users, { id: currentUser.id, role: INSTRUCTOR_ROLE })[0]) {
       roles.isInstructor = true;
-      roles.isNonstudent = true;
+      roles.isAdvancedRole = true;
       roles.isEnrolled = true;
     }
     if (getFiltered(users, { id: currentUser.id, role: CAMPUS_VOLUNTEER_ROLE })[0]) {
       roles.isCampusVolunteer = true;
-      roles.isNonstudent = true;
+      roles.isAdvancedRole = true;
       roles.isEnrolled = true;
     }
     if (getFiltered(users, { id: currentUser.id, role: ONLINE_VOLUNTEER_ROLE })[0]) {
       roles.isOnlineVolunteer = true;
-      roles.isNonstudent = true;
+      roles.isAdvancedRole = true;
       roles.isEnrolled = true;
     }
     if (getFiltered(users, { id: currentUser.id, role: STAFF_ROLE })[0]) {
       roles.isStaff = true;
-      roles.isNonstudent = true;
+      roles.isAdvancedRole = true;
       roles.isEnrolled = true;
     }
     if (!roles.isEnrolled) {
@@ -35,10 +35,10 @@ const UserUtils = class {
     }
     if (currentUser.admin) {
       roles.isAdmin = true;
-      roles.isNonstudent = true;
+      roles.isAdvancedRole = true;
     }
     if (currentUser.campaign_organizer) {
-      roles.isNonstudent = true;
+      roles.isAdvancedRole = true;
     }
     return roles;
   }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -240,6 +240,7 @@ class CoursesController < ApplicationController
   def update_flags
     update_boolean_flag :timeline_enabled
     update_boolean_flag :wiki_edits_enabled
+    update_boolean_flag :online_volunteers_enabled
     update_edit_settings
   end
 

--- a/app/controllers/self_enrollment_controller.rb
+++ b/app/controllers/self_enrollment_controller.rb
@@ -81,9 +81,14 @@ class SelfEnrollmentController < ApplicationController
   end
 
   def add_student_to_course
+    role = if params[:role] == 'online_volunteer'
+             CoursesUsers::Roles::ONLINE_VOLUNTEER_ROLE
+           else
+             CoursesUsers::Roles::STUDENT_ROLE
+           end
     @result = JoinCourse.new(course: @course,
                              user: current_user,
-                             role: CoursesUsers::Roles::STUDENT_ROLE,
+                             role: role,
                              real_name: current_user.real_name).result
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -355,6 +355,10 @@ class Course < ApplicationRecord
     flags[:timeline_enabled].present?
   end
 
+  def online_volunteers_enabled?
+    flags[:online_volunteers_enabled].present?
+  end
+
   # Overridden for some course types
   def cloneable?
     !tag?('no_clone')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,8 +169,6 @@ class User < ApplicationRecord
   end
 
   EDITING_ROLES = [CoursesUsers::Roles::INSTRUCTOR_ROLE,
-                   CoursesUsers::Roles::CAMPUS_VOLUNTEER_ROLE,
-                   CoursesUsers::Roles::ONLINE_VOLUNTEER_ROLE,
                    CoursesUsers::Roles::WIKI_ED_STAFF_ROLE].freeze
   def can_edit?(course)
     return true if admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,8 +106,8 @@ class User < ApplicationRecord
   ####################
   # Instance methods #
   ####################
-  def roles(_course)
-    { id: id, admin: admin? }
+  def roles(course)
+    { id: id, admin: admin?, campaign_organizer: campaign_organizer?(course) }
   end
 
   def talk_page
@@ -174,7 +174,14 @@ class User < ApplicationRecord
                    CoursesUsers::Roles::WIKI_ED_STAFF_ROLE].freeze
   def can_edit?(course)
     return true if admin?
-    EDITING_ROLES.include? role(course)
+    return true if EDITING_ROLES.include? role(course)
+    return true if campaign_organizer?(course)
+    false
+  end
+
+  def campaign_organizer?(course)
+    CampaignsUsers.exists?(user: self, campaign: course.campaigns,
+                           role: CampaignsUsers::Roles::ORGANIZER_ROLE)
   end
 
   REAL_NAME_ROLES = [CoursesUsers::Roles::INSTRUCTOR_ROLE,

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -18,6 +18,7 @@ json.course do
   json.wiki_course_page_enabled @course.wiki_course_page_enabled?
   json.enrollment_edits_enabled @course.enrollment_edits_enabled?
   json.account_requests_enabled @course.account_requests_enabled?
+  json.online_volunteers_enabled @course.online_volunteers_enabled?
   json.term @course.cloned_status == 1 ? '' : @course.term
   json.legacy @course.legacy?
   json.ended @course.end < Time.zone.now

--- a/app/views/recent_activity/index.html.haml
+++ b/app/views/recent_activity/index.html.haml
@@ -1,3 +1,3 @@
 - content_for :before_title, "Recent Activity — "
 
-#react_root{"data-current_user" => user_signed_in? ? current_user.roles(@course).to_json : '{ "admin": false, "id": null }'}
+#react_root{"data-current_user" => false ? { admin: current_user.admin?, id: current_user.id }.to_json : '{ "admin": false, "id": null }'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -544,6 +544,8 @@ en:
       This will post a reminder on the talk pages for all students who overdue
       for completing assigned training modules. Are you sure you want to do this?
     no_available_actions: No available actions
+    online_volunteers_enabled: Online Volunteers enabled
+    online_volunteers_tooltip: Enabling Online Volunteers allows user editors to join as a volunteer. Their edits will not be tracked.
     ores_plot: ORES
     overview: Home
     passcode: Passcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -493,6 +493,7 @@ en:
       (Shared accounts are not allowed.)
     join: Join
     join_course: Join course
+    join_course_as_volunteer: Volunteer to help
     join_prompt: Join '%{title}'?
     join_successful: >
       You’ve successfully joined %{title}.

--- a/test/components/alerts/course_alerts.spec.jsx
+++ b/test/components/alerts/course_alerts.spec.jsx
@@ -23,7 +23,7 @@ describe('CourseAlerts', () => {
     const requestedAccountProps = {
       ...props,
       userRoles: {
-        isNonstudent: true
+        isAdvancedRole: true
       },
       course: { requestedAccounts: 1 }
     };

--- a/test/components/common/get_help_button.spec.jsx
+++ b/test/components/common/get_help_button.spec.jsx
@@ -18,7 +18,7 @@ const reduxStoreWithUsers = createStore(reducer, initialState, compose(applyMidd
 
 describe('GetHelpButton', () => {
   describe('Content', () => {
-    const currentUser = { isNonstudent: 1 };
+    const currentUser = { isAdvancedRole: 1 };
 
     const TestGetHelpButton = ReactTestUtils.renderIntoDocument(
       <Provider store={reduxStoreWithUsers}>
@@ -42,7 +42,7 @@ describe('GetHelpButton', () => {
   });
 
   describe('Interactions', () => {
-    const currentUser = { isNonstudent: 1 };
+    const currentUser = { isAdvancedRole: 1 };
 
     const TestGetHelpButton = ReactTestUtils.renderIntoDocument(
       <Provider store={reduxStoreWithUsers}>
@@ -81,7 +81,7 @@ describe('GetHelpButton', () => {
   });
 
   describe('As an instructor', () => {
-    const currentUser = { isNonstudent: true };
+    const currentUser = { isAdvancedRole: true };
 
     const TestGetHelpButton = ReactTestUtils.renderIntoDocument(
       <Provider store={reduxStoreWithUsers}>

--- a/test/components/overview/course_cloned_modal.spec.jsx
+++ b/test/components/overview/course_cloned_modal.spec.jsx
@@ -16,7 +16,7 @@ describe('CourseClonedModal', () => {
   const currentUser = {
     admin: false,
     id: 123,
-    isNonstudent: true
+    isAdvancedRole: true
   };
 
   const TestModal = mount(


### PR DESCRIPTION
This adds 'Volunteer to help' button in Available Actions to self-enroll as an online volunteer.

The caveats are:
* Volunteer roles are no longer 'advanced' roles and do not allow the user to edit.
* If there is a passcode for the course, a user will need that in order to join as a volunteer.