### PR TITLE
Activity: refactor UNSAFE react methods

### DIFF
--- a/app/assets/javascripts/components/activity/activity_table.jsx
+++ b/app/assets/javascripts/components/activity/activity_table.jsx
@@ -23,18 +23,6 @@ const ActivityTable = createReactClass({
     toggleDrawer: PropTypes.func
   },
 
-  getInitialState() {
-    return {
-      activity: this.props.activity
-    };
-  },
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.activity !== this.state.activity) {
-      this.setState({ activity: nextProps.activity });
-    }
-  },
-
   clearAllSortableClassNames() {
     Array.prototype.forEach.call(document.getElementsByClassName('sortable'), (el) => {
       el.classList.remove('asc');
@@ -47,7 +35,7 @@ const ActivityTable = createReactClass({
   },
 
   _renderActivites() {
-    return this.state.activity.map((revision) => {
+    return this.props.activity.map((revision) => {
       const roundedRevisionScore = Math.round(revision.revision_score) || 'unknown';
       const revisionDateTime = moment(revision.datetime).format('YYYY/MM/DD h:mm a');
       const talkPageLink = `${revision.base_url}/wiki/User_talk:${revision.username}`;
@@ -74,7 +62,7 @@ const ActivityTable = createReactClass({
   },
 
   _renderDrawers() {
-    return this.state.activity.map((revision) => {
+    return this.props.activity.map((revision) => {
       const courses = revision.courses.map((course) => {
         return (
           <li key={`${revision.key}-${course.slug}`}>

--- a/app/assets/javascripts/components/activity/did_you_know_handler.jsx
+++ b/app/assets/javascripts/components/activity/did_you_know_handler.jsx
@@ -23,13 +23,13 @@ const DidYouKnowHandler = createReactClass({
     loading: PropTypes.bool
   },
 
+  componentDidMount() {
+    this.props.fetchDYKArticles();
+  },
+
   setCourseScope(e) {
     const scoped = e.target.checked;
     this.props.fetchDYKArticles({ scoped });
-  },
-
-  UNSAFE_componentWillMount() {
-    this.props.fetchDYKArticles();
   },
 
   render() {

--- a/app/assets/javascripts/components/activity/plagiarism_handler.jsx
+++ b/app/assets/javascripts/components/activity/plagiarism_handler.jsx
@@ -24,13 +24,13 @@ const PlagiarismHandler = createReactClass({
     loading: PropTypes.bool
   },
 
+  componentDidMount() {
+    return this.props.fetchSuspectedPlagiarism();
+  },
+
   setCourseScope(e) {
     const scoped = e.target.checked;
     return this.props.fetchSuspectedPlagiarism({ scoped });
-  },
-
-  UNSAFE_componentWillMount() {
-    return this.props.fetchSuspectedPlagiarism();
   },
 
   render() {

--- a/app/assets/javascripts/components/activity/recent_edits_handler.jsx
+++ b/app/assets/javascripts/components/activity/recent_edits_handler.jsx
@@ -24,13 +24,13 @@ const RecentEditsHandler = createReactClass({
     loading: PropTypes.bool
   },
 
+  componentDidMount() {
+    return this.props.fetchRecentEdits();
+  },
+
   setCourseScope(e) {
     const scoped = e.target.checked;
     this.props.fetchRecentEdits({ scoped });
-  },
-
-  UNSAFE_componentWillMount() {
-    return this.props.fetchRecentEdits();
   },
 
   render() {

--- a/app/assets/javascripts/components/activity/recent_uploads_handler.jsx
+++ b/app/assets/javascripts/components/activity/recent_uploads_handler.jsx
@@ -17,7 +17,7 @@ export const RecentUploadsHandlerBase = createReactClass({
     loading: PropTypes.bool
    },
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     return this.props.fetchRecentUploads();
   },
 


### PR DESCRIPTION
# What this PR does
One of several PRs coming to address Issue #3478.

Refactored any files in app/assets/javascripts/components/activity
to use the new react lifecycle react methods and stop using soon-to-be-deprecated UNSAFE_ react methods.

## Open questions and concerns
No bugs found from this change. Please let me know if you find any.

### Note:
Got rid of chunks of code in `app/assets/javascripts/components/activity/activity_table.jsx`.

Entirely removed `UNSAFE_componentWillReceiveProps`
and replaced instances of `this.state.activity` with `this.props.activity`

### Why the big change?
Use of `UNSAFE_componentWillReceiveProps` was only being used to keep `state.activity` matching `props.activity`. Since `activity` was already a prop, there was no need to keep `state.activity` as well. The React documentation calls it an "anti-pattern" that makes the application more bloated than necessary. 

[React: Why You Probably Don't Need Derived State](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#when-to-use-derived-state)