### PR TITLE
Include Group Members text for assignments

### DIFF
--- a/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 // Components
 import BibliographyLink from './BibliographyLink';
 import SandboxLink from './SandboxLink';
+import GroupMembersLink from './GroupMembersLink';
 import PeerReviewLink from './PeerReviewLink';
 import AllPeerReviewLinks from './AllPeerReviewLinks';
 import Separator from '@components/overview/my_articles/common/Separator.jsx';
@@ -43,6 +44,11 @@ const AssignmentLinks = ({ assignment, courseType, user }) => {
     <a key={`article-${id}`} href={article_url} target="_blank">{I18n.t('assignments.article_link')}</a>
   );
 
+  let groupMembers;
+  if (assignment.editors && role === ASSIGNED_ROLE) {
+    groupMembers = <GroupMembersLink members={assignment.editors} />;
+  }
+
   let reviewers;
   if (assignment.reviewers && role === ASSIGNED_ROLE) {
     reviewers = <AllPeerReviewLinks assignment={assignment} />;
@@ -55,7 +61,10 @@ const AssignmentLinks = ({ assignment, courseType, user }) => {
     <>
       <p className="assignment-links">{ links }</p>
       {
-        reviewers && <p className="reviewers">{ reviewers }</p>
+        groupMembers && <p className="assignment-links editors">{groupMembers}</p>
+      }
+      {
+        reviewers && <p className="assignment-links reviewers">{ reviewers }</p>
       }
     </>
   );

--- a/app/assets/javascripts/components/common/AssignmentLinks/GroupMembersLink.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/GroupMembersLink.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import AssignedToLink from '@components/overview/my_articles/common/AssignedToLink.jsx';
+
+export const GroupMembersLink = ({ members }) => {
+  return <AssignedToLink members={members} name="group_members" />;
+};
+
+GroupMembersLink.propTypes = {
+  // props
+  members: PropTypes.array,
+};
+
+export default GroupMembersLink;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Links.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Links.jsx
@@ -6,6 +6,7 @@ import BibliographyLink from '@components/common/AssignmentLinks/BibliographyLin
 import SandboxLink from '@components/common/AssignmentLinks/SandboxLink.jsx';
 import PeerReviewLink from '@components/common/AssignmentLinks/PeerReviewLink.jsx';
 import EditorLink from '@components/common/AssignmentLinks/EditorLink.jsx';
+import GroupMembersLink from '@components/common/AssignmentLinks/GroupMembersLink.jsx';
 import ReviewerLink from '@components/common/AssignmentLinks/ReviewerLink.jsx';
 
 import Separator from '@components/overview/my_articles/common/Separator.jsx';
@@ -50,7 +51,11 @@ export const Links = ({ articleTitle, assignment, courseType, current_user }) =>
   const assignedTo = (editors || reviewers)
     ? (
       <>
-        <EditorLink key={`editor-${id}`} editors={editors} />
+        {
+          assignment.role === REVIEWING_ROLE
+            ? <EditorLink key={`editor-${id}`} editors={editors} />
+            : <GroupMembersLink key={`editor-${id}`} members={editors} />
+        }
         {(editors && reviewers) ? <Separator key="member-links" /> : null}
         <ReviewerLink key={`reviewer-${id}`} reviewers={reviewers} />
       </>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,6 +237,7 @@ en:
     confirm_addition: Are you sure you want to assign %{title} to %{username}?
     confirm_deletion: Are you sure you want to delete this article assignment?
     editors: Assigned to
+    group_members: Group members
     label: Assign
     loading: Loading assignments...
     none_short: No articles assigned

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/index.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/index.spec.jsx
@@ -29,14 +29,14 @@ describe('Links', () => {
     expect(component.find('PeerReviewLink').length).toEqual(1);
   });
 
-  it('should show EditorLink and ReviewerLink if there are editors or reviewers', () => {
+  it('should show GroupMembersLink and ReviewerLink if there are editors or reviewers', () => {
     const assignment = {
       ...props.assignment,
       editors: ['editor'],
       reviewers: ['reviewer']
     };
     const component = shallow(<Links {...props} assignment={assignment} />);
-    expect(component.find('EditorLink').length).toEqual(1);
+    expect(component.find('GroupMembersLink').length).toEqual(1);
     expect(component.find('ReviewerLink').length).toEqual(1);
   });
 });


### PR DESCRIPTION
## What this PR does

This PR adds text for Group Members to assignments. Also changes text on the My Articles section to match.

## Screenshots

<img width="860" alt="image" src="https://user-images.githubusercontent.com/1316902/74964880-0ffd1e80-53c9-11ea-8c11-1df067e8442b.png">
