### PR TITLE
Exclude article UI

### DIFF
--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -5,6 +5,7 @@ import CourseUtils from '../../utils/course_utils.js';
 import ArticleViewer from '../common/article_viewer.jsx';
 import DiffViewer from '../revisions/diff_viewer.jsx';
 import ArticleGraphs from './article_graphs.jsx';
+import Switch from 'react-switch';
 
 const Article = createReactClass({
   displayName: 'Article',
@@ -14,6 +15,7 @@ const Article = createReactClass({
     index: PropTypes.number,
     course: PropTypes.object.isRequired,
     fetchArticleDetails: PropTypes.func.isRequired,
+    updateArticleTrackedStatus: PropTypes.func,
     articleDetails: PropTypes.object,
     wikidataLabel: PropTypes.string,
     showOnMount: PropTypes.bool,
@@ -22,10 +24,21 @@ const Article = createReactClass({
     selectedIndex: PropTypes.number
   },
 
+  getInitialState() {
+    return {
+      tracked: this.props.article.tracked
+    };
+  },
+
   fetchArticleDetails() {
     if (!this.props.articleDetails) {
       this.props.fetchArticleDetails(this.props.article.id, this.props.course.id);
     }
+  },
+
+  handleTrackedChange(tracked) {
+    this.props.updateArticleTrackedStatus(this.props.article.id, this.props.course.id, tracked);
+    this.setState({ tracked });
   },
 
   render() {
@@ -35,6 +48,14 @@ const Article = createReactClass({
     // Uses Course Utils Helper
     const formattedTitle = CourseUtils.formattedArticleTitle(this.props.article, this.props.course.home_wiki, this.props.wikidataLabel);
     const historyUrl = `${this.props.article.url}?action=history`;
+
+    const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
+
+    const tracked = (
+      <td className="tracking">
+        <Switch onChange={this.handleTrackedChange} disabled={!trackedEditable} checked={this.state.tracked} onColor="#676eb4" />
+      </td>
+    );
 
     return (
       <tr className="article">
@@ -83,6 +104,7 @@ const Article = createReactClass({
             selectedIndex={this.props.selectedIndex}
           />
         </td>
+        {tracked}
       </tr>
     );
   }

--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -51,11 +51,14 @@ const Article = createReactClass({
 
     const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
 
-    const tracked = (
-      <td className="tracking">
-        <Switch onChange={this.handleTrackedChange} disabled={!trackedEditable} checked={this.state.tracked} onColor="#676eb4" />
-      </td>
-    );
+    let tracked;
+    if (this.props.course.type !== 'ClassroomProgramCourse') {
+      tracked = (
+        <td className="tracking">
+          <Switch onChange={this.handleTrackedChange} disabled={!trackedEditable} checked={this.state.tracked} onColor="#676eb4" />
+        </td>
+      );
+    }
 
     return (
       <tr className="article">

--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -52,10 +52,10 @@ const Article = createReactClass({
     const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
 
     let tracked;
-    if (this.props.course.type !== 'ClassroomProgramCourse') {
+    if (this.props.course.type !== 'ClassroomProgramCourse' && trackedEditable) {
       tracked = (
         <td className="tracking">
-          <Switch onChange={this.handleTrackedChange} disabled={!trackedEditable} checked={this.state.tracked} onColor="#676eb4" />
+          <Switch onChange={this.handleTrackedChange} checked={this.state.tracked} onColor="#676eb4" />
         </td>
       );
     }

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -86,6 +86,11 @@ const ArticleList = createReactClass({
         label: I18n.t('articles.tools'),
         desktop_only: false,
         sortable: false
+      },
+      tracked: {
+        label: I18n.t('articles.tracked'),
+        desktop_only: true,
+        sortable: false
       }
     };
 
@@ -110,6 +115,7 @@ const ArticleList = createReactClass({
         // eslint-disable-next-line
         current_user={this.props.current_user}
         fetchArticleDetails={this.props.actions.fetchArticleDetails}
+        updateArticleTrackedStatus={this.props.actions.updateArticleTrackedStatus}
         articleDetails={this.props.articleDetails[article.id] || null}
         setSelectedIndex={this.showDiff}
         lastIndex={this.props.articles.length}

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -89,11 +89,14 @@ const ArticleList = createReactClass({
       },
     };
 
-    if (this.props.course.type !== 'ClassroomProgramCourse') {
+    const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
+
+    if (this.props.course.type !== 'ClassroomProgramCourse' && trackedEditable) {
       keys.tracked = {
         label: I18n.t('articles.tracked'),
         desktop_only: true,
-        sortable: false
+        sortable: false,
+        info_key: 'articles.tracked_doc'
       };
     }
 

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -87,12 +87,15 @@ const ArticleList = createReactClass({
         desktop_only: false,
         sortable: false
       },
-      tracked: {
+    };
+
+    if (this.props.course.type !== 'ClassroomProgramCourse') {
+      keys.tracked = {
         label: I18n.t('articles.tracked'),
         desktop_only: true,
         sortable: false
-      }
-    };
+      };
+    }
 
     const sort = this.props.sort;
     if (sort.key) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,7 +175,7 @@ en:
     show_current_version_with_authorship_highlighting: 'Current Version w/ Authorship Highlighting'
     title: Title
     tracked: Tracked
-    tracked_doc: The status of whether or not an article has been tracked. The course stats depend only on tracked articles so articles deemed not relevant to the course can be untracked here and the stats will reflect that the next time the course is updated.
+    tracked_doc: Only tracked articles contribute to the the statistics for this program. When articles are marked as untracked, they will be removed from the statistics during the next data update.
     title_example: Article title
     tools: Assessment tools
     view: View Article

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,6 +175,7 @@ en:
     show_current_version_with_authorship_highlighting: 'Current Version w/ Authorship Highlighting'
     title: Title
     tracked: Tracked
+    tracked_doc: The status of whether or not an article has been tracked. The course stats depend only on tracked articles so articles deemed not relevant to the course can be untracked here and the stats will reflect that the next time the course is updated.
     title_example: Article title
     tools: Assessment tools
     view: View Article

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -426,4 +426,26 @@ describe 'the course page', type: :feature, js: true do
       end
     end
   end
+
+  describe 'articles tracking' do
+    it 'does not allow articles to be marked for tracking by students' do
+      js_visit "/courses/#{Course.last.slug}/articles"
+      expect(first('.tracking').find('input').disabled?).to eq(true)
+    end
+
+    it 'does allows articles to be marked for tracking by instructors/admin' do
+      login_as(admin)
+      js_visit "/courses/#{Course.last.slug}/articles"
+      expect(first('.tracking').find('input').disabled?).to eq(false)
+    end
+
+    it 'marks an article to be excluded once it is untracked' do
+      login_as(admin)
+      course = Course.last
+      js_visit "/courses/#{course.slug}/articles"
+      expect(course.tracked_revisions.count).to eq(course.revisions.count)
+      first('.tracking').click
+      expect(course.tracked_revisions.count).to be < course.revisions.count
+    end
+  end
 end

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -456,7 +456,9 @@ describe 'the course page', type: :feature, js: true do
 
     it 'does not allow articles to be marked for tracking by students' do
       js_visit "/courses/#{course.slug}/articles"
-      expect(first('.tracking').find('input').disabled?).to eq(true)
+      expect do
+        find('.tracking')
+      end.to raise_error(Capybara::ElementNotFound)
     end
 
     it 'does allows articles to be marked for tracking by instructors/admin' do

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -437,12 +437,9 @@ describe 'the course page', type: :feature, js: true do
     before do
       create(:articles_course, article: article, course: editathon)
       create(:articles_course, article: article2, course: editathon)
-      create(:articles_course, article: article, course: classroom_program_course)
-      create(:articles_course, article: article2, course: classroom_program_course)
       create(:revision, article_id: article.id, user_id: user.id, date: editathon.start + 1.hour)
       create(:revision, article_id: article2.id, user_id: user.id, date: editathon.start + 1.hour)
       editathon.students << user
-      classroom_program_course.students << user
     end
 
     it 'does not allow articles to be marked for tracking by students' do


### PR DESCRIPTION
## What this PR does
First pass at resolving #2762 This PR contains the UI changes.
## Screenshots
Before:
![image](https://user-images.githubusercontent.com/5158554/61170072-cb331e80-a581-11e9-8100-b24257197192.png)

After:
![image](https://user-images.githubusercontent.com/5158554/61170057-a2128e00-a581-11e9-8d89-3fe272c5681d.png)

Also, for non advanced roles, the tracking toggle is greyed out and disabled thus still showing if the article is tracked or not to the commonfolk. 
