### PR TITLE
Disable W3C requests for Selenium

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,10 +13,15 @@ require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 
 Capybara.register_driver :selenium do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities
+                 .chrome(chromeOptions: { w3c: false })
   options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[headless no-sandbox disable-gpu --window-size=1200,1200]
   )
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 options: options,
+                                 desired_capabilities: capabilities)
 end
 
 Rails.cache.clear


### PR DESCRIPTION
## What this PR does
This should fix the errors we're receiving on Travis CI. Ideally, we would not need to disable this but, eh.

To locally upgrade your version of Chrome, you should be able to run `chromedriver-update`. You can also specify a version number if you choose.