### PR TITLE
Add hidden text in no-enrolled-students emails for first-time instruc…

### DIFF
--- a/app/views/no_enrolled_students_alert_mailer/email.html.haml
+++ b/app/views/no_enrolled_students_alert_mailer/email.html.haml
@@ -31,3 +31,5 @@
 .hidden
   %p -- DO NOT DELETE ANYTHING BELOW THIS LINE --
   %p ignore_creating_dashboard_ticket
+  - if @course.tags.include?('first_time_instructor')
+    %p first_time_instructor_no_enrolled_students


### PR DESCRIPTION
…tors

Helaine wants to follow up with first-time instructors who don't get to the point of students enrolling. With this, she'll be able to adjust her email filter to surface the ones from first-time instructors.

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
