### PR TITLE
Updating scores for all revisions

### DIFF
--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -7,7 +7,7 @@ require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
 require_dependency "#{Rails.root}/lib/article_status_manager"
 require_dependency "#{Rails.root}/lib/importers/upload_importer"
-require_dependency "#{Rails.root}/lib/importers/ores_scores_before_and_after_importer"
+require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
 # Executes all the steps of 'update_constantly' data import task
@@ -68,7 +68,7 @@ class DailyUpdate
     ArticleStatusManager.update_article_status
 
     log_message 'Updating wp10 scores for before and after edits'
-    OresScoresBeforeAndAfterImporter.import_all
+    RevisionScoreImporter.new.update_all_revision_scores_for_articles Article.all
   end
 
   def update_category_data

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -42,17 +42,12 @@ class RevisionScoreImporter
     end
   end
 
-  def update_all_revision_scores_for_articles(articles)
+  def update_all_revision_scores_for_articles(articles=nil)
     page_ids = articles.map(&:mw_page_id)
     revisions = Revision.where(wiki_id: @wiki.id, mw_page_id: page_ids)
     update_revision_scores revisions
 
-    first_revisions = []
-    page_ids.each do |id|
-      first_revisions << Revision.where(mw_page_id: id, wiki_id: @wiki.id).first
-    end
-
-    update_previous_wp10_scores(first_revisions)
+    update_previous_wp10_scores(revisions)
   end
 
   def update_previous_wp10_scores(revisions)

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -14,20 +14,23 @@ describe DailyUpdate do
 
   describe 'on initialization' do
     it 'calls lots of update routines' do
-      expect(UserImporter).to receive(:update_users)
-      expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
-      expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
-      expect(RatingImporter).to receive(:update_all_ratings)
-      expect(ArticleStatusManager).to receive(:update_article_status)
-      expect(OresScoresBeforeAndAfterImporter).to receive(:import_all)
-      expect(UploadImporter).to receive(:find_deleted_files)
-      expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
-      expect(PushCourseToSalesforce).to receive(:new)
-      expect(UpdateCourseFromSalesforce).to receive(:new)
-      expect(Raven).to receive(:capture_message).and_call_original
-      update = described_class.new
-      sentry_logs = update.instance_variable_get(:@sentry_logs)
-      expect(sentry_logs.grep(/Pushing course data to Salesforce/).any?).to eq(true)
+      VCR.use_cassette 'revision_scores/deleted_revision' do
+        expect(UserImporter).to receive(:update_users)
+        expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
+        expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
+        expect(RatingImporter).to receive(:update_all_ratings)
+        expect(ArticleStatusManager).to receive(:update_article_status)
+        expect_any_instance_of(RevisionScoreImporter)
+          .to receive(:update_all_revision_scores_for_articles)
+        expect(UploadImporter).to receive(:find_deleted_files)
+        expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
+        expect(PushCourseToSalesforce).to receive(:new)
+        expect(UpdateCourseFromSalesforce).to receive(:new)
+        expect(Raven).to receive(:capture_message).and_call_original
+        update = described_class.new
+        sentry_logs = update.instance_variable_get(:@sentry_logs)
+        expect(sentry_logs.grep(/Pushing course data to Salesforce/).any?).to eq(true)
+      end
     end
 
     it 'reports logs to sentry even when it errors out' do

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -61,10 +61,14 @@ describe RevisionScoreImporter do
       articles = Article.all
       described_class.new
                      .update_all_revision_scores_for_articles(articles)
-      early_score = Revision.find_by(mw_rev_id: 46745264).wp10.to_f
-      later_score = Revision.find_by(mw_rev_id: 662106477).wp10.to_f
-      expect(early_score).to be_between(0, 100)
-      expect(later_score).to be_between(early_score, 100)
+      all_score = Revision.all.map(&:wp10)
+      all_previous_score = Revision.all.map(&:wp10_previous)
+      all_score.each do |sc|
+        expect(sc || 0).to be_between(0, 100)
+      end
+      all_previous_score.each do |sc|
+        expect(sc || 0).to be_between(0, 100)
+      end
     end
   end
 


### PR DESCRIPTION
Updating revision scores for all revisions using #update_all_revision_scores_for_articles to take all revisions and update wp10_previous and features_previous for all revisions using #update_previous_wp10_scores
