### PR TITLE
Add Wikidata ORES importing to RevisionScoreImporter

### DIFF
--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -158,13 +158,29 @@ describe RevisionScoreImporter do
   end
 
   describe '#fetch_ores_data_for_revision_id' do
-    let(:rev_id) { 860858080 } # https://en.wikipedia.org/w/index.php?title=Hamlin_Park&oldid=860858080
-    let(:subject) { described_class.new.fetch_ores_data_for_revision_id(rev_id) }
+    let(:rev_id) { 860858080 }
+    # https://en.wikipedia.org/w/index.php?title=Hamlin_Park&oldid=860858080
+    # https://www.wikidata.org/w/index.php?title=Q61734980&oldid=860858080
+    let(:language) { 'en' }
+    let(:project) { 'wikipedia'}
+    let(:subject) { described_class.new(language, project).fetch_ores_data_for_revision_id(rev_id) }
 
     it 'returns a hash with a predicted rating and features' do
       VCR.use_cassette 'revision_scores/single_revision' do
         expect(subject[:features]).to have_key('feature.wikitext.revision.wikilinks')
         expect(subject[:rating]).to eq('Stub')
+      end
+    end
+
+    context 'for Wikidata revisions' do
+      let(:language) { nil }
+      let(:project) { 'wikidata' }
+
+      it 'returns a hash with features' do
+        VCR.use_cassette 'revision_scores/single_revision' do
+          expect(subject[:features]).to have_key(Revision::WIKIDATA_REFERENCES)
+          expect(subject[:rating]).to eq('E')
+        end
       end
     end
   end

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -170,6 +170,8 @@ describe RevisionScoreImporter do
   end
 
   context '.update_revision_scores_for_all_wikis' do
+    let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
+
     before do
       stub_wiki_validation
       RevisionScoreImporter::AVAILABLE_WIKIPEDIAS.each do |lang|
@@ -177,6 +179,8 @@ describe RevisionScoreImporter do
         article = create(:article, wiki: wiki)
         create(:revision, article: article, wiki: wiki, mw_rev_id: 12345)
       end
+      wikidata_item = create(:article, wiki: wikidata)
+      create(:revision, article: wikidata_item, wiki: wikidata, mw_rev_id: 12345)
     end
 
     it 'imports data and calcuates an article completeness score for available wikis' do
@@ -189,6 +193,8 @@ describe RevisionScoreImporter do
           # revision 12345. But it works so far.
           expect(wiki.revisions.first.wp10).to be_between(0, 100)
         end
+
+        expect(wikidata.revisions.first.features).not_to be_empty
       end
     end
   end


### PR DESCRIPTION
Adds handling for Wikidata in RevisionScoreImporter, so that we will routinely import ORES features for all wikidata revisions.