### PR TITLE
Adapt CourseStats for Wikidata and other non-Wikipedia courses

### DIFF
--- a/app/assets/javascripts/components/overview/course_stats.jsx
+++ b/app/assets/javascripts/components/overview/course_stats.jsx
@@ -47,9 +47,7 @@ const CourseStats = ({ course }) => {
         <small>{I18n.t('metrics.word_count')}</small>
       </div>
     );
-  } else if (isWikidata) {
-    // noop
-  } else {
+  } else if (!isWikidata) {
     contentCount = (
       <div className="stat-display__stat" id="bytes-added">
         <div className={valueClass('word_count')}>{course.character_sum_human}</div>

--- a/app/assets/javascripts/components/overview/course_stats.jsx
+++ b/app/assets/javascripts/components/overview/course_stats.jsx
@@ -29,6 +29,16 @@ const CourseStats = ({ course }) => {
   let trainedTooltip;
   let uploadCount;
 
+  let articlesCreated;
+  if (course.created_count !== '0') {
+    articlesCreated = (
+      <div className="stat-display__stat" id="articles-created">
+        <div className={valueClass('created_count')}>{course.created_count}</div>
+        <small>{createdLabel}</small>
+      </div>
+    );
+  }
+
   let contentCount;
   if (course.home_wiki.language === 'en') {
     contentCount = (
@@ -109,10 +119,7 @@ const CourseStats = ({ course }) => {
 
   return (
     <div className="stat-display">
-      <div className="stat-display__stat" id="articles-created">
-        <div className={valueClass('created_count')}>{course.created_count}</div>
-        <small>{createdLabel}</small>
-      </div>
+      {articlesCreated}
       <div className="stat-display__stat" id="articles-edited">
         <div className={valueClass('edited_count')}>{course.edited_count}</div>
         <small>{editedLabel}</small>

--- a/app/assets/javascripts/components/overview/course_stats.jsx
+++ b/app/assets/javascripts/components/overview/course_stats.jsx
@@ -3,14 +3,31 @@ import PropTypes from 'prop-types';
 import CourseUtils from '../../utils/course_utils.js';
 
 const CourseStats = ({ course }) => {
+  const isWikidata = course.home_wiki.project === 'wikidata';
+  const isWikipedia = course.home_wiki.project === 'wikipedia';
+
   const valueClass = (stat) => {
     if (!course.newStats) { return 'stat-display__value'; }
     return course.newStats[stat] ? 'stat-display__value stat-change' : 'stat-display__value';
   };
 
-  let viewData;
+  let editedLabel;
+  let createdLabel;
+  if (isWikidata) {
+    createdLabel = I18n.t('metrics.articles_created_wikidata');
+    editedLabel = I18n.t('metrics.articles_edited_wikidata');
+  } else if (isWikipedia) {
+    createdLabel = I18n.t('metrics.articles_created');
+    editedLabel = I18n.t('metrics.articles_edited');
+  } else {
+    createdLabel = I18n.t('metrics.articles_created_generic');
+    editedLabel = I18n.t('metrics.articles_edited_generic');
+  }
+
+  let pageviews;
   let infoImg;
   let trainedTooltip;
+  let uploadCount;
 
   let contentCount;
   if (course.home_wiki.language === 'en') {
@@ -20,6 +37,8 @@ const CourseStats = ({ course }) => {
         <small>{I18n.t('metrics.word_count')}</small>
       </div>
     );
+  } else if (isWikidata) {
+    // noop
   } else {
     contentCount = (
       <div className="stat-display__stat" id="bytes-added">
@@ -48,16 +67,13 @@ const CourseStats = ({ course }) => {
   if (course.upload_usages_count === undefined) {
     return <div className="stat-display" />;
   }
-  if (course.view_count === '0' && course.edited_count !== '0') {
-    viewData = (
-      <div className="stat-display__data">
-        {I18n.t('metrics.view_data_unavailable')}
-      </div>
-    );
-  } else {
-    viewData = (
-      <div className={valueClass('view_count')}>
-        {course.view_count}
+  if (course.view_count !== '0') {
+    pageviews = (
+      <div className="stat-display__stat" id="view-count">
+        <div className={valueClass('view_count')}>
+          {course.view_count}
+        </div>
+        <small>{I18n.t('metrics.view_count_description')}</small>
       </div>
     );
   }
@@ -73,15 +89,33 @@ const CourseStats = ({ course }) => {
     );
   }
 
+  if (course.upload_count) {
+    uploadCount = (
+      <div className="stat-display__stat tooltip-trigger" id="upload-count">
+        <div className={valueClass('upload_count')}>
+          {course.upload_count}
+          <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
+        </div>
+        <small>{I18n.t('metrics.upload_count')}</small>
+        <div className="tooltip dark" id="upload-usage">
+          <h4 className="stat-display__value">{course.upload_usages_count}</h4>
+          <p>{I18n.t('metrics.uploads_in_use_count', { count: course.uploads_in_use_count })}</p>
+          <h4 className="stat-display__value">{course.upload_usages_count}</h4>
+          <p>{I18n.t('metrics.upload_usages_count', { count: course.upload_usages_count })}</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="stat-display">
       <div className="stat-display__stat" id="articles-created">
         <div className={valueClass('created_count')}>{course.created_count}</div>
-        <small>{I18n.t('metrics.articles_created')}</small>
+        <small>{createdLabel}</small>
       </div>
       <div className="stat-display__stat" id="articles-edited">
         <div className={valueClass('edited_count')}>{course.edited_count}</div>
-        <small>{I18n.t('metrics.articles_edited')}</small>
+        <small>{editedLabel}</small>
       </div>
       <div className="stat-display__stat" id="total-edits">
         <div className={valueClass('edit_count')}>{course.edit_count}</div>
@@ -97,23 +131,8 @@ const CourseStats = ({ course }) => {
       </div>
       {contentCount}
       {refCount}
-      <div className="stat-display__stat" id="view-count">
-        {viewData}
-        <small>{I18n.t('metrics.view_count_description')}</small>
-      </div>
-      <div className="stat-display__stat tooltip-trigger" id="upload-count">
-        <div className={valueClass('upload_count')}>
-          {course.upload_count}
-          <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
-        </div>
-        <small>{I18n.t('metrics.upload_count')}</small>
-        <div className="tooltip dark" id="upload-usage">
-          <h4 className="stat-display__value">{course.upload_usages_count}</h4>
-          <p>{I18n.t('metrics.uploads_in_use_count', { count: course.uploads_in_use_count })}</p>
-          <h4 className="stat-display__value">{course.upload_usages_count}</h4>
-          <p>{I18n.t('metrics.upload_usages_count', { count: course.upload_usages_count })}</p>
-        </div>
-      </div>
+      {pageviews}
+      {uploadCount}
     </div>
   );
 };

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -813,7 +813,11 @@ en:
     activity: Recent Activity
     are_trained: are up-to-date with training
     articles_created: Articles Created
+    articles_created_generic: Pages Created
+    articles_created_wikidata: Items Created
     articles_edited: Articles Edited
+    articles_edited_generic: Pages Edited
+    articles_edited_wikidata: Items Edited
     bytes_added: Bytes Added
     characters: Characters
     char_added: Chars Added


### PR DESCRIPTION
This is the start of making CourseStats more flexible based on the course stats present and the home wiki. It hides 'bytes added' for Wikidata courses, and updates the labels for Wikidata and for other non-Wikipedia courses, and also hides the uploads count unless there is at least one upload.

## Screenshots
For a Wikidata course...

Before:
![old course stats](https://user-images.githubusercontent.com/848483/71111755-e59ba480-217e-11ea-941c-e5aaad84ed86.png)

After:
![Screenshot from 2019-12-18 10-08-14](https://user-images.githubusercontent.com/848483/71111691-d0267a80-217e-11ea-8069-968dbdddd406.png)

For an empty course:

Before:
![empty course before](https://user-images.githubusercontent.com/848483/71112356-234cfd00-2180-11ea-8275-e5f4ad44d89a.png)

After:
![empty course](https://user-images.githubusercontent.com/848483/71112361-2942de00-2180-11ea-8792-eef8da6103eb.png)
