### PR TITLE
Fixes prefix missing from Article Assignments for i18n

### DIFF
--- a/app/assets/javascripts/components/students/containers/StudentsTabHandler.jsx
+++ b/app/assets/javascripts/components/students/containers/StudentsTabHandler.jsx
@@ -76,7 +76,7 @@ const StudentsHandler = createReactClass({
               '/courses/:course_school/:course_title/students/articles/:username'
             ]}
             render={() => {
-              return <Articles {...this.props} />;
+              return <Articles {...props} />;
             }}
           />
           <Route


### PR DESCRIPTION
This should solve the bug that's currently cropping up with a value missing from `i18n`.