### PR TITLE
courses starting on sunday do not have empty first week

### DIFF
--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -129,13 +129,8 @@ const CourseDateUtils = {
     __range__(0, (courseWeeks - 1), true).forEach((week) => {
       weekStart = moment(recurrence.startDate()).startOf('week').add(week, 'weeks');
 
-      // Account for the first partial week, which may not have 7 days.
       let firstDayOfWeek;
-      if (week === 0) {
-        firstDayOfWeek = firstWeekStart;
-      } else {
-        firstDayOfWeek = 0;
-      }
+      firstDayOfWeek = 0;
 
       const ms = [];
       __range__(firstDayOfWeek, 6, true).forEach((i) => {


### PR DESCRIPTION
## What this PR does
< Resolves issue #2360  >

## Screenshots
Before: 
![Timeline_Sunday(before)](https://user-images.githubusercontent.com/43354059/74967037-3a3cf380-543e-11ea-96af-93a581746edb.png)
 
After:
![Timeline_Sunday](https://user-images.githubusercontent.com/43354059/74967054-41640180-543e-11ea-97b7-12cc49fe7545.png)

## Open questions and concerns
I've made the first day of the week as Sunday irrespective of which day the course starts on. The timeline is looking fine for all courses irrespective of which day the course starts on,  in my local machine. Please let me know if I need to make some changes.
