### PR TITLE
Add aria-label for article viewer open/close buttons

### DIFF
--- a/app/assets/javascripts/components/common/article_viewer.jsx
+++ b/app/assets/javascripts/components/common/article_viewer.jsx
@@ -293,7 +293,8 @@ const ArticleViewer = createReactClass({
       if (this.props.title) {
         return (
           <div className={`tooltip-trigger ${this.props.showButtonClass || ''}`}>
-            <button onClick={this.showArticle}>{this.props.title}</button>
+            <button onClick={this.showArticle} aria-describedby="icon-article-viewer-desc">{this.props.title}</button>
+            <p id="icon-article-viewer-desc">Open Article Viewer</p>
             <div className="tooltip tooltip-title dark large">
               <p>{this.showButtonLabel()}</p>
             </div>
@@ -302,14 +303,14 @@ const ArticleViewer = createReactClass({
       }
       return (
         <div className={`tooltip-trigger ${this.props.showButtonClass}`}>
-          <button onClick={this.showArticle} className="icon icon-article-viewer" />
+          <button onClick={this.showArticle} aria-label="Open Article Viewer" className="icon icon-article-viewer" />
           <div className="tooltip tooltip-center dark large">
             <p>{this.showButtonLabel()}</p>
           </div>
         </div>
       );
     }
-    const closeButton = <button onClick={this.hideArticle} className="pull-right article-viewer-button icon-close" />;
+    const closeButton = <button onClick={this.hideArticle} className="pull-right article-viewer-button icon-close" aria-label="Close Article Viewer" />;
 
     let style = 'hidden';
     if (this.state.showArticle) {

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -11,7 +11,9 @@
   box-shadow 0 0 20px 0 rgba(0, 0, 0, .6)
   transform translateX(-50%)
 
-
+#icon-article-viewer-desc
+  display none
+  
 .article-header
   border none !important
   padding 5px 10px 5px 10px


### PR DESCRIPTION
Fixes #2490

Added `aria-label` attribute to buttons which have icons as labels.
Added `aria-describedby` attribute to button with text labels.