### PR TITLE
For account creations, first try the course home wiki, then fall back to en.wiki

### DIFF
--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -22,7 +22,8 @@ class CreateRequestedAccount
     @use_backup_creator = false
 
     course_link = "#{ENV['dashboard_url']}/courses/#{@course.slug}"
-    @creation_reason = I18n.t('wiki_api.create_account_reason', event: course_link)
+    @creation_reason = I18n.t('wiki_api.create_account_reason', event: course_link,
+                                                                locale: @wiki.language)
     process_request(@creator, @creation_reason)
   end
 

--- a/spec/services/create_requested_account_spec.rb
+++ b/spec/services/create_requested_account_spec.rb
@@ -5,24 +5,33 @@ require 'rails_helper'
 describe CreateRequestedAccount do
   let(:creator) { create(:admin) }
   let(:super_admin) { create(:super_admin) }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, home_wiki: home_wiki) }
+  let(:home_wiki) { Wiki.get_or_create(language: 'fr', project: 'wikipedia') }
+  let(:en_wiki) { Wiki.find 1 }
   let(:user) { create(:user) }
   let(:requested_account) do
     create(
       :requested_account,
-      course_id: course.id,
+      course: course,
       username: user.username,
       email: 'email@example.com'
     )
   end
-  let(:wiki_edits) { WikiEdits.new(Wiki.find(1)) }
+  let(:en_wiki_edits) { WikiEdits.new(en_wiki) }
+  let(:homewiki_wiki_edits) { WikiEdits.new(home_wiki) }
 
   let(:subject) do
     described_class.new(requested_account, creator)
   end
 
+  before do
+    stub_wiki_validation
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('edit_fr.wikipedia.org').and_return('true')
+  end
+
   it 'creates the requested accounts' do
-    stub_account_creation
+    stub_account_creation(wiki: home_wiki)
     allow(UserImporter).to receive(:new_from_username).and_return(user)
     expect(subject.result[:success]).not_to be_nil
     expect(user.username).to eq('Ragesock')
@@ -30,14 +39,14 @@ describe CreateRequestedAccount do
   end
 
   it 'destroys the requested account if the username already exist' do
-    stub_account_creation_failure_userexists
+    stub_account_creation_failure_userexists(wiki: home_wiki)
     expect(subject.result[:failure]).not_to be_nil
     expect(RequestedAccount.count).to eq(0)
   end
 
   it 'logs an error and keeps the requested account when unexpected responses' do
     expect(Raven).to receive(:capture_exception)
-    stub_account_creation_failure_unexpected
+    stub_account_creation_failure_unexpected(wiki: home_wiki)
     expect(subject.result[:failure]).not_to be_nil
     expect(RequestedAccount.count).to eq(1)
   end
@@ -46,14 +55,18 @@ describe CreateRequestedAccount do
     SpecialUsers.set_user(:backup_account_creator, super_admin.username)
     # This will stub the request so that it fails with the appropriate
     # error message, which in turn will change the creator to the super admin
-    stub_account_creation_failure_throttle
-    expect(WikiEdits).to receive(:new).and_return(wiki_edits)
-    expect(wiki_edits).to receive(:create_account)
+    stub_account_creation_failure_throttle(wiki: home_wiki)
+    stub_account_creation(wiki: en_wiki)
+    expect(WikiEdits).to receive(:new).twice.and_call_original
+    expect(WikiEdits).to receive(:new).with(home_wiki).and_return(homewiki_wiki_edits)
+    expect(WikiEdits).to receive(:new).with(en_wiki).and_return(en_wiki_edits)
+
+    expect(homewiki_wiki_edits).to receive(:create_account)
       .with(creator: creator, username: anything, email: anything, reason: anything)
-      .ordered.and_call_original
-    expect(wiki_edits).to receive(:create_account)
+      .and_call_original
+    expect(en_wiki_edits).to receive(:create_account)
       .with(creator: super_admin, username: anything, email: anything, reason: anything)
-      .ordered.and_call_original
+      .and_call_original
     subject
   end
 
@@ -61,25 +74,29 @@ describe CreateRequestedAccount do
     SpecialUsers.set_user(:backup_account_creator, super_admin.username)
     # This will stub the request so that it fails with the appropriate
     # error message, which in turn will change the creator to the super admin
-    stub_account_creation_failure_captcha
-    expect(WikiEdits).to receive(:new).and_return(wiki_edits)
-    expect(wiki_edits).to receive(:create_account)
+    stub_account_creation_failure_captcha(wiki: home_wiki)
+    stub_account_creation(wiki: en_wiki)
+    expect(WikiEdits).to receive(:new).twice.and_call_original
+    expect(WikiEdits).to receive(:new).with(home_wiki).and_return(homewiki_wiki_edits)
+    expect(WikiEdits).to receive(:new).with(en_wiki).and_return(en_wiki_edits)
+    expect(homewiki_wiki_edits).to receive(:create_account)
       .with(creator: creator, username: anything, email: anything, reason: anything)
-      .ordered.and_call_original
-    expect(wiki_edits).to receive(:create_account)
+      .and_call_original
+    expect(en_wiki_edits).to receive(:create_account)
       .with(creator: super_admin, username: anything, email: anything, reason: anything)
-      .ordered.and_call_original
+      .and_call_original
     subject
   end
 
   it 'only retries account creation if the request fails because of expected failure messages' do
     SpecialUsers.set_user(:backup_account_creator, super_admin.username)
-    stub_account_creation_failure_unexpected
-    expect(WikiEdits).to receive(:new).and_return(wiki_edits)
-    expect(wiki_edits).to receive(:create_account)
+    stub_account_creation_failure_unexpected(wiki: home_wiki)
+    expect(WikiEdits).to receive(:new).twice.and_call_original
+    expect(WikiEdits).to receive(:new).with(home_wiki).and_return(homewiki_wiki_edits)
+    expect(homewiki_wiki_edits).to receive(:create_account)
       .with(creator: creator, username: anything, email: anything, reason: anything)
       .and_call_original
-    expect(wiki_edits).not_to receive(:create_account)
+    expect(en_wiki_edits).not_to receive(:create_account)
       .with(creator: super_admin, username: anything, email: anything, reason: anything)
     subject
     expect(RequestedAccount.count).to eq(1)

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -13,9 +13,9 @@ module RequestHelpers
       .to_return(status: 200, body: fake_tokens, headers: {})
   end
 
-  def stub_account_creation_token_request
+  def stub_account_creation_token_request(wiki: nil)
     fake_tokens = '{"query":{"tokens":{"createaccounttoken":"faketoken+\\\\"}}}'
-    lang = ENV['wiki_language']
+    lang = wiki&.language || ENV['wiki_language']
     params_url = 'action=query&meta=tokens&format=json&type=createaccount'
     url = "https://#{lang}.wikipedia.org/w/api.php?#{params_url}"
     stub_request(:get, url)
@@ -55,24 +55,25 @@ module RequestHelpers
       .to_return(status: 200, body: success, headers: {})
   end
 
-  def stub_account_creation
+  def stub_account_creation(wiki: nil)
     # Stub out the creation of accounts at Wikipedia
     # First the request for edit tokens for a user
-    stub_account_creation_token_request
+    stub_account_creation_token_request(wiki: wiki)
 
     # Then the account creation request itself
-    success = '{"createaccount":{"status":"PASS", "username":"Ragetest 99"}}'
-    stub_request(:post, /.*wikipedia.*/)
+    success = '{"createaccount":{"status":"PASS", "username":"Ragesock"}}'
+    lang = wiki&.language || ENV['wiki_language']
+    stub_request(:post, /.*#{lang}.wikipedia.*/)
       .to_return(status: 200, body: success, headers: {})
 
     # After account creation, stub the query for user info for UserImporter
     stub_list_users_query
   end
 
-  def stub_account_creation_failure_userexists
+  def stub_account_creation_failure_userexists(wiki: nil)
     # Stub out the creation of accounts at Wikipedia
     # First the request for edit tokens for a user
-    stub_account_creation_token_request
+    stub_account_creation_token_request(wiki: wiki)
 
     # Then the account creation request itself
     failure = '{"createaccount":{"status":"FAIL",
@@ -84,10 +85,10 @@ module RequestHelpers
     stub_list_users_query
   end
 
-  def stub_account_creation_failure_unexpected
+  def stub_account_creation_failure_unexpected(wiki: nil)
     # Stub out the creation of accounts at Wikipedia
     # First the request for edit tokens for a user
-    stub_account_creation_token_request
+    stub_account_creation_token_request(wiki: wiki)
 
     # Then the account creation request itself
     failure = '{"createaccount":{"username":"Ragetest 99"}}'
@@ -98,10 +99,10 @@ module RequestHelpers
     stub_list_users_query
   end
 
-  def stub_account_creation_failure_throttle
+  def stub_account_creation_failure_throttle(wiki: nil)
     # Stub out the creation of accounts at Wikipedia
     # First the request for edit tokens for a user
-    stub_account_creation_token_request
+    stub_account_creation_token_request(wiki: wiki)
 
     # Then the account creation request itself
     failure = '{"createaccount":{"status":"FAIL",
@@ -113,10 +114,10 @@ module RequestHelpers
     stub_list_users_query
   end
 
-  def stub_account_creation_failure_captcha
+  def stub_account_creation_failure_captcha(wiki: nil)
     # Stub out the creation of accounts at Wikipedia
     # First the request for edit tokens for a user
-    stub_account_creation_token_request
+    stub_account_creation_token_request(wiki: wiki)
 
     # Then the account creation request itself
     failure = '{"createaccount":{"status":"FAIL",


### PR DESCRIPTION
This changes the behavior of requestsed accounts so that the first try will be done against the home wiki for a course, and the fallback will go to en.wiki. It should also use the appropriate translation for whatever wiki the account gets created at, for the log message.

This is hard to test without doing it live, so I would much appreciate a careful review of the logic.