### PR TITLE
Verify training modules usage enhancement#3500

### DIFF
--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -13,7 +13,9 @@ export const TrainingModuleRows = ({ trainingModules }) => {
     if (trainingModule.completion_date) {
       moduleStatus = (
         <span className="completed">
-          Completed at {moment(trainingModule.completion_date).format('YYYY-MM-DD   h:mm A')}
+          {I18n.t('training_status.completed_at')}: {moment(trainingModule.completion_date).format('YYYY-MM-DD   h:mm A')}
+          <br/>
+          {I18n.t('training_status.completion_time')}: {moment.utc(trainingModule.completion_time * 1000).format('HH:mm:ss')}
         </span>
       );
     } else {

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -11,17 +11,15 @@ export const TrainingModuleRows = ({ trainingModules }) => {
   return trainings.map((trainingModule) => {
     let moduleStatus;
     if (trainingModule.completion_date) {
-      let completionTime;
+      let completionTime = '';
       if (trainingModule.completion_time <= 60 * 60) {
-        completionTime = moment.utc(trainingModule.completion_time * 1000).format('HH:mm:ss');
-      } else {
-        completionTime = I18n.t('training_status.sufficient_time_allocation');
+        completionTime = `${I18n.t('training_status.completion_time')}: ${moment.utc(trainingModule.completion_time * 1000).format('HH:mm:ss')}`;
       }
       moduleStatus = (
         <span className="completed">
           {I18n.t('training_status.completed_at')}: {moment(trainingModule.completion_date).format('YYYY-MM-DD   h:mm A')}
           <br/>
-          {I18n.t('training_status.completion_time')}: {completionTime}
+          {completionTime}
         </span>
       );
     } else {

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -11,11 +11,17 @@ export const TrainingModuleRows = ({ trainingModules }) => {
   return trainings.map((trainingModule) => {
     let moduleStatus;
     if (trainingModule.completion_date) {
+      let completionTime;
+      if (trainingModule.completion_time <= 60 * 60) {
+        completionTime = moment.utc(trainingModule.completion_time * 1000).format('HH:mm:ss');
+      } else {
+        completionTime = I18n.t('training_status.sufficient_time_allocation');
+      }
       moduleStatus = (
         <span className="completed">
           {I18n.t('training_status.completed_at')}: {moment(trainingModule.completion_date).format('YYYY-MM-DD   h:mm A')}
           <br/>
-          {I18n.t('training_status.completion_time')}: {moment.utc(trainingModule.completion_time * 1000).format('HH:mm:ss')}
+          {I18n.t('training_status.completion_time')}: {completionTime}
         </span>
       );
     } else {

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -13,7 +13,7 @@ export const TrainingModuleRows = ({ trainingModules }) => {
     if (trainingModule.completion_date) {
       let completionTime = '';
       if (trainingModule.completion_time <= 60 * 60) {
-        completionTime = `${I18n.t('training_status.completion_time')}: ${moment.utc(trainingModule.completion_time * 1000).format('HH:mm:ss')}`;
+        completionTime = `${I18n.t('training_status.completion_time')}: ${moment.utc(trainingModule.completion_time * 1000).format(`mm [${I18n.t('users.training_module_time.minutes')}] ss [${I18n.t('users.training_module_time.seconds')}]`)}`;
       }
       moduleStatus = (
         <span className="completed">

--- a/app/views/training_status/show.json.jbuilder
+++ b/app/views/training_status/show.json.jbuilder
@@ -2,13 +2,13 @@
 
 json.course do
   json.training_modules @assigned_training_modules do |training_module|
-    tp_manager = TrainingProgressManager.new(@user, training_module)
+    training_progress_manager = TrainingProgressManager.new(@user, training_module)
 
     json.id training_module.id
     json.module_name training_module.name
     json.kind training_module.kind
-    json.status tp_manager.status
-    json.completion_date tp_manager.completion_date
-    json.completion_time tp_manager.completion_time
+    json.status training_progress_manager.status
+    json.completion_date training_progress_manager.completion_date
+    json.completion_time training_progress_manager.completion_time
   end
 end

--- a/app/views/training_status/show.json.jbuilder
+++ b/app/views/training_status/show.json.jbuilder
@@ -2,12 +2,14 @@
 
 json.course do
   json.training_modules @assigned_training_modules do |training_module|
-    training_progress_manager = TrainingProgressManager.new(@user, training_module)
+    tp_manager = TrainingProgressManager.new(@user, training_module)
 
     json.id training_module.id
     json.module_name training_module.name
     json.kind training_module.kind
-    json.status training_progress_manager.status
-    json.completion_date training_progress_manager.completion_date
+    json.status tp_manager.status
+    json.completion_date tp_manager.completion_date
+    tmu = TrainingModulesUsers.find_by(user_id: @user.id, training_module_id: training_module.id)
+    json.completion_time tmu.completed_at - tmu.created_at if tp_manager.completion_date
   end
 end

--- a/app/views/training_status/show.json.jbuilder
+++ b/app/views/training_status/show.json.jbuilder
@@ -9,7 +9,6 @@ json.course do
     json.kind training_module.kind
     json.status tp_manager.status
     json.completion_date tp_manager.completion_date
-    tmu = TrainingModulesUsers.find_by(user_id: @user.id, training_module_id: training_module.id)
-    json.completion_time tmu.completed_at - tmu.created_at if tp_manager.completion_date
+    json.completion_time tp_manager.completion_time
   end
 end

--- a/app/views/training_status/user.json.jbuilder
+++ b/app/views/training_status/user.json.jbuilder
@@ -10,7 +10,7 @@ json.user do
       tp_manager = TrainingProgressManager.new(@user, training_module, training_module_user: tmu)
       json.status tp_manager.status
       json.completion_date tp_manager.completion_date
-      json.completion_time tmu.completed_at - tmu.created_at if tp_manager.completion_date
+      json.completion_time tp_manager.completion_time
     end
   end
 end

--- a/app/views/training_status/user.json.jbuilder
+++ b/app/views/training_status/user.json.jbuilder
@@ -10,6 +10,7 @@ json.user do
       tp_manager = TrainingProgressManager.new(@user, training_module, training_module_user: tmu)
       json.status tp_manager.status
       json.completion_date tp_manager.completion_date
+      json.completion_time tmu.completed_at - tmu.created_at if tp_manager.completion_date
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1172,6 +1172,9 @@ en:
       other: "%{completed_count}/%{count} training modules completed"
     training_module_name: Training module
     training_module_status: Status
+    training_module_time:
+      minutes: Min
+      seconds: Sec
     user_training_status: Training Status
     user_no_training_status: This user has not completed any training modules.
     up_to_date_with_training: 'up-to-date with training'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1366,6 +1366,7 @@ en:
     continue: "Continue"
     completed_at: "Completed at"
     completion_time: "Completion time"
+    sufficient_time_allocation: "Sufficient time allocated"
     view: "View"
     started: "Started"
     not_started: "Not started"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1364,6 +1364,8 @@ en:
   training_status:
     completed: "Completed"
     continue: "Continue"
+    completed_at: "Completed at"
+    completion_time: "Completion time"
     view: "View"
     started: "Started"
     not_started: "Not started"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1366,7 +1366,6 @@ en:
     continue: "Continue"
     completed_at: "Completed at"
     completion_time: "Completion time"
-    sufficient_time_allocation: "Sufficient time allocated"
     view: "View"
     started: "Started"
     not_started: "Not started"

--- a/lib/training_progress_manager.rb
+++ b/lib/training_progress_manager.rb
@@ -75,7 +75,8 @@ class TrainingProgressManager
   end
 
   def completion_time
-    return @tmu.completed_at - @tmu.created_at if completion_date
+    return unless module_completed?
+    @tmu.completed_at - @tmu.created_at
   end
 
   private

--- a/lib/training_progress_manager.rb
+++ b/lib/training_progress_manager.rb
@@ -74,6 +74,10 @@ class TrainingProgressManager
     module_completed? ? I18n.t('training_status.completed') : completing
   end
 
+  def completion_time
+    return @tmu.completed_at - @tmu.created_at if completion_date
+  end
+
   private
 
   def last_completed_slide_slug


### PR DESCRIPTION
## What this PR does
Fixes #3500. Adds time fields to relevant data json fields which are rendered in the training module status of the user.

## Screenshots
Before:
![Screenshot from 2020-03-25 00-59-11](https://user-images.githubusercontent.com/37243661/77468676-ed30b080-6e33-11ea-8700-ef45a6702ee7.png)
![Screenshot from 2020-03-01 03-08-56](https://user-images.githubusercontent.com/37243661/75615520-aae4be00-5b6a-11ea-882a-82476a5a5b7d.png)
![Screenshot from 2020-03-01 03-09-13](https://user-images.githubusercontent.com/37243661/75615522-addfae80-5b6a-11ea-9dae-726ebe25f480.png)


After:
![Screenshot from 2020-03-25 00-57-59](https://user-images.githubusercontent.com/37243661/77468569-c2465c80-6e33-11ea-85de-cd14209369c0.png)
![Screenshot from 2020-03-03 02-20-30](https://user-images.githubusercontent.com/37243661/75716643-a0a2fb00-5cf5-11ea-926c-952ebe9e26e6.png)
![Screenshot from 2020-03-03 02-20-32](https://user-images.githubusercontent.com/37243661/75716654-a6004580-5cf5-11ea-9750-0455d8cf7b83.png)

## Note

Continuation of #3828 . Some bad rebasing occurred in 3828 branch, new branch with required changes created.
