### PR TITLE
Add instructions for marking an exercise complete

### DIFF
--- a/app/assets/stylesheets/training_modules/_slides.styl
+++ b/app/assets/stylesheets/training_modules/_slides.styl
@@ -146,3 +146,8 @@
     transform rotate(360deg)
   }
 }
+
+.training__note
+  background-color white
+  border 1px solid $border_med
+  padding 20px

--- a/training_content/wiki_ed/slides/34-evaluate-wikipedia-exercise/3407-option-activity.yml
+++ b/training_content/wiki_ed/slides/34-evaluate-wikipedia-exercise/3407-option-activity.yml
@@ -5,3 +5,8 @@ content: |
   Choose at least 1 question relevant to the article you're evaluating and
   leave your evaluation on the article's Talk page. Be sure to sign your
   feedback with four tildes — ~~~~.
+
+  <p class="training__note">
+  NOTE: Once you've completed this exercise, be sure to click <strong>Mark Complete</strong>
+  from your course page Home tab.
+  </p>

--- a/training_content/wiki_ed/slides/35-add-to-article-exercise/3502-creating-new-article.yml
+++ b/training_content/wiki_ed/slides/35-add-to-article-exercise/3502-creating-new-article.yml
@@ -16,3 +16,8 @@ content: |
     </figure>
   
   Summarize a statement from one of your sources and cite that statement to your source.
+
+  <p class="training__note">
+  NOTE: Once you've completed this exercise, be sure to click <strong>Mark Complete</strong>
+  from your course page Home tab.
+  </p>

--- a/training_content/wiki_ed/slides/36-choose-topic-from-list-exercise/3603-think-about-sources.yml
+++ b/training_content/wiki_ed/slides/36-choose-topic-from-list-exercise/3603-think-about-sources.yml
@@ -13,3 +13,8 @@ content: |
   "View history" will help you keep track. If you've added your email to your
   account (which is a *really* good idea), you'll get notifications if something
   on the page changes.
+
+  <p class="training__note">
+  NOTE: Once you've completed this exercise, be sure to click <strong>Mark Complete</strong>
+  from your course page Home tab.
+  </p>

--- a/training_content/wiki_ed/slides/37-choose-topic-exercise/3704-present-articles.yml
+++ b/training_content/wiki_ed/slides/37-choose-topic-exercise/3704-present-articles.yml
@@ -15,3 +15,8 @@ content: |
   to reference easily when you start writing. Once you've assigned yourself the article, your bibliography
   can be found by going to the **My Articles** section and clicking on the **Bibliography** link underneath
   the article you are working on.
+
+  <p class="training__note">
+  NOTE: Once you've completed this exercise, be sure to click <strong>Mark Complete</strong>
+  from your course page Home tab.
+  </p>

--- a/training_content/wiki_ed/slides/38-finalize-topic-exercise/3802-expand-bibliography.yml
+++ b/training_content/wiki_ed/slides/38-finalize-topic-exercise/3802-expand-bibliography.yml
@@ -22,3 +22,8 @@ content: |
   "View history" will help you keep track. If you've added your email to your
   account (which is a *really* good idea), you'll get notifications if something
   on the page changes.
+
+  <p class="training__note">
+  NOTE: Once you've completed this exercise, be sure to click <strong>Mark Complete</strong>
+  from your course page Home tab.
+  </p>


### PR DESCRIPTION
This adds a note at the end of each of the core exercises for students to use the 'Mark Complete' button; this should further reduce confusion around how to get to 'complete' status for exercise modules.

## Screenshot

!['Mark Complete' note](https://user-images.githubusercontent.com/848483/79365919-2bcffd00-7f00-11ea-8a04-ea8a51178d94.png)
