### PR TITLE
Make training progress queries more efficient

### DIFF
--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -16,13 +16,9 @@ require_dependency "#{Rails.root}/lib/training_progress_manager"
 
 class TrainingModulesUsers < ApplicationRecord
   belongs_to :user
-  has_one :training_module
+  belongs_to :training_module
 
   serialize :flags, Hash
-
-  def training_module
-    @training_module ||= TrainingModule.find(training_module_id)
-  end
 
   def furthest_slide?(slide_slug)
     return true if last_slide_completed.nil?

--- a/app/views/courses/_block.json.jbuilder
+++ b/app/views/courses/_block.json.jbuilder
@@ -3,7 +3,7 @@
 user ||= current_user
 json.call(block, :id, :kind, :content, :week_id, :title,
           :order, :due_date, :training_module_ids, :points)
-if block.training_modules.any?
+if block.training_module_ids.present?
   json.training_modules block.training_modules do |tm|
     # The available training modules may change over time, especially on
     # Programs & Events Dashboard where wiki trainings are enabled.

--- a/lib/course_training_progress_manager.rb
+++ b/lib/course_training_progress_manager.rb
@@ -91,7 +91,7 @@ class CourseTrainingProgressManager
   end
 
   def assigned_module_ids
-    @course.training_modules.collect(&:id)
+    @assigned_module_ids ||= @course.training_modules.collect(&:id)
   end
 
   def incomplete_module_ids
@@ -100,14 +100,16 @@ class CourseTrainingProgressManager
 
   def completed_training_modules_for_user_and_course
     TrainingModulesUsers
+      .includes(:training_module)
       .where(user_id: @user.id)
       .where(training_module_id: training_modules_for_course)
       .where.not(completed_at: nil)
-      .count { |tmu| TrainingModule.find(tmu.training_module_id).training? }
+      .count { |tmu| tmu.training_module.training? }
   end
 
   def completed_exercise_modules_for_user_and_course
     TrainingModulesUsers
+      .includes(:training_module)
       .where(user_id: @user.id)
       .where(training_module_id: exercise_modules_for_course)
       .count do |tmu|
@@ -131,10 +133,12 @@ class CourseTrainingProgressManager
       .uniq
   end
 
+  def modules_for_course
+    @modules_for_course ||= TrainingModule.where(id: module_ids_for_course)
+  end
+
   def training_modules_for_course
-    module_ids_for_course.select do |id|
-      TrainingModule.find(id).training?
-    end
+    @training_modules_for_course ||= modules_for_course.select(&:training?)
   end
 
   def total_training_modules_for_course
@@ -142,9 +146,7 @@ class CourseTrainingProgressManager
   end
 
   def exercise_modules_for_course
-    module_ids_for_course.select do |id|
-      TrainingModule.find(id).exercise?
-    end
+    @exercise_modules_for_course ||= modules_for_course.select(&:exercise?)
   end
 
   def total_exercise_modules_for_course


### PR DESCRIPTION
This fixes a number of N+1 queries in the training module progress code.

ActiveRecord can handle the relationship between a TrainingModulesUsers record and the corresponding TrainingModule better than the manual caching we had in TrainingModulesUsers, which required an extra query for every TrainingModulesUsers record instead of allowing the database to load them all at once.

We can avoid individually loading each TrainingModule for a course with a separate query, when trying to sort the trainings from the exercises, and instead collect all the modules for a course and reuse them for exercises vs trainings.

For the completion data for an individual user in a course, loading the training_modules as part of the TrainingModulesUsers query means we don't have to load each module individually to see if it's an exercise or training.