### PR TITLE
Redundant enrollment edits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Metrics/ClassLength:
     - 'app/controllers/courses_controller.rb'
     - 'lib/importers/revision_score_importer.rb'
     - 'lib/wizard_timeline_manager.rb'
+    - 'lib/wiki_course_edits.rb'
 
 Metrics/AbcSize:
   Max: 23 # We should bring this down, ideally to the default of 15

--- a/app/services/greet_ungreeted_students.rb
+++ b/app/services/greet_ungreeted_students.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/student_greeting_checker"
+require_dependency "#{Rails.root}/lib/wiki_course_edits"
 
 class GreetUngreetedStudents
   def initialize(course, greeter)
@@ -15,7 +16,15 @@ class GreetUngreetedStudents
 
   def greet_ungreeted
     @course.students.where(greeted: false).each do |student|
-      @greeting_checker.check(student, @wiki) # update greeted status
+      # update greeted status
+      @greeting_checker.check(student, @wiki)
+
+      # add enrollment templates if not already present
+      WikiCourseEdits.new(action: :enroll_in_course,
+                          course: @course,
+                          current_user: @greeter,
+                          enrolling_user: student)
+
       next if student.greeted
       greet(student)
     end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -54,26 +54,14 @@ class WikiCourseEdits
   # adds a template to their /sandbox page — creating it if it does not
   # already exist.
   def enroll_in_course(enrolling_user:)
-    generator = WikiUserpageOutput.new(@course)
+    @generator = WikiUserpageOutput.new(@course)
 
-    # Add a template to the user page
-    template = generator.enrollment_template
-    user_page = "User:#{enrolling_user.username}"
-    summary = generator.enrollment_summary
-    @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)
-
-    # Add a template to the user's talk page
-    talk_template = generator.enrollment_talk_template
-    talk_page = "User_talk:#{enrolling_user.username}"
-    talk_summary = "adding {{#{template_name(@templates, 'user_talk')}}}"
-    @wiki_editor.add_to_page_top(talk_page, @current_user, talk_template, talk_summary)
+    add_template_to_user_page(enrolling_user)
+    add_template_to_user_talk_page(enrolling_user)
 
     # Pre-create the user's sandbox
     return unless Features.wiki_ed?
-    sandbox = user_page + '/sandbox'
-    sandbox_template = generator.sandbox_template(@dashboard_url)
-    sandbox_summary = "adding {{#{@dashboard_url} sandbox}}"
-    @wiki_editor.add_to_page_top(sandbox, @current_user, sandbox_template, sandbox_summary)
+    add_template_to_sandbox(enrolling_user)
   end
 
   # Updates the assignment template for every Assignment for the course.
@@ -133,6 +121,27 @@ class WikiCourseEdits
     # Edits can only be made to the course's home wiki through WikiCourseEdits
     return false unless @home_wiki.edits_enabled?
     true
+  end
+
+  def add_template_to_user_page(enrolling_user)
+    template = @generator.enrollment_template
+    user_page = "User:#{enrolling_user.username}"
+    summary = @generator.enrollment_summary
+    @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)
+  end
+
+  def add_template_to_user_talk_page(enrolling_user)
+    talk_template = @generator.enrollment_talk_template
+    talk_page = "User_talk:#{enrolling_user.username}"
+    talk_summary = "adding {{#{template_name(@templates, 'user_talk')}}}"
+    @wiki_editor.add_to_page_top(talk_page, @current_user, talk_template, talk_summary)
+  end
+
+  def add_template_to_sandbox(enrolling_user)
+    sandbox = "User:#{enrolling_user.username}/sandbox"
+    sandbox_template = @generator.sandbox_template(@dashboard_url)
+    sandbox_summary = "adding {{#{@dashboard_url} sandbox}}"
+    @wiki_editor.add_to_page_top(sandbox, @current_user, sandbox_template, sandbox_summary)
   end
 
   def repost_with_sanitized_links(wiki_title, wiki_text, summary, spamlist)

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -18,6 +18,7 @@ class WikiCourseEdits
     validate(action) { return }
 
     @wiki_editor = WikiEdits.new(@home_wiki)
+    @wiki_api = WikiApi.new(@home_wiki)
     @dashboard_url = ENV['dashboard_url']
     @current_user = current_user
     @templates = @home_wiki.edit_templates
@@ -130,7 +131,7 @@ class WikiCourseEdits
     user_page = "User:#{@enrolling_user.username}"
 
     # Never double-post the enrollment template
-    initial_page_content = WikiApi.new(@home_wiki).get_page_content(user_page)
+    initial_page_content = @wiki_api.get_page_content(user_page)
     return if initial_page_content.include?(template)
 
     summary = @generator.enrollment_summary
@@ -142,7 +143,7 @@ class WikiCourseEdits
     talk_page = "User_talk:#{@enrolling_user.username}"
 
     # Never double-post the talk template
-    initial_page_content = WikiApi.new(@home_wiki).get_page_content(talk_page)
+    initial_page_content = @wiki_api.get_page_content(talk_page)
     return if initial_page_content.include?(talk_template)
 
     talk_summary = "adding {{#{template_name(@templates, 'user_talk')}}}"
@@ -154,7 +155,7 @@ class WikiCourseEdits
     sandbox_template = @generator.sandbox_template(@dashboard_url)
 
     # Never double-post the sandbox template
-    initial_page_content = WikiApi.new(@home_wiki).get_page_content(sandbox)
+    initial_page_content = @wiki_api.get_page_content(sandbox)
     return if initial_page_content.include?(sandbox_template)
 
     sandbox_summary = "adding {{#{@dashboard_url} sandbox}}"

--- a/spec/controllers/mass_enrollment_controller_spec.rb
+++ b/spec/controllers/mass_enrollment_controller_spec.rb
@@ -34,6 +34,7 @@ describe MassEnrollmentController, type: :request do
         course.campaigns << Campaign.first
         stub_add_user_to_channel_success
         stub_oauth_edit
+        stub_raw_action
       end
 
       it 'adds only real users to a course' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -96,6 +96,7 @@ describe UsersController, type: :request do
       before do
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
         stub_oauth_edit
+        stub_raw_action
       end
 
       let(:post_params) do

--- a/spec/features/online_volunteer_role_spec.rb
+++ b/spec/features/online_volunteer_role_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 
 describe 'Online Volunteer users', type: :feature, js: true do
   let(:user) { create(:user) }
-  let(:course) { create(:course, end: 1.day.from_now, flags: { online_volunteers_enabled: true }) }
+  let(:course) do
+    create(:basic_course, end: 1.day.from_now,
+                          flags: { online_volunteers_enabled: true, wiki_edits_enabled: false })
+  end
 
   before do
     include type: :feature

--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -88,6 +88,7 @@ describe 'Student users', type: :feature, js: true do
     it 'joins and leaves a course' do
       login_as(user, scope: :user)
       stub_oauth_edit
+      stub_raw_action
 
       # click enroll button, enter passcode in alert popup to enroll
       visit "/courses/#{Course.first.slug}"
@@ -135,6 +136,7 @@ describe 'Student users', type: :feature, js: true do
         click_button 'Enroll'
       end
       stub_oauth_edit
+      stub_raw_action
       click_link 'Join'
       expect(page).to have_content 'successfully joined'
       click_link 'Students'
@@ -166,6 +168,7 @@ describe 'Student users', type: :feature, js: true do
     it 'joins a course' do
       login_as(user, scope: :user)
       stub_oauth_edit
+      stub_raw_action
 
       visit "/courses/#{Course.first.slug}?enroll=passcode"
       expect(page).to have_content User.last.username
@@ -191,6 +194,7 @@ describe 'Student users', type: :feature, js: true do
         credentials: { token: 'foo', secret: 'bar' }
       )
       stub_oauth_edit
+      stub_raw_action
       logout
       visit "/courses/#{Course.first.slug}?enroll=passcode"
       find(:link, 'Log in with Wikipedia', match: :first).click
@@ -215,6 +219,7 @@ describe 'Student users', type: :feature, js: true do
       )
       allow_any_instance_of(WikiApi).to receive(:get_user_id).and_return(234567)
       stub_oauth_edit
+      stub_raw_action
       logout
       visit "/courses/#{Course.first.slug}?enroll=passcode"
       find(:link, 'Log in with Wikipedia', match: :first).click

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -126,6 +126,7 @@ describe WikiCourseEdits do
 
     it 'posts to the userpage of the enrolling student and their sandbox' do
       expect_any_instance_of(WikiEdits).to receive(:add_to_page_top).thrice
+      allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return('')
       described_class.new(action: :enroll_in_course,
                           course: course,
                           current_user: user,

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -7,6 +7,9 @@ describe WikiCourseEdits do
   let(:course) { create(:course, id: 1, submitted: true, home_wiki_id: 1) }
   let(:user) { create(:user) }
   let(:enrolling_user) { create(:user, username: 'EnrollingUser') }
+  let(:user_template) { WikiUserpageOutput.new(course).enrollment_template }
+  let(:talk_template) { WikiUserpageOutput.new(course).enrollment_talk_template }
+  let(:sandbox_template) { WikiUserpageOutput.new(course).sandbox_template(ENV['dashboard_url']) }
 
   before do
     stub_oauth_edit
@@ -127,6 +130,17 @@ describe WikiCourseEdits do
     it 'posts to the userpage of the enrolling student and their sandbox' do
       expect_any_instance_of(WikiEdits).to receive(:add_to_page_top).thrice
       allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return('')
+      described_class.new(action: :enroll_in_course,
+                          course: course,
+                          current_user: user,
+                          enrolling_user: enrolling_user)
+    end
+
+    it 'does not repost templates that are already present' do
+      expect_any_instance_of(WikiEdits).not_to receive(:add_to_page_top)
+      allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return(user_template,
+                                                                              talk_template,
+                                                                              sandbox_template)
       described_class.new(action: :enroll_in_course,
                           course: course,
                           current_user: user,

--- a/spec/services/greet_ungreeted_students_spec.rb
+++ b/spec/services/greet_ungreeted_students_spec.rb
@@ -15,9 +15,12 @@ describe GreetUngreetedStudents do
     stub_oauth_edit
   end
 
-  it 'posts a welcome message to the talk page of ungreeted students' do
+  it 'posts enrollment templates and welcome message for an ungreeted student' do
     expect(student.greeted).to eq(false)
+    # New section for the welcome message
     expect_any_instance_of(WikiEdits).to receive(:add_new_section).and_call_original
+    # Templates are added to the top of user page, talk page, sandbox
+    expect_any_instance_of(WikiEdits).to receive(:add_to_page_top).thrice.and_call_original
     subject
     expect(student.reload.greeted).to eq(true)
   end


### PR DESCRIPTION
This set of changes has two parts:

1. Make the set of three enrollment edits (user page template, talk page template, sandbox template) idempotent so that the edit only happens if the template is not already on the page.
2. Add those three edits, done by a Wikipedia Expert instead of the student, to the `GreetUngreetedStudents` routine.

The idea here is that if any of those edits fail when the Dashboard tries making them with the student's account immediately after enrollment, they'll get get done by the Wikipedia Expert when they use the greeting tool, so no students end up with redlinked userpages or sandboxes that get autopopulated with the default sandbox template (which leads toward Articles for Creation) instead of our alternative sandbox template.