### PR TITLE
Change passcode detail to be a link - #2520

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -209,10 +209,12 @@ const Details = createReactClass({
           />
         );
       } else {
+        const studentLink = this.props.course.enroll_url.substring(0, this.props.course.enroll_url.indexOf('/enroll'));
+        const enrollToken = `?enroll=${this.props.course.passcode}`;
         passcode = (
           <TextInput
             onChange={this.updateDetails}
-            value={<a href={`${this.props.course.enroll_url}${this.props.course.passcode}`}>{this.props.course.passcode}</a>}
+            value={<a href={`${studentLink}${enrollToken}`}>{this.props.course.passcode}</a>}
             value_key="passcode"
             editable={this.props.editable}
             type="text"

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -195,18 +195,33 @@ const Details = createReactClass({
 
     let passcode;
     if (this.props.course.passcode || this.props.editable) {
-      passcode = (
-        <TextInput
-          onChange={this.updateDetails}
-          value={this.props.course.passcode}
-          value_key="passcode"
-          editable={this.props.editable}
-          type="text"
-          label={I18n.t('courses.passcode')}
-          placeholder={I18n.t('courses.passcode_none')}
-          required={!!this.props.course.passcode_required}
-        />
-      );
+      if (this.props.editable) {
+        passcode = (
+          <TextInput
+            onChange={this.updateDetails}
+            value={this.props.course.passcode}
+            value_key="passcode"
+            editable={this.props.editable}
+            type="text"
+            label={I18n.t('courses.passcode')}
+            placeholder={I18n.t('courses.passcode_none')}
+            required={!!this.props.course.passcode_required}
+          />
+        );
+      } else {
+        passcode = (
+          <TextInput
+            onChange={this.updateDetails}
+            value={<a href={`${this.props.course.enroll_url}${this.props.course.passcode}`}>{this.props.course.passcode}</a>}
+            value_key="passcode"
+            editable={this.props.editable}
+            type="text"
+            label={I18n.t('courses.passcode')}
+            placeholder={I18n.t('courses.passcode_none')}
+            required={!!this.props.course.passcode_required}
+          />
+        );
+      }
     }
 
     let expectedStudents;


### PR DESCRIPTION
## What this PR does
This is a fix for Issue #2520 

## Screenshots
Before:
![Before](https://user-images.githubusercontent.com/855005/70263377-6c9a5700-1753-11ea-96cd-d435406b6005.png)


After:
![After](https://user-images.githubusercontent.com/855005/70263414-863b9e80-1753-11ea-8b18-3edfb051f5e9.png)


## Open questions and concerns
The link in the above example would lead to http://localhost:3000/courses/MSU_Denver/Example/enroll/rwsijmf
This does not include the copy-to-clipboard button like what was talked about in the issue comments.
