### PR TITLE
Discretionary sanctions monitor assignment based#3943

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Layout/LineLength:
 Metrics/ClassLength:
   Max: 127 # We should bring this down, ideally to the default of 100
   Exclude: # These are too big, and should be shrunk if feasible.
+    - 'app/models/alert.rb'
     - 'app/models/course.rb'
     - 'app/controllers/surveys_controller.rb'
     - 'app/controllers/campaigns_controller.rb'
@@ -104,7 +105,7 @@ Layout/TrailingWhitespace: # To disallow trailing whitespaces
   Enabled: true
 Layout/HashAlignment:
   Enabled: false # Hashes look uglier when corrected
-  
+
 ########################
 # Temporary exceptions #
 ########################

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,7 +105,7 @@ Layout/TrailingWhitespace: # To disallow trailing whitespaces
   Enabled: true
 Layout/HashAlignment:
   Enabled: false # Hashes look uglier when corrected
-
+  
 ########################
 # Temporary exceptions #
 ########################

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -39,6 +39,7 @@ class Alert < ApplicationRecord
     BlockedUserAlert
     ContinuedCourseActivityAlert
     DeletedUploadsAlert
+    DiscretionarySanctionsAssignmentAlert
     DiscretionarySanctionsEditAlert
     DYKNominationAlert
     FirstEnrolledStudentAlert
@@ -60,6 +61,7 @@ class Alert < ApplicationRecord
     ArticlesForDeletionAlert
     BadWorkAlert
     ContinuedCourseActivityAlert
+    DiscretionarySanctionsAssignmentAlert
     DiscretionarySanctionsEditAlert
     DYKNominationAlert
     GANominationAlert
@@ -74,6 +76,7 @@ class Alert < ApplicationRecord
     BlockedUserAlert
     ContinuedCourseActivityAlert
     DeletedUploadsAlert
+    DiscretionarySanctionsAssignmentAlert
     DiscretionarySanctionsEditAlert
     DYKNominationAlert
     GANominationAlert

--- a/app/models/alert_types/discretionary_sanctions_assignment_alert.rb
+++ b/app/models/alert_types/discretionary_sanctions_assignment_alert.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id             :integer          not null, primary key
+#  course_id      :integer
+#  user_id        :integer
+#  article_id     :integer
+#  revision_id    :integer
+#  type           :string(255)
+#  email_sent_at  :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  message        :text(65535)
+#  target_user_id :integer
+#  subject_id     :integer
+#  resolved       :boolean          default(FALSE)
+#  details        :text(65535)
+#
+
+# Alert for when an article under discretionary sanctions on Wikipedia has been
+# chosen as an assignment by a student.
+class DiscretionarySanctionsAssignmentAlert < Alert
+  def main_subject
+    "#{article.title} — #{course&.slug}"
+  end
+
+  def url
+    article.url
+  end
+
+  def resolvable?
+    !resolved
+  end
+
+  def resolve_explanation
+    <<~EXPLANATION
+      Resolve this alert if you want to be alerted again for future assignments to
+      the article. The Dashboard will issue a new alert only if there assignments to
+      this article that happen after the resolved alert was generated.
+    EXPLANATION
+  end
+end

--- a/app/models/alert_types/discretionary_sanctions_assignment_alert.rb
+++ b/app/models/alert_types/discretionary_sanctions_assignment_alert.rb
@@ -38,8 +38,9 @@ class DiscretionarySanctionsAssignmentAlert < Alert
   def resolve_explanation
     <<~EXPLANATION
       Resolve this alert if you want to be alerted again for future assignments to
-      the article. The Dashboard will issue a new alert only if there assignments to
-      this article that happen after the resolved alert was generated.
+      the article in the same course. The Dashboard will issue a new alert only if
+      there assignments to this article in the same course that happen after the
+      resolved alert was generated.
     EXPLANATION
   end
 end

--- a/app/models/alert_types/discretionary_sanctions_edit_alert.rb
+++ b/app/models/alert_types/discretionary_sanctions_edit_alert.rb
@@ -38,8 +38,9 @@ class DiscretionarySanctionsEditAlert < Alert
   def resolve_explanation
     <<~EXPLANATION
       Resolve this alert if you want to be alerted again for future edits to
-      the article. The Dashboard will issue a new alert only if there edits to
-      this article that happen after the resolved alert was generated.
+      the article in the same course. The Dashboard will issue a new alert only
+      if there edits to this article in the same course that happen after the
+      resolved alert was generated.
     EXPLANATION
   end
 end

--- a/lib/alerts/discretionary_sanctions_monitor.rb
+++ b/lib/alerts/discretionary_sanctions_monitor.rb
@@ -23,7 +23,7 @@ class DiscretionarySanctionsMonitor
     course_assignments = Assignment.joins(:article)
                                    .where(articles: { title: @page_titles, wiki_id: @wiki.id })
     course_articles.each do |articles_course|
-      create_alert(articles_course)
+      create_edit_alert(articles_course)
     end
     course_assignments.each do |assignments_course|
       create_assignment_alert(assignments_course)
@@ -54,11 +54,11 @@ class DiscretionarySanctionsMonitor
     @page_titles.uniq!
   end
 
-  def create_alert(articles_course)
-    return if unresolved_alert_already_exists?(articles_course)
+  def create_edit_alert(articles_course)
+    return if unresolved_edit_alert_already_exists?(articles_course)
     revisions = articles_course.course.revisions.where(article_id: articles_course.article_id)
     last_revision = revisions.last
-    return if resolved_alert_covers_latest_revision?(articles_course, last_revision)
+    return if resolved_edit_alert_covers_latest_revision?(articles_course, last_revision)
     first_revision = revisions.first
     alert = Alert.create!(type: 'DiscretionarySanctionsEditAlert',
                           article_id: articles_course.article_id,
@@ -77,7 +77,7 @@ class DiscretionarySanctionsMonitor
     alert.email_content_expert
   end
 
-  def unresolved_alert_already_exists?(articles_course)
+  def unresolved_edit_alert_already_exists?(articles_course)
     DiscretionarySanctionsEditAlert.exists?(article_id: articles_course.article_id,
                                             course_id: articles_course.course_id,
                                             resolved: false)
@@ -89,7 +89,7 @@ class DiscretionarySanctionsMonitor
                                                   resolved: false)
   end
 
-  def resolved_alert_covers_latest_revision?(articles_course, last_revision)
+  def resolved_edit_alert_covers_latest_revision?(articles_course, last_revision)
     return false if last_revision.nil?
     last_resolved = DiscretionarySanctionsEditAlert.where(article_id: articles_course.article_id,
                                                           course_id: articles_course.course_id,

--- a/lib/alerts/discretionary_sanctions_monitor.rb
+++ b/lib/alerts/discretionary_sanctions_monitor.rb
@@ -22,6 +22,7 @@ class DiscretionarySanctionsMonitor
                                      .where(articles: { title: @page_titles, wiki_id: @wiki.id })
     course_assignments = Assignment.joins(:article)
                                    .where(articles: { title: @page_titles, wiki_id: @wiki.id })
+                                   .where(course: Course.current)
     course_articles.each do |articles_course|
       create_edit_alert(articles_course)
     end

--- a/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
+++ b/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
@@ -9,7 +9,7 @@ end
 
 describe DiscretionarySanctionsMonitor do
   describe '.create_alerts_for_course_articles' do
-    let(:course) { create(:course) }
+    let(:course) { create(:course, start: 1.month.ago, end: 1.month.after) }
     let(:student) { create(:user, username: 'student') }
     let!(:courses_user) do
       create(:courses_user, user_id: student.id,


### PR DESCRIPTION
## What this PR does
Fixes #3943 . Adds a new feature (enhancement) of adding alert when a discretionary sanctions article is chosen as an article by a student.
## Screenshots
After:
![Screenshot from 2020-04-09 01-34-31](https://user-images.githubusercontent.com/37243661/78828546-7df5b780-7a02-11ea-88ad-c8cf4cd36759.png)
![Screenshot from 2020-04-09 01-05-37](https://user-images.githubusercontent.com/37243661/78828562-84842f00-7a02-11ea-83a0-87ab4e1bc235.png)
![Screenshot from 2020-04-09 01-05-43](https://user-images.githubusercontent.com/37243661/78828580-88b04c80-7a02-11ea-813a-db79270caa5b.png)

