### PR TITLE
Categories: refactor UNSAFE react methods with new lifecycle

### DIFF
--- a/app/assets/javascripts/components/categories/category_handler.jsx
+++ b/app/assets/javascripts/components/categories/category_handler.jsx
@@ -15,7 +15,7 @@ const CategoryHandler = createReactClass({
     current_user: PropTypes.object
   },
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.props.fetchCategories(this.props.course.slug);
   },
 


### PR DESCRIPTION
# What this PR does
One of several PRs coming to address Issue #3478.

Refactored any files in app/assets/javascripts/components/categories 
to use the new react lifecycle react methods and stop using soon-to-be-deprecated UNSAFE_ react methods.

## Open questions and concerns
No errors so far.

@ragesoss @khyatisoneji 
How do I navigate to the frontend page were I can observe this component? 
