### PR TITLE
Alerts: refactor UNSAFE react methods with new lifecycle

### DIFF
--- a/app/assets/javascripts/components/alerts/alerts_handler.jsx
+++ b/app/assets/javascripts/components/alerts/alerts_handler.jsx
@@ -32,13 +32,13 @@ const AlertsHandler = createReactClass({
     alerts: PropTypes.array,
   },
 
-  getCampaignSlug() {
-    return `${this.props.match.params.campaign_slug}`;
-  },
-
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     const campaignSlug = this.getCampaignSlug();
     return this.props.fetchAlerts(campaignSlug);
+  },
+
+  getCampaignSlug() {
+    return `${this.props.match.params.campaign_slug}`;
   },
 
   fetchAlerts(campaignSlug) {


### PR DESCRIPTION
# What this PR does
One of several PRs coming to address Issue #3478.

Refactored any files in app/assets/javascripts/components/alerts 
to use the new react lifecycle react methods and stop using soon-to-be-deprecated UNSAFE_ react methods.

## Open questions and concerns
No bugs found from this change. Please let me know if you find any.