### PR TITLE
Fixing view-buttons distortion

### DIFF
--- a/app/assets/stylesheets/modules/_uploads.styl
+++ b/app/assets/stylesheets/modules/_uploads.styl
@@ -90,16 +90,27 @@
     .info
       text-align left
 
-.view-buttons
-  position absolute
-  top 20px
-  right 80px
+@media (min-width: 721px)
+  .view-buttons
+    position absolute
+    top 20px
+    right 80px
 
-  button
-    padding 0
-    width 40px
-    height 40px
-    border-radius 50%
+    button
+      padding 0
+      width 40px
+      height 40px
+      border-radius 50%
+
+@media (max-width: 720px)
+  .view-buttons
+    width 100%
+
+    button
+      padding 0
+      width 40px
+      height 40px
+      border-radius 50%
 
 #uploads .Select
   width 33%

--- a/app/assets/stylesheets/modules/_uploads.styl
+++ b/app/assets/stylesheets/modules/_uploads.styl
@@ -90,27 +90,19 @@
     .info
       text-align left
 
-@media (min-width: 721px)
-  .view-buttons
+.view-buttons
+  +above(desktop)
     position absolute
     top 20px
     right 80px
-
-    button
-      padding 0
-      width 40px
-      height 40px
-      border-radius 50%
-
-@media (max-width: 720px)
-  .view-buttons
+  +below(desktop)
     width 100%
+  button
+    padding 0
+    width 40px
+    height 40px
+    border-radius 50%
 
-    button
-      padding 0
-      width 40px
-      height 40px
-      border-radius 50%
 
 #uploads .Select
   width 33%


### PR DESCRIPTION
## What this PR does
This PR attempts to fix part of #1318. The uploads page had **view-buttons** div distorted for smaller screens. Added some **media queries** to prevent distortion.

## Screenshots
Before(left) / After(Right)
![image](https://user-images.githubusercontent.com/32016324/72407721-808b9c80-3786-11ea-937b-54d703a567c7.png)

As this PR is part of bigger issue, next would like to fix distortion of **articles** page.