### PR TITLE
Add `sandbox_url` to Assignments

### DIFF
--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -74,10 +74,9 @@ class Assignment < ApplicationRecord
   end
 
   def set_sandbox_url
-    return unless wiki && user
+    return unless user
     # If the sandbox already exists, use that URL instead
-    existing = Assignment.where(course: course, article: article,
-                                wiki: wiki)
+    existing = Assignment.where(course: course, article_title: article_title, wiki: wiki)
                          .where.not(user: user).first
     if existing
       self.sandbox_url = existing.sandbox_url

--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -75,7 +75,15 @@ class Assignment < ApplicationRecord
 
   def set_sandbox_url
     return unless wiki && user
-    base_url = "https://#{wiki.language}.#{wiki.project}.org/wiki"
-    self.sandbox_url = "#{base_url}/User:#{user.username}/#{article_title}"
+    # If the sandbox already exists, use that URL instead
+    existing = Assignment.where(course: course, article: article,
+                                wiki: wiki)
+                         .where.not(user: user).first
+    if existing
+      self.sandbox_url = existing.sandbox_url
+    else
+      base_url = "https://#{wiki.language}.#{wiki.project}.org/wiki"
+      self.sandbox_url = "#{base_url}/User:#{user.username}/#{article_title}"
+    end
   end
 end

--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -13,6 +13,7 @@
 #  article_title :string(255)
 #  role          :integer
 #  wiki_id       :integer
+#  sandbox_url   :text(65535)
 #
 
 require_dependency "#{Rails.root}/lib/article_utils"
@@ -33,6 +34,7 @@ class Assignment < ApplicationRecord
   scope :reviewing, -> { where(role: 1) }
 
   before_validation :set_defaults_and_normalize
+  before_save :set_sandbox_url
 
   #############
   # CONSTANTS #
@@ -69,5 +71,11 @@ class Assignment < ApplicationRecord
     self.wiki_id ||= course.home_wiki.id
     return if article_title.nil?
     self.article_title = ArticleUtils.format_article_title(article_title, wiki)
+  end
+
+  def set_sandbox_url
+    return unless wiki && user
+    base_url = "https://#{wiki.language}.#{wiki.project}.org/wiki"
+    self.sandbox_url = "#{base_url}/User:#{user.username}/#{article_title}"
   end
 end

--- a/db/migrate/20190715195734_add_sandbox_url_to_assignments.rb
+++ b/db/migrate/20190715195734_add_sandbox_url_to_assignments.rb
@@ -1,0 +1,5 @@
+class AddSandboxUrlToAssignments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :assignments, :sandbox_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_24_123708) do
+ActiveRecord::Schema.define(version: 2019_07_15_195734) do
+
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -81,6 +82,7 @@ ActiveRecord::Schema.define(version: 2019_06_24_123708) do
     t.string "article_title"
     t.integer "role"
     t.integer "wiki_id"
+    t.text "sandbox_url"
     t.index ["course_id", "user_id"], name: "index_assignments_on_course_id_and_user_id"
     t.index ["course_id"], name: "index_assignments_on_course_id"
   end

--- a/lib/tasks/assignment.rake
+++ b/lib/tasks/assignment.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+def generate_generic_sandbox_url(assignment)
+  # If there's already a sandbox_url, do nothing
+  return false if assignment.sandbox_url
+
+  wiki = assignment.wiki
+  user = assignment.user
+
+  # If the assignment doesn't have a user or wiki, do nothing
+  return false unless wiki && user
+
+  language = wiki.language || 'en'
+  base_url = "https://#{language}.#{wiki.project}.org/wiki"
+  "#{base_url}/User:#{user.username}/sandbox"
+end
+
+namespace :assignment do
+  # This task will assign sandbox_urls to all valid assignments
+  # that were created before August 2019
+  desc 'Give assignments default sandbox_url'
+  task set_sandbox_url: :environment do
+    Rails.logger.debug 'Setting sandbox_url for all assignments'
+    Assignment.where(created_at: '2019-08-01'.to_date).each do |assignment|
+      url = generate_generic_sandbox_url(assignment)
+      # update_columns will skip the callbacks on assignment
+      assignment.update_columns(sandbox_url: url) if url
+    end
+  end
+end

--- a/lib/tasks/assignment.rake
+++ b/lib/tasks/assignment.rake
@@ -21,7 +21,7 @@ namespace :assignment do
   desc 'Give assignments default sandbox_url'
   task set_sandbox_url: :environment do
     Rails.logger.debug 'Setting sandbox_url for all assignments'
-    Assignment.where(created_at: '2019-08-01'.to_date).each do |assignment|
+    Assignment.where('created_at < ?', '2019-08-01'.to_date).each do |assignment|
       url = generate_generic_sandbox_url(assignment)
       # update_columns will skip the callbacks on assignment
       assignment.update_columns(sandbox_url: url) if url

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -13,6 +13,7 @@
 #  article_title :string(255)
 #  role          :integer
 #  wiki_id       :integer
+#  sandbox_url   :text(65535)
 #
 
 require 'rails_helper'
@@ -29,6 +30,32 @@ describe Assignment do
 
         expect(assignment.id).to be_kind_of(Integer)
         expect(assignment2.article_id).to be_nil
+      end
+
+      it 'generates a sandbox_url by default' do
+        course = create(:course)
+        user = create(:user)
+        article = create(:article)
+        article_title = article.title
+        assignment = create(:assignment, course: course, user: user,
+                             article: article, article_title: article.title,
+                             wiki_id: 1)
+
+        base_url = "https://#{assignment.wiki.language}.#{assignment.wiki.project}.org/wiki"
+        expected = "#{base_url}/User:#{user.username}/#{article_title}"
+        expect(assignment.sandbox_url).to eq(expected)
+      end
+
+      it 'generates a sandbox_url for new articles' do
+        course = create(:course)
+        user = create(:user)
+        article_title = 'New_Article'
+        assignment = create(:assignment, course: course, user: user,
+                             article_title: article_title, wiki_id: 1)
+
+        base_url = "https://#{assignment.wiki.language}.#{assignment.wiki.project}.org/wiki"
+        expected = "#{base_url}/User:#{user.username}/#{article_title}"
+        expect(assignment.sandbox_url).to eq(expected)
       end
     end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -46,6 +46,26 @@ describe Assignment do
         expect(assignment.sandbox_url).to eq(expected)
       end
 
+      it 'uses an already existing sandbox URL for assignments with the same article' do
+        course = create(:course)
+        user = create(:user)
+        article = create(:article)
+        article_title = article.title
+
+        # Another classmate is assigned that article first
+        classmate = create(:user, username: 'ClassmateUsername')
+        create(:assignment, course: course, user: classmate,
+                article: article, article_title: article_title, wiki_id: 1)
+
+        assignment = create(:assignment, course: course, user: user,
+                             article: article, article_title: article_title,
+                             wiki_id: 1)
+
+        base_url = "https://#{assignment.wiki.language}.#{assignment.wiki.project}.org/wiki"
+        expected = "#{base_url}/User:#{classmate.username}/#{article_title}"
+        expect(assignment.sandbox_url).to eq(expected)
+      end
+
       it 'generates a sandbox_url for new articles' do
         course = create(:course)
         user = create(:user)


### PR DESCRIPTION
# What this PR does

At the moment, this PR:
- Adds `sandbox_url` to Assignments
- Before an Assignment is saved, creates a relevant `sandbox_url`
- If that assignment already exists in the same course, use the same `sandbox_url` for the previous assignment
- Adds a script that will backfill `sandbox_urls` for past Assignments