### PR TITLE
Fix Article Finder Row button toggle

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -279,8 +279,8 @@ const ArticleFinder = createReactClass({
       const elements = _.map(this.props.articles, (article, title) => {
         let assignment;
         if (this.props.course_id) {
-          if (this.props.current_user.isNonstudent) {
-            assignment = _.find(this.props.assignments, { article_title: title, user_id: null, language: this.props.home_wiki.language, project: this.props.home_wiki.project });
+          if (this.props.current_user.role !== STUDENT_ROLE) {
+            assignment = _.find(this.props.assignments, { article_title: title, user_id: null });
           } else if (this.props.current_user.role === STUDENT_ROLE) {
             assignment = _.find(this.props.assignments, { article_title: title, user_id: this.props.current_user.id, language: this.props.home_wiki.language, project: this.props.home_wiki.project });
           }


### PR DESCRIPTION
## What this PR does
Fixes #3515 Article Finder Row buttons not toggling
Affects behavior in #3506 Article Finder: refactor UNSAFE react methods

## Screenshots
Before:
![ArticleFinderToggle Issue](https://user-images.githubusercontent.com/2976514/69213904-5cab3200-0b1a-11ea-98e3-b88d3382f77a.gif)

After:
![ArticleFinderToggle PR](https://user-images.githubusercontent.com/2976514/69214099-df33f180-0b1a-11ea-8816-599df0e98c26.gif)

## Open questions and concerns

### `language` and `project` search fields:
Had to remove `language` and `project` search fields to get results from searching this.props.assignments array. This seems to produce the desired result, but let me know if you find otherwise. 

### `STUDENT_ROLE`:
Still need to test the fix in the `STUDENT_ROLE` case. @ragesoss @khyatisoneji How can I do that? Also in general how do you want `STUDENT_ROLE` article finder and assignments to behave differently from non `STUDENT_ROLE` ones?