### PR TITLE
Set diff table width to 100%

### DIFF
--- a/app/assets/stylesheets/modules/_diff_viewer.styl
+++ b/app/assets/stylesheets/modules/_diff_viewer.styl
@@ -23,6 +23,9 @@
   overflow-y: scroll
   overflow-x: hidden
 
+.diff-viewer-scrollbox > table
+  width 100%
+  
 .diff-viewer-footer
   border-top 1px solid mischka !important
   font-size 90%


### PR DESCRIPTION
## What this PR does
As explained in Issue #3482 
The diff table width in diff viewer is set to 100% so that the Loading element animation can take up the full width of the diff table.

## Screenshots
Before:
![loading element diff_viewer issue](https://user-images.githubusercontent.com/2976514/68831241-a4394600-0662-11ea-8ba5-ef6bcbdcf570.gif)

After:
![loading element diff_viewer PR](https://user-images.githubusercontent.com/2976514/68831247-a8fdfa00-0662-11ea-98a3-f41de5091148.gif)
