### PR TITLE
Training modules users fixup

### DIFF
--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -2,10 +2,11 @@
 
 class TrainingModulesUsersController < ApplicationController
   respond_to :json
+  before_action :require_signed_in
 
   def create_or_update
     set_slide
-    @training_module_user = find_or_create_tmu(params)
+    set_training_module_user
     return if @slide.nil?
     complete_slide if should_set_slide_completed?
     complete_module if last_slide?
@@ -24,9 +25,9 @@ class TrainingModulesUsersController < ApplicationController
     render json: { slide: @slide, completed: @completed }
   end
 
-  def find_or_create_tmu(params)
-    TrainingModulesUsers.find_or_initialize_by(
-      user_id: params[:user_id],
+  def set_training_module_user
+    @training_module_user = TrainingModulesUsers.find_or_create_by(
+      user: current_user,
       training_module_id: @training_module.id
     )
   end

--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -15,6 +15,7 @@ require_dependency "#{Rails.root}/lib/training_progress_manager"
 
 class TrainingModulesUsers < ApplicationRecord
   belongs_to :user
+  has_one :training_module
 
   def training_module
     @training_module ||= TrainingModule.find(training_module_id)

--- a/db/cleanup/training_modules_users_cleanup.rb
+++ b/db/cleanup/training_modules_users_cleanup.rb
@@ -1,0 +1,16 @@
+# Destroy all the records with user_id 0
+# No new ones should be created once we switch to setting the user server-side
+TrainingModulesUsers.where(user_id: 0).destroy_all
+
+# These are all the records where we have a duplicate TrainingModulesUsers record for the same user+module combination.
+# We need delete the duplicates before adding a unique index.
+duplicates = TrainingModulesUsers.select(:user_id, :training_module_id).group(:user_id, :training_module_id).having("count(*) > 1").size
+
+# We want to keep either the earliest record that represents having completed the module, or just the earliest record
+# if none record module completion.
+duplicates.keys.each do |user_and_module|
+  tmus = TrainingModulesUsers.where(user_id: user_and_module[0], training_module_id: user_and_module[1]).to_a
+  keeper = tmus.detect { |tmu| tmu.completed_at.present? }
+  keeper ||= tmus.first
+  (tmus - [keeper]).each(&:destroy)
+end


### PR DESCRIPTION
This is part one out of two.

The controller change should prevent creation of new records that have `user_id: 0`.

The cleanup script removes those records, along with the extra copies of records for the same user+module, which we need to do before adding an uniqueness constraint to the database. It will still be possible to create new duplicates in the meantime, though, so this will need to be run right before part two gets deployed with the schema change.