### PR TITLE
Training modules users fixup phase2

### DIFF
--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -2,10 +2,11 @@
 
 class TrainingModulesUsersController < ApplicationController
   respond_to :json
+  before_action :require_signed_in
 
   def create_or_update
     set_slide
-    @training_module_user = find_or_create_tmu(params)
+    set_training_module_user
     return if @slide.nil?
     complete_slide if should_set_slide_completed?
     complete_module if last_slide?
@@ -24,9 +25,9 @@ class TrainingModulesUsersController < ApplicationController
     render json: { slide: @slide, completed: @completed }
   end
 
-  def find_or_create_tmu(params)
-    TrainingModulesUsers.find_or_initialize_by(
-      user_id: params[:user_id],
+  def set_training_module_user
+    @training_module_user = TrainingModulesUsers.find_or_create_by(
+      user: current_user,
       training_module_id: @training_module.id
     )
   end

--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -26,7 +26,7 @@ class TrainingModulesUsersController < ApplicationController
   end
 
   def set_training_module_user
-    @training_module_user = TrainingModulesUsers.find_or_create_by(
+    @training_module_user = TrainingModulesUsers.create_or_find_by(
       user: current_user,
       training_module_id: @training_module.id
     )

--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -15,6 +15,7 @@ require_dependency "#{Rails.root}/lib/training_progress_manager"
 
 class TrainingModulesUsers < ApplicationRecord
   belongs_to :user
+  has_one :training_module
 
   def training_module
     @training_module ||= TrainingModule.find(training_module_id)

--- a/db/cleanup/training_modules_users_cleanup.rb
+++ b/db/cleanup/training_modules_users_cleanup.rb
@@ -1,0 +1,16 @@
+# Destroy all the records with user_id 0
+# No new ones should be created once we switch to setting the user server-side
+TrainingModulesUsers.where(user_id: 0).destroy_all
+
+# These are all the records where we have a duplicate TrainingModulesUsers record for the same user+module combination.
+# We need delete the duplicates before adding a unique index.
+duplicates = TrainingModulesUsers.select(:user_id, :training_module_id).group(:user_id, :training_module_id).having("count(*) > 1").size
+
+# We want to keep either the earliest record that represents having completed the module, or just the earliest record
+# if none record module completion.
+duplicates.keys.each do |user_and_module|
+  tmus = TrainingModulesUsers.where(user_id: user_and_module[0], training_module_id: user_and_module[1]).to_a
+  keeper = tmus.detect { |tmu| tmu.completed_at.present? }
+  keeper ||= tmus.first
+  (tmus - [keeper]).each(&:destroy)
+end

--- a/db/migrate/20191009175313_unique_index_on_training_modules_users.rb
+++ b/db/migrate/20191009175313_unique_index_on_training_modules_users.rb
@@ -1,0 +1,6 @@
+class UniqueIndexOnTrainingModulesUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :training_modules_users, [:user_id, :training_module_id]
+    add_index :training_modules_users, [:user_id, :training_module_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_165123) do
+ActiveRecord::Schema.define(version: 2019_10_09_175313) do
 
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
@@ -483,7 +483,7 @@ ActiveRecord::Schema.define(version: 2019_07_31_165123) do
     t.datetime "completed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["user_id", "training_module_id"], name: "index_training_modules_users_on_user_id_and_training_module_id"
+    t.index ["user_id", "training_module_id"], name: "index_training_modules_users_on_user_id_and_training_module_id", unique: true
   end
 
   create_table "training_slides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
Part 2, which adds the unique index and replaces `find_or_create_by` with `create_or_find_by`, per https://sikac.hu/use-create-or-find-by-to-avoid-race-condition-in-rails-6-0-f44fca97d16b