### PR TITLE
Fixes the Edit in Survey and Adds Preview to Question Group

### DIFF
--- a/app/views/rapidfire/questions/_question_group_list.html.haml
+++ b/app/views/rapidfire/questions/_question_group_list.html.haml
@@ -4,6 +4,8 @@
     = link_to "Add New Question", new_question_group_question_path(@question_group), :class => 'button dark button--no-margin'
   - if @questions.length > 1
     .survey__admin-tools
+      = link_to "Preview Question Group", new_question_group_answer_group_path(@question_group) + '?preview'
+      %br
       %span.contextual Drag to reorder questions. (Changes will be saved automatically.)
   %table.table.list--survey{"data-sortable-questions" => @question_group.id}
     %tbody

--- a/app/views/surveys/_form.html.haml
+++ b/app/views/surveys/_form.html.haml
@@ -35,7 +35,7 @@
                     .course-list__row__title
                       %strong= question_group.name
                   %td
-                    %div= link_to "Edit", rapidfire.question_group_questions_path(question_group)
+                    %div= link_to "Edit", rapidfire.edit_question_group_path(question_group)
 
 
         %div.light-text


### PR DESCRIPTION
## What this PR does
This PR basically re navigates the "Edit" in Survey section and Also a Preview link is added to the Question group as mentioned in the issue #3905 

## Screenshots
Before:

![Before(1)](https://user-images.githubusercontent.com/43814493/77816620-01053c80-70ea-11ea-8a15-28aad16cd21b.gif)



After:

![After(1)](https://user-images.githubusercontent.com/43814493/77816656-580b1180-70ea-11ea-9eac-a1ded31048a2.gif)

