### PR TITLE
Fix assign my self an article button

### DIFF
--- a/app/assets/javascripts/components/students/assign_button.jsx
+++ b/app/assets/javascripts/components/students/assign_button.jsx
@@ -193,12 +193,12 @@ const EditButton = ({
   );
 };
 
-const FindArticles = ({ course }) => {
+const FindArticles = ({ course, open }) => {
   return (
     <tr className="assignment find-articles-section">
       <td>
         <Link to={`/courses/${course.slug}/article_finder`}>
-          <button className="button border small link">
+          <button className="button border small link" onClick={open}>
             Search Wikipedia for an Article
           </button>
         </Link>
@@ -467,7 +467,7 @@ export class AssignButton extends React.Component {
 
     // Add the FindArticles button
     if (role === ASSIGNED_ROLE && !isStudentsPage) {
-      assignmentRows.push(<FindArticles course={course} key="find-articles-link" />);
+      assignmentRows.push(<FindArticles course={course} open={open} key="find-articles-link" />);
     }
 
     return (


### PR DESCRIPTION
## Fixes assign button response to first click when user navigates away and back while it's open
Fixes #3101 
**Before:**
1. In the MyArticles section, click 'Assign myself an article'
2. Within the popover at the bottom, click 'Search Wikipedia for an Article'
3. Navigate back to the MyArticles tab
4. Click 'Assign myself an article' again. The first click does not open the popover, (I think) because the 'ui' reducer state has it marked as open (and so the click sets it to closed).

**After:**
1. In the MyArticles section, click 'Assign myself an article'
2. Within the popover at the bottom, click 'Search Wikipedia for an Article'
3. Navigate back to the MyArticles tab
4. Click 'Assign myself an article' again. popover will open.