### PR TITLE
Included shortened footnotes in references added counts

### DIFF
--- a/app/controllers/courses_by_wiki_controller.rb
+++ b/app/controllers/courses_by_wiki_controller.rb
@@ -7,6 +7,7 @@ class CoursesByWikiController < ApplicationController
 
   def show
     @courses_list = Course.where(home_wiki: @wiki).order(id: :desc)
+    @courses_list = @courses_list.where("year(created_at) = #{params[:year].to_i}") if params[:year]
     @presenter = CoursesPresenter.new(current_user: current_user, courses_list: @courses_list)
   end
 


### PR DESCRIPTION
I had to remove the prior PR, because of certain mistakes in the commits and the file changed. I squash ed my commit and older commits by mistake, therefore I closed the earlier PR.https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/3435 to make a new one. closes #3276

Included shortened footnotes in references added counts by creating a new variable WIKITEXT_SHORT_TEMPLATE and   WIKITEXT_REF_TAGS_SHORT_TEMPLATE, where the latter is the sum of 'feature.wikitext.revision.ref_tags' and 'feature.enwiki.revision.shortened_footnote_templates'.