### PR TITLE
Add showing xx of xx  in articles edited list

### DIFF
--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -215,14 +215,20 @@ const ArticleList = createReactClass({
       </div>
     );
 
-    let showMoreButton;
+    let showMore;
     if (!this.props.limitReached) {
-      showMoreButton = <div><button className="button ghost stacked right" onClick={this.showMore}>{I18n.t('articles.see_more')}</button></div>;
+      showMore = (
+        <div className="see-more">
+          <button className="button ghost" onClick={this.showMore}>{I18n.t('articles.see_more')}</button>
+          <p>{I18n.t('articles.showing_of', { count: articleElements.length, total: this.props.course.edited_count })}</p>
+        </div>
+      );
     }
 
     return (
       <div id="articles" className="mt4">
         {sectionHeader}
+        {showMore}
         <List
           elements={articleElements}
           keys={keys}
@@ -232,7 +238,6 @@ const ArticleList = createReactClass({
           none_message={CourseUtils.i18n('articles_none', this.props.course.string_prefix)}
           sortBy={this.props.sortArticles}
         />
-        {showMoreButton}
       </div>
     );
   }

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -215,12 +215,12 @@ const ArticleList = createReactClass({
       </div>
     );
 
-    let showMore;
+    let showMoreSection;
     if (!this.props.limitReached) {
-      showMore = (
+      showMoreSection = (
         <div className="see-more">
           <button className="button ghost" onClick={this.showMore}>{I18n.t('articles.see_more')}</button>
-          <p>{I18n.t('articles.showing_of', { count: articleElements.length, total: this.props.course.edited_count })}</p>
+          <p>{I18n.t('articles.articles_shown', { count: articleElements.length, total: this.props.course.edited_count })}</p>
         </div>
       );
     }
@@ -228,7 +228,7 @@ const ArticleList = createReactClass({
     return (
       <div id="articles" className="mt4">
         {sectionHeader}
-        {showMore}
+        {showMoreSection}
         <List
           elements={articleElements}
           keys={keys}

--- a/app/assets/stylesheets/modules/_articles.styl
+++ b/app/assets/stylesheets/modules/_articles.styl
@@ -27,7 +27,14 @@
     select
       font-size: 12px;
       font-weight: 600;
-
+      
+  .see-more
+    p
+      padding-top :12px
+      font-size: 15px;
+    button
+      float right
+  
   .article-sort
     width: 60px
     .sorts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,7 @@ en:
 
   articles:
     article_development: (article development)
+    articles_shown: 'Showing %{count} of %{total}'
     assigned: Assigned Articles
     available: Available Articles
     no_available: No Available Articles
@@ -180,7 +181,6 @@ en:
       ?: Unrated — an article that hasn't yet been rated on Wikipedia's quality scale
       does_not_exist: This article does not exist on Wikipedia
     see_more: See more
-    showing_of: 'Showing %{count} of %{total}'
     show_cumulative_changes: Show Cumulative Changes
     show_current_version: Show Current Version
     show_current_version_with_authorship_highlighting: 'Current Version w/ Authorship Highlighting'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,7 @@ en:
       ?: Unrated — an article that hasn't yet been rated on Wikipedia's quality scale
       does_not_exist: This article does not exist on Wikipedia
     see_more: See more
+    showing_of: 'Showing %{count} of %{total}'
     show_cumulative_changes: Show Cumulative Changes
     show_current_version: Show Current Version
     show_current_version_with_authorship_highlighting: 'Current Version w/ Authorship Highlighting'


### PR DESCRIPTION

## What this PR does
Fixes issue #2990. Added showing x of y where x is the no of articles loaded at the instant and y is the total no of edited articles. Shifted See More button from the bottom to top of the table.

## Screenshots
Before:
![DeepinScreenshot_select-area_20191218210148](https://user-images.githubusercontent.com/32136294/71099633-9f276380-21d9-11ea-862e-40a1f8069416.png)

After:
![DeepinScreenshot_select-area_20191218205102](https://user-images.githubusercontent.com/32136294/71099650-a5b5db00-21d9-11ea-8e44-3f591bf9bbbe.png)
