### PR TITLE
Private information page

### DIFF
--- a/app/controllers/about_this_site_controller.rb
+++ b/app/controllers/about_this_site_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AboutThisSiteController < ApplicationController
+  respond_to :html
+
+  def private_information; end
+end

--- a/app/views/about_this_site/private_information.html.haml
+++ b/app/views/about_this_site/private_information.html.haml
@@ -1,0 +1,18 @@
+.container
+  %h2 Private Information
+  %p This site retains the following private information:
+  %ul
+    %li Wikimedia usernames
+    %li For logged in users: OAuth credentials that allow partial access to to your Wikimedia account, including making edits on your behalf
+    - if Features.wiki_ed?
+      %li Names of instructors, which are publicly associated with their courses
+      %li Email addresses of instructors, which are used for course-related information, surveys, and related communication
+      %li Names of students, which are shown only to their instructors and to Wiki Education staff
+      %li Email addresses of students, which are used sparingly for course-related information and related communication
+      %li In error logs to help us diagnose problems: the username, IP address, and browser for each error
+    %li The email address and requested username for Requested Accounts; the email address is used to create a Wikimedia account, and removed from this site upon creation.
+
+  - if Features.wiki_ed?
+    %p For additional details, see our Terms of Use and Privacy Policy links below.
+  - else
+    %p Data use and retention is governed by the Wikimedia Cloud Services terms of use. For more details on this, see the link below.

--- a/app/views/about_this_site/private_information.html.haml
+++ b/app/views/about_this_site/private_information.html.haml
@@ -5,12 +5,13 @@
     %li Wikimedia usernames
     %li For logged in users: OAuth credentials that allow partial access to to your Wikimedia account, including making edits on your behalf
     - if Features.wiki_ed?
-      %li Names of instructors, which are publicly associated with their courses
+      %li Full names of instructors, which are publicly associated with their courses
       %li Email addresses of instructors, which are used for course-related information, surveys, and related communication
-      %li Names of students, which are shown only to their instructors and to Wiki Education staff
-      %li Email addresses of students, which are used sparingly for course-related information and related communication
+      %li Full names of learners, which are shown only to their instructors and to Wiki Education staff
+      %li Email addresses of learners, which are used sparingly for course-related information and related communication
       %li In error logs to help us diagnose problems: the username, IP address, and browser for each error
-    %li The email address and requested username for Requested Accounts; the email address is used to create a Wikimedia account, and removed from this site upon creation.
+    - else
+      %li The email address and requested username for Requested Accounts; the email address is used to create a Wikimedia account, and removed from this site upon creation.
 
   - if Features.wiki_ed?
     %p For additional details, see our Terms of Use and Privacy Policy links below.

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -4,6 +4,8 @@
     = link_to 'Wiki Education', 'https://wikiedu.org', target: '_blank'
     = "running on Wikimedia Cloud Services, and is subject to the"
     = link_to 'Cloud Services Terms of use', 'https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_Terms_of_use', target: '_blank'
+    = '. It makes limited use of'
+    = link_to 'Private Information', '/private_information'
     = '. All content is'
     = link_to 'CC-BY-SA', 'https://creativecommons.org/licenses/by-sa/4.0/', target: '_blank'
     = '.'

--- a/app/views/shared/_wiki_ed_footer.html.haml
+++ b/app/views/shared/_wiki_ed_footer.html.haml
@@ -6,6 +6,8 @@
     = link_to 'Terms of Service', 'https://wikiedu.org/terms-of-service'
     = 'and'
     = link_to 'Privacy Policy', 'https://wikiedu.org/privacy-policy'
+    = '. It makes limited use of'
+    = link_to 'Private Information', '/private_information'
     = '. All content is'
     = link_to 'CC-BY-SA', 'https://creativecommons.org/licenses/by-sa/3.0/'
     = '.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
+  get '/private_information' => 'about_this_site#private_information'
   get '/styleguide' => 'styleguide#index'
 
   # Errors


### PR DESCRIPTION
## What this PR does
Adds a Private Information page describing the private information retained by the dashboard (and why), with a new link to this page from the footer.

This addresses a somewhat common information request, and should be a step towards compliance with GDPR-type rules.

## Screenshots
Wiki Education version:
![Wiki Education PI](https://user-images.githubusercontent.com/848483/59534485-4cc05f80-8ea3-11e9-9f86-e99c593e7d97.png)

Programs & Events version:
![P E PI](https://user-images.githubusercontent.com/848483/59534490-4fbb5000-8ea3-11e9-9763-7312f4f4be4b.png)