### PR TITLE
Update TrainingSlide table to support 4-byte unicode characters

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -4,7 +4,7 @@
 
 default: &default
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   username: wiki
   password: wikiedu
   host: 127.0.0.1

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,6 +1,6 @@
 test: &test
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   username: root
   password:
   database: test

--- a/db/migrate/20200327172134_convert_training_modules_to_utf8_mb4.rb
+++ b/db/migrate/20200327172134_convert_training_modules_to_utf8_mb4.rb
@@ -1,0 +1,7 @@
+class ConvertTrainingModulesToUtf8Mb4 < ActiveRecord::Migration[6.0]
+  def change
+    execute "ALTER TABLE training_slides CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    execute "ALTER TABLE training_slides MODIFY content TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+    execute "ALTER TABLE training_slides MODIFY translations TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_15_181443) do
+ActiveRecord::Schema.define(version: 2020_03_27_172134) do
 
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
@@ -488,7 +488,7 @@ ActiveRecord::Schema.define(version: 2019_10_15_181443) do
     t.index ["user_id", "training_module_id"], name: "index_training_modules_users_on_user_id_and_training_module_id", unique: true
   end
 
-  create_table "training_slides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "training_slides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "title_prefix"
     t.string "summary"

--- a/training_content/wiki_ed/slides/2-editing_basics/212-visual-editor-formatting.yml
+++ b/training_content/wiki_ed/slides/2-editing_basics/212-visual-editor-formatting.yml
@@ -22,7 +22,7 @@ content: |
   * The "Underline" item (<span style="text-decoration: underline">U</span>) adds a solid line beneath the selected text.
   * The "Language" item (Aあ) allows you to label the language (for example,
   Japanese) and direction (for example, right-to-left) of the selected text.
-  * The final item, "Clear styling" (&nbsp;   ⃠ ), removes all character formatting from the
+  * The final item, "Clear styling" (🛇), removes all character formatting from the
   selected text, including links.
 
   If you have not selected any text, then when you click the "<span style="text-decoration: underline">***A***</span>"

--- a/training_content/wiki_ed/slides/23-how-to-edit-professional/2307-visual-editor-buttons-professional.yml
+++ b/training_content/wiki_ed/slides/23-how-to-edit-professional/2307-visual-editor-buttons-professional.yml
@@ -30,7 +30,7 @@ content: |
   <u>***A***</u> : Highlight your text, then click here to format it with
   bold, italics, etc. The “More” options allows you to underline
   (<u>U</u>), cross-out text (~~S~~), add code snippets ({}), change
-  language keyboards (Aあ), and clear all formatting (&nbsp;  ⃠ ).
+  language keyboards (Aあ), and clear all formatting (🛇).
 
   **Links**: Highlight text and push this button to make it a link. The
   Visual Editor will automatically suggest related Wikipedia articles for

--- a/training_content/wiki_ed/slides/28-how-to-edit/2807-visual-editor-buttons-v2.yml
+++ b/training_content/wiki_ed/slides/28-how-to-edit/2807-visual-editor-buttons-v2.yml
@@ -29,7 +29,7 @@ content: |
   <u>***A***</u> : Highlight your text, then click here to format it with
   bold, italics, etc. The “More” options allows you to underline
   (<u>U</u>), cross-out text (~~S~~), add code snippets ( { } ), change
-  language keyboards (Aあ), and clear all formatting ( ⃠ ).
+  language keyboards (Aあ), and clear all formatting (🛇).
 
   **Links**: Highlight text and push this button to make it a link. The
   Visual Editor will automatically suggest related Wikipedia articles for


### PR DESCRIPTION
This adds 4-byte unicode support to the 'content' and 'translations' fields of TrainingSlide, and fixes the 'prohibition sign / no symbol' on several slides.

See https://en.wikipedia.org/wiki/No_symbol

We've been using the "Combining Enclosing Circle Backslash" for this, but it doesn't render in Chrome (and requires extra spaces as a workaround, since it is supposed to render on top of the previous character). The "prohibition sign" is the same symbol, but it's a 4-byte character that requires schema changes to work.

This change will also require changes to the database.yml `encoding` setting; it should be changed in production before deployment (and will need to be changed in local development environments as well).
