### PR TITLE
Update box-shadow for student drawer

### DIFF
--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -128,7 +128,7 @@
         border-right-color $brand_primary
 
   > tbody .drawer > td
-    box-shadow 0px 1px 5px rgba(0,0,0,0.3)
+    box-shadow 0px -1px 5px rgba(0,0,0,0.3)
     position relative
     z-index 1
 


### PR DESCRIPTION
#### What this PR does

This is a minor change that changes the look of the revision box. It removes a small sliver of white at the bottom of the drawer.

##### Before

![image](https://user-images.githubusercontent.com/1316902/74780028-9c85d080-5253-11ea-8998-0cbeae1550fc.png)

##### After

![image](https://user-images.githubusercontent.com/1316902/74780001-8a0b9700-5253-11ea-9430-afcb5e58b9d4.png)
