### PR TITLE
add ref to diff, resize empty diff col, wrap Loading element in tbody, rename certain react components UNSAFE_

### DIFF
--- a/app/assets/javascripts/components/activity/activity_table.jsx
+++ b/app/assets/javascripts/components/activity/activity_table.jsx
@@ -29,7 +29,7 @@ const ActivityTable = createReactClass({
     };
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.activity !== this.state.activity) {
       this.setState({ activity: nextProps.activity });
     }

--- a/app/assets/javascripts/components/activity/did_you_know_handler.jsx
+++ b/app/assets/javascripts/components/activity/did_you_know_handler.jsx
@@ -23,13 +23,13 @@ const DidYouKnowHandler = createReactClass({
     loading: PropTypes.bool
   },
 
-  componentWillMount() {
-    this.props.fetchDYKArticles();
-  },
-
   setCourseScope(e) {
     const scoped = e.target.checked;
     this.props.fetchDYKArticles({ scoped });
+  },
+
+  UNSAFE_componentWillMount() {
+    this.props.fetchDYKArticles();
   },
 
   render() {

--- a/app/assets/javascripts/components/activity/plagiarism_handler.jsx
+++ b/app/assets/javascripts/components/activity/plagiarism_handler.jsx
@@ -24,13 +24,13 @@ const PlagiarismHandler = createReactClass({
     loading: PropTypes.bool
   },
 
-  componentWillMount() {
-    return this.props.fetchSuspectedPlagiarism();
-  },
-
   setCourseScope(e) {
     const scoped = e.target.checked;
     return this.props.fetchSuspectedPlagiarism({ scoped });
+  },
+
+  UNSAFE_componentWillMount() {
+    return this.props.fetchSuspectedPlagiarism();
   },
 
   render() {

--- a/app/assets/javascripts/components/activity/recent_edits_handler.jsx
+++ b/app/assets/javascripts/components/activity/recent_edits_handler.jsx
@@ -24,13 +24,13 @@ const RecentEditsHandler = createReactClass({
     loading: PropTypes.bool
   },
 
-  componentWillMount() {
-    return this.props.fetchRecentEdits();
-  },
-
   setCourseScope(e) {
     const scoped = e.target.checked;
     this.props.fetchRecentEdits({ scoped });
+  },
+
+  UNSAFE_componentWillMount() {
+    return this.props.fetchRecentEdits();
   },
 
   render() {

--- a/app/assets/javascripts/components/activity/recent_uploads_handler.jsx
+++ b/app/assets/javascripts/components/activity/recent_uploads_handler.jsx
@@ -17,7 +17,7 @@ export const RecentUploadsHandlerBase = createReactClass({
     loading: PropTypes.bool
    },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     return this.props.fetchRecentUploads();
   },
 

--- a/app/assets/javascripts/components/alerts/alerts_handler.jsx
+++ b/app/assets/javascripts/components/alerts/alerts_handler.jsx
@@ -32,13 +32,13 @@ const AlertsHandler = createReactClass({
     alerts: PropTypes.array,
   },
 
-  componentWillMount() {
-    const campaignSlug = this.getCampaignSlug();
-    return this.props.fetchAlerts(campaignSlug);
-  },
-
   getCampaignSlug() {
     return `${this.props.match.params.campaign_slug}`;
+  },
+
+  UNSAFE_componentWillMount() {
+    const campaignSlug = this.getCampaignSlug();
+    return this.props.fetchAlerts(campaignSlug);
   },
 
   fetchAlerts(campaignSlug) {

--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -36,16 +36,6 @@ const ArticleFinder = createReactClass({
     };
   },
 
-  componentWillMount() {
-    if (window.location.search.substring(1)) {
-      this.getParamsURL();
-    }
-    if (this.props.course_id && this.props.loadingAssignments) {
-      this.props.fetchAssignments(this.props.course_id);
-    }
-    return this.updateFields('home_wiki', this.props.course.home_wiki);
-  },
-
   componentWillUnmount() {
     return this.props.resetArticleFinder();
   },
@@ -65,6 +55,17 @@ const ArticleFinder = createReactClass({
       return this.updateFields(key, val);
     });
   },
+
+  UNSAFE_componentWillMount() {
+    if (window.location.search.substring(1)) {
+      this.getParamsURL();
+    }
+    if (this.props.course_id && this.props.loadingAssignments) {
+      this.props.fetchAssignments(this.props.course_id);
+    }
+    return this.updateFields('home_wiki', this.props.course.home_wiki);
+  },
+
   updateFields(key, value) {
     const update_field = this.props.updateFields(key, value);
     Promise.resolve(update_field).then(() => {

--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -14,7 +14,7 @@ const ArticleFinderRow = createReactClass({
     };
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.state.isLoading && (this.props.assignment !== nextProps.assignment)) {
       this.setState({
         isLoading: false,

--- a/app/assets/javascripts/components/articles/articles_handler.jsx
+++ b/app/assets/javascripts/components/articles/articles_handler.jsx
@@ -37,7 +37,7 @@ export const ArticlesHandler = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     delayFetchAssignmentsAndArticles(this.props, () => this.setState({ loading: false }));
   },
 

--- a/app/assets/javascripts/components/categories/category_handler.jsx
+++ b/app/assets/javascripts/components/categories/category_handler.jsx
@@ -15,7 +15,7 @@ const CategoryHandler = createReactClass({
     current_user: PropTypes.object
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.fetchCategories(this.props.course.slug);
   },
 

--- a/app/assets/javascripts/components/common/article_viewer.jsx
+++ b/app/assets/javascripts/components/common/article_viewer.jsx
@@ -45,7 +45,7 @@ const ArticleViewer = createReactClass({
   // fetched until the usernames are available, so 'show' will fetch the usernames
   // first in that case. In that case, componentWillReceiveProps fetches the
   // user ids as soon as usernames are avaialable.
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!this.props.users && nextProps.users) {
       if (!this.state.userIdsFetched) {
         this.fetchUserIds(nextProps.users);

--- a/app/assets/javascripts/components/common/calendar.jsx
+++ b/app/assets/javascripts/components/common/calendar.jsx
@@ -26,12 +26,6 @@ const Calendar = createReactClass({
   getInitialState() {
     return ({ initialMonth: moment(this.props.course.start, 'YYYY-MM-DD').toDate() });
   },
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.course.start !== moment(this.state.initialMonth).format('YYYY-MM-DD')) {
-      return this.setState(
-        { initialMonth: moment(nextProps.course.start, 'YYYY-MM-DD').toDate() });
-    }
-  },
   shouldComponentUpdate(nextProps) {
     if (nextProps.course) {
       const start = moment(nextProps.course.start, 'YYYY-MM-DD');
@@ -39,6 +33,12 @@ const Calendar = createReactClass({
       return start.isValid() && end.isValid();
     }
     return true;
+  },
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (nextProps.course.start !== moment(this.state.initialMonth).format('YYYY-MM-DD')) {
+      return this.setState(
+        { initialMonth: moment(nextProps.course.start, 'YYYY-MM-DD').toDate() });
+    }
   },
   selectDay(day) {
     let exceptions;

--- a/app/assets/javascripts/components/common/modal.jsx
+++ b/app/assets/javascripts/components/common/modal.jsx
@@ -7,11 +7,11 @@ const Modal = createReactClass({
     modalClass: PropTypes.string,
     children: PropTypes.node
   },
-  componentWillMount() {
-    return $('body').addClass('modal-open');
-  },
   componentWillUnmount() {
     return $('body').removeClass('modal-open');
+  },
+  UNSAFE_componentWillMount() {
+    return $('body').addClass('modal-open');
   },
   render() {
     const className = `wizard active ${this.props.modalClass}`;

--- a/app/assets/javascripts/components/common/rocket_chat.jsx
+++ b/app/assets/javascripts/components/common/rocket_chat.jsx
@@ -20,15 +20,15 @@ const RocketChat = createReactClass({
     };
   },
 
-  componentWillMount() {
-    if (Features.enableChat && !this.props.authToken) {
-      this.props.requestAuthToken();
-    }
-  },
-
   componentDidMount() {
     if (Features.enableChat && this.props.authToken && !this.state.showChat) {
       this.loginOnFrameLoad();
+    }
+  },
+
+  UNSAFE_componentWillMount() {
+    if (Features.enableChat && !this.props.authToken) {
+      this.props.requestAuthToken();
     }
   },
 

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -57,7 +57,7 @@ const CourseCreator = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // If a campaign slug is provided, fetch the campaign.
     const campaignParam = this.campaignParam();
     if (campaignParam) {
@@ -66,7 +66,7 @@ const CourseCreator = createReactClass({
     this.props.fetchCoursesForUser(window.currentUser.id);
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.course.school !== '' && nextProps.course.title !== '') {
       this.state.tempCourseId = CourseUtils.generateTempId(nextProps.course);
     } else {

--- a/app/assets/javascripts/components/high_order/expandable.jsx
+++ b/app/assets/javascripts/components/high_order/expandable.jsx
@@ -19,7 +19,7 @@ const Expandable = function (Component) {
       return { is_open: false };
     },
 
-    componentWillReceiveProps(props) {
+    UNSAFE_componentWillReceiveProps(props) {
       this.setState({
         is_open: this.refs.component.getKey() === props.openKey
       });

--- a/app/assets/javascripts/components/high_order/input_hoc.jsx
+++ b/app/assets/javascripts/components/high_order/input_hoc.jsx
@@ -37,22 +37,6 @@ const InputHOC = (Component) => {
       return { value: this.props.value };
     },
 
-    componentWillReceiveProps(props) {
-      const valid = getValidation(props.value_key, props.validations);
-
-      return this.setState(
-        {
-          value: props.value,
-          invalid: !valid,
-          id: props.id || this.state.id || uuid.v4() // create a UUID if no id prop
-        }, function () {
-          if (valid && this.props.required && (!props.value || props.value === null || props.value.length === 0)) {
-            return this.props.addValidation(this.props.value_key, I18n.t('application.field_required'));
-          }
-        }
-      );
-    },
-
     shouldComponentUpdate(nextProps, nextState) {
       if (this.state.value === nextState.value
             && this.state.id === nextState.id
@@ -79,6 +63,22 @@ const InputHOC = (Component) => {
           return this.validate();
         });
       }
+    },
+
+    UNSAFE_componentWillReceiveProps(props) {
+      const valid = getValidation(props.value_key, props.validations);
+
+      return this.setState(
+        {
+          value: props.value,
+          invalid: !valid,
+          id: props.id || this.state.id || uuid.v4() // create a UUID if no id prop
+        }, function () {
+          if (valid && this.props.required && (!props.value || props.value === null || props.value.length === 0)) {
+            return this.props.addValidation(this.props.value_key, I18n.t('application.field_required'));
+          }
+        }
+      );
     },
 
     validate() {

--- a/app/assets/javascripts/components/high_order/popover_expandable.jsx
+++ b/app/assets/javascripts/components/high_order/popover_expandable.jsx
@@ -27,7 +27,7 @@ const PopoverExpandable = function (Component) {
       return { is_open: false };
     },
 
-    componentWillReceiveProps(props) {
+    UNSAFE_componentWillReceiveProps(props) {
       this.setState({
         is_open: this.refs.component.getKey() === props.openKey
       });

--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -50,15 +50,16 @@ const Nav = createReactClass({
     };
   },
 
-  componentWillMount() {
-    this.updateDimensions();
-  },
-
   componentDidMount() {
     window.addEventListener('resize', this.updateDimensions);
   },
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateDimensions);
+  },
+
+  UNSAFE_componentWillMount() {
+    this.updateDimensions();
   },
 
   updateDimensions() {

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -32,18 +32,6 @@ const CourseClonedModal = createReactClass({
     };
   },
 
-  componentWillReceiveProps(newProps) {
-    let isPersisting = this.state.isPersisting;
-    if (newProps.firstErrorMessage && !this.props.firstErrorMessage) {
-      document.querySelector('.wizard').scrollTo({ top: 0, behavior: 'smooth' });
-      isPersisting = false;
-    }
-    return this.setState({
-      isPersisting,
-      tempCourseId: CourseUtils.generateTempId(this.state.course)
-    });
-  },
-
   setAnyDatesSelected(bool) {
     return this.setState({ anyDatesSelected: bool });
   },
@@ -55,6 +43,18 @@ const CourseClonedModal = createReactClass({
   setNoBlackoutDatesChecked() {
     const { checked } = this.noDates;
     return this.updateCourse('no_day_exceptions', checked);
+  },
+
+  UNSAFE_componentWillReceiveProps(newProps) {
+    let isPersisting = this.state.isPersisting;
+    if (newProps.firstErrorMessage && !this.props.firstErrorMessage) {
+      document.querySelector('.wizard').scrollTo({ top: 0, behavior: 'smooth' });
+      isPersisting = false;
+    }
+    return this.setState({
+      isPersisting,
+      tempCourseId: CourseUtils.generateTempId(this.state.course)
+    });
   },
 
   cloneCompletedStatus: 2,

--- a/app/assets/javascripts/components/overview/course_type_selector.jsx
+++ b/app/assets/javascripts/components/overview/course_type_selector.jsx
@@ -12,7 +12,7 @@ const CourseTypeSelector = createReactClass({
     updateCourse: PropTypes.func.isRequired
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       id: uuid.v4(),
       selectedOption: { value: this.props.course.type, label: this._getFormattedCourseType(this.props.course.type) },

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -53,6 +53,22 @@ const DiffViewer = createReactClass({
     this.props.setSelectedIndex(index);
   },
 
+  // sets the ref for the diff, calls method to resize first empty diff
+  setDiffBodyRef(element) {
+    this.diffBody = element;
+    this.resizeFirstEmptyDiff();
+  },
+
+  // resizes first empty diff element to 50% width in table
+  resizeFirstEmptyDiff() {
+    if (this.diffBody) {
+      const emptyDiff = this.diffBody.querySelector('.diff-empty');
+      if (emptyDiff) {
+        emptyDiff.setAttribute('style', 'width: 50%;');
+      }
+    }
+  },
+
   showButtonLabel() {
     if (this.props.showButtonLabel) {
       return this.props.showButtonLabel;
@@ -259,11 +275,13 @@ const DiffViewer = createReactClass({
 
     let diff;
     if (!this.state.fetched) {
-      diff = <Loading/>;
+      // div cannot appear as a child of tbody
+      diff = <tbody><tr><td><Loading/></td></tr></tbody>;
     } else if (this.state.diff === '') {
-      diff = <div> —</div>;
+      diff = <tbody><tr><td> —</td></tr></tbody>;
     } else {
-      diff = <tbody dangerouslySetInnerHTML={{ __html: this.state.diff }}/>;
+      // adds a ref for the diff, used to format parts of diff element above
+      diff = <tbody dangerouslySetInnerHTML={{ __html: this.state.diff }} ref={this.setDiffBodyRef}/>;
     }
 
     const wikiDiffUrl = this.webDiffUrl();

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -37,26 +37,26 @@ const DiffViewer = createReactClass({
     };
   },
 
-  // When 'show' is clicked, this component may or may not already have
-  // users data (a list of usernames) in its props. If it does, then 'show' will
-  // fetch the MediaWiki user ids, which are used for coloration. Those can't be
-  // fetched until the usernames are available, so 'show' will fetch the usernames
-  // first in that case. In that case, componentWillReceiveProps fetches the
-  // user ids as soon as usernames are avaialable.
-  componentWillReceiveProps(nextProps) {
-    if (this.shouldShowDiff(nextProps) && !this.state.fetched) {
-      this.fetchRevisionDetails(nextProps);
-    }
+  // sets the ref for the diff, calls method to resize first empty diff
+  setDiffBodyRef(element) {
+    this.diffBody = element;
+    this.resizeFirstEmptyDiff();
   },
 
   setSelectedIndex(index) {
     this.props.setSelectedIndex(index);
   },
 
-  // sets the ref for the diff, calls method to resize first empty diff
-  setDiffBodyRef(element) {
-    this.diffBody = element;
-    this.resizeFirstEmptyDiff();
+  // When 'show' is clicked, this component may or may not already have
+  // users data (a list of usernames) in its props. If it does, then 'show' will
+  // fetch the MediaWiki user ids, which are used for coloration. Those can't be
+  // fetched until the usernames are available, so 'show' will fetch the usernames
+  // first in that case. In that case, componentWillReceiveProps fetches the
+  // user ids as soon as usernames are avaialable.
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (this.shouldShowDiff(nextProps) && !this.state.fetched) {
+      this.fetchRevisionDetails(nextProps);
+    }
   },
 
   // resizes first empty diff element to 50% width in table

--- a/app/assets/javascripts/components/revisions/revisions_handler.jsx
+++ b/app/assets/javascripts/components/revisions/revisions_handler.jsx
@@ -19,7 +19,7 @@ const RevisionHandler = createReactClass({
     loadingRevisions: PropTypes.bool
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.loadingRevisions) {
       this.props.fetchRevisions(this.props.course_id, this.props.limit);
     }

--- a/app/assets/javascripts/components/settings/settings_handler.jsx
+++ b/app/assets/javascripts/components/settings/settings_handler.jsx
@@ -26,7 +26,7 @@ export const SettingsHandler = createReactClass({
     specialUsers: PropTypes.object
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.fetchAdminUsers();
     this.props.fetchSpecialUsers();
   },

--- a/app/assets/javascripts/components/settings/views/add_admin_form.jsx
+++ b/app/assets/javascripts/components/settings/views/add_admin_form.jsx
@@ -13,7 +13,7 @@ const AddAdminForm = createReactClass({
     return { confirming: false };
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // if `this.props.submittingNewAdmin` goes from `true->false` that means the component should reset
 
     if (this.props.submittingNewAdmin && !nextProps.submittingNewAdmin) {

--- a/app/assets/javascripts/components/settings/views/add_special_user_form.jsx
+++ b/app/assets/javascripts/components/settings/views/add_special_user_form.jsx
@@ -16,7 +16,7 @@ const AddSpecialUserForm = createReactClass({
     return { confirming: false, enabled: false };
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // if `this.props.submittingNewSpecialUser` goes from `true->false` that means the component should reset
 
     if (this.props.submittingNewSpecialUser && !nextProps.submittingNewSpecialUser) {

--- a/app/assets/javascripts/components/students/enroll_button.jsx
+++ b/app/assets/javascripts/components/students/enroll_button.jsx
@@ -37,7 +37,11 @@ const EnrollButton = createReactClass({
     });
   },
 
-  componentWillReceiveProps(newProps) {
+  getKey() {
+    return `add_user_role_${this.props.role}`;
+  },
+
+  UNSAFE_componentWillReceiveProps(newProps) {
     // This handles an added user showing up after being successfully added
     if (!this.refs.username || !this.refs.username.value) { return; }
     const username = this.refs.username.value;
@@ -49,9 +53,6 @@ const EnrollButton = createReactClass({
       });
       return this.refs.username.value = '';
     }
-  },
-  getKey() {
-    return `add_user_role_${this.props.role}`;
   },
 
   enroll(e) {

--- a/app/assets/javascripts/components/students/students_handler.jsx
+++ b/app/assets/javascripts/components/students/students_handler.jsx
@@ -28,7 +28,7 @@ const StudentsHandler = createReactClass({
     return { loading: true };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     delayFetchAssignmentsAndArticles(this.props, () => this.setState({ loading: false }));
   },
 

--- a/app/assets/javascripts/components/uploads/upload.jsx
+++ b/app/assets/javascripts/components/uploads/upload.jsx
@@ -22,16 +22,6 @@ const Upload = createReactClass({
     };
   },
 
-  componentWillMount() {
-    this.setImageFile();
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (!this.state.imageFile) {
-      this.setState({ imageFile: nextProps.upload.thumburl });
-    }
-  },
-
   setImageFile() {
     let imageFile = this.props.upload.thumburl;
     if (this.props.upload.deleted) {
@@ -49,6 +39,16 @@ const Upload = createReactClass({
     img.onload = function () {
       component.setState({ width: this.width, height: this.height });
     };
+  },
+
+  UNSAFE_componentWillMount() {
+    this.setImageFile();
+  },
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (!this.state.imageFile) {
+      this.setState({ imageFile: nextProps.upload.thumburl });
+    }
   },
 
   isUploadViewerOpen() {

--- a/app/assets/javascripts/components/uploads/upload_viewer.jsx
+++ b/app/assets/javascripts/components/uploads/upload_viewer.jsx
@@ -21,10 +21,6 @@ const UploadViewer = createReactClass({
     };
   },
 
-  componentWillMount() {
-    this.props.setUploadViewerMetadata(this.props.upload);
-  },
-
   componentDidUpdate() {
     const metadata = _.get(this.props.uploadMetadata, `query.pages[${this.props.upload.id}]`);
     const fileUsage = _.get(metadata, 'globalusage', []);
@@ -37,6 +33,10 @@ const UploadViewer = createReactClass({
 
   componentWillUnmount() {
     this.props.resetUploadsViews();
+  },
+
+  UNSAFE_componentWillMount() {
+    this.props.setUploadViewerMetadata(this.props.upload);
   },
 
   handleGetFileViews(files) {

--- a/app/assets/javascripts/components/uploads/uploads_handler.jsx
+++ b/app/assets/javascripts/components/uploads/uploads_handler.jsx
@@ -27,23 +27,6 @@ const UploadsHandler = createReactClass({
     };
   },
 
-  componentWillMount() {
-    if (this.props.loadingUploads) {
-      return this.props.receiveUploads(this.props.course_id);
-    }
-  },
-
-  componentWillReceiveProps(nextProps) {
-    const data = nextProps.selectedUploads.slice(this.state.offset, this.state.offset + UPLOADS_PER_PAGE);
-    this.setState({
-      data: data,
-      pageCount: Math.ceil(nextProps.selectedUploads.length / UPLOADS_PER_PAGE),
-     });
-     if (this.state.currentPage === 0) {
-       this.setUploadMetadata(data);
-     }
-  },
-
   setUploadData(offset, selectedPage) {
     const data = this.props.selectedUploads.slice(offset, offset + UPLOADS_PER_PAGE);
     this.setUploadMetadata(data);
@@ -62,6 +45,23 @@ const UploadsHandler = createReactClass({
 
   setUploadMetadata(uploads) {
     return this.props.setUploadMetadata(uploads);
+  },
+
+  UNSAFE_componentWillMount() {
+    if (this.props.loadingUploads) {
+      return this.props.receiveUploads(this.props.course_id);
+    }
+  },
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const data = nextProps.selectedUploads.slice(this.state.offset, this.state.offset + UPLOADS_PER_PAGE);
+    this.setState({
+      data: data,
+      pageCount: Math.ceil(nextProps.selectedUploads.length / UPLOADS_PER_PAGE),
+     });
+     if (this.state.currentPage === 0) {
+       this.setUploadMetadata(data);
+     }
   },
 
   handlePageClick(data) {

--- a/app/assets/javascripts/training/components/quiz.jsx
+++ b/app/assets/javascripts/training/components/quiz.jsx
@@ -21,16 +21,16 @@ const Quiz = createReactClass({
     return { selectedAnswerId: this.props.selectedAnswerId };
   },
 
-  componentWillReceiveProps(newProps) {
-    return this.setState({ selectedAnswerId: newProps.selectedAnswerId });
-  },
-
   setSelectedAnswer(id) {
     return this.props.setSelectedAnswer(id);
   },
 
   setAnswer(e) {
     return this.setState({ selectedAnswerId: e.currentTarget.getAttribute('data-answer-id') });
+  },
+
+  UNSAFE_componentWillReceiveProps(newProps) {
+    return this.setState({ selectedAnswerId: newProps.selectedAnswerId });
   },
 
   verifyAnswer(e) {

--- a/app/assets/javascripts/training/components/slide_menu.jsx
+++ b/app/assets/javascripts/training/components/slide_menu.jsx
@@ -15,12 +15,12 @@ const SlideMenu = createReactClass({
     menuClass: PropTypes.string
   },
 
-  componentWillMount() {
-    return window.addEventListener('click', this.props.closeMenu, false);
-  },
-
   componentWillUnmount() {
     return window.removeEventListener('click', this.props.closeMenu, false);
+  },
+
+  UNSAFE_componentWillMount() {
+    return window.addEventListener('click', this.props.closeMenu, false);
   },
 
   linkParams(props) {

--- a/app/assets/javascripts/training/components/training_module_handler.jsx
+++ b/app/assets/javascripts/training/components/training_module_handler.jsx
@@ -8,7 +8,7 @@ import { fetchTrainingModule } from '../../actions/training_actions.js';
 const TrainingModuleHandler = createReactClass({
   displayName: 'TrainingModuleHandler',
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const moduleId = document.getElementById('react_root').getAttribute('data-module-id');
     return this.props.fetchTrainingModule({ module_id: moduleId });
   },


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does

- Address issue  #1088 Diff Viewer shows only one column, on left, if all changes are new paragraphs 
- Fixes a bug within the diff table

Files changed: 
app/assets/javascripts/components/revisions/diff_viewer.jsx
- Add ref to diff:
  The Dangerously Set HTML from the Wikipedia Diff URL did not previously have a ref. I added one, including a setDiff method for it.

- Resize empty diff column: 
  When the table cells, td elements, are empty, they previously lost their width. This is what was causing issue #1088. This PR sets the first empty cell to 50% width in the table, so that both (-) and (+) columns can take up half the table width.

- Wrap Loading and (-) diff marker elements in tbody:
  There were previously errors caused by the <Loading/> and (-) diff marker elements because they were within a table without being wrapped in tbody. This PR wraps both in tbody, tr, and td, fixing the errors.

## Screenshots
Before:
<img width="1109" alt="Screen Shot 2019-11-05 at 6 39 10 AM" src="https://user-images.githubusercontent.com/2976514/68524119-a58bfc80-0277-11ea-9a75-de81d31307fc.png">


After:
<img width="1200" alt="Screen Shot 2019-11-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/2976514/68524103-5b0a8000-0277-11ea-9a98-bae2bb1cb92d.png">

## Open questions and concerns
I learned how to use dangerouslySetInnerHTML in React, how to add refs to elements using JSX in React components, and that divs within tables must be wrapped in a tbody, tr, and td. 
