### PR TITLE
Update component ArticleFinder to reuse component SelectedWikiOption

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -4,8 +4,7 @@ import { connect } from 'react-redux';
 import InputRange from 'react-input-range';
 import _ from 'lodash';
 import qs from 'query-string';
-import selectStyles from '../../styles/select';
-import WikiSelect from '../common/wiki_select.jsx';
+import SelectedWikiOption from '../common/selected_wiki_option';
 
 import TextInput from '../common/text_input.jsx';
 import ArticleFinderRow from './article_finder_row.jsx';
@@ -34,7 +33,6 @@ const ArticleFinder = createReactClass({
     return {
       isSubmitted: false,
       showFilters: false,
-      showLanguageAndWikiSelectors: false,
     };
   },
 
@@ -122,12 +120,6 @@ const ArticleFinder = createReactClass({
     this.setState({ isSubmitted: false });
     this.props.clearResults();
     return this.updateFields('home_wiki', { language: wiki.language, project: wiki.project });
-  },
-
-  toggleLanguageAndWikiSelector(e) {
-    e.preventDefault();
-    return this.setState(
-      { showLanguageAndWikiSelectors: !this.state.showLanguageAndWikiSelectors });
   },
 
   sortSelect(e) {
@@ -370,34 +362,13 @@ const ArticleFinder = createReactClass({
       );
     }
 
-    let options = (
-      <div className="selector-block">
-        <div className="small-block-link pull-right">
-          {this.props.home_wiki.language}.{this.props.home_wiki.project}.org <a href="#" onClick={this.toggleLanguageAndWikiSelector}>({I18n.t('application.change')})</a>
-        </div>
-      </div>
+    const options = (
+      <SelectedWikiOption
+        language={this.props.home_wiki.language}
+        project={this.props.home_wiki.project}
+        handleWikiChange={this.handleWikiChange}
+      />
     );
-    if (this.state.showLanguageAndWikiSelectors) {
-      options = (
-        <div className="wiki-selector">
-          <div>
-            <WikiSelect
-              wikis={
-                [{ language: this.props.home_wiki.language, project: this.props.home_wiki.project }]
-              }
-              onChange={this.handleWikiChange}
-              multi={false}
-              styles={{ ...selectStyles, singleValue: null }}
-            />
-          </div>
-          <div className="selector-block">
-            <div className="small-block-link pull-right">
-              {this.props.home_wiki.language}.{this.props.home_wiki.project}.org <a href="#" onClick={this.toggleLanguageAndWikiSelector}>({I18n.t('articles.hide')})</a>
-            </div>
-          </div>
-        </div>
-      );
-    }
 
     return (
       <div className="container">

--- a/app/assets/javascripts/components/common/selected_wiki_option.jsx
+++ b/app/assets/javascripts/components/common/selected_wiki_option.jsx
@@ -14,7 +14,7 @@ export default class SelectedWikiOption extends React.Component {
 
   handleShowOptions(e) {
     e.preventDefault();
-    return this.setState(prevState => ({ show: !prevState.show }));
+    return this.setState({ show: true });
   }
 
   render() {
@@ -28,9 +28,6 @@ export default class SelectedWikiOption extends React.Component {
             multi={false}
             styles={{ ...selectStyles, singleValue: null }}
           />
-          <div className="small-block-link">
-            {language}.{project}.org <a href="#" onClick={this.handleShowOptions.bind(this)}>({I18n.t('articles.hide')})</a>
-          </div>
         </div>
       );
     }

--- a/app/assets/javascripts/components/common/selected_wiki_option.jsx
+++ b/app/assets/javascripts/components/common/selected_wiki_option.jsx
@@ -14,7 +14,7 @@ export default class SelectedWikiOption extends React.Component {
 
   handleShowOptions(e) {
     e.preventDefault();
-    return this.setState({ show: true });
+    return this.setState(prevState => ({ show: !prevState.show }));
   }
 
   render() {
@@ -28,14 +28,16 @@ export default class SelectedWikiOption extends React.Component {
             multi={false}
             styles={{ ...selectStyles, singleValue: null }}
           />
+          <div className="small-block-link">
+            {language}.{project}.org <a href="#" onClick={this.handleShowOptions.bind(this)}>({I18n.t('articles.hide')})</a>
+          </div>
         </div>
       );
     }
 
     return (
       <div className="small-block-link">
-        {language}.{project}.org
-        <a href="#" onClick={this.handleShowOptions.bind(this)}>({I18n.t('application.change')})</a>
+        {language}.{project}.org <a href="#" onClick={this.handleShowOptions.bind(this)}>({I18n.t('application.change')})</a>
       </div>
     );
   }

--- a/app/assets/stylesheets/modules/_article_finder.styl
+++ b/app/assets/stylesheets/modules/_article_finder.styl
@@ -61,9 +61,6 @@
   display flex
   flex-direction column
 
-.wiki-selector
-  max-width: 300px;
-
 .article-finder-stats
   display flex
   align-items center

--- a/app/assets/stylesheets/modules/_selects.styl
+++ b/app/assets/stylesheets/modules/_selects.styl
@@ -50,3 +50,4 @@
 
 .wiki-select
   padding-top 10px
+  max-width 300px


### PR DESCRIPTION
## What this PR does
Update component `ArticleFinder` to use existing component `SelectedWikiOption`. This is to consolidate the component for selecting wiki and show the selection. The behavior in `ArticleFinder` is slightly different from `SelectedWikiOption`, where it includes the UI to hide the wiki selection.

With the changes, the UI in component `SelectedWikiOption` should remain the same. The UI in component `ArticleFinder` is changed to remove UI for "hiding the wiki selection" when it's shown.

Issue #2888 

## Screenshots
UI for component `ArticleFinder`.
Before:
![image](https://user-images.githubusercontent.com/19353500/66862698-4d96fa00-ef46-11e9-800b-d4e8ed0d971e.png)

After:
![image](https://user-images.githubusercontent.com/19353500/66862575-027ce700-ef46-11e9-978b-693927cf57c0.png)

## Open questions and concerns
The issue also mentioned possibly updating components `CourseCreator` and `Details`. This PR does not include changes for these components. Will look into these next.

