### PR TITLE
Remove new line when checking whether or not to post wiki edits

### DIFF
--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -135,7 +135,8 @@ class WikiCourseEdits
     return if initial_page_content.include?(template)
 
     summary = @generator.enrollment_summary
-    @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)
+    new_line_template = template + "\n"
+    @wiki_editor.add_to_page_top(user_page, @current_user, new_line_template, summary)
   end
 
   def add_template_to_user_talk_page
@@ -147,19 +148,21 @@ class WikiCourseEdits
     return if initial_page_content.include?(talk_template)
 
     talk_summary = "adding {{#{template_name(@templates, 'user_talk')}}}"
-    @wiki_editor.add_to_page_top(talk_page, @current_user, talk_template, talk_summary)
+    new_line_template = talk_template + "\n"
+    @wiki_editor.add_to_page_top(talk_page, @current_user, new_line_template, talk_summary)
   end
 
   def add_template_to_sandbox
-    sandbox = "User:#{@enrolling_user.username}/sandbox"
     sandbox_template = @generator.sandbox_template(@dashboard_url)
+    sandbox = "User:#{@enrolling_user.username}/sandbox"
 
     # Never double-post the sandbox template
     initial_page_content = @wiki_api.get_page_content(sandbox)
     return if initial_page_content.include?(sandbox_template)
 
     sandbox_summary = "adding {{#{@dashboard_url} sandbox}}"
-    @wiki_editor.add_to_page_top(sandbox, @current_user, sandbox_template, sandbox_summary)
+    new_line_template = sandbox_template + "\n"
+    @wiki_editor.add_to_page_top(sandbox, @current_user, new_line_template, sandbox_summary)
   end
 
   def repost_with_sanitized_links(wiki_title, wiki_text, summary, spamlist)

--- a/lib/wiki_userpage_output.rb
+++ b/lib/wiki_userpage_output.rb
@@ -15,7 +15,7 @@ class WikiUserpageOutput
     "#{course_page_param}"\
     "#{course_slug_param}"\
     "#{course_type_param}"\
-    " }}\n"
+    ' }}'
   end
 
   def enrollment_summary
@@ -32,7 +32,7 @@ class WikiUserpageOutput
     "#{course_page_param}"\
     "#{course_slug_param}"\
     "#{course_type_param}"\
-    " }}\n"
+    ' }}'
   end
 
   def sandbox_template(dashboard_url)

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -4,9 +4,15 @@ require 'rails_helper'
 require "#{Rails.root}/lib/wiki_course_edits"
 
 describe WikiCourseEdits do
-  let(:course) { create(:course, id: 1, submitted: true, home_wiki_id: 1) }
+  let(:slug) { 'Missouri_SandT/History_of_Science_(Fall_2019)' }
+  let(:course) { create(:course, id: 1, submitted: true, home_wiki_id: 1, slug: slug) }
   let(:user) { create(:user) }
-  let(:enrolling_user) { create(:user, username: 'EnrollingUser') }
+  let(:enrolling_user) { create(:user, username: 'Belajane41') }
+  # rubocop:disable Metrics/LineLength
+  let(:user_page_content) do
+    '{{dashboard.wikiedu.org student editor | course = [[Wikipedia:Wiki_Ed/Missouri_SandT/History_of_Science_(Fall_2019)]] | slug = Missouri_SandT/History_of_Science_(Fall_2019) }}'
+  end
+  # rubocop:enable Metrics/LineLength
   let(:user_template) { WikiUserpageOutput.new(course).enrollment_template }
   let(:talk_template) { WikiUserpageOutput.new(course).enrollment_talk_template }
   let(:sandbox_template) { WikiUserpageOutput.new(course).sandbox_template(ENV['dashboard_url']) }
@@ -138,9 +144,10 @@ describe WikiCourseEdits do
 
     it 'does not repost templates that are already present' do
       expect_any_instance_of(WikiEdits).not_to receive(:add_to_page_top)
-      allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return(user_template,
-                                                                              talk_template,
-                                                                              sandbox_template)
+      allow_any_instance_of(WikiApi).to receive(:get_page_content)
+        .and_return(user_page_content,
+                    talk_template,
+                    sandbox_template)
       described_class.new(action: :enroll_in_course,
                           course: course,
                           current_user: user,


### PR DESCRIPTION
This just removes the `"\n"` at the end of the template when making edits for a user getting enrolled in a course.