### PR TITLE
Rails output safety rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,8 +118,6 @@ Rails/FilePath:
   Enabled: false
 Rails/SkipsModelValidations:
   Enabled: false
-Rails/OutputSafety:
-  Enabled: false
 Performance/UnfreezeString:
   Enabled: false
 Style/GuardClause:

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -15,6 +15,6 @@ module CampaignHelper
   def html_from_markdown(markdown)
     return unless markdown
     converter = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
-    raw converter.render(markdown)
+    sanitize converter.render(markdown)
   end
 end


### PR DESCRIPTION
## What this PR does
This PR fixes a safety threat by replacing `raw` with `sanitize` in the markdown text so that no code can be introduced between `<script> `tags. Also rubocop violation regarding this is fixed and removed. A small example is given below. `sanitize` basically encodes all tags and strips all attributes that are not specifically allowed. 

## Screenshots
![Screenshot from 2020-04-17 23-59-35](https://user-images.githubusercontent.com/37243661/79602603-6a380880-8108-11ea-9b29-58cf236ae008.png)

