### PR TITLE
Normalizes the labels of revision titles

### DIFF
--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -8,7 +8,7 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
   const ratingClass = `rating ${revision.rating}`;
   const ratingMobileClass = `${ratingClass} tablet-only`;
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
-
+  const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
@@ -20,7 +20,7 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
       </td>
       <td>
         <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>
-        <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}</p></a>
+        <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}</p><small>{subtitle}</small></a>
       </td>
       <td className="desktop-only-tc">{revision.revisor}</td>
       <td className="desktop-only-tc">{revision.characters}</td>

--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -20,7 +20,7 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
       </td>
       <td>
         <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>
-        <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}</p><small>{subtitle}</small></a>
+        <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}&nbsp;<small>{subtitle}</small></p></a>
       </td>
       <td className="desktop-only-tc">{revision.revisor}</td>
       <td className="desktop-only-tc">{revision.characters}</td>

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -144,7 +144,7 @@ export default class CourseUtils {
       projectPrefix = `${article.project}:`;
     }
 
-    let title = this.removeNamespace(article.title); // Remove unwanted namespace in labels.
+    let title = article.title;
     if (article.project === 'wikidata' && wikidataLabel) {
       title = wikidataLabel;
     }

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -144,7 +144,7 @@ export default class CourseUtils {
       projectPrefix = `${article.project}:`;
     }
 
-    let title = article.title;
+    let title = this.removeNamespace(article.title); // Remove unwanted namespace in labels.
     if (article.project === 'wikidata' && wikidataLabel) {
       title = wikidataLabel;
     }

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -131,7 +131,7 @@ export default class CourseUtils {
   // default one.
   static formattedArticleTitle(article, defaultWiki, wikidataLabel) {
     let languagePrefix = '';
-    if (!defaultWiki || !article.language || article.language === defaultWiki.language) {
+    if (!defaultWiki || !defaultWiki.language || !article.language || article.language === defaultWiki.language) {
       languagePrefix = '';
     } else {
       languagePrefix = `${article.language}:`;

--- a/app/models/wiki_content/article.rb
+++ b/app/models/wiki_content/article.rb
@@ -56,8 +56,12 @@ class Article < ApplicationRecord
     USER_TALK      = 3
     WIKIPEDIA      = 4
     WIKIPEDIA_TALK = 5
+    FILE           = 6
     TEMPLATE       = 10
     TEMPLATE_TALK  = 11
+    PAGE           = 104
+    WIKIJUNIOR     = 110
+    TRANSLATION    = 114
     DRAFT          = 118
     DRAFT_TALK     = 119
     PROPERTY       = 120
@@ -78,7 +82,29 @@ class Article < ApplicationRecord
     Namespaces::DRAFT_TALK => 'Draft_talk:',
     Namespaces::PROPERTY => 'Property:',
     Namespaces::QUERY => 'Query:',
-    Namespaces::LEXEME => 'Lexeme:'
+    Namespaces::LEXEME => 'Lexeme:',
+    Namespaces::FILE => 'File:',
+    Namespaces::PAGE => 'Page:',
+    Namespaces::WIKIJUNIOR => 'Wikijunior:',
+    Namespaces::TRANSLATION => 'Translation:',
+    # The following namespace index are spread over
+    # several wikis and needs to be additionally
+    # namespaced via project
+    100 => {
+      'wiktionary' => 'Appendix:',
+      'wikisource' => 'Portal:',
+      'wikiversity' => 'School:'
+    },
+    102 => {
+      'wikisource' => 'Author:',
+      'wikibooks' => 'Cookbook:',
+      'wikiversity' => 'Portal:'
+    },
+    106 => {
+      'wiktionary' => 'Rhymes:',
+      'wikisource' => 'Index:',
+      'wikiversity' => 'Collection:'
+    }
   }.freeze
 
   ####################
@@ -98,7 +124,9 @@ class Article < ApplicationRecord
   end
 
   def namespace_prefix
-    NS_PREFIX[namespace]
+    prefix = NS_PREFIX[namespace]
+    return prefix if prefix.is_a?(String)
+    prefix[wiki.project]
   end
 
   private


### PR DESCRIPTION
## What this PR does
After consolidating the wgContentNamespaces, this PR makes sure the labels in the revisions don't have too much information in them.


## Screenshots
![image](https://user-images.githubusercontent.com/5158554/60905209-3505ac80-a292-11e9-9b57-edd14633e696.png)

