### PR TITLE
Developed a prefix scheme to display different label based on home wi…

### DIFF
--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -84,12 +84,6 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
     );
   }
 
-  // ///////////////////////
-  // Prefix for home wiki /
-  // //////////////////////
-  let string_article_prefix = course.home_wiki.project === 'wikidata' ? 'wikidata' : 'others';
-  string_article_prefix = `${course.string_prefix}.${string_article_prefix}`;
-
   return (
     <div className="container">
       {courseLinkElement}
@@ -102,7 +96,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
           <p><NavLink to={studentsLink} activeClassName="active">{CourseUtils.i18n('students_short', course.string_prefix)}</NavLink></p>
         </div>
         <div className="nav__item" id="articles-link">
-          <p><NavLink to={articlesLink} activeClassName="active">{CourseUtils.i18n('articles_short', string_article_prefix)}</NavLink></p>
+          <p><NavLink to={articlesLink} activeClassName="active">{CourseUtils.i18n('articles_short', course.wiki_prefix)}</NavLink></p>
         </div>
         <div className="nav__item" id="uploads-link">
           <p><NavLink to={uploadsLink} activeClassName="active">{I18n.t('uploads.label')}</NavLink></p>

--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -84,6 +84,12 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
     );
   }
 
+  // ///////////////////////
+  // Prefix for home wiki /
+  // //////////////////////
+  let string_article_prefix = course.home_wiki.project === 'wikidata' ? 'wikidata' : 'others';
+  string_article_prefix = `${course.string_prefix}.${string_article_prefix}`;
+
   return (
     <div className="container">
       {courseLinkElement}
@@ -96,7 +102,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
           <p><NavLink to={studentsLink} activeClassName="active">{CourseUtils.i18n('students_short', course.string_prefix)}</NavLink></p>
         </div>
         <div className="nav__item" id="articles-link">
-          <p><NavLink to={articlesLink} activeClassName="active">{I18n.t('articles.label')}</NavLink></p>
+          <p><NavLink to={articlesLink} activeClassName="active">{CourseUtils.i18n('articles_short', string_article_prefix)}</NavLink></p>
         </div>
         <div className="nav__item" id="uploads-link">
           <p><NavLink to={uploadsLink} activeClassName="active">{I18n.t('uploads.label')}</NavLink></p>

--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -96,7 +96,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
           <p><NavLink to={studentsLink} activeClassName="active">{CourseUtils.i18n('students_short', course.string_prefix)}</NavLink></p>
         </div>
         <div className="nav__item" id="articles-link">
-          <p><NavLink to={articlesLink} activeClassName="active">{CourseUtils.i18n('articles_short', course.wiki_prefix)}</NavLink></p>
+          <p><NavLink to={articlesLink} activeClassName="active">{CourseUtils.i18n('articles_short', course.wiki_string_prefix)}</NavLink></p>
         </div>
         <div className="nav__item" id="uploads-link">
           <p><NavLink to={uploadsLink} activeClassName="active">{I18n.t('uploads.label')}</NavLink></p>

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -120,6 +120,17 @@ class Wiki < ApplicationRecord
     edit_templates['course_prefix']
   end
 
+  def string_prefix
+    case project
+      when 'wikipedia'
+        'articles'
+      when 'wikidata'
+        'articles_wikidata'
+      else
+        'articles_generic'
+    end
+  end
+
   private
 
   def template_file_path

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -122,12 +122,12 @@ class Wiki < ApplicationRecord
 
   def string_prefix
     case project
-      when 'wikipedia'
-        'articles'
-      when 'wikidata'
-        'articles_wikidata'
-      else
-        'articles_generic'
+    when 'wikipedia'
+      'articles'
+    when 'wikidata'
+      'articles_wikidata'
+    else
+      'articles_generic'
     end
   end
 

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -27,7 +27,7 @@ json.course do
   json.published CampaignsCourses.exists?(course_id: @course.id)
   json.closed @course.closed?
   json.enroll_url "#{request.base_url}#{course_slug_path(@course.slug)}/enroll/"
-  json.wiki_prefix @course.home_wiki.project == 'wikidata' ? 'articles.items' : 'articles.pages'
+  json.wiki_string_prefix @course.home_wiki.project == 'wikipedia' ? 'articles' : @course.home_wiki.project == 'wikidata' ? 'articles_wikidata' : 'articles_generic'
 
   json.created_count number_to_human @course.new_article_count
   json.edited_count number_to_human @course.article_count

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -27,7 +27,7 @@ json.course do
   json.published CampaignsCourses.exists?(course_id: @course.id)
   json.closed @course.closed?
   json.enroll_url "#{request.base_url}#{course_slug_path(@course.slug)}/enroll/"
-  json.wiki_string_prefix @course.home_wiki.project == 'wikipedia' ? 'articles' : @course.home_wiki.project == 'wikidata' ? 'articles_wikidata' : 'articles_generic'
+  json.wiki_string_prefix @course.home_wiki.string_prefix
 
   json.created_count number_to_human @course.new_article_count
   json.edited_count number_to_human @course.article_count

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -27,6 +27,7 @@ json.course do
   json.published CampaignsCourses.exists?(course_id: @course.id)
   json.closed @course.closed?
   json.enroll_url "#{request.base_url}#{course_slug_path(@course.slug)}/enroll/"
+  json.wiki_prefix @course.home_wiki.project == 'wikidata' ? 'articles.items' : 'articles.pages'
 
   json.created_count number_to_human @course.new_article_count
   json.edited_count number_to_human @course.article_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,17 +81,6 @@ en:
     opt_yes: 'yes'
     opt_no: 'no'
 
-  article_statuses:
-    not_yet_started: Getting Started
-    in_progress: Working in Sandbox
-    ready_for_review: Expanding Draft
-    ready_for_mainspace: Moving Work to Mainspace
-    assignment_completed: Assignment Marked Complete
-    reading_the_article: Reading Article
-    providing_feedback: Providing Feedback
-    post_to_talk: Posting to Talk Page
-    peer_review_completed: Review Completed
-
   dashboard:
     create_note:
       Click on Create Course to create your first course.
@@ -245,10 +234,9 @@ en:
     peer_review_count: "%{currentCount}/%{total} selected"
     peer_review_count_tooltip: You should select %{total} articles to peer review.
     peer_review_link: Peer Review
-    peer_review_link_personalized: "%{username}'s Peer Review"
     remove: Remove
     reviewers: Reviewer(s)
-    review_other: Assign a peer review
+    review_other: Assign a review
     review_self: Review an article
     review_tooltip: This is for article(s) you plan to peer review or provide feedback on.
     sandbox_draft_link: Sandbox Draft
@@ -357,7 +345,8 @@ en:
       This will allow participants to enter their email address and desired
       username, instead of creating new accounts themselves. You will then be
       able to create the accounts from this Dashboard, and add them as
-      program participants at the same time.
+      program participants at the same time. To use this feature, you should
+      have 'account creator' permission on the home wiki for this program.
     accounts_generation_confirm_message: Are you sure you want to enable account requests?
     activity: Activity
     active_courses: Active %{course_type}
@@ -634,7 +623,6 @@ en:
     search_courses: Search courses
     start: Start
     start_typing: Start typing
-    student: Student
     students: Students
     students_taught: Students Taught
     students_count: "# Students"
@@ -710,6 +698,10 @@ en:
     survey:
       notification_message: Take our survey for this course.
       link: Take Survey
+    wikidata: 
+      articles_short: Items
+    others: 
+      articles_short: Pages
 
   # These are strings that are not specific to education/classroom contexts
   courses_generic:
@@ -798,7 +790,6 @@ en:
     search_courses: Search programs
     start: Activity tracking start
     student_editors: Editors
-    student: Editor
     students: Editors
     students_taught: Total Editors
     students_none: This project has no editors enrolled.
@@ -812,6 +803,10 @@ en:
     view_page: View Program Page
     word_count_doc: An estimate of the number of words added to mainspace articles by the program's editors during the program term
     yourcourses: Your Programs
+    wikidata: 
+      articles_short: Items
+    others: 
+      articles_short: Pages
 
   editable:
     edit: Edit
@@ -821,21 +816,6 @@ en:
     edit_details: Edit Details
     edit_template: Edit Template
     rename_confirmation: The course fields that form the URL have changed. This will change the URL and break any incoming links. Are you sure you want to do this?
-
-  instructor_view:
-    article_assignments: "%{prefix} Assignments"
-    assignments_table:
-      article_name: Article Name
-      current_stage: Current Stage
-      relevant_links: Relevant Links
-    assigned_articles: Assigned Articles
-    exercises_and_trainings: "%{prefix} Exercises & Trainings"
-    no_assignments: "This student currently has no assigned articles. You can assign an article by using the buttons above."
-    overview: "%{prefix} Overview"
-    reviewing_articles: Reviewing Articles
-    select_student:
-      title: "Select %{prefix}"
-      content: to assign and view article assignments
 
   metrics:
     label: Course Activity
@@ -1106,9 +1086,6 @@ en:
     enroll_confirmation: Are you sure you want to add %{username}?
     enroll_url: 'Users may join by visiting this URL:'
     enrolled_success: '%{username} was added successfully!'
-    exercise_modules_completed:
-      one: "%{completed_count}/%{count} exercise completed"
-      other: "%{completed_count}/%{count} exercises completed"
     first_name: First name
     last_name: Last name
     loading: Loading users...
@@ -1135,11 +1112,6 @@ en:
     reviewers: Reviewer(s)
     reviewing: Reviewing
     sandboxes: sandboxes
-    sub_navigation:
-      article_assignments: Article Assignments
-      editor_overview: Editor Overview
-      exercises_and_trainings: Exercises & Trainings
-      student_overview: Student Overview
     total_uploads: "Total Uploads"
     training_complete:
       one: "is up-to-date with training"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,10 +218,13 @@ en:
       usually indicates that an article follow Wikipedia's conventions for the
       structure of a good article, but it does not take into account the content
       itself. (These scores are only available for English Wikipedia articles.)
-    items:
-      articles_short: Items
-    pages:
-      articles_short: Pages
+    articles_short: Articles
+
+  articles_wikidata:
+    articles_short: Items
+  
+  articles_generic:
+    articles_short: Pages
 
   assignments:
     article: The article %{title} is now assigned to you.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,17 @@ en:
     opt_yes: 'yes'
     opt_no: 'no'
 
+  article_statuses:
+    not_yet_started: Getting Started
+    in_progress: Working in Sandbox
+    ready_for_review: Expanding Draft
+    ready_for_mainspace: Moving Work to Mainspace
+    assignment_completed: Assignment Marked Complete
+    reading_the_article: Reading Article
+    providing_feedback: Providing Feedback
+    post_to_talk: Posting to Talk Page
+    peer_review_completed: Review Completed
+
   dashboard:
     create_note:
       Click on Create Course to create your first course.
@@ -207,6 +218,10 @@ en:
       usually indicates that an article follow Wikipedia's conventions for the
       structure of a good article, but it does not take into account the content
       itself. (These scores are only available for English Wikipedia articles.)
+    items:
+      articles_short: Items
+    pages:
+      articles_short: Pages
 
   assignments:
     article: The article %{title} is now assigned to you.
@@ -226,6 +241,7 @@ en:
     confirm_addition: Are you sure you want to assign %{title} to %{username}?
     confirm_deletion: Are you sure you want to delete this article assignment?
     editors: Assigned to
+    group_members: Group members
     label: Assign
     loading: Loading assignments...
     none_short: No articles assigned
@@ -234,9 +250,10 @@ en:
     peer_review_count: "%{currentCount}/%{total} selected"
     peer_review_count_tooltip: You should select %{total} articles to peer review.
     peer_review_link: Peer Review
+    peer_review_link_personalized: "%{username}'s Peer Review"
     remove: Remove
     reviewers: Reviewer(s)
-    review_other: Assign a review
+    review_other: Assign a peer review
     review_self: Review an article
     review_tooltip: This is for article(s) you plan to peer review or provide feedback on.
     sandbox_draft_link: Sandbox Draft
@@ -345,8 +362,7 @@ en:
       This will allow participants to enter their email address and desired
       username, instead of creating new accounts themselves. You will then be
       able to create the accounts from this Dashboard, and add them as
-      program participants at the same time. To use this feature, you should
-      have 'account creator' permission on the home wiki for this program.
+      program participants at the same time.
     accounts_generation_confirm_message: Are you sure you want to enable account requests?
     activity: Activity
     active_courses: Active %{course_type}
@@ -623,6 +639,7 @@ en:
     search_courses: Search courses
     start: Start
     start_typing: Start typing
+    student: Student
     students: Students
     students_taught: Students Taught
     students_count: "# Students"
@@ -698,10 +715,6 @@ en:
     survey:
       notification_message: Take our survey for this course.
       link: Take Survey
-    wikidata: 
-      articles_short: Items
-    others: 
-      articles_short: Pages
 
   # These are strings that are not specific to education/classroom contexts
   courses_generic:
@@ -790,6 +803,7 @@ en:
     search_courses: Search programs
     start: Activity tracking start
     student_editors: Editors
+    student: Editor
     students: Editors
     students_taught: Total Editors
     students_none: This project has no editors enrolled.
@@ -803,10 +817,6 @@ en:
     view_page: View Program Page
     word_count_doc: An estimate of the number of words added to mainspace articles by the program's editors during the program term
     yourcourses: Your Programs
-    wikidata: 
-      articles_short: Items
-    others: 
-      articles_short: Pages
 
   editable:
     edit: Edit
@@ -816,6 +826,21 @@ en:
     edit_details: Edit Details
     edit_template: Edit Template
     rename_confirmation: The course fields that form the URL have changed. This will change the URL and break any incoming links. Are you sure you want to do this?
+
+  instructor_view:
+    article_assignments: "%{prefix} Assignments"
+    assignments_table:
+      article_name: Article Name
+      current_stage: Current Stage
+      relevant_links: Relevant Links
+    assigned_articles: Assigned Articles
+    exercises_and_trainings: "%{prefix} Exercises & Trainings"
+    no_assignments: "This student currently has no assigned articles. You can assign an article by using the buttons above."
+    overview: "%{prefix} Overview"
+    reviewing_articles: Reviewing Articles
+    select_student:
+      title: "Select %{prefix}"
+      content: to assign and view article assignments
 
   metrics:
     label: Course Activity
@@ -1086,6 +1111,9 @@ en:
     enroll_confirmation: Are you sure you want to add %{username}?
     enroll_url: 'Users may join by visiting this URL:'
     enrolled_success: '%{username} was added successfully!'
+    exercise_modules_completed:
+      one: "%{completed_count}/%{count} exercise completed"
+      other: "%{completed_count}/%{count} exercises completed"
     first_name: First name
     last_name: Last name
     loading: Loading users...
@@ -1112,6 +1140,11 @@ en:
     reviewers: Reviewer(s)
     reviewing: Reviewing
     sandboxes: sandboxes
+    sub_navigation:
+      article_assignments: Article Assignments
+      editor_overview: Editor Overview
+      exercises_and_trainings: Exercises & Trainings
+      student_overview: Student Overview
     total_uploads: "Total Uploads"
     training_complete:
       one: "is up-to-date with training"


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This displays different labels on course navbar based on home wiki data. 
This solves the issue #3596 

## Screenshots
Before:
![Screenshot from 2020-02-21 01-53-49](https://user-images.githubusercontent.com/43990819/74975447-10d79400-544d-11ea-951c-3fafd4c98acf.png)


After:
![3596_after](https://user-images.githubusercontent.com/43990819/74975473-1a60fc00-544d-11ea-8437-2638fa961e0e.gif)


## Open questions and concerns
Have created a prefix scheme to display different labels based on home wiki data further, I'll fix the labels in sub-navigation displaying articles Available/ Assigned and Edited in upcoming PRs. 
