### PR TITLE
Pull Sandbox domain from assignment rather than course wiki

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles.jsx
+++ b/app/assets/javascripts/components/overview/my_articles.jsx
@@ -29,8 +29,14 @@ export const MyArticles = createReactClass({
     }
   },
 
-  sandboxUrl(course, username) {
-    const { language, project } = course.home_wiki;
+  sandboxUrl(course, assignment) {
+    const { username } = assignment;
+    let { language, project } = assignment;
+    if (!language || !project) {
+      language = course.home_wiki.language || 'www';
+      project = course.home_wiki.project || 'wikipedia';
+    }
+
     return `https://${language}.${project}.org/wiki/User:${username}/sandbox`;
   },
 
@@ -54,7 +60,7 @@ export const MyArticles = createReactClass({
     return (assignment) => {
       const result = {
         ...assignment,
-        sandboxUrl: this.sandboxUrl(course, assignment.username)
+        sandboxUrl: this.sandboxUrl(course, assignment)
       };
 
       if (assignment.role === REVIEWING_ROLE) {
@@ -63,7 +69,7 @@ export const MyArticles = createReactClass({
         });
 
         if (related) {
-          result.sandboxUrl = this.sandboxUrl(course, related.username);
+          result.sandboxUrl = this.sandboxUrl(course, related);
         }
       }
 


### PR DESCRIPTION
## What this PR does
Assign the Sandbox URL first according to the assignment, then according to the course's home wiki, then defaulting to wikipedia.

Currently, if the home wiki is set to `www.wikidata.org`, the Sandbox will point to an invalid URL. This should fix the issue and generally point towards the wiki-specific sandbox.