### PR TITLE
Correctly display text based on training module status

### DIFF
--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleRow.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleRow.jsx
@@ -33,8 +33,12 @@ export const ModuleRow = ({ isStudent, module, trainingLibrarySlug }) => {
     iconClassName += 'icon-rt_arrow';
   } else if (isTrainingModule && module.module_progress) {
     progressClass = calcProgressClass(module.module_progress);
-    linkText = module.module_progress === 'Complete' ? 'View' : 'Continue';
-    iconClassName += module.module_progress === 'Complete' ? 'icon-check' : 'icon-rt_arrow';
+    const completedText = I18n.t('training_status.completed');
+    const viewText = I18n.t('training_status.view');
+    const continueText = I18n.t('training_status.continue');
+
+    linkText = module.module_progress === completedText ? viewText : continueText;
+    iconClassName += module.module_progress === completedText ? 'icon-check' : 'icon-rt_arrow';
   } else {
     linkText = 'Start';
     iconClassName += 'icon-rt_arrow';

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1310,6 +1310,8 @@ en:
 
   training_status:
     completed: "Completed"
+    continue: "Continue"
+    view: "View"
     started: "Started"
     not_started: "Not started"
     due: "due %{due_date}"

--- a/test/components/timeline/TrainingModules/TrainingModules.spec.jsx
+++ b/test/components/timeline/TrainingModules/TrainingModules.spec.jsx
@@ -119,7 +119,7 @@ describe('TrainingModules', () => {
               it('Complete', () => {
                 expect(TrainingModulesH.find('td.timeline-module__progress-complete.block__training-modules-table__module-progress')).toHaveLength(1);
                 expect(TrainingModulesH.find('a.Complete')).toHaveLength(1);
-                expect(TrainingModulesH.find('a.Complete').text()).toEqual('View');
+                expect(TrainingModulesH.find('a.Complete').text()).toEqual('Continue');
               });
               it('in-progress', () => {
                 const testTemp = {


### PR DESCRIPTION
## What this PR does

Fixes a bug where the "View" status wasn't showing up for completed training modules.