### PR TITLE
New Wiki Scholars/Scientists 'editing medical topics' training

### DIFF
--- a/training_content/wiki_ed/libraries/professional-development.yml
+++ b/training_content/wiki_ed/libraries/professional-development.yml
@@ -21,10 +21,10 @@ categories:
         description: How to read Wikipedia articles, and potential sources, with a critical eye
       - slug: finding-your-article-professional
         name: Finding your article
-        description: Special rules and advice for working on content related to medicine or human health (including psychology topics)
+        description: How to find a good article to work on
       - slug: editing-medical-topics-professional
         name: Editing health and psychology topics
-        description: How to find a good article to work on
+        description: Special rules and advice for working on content related to medicine or human health (including psychology topics)
       - slug: drafting-professional
         name: Drafting in the sandbox
         description: Practical steps for working in a sandbox, and beginning to draft of an article

--- a/training_content/wiki_ed/libraries/professional-development.yml
+++ b/training_content/wiki_ed/libraries/professional-development.yml
@@ -22,6 +22,9 @@ categories:
       - slug: finding-your-article-professional
         name: Finding your article
         description: How to find a good article to work on
+      - slug: editing-medical-topics-professional
+        name: Editing health and psychology topics
+        description: How to find a good article to work on
       - slug: drafting-professional
         name: Drafting in the sandbox
         description: Practical steps for working in a sandbox, and beginning to draft of an article

--- a/training_content/wiki_ed/libraries/professional-development.yml
+++ b/training_content/wiki_ed/libraries/professional-development.yml
@@ -21,7 +21,7 @@ categories:
         description: How to read Wikipedia articles, and potential sources, with a critical eye
       - slug: finding-your-article-professional
         name: Finding your article
-        description: How to find a good article to work on
+        description: Special rules and advice for working on content related to medicine or human health (including psychology topics)
       - slug: editing-medical-topics-professional
         name: Editing health and psychology topics
         description: How to find a good article to work on

--- a/training_content/wiki_ed/modules/editing-medical-topics-professional.yml
+++ b/training_content/wiki_ed/modules/editing-medical-topics-professional.yml
@@ -1,0 +1,20 @@
+name: 'Editing health and psychology topics'
+id: 48
+description: |
+  This tutorial will take you through the requirements for writing, and
+  sourcing, medical and psychology articles on Wikipedia.
+estimated_ttc: 10 minutes
+slides:
+  - slug: the-challenge-of-medical-topics-professional # 4801
+  - slug: when-do-medical-guidelines-apply-professional # 4802
+  - slug: when-does-medrs-not-apply-professional # 4803
+  - slug: first-rule-of-reliable-medical-sources-professional # 4804
+  - slug: poor-medical-sources-professional # 4805
+  - slug: good-medical-sources-professional # 4806
+  - slug: style-conventions-for-medical-topics-professional # 4807
+  - slug: medicine-and-original-research-professional # 4808
+  - slug: working-with-the-medrs-community-professional # 4809
+  - slug: medical-topics-best-practices-professional # 4810
+  - slug: medical-editing-video-professional # 4813
+  - slug: medrs-quiz-professional # 4811
+  - slug: medical-topics-complete-professional # 4812

--- a/training_content/wiki_ed/modules/editing-medical-topics-professional.yml
+++ b/training_content/wiki_ed/modules/editing-medical-topics-professional.yml
@@ -1,4 +1,4 @@
-name: 'Editing health and psychology topics'
+name: 'Editing health and psychology topics (Professional)'
 id: 48
 description: |
   This tutorial will take you through the requirements for writing, and

--- a/training_content/wiki_ed/modules/editing-medical-topics-professional.yml
+++ b/training_content/wiki_ed/modules/editing-medical-topics-professional.yml
@@ -1,8 +1,8 @@
 name: 'Editing health and psychology topics (Professional)'
 id: 48
 description: |
-  This tutorial will take you through the requirements for writing, and
-  sourcing, medical and psychology articles on Wikipedia.
+  This tutorial will take you through the requirements for writing and
+  sourcing medical and psychology articles on Wikipedia.
 estimated_ttc: 10 minutes
 slides:
   - slug: the-challenge-of-medical-topics-professional # 4801

--- a/training_content/wiki_ed/modules/editing-medical-topics.yml
+++ b/training_content/wiki_ed/modules/editing-medical-topics.yml
@@ -1,8 +1,8 @@
 name: 'Editing health and psychology topics'
 id: 11
 description: |
-  This tutorial will take you through the requirements for writing, and
-  sourcing, medical and psychology articles on Wikipedia.
+  This tutorial will take you through the requirements for writing and
+  sourcing medical and psychology articles on Wikipedia.
 estimated_ttc: 10 minutes
 slides:
   - slug: the-challenge-of-medical-topics # 1101

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4801-the-challenge-of-medical-topics-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4801-the-challenge-of-medical-topics-professional.yml
@@ -1,0 +1,21 @@
+id: 4801
+title: The challenges of editing topics related to human health
+summary:
+content: |
+  Wikipedia has its own rules for editing topics related to medicine and psychology.
+  That's because Wikipedia is one of the leading websites people turn to for health
+  information, more so than websites from the National Institute of Health,
+  World Health Organization, or WebMD.
+
+  Poor information about health topics can have real-world consequences for
+  readers who don't always bring the amount of skepticism they should to
+  Wikipedia's health information.
+
+  That's why MEDRS exists. MEDRS is short for "Medical Reliable Sources," and
+  it's the set of guidelines for identifying reliable sources in medicine and
+  psychology. These standards can make it challenging for those new to Wikipedia to
+  contribute content to these topics.
+
+  This orientation will give you an overview of those requirements, which are
+  available in detail by typing the Wikipedia shortcut `WP:MEDRS`
+  into Wikipedia's search bar.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4802-when-do-medical-guidelines-apply-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4802-when-do-medical-guidelines-apply-professional.yml
@@ -2,9 +2,9 @@ id: 4802
 title: When do these MEDRS guidelines apply?
 summary:
 content: |
-  "MEDRS" guidelines apply specifically to "biomedical content." That means
-  they apply to any statement related to the medical or mental health of human
-  beings on Wikipedia, wherever they appear.
+  "MEDRS" guidelines apply specifically to biomedical content. They apply to
+  *any* statement related to the medical or mental health of human beings on
+  Wikipedia, wherever they appear.
 
   Ask yourself: Could someone conceivably use the statements to draw conclusions
   about their own physical or mental health? If so, use MEDRS.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4802-when-do-medical-guidelines-apply-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4802-when-do-medical-guidelines-apply-professional.yml
@@ -1,0 +1,21 @@
+id: 4802
+title: When do these MEDRS guidelines apply?
+summary:
+content: |
+  "MEDRS" guidelines apply specifically to "biomedical content." That means
+  they apply to any statement related to the medical or mental health of human
+  beings on Wikipedia, wherever they appear.
+
+  Ask yourself: Could someone conceivably use the statements to draw conclusions
+  about their own physical or mental health? If so, use MEDRS.
+
+  This includes:
+  * Statements about medicine, diseases, conditions, or diagnoses on Wikipedia
+  * Individual statements about human health, even within non-medical articles
+  * Content about human biochemistry or medical research in animals (if it
+  is relevant to human health)
+
+  Note that MEDRS applies to *statements*, not just articles. So, if you're
+  writing about a plant in a botany article and decide to describe its medical
+  uses, those statements would require MEDRS sourcing. The opposite is also
+  true, as we'll see in the next slide.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4803-when-does-medrs-not-apply-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4803-when-does-medrs-not-apply-professional.yml
@@ -1,0 +1,23 @@
+id: 4803
+title: "When doesn't MEDRS apply?"
+summary:
+content: |
+  It's important to be careful, but don't panic. Not *every* statement in a
+  biomedical article requires you follow the MEDRS guidelines.
+
+  MEDRS does *not* apply to statements that *don't* touch on human biomedical
+  topics, *even if the statement appears within a biomedical-related article*.
+
+  Oftentimes, this level of sourcing would be inappropriate or impossible, and
+  could actually stand in the way of writing a strong article.
+
+  For example:
+  * A sentence in the "culture" section of the "Black Death" article describing
+  its impact on 14th century religious fervor in Europe
+  * A "history" section within the "Opium" article, describing its use in ancient
+  times
+  * A "popular culture" section mentioning that the fictional protagonist of the
+  spy-thriller series Homeland was diagnosed with bipolar disorder
+
+  Though you should always use the best-quality sources you can find, these
+  types of statements do *not* require MEDRS.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4804-first-rule-of-reliable-medical-sources-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4804-first-rule-of-reliable-medical-sources-professional.yml
@@ -1,0 +1,8 @@
+id: 4804
+title: Identifying reliable medical sources
+summary:
+content: |
+  In the next few slides, we'll review the requirements that apply specifically
+  to biomedical statements on Wikipedia.
+
+  The first rule is to cite a good, reliable source.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4805-poor-medical-sources-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4805-poor-medical-sources-professional.yml
@@ -1,0 +1,26 @@
+id: 4805
+title: What are poor sources for Wikipedia?
+summary:
+content: |
+  For medicine and psychology, a single research study — no matter how popular it may be in
+  newspapers or blog posts — is not relevant for Wikipedia until a medical
+  consensus has emerged. This can be difficult for non-scientists to track on
+  their own, which is why the medical editing community on Wikipedia strongly
+  discourages the use of primary sources.
+
+  Primary sources are those where authors directly participated in the research,
+  or documented their personal experiences. If an author has examined the
+  patients, injected the rats, filled the test tubes, or supervised those who
+  did, avoid using that source on Wikipedia. This doesn't make it a "bad study,"
+  or "bad science." Even top researchers published in top journals should be
+  avoided. Instead, use articles that summarize *many* findings from a variety
+  of researchers, and report back on findings across the field.
+
+  For biomedical information on Wikipedia, avoid:
+  * Nearly all papers published in medical journals (except for systematic
+  reviews or literature reviews that examine a wide variety of studies)
+  * Popular press articles
+  * Blogs
+
+  You can read the full guidelines on
+  [identifying reliable medical sources](https://en.wikipedia.org/wiki/Wikipedia:Identifying_reliable_sources_(medicine)).

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4806-good-medical-sources-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4806-good-medical-sources-professional.yml
@@ -1,0 +1,17 @@
+id: 4806
+title: What are good choices for medical sources on Wikipedia?
+summary:
+content: |
+  Good sources:
+  * are typically no more than 5 years old
+  * summarize secondary sources or many primary sources
+  * provide an overview of the current understanding of the topic
+  * combine the results of several studies
+  * are published independently of the research
+
+  For example:
+  * literature reviews or systematic reviews found in reputable medical journals
+  * academic and professional books written by experts in the relevant field,
+  from a respected publisher
+  * medical guidelines or position statements from nationally or internationally
+  recognized expert bodies

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4807-style-conventions-for-medical-topics-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4807-style-conventions-for-medical-topics-professional.yml
@@ -1,0 +1,15 @@
+id: 4807
+title: Style conventions for medical topics
+summary:
+content: |
+  Wikipedia has a detailed
+  [Manual of Style for medicine-related articles](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Medicine-related_articles).
+
+  Two elements in particular can help avoid common problems:
+  * **PMID references:** for references to sources in PubMed, be sure to include
+  the PMIDs within your citation. That way, other editors can easily track down
+  and verify your sources. If other editors can't find your source, they may
+  remove your work. You can find the PMID# at the bottom of an article's abstract.
+  * **Recommended article sections:** common medicine-related topics have
+  a [recommended outline](https://en.wikipedia.org/wiki/Wikipedia:MEDSECTIONS)
+  you should follow as starting points when structuring an article.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4808-medicine-and-original-research-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4808-medicine-and-original-research-professional.yml
@@ -3,8 +3,8 @@ title: No original research
 summary:
 content: |
   "Original research" on Wikipedia means drawing any conclusions that are not
-  specifically mentioned within a cited source. This is true of all articles,
-  but is particularly crucial for medical content.
+  specifically mentioned within a cited source. Original research is not allowed in any article,
+  but it's particularly crucial to avoid with medical content.
 
   Never use material from different sources to suggest a conclusion that isn’t
   explicitly stated by those sources. If one reliable source says A, and another

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4808-medicine-and-original-research-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4808-medicine-and-original-research-professional.yml
@@ -1,0 +1,14 @@
+id: 4808
+title: No original research
+summary:
+content: |
+  "Original research" on Wikipedia means drawing any conclusions that are not
+  specifically mentioned within a cited source. This is true of all articles,
+  but is particularly crucial for medical content.
+
+  Never use material from different sources to suggest a conclusion that isn’t
+  explicitly stated by those sources. If one reliable source says A, and another
+  says B, resist the temptation to connect A and B in your article.
+
+  Pay close attention to your paraphrasing of medical information, and make sure
+  that your content is accurate without citing the original text too closely.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4809-working-with-the-medrs-community-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4809-working-with-the-medrs-community-professional.yml
@@ -1,0 +1,12 @@
+id: 4809
+title: Working with the community
+summary:
+content: |
+  When you edit medical topics, you are submitting work to a group of editors
+  with a sincere commitment to accuracy on Wikipedia's medical pages.
+
+  Keep in mind:
+  * Wikipedia's sourcing requirements may seem counterintuitive at times, but
+  they are designed to prevent confusing verification issues.
+  * Experienced editors sometimes treat medical content with a sense of urgency.
+  That's because bad information on medicine, wherever it appears, is dangerous.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4809-working-with-the-medrs-community-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4809-working-with-the-medrs-community-professional.yml
@@ -2,7 +2,7 @@ id: 4809
 title: Working with the community
 summary:
 content: |
-  When you edit medical topics, you are submitting work to a group of editors
+  When you edit medical topics, your work will be seen by a group of editors
   with a sincere commitment to accuracy on Wikipedia's medical pages.
 
   Keep in mind:

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4810-medical-topics-best-practices-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4810-medical-topics-best-practices-professional.yml
@@ -1,0 +1,10 @@
+id: 4810
+title: Best practices
+summary:
+content: |
+  * Ask questions to your instructor, to the Wikipedia Expert listed on your course page, and on the Talk page of the article you're editing.
+  * Be prepared to participate in Talk page discussions.
+  * Post your sources to article Talk pages before you begin writing.
+  * Give experienced editors a chance to review the appropriateness of your
+  sources ahead of time.
+  * Be prepared to impress the community not only with your level of preparedness, but also your engagement and willingness to listen.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4810-medical-topics-best-practices-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4810-medical-topics-best-practices-professional.yml
@@ -2,7 +2,7 @@ id: 4810
 title: Best practices
 summary:
 content: |
-  * Ask questions to your instructor, to the Wikipedia Expert listed on your course page, and on the Talk page of the article you're editing.
+  * Ask questions of your instructor, the Wikipedia Expert, and on the Talk page of the article you're editing.
   * Be prepared to participate in Talk page discussions.
   * Post your sources to article Talk pages before you begin writing.
   * Give experienced editors a chance to review the appropriateness of your

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4810-medical-topics-best-practices-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4810-medical-topics-best-practices-professional.yml
@@ -2,7 +2,7 @@ id: 4810
 title: Best practices
 summary:
 content: |
-  * Ask questions of your instructor, the Wikipedia Expert, and on the Talk page of the article you're editing.
+  * Ask questions of the Wiki Education staff members working with your course and on the Talk page of the article you're editing.
   * Be prepared to participate in Talk page discussions.
   * Post your sources to article Talk pages before you begin writing.
   * Give experienced editors a chance to review the appropriateness of your

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4811-medrs-quiz-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4811-medrs-quiz-professional.yml
@@ -1,0 +1,36 @@
+id: 4811
+title: MEDRS quiz
+summary:
+content:
+assessment:
+  correct_answer_id: 3
+  question: |
+    Which of the following is NOT a good source for medical statements on Wikipedia?
+  answers:
+    - id: 1
+      text: |
+        literature reviews or systematic reviews found in reputable medical journals
+      explanation: |
+        INCORRECT. Literature reviews, and systematic reviews, are great sources
+        for Wikipedia content, because they reflect a broad consensus of the
+        current knowledge in the field.
+    - id: 2
+      text: |
+        medical guidelines or position statements from nationally or
+        internationally recognized expert bodies
+      explanation: |
+        INCORRECT.This is a fine source, as long as it reflects consensus in the
+        field.
+    - id: 3
+      text: |
+        a study of 1,700 patients published in a reputable medical journal
+      explanation: |
+        CORRECT! While the science may be good, this is a POOR source for
+        medical articles on Wikipedia, because it's a primary source.
+    - id: 4
+      text: |
+        academic and professional books written by experts in the relevant
+        field, from a respected publisher
+      explanation: |
+        INCORRECT. Academic and professional texts from reliable publishers are
+        great sources for Wikipedia articles.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4812-medical-topics-complete-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4812-medical-topics-complete-professional.yml
@@ -1,0 +1,7 @@
+id: 4812
+title: "That's it!"
+summary:
+content: |
+  Happy editing!
+
+  You can review this training at any point.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4812-medical-topics-complete-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4812-medical-topics-complete-professional.yml
@@ -4,4 +4,5 @@ summary:
 content: |
   Happy editing!
 
-  You can review this training at any point.
+  You can review this training at any point under the **Resources** tab of
+  your Dashboard course page.

--- a/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4813-medical-editing-video-professional.yml
+++ b/training_content/wiki_ed/slides/48-editing-medical-topics-professional/4813-medical-editing-video-professional.yml
@@ -1,0 +1,8 @@
+id: 4813
+title: Resources and advice for medical editing
+summary:
+content: |
+  This 5-minute video demonstrates some of the medicine-related resources
+  available on Wikipedia and covers the citation standards for medical topics.
+
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/7JbVdtR2ACc" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
I duplicated the student 'editing medical topics' training for Wiki Scientists/Scholars courses. Language is largely the same with slight copy edits (speaking to participants instead of students). I added training to Professional Development training library