### PR TITLE
Solve calling method on undefined error in addSandboxUrl

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles.jsx
+++ b/app/assets/javascripts/components/overview/my_articles.jsx
@@ -62,7 +62,9 @@ export const MyArticles = createReactClass({
           return id && article_id === assignment.article_id && id !== user_id;
         });
 
-        result.sandboxUrl = this.sandboxUrl(course, related.username);
+        if (related) {
+          result.sandboxUrl = this.sandboxUrl(course, related.username);
+        }
       }
 
       return result;


### PR DESCRIPTION
- Add a catch so that if the related assignment does not exist, do not attempt to create a sandbox url. Related to Sentry issue PRODUCTION-172