### PR TITLE
Move DailyUpdate data tasks to Sidekiq

### DIFF
--- a/app/workers/daily_update/clean_articles_courses_worker.rb
+++ b/app/workers/daily_update/clean_articles_courses_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
+
+class CleanArticlesCoursesWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    ArticlesCoursesCleaner.rebuild_articles_courses
+  end
+end

--- a/app/workers/daily_update/find_assignments_worker.rb
+++ b/app/workers/daily_update/find_assignments_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/importers/assigned_article_importer"
+
+class FindAssignmentsWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    AssignedArticleImporter.import_articles_for_assignments
+  end
+end

--- a/app/workers/daily_update/import_ratings_worker.rb
+++ b/app/workers/daily_update/import_ratings_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/importers/rating_importer"
+
+class ImportRatingsWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    RatingImporter.update_all_ratings
+  end
+end

--- a/app/workers/daily_update/overdue_training_alert_worker.rb
+++ b/app/workers/daily_update/overdue_training_alert_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
+
+class OverdueTrainingAlertWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    OverdueTrainingAlertManager.new(Course.strictly_current).create_alerts
+  end
+end

--- a/app/workers/daily_update/refresh_categories_worker.rb
+++ b/app/workers/daily_update/refresh_categories_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RefreshCategoriesWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    Category.refresh_categories_for(Course.current)
+  end
+end

--- a/app/workers/daily_update/salesforce_sync_worker.rb
+++ b/app/workers/daily_update/salesforce_sync_worker.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SalesforceSyncWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    Course.current.each do |course|
+      next unless course.flags[:salesforce_id]
+      PushCourseToSalesforce.new(course)
+    end
+    ClassroomProgramCourse
+      .archived
+      .where(withdrawn: false)
+      .reject(&:closed?)
+      .select(&:approved?).each do |course|
+      UpdateCourseFromSalesforce.new(course)
+    end
+  end
+end

--- a/app/workers/daily_update/update_article_status_worker.rb
+++ b/app/workers/daily_update/update_article_status_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/article_status_manager"
+
+class UpdateArticleStatusWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    ArticleStatusManager.update_article_status
+  end
+end

--- a/app/workers/daily_update/update_commons_uploads_worker.rb
+++ b/app/workers/daily_update/update_commons_uploads_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/importers/upload_importer"
+
+class UpdateCommonsUploadsWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    UploadImporter.find_deleted_files
+  end
+end

--- a/app/workers/daily_update/update_users_worker.rb
+++ b/app/workers/daily_update/update_users_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/importers/user_importer"
+
+class UpdateUsersWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform
+    UserImporter.update_users
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,11 +25,12 @@ set :ssh_options, forward_agent: true
 set :pty, false
 
 # Sidekiq settings
-set :sidekiq_processes, 4
+set :sidekiq_processes, 5
 set :sidekiq_options_per_process, ["--queue default --concurrency 2",
                                    "--queue short_update --queue medium_update --concurrency 1",
                                    "--queue medium_update --queue short_update --concurrency 1",
-                                   "--queue long_update --queue medium_update --concurrency 1"]
+                                   "--queue long_update --queue medium_update --concurrency 1",
+                                   "--queue daily_update --concurrency 1"]
 
 
 # Default value for :linked_files is []

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -25,3 +25,4 @@ test:
  - short_update
  - medium_update
  - long_update
+ - daily_update

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -16,6 +16,8 @@ require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 class DailyUpdate
   include BatchUpdateLogging
 
+  QUEUE = 'daily_update'
+
   def initialize
     setup_logger
     return if updates_paused?
@@ -48,31 +50,31 @@ class DailyUpdate
 
   def update_users
     log_message 'Updating registration dates for new Users'
-    UpdateUsersWorker.perform_async
+    UpdateUsersWorker.set(queue: QUEUE).perform_async
   end
 
   def update_commons_uploads
     log_message 'Identifying deleted Commons uploads'
-    UpdateCommonsUploadsWorker.perform_async
+    UpdateCommonsUploadsWorker.set(queue: QUEUE).perform_async
   end
 
   def update_article_data
     log_message 'Finding articles that match assignment titles'
-    FindAssignmentsWorker.perform_async
+    FindAssignmentsWorker.set(queue: QUEUE).perform_async
 
     log_message 'Rebuilding ArticlesCourses for all current students'
-    CleanArticlesCoursesWorker.perform_async
+    CleanArticlesCoursesWorker.set(queue: QUEUE).perform_async
 
     log_message 'Updating ratings for all articles'
-    ImportRatingsWorker.perform_async
+    ImportRatingsWorker.set(queue: QUEUE).perform_async
 
     log_message 'Updating article namespace and deleted status'
-    UpdateArticleStatusWorker.perform_async
+    UpdateArticleStatusWorker.set(queue: QUEUE).perform_async
   end
 
   def update_category_data
     log_message 'Updating tracked categories'
-    RefreshCategoriesWorker.perform_async
+    RefreshCategoriesWorker.set(queue: QUEUE).perform_async
   end
 
   ##########
@@ -80,7 +82,7 @@ class DailyUpdate
   ##########
   def generate_overdue_training_alerts
     log_message 'Generating alerts for overdue trainings'
-    OverdueTrainingAlertWorker.perform_async
+    OverdueTrainingAlertWorker.set(queue: QUEUE).perform_async
   end
 
   ###############
@@ -88,6 +90,6 @@ class DailyUpdate
   ###############
   def push_course_data_to_salesforce
     log_message 'Pushing course data to Salesforce'
-    SalesforceSyncWorker.perform_async
+    SalesforceSyncWorker.set(queue: QUEUE).perform_async
   end
 end

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -8,7 +8,6 @@ require_dependency "#{Rails.root}/app/workers/daily_update/import_ratings_worker
 require_dependency "#{Rails.root}/app/workers/daily_update/update_article_status_worker"
 
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
 # Executes all the steps of 'update_constantly' data import task

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -2,8 +2,8 @@
 
 require_dependency "#{Rails.root}/app/workers/daily_update/update_users_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/update_commons_uploads_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/find_assignments_worker"
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/importers/assigned_article_importer"
 require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
 require_dependency "#{Rails.root}/lib/article_status_manager"
@@ -56,7 +56,7 @@ class DailyUpdate
 
   def update_article_data
     log_message 'Finding articles that match assignment titles'
-    AssignedArticleImporter.import_articles_for_assignments
+    FindAssignmentsWorker.perform_async
 
     log_message 'Rebuilding ArticlesCourses for all current students'
     ArticlesCoursesCleaner.rebuild_articles_courses

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -7,9 +7,8 @@ require_dependency "#{Rails.root}/app/workers/daily_update/clean_articles_course
 require_dependency "#{Rails.root}/app/workers/daily_update/import_ratings_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/update_article_status_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/refresh_categories_worker"
-
+require_dependency "#{Rails.root}/app/workers/daily_update/overdue_training_alert_worker"
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
 # Executes all the steps of 'update_constantly' data import task
 class DailyUpdate
@@ -79,7 +78,7 @@ class DailyUpdate
   ##########
   def generate_overdue_training_alerts
     log_message 'Generating alerts for overdue trainings'
-    OverdueTrainingAlertManager.new(Course.strictly_current).create_alerts
+    OverdueTrainingAlertWorker.perform_async
   end
 
   ###############

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -4,8 +4,8 @@ require_dependency "#{Rails.root}/app/workers/daily_update/update_users_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/update_commons_uploads_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/find_assignments_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/clean_articles_courses_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/import_ratings_worker"
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/importers/rating_importer"
 require_dependency "#{Rails.root}/lib/article_status_manager"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
@@ -62,7 +62,7 @@ class DailyUpdate
     CleanArticlesCoursesWorker.perform_async
 
     log_message 'Updating ratings for all articles'
-    RatingImporter.update_all_ratings
+    ImportRatingsWorker.perform_async
 
     log_message 'Updating article namespace and deleted status'
     ArticleStatusManager.update_article_status

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/app/workers/daily_update/update_users_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/update_commons_uploads_worker"
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 require_dependency "#{Rails.root}/lib/importers/assigned_article_importer"
 require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
 require_dependency "#{Rails.root}/lib/article_status_manager"
-require_dependency "#{Rails.root}/lib/importers/upload_importer"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
@@ -51,7 +51,7 @@ class DailyUpdate
 
   def update_commons_uploads
     log_message 'Identifying deleted Commons uploads'
-    UploadImporter.find_deleted_files
+    UpdateCommonsUploadsWorker.perform_async
   end
 
   def update_article_data

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/app/workers/daily_update/update_users_worker"
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/importers/user_importer"
 require_dependency "#{Rails.root}/lib/importers/assigned_article_importer"
 require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
@@ -46,7 +46,7 @@ class DailyUpdate
 
   def update_users
     log_message 'Updating registration dates for new Users'
-    UserImporter.update_users
+    UpdateUsersWorker.perform_async
   end
 
   def update_commons_uploads

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -6,6 +6,7 @@ require_dependency "#{Rails.root}/app/workers/daily_update/find_assignments_work
 require_dependency "#{Rails.root}/app/workers/daily_update/clean_articles_courses_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/import_ratings_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/update_article_status_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/refresh_categories_worker"
 
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
@@ -70,7 +71,7 @@ class DailyUpdate
 
   def update_category_data
     log_message 'Updating tracked categories'
-    Category.refresh_categories_for(Course.current)
+    RefreshCategoriesWorker.perform_async
   end
 
   ##########

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -3,8 +3,8 @@
 require_dependency "#{Rails.root}/app/workers/daily_update/update_users_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/update_commons_uploads_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/find_assignments_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/clean_articles_courses_worker"
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
 require_dependency "#{Rails.root}/lib/article_status_manager"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
@@ -59,7 +59,7 @@ class DailyUpdate
     FindAssignmentsWorker.perform_async
 
     log_message 'Rebuilding ArticlesCourses for all current students'
-    ArticlesCoursesCleaner.rebuild_articles_courses
+    CleanArticlesCoursesWorker.perform_async
 
     log_message 'Updating ratings for all articles'
     RatingImporter.update_all_ratings

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -5,8 +5,9 @@ require_dependency "#{Rails.root}/app/workers/daily_update/update_commons_upload
 require_dependency "#{Rails.root}/app/workers/daily_update/find_assignments_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/clean_articles_courses_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/import_ratings_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/update_article_status_worker"
+
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
-require_dependency "#{Rails.root}/lib/article_status_manager"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/alerts/overdue_training_alert_manager"
 
@@ -65,7 +66,7 @@ class DailyUpdate
     ImportRatingsWorker.perform_async
 
     log_message 'Updating article namespace and deleted status'
-    ArticleStatusManager.update_article_status
+    UpdateArticleStatusWorker.perform_async
   end
 
   def update_category_data


### PR DESCRIPTION
This replaces the long-running DailyUpdate process with a set of equivalent Sidekiq jobs, so that the cron-initiated update itself will run more-or-less instantly and just put each of the steps in the update process into a new dedicated queue for processesing.

This means that an error during one step will not cause the entire update to fail and skip any later tasks for the day, which is the current situation.

The downside is that the logging, which had been tracking how long each step in the update process takes to run, will not longer be useful. We'll need to rely on monitoring the Sidekiq queue itself to spot any overly long jobs.