### PR TITLE
Refactor Gulp imports

### DIFF
--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,13 +1,11 @@
-import gulp from 'gulp';
+import { task } from 'gulp';
 import del from 'del';
 import config from '../config.js';
 
-gulp.task('clean', () => {
-  return del([
-    `${config.outputPath}/fonts/*`,
-    `${config.outputPath}/images/*`,
-    `${config.outputPath}/stylesheets/*`,
-    `!${config.outputPath}/javascripts/jquery-uls.js`,
-    `${config.outputPath}/javascripts/*`
-  ]);
-});
+task('clean', () => del([
+  `${config.outputPath}/fonts/*`,
+  `${config.outputPath}/images/*`,
+  `${config.outputPath}/stylesheets/*`,
+  `!${config.outputPath}/javascripts/jquery-uls.js`,
+  `${config.outputPath}/javascripts/*`
+]));

--- a/gulp/tasks/copy-static.js
+++ b/gulp/tasks/copy-static.js
@@ -1,28 +1,24 @@
-import gulp from 'gulp';
+import { task, parallel, dest, src } from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import config from '../config.js';
 
 const plugins = loadPlugins();
 
-gulp.task('copy-images', () => {
-  return gulp.src(`${config.sourcePath}/${config.imagesDirectory}/**/*`)
+task('copy-images', () => src(`${config.sourcePath}/${config.imagesDirectory}/**/*`)
     .pipe(plugins.plumber())
     .pipe(plugins.newer(`${config.outputPath}/${config.imagesDirectory}`))
     // .pipe(plugins.imagemin({
     //   optimizationLevel: 5
     // }))
-    .pipe(gulp.dest(`${config.outputPath}/${config.imagesDirectory}`));
-});
+    .pipe(dest(`${config.outputPath}/${config.imagesDirectory}`))
+);
 
-gulp.task('copy-fonts', () => {
-  return gulp.src(`${config.sourcePath}/${config.fontsDirectory}/**/*`)
-    .pipe(gulp.dest(`${config.outputPath}/${config.fontsDirectory}`));
-});
+task('copy-fonts', () => src(`${config.sourcePath}/${config.fontsDirectory}/**/*`)
+    .pipe(dest(`${config.outputPath}/${config.fontsDirectory}`))
+);
 
-gulp.task('copy-tinymce-skins', () => {
-  return gulp.src('./node_modules/tinymce/skins/**/*')
-    .pipe(gulp.dest(`${config.outputPath}/${config.jsDirectory}/skins`));
-});
+task('copy-tinymce-skins', () => src('./node_modules/tinymce/skins/**/*')
+    .pipe(dest(`${config.outputPath}/${config.jsDirectory}/skins`))
+);
 
-gulp.task('copy-static',
-  gulp.parallel('copy-images', 'copy-fonts', 'copy-tinymce-skins'));
+task('copy-static', parallel('copy-images', 'copy-fonts', 'copy-tinymce-skins'));

--- a/gulp/tasks/i18n.js
+++ b/gulp/tasks/i18n.js
@@ -1,8 +1,8 @@
-import gulp from 'gulp';
+import { task } from 'gulp';
 import gutil from 'gulp-util';
 import { exec } from 'child_process';
 
-gulp.task('i18n', cb =>
+task('i18n', cb =>
   exec('bundle exec rails i18n:js:export', (err, stdout, stderr) => {
     if (stdout) {
       gutil.log(stdout);

--- a/gulp/tasks/icon-font.js
+++ b/gulp/tasks/icon-font.js
@@ -1,10 +1,10 @@
-import gulp from 'gulp';
+import { task, src, dest } from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import config from '../config.js';
 
 const plugins = loadPlugins();
 
-gulp.task('icon-font', () => {
+task('icon-font', () => {
   const cssTemplateFilename = 'icon-font-template.css';
   const cssOutputFilename = '_icons.styl';
   const fontName = 'icons';
@@ -12,7 +12,7 @@ gulp.task('icon-font', () => {
   const className = 'icon';
 
   // Grab SVGs from 'svg' directory
-  const fileSvgStream = gulp.src(`${config.sourcePath}/${config.svgDirectory}/*.svg`);
+  const fileSvgStream = src(`${config.sourcePath}/${config.svgDirectory}/*.svg`);
 
   // Generate Font and CSS from all SVGs
   return fileSvgStream
@@ -27,7 +27,7 @@ gulp.task('icon-font', () => {
         };
       });
 
-      return gulp.src(`${config.sourcePath}/${config.svgDirectory}/${cssTemplateFilename}`)
+      return src(`${config.sourcePath}/${config.svgDirectory}/${cssTemplateFilename}`)
         .pipe(plugins.consolidate('lodash', {
           glyphs: mapped,
           fontName,
@@ -35,6 +35,6 @@ gulp.task('icon-font', () => {
           className
         }))
         .pipe(plugins.rename(cssOutputFilename))
-        .pipe(gulp.dest(`${config.sourcePath}/${config.cssDirectory}`));
-    })).pipe(gulp.dest(`${config.sourcePath}/${config.fontsDirectory}`));
+        .pipe(dest(`${config.sourcePath}/${config.cssDirectory}`));
+    })).pipe(dest(`${config.sourcePath}/${config.fontsDirectory}`));
 });

--- a/gulp/tasks/jquery.uls.js
+++ b/gulp/tasks/jquery.uls.js
@@ -1,19 +1,17 @@
-import gulp from 'gulp';
-import loadPlugins from 'gulp-load-plugins';
+import { task, dest, src } from 'gulp';
+// import loadPlugins from 'gulp-load-plugins';
 import config from '../config.js';
+import concat from 'gulp-concat';
 
-const plugins = loadPlugins();
-
+// const plugins = loadPlugins();
 
 //--------------------------------------------------------
 // Concatenate jquery-uls libraries
 //--------------------------------------------------------
-const jqueryUlsPath = [
-  'node_modules/@bower_components/jquery/dist/jquery.js'
-  ];
+const jqueryUlsPath = 'node_modules/@bower_components/jquery/dist/jquery.js';
 
-gulp.task('jquery-uls', () => {
-  return gulp.src(jqueryUlsPath)
-    .pipe(plugins.concat('jquery-uls.js'))
-    .pipe(gulp.dest(`${config.outputPath}/${config.jsDirectory}`));
+task('jquery-uls', () => {
+  return src(jqueryUlsPath)
+    .pipe(concat('jquery-uls.js'))
+    .pipe(dest(`${config.outputPath}/${config.jsDirectory}`));
 });

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -1,4 +1,4 @@
-import gulp from 'gulp';
+import { task, series, src, watch } from 'gulp';
 import path from 'path';
 import loadPlugins from 'gulp-load-plugins';
 import config from '../config.js';
@@ -12,27 +12,25 @@ const jsPath = [
   'test/**/*.{jsx,js}'
 ];
 
-gulp.task('lintjs', () => {
-  return gulp.src(jsPath)
-    .pipe(plugins.eslint())
-    .pipe(plugins.eslint.format())
-    .pipe(plugins.eslint.failAfterError());
-});
+task('lintjs', () => src(jsPath)
+  .pipe(plugins.eslint())
+  .pipe(plugins.eslint.format())
+  .pipe(plugins.eslint.failAfterError())
+);
 
-gulp.task('cached-lintjs', () => {
-  return gulp.src(jsPath)
-    .pipe(plugins.cached('eslint'))
-    .pipe(plugins.eslint())
-    .pipe(plugins.eslint.format())
-    .pipe(plugins.eslint.result((result) => {
-      if (result.warningCount > 0 || result.errorCount > 0) {
-        delete plugins.cached.caches.eslint[path.resolve(result.filePath)];
-      }
-    }));
-});
+task('cached-lintjs', () => src(jsPath)
+  .pipe(plugins.cached('eslint'))
+  .pipe(plugins.eslint())
+  .pipe(plugins.eslint.format())
+  .pipe(plugins.eslint.result((result) => {
+    if (result.warningCount > 0 || result.errorCount > 0) {
+      delete plugins.cached.caches.eslint[path.resolve(result.filePath)];
+    }
+  }))
+);
 
 function watchCachedLintJS(done) {
-  gulp.watch(jsPath, gulp.series('cached-lintjs'), (event) => {
+  watch(jsPath, series('cached-lintjs'), (event) => {
     if (event.type === 'deleted' && plugins.cached.caches.eslint) {
       delete plugins.cached.caches.eslint[event.path];
     }
@@ -40,4 +38,4 @@ function watchCachedLintJS(done) {
   done();
 }
 
-gulp.task('cached-lintjs-watch', gulp.series('cached-lintjs', watchCachedLintJS));
+task('cached-lintjs-watch', series('cached-lintjs', watchCachedLintJS));

--- a/gulp/tasks/minify.js
+++ b/gulp/tasks/minify.js
@@ -1,20 +1,20 @@
-import gulp from 'gulp';
+import { task, dest, src } from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import merge from 'merge-stream';
 import config from '../config.js';
 
 const plugins = loadPlugins();
 
-gulp.task('minify', () => {
+task('minify', () => {
   // Compress Vendor JavaScript
-  const vendor = gulp.src(`${config.outputPath}/${config.jsDirectory}/jquery-uls.js`)
+  const vendor = src(`${config.outputPath}/${config.jsDirectory}/jquery-uls.js`)
     .pipe(plugins.uglify())
-    .pipe(gulp.dest(`${config.outputPath}/${config.jsDirectory}/`));
+    .pipe(dest(`${config.outputPath}/${config.jsDirectory}/`));
 
   // Minify CSS
-  const css = gulp.src(`${config.outputPath}/${config.cssDirectory}/*.css`)
+  const css = src(`${config.outputPath}/${config.cssDirectory}/*.css`)
     .pipe(plugins.minifyCss())
-    .pipe(gulp.dest(`${config.outputPath}/${config.cssDirectory}`));
+    .pipe(dest(`${config.outputPath}/${config.cssDirectory}`));
 
   return merge(vendor, css);
 });

--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -1,12 +1,11 @@
-import gulp from 'gulp';
+import { task, src } from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 
 const plugins = loadPlugins();
 
-gulp.task('server', () => {
-  return gulp.src('public')
-    .pipe(plugins.webserver({
-      port: 3000,
-      livereload: true
-    }));
-});
+task('server', () => src('public')
+  .pipe(plugins.webserver({
+    port: 3000,
+    livereload: true
+  }))
+);

--- a/gulp/tasks/set-development.js
+++ b/gulp/tasks/set-development.js
@@ -1,12 +1,12 @@
-import gulp from 'gulp';
+import { task } from 'gulp';
 import config from '../config.js';
 
-gulp.task('set-development', (done) => {
+task('set-development', (done) => {
   config.development = true;
   done();
 });
 
-gulp.task('set-watch-js', (done) => {
+task('set-watch-js', (done) => {
   config.watch_js = true;
   done();
 });

--- a/gulp/tasks/stylesheets.js
+++ b/gulp/tasks/stylesheets.js
@@ -1,4 +1,4 @@
-import gulp from 'gulp';
+import { task, dest, src } from 'gulp';
 import flipper from 'gulp-css-flipper';
 import rename from 'gulp-rename';
 import revDel from 'rev-del';
@@ -8,10 +8,10 @@ import config from '../config.js';
 
 const plugins = loadPlugins();
 
-gulp.task('stylesheets', () => {
+task('stylesheets', () => {
   const styleDir = `${config.outputPath}/${config.cssDirectory}`;
 
-  const stream = gulp.src([`${config.sourcePath}/${config.cssDirectory}/${config.cssMainFiles}.styl`])
+  const stream = src([`${config.sourcePath}/${config.cssDirectory}/${config.cssMainFiles}.styl`])
     .pipe(plugins.plumber())
     .pipe(plugins.stylus({
       'include css': true,
@@ -24,32 +24,32 @@ gulp.task('stylesheets', () => {
     }))
     .pipe(plugins.autoprefixer())
     .pipe(plugins.sourcemaps.write())
-    .pipe(gulp.dest(styleDir));
+    .pipe(dest(styleDir));
 
   return stream.on('end', () => {
-    const versionedStream = gulp.src([`${config.outputPath}/${config.cssDirectory}/${config.cssMainFiles}.css`])
+    const versionedStream = src([`${config.outputPath}/${config.cssDirectory}/${config.cssMainFiles}.css`])
       .pipe(plugins.rev()) // apply revision hash to the file name
-      .pipe(gulp.dest(styleDir)) // save the files
+      .pipe(dest(styleDir)) // save the files
       .pipe(plugins.rev.manifest()) // create rev.manifest file with the revision hashes
       .pipe(revDel({ dest: styleDir }))
-      .pipe(gulp.dest(styleDir));
+      .pipe(dest(styleDir));
 
     // Generate RTL stylesheets
     versionedStream.on('end', () => {
-      gulp.src([`${styleDir}/${config.cssMainFiles}.css`])
+      src([`${styleDir}/${config.cssMainFiles}.css`])
         .pipe(plugins.rev()) // apply revision hashes before flipping,
-                             // so it matches the already-created rev.manifest
+        // so it matches the already-created rev.manifest
         .pipe(flipper()) // do the css flip
         .pipe(rename({ prefix: 'rtl-' })) // add the file prefix rtl-
-        .pipe(gulp.dest(styleDir)); // save in the same directory
+        .pipe(dest(styleDir)); // save in the same directory
     });
   });
 });
 
-gulp.task('stylesheets-livereload', () => {
+task('stylesheets-livereload', () => {
   const styleDir = `${config.outputPath}/${config.cssDirectory}`;
 
-  return gulp.src([`${config.sourcePath}/${config.cssDirectory}/${config.cssMainFiles}.styl`])
+  return src([`${config.sourcePath}/${config.cssDirectory}/${config.cssMainFiles}.styl`])
     .pipe(plugins.plumber())
     .pipe(plugins.stylus({
       'include css': true,
@@ -62,5 +62,5 @@ gulp.task('stylesheets-livereload', () => {
     }))
     .pipe(plugins.autoprefixer())
     .pipe(plugins.sourcemaps.write())
-    .pipe(gulp.dest(styleDir));
+    .pipe(dest(styleDir));
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,21 +1,21 @@
-import gulp from 'gulp';
+import { task, series, watch } from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import config from '../config.js';
 
 const plugins = loadPlugins();
 
-gulp.task('watch', () => {
+task('watch', () => {
   plugins.watch(`${config.sourcePath}/${config.cssDirectory}/**/*.{styl,sass,scss,css}`, () => {
-    return gulp.series('stylesheets');
+    return series('stylesheets');
   });
 
   plugins.watch(`${config.sourcePath}/${config.imagesDirectory}/**/*`, () => {
-    return gulp.series('copy-images');
+    return series('copy-images');
   });
 
   plugins.livereload.listen();
 
-  gulp.watch(`${config.outputPath}/${config.cssDirectory}/*.css`, (e) => {
+  watch(`${config.outputPath}/${config.cssDirectory}/*.css`, (e) => {
     return plugins.livereload.changed(e.path);
   });
   plugins.livereload.listen();

--- a/gulp/tasks/webpack.js
+++ b/gulp/tasks/webpack.js
@@ -1,4 +1,4 @@
-import gulp from 'gulp';
+import { task, series } from 'gulp';
 import loadPlugins from 'gulp-load-plugins';
 import webpack from 'webpack';
 import path from 'path';
@@ -114,4 +114,4 @@ function startWebpack(cb) {
     });
   }
 }
-gulp.task('webpack', gulp.series('jquery-uls', startWebpack));
+task('webpack', series('jquery-uls', startWebpack));

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,33 +1,32 @@
-import gulp from 'gulp';
+import { series, parallel, task } from 'gulp';
 import requireDir from 'require-dir';
 
 // Require individual tasks
 requireDir('./gulp/tasks', { recurse: true });
 
-const { series, parallel } = gulp;
-gulp.task('dev',
-  series(
-    'clean',
-    'set-development',
-    'set-watch-js',
-    parallel('i18n', 'copy-static', 'jquery-uls', 'stylesheets', 'cached-lintjs-watch'),
-    parallel('webpack', 'watch')
-  )
+task('dev',
+    series(
+        'clean',
+        'set-development',
+        'set-watch-js',
+        parallel('i18n', 'copy-static', 'jquery-uls', 'stylesheets', 'cached-lintjs-watch'),
+        parallel('webpack', 'watch')
+    )
 );
 
-gulp.task('default', gulp.series('dev'));
+task('default', series('dev'));
 
-gulp.task('hot-dev',
-  series(
-    'clean',
-    'set-development',
-    parallel('i18n', 'copy-static', 'jquery-uls', 'stylesheets-livereload', 'cached-lintjs-watch'),
-    parallel('webpack', 'watch'))
+task('hot-dev',
+    series(
+        'clean',
+        'set-development',
+        parallel('i18n', 'copy-static', 'jquery-uls', 'stylesheets-livereload', 'cached-lintjs-watch'),
+        parallel('webpack', 'watch'))
 );
 
-gulp.task('build',
-  series(
-    'clean',
-    parallel('i18n', 'copy-static', 'jquery-uls', 'stylesheets', 'lintjs'),
-    parallel('webpack', 'minify'))
+task('build',
+    series(
+        'clean',
+        parallel('i18n', 'copy-static', 'jquery-uls', 'stylesheets', 'lintjs'),
+        parallel('webpack', 'minify'))
 );


### PR DESCRIPTION
## What this PR does
Changes
```js
import gulp from 'gulp';
```
to suitable *`named import(s)`*

## Screenshots
Before:
n/a

After:
n/a
## Open questions and concerns
| `gulp`  | module imports | named imports |
| ------- | --- | --- |
| `build` | 80s | 51s |

(maybe it is a coincidence, but I ran this several times to check. The difference is always around 30sec on my computer)
(theoretically named imports should be faster than module imports)