### PR TITLE
Add MyArticles section to Articles main page

### DIFF
--- a/app/assets/javascripts/components/articles/articles_handler.jsx
+++ b/app/assets/javascripts/components/articles/articles_handler.jsx
@@ -108,7 +108,7 @@ export const ArticlesHandler = createReactClass({
             render={() => {
               // If at any point there are no available articles, redirect the user
               if (!this.state.loading && this.hideAssignments()) {
-                return <Redirect to={`/courses/${this.props.course.slug}/articles/assigned`} />;
+                return <Redirect to={`/courses/${this.props.course.slug}`} />;
               }
 
               return <AvailableArticles {...this.props} />;

--- a/app/assets/javascripts/components/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/articles/available_articles.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import AssignCell from '../students/assign_cell.jsx';
 import ConnectedAvailableArticle from './available_article.jsx';
 import AvailableArticlesList from '../articles/available_articles_list.jsx';
+import MyArticlesContainer from '../overview/my_articles/containers';
 import { ASSIGNED_ROLE } from '../../constants';
 
 const AvailableArticles = createReactClass({
@@ -64,6 +65,13 @@ const AvailableArticles = createReactClass({
     }
 
     const showAvailableArticles = elements.length > 0 || this.props.current_user.isAdvancedRole;
+    const showMyArticlesSection = this.props.current_user.isStudent;
+    let myArticles;
+    if (showMyArticlesSection) {
+      myArticles = (
+        <MyArticlesContainer current_user={this.props.current_user} />
+      );
+    }
 
     if (showAvailableArticles) {
       availableArticles = (
@@ -83,7 +91,12 @@ const AvailableArticles = createReactClass({
       availableArticles = null;
     }
 
-    return availableArticles;
+    return (
+      <>
+        {myArticles}
+        {availableArticles}
+      </>
+    );
   }
 });
 

--- a/app/assets/javascripts/components/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/articles/available_articles.jsx
@@ -9,6 +9,7 @@ import ConnectedAvailableArticle from './available_article.jsx';
 import AvailableArticlesList from '../articles/available_articles_list.jsx';
 import MyArticlesContainer from '../overview/my_articles/containers';
 import { ASSIGNED_ROLE } from '../../constants';
+import { processAssignments } from '../overview/my_articles/utils/processAssignments';
 
 const AvailableArticles = createReactClass({
   displayName: 'AvailableArticles',
@@ -25,6 +26,7 @@ const AvailableArticles = createReactClass({
     let availableArticles;
     let elements = [];
     let findingArticlesTraining;
+
     if (Features.wikiEd && this.props.current_user.isAdvancedRole) {
       findingArticlesTraining = (
         <a href="/training/instructors/finding-articles" target="_blank" className="button ghost-button small">
@@ -64,8 +66,8 @@ const AvailableArticles = createReactClass({
       );
     }
 
-    const showAvailableArticles = elements.length > 0 || this.props.current_user.isAdvancedRole;
-    const showMyArticlesSection = this.props.current_user.isStudent;
+    const { assigned } = processAssignments(this.props);
+    const showMyArticlesSection = assigned.length && this.props.current_user.isStudent;
     let myArticles;
     if (showMyArticlesSection) {
       myArticles = (
@@ -73,6 +75,7 @@ const AvailableArticles = createReactClass({
       );
     }
 
+    const showAvailableArticles = elements.length > 0 || this.props.current_user.isAdvancedRole;
     if (showAvailableArticles) {
       availableArticles = (
         <div id="available-articles" className="mt4">

--- a/app/assets/javascripts/components/overview/my_articles/containers/index.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/containers/index.jsx
@@ -72,6 +72,7 @@ export class MyArticlesContainer extends React.Component {
 MyArticlesContainer.propTypes = {
   // props
   assignments: PropTypes.array.isRequired,
+  course: PropTypes.object.isRequired,
   current_user: PropTypes.object,
   loading: PropTypes.bool.isRequired,
   wikidataLabels: PropTypes.object.isRequired,
@@ -82,6 +83,7 @@ MyArticlesContainer.propTypes = {
 
 const mapStateToProps = state => ({
   assignments: state.assignments.assignments,
+  course: state.course,
   loading: state.assignments.loading,
   wikidataLabels: state.wikidataLabels
 });

--- a/test/components/overview/my_articles/containers/index.spec.jsx
+++ b/test/components/overview/my_articles/containers/index.spec.jsx
@@ -10,24 +10,21 @@ import MyArticlesContainer from '../../../../../app/assets/javascripts/component
 describe('MyArticlesContainer', () => {
   describe('Features.wikiEd = true', () => {
     Features.wikiEd = true;
-    const template = {
+    const initialState = {
+      assignments: { assignments: [], loading: false },
       course: {
         home_wiki: { language: 'en', project: 'wikipedia' },
         slug: 'course/slug',
         type: 'ClassroomProgramCourse'
       },
-      current_user: {}
+      wikidataLabels: {},
+      ui: {}
     };
 
     it('displays a message if there are no assignments', () => {
-      const store = configureMockStore()({
-        assignments: { assignments: [], loading: false },
-        wikidataLabels: {},
-        ui: {}
-      });
+      const store = configureMockStore()(initialState);
 
       const props = {
-        ...template,
         current_user: { isStudent: true, username: 'Username' }
       };
 
@@ -45,13 +42,9 @@ describe('MyArticlesContainer', () => {
     });
 
     it('does not display for an admin', () => {
-      const store = configureMockStore()({
-        assignments: { assignments: [], loading: false },
-        wikidataLabels: {}
-      });
+      const store = configureMockStore()(initialState);
 
       const props = {
-        ...template,
         current_user: { isStudent: false, username: 'Username' }
       };
 
@@ -88,13 +81,17 @@ describe('MyArticlesContainer', () => {
           ],
           loading: false
         },
+        course: {
+          home_wiki: { language: 'en', project: 'wikipedia' },
+          slug: 'course/slug',
+          type: 'ClassroomProgramCourse'
+        },
         feedback: {},
         wikidataLabels: {},
         ui: { openKey: true }
       });
 
       const props = {
-        ...template,
         current_user: { id: 1, isStudent: true, username: 'Username' }
       };
 


### PR DESCRIPTION
## What this PR does

This adds the MyArticles section to the Articles main page. It essentially works as intended but there's a couple notes I have:

1. Is this entirely necessary? There is a notification that should show up each time someone assigns an article to themselves.
2. When all Assigned Articles are gone, we currently have it redirect to the "Assigned Articles" page. This makes it a bit confusing when selecting the last article. Is there somewhere else this should redirect?

## Screenshots
![image](https://user-images.githubusercontent.com/1316902/66785507-50381780-ee92-11e9-912f-2e066f6d94a0.png)
