### PR TITLE
Check that TrainingModuleUser has a created_at before checking completion

### DIFF
--- a/lib/training_progress_manager.rb
+++ b/lib/training_progress_manager.rb
@@ -75,7 +75,7 @@ class TrainingProgressManager
   end
 
   def completion_time
-    return unless module_completed?
+    return unless module_completed? && @tmu.created_at.present?
     @tmu.completed_at - @tmu.created_at
   end
 


### PR DESCRIPTION
I think this should be the fix, but _I have questions._

1. There are a _number_ of training module records in our existing database that do not have a `:created_at` date. How did this happen?
1. I tried creating some tests for this, but was unable to do so in part because creating a TrainingModule is a bit more difficult in tests, but also because there is a database failure on creating a TrainingModule with a `nil` value for `:created_at`. What would be a way to test for this then?
1. If we ever find `created_at: nil`, should we correct it somehow? Or, update our existing database to correct it?