### PR TITLE
Fixed -Log in with Wikipedia- text alignment.

### DIFF
--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -110,15 +110,14 @@ nav.top-nav
     margin-bottom: -1px;
     display: inline-block;
     font-size 16px
-    vertical-align middle
+    vertical-align top
 
   .expand
-    overflow hidden
     display inline-block
     width 0
     transition all 250ms ease-in-out
     opacity 0
-    vertical-align middle
+    vertical-align top
     white-space nowrap
     text-align left
 

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -118,7 +118,7 @@ nav.top-nav
     width 0
     transition all 250ms ease-in-out
     opacity 0
-    vertical-align top
+    vertical-align middle
     white-space nowrap
     text-align left
 

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -113,6 +113,7 @@ nav.top-nav
     vertical-align top
 
   .expand
+    overflow hidden
     display inline-block
     width 0
     transition all 250ms ease-in-out

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -117,7 +117,7 @@ nav.top-nav
     width 0
     transition all 250ms ease-in-out
     opacity 0
-    vertical-align top
+    vertical-align inherit
     white-space nowrap
     text-align left
 
@@ -127,6 +127,7 @@ nav.top-nav
   li > a
     color $text
     border-bottom 0
+    vertical-align top
     +below(desktop)
       margin-left 0
 


### PR DESCRIPTION

## What this PR does
Align the 'Log in with Wikipedia' text correctly. Fixes #3807 

## Screenshots
Before:
![Screenshot from 2020-02-28 00-50-45](https://user-images.githubusercontent.com/37243661/75485392-a2588000-59d0-11ea-966a-1d3b3d7c2e7c.png)


After:
![Screenshot from 2020-02-28 02-16-11](https://user-images.githubusercontent.com/37243661/75485416-abe1e800-59d0-11ea-81d4-70702516685d.png)

