### PR TITLE
Update stylings for training modules to include tables

### DIFF
--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -23,7 +23,7 @@
   padding 12px
   text-overflow ellipsis
 
-.table
+.table, .training table
   width 100%
   border-collapse separate
 

--- a/app/assets/stylesheets/training.styl
+++ b/app/assets/stylesheets/training.styl
@@ -72,4 +72,23 @@ old-ie ?= false
 @import "_training_base"
 @import "modules/_nav"
 @import "modules/_language_picker"
+@import "modules/_tables"
 @import "training_modules/*"
+
+// Overwriting some table styles
+.training .training__slide
+  table
+    margin-bottom 20px
+  table td, table th
+    font-size 16px
+  table th
+    background $border_med
+    border 1px solid #ddd
+    border-bottom none
+    color $type_dark
+
+    &:first-child
+      border-left 1px solid #ddd
+    &:last-child
+      border-right 1px solid #ddd
+


### PR DESCRIPTION
## What this PR does
Adds style to Training Module tables.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1316902/60545282-91cff880-9ccf-11e9-84db-0304c49b4286.png)


After:
![image](https://user-images.githubusercontent.com/1316902/60547706-402a6c80-9cd5-11e9-933e-1de98da62819.png)