### PR TITLE
add ref to diff, resize empty diff col, wrap Loading element in tbody

### DIFF
--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -53,6 +53,22 @@ const DiffViewer = createReactClass({
     this.props.setSelectedIndex(index);
   },
 
+  // sets the ref for the diff, calls method to resize first empty diff
+  setDiffBodyRef(element) {
+    this.diffBody = element;
+    this.resizeFirstEmptyDiff();
+  },
+
+  // resizes first empty diff element to 50% width in table
+  resizeFirstEmptyDiff() {
+    if (this.diffBody) {
+      const emptyDiff = this.diffBody.querySelector('.diff-empty');
+      if (emptyDiff) {
+        emptyDiff.setAttribute('style', 'width: 50%;');
+      }
+    }
+  },
+
   showButtonLabel() {
     if (this.props.showButtonLabel) {
       return this.props.showButtonLabel;
@@ -259,11 +275,13 @@ const DiffViewer = createReactClass({
 
     let diff;
     if (!this.state.fetched) {
-      diff = <Loading/>;
+      // div cannot appear as a child of tbody
+      diff = <tbody><tr><td><Loading/></td></tr></tbody>;
     } else if (this.state.diff === '') {
-      diff = <div> —</div>;
+      diff = <tbody><tr><td> —</td></tr></tbody>;
     } else {
-      diff = <tbody dangerouslySetInnerHTML={{ __html: this.state.diff }}/>;
+      // adds a ref for the diff, used to format parts of diff element above
+      diff = <tbody dangerouslySetInnerHTML={{ __html: this.state.diff }} ref={this.setDiffBodyRef}/>;
     }
 
     const wikiDiffUrl = this.webDiffUrl();


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does

- Address issue  #1088 Diff Viewer shows only one column, on left, if all changes are new paragraphs 
- Fixes a bug within the diff table

Files changed: 
app/assets/javascripts/components/revisions/diff_viewer.jsx
- Add ref to diff:
  The Dangerously Set HTML from the Wikipedia Diff URL did not previously have a ref. I added one, including a setDiff method for it.

- Resize empty diff column: 
  When the table cells, td elements, are empty, they previously lost their width. This is what was causing issue #1088. This PR sets the first empty cell to 50% width in the table, so that both (-) and (+) columns can take up half the table width.

- Wrap Loading and (-) diff marker elements in tbody:
  There were previously errors caused by the <Loading/> and (-) diff marker elements because they were within a table without being wrapped in tbody. This PR wraps both in tbody, tr, and td, fixing the errors.

## Screenshots
Before:
<img width="1109" alt="Screen Shot 2019-11-05 at 6 39 10 AM" src="https://user-images.githubusercontent.com/2976514/68524119-a58bfc80-0277-11ea-9a75-de81d31307fc.png">


After:
<img width="1200" alt="Screen Shot 2019-11-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/2976514/68524103-5b0a8000-0277-11ea-9a98-bae2bb1cb92d.png">

## Open questions and concerns
I learned how to use dangerouslySetInnerHTML in React, how to add refs to elements using JSX in React components, and that divs within tables must be wrapped in a tbody, tr, and td. 
