### PR TITLE
Should fix a bug where the Peer Review link is incorrectly matched for new articles

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles/utils/processAssignments.js
+++ b/app/assets/javascripts/components/overview/my_articles/utils/processAssignments.js
@@ -62,8 +62,12 @@ export const addSandboxUrl = (assignments, course, user_id) => {
     };
 
     if (assignment.role === REVIEWING_ROLE) {
-      const related = assignments.find(({ article_id, user_id: id }) => {
-        return id && article_id === assignment.article_id && id !== user_id;
+      const related = assignments.find(({ article_id, article_title, role, user_id: id }) => {
+        return id
+          && role === ASSIGNED_ROLE
+          && article_id === assignment.article_id
+          && article_title === assignment.article_title
+          && id !== user_id;
       });
 
       if (related) {


### PR DESCRIPTION
To reproduce:
* Assign two new articles (articles without IDs) to review
* Note that both Peer Review links will be the same

This should fix the issue in that we are now checking to make sure that the article title matches as well.