### PR TITLE
Requested account creation status display.#3822

### DIFF
--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -36,13 +36,13 @@ class RequestedAccountsCampaignsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    if result[:success]
-      # If it was successful, enroll the user in the course
-      user = creation_attempt.user
-      JoinCourse.new(course: requested_account.course, user: user,
-                     role: CoursesUsers::Roles::STUDENT_ROLE)
-    end
-    return result
+    return result unless result[:success]
+    # If it was successful, enroll the user in the course
+    user = creation_attempt.user
+    JoinCourse.new(course: requested_account.course,
+                   user: user,
+                   role: CoursesUsers::Roles::STUDENT_ROLE)
+    result
   end
 
   def check_creation_permissions

--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -37,8 +37,8 @@ class RequestedAccountsCampaignsController < ApplicationController
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
     if result[:failure]
-      result[:failure] = result[:failure].sub("response: {}", "")
-      result[:failure] = result[:failure].sub("https://en.wikipedia.org", "")
+      result[:failure] = result[:failure].sub('response: {}', '')
+      result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
       return result
     elsif result[:success]
       # If it was successful, enroll the user in the course

--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -37,8 +37,7 @@ class RequestedAccountsCampaignsController < ApplicationController
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
     if result[:failure]
-      result[:failure] = result[:failure].sub('response: {}', '')
-      result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
+      result = CreateRequestedAccount.format_failure_requested_account_result(result)
       return result
     elsif result[:success]
       # If it was successful, enroll the user in the course

--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -36,7 +36,6 @@ class RequestedAccountsCampaignsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    result[:result_description] = creation_attempt.result_description(result)
     if result[:success]
       # If it was successful, enroll the user in the course
       user = creation_attempt.user

--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -36,16 +36,14 @@ class RequestedAccountsCampaignsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    if result[:failure]
-      result = CreateRequestedAccount.format_failure_requested_account_result(result)
-      return result
-    elsif result[:success]
+    result[:result_description] = creation_attempt.result_description(result)
+    if result[:success]
       # If it was successful, enroll the user in the course
       user = creation_attempt.user
       JoinCourse.new(course: requested_account.course, user: user,
                      role: CoursesUsers::Roles::STUDENT_ROLE)
-      return result
     end
+    return result
   end
 
   def check_creation_permissions

--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -36,12 +36,17 @@ class RequestedAccountsCampaignsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    return result unless result[:success]
-    # If it was successful, enroll the user in the course
-    user = creation_attempt.user
-    JoinCourse.new(course: requested_account.course, user: user,
-                   role: CoursesUsers::Roles::STUDENT_ROLE)
-    result
+    if result[:failure]
+      result[:failure] = result[:failure].sub("response: {}", "")
+      result[:failure] = result[:failure].sub("https://en.wikipedia.org", "")
+      return result
+    elsif result[:success]
+      # If it was successful, enroll the user in the course
+      user = creation_attempt.user
+      JoinCourse.new(course: requested_account.course, user: user,
+                     role: CoursesUsers::Roles::STUDENT_ROLE)
+      return result
+    end
   end
 
   def check_creation_permissions

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -89,16 +89,14 @@ class RequestedAccountsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    if result[:failure]
-      result = CreateRequestedAccount.format_failure_requested_account_result(result)
-      return result
-    elsif result[:success]
+    result[:result_description] = creation_attempt.result_description(result)
+    if result[:success]
       # If it was successful, enroll the user in the course
       user = creation_attempt.user
       JoinCourse.new(course: requested_account.course, user: user,
                      role: CoursesUsers::Roles::STUDENT_ROLE)
-      return result
     end
+    return result
   end
 
   def check_creation_permissions

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -89,7 +89,6 @@ class RequestedAccountsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    result[:result_description] = creation_attempt.result_description(result)
     if result[:success]
       # If it was successful, enroll the user in the course
       user = creation_attempt.user

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -90,8 +90,7 @@ class RequestedAccountsController < ApplicationController
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
     if result[:failure]
-      result[:failure] = result[:failure].sub('response: {}', '')
-      result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
+      result = CreateRequestedAccount.format_failure_requested_account_result(result)
       return result
     elsif result[:success]
       # If it was successful, enroll the user in the course

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -25,7 +25,6 @@ class RequestedAccountsController < ApplicationController
       render json: { message: I18n.t('courses.new_account_submitted') }
       return
     end
-    
     result = create_account(@requested)
     if result[:success]
       render json: { message: result.values.first }
@@ -91,8 +90,8 @@ class RequestedAccountsController < ApplicationController
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
     if result[:failure]
-      result[:failure] = result[:failure].sub("response: {}", "")
-      result[:failure] = result[:failure].sub("https://en.wikipedia.org", "")
+      result[:failure] = result[:failure].sub('response: {}', '')
+      result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
       return result
     elsif result[:success]
       # If it was successful, enroll the user in the course

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -89,13 +89,13 @@ class RequestedAccountsController < ApplicationController
   def create_account(requested_account)
     creation_attempt = CreateRequestedAccount.new(requested_account, current_user)
     result = creation_attempt.result
-    if result[:success]
-      # If it was successful, enroll the user in the course
-      user = creation_attempt.user
-      JoinCourse.new(course: requested_account.course, user: user,
-                     role: CoursesUsers::Roles::STUDENT_ROLE)
-    end
-    return result
+    return result unless result[:success]
+    # If it was successful, enroll the user in the course
+    user = creation_attempt.user
+    JoinCourse.new(course: requested_account.course,
+                   user: user,
+                   role: CoursesUsers::Roles::STUDENT_ROLE)
+    result
   end
 
   def check_creation_permissions

--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -107,5 +107,11 @@ class CreateRequestedAccount
     Raven.capture_exception(e, extra: { response: @response })
   end
 
+  def self.format_failure_requested_account_result(result)
+    result[:failure] = result[:failure].sub('response: {}', '')
+    result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
+    return result
+  end
+
   class AccountCreationError < StandardError; end
 end

--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -28,14 +28,13 @@ class CreateRequestedAccount
 
   def set_result_description
     if @result[:failure]
-      @result[:result_description] = @result[:failure].sub('response: {}', '')
-                                                      .sub('https://en.wikipedia.org', '')
+      formatted_failure_message = @result[:failure].sub('response: {}', '')
+                                                   .sub('https://en.wikipedia.org', '')
       @result[:result_description] = I18n.t('users.requested_account_status.failure_message',
-                                            result_description: @result[:result_description])
+                                            result_description: formatted_failure_message)
     elsif @result[:success]
-      @result[:result_description] = @result[:success]
       @result[:result_description] = I18n.t('users.requested_account_status.success_message',
-                                            result_description: @result[:result_description])
+                                            result_description: @result[:success])
     end
   end
 

--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -62,6 +62,7 @@ class CreateRequestedAccount
                                                       'messagecode')
 
     status == 'PASS' ? create_account : handle_failed_account_creation(message, messagecode)
+    @result[:result_description] = result_description(@result)
   end
 
   def create_account

--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -26,6 +26,12 @@ class CreateRequestedAccount
     process_request(@creator, @creation_reason)
   end
 
+  def self.format_failure_requested_account_result(result)
+    result[:failure] = result[:failure].sub('response: {}', '')
+    result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
+    return result
+  end
+
   private
 
   def en_wiki
@@ -105,12 +111,6 @@ class CreateRequestedAccount
     raise AccountCreationError, 'unexpected account creation response'
   rescue AccountCreationError => e
     Raven.capture_exception(e, extra: { response: @response })
-  end
-
-  def self.format_failure_requested_account_result(result)
-    result[:failure] = result[:failure].sub('response: {}', '')
-    result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
-    return result
   end
 
   class AccountCreationError < StandardError; end

--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -26,14 +26,16 @@ class CreateRequestedAccount
     process_request(@creator, @creation_reason)
   end
 
-  def result_description(result)
-    if result[:failure]
-      result_description = result[:failure].sub('response: {}', '')
-                                           .sub('https://en.wikipedia.org', '')
-      return I18n.t('users.requested_account_status.failure') + ': ' + result_description
-    elsif result[:success]
-      result_description = result[:success]
-      return I18n.t('users.requested_account_status.success') + ': ' + result_description
+  def set_result_description
+    if @result[:failure]
+      @result[:result_description] = @result[:failure].sub('response: {}', '')
+                                                      .sub('https://en.wikipedia.org', '')
+      @result[:result_description] = I18n.t('users.requested_account_status.failure_message',
+                                            result_description: @result[:result_description])
+    elsif @result[:success]
+      @result[:result_description] = @result[:success]
+      @result[:result_description] = I18n.t('users.requested_account_status.success_message',
+                                            result_description: @result[:result_description])
     end
   end
 
@@ -62,7 +64,7 @@ class CreateRequestedAccount
                                                       'messagecode')
 
     status == 'PASS' ? create_account : handle_failed_account_creation(message, messagecode)
-    @result[:result_description] = result_description(@result)
+    set_result_description
   end
 
   def create_account

--- a/app/services/create_requested_account.rb
+++ b/app/services/create_requested_account.rb
@@ -26,10 +26,15 @@ class CreateRequestedAccount
     process_request(@creator, @creation_reason)
   end
 
-  def self.format_failure_requested_account_result(result)
-    result[:failure] = result[:failure].sub('response: {}', '')
-    result[:failure] = result[:failure].sub('https://en.wikipedia.org', '')
-    return result
+  def result_description(result)
+    if result[:failure]
+      result_description = result[:failure].sub('response: {}', '')
+                                           .sub('https://en.wikipedia.org', '')
+      return I18n.t('users.requested_account_status.failure') + ': ' + result_description
+    elsif result[:success]
+      result_description = result[:success]
+      return I18n.t('users.requested_account_status.success') + ': ' + result_description
+    end
   end
 
   private

--- a/app/views/requested_accounts/create_accounts.html.haml
+++ b/app/views/requested_accounts/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= result
+    %li= if result[:success] then 'Sucess : ' + result[:success] else 'Failure : ' + result[:failure] end
 
 .container
   %a.button{href: "/courses/#{@course.slug}"} Return to course page

--- a/app/views/requested_accounts/create_accounts.html.haml
+++ b/app/views/requested_accounts/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= if result[:success] then 'Sucess : ' + result[:success] else 'Failure : ' + result[:failure] end
+    %li= if result[:success] then I18n.t('courses.requested_account_status.success') + ': ' + result[:success] else I18n.t('courses.requested_account_status.failure') + ': ' + result[:failure] end
 
 .container
   %a.button{href: "/courses/#{@course.slug}"} Return to course page

--- a/app/views/requested_accounts/create_accounts.html.haml
+++ b/app/views/requested_accounts/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= if result[:success] then I18n.t('courses.requested_account_status.success') + ': ' + result[:success] else I18n.t('courses.requested_account_status.failure') + ': ' + result[:failure] end
+    %li= if result[:success] then I18n.t('users.requested_account_status.success') + ': ' + result[:success] else I18n.t('users.requested_account_status.failure') + ': ' + result[:failure] end
 
 .container
   %a.button{href: "/courses/#{@course.slug}"} Return to course page

--- a/app/views/requested_accounts/create_accounts.html.haml
+++ b/app/views/requested_accounts/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= if result[:success] then I18n.t('users.requested_account_status.success') + ': ' + result[:success] else I18n.t('users.requested_account_status.failure') + ': ' + result[:failure] end
+    %li= result[:result_description]
 
 .container
   %a.button{href: "/courses/#{@course.slug}"} Return to course page

--- a/app/views/requested_accounts_campaigns/create_accounts.html.haml
+++ b/app/views/requested_accounts_campaigns/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= if result[:success] then I18n.t('campaigns.requested_account_status.success') + ': ' + result[:success] else I18n.t('campaigns.requested_account_status.success') + ': ' + result[:failure] end
+    %li= if result[:success] then I18n.t('users.requested_account_status.success') + ': ' + result[:success] else I18n.t('users.requested_account_status.success') + ': ' + result[:failure] end
 
 .container
   %a.button{href: "/campaigns/#{@campaign.slug}"} Return to campaign page

--- a/app/views/requested_accounts_campaigns/create_accounts.html.haml
+++ b/app/views/requested_accounts_campaigns/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= if result[:success] then 'Sucess : ' + result[:success] else 'Failure : ' + result[:failure] end
+    %li= if result[:success] then I18n.t('campaigns.requested_account_status.success') + ': ' + result[:success] else I18n.t('campaigns.requested_account_status.success') + ': ' + result[:failure] end
 
 .container
   %a.button{href: "/campaigns/#{@campaign.slug}"} Return to campaign page

--- a/app/views/requested_accounts_campaigns/create_accounts.html.haml
+++ b/app/views/requested_accounts_campaigns/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= result
+    %li= if result[:success] then 'Sucess : ' + result[:success] else 'Failure : ' + result[:failure] end
 
 .container
   %a.button{href: "/campaigns/#{@campaign.slug}"} Return to campaign page

--- a/app/views/requested_accounts_campaigns/create_accounts.html.haml
+++ b/app/views/requested_accounts_campaigns/create_accounts.html.haml
@@ -1,7 +1,7 @@
 .container
   %h1 Results
   - @results.each do |result|
-    %li= if result[:success] then I18n.t('users.requested_account_status.success') + ': ' + result[:success] else I18n.t('users.requested_account_status.success') + ': ' + result[:failure] end
+    %li= result[:result_description]
 
 .container
   %a.button{href: "/campaigns/#{@campaign.slug}"} Return to campaign page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,9 @@ en:
       the text in this area will be copied over as a description on the program page
     random_passcode: a random passcode
     requested_accounts: Requested accounts
+    requested_account_status:
+      success: 'Success'
+      failure: 'Failure'
     title: Title
     slug: Slug
     search_campaigns: Search campaigns
@@ -626,6 +629,9 @@ en:
       one: '%{count} requested account pending.'
       other: '%{count} requested accounts pending.'
     requested_accounts_alert_view: 'View'
+    requested_account_status:
+      success: 'Success'
+      failure: 'Failure'
 
     review_timeline: >
       Now, review your assignment timeline, customizing it to fit your needs.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,9 +320,6 @@ en:
       the text in this area will be copied over as a description on the program page
     random_passcode: a random passcode
     requested_accounts: Requested accounts
-    requested_account_status:
-      success: 'Success'
-      failure: 'Failure'
     title: Title
     slug: Slug
     search_campaigns: Search campaigns
@@ -629,9 +626,6 @@ en:
       one: '%{count} requested account pending.'
       other: '%{count} requested accounts pending.'
     requested_accounts_alert_view: 'View'
-    requested_account_status:
-      success: 'Success'
-      failure: 'Failure'
 
     review_timeline: >
       Now, review your assignment timeline, customizing it to fit your needs.
@@ -1144,6 +1138,9 @@ en:
     recent_revisions: Recent Edits
     remove_confirmation: Are you sure you want to remove %{username}?
     request_confirmation: Are you sure you want to request this account?
+    requested_account_status:
+      success: 'Success'
+      failure: 'Failure'
     revision_characters_and_views: 'Chars Added: %{characters}, Views: %{views}'
     revisions_doc: The number of edits made by this editor in the past 7 days
     references_doc: The number of references added or removed by this editor

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1139,8 +1139,8 @@ en:
     remove_confirmation: Are you sure you want to remove %{username}?
     request_confirmation: Are you sure you want to request this account?
     requested_account_status:
-      success: 'Success'
-      failure: 'Failure'
+      success_message: 'Success: %{result_description}'
+      failure_message: 'Failure: %{result_description}'
     revision_characters_and_views: 'Chars Added: %{characters}, Views: %{views}'
     revisions_doc: The number of edits made by this editor in the past 7 days
     references_doc: The number of references added or removed by this editor

--- a/spec/services/create_requested_account_spec.rb
+++ b/spec/services/create_requested_account_spec.rb
@@ -34,6 +34,7 @@ describe CreateRequestedAccount do
     stub_account_creation(wiki: home_wiki)
     allow(UserImporter).to receive(:new_from_username).and_return(user)
     expect(subject.result[:success]).not_to be_nil
+    expect(subject.result[:result_description]).not_to be_nil
     expect(user.username).to eq('Ragesock')
     expect(RequestedAccount.count).to eq(0)
   end
@@ -41,6 +42,7 @@ describe CreateRequestedAccount do
   it 'destroys the requested account if the username already exist' do
     stub_account_creation_failure_userexists(wiki: home_wiki)
     expect(subject.result[:failure]).not_to be_nil
+    expect(subject.result[:result_description]).not_to be_nil
     expect(RequestedAccount.count).to eq(0)
   end
 
@@ -48,6 +50,7 @@ describe CreateRequestedAccount do
     expect(Raven).to receive(:capture_exception)
     stub_account_creation_failure_unexpected(wiki: home_wiki)
     expect(subject.result[:failure]).not_to be_nil
+    expect(subject.result[:result_description]).not_to be_nil
     expect(RequestedAccount.count).to eq(1)
   end
 

--- a/spec/services/create_requested_account_spec.rb
+++ b/spec/services/create_requested_account_spec.rb
@@ -34,7 +34,9 @@ describe CreateRequestedAccount do
     stub_account_creation(wiki: home_wiki)
     allow(UserImporter).to receive(:new_from_username).and_return(user)
     expect(subject.result[:success]).not_to be_nil
-    expect(subject.result[:result_description]).not_to be_nil
+    expect(subject.result[:result_description])
+      .to include(I18n.t('users.requested_account_status.success_message',
+                         result_description: ''))
     expect(user.username).to eq('Ragesock')
     expect(RequestedAccount.count).to eq(0)
   end
@@ -42,7 +44,9 @@ describe CreateRequestedAccount do
   it 'destroys the requested account if the username already exist' do
     stub_account_creation_failure_userexists(wiki: home_wiki)
     expect(subject.result[:failure]).not_to be_nil
-    expect(subject.result[:result_description]).not_to be_nil
+    expect(subject.result[:result_description])
+      .to include(I18n.t('users.requested_account_status.failure_message',
+                         result_description: ''))
     expect(RequestedAccount.count).to eq(0)
   end
 
@@ -50,7 +54,9 @@ describe CreateRequestedAccount do
     expect(Raven).to receive(:capture_exception)
     stub_account_creation_failure_unexpected(wiki: home_wiki)
     expect(subject.result[:failure]).not_to be_nil
-    expect(subject.result[:result_description]).not_to be_nil
+    expect(subject.result[:result_description])
+      .to include(I18n.t('users.requested_account_status.failure_message',
+                         result_description: ''))
     expect(RequestedAccount.count).to eq(1)
   end
 


### PR DESCRIPTION
## What this PR does
Solves #3822 . Displayes the status of requested accounts creation properly instead of unprocessed JSON Ruby Hash earlier.

## Screenshots
Before:
![Screenshot from 2020-02-28 21-26-37](https://user-images.githubusercontent.com/37243661/75572116-83b1c200-5a80-11ea-8b00-0ac42cd66ec8.png)


After:
![Screenshot from 2020-02-29 01-23-47](https://user-images.githubusercontent.com/37243661/75582771-50782e80-5a92-11ea-878f-77ccd18d3849.png)
