### PR TITLE
Correctly send survey_url to survey notification

### DIFF
--- a/app/assets/javascripts/components/course/course_alerts.jsx
+++ b/app/assets/javascripts/components/course/course_alerts.jsx
@@ -127,7 +127,26 @@ const CourseAlerts = createReactClass({
     if (course.survey_notifications && course.survey_notifications.length) {
       course.survey_notifications.forEach((notification) => {
         const dismissOnClick = () => this.dismissSurvey(notification.id);
-        return alerts.push(<CourseAlert key={`survey_notification_${notification.id}`} message={notification.message || I18n.t('courses.survey.notification_message')} className="notification--survey" actionLink={notification.survey_url} actionClassName="pull-right" actionMessage={I18n.t('courses.survey.link')} components={<button className="button small pull-right border inverse-border" onClick={dismissOnClick}>{I18n.t('courses.dismiss_survey')}</button>} />);
+        const components = (
+          <button
+            className="button small pull-right border inverse-border"
+            onClick={dismissOnClick}
+          >
+            {I18n.t('courses.dismiss_survey')}
+          </button>
+        );
+
+        return alerts.push(
+          <CourseAlert
+            key={`survey_notification_${notification.id}`}
+            actionClassName="pull-right"
+            actionMessage={I18n.t('courses.survey.link')}
+            className="notification--survey"
+            components={components}
+            href={notification.survey_url}
+            message={notification.message || I18n.t('courses.survey.notification_message')}
+          />
+        );
       });
     }
 

--- a/spec/features/surveys_spec.rb
+++ b/spec/features/surveys_spec.rb
@@ -19,7 +19,7 @@ describe 'Surveys', type: :feature, js: true do
   describe 'Instructor takes survey' do
     before do
       @instructor = create(:user)
-      @course = create(:course, title: 'My Active Course')
+      @course = create(:course, title: 'My Active Course', slug: 'my_active/course')
       article = create(:article)
       create(:articles_course, article_id: article.id, course_id: @course.id)
 
@@ -121,9 +121,21 @@ describe 'Surveys', type: :feature, js: true do
              courses_users_id: @courses_user.id)
     end
 
-    it 'sets the course and shows the progress bar' do
+    it 'sets the course and shows the progress bar by going directly to the survey' do
       login_as(@instructor, scope: :user)
       visit survey_path(@survey)
+      # Sets the course automatically
+      expect(page).to have_content 'Survey for My Active Course'
+      expect(page).to have_content 'progress'
+    end
+
+    it 'sets the course and shows the progress bar by going to the course page' do
+      stub_token_request
+      login_as(@instructor, scope: :user)
+
+      visit "/courses/#{@course.slug}"
+      expect(page).to have_content 'Take our survey for this course.'
+      click_link 'Take Survey'
       # Sets the course automatically
       expect(page).to have_content 'Survey for My Active Course'
       expect(page).to have_content 'progress'


### PR DESCRIPTION
## What this PR does

This PR corrects a bug where a survey notification shown on a course's home page would not link to the survey. It should now correctly send the user to the survey link.