### PR TITLE
Switch to 'Words Added' for Students and Articles

### DIFF
--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -60,6 +60,14 @@ const Article = createReactClass({
       );
     }
 
+    let contentAdded;
+    if (this.props.course.home_wiki_bytes_per_word) {
+      const wordsAdded = Math.round(this.props.article.character_sum / this.props.course.home_wiki_bytes_per_word);
+      contentAdded = <td className="desktop-only-tc">{wordsAdded}</td>;
+    } else {
+      contentAdded = <td className="desktop-only-tc">{this.props.article.character_sum}</td>;
+    }
+
     const { project, title } = this.props.article;
     let { language } = this.props.article;
     if (project === 'wikidata') language = 'www';
@@ -84,7 +92,7 @@ const Article = createReactClass({
             </small>
           </div>
         </td>
-        <td className="desktop-only-tc">{this.props.article.character_sum}</td>
+        {contentAdded}
         <td className="desktop-only-tc">{this.props.article.references_count || ''}</td>
         <td className="desktop-only-tc">
           <a href={pageviewUrl} target="_blank" className="inline">{this.props.article.view_count}</a>

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -60,6 +60,21 @@ const ArticleList = createReactClass({
     return this.props.sortArticles(e.target.value);
   },
 
+  contentAddedKey() {
+    if (this.props.course.home_wiki_bytes_per_word) {
+      return {
+        label: I18n.t('metrics.word_count'),
+        desktop_only: true,
+        info_key: `${this.props.course.string_prefix}.word_count_doc`
+      };
+    }
+    return {
+      label: I18n.t('metrics.char_added'),
+      desktop_only: true,
+      info_key: 'articles.character_doc'
+    };
+  },
+
   render() {
     const keys = {
       rating_num: {
@@ -71,11 +86,7 @@ const ArticleList = createReactClass({
         label: I18n.t('articles.title'),
         desktop_only: false
       },
-      character_sum: {
-        label: I18n.t('metrics.char_added'),
-        desktop_only: true,
-        info_key: 'articles.character_doc'
-      },
+      character_sum: this.contentAddedKey(),
       references_count: {
         label: I18n.t('metrics.references_count'),
         desktop_only: true,

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -8,6 +8,7 @@ import * as ArticleActions from '../../actions/article_actions';
 import List from '../common/list.jsx';
 import Article from './article.jsx';
 import CourseOresPlot from './course_ores_plot.jsx';
+import articleListKeys from './article_list_keys';
 import CourseUtils from '../../utils/course_utils.js';
 
 const ArticleList = createReactClass({
@@ -60,49 +61,8 @@ const ArticleList = createReactClass({
     return this.props.sortArticles(e.target.value);
   },
 
-  contentAddedKey() {
-    if (this.props.course.home_wiki_bytes_per_word) {
-      return {
-        label: I18n.t('metrics.word_count'),
-        desktop_only: true,
-        info_key: `${this.props.course.string_prefix}.word_count_doc`
-      };
-    }
-    return {
-      label: I18n.t('metrics.char_added'),
-      desktop_only: true,
-      info_key: 'articles.character_doc'
-    };
-  },
-
   render() {
-    const keys = {
-      rating_num: {
-        label: I18n.t('articles.rating'),
-        desktop_only: true,
-        info_key: 'articles.rating_doc'
-      },
-      title: {
-        label: I18n.t('articles.title'),
-        desktop_only: false
-      },
-      character_sum: this.contentAddedKey(),
-      references_count: {
-        label: I18n.t('metrics.references_count'),
-        desktop_only: true,
-        info_key: 'metrics.references_doc'
-      },
-      view_count: {
-        label: I18n.t('metrics.view'),
-        desktop_only: true,
-        info_key: 'articles.view_doc'
-      },
-      tools: {
-        label: I18n.t('articles.tools'),
-        desktop_only: false,
-        sortable: false
-      },
-    };
+    const keys = articleListKeys(this.props.course);
 
     const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
 

--- a/app/assets/javascripts/components/articles/article_list_keys.js
+++ b/app/assets/javascripts/components/articles/article_list_keys.js
@@ -1,0 +1,46 @@
+const contentAddedKey = (course) => {
+  if (course.home_wiki_bytes_per_word) {
+    return {
+      label: I18n.t('metrics.word_count'),
+      desktop_only: true,
+      info_key: `${course.string_prefix}.word_count_doc`
+    };
+  }
+  return {
+    label: I18n.t('metrics.char_added'),
+    desktop_only: true,
+    info_key: 'articles.character_doc'
+  };
+};
+
+const articleListKeys = (course) => {
+  return {
+    rating_num: {
+      label: I18n.t('articles.rating'),
+      desktop_only: true,
+      info_key: 'articles.rating_doc'
+    },
+    title: {
+      label: I18n.t('articles.title'),
+      desktop_only: false
+    },
+    character_sum: contentAddedKey(course),
+    references_count: {
+      label: I18n.t('metrics.references_count'),
+      desktop_only: true,
+      info_key: 'metrics.references_doc'
+    },
+    view_count: {
+      label: I18n.t('metrics.view'),
+      desktop_only: true,
+      info_key: 'articles.view_doc'
+    },
+    tools: {
+      label: I18n.t('articles.tools'),
+      desktop_only: false,
+      sortable: false
+    },
+  };
+};
+
+export default articleListKeys;

--- a/app/assets/javascripts/components/students/shared/StudentList/Student/ContentAdded.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/ContentAdded.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { bytesToWords } from '~/app/assets/javascripts/utils/wordcount_utils';
+
+const ContentAdded = ({ student, course }) => {
+  if (course.home_wiki_bytes_per_word) {
+    const mainspaceWords = bytesToWords(student.character_sum_ms, course.home_wiki_bytes_per_word);
+    const userspaceWords = bytesToWords(student.character_sum_us, course.home_wiki_bytes_per_word);
+    const draftWords = bytesToWords(student.character_sum_draft, course.home_wiki_bytes_per_word);
+    return (
+      <td className="desktop-only-tc">
+        {mainspaceWords} | {userspaceWords} | {draftWords}
+      </td>
+    );
+  }
+  return (
+    <td className="desktop-only-tc">
+      {student.character_sum_ms} | {student.character_sum_us} | {student.character_sum_draft}
+    </td>
+  );
+};
+
+export default ContentAdded;

--- a/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
@@ -131,6 +131,24 @@ const Student = createReactClass({
       );
     }
 
+    let contentAdded;
+    if (course.home_wiki_bytes_per_word) {
+      const mainspaceWords = Math.round(student.character_sum_ms / course.home_wiki_bytes_per_word);
+      const userspaceWords = Math.round(student.character_sum_us / course.home_wiki_bytes_per_word);
+      const draftWords = Math.round(student.character_sum_draft / course.home_wiki_bytes_per_word);
+      contentAdded = (
+        <td className="desktop-only-tc">
+          {mainspaceWords} | {userspaceWords} | {draftWords}
+        </td>
+      );
+    } else {
+      contentAdded = (
+        <td className="desktop-only-tc">
+          {student.character_sum_ms} | {student.character_sum_us} | {student.character_sum_draft}
+        </td>
+      );
+    }
+
     const uploadsLink = `/courses/${course.slug}/uploads`;
 
     return (
@@ -163,9 +181,7 @@ const Student = createReactClass({
           {reviewButton}
         </td>
         {recentRevisions}
-        <td className="desktop-only-tc">
-          {student.character_sum_ms} | {student.character_sum_us} | {student.character_sum_draft}
-        </td>
+        {contentAdded}
         <td className="desktop-only-tc">
           {student.references_count}
         </td>

--- a/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
@@ -9,6 +9,7 @@ import { fetchUserRevisions } from '~/app/assets/javascripts/actions/user_revisi
 import { fetchTrainingStatus } from '~/app/assets/javascripts/actions/training_status_actions';
 import { groupByAssignmentType } from '@components/util/helpers';
 import { trunc } from '~/app/assets/javascripts/utils/strings';
+import ContentAdded from './ContentAdded';
 
 // Actions
 import {
@@ -131,24 +132,6 @@ const Student = createReactClass({
       );
     }
 
-    let contentAdded;
-    if (course.home_wiki_bytes_per_word) {
-      const mainspaceWords = Math.round(student.character_sum_ms / course.home_wiki_bytes_per_word);
-      const userspaceWords = Math.round(student.character_sum_us / course.home_wiki_bytes_per_word);
-      const draftWords = Math.round(student.character_sum_draft / course.home_wiki_bytes_per_word);
-      contentAdded = (
-        <td className="desktop-only-tc">
-          {mainspaceWords} | {userspaceWords} | {draftWords}
-        </td>
-      );
-    } else {
-      contentAdded = (
-        <td className="desktop-only-tc">
-          {student.character_sum_ms} | {student.character_sum_us} | {student.character_sum_draft}
-        </td>
-      );
-    }
-
     const uploadsLink = `/courses/${course.slug}/uploads`;
 
     return (
@@ -181,7 +164,7 @@ const Student = createReactClass({
           {reviewButton}
         </td>
         {recentRevisions}
-        {contentAdded}
+        <ContentAdded course={course} student={student} />
         <td className="desktop-only-tc">
           {student.references_count}
         </td>

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentList.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentList.jsx
@@ -21,6 +21,21 @@ const showRecent = (course) => {
   return moment.utc(lastUpdate.end_time).add(7, 'days').isAfter(moment());
 };
 
+const charactersAddedKey = {
+  label: I18n.t('users.chars_added'),
+  desktop_only: true,
+  sortable: true,
+  info_key: 'users.character_doc'
+};
+
+const wordsAddedKey = {
+  label: I18n.t('users.words_added'),
+  desktop_only: true,
+  sortable: true,
+  info_key: 'users.character_doc'
+};
+
+
 export const StudentList = (props) => {
   const {
     assignments, course, current_user, editAssignments, exerciseView, openKey, sort, students,
@@ -56,6 +71,8 @@ export const StudentList = (props) => {
   ));
 
   const elements = _.flatten(_.zip(rows, drawers));
+
+  const contentAddedKey = course.home_wiki_bytes_per_word ? wordsAddedKey : charactersAddedKey;
   const keys = {
     username: {
       label: I18n.t('users.name'),
@@ -78,12 +95,7 @@ export const StudentList = (props) => {
       sortable: true,
       info_key: 'users.revisions_doc'
     },
-    character_sum_ms: {
-      label: I18n.t('users.chars_added'),
-      desktop_only: true,
-      sortable: true,
-      info_key: 'users.character_doc'
-    },
+    character_sum_ms: contentAddedKey,
     references_count: {
       label: I18n.t('users.references_count'),
       desktop_only: true,

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentList.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentList.jsx
@@ -10,6 +10,7 @@ import StudentDrawer from './StudentDrawer/StudentDrawer';
 
 // Libraries
 import CourseUtils from '~/app/assets/javascripts/utils/course_utils.js';
+import studentListKeys from './student_list_keys';
 
 // Helper Functions
 const showRecent = (course) => {
@@ -20,21 +21,6 @@ const showRecent = (course) => {
   if (!lastUpdate) return false;
   return moment.utc(lastUpdate.end_time).add(7, 'days').isAfter(moment());
 };
-
-const charactersAddedKey = {
-  label: I18n.t('users.chars_added'),
-  desktop_only: true,
-  sortable: true,
-  info_key: 'users.character_doc'
-};
-
-const wordsAddedKey = {
-  label: I18n.t('users.words_added'),
-  desktop_only: true,
-  sortable: true,
-  info_key: 'users.character_doc'
-};
-
 
 export const StudentList = (props) => {
   const {
@@ -72,44 +58,7 @@ export const StudentList = (props) => {
 
   const elements = _.flatten(_.zip(rows, drawers));
 
-  const contentAddedKey = course.home_wiki_bytes_per_word ? wordsAddedKey : charactersAddedKey;
-  const keys = {
-    username: {
-      label: I18n.t('users.name'),
-      desktop_only: false,
-      sortable: true,
-    },
-    assignment_title: {
-      label: I18n.t('users.assigned'),
-      desktop_only: true,
-      sortable: false
-    },
-    reviewing_title: {
-      label: I18n.t('users.reviewing'),
-      desktop_only: true,
-      sortable: false
-    },
-    recent_revisions: {
-      label: I18n.t('users.recent_revisions'),
-      desktop_only: true,
-      sortable: true,
-      info_key: 'users.revisions_doc'
-    },
-    character_sum_ms: contentAddedKey,
-    references_count: {
-      label: I18n.t('users.references_count'),
-      desktop_only: true,
-      sortable: true,
-      info_key: 'metrics.references_doc'
-    },
-    total_uploads: {
-      label: I18n.t('users.total_uploads'),
-      desktop_only: true,
-      sortable: true,
-      info_key: 'users.uploads_doc'
-    }
-  };
-
+  const keys = studentListKeys(course);
   if (!showRecent(course)) delete keys.recent_revisions;
   if (sort.key && keys[sort.key]) keys[sort.key].order = (sort.sortKey) ? 'asc' : 'desc';
 

--- a/app/assets/javascripts/components/students/shared/StudentList/student_list_keys.js
+++ b/app/assets/javascripts/components/students/shared/StudentList/student_list_keys.js
@@ -1,0 +1,56 @@
+const charactersAddedKey = {
+  label: I18n.t('users.chars_added'),
+  desktop_only: true,
+  sortable: true,
+  info_key: 'users.character_doc'
+};
+
+const wordsAddedKey = {
+  label: I18n.t('users.words_added'),
+  desktop_only: true,
+  sortable: true,
+  info_key: 'users.character_doc'
+};
+
+const studentListKeys = (course) => {
+  const contentAddedKey = course.home_wiki_bytes_per_word ? wordsAddedKey : charactersAddedKey;
+
+  return {
+    username: {
+      label: I18n.t('users.name'),
+      desktop_only: false,
+      sortable: true,
+    },
+    assignment_title: {
+      label: I18n.t('users.assigned'),
+      desktop_only: true,
+      sortable: false
+    },
+    reviewing_title: {
+      label: I18n.t('users.reviewing'),
+      desktop_only: true,
+      sortable: false
+    },
+    recent_revisions: {
+      label: I18n.t('users.recent_revisions'),
+      desktop_only: true,
+      sortable: true,
+      info_key: 'users.revisions_doc'
+    },
+    character_sum_ms: contentAddedKey,
+    references_count: {
+      label: I18n.t('users.references_count'),
+      desktop_only: true,
+      sortable: true,
+      info_key: 'metrics.references_doc'
+    },
+    total_uploads: {
+      label: I18n.t('users.total_uploads'),
+      desktop_only: true,
+      sortable: true,
+      info_key: 'users.uploads_doc'
+    }
+  };
+};
+
+export default studentListKeys;

--- a/app/assets/javascripts/utils/wordcount_utils.js
+++ b/app/assets/javascripts/utils/wordcount_utils.js
@@ -1,0 +1,3 @@
+export const bytesToWords = (bytes, bytesPerWord) => {
+  return Math.round(bytes / bytesPerWord);
+};

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -9,6 +9,7 @@
 #  project  :string(16)
 #
 require_dependency "#{Rails.root}/lib/wiki_api"
+require_dependency "#{Rails.root}/lib/word_count"
 
 class Wiki < ApplicationRecord
   has_many :articles
@@ -129,6 +130,10 @@ class Wiki < ApplicationRecord
     else
       'articles_generic'
     end
+  end
+
+  def bytes_per_word
+    WordCount::BYTES_PER_WORD[domain]
   end
 
   private

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -14,6 +14,7 @@ json.course do
   json.wikis @course.wikis, :language, :project
   json.timeline_enabled @course.timeline_enabled?
   json.academic_system @course.academic_system
+  json.home_wiki_bytes_per_word @course.home_wiki.bytes_per_word
   json.home_wiki_edits_enabled @course.home_wiki.edits_enabled?
   json.wiki_edits_enabled @course.wiki_edits_enabled?
   json.assignment_edits_enabled @course.assignment_edits_enabled?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1187,6 +1187,9 @@ en:
     username_placeholder: Username
     useremail_placeholder: Email
     userpasscode_placeholder: Passcode
+    words_added:
+      Words Added<br>(article | user | draft)
+
 
     role:
       description: Role in course

--- a/lib/word_count.rb
+++ b/lib/word_count.rb
@@ -11,9 +11,12 @@ class WordCount
   # See graph with regression line here: https://commons.wikimedia.org/wiki/File:Bytes.content_length.scatter.correlation.enwiki.png
   # This is just a rough estimate, pending research on how bytes *added*
   # relates to changes in readable word count for work by student editors.
-  CHARACTERS_PER_WORD = 5.175
+  HALFAK_EN_WIKI_ESTIMATE = 5.175
+  BYTES_PER_WORD = {
+    'en.wikipedia.org' => HALFAK_EN_WIKI_ESTIMATE
+  }.freeze
 
   def self.from_characters(characters)
-    (characters / CHARACTERS_PER_WORD).to_i
+    (characters / HALFAK_EN_WIKI_ESTIMATE).to_i
   end
 end


### PR DESCRIPTION
We convert characters/bytes to words to give course-level estimates of content added, based on a value estimate for English Wikipedia. We want to do this also at the level of individual articles and editors as well, but without disrupting stats for other wikis where we don't have an estimate of bytes per word.

This patch addresses the issue by adding a `bytes_per_word` method for Wiki, which will return nil for any wiki that we don't have an estimate for (ie, everything but en.wikipedia.org). The strategy here is to pass that value for the home wiki of the course to the frontend, and then switch between words and bytes based whether a `home_wiki_bytes_per_word` value is received. This way, it should be easy to extend support for other wikis if/when we have bytes-per-word estimates for them.

### Before
![chars added](https://user-images.githubusercontent.com/848483/76905855-0cda3e80-6860-11ea-87ca-a335bf111a4b.png)

![chars per student](https://user-images.githubusercontent.com/848483/76905864-106dc580-6860-11ea-8487-eaf22ed9b0d9.png)

### After
![words added](https://user-images.githubusercontent.com/848483/76905871-1663a680-6860-11ea-9b17-a498a93d6607.png)

![words per student](https://user-images.githubusercontent.com/848483/76905877-1a8fc400-6860-11ea-80d8-7664296e01c8.png)
