### PR TITLE
Add stats download modal to Campaign overview

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign_overview_handler.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_overview_handler.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import CampaignStatsDownloadModal from './campaign_stats_download_modal';
+
+const CampaignOverviewHandler = (props) => {
+  return <CampaignStatsDownloadModal {...props} />;
+};
+
+export default CampaignOverviewHandler;

--- a/app/assets/javascripts/components/campaign/campaign_stats_download_modal.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_stats_download_modal.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+const CampaignStatsDownloadModal = ({ match }) => {
+  const [show, setShow] = useState(false);
+
+  const campaignSlug = match.params.campaign_slug;
+
+  const courseDataLink = `/campaigns/${campaignSlug}/courses.csv`;
+  const articlesEditedLink = `/campaigns/${campaignSlug}/articles_csv.csv`;
+  const editorsLink = `/campaigns/${campaignSlug}/students.csv`;
+  const editorsByCourseLink = `/campaigns/${campaignSlug}/students.csv?course=true`;
+  const instructorsLink = `/campaigns/${campaignSlug}/instructors.csv?course=true`;
+
+  if (!show) {
+    return (
+      <button onClick={() => setShow(true)} className="button">{I18n.t('courses.download_stats_data')}</button>
+    );
+  }
+
+  return (
+    <div className="basic-modal course-stats-download-modal">
+      <button onClick={() => setShow(false)} className="pull-right article-viewer-button icon-close" />
+      <h2>{I18n.t('campaign.data_download_info')}</h2>
+      <hr />
+      <p>
+        <a href={courseDataLink} className="button right">{I18n.t('campaign.data_courses')}</a>
+        {I18n.t('campaign.data_courses_info')}
+      </p>
+      <hr />
+      <p>
+        <a href={articlesEditedLink} className="button right">{I18n.t('campaign.data_articles')}</a>
+        {I18n.t('campaign.data_articles_info')}
+      </p>
+      <hr />
+      <p>
+        <a href={editorsLink} className="button right">{I18n.t('campaign.data_editor_usernames')}</a>
+        {I18n.t('campaign.data_editor_usernames_info')}
+      </p>
+      <hr />
+      <p>
+        <a href={editorsByCourseLink} className="button right">{I18n.t('campaign.data_editors_by_course')}</a>
+        {I18n.t('campaign.data_editors_by_course_info')}
+      </p>
+      <hr />
+      <p>
+        <a href={instructorsLink} className="button right">{I18n.t('campaign.data_instructors')}</a>
+        {I18n.t('campaign.data_instructors_info')}
+      </p>
+    </div>
+  );
+};
+
+export default CampaignStatsDownloadModal;

--- a/app/assets/javascripts/components/util/routes.jsx
+++ b/app/assets/javascripts/components/util/routes.jsx
@@ -6,6 +6,7 @@ import Onboarding from '../onboarding/index.jsx';
 import { ConnectedCourseCreator } from '../course_creator/course_creator.jsx';
 import ArticleFinder from '../article_finder/article_finder.jsx';
 import AlertsHandler from '../alerts/alerts_handler.jsx';
+import CampaignOverviewHandler from '../campaign/campaign_overview_handler.jsx';
 import CampaignOresPlot from '../campaign/campaign_ores_plot.jsx';
 import RecentActivityHandler from '../activity/recent_activity_handler.jsx';
 import TrainingApp from '../../training/components/training_app.jsx';
@@ -21,6 +22,7 @@ const routes = (
     <Route path="/courses/:course_school/:course_title" component={Course} />
     <Route path="/course_creator" component={ConnectedCourseCreator} />
     <Route path="/users/:username" component={UserProfile} />
+    <Route path="/campaigns/:campaign_slug/overview" component={CampaignOverviewHandler} />
     <Route path="/campaigns/:campaign_slug/alerts" component={AlertsHandler} />
     <Route path="/campaigns/:campaign_slug/ores_plot" component={CampaignOresPlot} />
     <Route path="/settings" component={SettingsHandler} />

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -134,7 +134,8 @@
                     = t('campaign.default_passcode')
                 %span.rails_editable-content
                   = @campaign.default_passcode
-
+      %section#campaign_stats
+        #react_root{data: {slug: @campaign.slug}}
       - if @campaign.template_description.present?
         = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
           .section-header

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,17 @@ en:
     create_campaign: Create a New Campaign
     create_my_campaign: Create my Campaign!
     customize_passcode: a default passcode
+    data_download_info: Download campaign data as CSVs
+    data_courses: Course overview data
+    data_courses_info: Basic metrics for each course/program
+    data_articles: Pages edited
+    data_articles_info: Details about each tracked page edited by the campaign
+    data_instructors: Instructors
+    data_instructors_info: List of instructors/facilitators and their courses/programs
+    data_editors_by_course: Editors by course
+    data_editors_by_course_info: List of enrolled editors and their courses/programs
+    data_editor_usernames: Editor usernames
+    data_editor_usernames_info: List of editor usernames, one per line
     default_course_type: Default Course Type
     default_passcode: Default Passcode
     default_passcode_explanation: "By default, new programs in this campaign should have:"


### PR DESCRIPTION
This adds the CSV downloads for a campaign, previously only available on the campaigns index, to the overview page of each campaign. The new feature is implemented with React, so it adds the start of a CampaignOverviewHandler component for gradually porting the rest of the view to React.

Also, it's implemented with React Hooks, the first use of Hooks in the codebase!

## Screenshots
![download stats](https://user-images.githubusercontent.com/848483/57979834-aa15dd80-79d7-11e9-8a1c-7cab456ddca5.png)

![download stats modal](https://user-images.githubusercontent.com/848483/57979837-ad10ce00-79d7-11e9-85e9-6529f09a0551.png)

