### PR TITLE
Add links with templates to bibliography and sandbox url

### DIFF
--- a/app/assets/javascripts/components/overview/my_assignment.jsx
+++ b/app/assets/javascripts/components/overview/my_assignment.jsx
@@ -74,7 +74,7 @@ const Actions = ({
 // Links Components
 const BibliographyLink = ({ assignment }) => {
   const link = `${assignment.sandboxUrl}/bibliography`;
-  const template = 'Template:Dashboard.wikiedu.org_biblography';
+  const template = 'Template:Dashboard.wikiedu.org_bibliography';
   const query = assignment.role === ASSIGNED_ROLE
     ? `?veaction=edit&preload=${template}`
     : '';

--- a/app/assets/javascripts/components/overview/my_assignment.jsx
+++ b/app/assets/javascripts/components/overview/my_assignment.jsx
@@ -76,7 +76,7 @@ const BibliographyLink = ({ assignment }) => {
   const link = `${assignment.sandboxUrl}/bibliography`;
   const template = 'Template:Dashboard.wikiedu.org_biblography';
   const query = assignment.role === ASSIGNED_ROLE
-    ? `?veaction=edit&preload=${template}%3ACn&action=edit`
+    ? `?veaction=edit&preload=${template}`
     : '';
   return (
     <a href={`${link}${query}`} target="_blank">
@@ -87,8 +87,9 @@ const BibliographyLink = ({ assignment }) => {
 
 const SandboxLink = ({ assignment }) => {
   const { sandboxUrl } = assignment;
+  const template = 'Template:Dashboard.wikiedu.org_sandbox_assignment';
   const query = assignment.role === ASSIGNED_ROLE
-    ? '?veaction=edit&preload=Template%3ACn&action=edit'
+    ? `?veaction=edit&preload=${template}`
     : '';
   return (
     <a href={`${sandboxUrl}${query}`} target="_blank">

--- a/app/assets/javascripts/components/overview/my_assignment.jsx
+++ b/app/assets/javascripts/components/overview/my_assignment.jsx
@@ -8,6 +8,7 @@ import PeerReviewChecklist from '../common/peer_review_checklist.jsx';
 import CourseUtils from '../../utils/course_utils.js';
 import Feedback from '../common/feedback.jsx';
 
+import { ASSIGNED_ROLE } from '../../constants';
 import { initiateConfirm } from '../../actions/confirm_actions';
 import { deleteAssignment } from '../../actions/assignment_actions';
 
@@ -53,9 +54,9 @@ const Actions = ({
         username={username}
       />
     );
-    if (assignment.role === 0 && !assignment.article_id) {
+    if (assignment.role === ASSIGNED_ROLE && !assignment.article_id) {
       actions.push(<MainspaceChecklist key="mainspace-button" />, feedback);
-    } else if (assignment.role === 0) {
+    } else if (assignment.role === ASSIGNED_ROLE) {
       actions.push(<FinalArticleChecklist key="final-article-button" />, feedback);
     } else {
       actions.push(<PeerReviewChecklist key="peer-review-button" />);
@@ -73,7 +74,27 @@ const Actions = ({
 // Links Components
 const BibliographyLink = ({ assignment }) => {
   const link = `${assignment.sandboxUrl}/bibliography`;
-  return <a href={link}>{I18n.t('assignments.bibliography')}</a>;
+  const template = 'Template:Dashboard.wikiedu.org_biblography';
+  const query = assignment.role === ASSIGNED_ROLE
+    ? `?veaction=edit&preload=${template}%3ACn&action=edit`
+    : '';
+  return (
+    <a href={`${link}${query}`} target="_blank">
+      {I18n.t('assignments.bibliography')}
+    </a>
+  );
+};
+
+const SandboxLink = ({ assignment }) => {
+  const { sandboxUrl } = assignment;
+  const query = assignment.role === ASSIGNED_ROLE
+    ? '?veaction=edit&preload=Template%3ACn&action=edit'
+    : '';
+  return (
+    <a href={`${sandboxUrl}${query}`} target="_blank">
+      {I18n.t('assignments.sandbox_draft_link')}
+    </a>
+  );
 };
 
 const AssignedToLink = ({ name, members }) => {
@@ -104,11 +125,11 @@ const ReviewerLink = ({ reviewers }) => {
 
 const Separator = () => <span> •&nbsp;</span>;
 
-const Links = ({ articleTitle, assignment }) => {
-  const { article_url, editors, id, reviewers, sandboxUrl } = assignment;
+const Links = ({ articleTitle, assignment, current_user }) => {
+  const { article_url, editors, id, reviewers } = assignment;
   const actions = [
     <BibliographyLink key={`bibliography-${id}`} assignment={assignment} />,
-    <a key={`sandbox-${id}`} href={sandboxUrl} target="_blank">{I18n.t('assignments.sandbox_draft_link')}</a>,
+    <SandboxLink key={`sandbox-${id}`} assignment={assignment} current_user={current_user} />,
     <a key={`article-${id}`} href={article_url}>{I18n.t('assignments.article_link')}</a>
   ].reduce((acc, link, index, collection) => {
     const limit = collection.length - 1;
@@ -179,7 +200,7 @@ export const MyAssignment = createReactClass({
 
     return (
       <div className="my-assignment mb1">
-        <Links articleTitle={articleTitle} assignment={assignment} />
+        <Links articleTitle={articleTitle} assignment={assignment} current_user={current_user} />
         <Actions
           article={article}
           assignment={assignment}


### PR DESCRIPTION
## What this PR does

This PR updates the Bibliography & Sandbox URL links on the My Articles section of the course page to include templates that will get students started right on their projects. It will only show if the student is actively working on the project (i.e. they are the ones editing it, not reviewing).

This currently uses relatively blank templates:
https://en.wikipedia.org/wiki/Template:Dashboard.wikiedu.org_biblography
https://en.wikipedia.org/wiki/Template:Dashboard.wikiedu.org_sandbox_assignment