### PR TITLE
Deleting all open requested accounts on course deletion.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -72,10 +72,7 @@ class Course < ApplicationRecord
   has_many :staff, -> { where('courses_users.role = 4') },
            through: :courses_users, source: :user
   has_many :survey_notifications, dependent: :destroy
-  has_many :requested_accounts,
-           class_name: 'RequestedAccount',
-           foreign_key: 'course_id',
-           dependent: :destroy
+  has_many :requested_accounts, dependent: :destroy
   has_many :tickets,
            class_name: 'TicketDispenser::Ticket',
            foreign_key: 'project_id',

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -72,7 +72,10 @@ class Course < ApplicationRecord
   has_many :staff, -> { where('courses_users.role = 4') },
            through: :courses_users, source: :user
   has_many :survey_notifications, dependent: :destroy
-  has_many :requested_accounts
+  has_many :requested_accounts,
+           class_name: 'RequestedAccount',
+           foreign_key: 'course_id',
+           dependent: :destroy
   has_many :tickets,
            class_name: 'TicketDispenser::Ticket',
            foreign_key: 'project_id',


### PR DESCRIPTION
## What this PR does
Fixes #3873 

This PR fixes the error by deleting all open requested accounts as they are linked to a course which is itself deleted.
