### PR TITLE
Remove isProduction variable from assignment actions

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/Actions.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/Actions.jsx
@@ -12,9 +12,25 @@ import PeerReviewChecklist from '~/app/assets/javascripts/components/common/peer
 import Feedback from '~/app/assets/javascripts/components/common/feedback.jsx';
 
 export const Actions = ({
-  article, assignment, courseSlug, current_user, isComplete, isProduction, username,
+  article, assignment, courseSlug, current_user, isComplete, username,
   isEnglishWikipedia, handleUpdateAssignment, refreshAssignments, unassign
 }) => {
+  if (isComplete) {
+    // If complete, only return the following
+    return (
+      <section className="actions">
+        <PageViews key="pageviews-button" article={article} />
+        <MarkAsIncompleteButton
+          key="mark-incomplete-button"
+          assignment={assignment}
+          courseSlug={courseSlug}
+          handleUpdateAssignment={handleUpdateAssignment}
+          refreshAssignments={refreshAssignments}
+        />
+      </section>
+    );
+  }
+
   const actions = [];
 
   if (assignment.article_id) {
@@ -40,22 +56,6 @@ export const Actions = ({
     }
   }
 
-  // TODO: Remove `isProduction` when ready
-  if (!isProduction && isComplete) {
-    return (
-      <section className="actions">
-        <PageViews key="pageviews-button" article={article} />
-        <MarkAsIncompleteButton
-          key="mark-incomplete-button"
-          assignment={assignment}
-          courseSlug={courseSlug}
-          handleUpdateAssignment={handleUpdateAssignment}
-          refreshAssignments={refreshAssignments}
-        />
-      </section>
-    );
-  }
-
   return (
     <section className="actions">
       {actions}
@@ -71,7 +71,6 @@ Actions.propTypes = {
   courseSlug: PropTypes.string.isRequired,
   current_user: PropTypes.object.isRequired,
   isComplete: PropTypes.bool.isRequired,
-  isProduction: PropTypes.bool, // TODO: Remove when ready
   username: PropTypes.string.isRequired,
 
   // actions

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
@@ -32,7 +32,7 @@ const unassign = ({ assignment, course, initiateConfirm, deleteAssignment }) => 
 };
 
 export const Header = ({
-  article, articleTitle, assignment, course, current_user, isComplete, isProduction, username,
+  article, articleTitle, assignment, course, current_user, isComplete, username,
   deleteAssignment, fetchAssignments, initiateConfirm, updateAssignmentStatus
 }) => (
   <header aria-label={`${articleTitle} assignment`} className="header-wrapper">
@@ -49,7 +49,6 @@ export const Header = ({
       current_user={current_user}
       isEnglishWikipedia={isEnglishWikipedia({ assignment, course })}
       isComplete={isComplete}
-      isProduction={isProduction} // TODO: Remove when ready
       refreshAssignments={fetchAssignments}
       unassign={unassign({ assignment, course, initiateConfirm, deleteAssignment })}
       handleUpdateAssignment={updateAssignmentStatus}
@@ -66,7 +65,6 @@ Header.propTypes = {
   course: PropTypes.object.isRequired,
   current_user: PropTypes.object.isRequired,
   isComplete: PropTypes.bool.isRequired,
-  isProduction: PropTypes.bool, // TODO: Remove when ready
   username: PropTypes.string.isRequired,
   // actions
   deleteAssignment: PropTypes.func.isRequired,


### PR DESCRIPTION
## What this PR does

This just removes the `isProduction` key that I don't think was being used anyway.