### PR TITLE
Import average views of articles during course data update

### DIFF
--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -6,6 +6,7 @@ require_dependency "#{Rails.root}/lib/importers/course_upload_importer"
 require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
+require_dependency "#{Rails.root}/lib/importers/average_views_importer"
 
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats
@@ -21,6 +22,7 @@ class UpdateCourseStats
     fetch_data
     update_categories if @course.needs_update
     update_article_status if @course.needs_update
+    update_average_pageviews
     update_caches
     @course.update(needs_update: false)
     @end_time = Time.zone.now
@@ -50,6 +52,10 @@ class UpdateCourseStats
   def update_article_status
     ArticleStatusManager.update_article_status_for_course(@course)
     log_update_progress :article_status_updated
+  end
+
+  def update_average_pageviews
+    AverageViewsImporter.update_outdated_average_views(@course.articles)
   end
 
   def update_caches

--- a/lib/importers/average_views_importer.rb
+++ b/lib/importers/average_views_importer.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class AverageViewsImporter
+  DAYS_UNTIL_OUTDATED = 14
+  def self.update_outdated_average_views(articles)
+    to_update = articles.where(average_views_updated_at: nil).or(
+      articles.where('average_views_updated_at < ?', DAYS_UNTIL_OUTDATED.days.ago)
+    )
+    update_average_views(to_update)
+  end
+
   def self.update_average_views(articles)
     article_batches = articles.each_slice(30)
     article_batches.each do |batch|

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -416,6 +416,7 @@ describe 'the course page', type: :feature, js: true do
 
       expect(CourseRevisionUpdater).to receive(:import_revisions)
       expect(RevisionScoreImporter).to receive(:update_revision_scores_for_course)
+      expect(AverageViewsImporter).to receive(:update_outdated_average_views)
       expect_any_instance_of(CourseUploadImporter).to receive(:run)
       visit "/courses/#{slug}/manual_update"
       updated_user_count = user_count + 1

--- a/spec/lib/importers/average_views_importer_spec.rb
+++ b/spec/lib/importers/average_views_importer_spec.rb
@@ -4,12 +4,23 @@ require 'rails_helper'
 require "#{Rails.root}/lib/importers/average_views_importer"
 
 describe AverageViewsImporter do
-  let(:article) { create(:article, title: 'Selfie') }
+  let!(:article) do
+    create(:article, title: 'Selfie', average_views: 1, average_views_updated_at: 1.day.ago)
+  end
 
-  it 'saves average page views on Article records' do
-    VCR.use_cassette 'average_views' do
-      described_class.update_average_views([article])
+  describe '.update_average_views' do
+    it 'saves average page views on Article records' do
+      VCR.use_cassette 'average_views' do
+        described_class.update_average_views(Article.all)
+      end
+      expect(article.reload.average_views).to be > 50
     end
-    expect(article.average_views).to be > 50
+  end
+
+  describe '.update_outdated_average_views' do
+    it 'does not update recently-updated records' do
+      described_class.update_outdated_average_views(Article.all)
+      expect(article.reload.average_views).to eq(1)
+    end
   end
 end

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -40,12 +40,17 @@ describe UpdateCourseStats do
     before do
       course.campaigns << Campaign.first
       JoinCourse.new(course: course, user: user, role: 0)
-    end
-
-    it 'imports the revisions and their ORES data' do
       VCR.use_cassette 'course_update' do
         subject
       end
+    end
+
+    it 'imports average views of edited articles' do
+      expect(course.articles.count).to eq(2)
+      expect(course.articles.last.average_views).to be > 0
+    end
+
+    it 'imports the revisions and their ORES data' do
       expect(course.revisions.count).to eq(2)
       course.revisions.each do |revision|
         expect(revision.features).to have_key('feature.wikitext.revision.ref_tags')


### PR DESCRIPTION
This lays the groundwork for switching to average views as the basis for pageview numbers, so that we can show estimated pageviews more immediately and update them indefinitely for older courses, and we won't have the current unsustainable view import bottleneck.

First step: deploy this, which will start importing Article data.

Second step: replace the revision-based view summing with estimates that are based on average views and time since first edit.