### PR TITLE
Add 'Articles Edited' to Explore campaign list, improve query performance

### DIFF
--- a/app/assets/javascripts/utils/course.js
+++ b/app/assets/javascripts/utils/course.js
@@ -34,7 +34,7 @@ $(() => {
     campaignList = new List('campaigns', {
       page: 500,
       valueNames: [
-        'title', 'num-courses', 'articles-created', 'characters', 'views', 'students', 'creation-date'
+        'title', 'num-courses', 'articles-created', 'articles-edited', 'characters', 'views', 'students', 'creation-date'
       ]
     });
   }

--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -84,23 +84,23 @@ class CoursesPresenter
   end
 
   def word_count
-    @word_count ||= WordCount.from_characters course_sums[0]
+    @word_count ||= WordCount.from_characters(course_sums[0] || 0)
   end
 
   def article_count
-    course_sums[1]
+    course_sums[1] || 0
   end
 
   def new_article_count
-    course_sums[2]
+    course_sums[2] || 0
   end
 
   def view_sum
-    course_sums[3]
+    course_sums[3] || 0
   end
 
   def user_count
-    course_sums[4]
+    course_sums[4] || 0
   end
 
   def course_string_prefix

--- a/app/views/campaigns/_campaigns.html.haml
+++ b/app/views/campaigns/_campaigns.html.haml
@@ -7,6 +7,7 @@
         %option{rel: "asc", value: "title"}= t("courses.title")
         %option{rel: "desc", value: "num-courses"}= t("#{Features.default_course_string_prefix}.courses")
         %option{rel: "desc", value: "articles-created"}= t('metrics.articles_created')
+        %option{rel: "desc", value: "articles-edited"}= t('metrics.articles_edited')
         %option{rel: "desc", value: "characters"}= t("metrics.word_count")
         %option{rel: "desc", value: "views"}= t("metrics.view")
         %option{rel: "desc", value: "students"}= t("users.editors")
@@ -22,9 +23,13 @@
           .tooltip-trigger
             = t("#{Features.default_course_string_prefix}.courses")
             %span.sortable-indicator
-        %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "articles-created", style: "width: 180px"}
+        %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "articles-created", style: "width: 140px"}
           .tooltip-trigger
             = t('metrics.articles_created')
+            %span.sortable-indicator
+        %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "articles-edited", style: "width: 140px"}
+          .tooltip-trigger
+            = t('metrics.articles_edited')
             %span.sortable-indicator
         %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "characters", style: "width: 172px;"}
           .tooltip-trigger

--- a/app/views/campaigns/_row.html.haml
+++ b/app/views/campaigns/_row.html.haml
@@ -6,21 +6,21 @@
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.num-courses-human
-        = number_to_human(presenter.courses.count)
+        = number_to_human(presenter.course_count)
       %span.num-courses.hidden
-        = presenter.courses.count
+        = presenter.course_count
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.articles-created-human
-        = number_to_human(presenter.courses.sum(:new_article_count))
+        = number_to_human(presenter.new_article_count)
       %span.articles-created.hidden
-        = presenter.courses.sum(:new_article_count)
+        = presenter.new_article_count
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.articles-edited-human
-        = number_to_human(presenter.courses.sum(:article_count))
+        = number_to_human(presenter.article_count)
       %span.articles-edited.hidden
-        = presenter.courses.sum(:article_count)
+        = presenter.article_count
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.characters-human
@@ -30,9 +30,9 @@
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.views-human
-        = number_to_human(presenter.courses.sum(:view_sum))
+        = number_to_human(presenter.view_sum)
       %span.views.hidden
-        = presenter.courses.sum(:view_sum)
+        = presenter.view_sum
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.students

--- a/app/views/campaigns/_row.html.haml
+++ b/app/views/campaigns/_row.html.haml
@@ -17,6 +17,12 @@
         = presenter.courses.sum(:new_article_count)
   %td{:class => "table-link-cell"}
     %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
+      %span.articles-edited-human
+        = number_to_human(presenter.courses.sum(:article_count))
+      %span.articles-edited.hidden
+        = presenter.courses.sum(:article_count)
+  %td{:class => "table-link-cell"}
+    %a.course-link{:href => "#{campaign_path(campaign.slug)}"}
       %span.characters-human
         = number_to_human(presenter.word_count)
       %span.characters.hidden


### PR DESCRIPTION
This adds a new column to the list of campaigns, Articles Edited, since this is a stat that one of the core Wiki Education program metrics (as opposed to Articles Created).

It also refactors how the counts get generated, so that a single SQL query most of the data that is summed across courses in one go.