### PR TITLE
Indicate when a Category has never been updated

### DIFF
--- a/app/assets/javascripts/components/categories/category.jsx
+++ b/app/assets/javascripts/components/categories/category.jsx
@@ -23,7 +23,9 @@ const Category = ({ course, category, remove, editable }) => {
   const lastUpdateMoment = moment.utc(lastUpdate);
   let lastUpdateMessage;
   if (lastUpdate) {
-    lastUpdateMessage = `${I18n.t('metrics.last_update')}: ${lastUpdateMoment.fromNow()}`;
+    lastUpdateMessage = moment(lastUpdate).isSame(category.created_at)
+      ? '---'
+      : `${I18n.t('metrics.last_update')}: ${lastUpdateMoment.fromNow()}`;
   }
 
   return (

--- a/app/views/courses/categories.json.jbuilder
+++ b/app/views/courses/categories.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.course do
   json.categories @course.categories.includes(:wiki) do |cat|
-    json.call(cat, :id, :depth, :wiki, :source, :updated_at, :name)
+    json.call(cat, :id, :depth, :wiki, :source, :updated_at, :created_at, :name)
     json.cat_name cat.name_with_prefix
     json.articles_count cat.article_titles.count
   end


### PR DESCRIPTION
## What this PR does
It fixes #3590 
It ensures "Last Updated On" column indicates "---" for a category that has never been updated.

## Screenshots
Before:
![Screenshot 2020-01-02 at 11 44 56 AM](https://user-images.githubusercontent.com/14357823/71663612-3520c980-2d56-11ea-9b29-30925c01cfa4.png)

After:
![Screenshot 2020-01-02 at 11 45 52 AM](https://user-images.githubusercontent.com/14357823/71663622-3eaa3180-2d56-11ea-996e-5868407ce884.png)

## Open questions and concerns
Please let me know if there's anything I am missing that I should have included in this PR.