### PR TITLE
Bug/progress tracker ui fixes

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/NavigationElements.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/NavigationElements.jsx
@@ -22,8 +22,8 @@ export const Navigation = ({ assignment, show }) => {
       { lis }
       {
         show
-          ? <li className="icon icon-arrow-reverse table-expandable-indicator" />
-          : <li className="icon icon-arrow table-expandable-indicator" />
+          ? <li className="icon icon-arrow-reverse table-expandable-indicator limit-size" />
+          : <li className="icon icon-arrow table-expandable-indicator limit-size" />
       }
     </ul>
   );

--- a/app/assets/javascripts/components/overview/my_articles/step_processes/reviews.js
+++ b/app/assets/javascripts/components/overview/my_articles/step_processes/reviews.js
@@ -2,7 +2,7 @@ export default assignment => ([
   {
     title: 'Read the article',
     content: 'Read the article and complete the Peer Review Exercise. This will help prepare you for providing feedback.',
-    status: 'not_yet_started',
+    status: 'reading_the_article',
     trainings: [
       {
         title: 'Peer Review Exercise',
@@ -14,7 +14,7 @@ export default assignment => ([
   {
     title: 'Provide feedback',
     content: 'Assess your classmate\'s proposed contributions.',
-    status: 'peer_review_started',
+    status: 'providing_feedback',
     trainings: [
       {
         title: 'Bibliography',
@@ -36,7 +36,7 @@ export default assignment => ([
   {
     title: 'Mark as complete',
     content: 'Let your classmate know that you\'ve reviewed their work by posting on their talk page so they can begin to incorporate your feedback into their draft.',
-    status: 'peer_review_completed',
+    status: 'post_to_talk',
     trainings: [
       {
         title: 'Sandbox',

--- a/app/assets/stylesheets/modules/_my_articles.styl
+++ b/app/assets/stylesheets/modules/_my_articles.styl
@@ -147,6 +147,8 @@
           color rgb(103, 110, 180)
         aside.step-links a
           color rgb(103, 110, 180)
+  .limit-size
+    max-width 30px
 
 .my-assignment-checklist
   font-size 120%

--- a/lib/assignment_pipeline.rb
+++ b/lib/assignment_pipeline.rb
@@ -13,8 +13,9 @@ class AssignmentPipeline
   end
 
   module ReviewStatuses
-    NOT_YET_STARTED = 'not_yet_started'
-    PEER_REVIEW_STARTED = 'peer_review_started'
+    READING_ARTICLE = 'reading_the_article'
+    PROVIDING_FEEDBACK = 'providing_feedback'
+    POST_TO_TALK = 'post_to_talk'
     PEER_REVIEW_COMPLETED = 'peer_review_completed'
   end
 
@@ -27,8 +28,9 @@ class AssignmentPipeline
       AssignmentStatuses::ASSIGNMENT_COMPLETED
     ].freeze,
     review: [
-      ReviewStatuses::NOT_YET_STARTED,
-      ReviewStatuses::PEER_REVIEW_STARTED,
+      ReviewStatuses::READING_ARTICLE,
+      ReviewStatuses::PROVIDING_FEEDBACK,
+      ReviewStatuses::POST_TO_TALK,
       ReviewStatuses::PEER_REVIEW_COMPLETED
     ].freeze
   }.freeze

--- a/spec/lib/assignment_pipeline_spec.rb
+++ b/spec/lib/assignment_pipeline_spec.rb
@@ -81,11 +81,11 @@ describe AssignmentPipeline do
     end
 
     describe '#status' do
-      it 'returns the "not_yet_started" status if there is no status' do
+      it 'returns the "reading_article" status if there is no status' do
         pipeline = described_class.new(assignment: assignment)
 
         actual = pipeline.status
-        expected = described_class::ReviewStatuses::NOT_YET_STARTED
+        expected = described_class::ReviewStatuses::READING_ARTICLE
         expect(actual).to equal(expected)
       end
     end
@@ -95,7 +95,7 @@ describe AssignmentPipeline do
         pipeline = described_class.new(assignment: assignment)
 
         actual = pipeline.all_statuses
-        expect(actual.length).to equal(3)
+        expect(actual.length).to equal(4)
       end
     end
 
@@ -114,7 +114,7 @@ describe AssignmentPipeline do
 
       it 'will only set the assignment if the status is valid' do
         pipeline = described_class.new(assignment: assignment)
-        in_progress_status = described_class::ReviewStatuses::NOT_YET_STARTED
+        in_progress_status = described_class::ReviewStatuses::READING_ARTICLE
         expect(pipeline.status).to eq(in_progress_status)
         expect(assignment.flags[:review]).to be(nil)
 


### PR DESCRIPTION
## What this PR does

There were two small bugs I found while working on the instructor view:
1. The navigation bar styling had changed so that the text of the first step appeared on two lines
1. When marking a review as completing, the last step viewable was skipped

This updates the styling to fix the first problem and adds an additional status to the AssignmentPipeline to solve the second problem.

After merging and deploying this change, we may need to update existing review Assignments to have the correct status. We can do so with something like this:
```ruby
all_assignments = Assignment.where(role: Assignment::Roles::REVIEWING_ROLE)
assignments = all_assignments.reject { |a| a.flags.empty? }
assignments.each do |assignment|
  status = AssignmentPipeline::ReviewStatuses::READING_ARTICLE
  assignment.assignment_pipeline.update_status(status)
end
```

## Screenshots
**Realigned Navigation Bar**
![image](https://user-images.githubusercontent.com/1316902/71129012-62407a00-21a3-11ea-9e0c-e7b8ac0af0ab.png)

**Last Step on Reviews now Accessible**
![image](https://user-images.githubusercontent.com/1316902/71129047-708e9600-21a3-11ea-8108-cf1ede6ee076.png)

