### PR TITLE
Revision scores import flow

### DIFF
--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -5,6 +5,7 @@ require_dependency "#{Rails.root}/lib/article_status_manager"
 require_dependency "#{Rails.root}/lib/importers/course_upload_importer"
 require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
+require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats
@@ -33,6 +34,10 @@ class UpdateCourseStats
     log_update_progress :start
     CourseRevisionUpdater.import_revisions(@course, all_time: @full_update)
     log_update_progress :revisions_imported
+
+    RevisionScoreImporter.update_revision_scores_for_course(@course)
+    log_update_progress :revision_scores_imported
+
     CourseUploadImporter.new(@course).run
     log_update_progress :uploads_imported
   end

--- a/lib/data_cycle/constant_update.rb
+++ b/lib/data_cycle/constant_update.rb
@@ -10,7 +10,6 @@ require_dependency "#{Rails.root}/app/models/course_data/block"
 
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 require_dependency "#{Rails.root}/lib/assignment_updater"
-require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/importers/plagiabot_importer"
 require_dependency "#{Rails.root}/lib/importers/view_importer"
 require_dependency "#{Rails.root}/lib/importers/rating_importer"
@@ -54,9 +53,6 @@ class ConstantUpdate
   def update_revisions_and_articles
     log_message 'Matching assignments to articles and syncing titles'
     AssignmentUpdater.update_assignment_article_ids_and_titles
-
-    log_message 'Importing articlequality scores for all revisions on supported wikis'
-    RevisionScoreImporter.update_revision_scores_for_all_wikis
 
     log_message 'Checking for plagiarism in recent revisions'
     PlagiabotImporter.find_recent_plagiarism

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -414,6 +414,7 @@ describe 'the course page', type: :feature, js: true do
       stub_oauth_edit
 
       expect(CourseRevisionUpdater).to receive(:import_revisions)
+      expect(RevisionScoreImporter).to receive(:update_revision_scores_for_course)
       expect_any_instance_of(CourseUploadImporter).to receive(:run)
       visit "/courses/#{slug}/manual_update"
       updated_user_count = user_count + 1

--- a/spec/lib/data_cycle/constant_update_spec.rb
+++ b/spec/lib/data_cycle/constant_update_spec.rb
@@ -12,7 +12,6 @@ describe ConstantUpdate do
 
     it 'calls lots of update routines' do
       expect(AssignmentUpdater).to receive(:update_assignment_article_ids_and_titles)
-      expect(RevisionScoreImporter).to receive(:update_revision_scores_for_all_wikis)
       expect(PlagiabotImporter).to receive(:find_recent_plagiarism)
       expect(StudentGreetingChecker).to receive(:check_all_ungreeted_students)
       expect(ArticlesForDeletionMonitor).to receive(:create_alerts_for_course_articles)

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -163,7 +163,10 @@ describe RevisionScoreImporter do
     # https://www.wikidata.org/w/index.php?title=Q61734980&oldid=860858080
     let(:language) { 'en' }
     let(:project) { 'wikipedia' }
-    let(:subject) { described_class.new(language, project).fetch_ores_data_for_revision_id(rev_id) }
+    let(:subject) do
+      described_class.new(language: language, project: project)
+                     .fetch_ores_data_for_revision_id(rev_id)
+    end
 
     it 'returns a hash with a predicted rating and features' do
       VCR.use_cassette 'revision_scores/single_revision' do
@@ -217,7 +220,7 @@ describe RevisionScoreImporter do
 
   context 'for a wiki without the articlequality model' do
     it 'raises an error' do
-      expect { described_class.new('zh').update_revision_scores }
+      expect { described_class.new(language: 'zh').update_revision_scores }
         .to raise_error(RevisionScoreImporter::InvalidWikiError)
     end
   end

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -32,4 +32,25 @@ describe UpdateCourseStats do
       subject
     end
   end
+
+  context 'when there are revisions' do
+    let(:course) { create(:course, start: '2018-11-23', end: '2018-11-30') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+
+    before do
+      course.campaigns << Campaign.first
+      JoinCourse.new(course: course, user: user, role: 0)
+    end
+
+    it 'imports the revisions and their ORES data' do
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+      expect(course.revisions.count).to eq(2)
+      course.revisions.each do |revision|
+        expect(revision.features).to have_key('feature.wikitext.revision.ref_tags')
+        expect(revision.features_previous).to have_key('feature.wikitext.revision.ref_tags')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This moves the ORES score importing into the course data update cycle, rather than the independent ConstantUpdate cycle, so that references added stats get updated accurately at the same time as the rest of the stats.