### PR TITLE
Fixes Popover Inputbox Focus

### DIFF
--- a/app/assets/javascripts/components/students/enroll_button.jsx
+++ b/app/assets/javascripts/components/students/enroll_button.jsx
@@ -192,7 +192,19 @@ const EnrollButton = createReactClass({
     const buttonText = this.props.inline ? '+' : CourseUtils.i18n('enrollment', this.props.course.string_prefix);
 
     // Remove this check when we re-enable adding users by username
-    const button = <button className={buttonClass} onClick={this.props.open}>{buttonText}</button>;
+    const button = (
+      <button
+        className={buttonClass}
+        onClick={() => {
+          this.props.open();
+          setTimeout(() => {
+            this.refs.username.focus();
+          }, 125);
+        }}
+      >
+        {buttonText}
+      </button>
+    );
 
     return (
       <div className="pop__container" onClick={this.stop}>


### PR DESCRIPTION
Fixes #3501 
Input box grab focus when 'Add/Remove Students' button of the 'Student' tabs of a course page is clicked. 

## Screenshots
Before:
![captured (7)](https://user-images.githubusercontent.com/24036721/69455764-17dc0100-0d8f-11ea-9246-aedc66b818ef.gif)

After:
![captured (6)](https://user-images.githubusercontent.com/24036721/69455775-1b6f8800-0d8f-11ea-86d7-10bf43a78bee.gif)

