### PR TITLE
Fixed toggling bug in article finder.

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -276,13 +276,24 @@ const ArticleFinder = createReactClass({
 
     let list;
     if (this.state.isSubmitted && !this.props.loading) {
+      const modifiedAssignmentsArray = _.map(this.props.assignments, (element) => {
+          if (!element.language && !element.project) {
+            return {
+                ...element,
+                language: this.props.home_wiki.language,
+                project: this.props.home_wiki.project
+              };
+          }
+          return element;
+      });
+
       const elements = _.map(this.props.articles, (article, title) => {
         let assignment;
         if (this.props.course_id) {
           if (this.props.current_user.isAdvancedRole) {
-            assignment = _.find(this.props.assignments, { article_title: title, user_id: null, language: this.props.home_wiki.language, project: this.props.home_wiki.project });
+            assignment = _.find(modifiedAssignmentsArray, { article_title: title, user_id: null, language: this.props.home_wiki.language, project: this.props.home_wiki.project });
           } else if (this.props.current_user.role === STUDENT_ROLE) {
-            assignment = _.find(this.props.assignments, { article_title: title, user_id: this.props.current_user.id, language: this.props.home_wiki.language, project: this.props.home_wiki.project });
+            assignment = _.find(modifiedAssignmentsArray, { article_title: title, user_id: this.props.current_user.id, language: this.props.home_wiki.language, project: this.props.home_wiki.project });
           }
         }
         return (


### PR DESCRIPTION
## What this PR does
Fixes #3515 . Referencing PR #3516
This PR basically sets `language` and `project` attributes to their default values as they are not sent by the system for articles under course's `home_wiki`, which earlier led them to being `undefined` and hence the bug.  

## Screenshots
Before:
![Peek 2020-04-21 03-42](https://user-images.githubusercontent.com/37243661/79804730-3e27bc00-8382-11ea-90b1-1865c46c9824.gif)

After:
![Peek 2020-04-21 03-38](https://user-images.githubusercontent.com/37243661/79804616-0587e280-8382-11ea-996e-7d8c679ea5d6.gif)

