### PR TITLE
Correctly display articles for Review an article button

### DIFF
--- a/app/assets/javascripts/components/util/helpers.js
+++ b/app/assets/javascripts/components/util/helpers.js
@@ -34,7 +34,6 @@ export const groupByAssignmentType = (assignments, user_id) => {
 
   // To find articles that are able to be reviewed...
   const pluckArticleId = pluck('article_id');
-  const assignedAndReviewingTitles = assigned.concat(reviewing).map(pluck('article_title'));
   const assignedArticleIds = assigned.map(pluckArticleId);
   const reviewingArticleIds = reviewing.map(pluckArticleId);
 
@@ -43,21 +42,27 @@ export const groupByAssignmentType = (assignments, user_id) => {
     // If the article doesn't have an article id, that means it's a new article,
     // so we want to allow for new articles to be reviewable as well as long as
     // it isn't the current user's new article.
-    const articleId = assignment.article_id;
-    if (!articleId && assignment.user_id !== user_id) {
-      return !assignedAndReviewingTitles.includes(assignment.article_title);
+    const { article_id: id, article_title: title, project } = assignment;
+    // Check that the assignment is assigned to someone else
+    if (!id && assignment.user_id && assignment.user_id !== user_id) {
+      const all = assigned.concat(reviewing);
+      // Find similar articles that have already been assigned
+      const alreadyAssigned = all.find((assign) => {
+        return assign.article_title === title && assign.project === project;
+      });
+      // Only return if it has not been assigned
+      return !alreadyAssigned;
     }
 
     return assignment.user_id // ...the article must have a user_id
       // which shouldn't match the current user's id
       && assignment.user_id !== user_id
       // and should not be an article that is assigned to them
-      && !assignedArticleIds.includes(articleId)
+      && !assignedArticleIds.includes(id)
       // and should not be an article they are already reviewing
-      && !reviewingArticleIds.includes(articleId);
+      && !reviewingArticleIds.includes(id);
   });
 
   const reviewable = _.uniqBy(reviewableDuplicates, 'article_url');
   return { assigned, reviewing, unassigned, reviewable };
-}
-;
+};


### PR DESCRIPTION
## What this PR does
This should fix an issue where completely new articles were showing up as available when clicking the "Review an article" button in the My Articles section. The problem is fixed by relying on `article_title` as the unique value as opposed to `artice_id`.