### PR TITLE
Disallow forward slashes in course details

### DIFF
--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -29,7 +29,7 @@ export default class CourseUtils {
     // It requires blank spaces(if any) in the beginning to be followed by at least one non-blank letter character
     // from the allowed characters, to be followed by zero or more of all allowed characters(including blank characters).
     // Adapted from http://stackoverflow.com/questions/150033/regular-expression-to-match-non-english-characters#comment19644791_150078
-    return /^[\w\-\s,'\u00BF-\u1FFF\u2C00-\uD7FF]*[\w\u00BF-\u1FFF\u2C00-\uD7FF][\w\-\s,'\u00BF-\u1FFF\u2C00-\uD7FF]*$/;
+    return /^[\w\-\s/,'\u00BF-\u1FFF\u2C00-\uD7FF]*^[\w\u00BF-\u1FFF\u2C00-\uD7FF][\w\-\s,'\u00BF-\u1FFF\u2C00-\uD7FF]*$/;
   }
 
   // Given a course object with title, school and term properties,


### PR DESCRIPTION
#### What this PR does

This PR disallows using a forward slash in Course details. If a user were to use them, it would cause routing issues.

Relates to issue #3232