### PR TITLE
The current loaded spec version of capistrano is returned to lock as a string#3955

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,4 +1,5 @@
-lock Gem.loaded_specs['capistrano'].version.to_s
+# config valid only for current version of Capistrano
+lock '3.13.0'
 
 set :application, 'wiki_edu_dashboard'
 set :repo_url, 'git@github.com:WikiEducationFoundation/WikiEduDashboard.git'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock Gem.loaded_specs["capistrano"].version.to_s
+lock Gem.loaded_specs['capistrano'].version.to_s
 
 set :application, 'wiki_edu_dashboard'
 set :repo_url, 'git@github.com:WikiEducationFoundation/WikiEduDashboard.git'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,4 +1,3 @@
-# config valid only for current version of Capistrano
 lock Gem.loaded_specs['capistrano'].version.to_s
 
 set :application, 'wiki_edu_dashboard'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.13.0'
+lock Gem.loaded_specs["capistrano"].version.to_s
 
 set :application, 'wiki_edu_dashboard'
 set :repo_url, 'git@github.com:WikiEducationFoundation/WikiEduDashboard.git'

--- a/spec/config/deploy_spec.rb
+++ b/spec/config/deploy_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe 'Deployment configuration' do
   it 'verifies that the Capistrano gem version being locked is correct' do
-    deploy_config_text = File.read("config/deploy.rb")
-    capistrano_version = deploy_config_text.scan(/lock '.*'/)[0].gsub("lock ", "").gsub(/[']/, "")
+    deploy_config_text = File.read('config/deploy.rb')
+    capistrano_version = deploy_config_text.scan(/lock '.*'/)[0].gsub('lock ', '').gsub(/[']/, '')
     expect(Gem.loaded_specs['capistrano'].version.to_s).to eq(capistrano_version)
   end
 end

--- a/spec/config/deploy_spec.rb
+++ b/spec/config/deploy_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Deployment configuration' do
+  it 'verifies that the Capistrano gem version being locked is correct' do
+    deploy_config_text = File.read("config/deploy.rb")
+    capistrano_version = deploy_config_text.scan(/lock '.*'/)[0].gsub("lock ", "").gsub(/[']/, "")
+    expect(Gem.loaded_specs['capistrano'].version.to_s).to eq(capistrano_version)
+  end
+end


### PR DESCRIPTION
## What this PR does
Fixes #3955 

## Screenshots
![Screenshot from 2020-04-14 13-41-49](https://user-images.githubusercontent.com/37243661/79202171-d2f85a00-7e56-11ea-969f-aa0fb37907ff.png)

