### PR TITLE
setup script: add 'elementary' to be recognized as debian

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ def osx_setup():
                    shell=True, check=True)
 
 if platform.platform().lower().find('ubuntu') != -1 \
-        or platform.platform().lower().find('debian') != -1:
+        or platform.platform().lower().find('debian') != -1 \
+        or platform.platform().lower().find('elementary') != -1:
     deb_setup()
 elif platform.platform().lower().find('fedora') != -1:
     dnf_setup()


### PR DESCRIPTION
## What this PR does
[Elementary OS](https://elementary.io/) is debian based, but it seems to not self identify (?) as such in the string returned from `platform.platform()`

This PR resolves the issue by adding 'elementary' to the platforms recognized as debian.  

![Screenshot from 2020-03-11 14-20-32@2x](https://user-images.githubusercontent.com/30638175/76450141-b4102f00-63a3-11ea-96a9-59b82707a7d5.png)

