### PR TITLE
Add defaults for language and project to assignments

### DIFF
--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -82,7 +82,9 @@ class Assignment < ApplicationRecord
     if existing
       self.sandbox_url = existing.sandbox_url
     else
-      base_url = "https://#{wiki.language}.#{wiki.project}.org/wiki"
+      language = wiki.language || 'www'
+      project = wiki.project || 'wikipedia'
+      base_url = "https://#{language}.#{project}.org/wiki"
       self.sandbox_url = "#{base_url}/User:#{user.username}/#{article_title}"
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -46,6 +46,21 @@ describe Assignment do
         expect(assignment.sandbox_url).to eq(expected)
       end
 
+      it 'generates a sandbox_url if no language is defined' do
+        wiki = create(:wiki, language: nil, project: 'wikidata')
+        course = create(:course)
+        user = create(:user)
+        article = create(:article)
+        article_title = article.title
+        assignment = create(:assignment, course: course, user: user,
+                             article: article, article_title: article.title,
+                             wiki: wiki)
+
+        base_url = 'https://www.wikidata.org/wiki'
+        expected = "#{base_url}/User:#{user.username}/#{article_title}"
+        expect(assignment.sandbox_url).to eq(expected)
+      end
+
       it 'uses an already existing sandbox URL for assignments with the same article' do
         course = create(:course)
         user = create(:user)


### PR DESCRIPTION
## What this PR does
This should solve the issue of wikidata articles being incorrectly formatted.

Once merged, we should also run the following on the backend:
```
Assignment.where('sandbox_url LIKE ?', 'https://.wikidata%').each { |a| a.save }
```