### PR TITLE
Include CC'd emails in recipients list for processing emails

### DIFF
--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -44,6 +44,7 @@ class EmailProcessor
 
   def define_owner
     recipient_emails = @email.to.pluck(:email)
+    recipient_emails += @email.cc.pluck(:email) if @email.cc.present?
     @owner = User.find_by(greeter: true, email: recipient_emails)
   end
 


### PR DESCRIPTION
The SuspectedPlagiarismMailer emails go to a course's instructors with Wiki Education staff as CC recipients, so when such tickets got forwarded to the Dashboard they were not being assigned.