### PR TITLE
Add training module on using My Articles, link to it

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles/components/NoAssignmentMessage.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/NoAssignmentMessage.jsx
@@ -4,6 +4,9 @@ export default () => (
   <div>
     <p>You have not chosen an article to work on. When you have found an article to work on, use the button above to assign it.</p>
     <aside>
+      <a href="/training/students/using-the-dashboard" target="_blank" className="button ghost-button">
+        How to use the Dashboard
+      </a>
       <a href="/training/students/finding-your-article" target="_blank" className="button ghost-button">
         How to find an article
       </a>

--- a/training_content/wiki_ed/libraries/students.yml
+++ b/training_content/wiki_ed/libraries/students.yml
@@ -41,6 +41,9 @@ categories:
     description: |
       These modules cover specific topics, in-depth, with how-to instructions.
     modules:
+      - slug: using-the-dashboard
+        name: Using the Dashboard to track assignments
+        description: How to use My Articles and other assignment-tracking features
       - slug: sources
         name: Adding citations
         description: What makes a good source, and how to create citations

--- a/training_content/wiki_ed/modules/using-the-dashboard.yml
+++ b/training_content/wiki_ed/modules/using-the-dashboard.yml
@@ -1,0 +1,11 @@
+name: Using the Dashboard to track assignments
+id: 60
+description: |
+  How to use My Articles and other assignment-tracking features
+slides:
+  - slug: add-an-article-to-work-on
+  - slug: add-peer-review-articles
+  - slug: stage-1-bibliography
+  - slug: stage-2-create-in-the-sandbox
+  - slug: stage-3-expand-your-draft
+  - slug: stage-4-move-your-work

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6001-add-an-article-to-work-on.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6001-add-an-article-to-work-on.yml
@@ -1,0 +1,20 @@
+id: 6001
+title: "Add the article you're working on"
+summary:
+content: |
+  The My Articles section of your course page is for keeping track of the main articles
+  you'll be focusing on for your Wikipedia project: the one(s) you're creating or improving,
+  and the ones your classmates are working on that you will peer review.
+
+  When it's time to choose your article(s), click the **Assign myself an article** button. You'll
+  be able to choose from any available articles your instructor compiled ahead of time, or you
+  can search Wikipedia by keyword to find underdeveloped article, or simply enter an article title.
+
+  <figure>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/e/e6/Dashbooard.wikiedu.org_-_My_Articles_-_choose_an_article.png" />
+  </figure>
+
+  Once you've assigned yourself an article, you'll get a set of links and tools along with a progress
+  tracker to show where to go for each stage of the assignment. For group assignments, the
+  **Sandbox Draft** link will point to the sandbox of the first group member who signs up for the article
+  so that you can work together in the same sandbox.

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6001-add-an-article-to-work-on.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6001-add-an-article-to-work-on.yml
@@ -8,7 +8,7 @@ content: |
 
   When it's time to choose your article(s), click the **Assign myself an article** button. You'll
   be able to choose from any available articles your instructor compiled ahead of time, or you
-  can search Wikipedia by keyword to find underdeveloped article, or simply enter an article title.
+  can search Wikipedia by keyword to find an underdeveloped article, or simply enter an article title.
 
   <figure>
     <img src="https://upload.wikimedia.org/wikipedia/commons/e/e6/Dashbooard.wikiedu.org_-_My_Articles_-_choose_an_article.png" />

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6002-add-peer-review-articles.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6002-add-peer-review-articles.yml
@@ -1,0 +1,14 @@
+id: 6002
+title: "Select articles to peer review"
+summary:
+content: |
+  Click "Review an article" to see the topics your classmates are working on and choose
+  which ones you will peer review.
+
+  When you select a classmate's article to review, the listing will include links to their
+  bibliography and draft pages, a link to the page where you should complete your peer review,
+  and a link to the current version of the article (if it's already live on Wikipedia).
+
+  <figure>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/8/88/Dashbooard.wikiedu.org_-_My_Articles_-_peer_review_stage_1.png" />
+  </figure>

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6002-add-peer-review-articles.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6002-add-peer-review-articles.yml
@@ -2,7 +2,7 @@ id: 6002
 title: "Select articles to peer review"
 summary:
 content: |
-  Click "Review an article" to see the topics your classmates are working on and choose
+  Click **Review an article** to see the topics your classmates are working on and choose
   which ones you will peer review.
 
   When you select a classmate's article to review, the listing will include links to their

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6003-stage-1-bibliography.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6003-stage-1-bibliography.yml
@@ -6,7 +6,7 @@ content: |
     <img src="https://upload.wikimedia.org/wikipedia/commons/9/96/Dashbooard.wikiedu.org_-_My_Articles_-_stage_1.png" />
   </figure
 
-  You can see the details for each stage of the article development process by clicking bar
+  You can see the details for each stage of the article development process by clicking the bar
   at the bottom of the article listing. For the first stage, compiling your set of sources,
   use the **Bibliography** link. This will open a wiki sandbox page that includes some basic
   structure to get you started.
@@ -14,5 +14,5 @@ content: |
   Follow the trainings link to review the trainined modules related to this stage of the assignment.
 
   Once you've compiled your initial bibliography, click **Mark Complete** to go to the next stage.
-  Keeping track of which step you're on will make it easier your instructor and your peer reviewers
+  Keeping track of which step you're on will make it easier for your instructor and your peer reviewers
   to know when your work is ready for review.

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6003-stage-1-bibliography.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6003-stage-1-bibliography.yml
@@ -1,0 +1,18 @@
+id: 6003
+title: "Stage 1: Bibliography"
+summary:
+content: |
+  <figure>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/9/96/Dashbooard.wikiedu.org_-_My_Articles_-_stage_1.png" />
+  </figure
+
+  You can see the details for each stage of the article development process by clicking bar
+  at the bottom of the article listing. For the first stage, compiling your set of sources,
+  use the **Bibliography** link. This will open a wiki sandbox page that includes some basic
+  structure to get you started.
+
+  Follow the trainings link to review the trainined modules related to this stage of the assignment.
+
+  Once you've compiled your initial bibliography, click **Mark Complete** to go to the next stage.
+  Keeping track of which step you're on will make it easier your instructor and your peer reviewers
+  to know when your work is ready for review.

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6004-stage-2-create-in-the-sandbox.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6004-stage-2-create-in-the-sandbox.yml
@@ -6,7 +6,7 @@ content: |
     <img src="https://upload.wikimedia.org/wikipedia/commons/6/62/Dashbooard.wikiedu.org_-_My_Articles_-_stage_2.png" />
   </figure>
 
-  Once you've compiled your bibliography, it's time to draft your contribution. Follow the Sandbox link
+  Once you've compiled your bibliography, it's time to draft your contribution. Follow the **Sandbox** link
   so that your draft will be easily accessible to instructors and classmates. The sandbox for your draft
   will include the name of the article you're working on.
 

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6004-stage-2-create-in-the-sandbox.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6004-stage-2-create-in-the-sandbox.yml
@@ -1,0 +1,16 @@
+id: 6004
+title: "Stage 2: Create in the sandbox"
+summary:
+content: |
+  <figure>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/6/62/Dashbooard.wikiedu.org_-_My_Articles_-_stage_2.png" />
+  </figure>
+
+  Once you've compiled your bibliography, it's time to draft your contribution. Follow the Sandbox link
+  so that your draft will be easily accessible to instructors and classmates. The sandbox for your draft
+  will include the name of the article you're working on.
+
+  The ***Drafting in the sandbox*** training module has more details about how to use a sandbox for an existing
+  article that you're improving versus a new article that hasn't been created yet.
+
+  Mark this stage *complete* to indicate that you're ready for peer review feedback.

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6005-stage-3-expand-your-draft.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6005-stage-3-expand-your-draft.yml
@@ -1,0 +1,16 @@
+id: 6005
+title: "Stage 3: Expand your draft"
+summary:
+content: |
+  <figure>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/b/b7/Dashbooard.wikiedu.org_-_My_Articles_-_stage_3.png" />
+  </figure>
+
+  In this stage, you'll continue improving your draft, and you'll incorporate the feeback you
+  get from your classmates' peer reviews. You'll find links to the peer review page for each classmate
+  who has signed up to review your article. (If the linked pages are blank, the reviewers haven't submitted
+  their reviews yet.)
+
+  This is also when you should complete your reviews of your classmates' drafts.
+
+  Mark this stage *complete* when you're ready to publish your work live on Wikipedia.

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6005-stage-3-expand-your-draft.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6005-stage-3-expand-your-draft.yml
@@ -6,7 +6,7 @@ content: |
     <img src="https://upload.wikimedia.org/wikipedia/commons/b/b7/Dashbooard.wikiedu.org_-_My_Articles_-_stage_3.png" />
   </figure>
 
-  In this stage, you'll continue improving your draft, and you'll incorporate the feeback you
+  In this stage, you'll continue improving your draft and you'll incorporate the feeback you
   get from your classmates' peer reviews. You'll find links to the peer review page for each classmate
   who has signed up to review your article. (If the linked pages are blank, the reviewers haven't submitted
   their reviews yet.)

--- a/training_content/wiki_ed/slides/60-using-the-dashboard/6006-stage-4-move-your-work.yml
+++ b/training_content/wiki_ed/slides/60-using-the-dashboard/6006-stage-4-move-your-work.yml
@@ -1,0 +1,14 @@
+id: 6006
+title: "Stage 4: Move your work"
+summary:
+content: |
+  <figure>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/4/47/Dashbooard.wikiedu.org_-_My_Articles_-_stage_4.png" />
+  </figure>
+
+  In this stage, you'll move from your sandbox to a live Wikipedia article. Details on how to do that
+  are in the ***Moving work out of the sandbox*** training module.
+
+  Once you've made the transition out of your sandbox, you can mark this stage as complete. You can
+  continue improving the live Wikipedia article from there until the final due date (and beyond,
+  if you like).


### PR DESCRIPTION
This adds a short module walking through the intended use of the My Articles progress tracking features, which is linked from My Articles when empty and can also be pointed to when instructors want to know what students see.

## Screenshots
Before:
![before my articles](https://user-images.githubusercontent.com/848483/70651204-410ce600-1c05-11ea-8409-dba69d68bce0.png)


After:
![how to use the dashboard](https://user-images.githubusercontent.com/848483/70651274-5c77f100-1c05-11ea-9608-7a3f40746200.png)
![module index](https://user-images.githubusercontent.com/848483/70651304-64379580-1c05-11ea-8de7-a8a64f574091.png)
![slide 1](https://user-images.githubusercontent.com/848483/70651302-639eff00-1c05-11ea-85a8-499141171207.png)
![slide 2](https://user-images.githubusercontent.com/848483/70651301-639eff00-1c05-11ea-8385-aa1b6345241a.png)
![slide 3](https://user-images.githubusercontent.com/848483/70651300-639eff00-1c05-11ea-85fc-73effb8614ff.png)
![slide 4](https://user-images.githubusercontent.com/848483/70651299-63066880-1c05-11ea-9476-5ffd1e56bc49.png)
![slide 5](https://user-images.githubusercontent.com/848483/70651296-63066880-1c05-11ea-8f30-c0e13ecbc6e4.png)
![slide 6](https://user-images.githubusercontent.com/848483/70651293-63066880-1c05-11ea-9500-a42483b70665.png)

## Open questions and concerns
Should we add a link to the instructor view to preempt questions about what the student interface looks like?
