### PR TITLE
Article Finder: refactor UNSAFE react methods

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -36,6 +36,16 @@ const ArticleFinder = createReactClass({
     };
   },
 
+  componentDidMount() {
+    if (window.location.search.substring(1)) {
+      this.getParamsURL();
+    }
+    if (this.props.course_id && this.props.loadingAssignments) {
+      this.props.fetchAssignments(this.props.course_id);
+    }
+    return this.updateFields('home_wiki', this.props.course.home_wiki);
+  },
+
   componentWillUnmount() {
     return this.props.resetArticleFinder();
   },
@@ -54,16 +64,6 @@ const ArticleFinder = createReactClass({
       val = (key === 'article_quality') ? parseInt(val) : val;
       return this.updateFields(key, val);
     });
-  },
-
-  UNSAFE_componentWillMount() {
-    if (window.location.search.substring(1)) {
-      this.getParamsURL();
-    }
-    if (this.props.course_id && this.props.loadingAssignments) {
-      this.props.fetchAssignments(this.props.course_id);
-    }
-    return this.updateFields('home_wiki', this.props.course.home_wiki);
   },
 
   updateFields(key, value) {

--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -14,12 +14,19 @@ const ArticleFinderRow = createReactClass({
     };
   },
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.state.isLoading && (this.props.assignment !== nextProps.assignment)) {
+  async addOrDelete(addOrDel, assignment) {
+    let response;
+    if (addOrDel === 'add') {
+      response = await this.props.addAssignment(assignment);
+    } else if (addOrDel === 'del') {
+      response = await this.props.deleteAssignment(assignment);
+    }
+    if (response !== undefined) {
       this.setState({
         isLoading: false,
       });
     }
+    return response;
   },
 
   assignArticle(userId = null) {
@@ -34,7 +41,7 @@ const ArticleFinderRow = createReactClass({
     this.setState({
       isLoading: true,
     });
-    return this.props.addAssignment(assignment);
+    return this.addOrDelete('add', assignment);
   },
 
   unassignArticle(userId = null) {
@@ -51,7 +58,7 @@ const ArticleFinderRow = createReactClass({
     this.setState({
       isLoading: true,
     });
-    return this.props.deleteAssignment(assignment);
+    return this.addOrDelete('del', assignment);
   },
 
   render() {


### PR DESCRIPTION
# What this PR does
One of several PRs coming to address Issue #3478.

Refactored any files in app/assets/javascripts/components/article_finder
to use the new react lifecycle react methods and stop using soon-to-be-deprecated UNSAFE_ react methods.

## Open questions and concerns
No bugs found from this change. Please let me know if you find any.

### Note:
Larger refactor in `app/assets/javascripts/components/article_finder/article_finder_row.jsx`.

Entirely removed `UNSAFE_componentWillReceiveProps`
and replaced custom async function wrapped around an `await` 
which sets `state.isLoading` once `await` is resolved

### Why this change?
The new React lifecycle method to help replace `UNSAFE_componentWillReceiveProps` is `getDerivedStateFromProps`. However, the React documentation strongly advises against using `getDerivedStateFromProps` if it can be avoided, as it makes the whole component and whole app more complicated.

This is what I did to avoid using `getDerivedStateFromProps`:

In this component, `UNSAFE_componentWillReceiveProps` was used to update `state.isLoading` once a change in assignment is loaded. So I wrote a custom `async` function to do assignment updates and also update the update state as a side effect, once the await that stores the response resolves. 

@ragesoss @khyatisoneji please let me know what you think of this refactor ^ 

[React: Why You Probably Don't Need Derived State](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#when-to-use-derived-state)