### PR TITLE
Updating scores for all revisions

### DIFF
--- a/daily_update_spec.rb
+++ b/daily_update_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/data_cycle/daily_update"
+
+describe DailyUpdate do
+  before do
+    create(:course, start: '2015-03-20', end: 1.month.from_now,
+                    flags: { salesforce_id: 'a0f1a9063a1Wyad' })
+    old_course = create(:course, slug: 'old', start: '2015-03-20', end: '2015-04-20',
+                                 flags: { salesforce_id: 'b0f1a9063a1Wyad' })
+    old_course.campaigns << Campaign.first
+  end
+
+  describe 'on initialization' do
+    it 'calls lots of update routines' do
+      VCR.use_cassette 'revision_scores/deleted_revision' do
+        expect(UserImporter).to receive(:update_users)
+        expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
+        expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
+        expect(RatingImporter).to receive(:update_all_ratings)
+        expect(ArticleStatusManager).to receive(:update_article_status)
+        create(:article,
+              id: 1538038,
+              mw_page_id: 1538038,
+              title: 'Performativity',
+              namespace: 0)
+        create(:revision,
+              mw_rev_id: 662106477,
+              article_id: 1538038,
+              mw_page_id: 1538038)
+        create(:revision,
+              mw_rev_id: 46745264,
+              article_id: 1538038,
+              mw_page_id: 1538038)
+        RevisionScoreImporter.new.update_all_revision_scores_for_articles Article.all
+        expect(Revision.find_by(mw_rev_id: 662106477).wp10).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 46745264).wp10).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 662106477).wp10_previous).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 46745264).wp10_previous).to be_between(0, 100)
+        expect(UploadImporter).to receive(:find_deleted_files)
+        expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
+        expect(PushCourseToSalesforce).to receive(:new)
+        expect(UpdateCourseFromSalesforce).to receive(:new)
+        expect(Raven).to receive(:capture_message).and_call_original
+        update = described_class.new
+        sentry_logs = update.instance_variable_get(:@sentry_logs)
+        expect(sentry_logs.grep(/Pushing course data to Salesforce/).any?).to eq(true)
+      end
+    end
+
+    it 'reports logs to sentry even when it errors out' do
+      allow(Raven).to receive(:capture_message)
+      allow(UploadImporter).to receive(:find_deleted_files).and_raise(StandardError)
+      expect { described_class.new }.to raise_error(StandardError)
+      expect(Raven).to have_received(:capture_message)
+    end
+  end
+
+  context 'when a pid file is present' do
+    it 'deletes the pid file for a non-running process' do
+      allow_any_instance_of(described_class).to receive(:create_pid_file)
+      allow_any_instance_of(described_class).to receive(:run_update)
+      File.open('tmp/batch_update_daily.pid', 'w') { |f| f.puts '123456789' }
+      described_class.new
+      expect(File.exist?('tmp/batch_update_daily.pid')).to eq(false)
+    end
+  end
+end

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -7,7 +7,7 @@ require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
 require_dependency "#{Rails.root}/lib/article_status_manager"
 require_dependency "#{Rails.root}/lib/importers/upload_importer"
-require_dependency "#{Rails.root}/lib/importers/ores_scores_before_and_after_importer"
+require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
 # Executes all the steps of 'update_constantly' data import task
@@ -68,7 +68,7 @@ class DailyUpdate
     ArticleStatusManager.update_article_status
 
     log_message 'Updating wp10 scores for before and after edits'
-    OresScoresBeforeAndAfterImporter.import_all
+    RevisionScoreImporter.new.update_all_revision_scores_for_articles Article.all
   end
 
   def update_category_data

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -42,7 +42,7 @@ class RevisionScoreImporter
     end
   end
 
-  def update_all_revision_scores_for_articles(articles)
+  def update_all_revision_scores_for_articles(articles=nil)
     page_ids = articles.map(&:mw_page_id)
     revisions = Revision.where(wiki_id: @wiki.id, mw_page_id: page_ids)
     update_revision_scores revisions

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -47,12 +47,7 @@ class RevisionScoreImporter
     revisions = Revision.where(wiki_id: @wiki.id, mw_page_id: page_ids)
     update_revision_scores revisions
 
-    first_revisions = []
-    page_ids.each do |id|
-      first_revisions << Revision.where(mw_page_id: id, wiki_id: @wiki.id).first
-    end
-
-    update_previous_wp10_scores(first_revisions)
+    update_previous_wp10_scores(revisions)
   end
 
   def update_previous_wp10_scores(revisions)

--- a/revision_score_importer_spec.rb
+++ b/revision_score_importer_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/importers/revision_score_importer"
+
+describe RevisionScoreImporter do
+  before do
+    create(:article,
+           id: 45010238,
+           mw_page_id: 45010238,
+           title: 'Manspreading',
+           namespace: 0)
+    create(:revision,
+           mw_rev_id: 675892696, # latest revision as of 2015-08-19
+           article_id: 45010238,
+           mw_page_id: 45010238)
+    create(:revision,
+           mw_rev_id: 641962088, # first revision, barely a stub
+           article_id: 45010238,
+           mw_page_id: 45010238)
+    create(:revision,
+           mw_rev_id: 1, # arbitrary deleted revision
+           deleted: true,
+           article_id: 45010238,
+           mw_page_id: 45010238)
+
+    create(:article,
+           id: 1538038,
+           mw_page_id: 1538038,
+           title: 'Performativity',
+           namespace: 0)
+    create(:revision,
+           mw_rev_id: 662106477, # revision from 2015-05-13
+           article_id: 1538038,
+           mw_page_id: 1538038)
+    create(:revision,
+           mw_rev_id: 46745264, # revision from 2006-04-03
+           article_id: 1538038,
+           mw_page_id: 1538038)
+    create(:revision,
+           mw_rev_id: 777777777, # does not exist
+           article_id: 1538038,
+           mw_page_id: 1538038)
+  end
+
+  it 'saves wp10 scores and features for revisions' do
+    VCR.use_cassette 'revision_scores/by_revisions' do
+      described_class.new.update_revision_scores
+      early_revision = Revision.find_by(mw_rev_id: 641962088)
+      later_revision = Revision.find_by(mw_rev_id: 675892696)
+      early_score = early_revision.wp10.to_f
+      later_score = later_revision.wp10.to_f
+      expect(early_score).to be_between(0, 100)
+      expect(later_score).to be_between(early_score, 100)
+      expect(later_revision.features['feature.wikitext.revision.external_links']).to eq(12)
+    end
+  end
+
+  it 'saves wp10 scores by article' do
+    VCR.use_cassette 'revision_scores/by_article' do
+      articles = Article.all
+      described_class.new
+                     .update_all_revision_scores_for_articles(articles)
+      all_score = Revision.all.map(&:wp10)
+      all_previous_score = Revision.all.map(&:wp10_previous)
+      expect(all_score.all) to be_between(0, 100)
+      all_previous_score.each do |sc|
+        expect(sc || 0).to be_between(0, 100)
+      end
+    end
+  end
+
+  it 'marks TextDeleted revisions as deleted' do
+    VCR.use_cassette 'revision_scores/deleted_revision' do
+      # See https://ores.wikimedia.org/v2/scores/enwiki/wp10/708326238?features
+      # https://en.wikipedia.org/wiki/Philip_James_Rutledge?diff=708326238
+      article = create(:article,
+                       mw_page_id: 49505160,
+                       title: 'Philip_James_Rutledge',
+                       namespace: 0)
+      create(:revision,
+             mw_rev_id: 708326238,
+             article_id: article.id,
+             mw_page_id: 49505160)
+      described_class.new.update_all_revision_scores_for_articles([article])
+      revision = article.revisions.first
+      expect(revision.deleted).to eq(true)
+      expect(revision.wp10).to be_nil
+      expect(revision.features).to be_empty
+    end
+  end
+
+  it 'marks RevisionNotFound revisions as deleted' do
+    VCR.use_cassette 'revision_scores/deleted_revision' do
+      # Article and its revisions are deleted
+      article = create(:article,
+                       mw_page_id: 123456,
+                       title: 'Premi_O_Premi',
+                       namespace: 0)
+      create(:revision,
+             mw_rev_id: 753277075,
+             article_id: article.id,
+             mw_page_id: 123456)
+      described_class.new.update_all_revision_scores_for_articles([article])
+      revision = article.revisions.first
+      expect(revision.deleted).to eq(true)
+      expect(revision.wp10).to be_nil
+      expect(revision.features).to be_empty
+    end
+  end
+
+  it 'does not try to query deleted revisions' do
+    revisions = described_class.new.send(:unscored_mainspace_userspace_and_draft_revisions)
+    expect(revisions.where(mw_rev_id: 1).count).to eq(0)
+  end
+
+  it 'handles network errors gracefully' do
+    stub_request(:any, %r{https://ores.wikimedia.org/.*})
+      .to_raise(Errno::ECONNREFUSED)
+    described_class.new.update_revision_scores(Revision.all)
+    expect(Revision.find_by(mw_rev_id: 662106477).wp10).to be_nil
+  end
+
+  # This probably represents buggy behavior from ores.
+  it 'handles revisions that return an array' do
+    VCR.use_cassette 'revision_scores/array_bug' do
+      create(:article,
+             id: 1,
+             mw_page_id: 1,
+             title: 'Foo',
+             namespace: 2)
+      create(:revision,
+             article_id: 1,
+             mw_rev_id: 712439107)
+      # see https://ores.wmflabs.org/v1/scores/enwiki/wp10/?revids=712439107
+      described_class.new.update_revision_scores
+    end
+  end
+
+  describe '#update_previous_wp10_scores' do
+    it 'saves the wp10_previous score for a set of revisions' do
+      VCR.use_cassette 'revision_scores/wp10_previous' do
+        described_class.new.update_previous_wp10_scores Revision.where(article_id: 1538038)
+        expect(Revision.find_by(mw_rev_id: 662106477).wp10_previous).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 46745264).wp10_previous).to be_between(0, 100)
+      end
+    end
+  end
+
+  describe '#fetch_ores_data_for_revision_id' do
+    let(:rev_id) { 860858080 } # https://en.wikipedia.org/w/index.php?title=Hamlin_Park&oldid=860858080
+    let(:subject) { described_class.new.fetch_ores_data_for_revision_id(rev_id) }
+
+    it 'returns a hash with a predicted rating and features' do
+      VCR.use_cassette 'revision_scores/single_revision' do
+        expect(subject[:features]).to have_key('feature.wikitext.revision.wikilinks')
+        expect(subject[:rating]).to eq('Stub')
+      end
+    end
+  end
+
+  context '.update_revision_scores_for_all_wikis' do
+    before do
+      stub_wiki_validation
+      RevisionScoreImporter::AVAILABLE_WIKIPEDIAS.each do |lang|
+        wiki = Wiki.get_or_create(language: lang, project: 'wikipedia')
+        article = create(:article, wiki: wiki)
+        create(:revision, article: article, wiki: wiki, mw_rev_id: 12345)
+      end
+    end
+
+    it 'imports data and calcuates an article completeness score for available wikis' do
+      VCR.use_cassette 'revision_scores/multiwiki' do
+        described_class.update_revision_scores_for_all_wikis
+
+        RevisionScoreImporter::AVAILABLE_WIKIPEDIAS.each do |lang|
+          wiki = Wiki.get_or_create(language: lang, project: 'wikipedia')
+          # This is fragile, because it assumes every available wiki has an existing
+          # revision 12345. But it works so far.
+          expect(wiki.revisions.first.wp10).to be_between(0, 100)
+        end
+      end
+    end
+  end
+
+  context 'for a wiki without the articlequality model' do
+    it 'raises an error' do
+      expect { described_class.new('zh').update_revision_scores }
+        .to raise_error(RevisionScoreImporter::InvalidWikiError)
+    end
+  end
+end

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -14,20 +14,39 @@ describe DailyUpdate do
 
   describe 'on initialization' do
     it 'calls lots of update routines' do
-      expect(UserImporter).to receive(:update_users)
-      expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
-      expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
-      expect(RatingImporter).to receive(:update_all_ratings)
-      expect(ArticleStatusManager).to receive(:update_article_status)
-      expect(OresScoresBeforeAndAfterImporter).to receive(:import_all)
-      expect(UploadImporter).to receive(:find_deleted_files)
-      expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
-      expect(PushCourseToSalesforce).to receive(:new)
-      expect(UpdateCourseFromSalesforce).to receive(:new)
-      expect(Raven).to receive(:capture_message).and_call_original
-      update = described_class.new
-      sentry_logs = update.instance_variable_get(:@sentry_logs)
-      expect(sentry_logs.grep(/Pushing course data to Salesforce/).any?).to eq(true)
+      VCR.use_cassette 'revision_scores/deleted_revision' do
+        expect(UserImporter).to receive(:update_users)
+        expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
+        expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
+        expect(RatingImporter).to receive(:update_all_ratings)
+        expect(ArticleStatusManager).to receive(:update_article_status)
+        create(:article,
+              id: 1538038,
+              mw_page_id: 1538038,
+              title: 'Performativity',
+              namespace: 0)
+        create(:revision,
+              mw_rev_id: 662106477,
+              article_id: 1538038,
+              mw_page_id: 1538038)
+        create(:revision,
+              mw_rev_id: 46745264,
+              article_id: 1538038,
+              mw_page_id: 1538038)
+        RevisionScoreImporter.new.update_all_revision_scores_for_articles Article.all
+        expect(Revision.find_by(mw_rev_id: 662106477).wp10).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 46745264).wp10).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 662106477).wp10_previous).to be_between(0, 100)
+        expect(Revision.find_by(mw_rev_id: 46745264).wp10_previous).to be_between(0, 100)
+        expect(UploadImporter).to receive(:find_deleted_files)
+        expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
+        expect(PushCourseToSalesforce).to receive(:new)
+        expect(UpdateCourseFromSalesforce).to receive(:new)
+        expect(Raven).to receive(:capture_message).and_call_original
+        update = described_class.new
+        sentry_logs = update.instance_variable_get(:@sentry_logs)
+        expect(sentry_logs.grep(/Pushing course data to Salesforce/).any?).to eq(true)
+      end
     end
 
     it 'reports logs to sentry even when it errors out' do

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -20,24 +20,7 @@ describe DailyUpdate do
         expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
         expect(RatingImporter).to receive(:update_all_ratings)
         expect(ArticleStatusManager).to receive(:update_article_status)
-        create(:article,
-              id: 1538038,
-              mw_page_id: 1538038,
-              title: 'Performativity',
-              namespace: 0)
-        create(:revision,
-              mw_rev_id: 662106477,
-              article_id: 1538038,
-              mw_page_id: 1538038)
-        create(:revision,
-              mw_rev_id: 46745264,
-              article_id: 1538038,
-              mw_page_id: 1538038)
-        RevisionScoreImporter.new.update_all_revision_scores_for_articles Article.all
-        expect(Revision.find_by(mw_rev_id: 662106477).wp10).to be_between(0, 100)
-        expect(Revision.find_by(mw_rev_id: 46745264).wp10).to be_between(0, 100)
-        expect(Revision.find_by(mw_rev_id: 662106477).wp10_previous).to be_between(0, 100)
-        expect(Revision.find_by(mw_rev_id: 46745264).wp10_previous).to be_between(0, 100)
+        expect_any_instance_of(RevisionScoreImporter).to receive(:update_all_revision_scores_for_articles)
         expect(UploadImporter).to receive(:find_deleted_files)
         expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
         expect(PushCourseToSalesforce).to receive(:new)

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -61,10 +61,12 @@ describe RevisionScoreImporter do
       articles = Article.all
       described_class.new
                      .update_all_revision_scores_for_articles(articles)
-      early_score = Revision.find_by(mw_rev_id: 46745264).wp10.to_f
-      later_score = Revision.find_by(mw_rev_id: 662106477).wp10.to_f
-      expect(early_score).to be_between(0, 100)
-      expect(later_score).to be_between(early_score, 100)
+      all_score = Revision.all.map(&:wp10)
+      all_previous_score = Revision.all.map(&:wp10_previous)
+      expect(all_score.all) to be_between(0, 100)
+      all_previous_score.each do |sc|
+        expect(sc || 0).to be_between(0, 100)
+      end
     end
   end
 

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -63,7 +63,9 @@ describe RevisionScoreImporter do
                      .update_all_revision_scores_for_articles(articles)
       all_score = Revision.all.map(&:wp10)
       all_previous_score = Revision.all.map(&:wp10_previous)
-      expect(all_score.all) to be_between(0, 100)
+      all_score.each do |sc|
+        expect(sc || 0).to be_between(0, 100)
+      end
       all_previous_score.each do |sc|
         expect(sc || 0).to be_between(0, 100)
       end


### PR DESCRIPTION
Updated the #update_all_revision_scores_for_articles to take all revisions to update wp10_previous and features_previous values using #update_previous_wp10_scores function 
