### PR TITLE
Counting only those revisions (course revision count) tracked by course.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -265,7 +265,7 @@ class Course < ApplicationRecord
 
   def tracked_revisions
     revisions.where.not(article_id: articles_courses.not_tracked.pluck(:article_id))
-             .where('revisions.wiki_id in (?)', wiki_ids)
+             .where(wiki_id: wiki_ids)
   end
 
   def tracked_articles

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -265,6 +265,7 @@ class Course < ApplicationRecord
 
   def tracked_revisions
     revisions.where.not(article_id: articles_courses.not_tracked.pluck(:article_id))
+             .where('revisions.wiki_id in (?)', wiki_ids)
   end
 
   def tracked_articles

--- a/lib/course_cache_manager.rb
+++ b/lib/course_cache_manager.rb
@@ -67,9 +67,7 @@ class CourseCacheManager
   end
 
   def update_revision_count
-    @course.revision_count = @course.tracked_revisions
-                                    .where('revisions.wiki_id in (?)', @course.wiki_ids)
-                                    .live.size
+    @course.revision_count = @course.tracked_revisions.live.size
   end
 
   def update_recent_revision_count

--- a/lib/course_cache_manager.rb
+++ b/lib/course_cache_manager.rb
@@ -67,7 +67,9 @@ class CourseCacheManager
   end
 
   def update_revision_count
-    @course.revision_count = @course.tracked_revisions.live.size
+    @course.revision_count = @course.tracked_revisions
+                                    .where('revisions.wiki_id in (?)', @course.wiki_ids)
+                                    .live.size
   end
 
   def update_recent_revision_count

--- a/spec/models/tracked_revisions_spec.rb
+++ b/spec/models/tracked_revisions_spec.rb
@@ -5,22 +5,34 @@ require_dependency "#{Rails.root}/lib/analytics/course_statistics.rb"
 
 describe 'Course#tracked_revisions' do
   let(:course) { create(:course, start: '10-07-2019'.to_date, end: '10-08-2019'.to_date) }
+  let(:different_wiki_course) do
+    create(:course,
+           title: 'Science',
+           school: 'WinterSchool',
+           term: 'Winter 2019',
+           slug: 'WinterSchool/Science_(Winter_2019)',
+           start: '10-07-2019'.to_date, end: '10-08-2019'.to_date,
+           home_wiki_id: 3)
+  end
   let(:user) { create(:user, username: 'Hbultra') }
 
   before do
     course.students << user
+    different_wiki_course.students << user
   end
 
   it 'fetches the course stats for only tracked articles' do
     # Fetch the original data
     VCR.use_cassette 'course_upload_importer/Hbultra' do
       UpdateCourseStats.new(course)
+      UpdateCourseStats.new(different_wiki_course)
     end
 
     # Check if the data is cached
     old_character_sum = course.character_sum
     old_course = course.dup
     expect(course.revision_count).to eq(old_course.revision_count)
+    expect(different_wiki_course.revision_count).to eq(0)
     expect(course.view_sum).to eq(old_course.view_sum)
     expect(course.references_count).to eq(old_course.references_count)
     expect(course.article_count).to eq(old_course.article_count)


### PR DESCRIPTION
## What this PR does
Fixes #3647 

## Screenshots
### Before:
![Screenshot from 2020-03-16 14-39-02](https://user-images.githubusercontent.com/37243661/76740821-7e4cbb00-6794-11ea-84e9-f33b4b626970.png)
![Screenshot from 2020-03-16 14-39-22](https://user-images.githubusercontent.com/37243661/76740843-84db3280-6794-11ea-9a69-fba7b05304e6.png)
![Screenshot from 2020-03-16 14-39-42](https://user-images.githubusercontent.com/37243661/76740854-89075000-6794-11ea-85cf-2c227796240e.png)


### After:
![Screenshot from 2020-03-16 14-27-44](https://user-images.githubusercontent.com/37243661/76740883-9290b800-6794-11ea-9b3f-547017db6e2a.png)
![Screenshot from 2020-03-16 14-26-53](https://user-images.githubusercontent.com/37243661/76740896-97ee0280-6794-11ea-9d3b-9b342d9e59cd.png)
![Screenshot from 2020-03-16 14-27-17](https://user-images.githubusercontent.com/37243661/76740906-9b818980-6794-11ea-9ab9-68c9b9fef48b.png)

## Open questions and concerns
@ragesoss Do I be have to make the same changes to the revision count of Course + User join model at app/models/course_data/courses_users.rb:109 or leave it as it is?
