### PR TITLE
Don't set 'edit_settings' flag for a new course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -32,7 +32,7 @@ class CoursesController < ApplicationController
     end
     @course = course_creation_manager.create
     update_courses_wikis
-    update_flags
+    update_academic_system
   end
 
   def update


### PR DESCRIPTION
The edit settings for a course live in course#flags, but they have default behavior when there are no edit settings flags (and the default varies by course type). These settings get set to the flags after the course is updated for the first time, because the default values get sent to the frontend from course.json.jbuilder and then saved as flag settings. The addition of an academic_system flag in the course creator, and adding the update_flags method to the flow of new course creation, resulted in setting an 'edit_settings' flag immediately upon course creation, which short-circuited the flow of setting the default settings as flags upon first update. This resulted in courses being set by default not to do enrollment edits.

See https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/3050

With this fix, we only set the academic_system flag during course creation, preserving the intended behavior of the other edit settings.