### PR TITLE
Feature/user ids on articles courses

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticleRow.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticleRow.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Components
+import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
+
+export const EditedUnassignedArticleRow = ({
+  article, course, current_user, fetchArticleDetails, showArticleId, user
+}) => (
+  <tr className="article-row">
+    <td className="article-title">{article.title}</td>
+    <td>
+      <p className="assignment-links">
+        <a href={article.url} target="_blank">
+          {I18n.t('assignments.article_link')}
+        </a>
+      </p>
+    </td>
+    <td className="article-actions">
+      <ArticleViewer
+        article={article}
+        course={course}
+        current_user={current_user}
+        fetchArticleDetails={fetchArticleDetails}
+        users={[user.username]}
+        showOnMount={showArticleId === article.id}
+      />
+    </td>
+  </tr>
+);
+
+EditedUnassignedArticleRow.propTypes = {
+  article: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    url: PropTypes.string.isRequired
+  }).isRequired,
+  course: PropTypes.object.isRequired,
+  current_user: PropTypes.object,
+  showArticleId: PropTypes.any,
+  user: PropTypes.shape({
+    username: PropTypes.string.isRequired
+  }).isRequired,
+  fetchArticleDetails: PropTypes.func.isRequired
+};
+
+export default EditedUnassignedArticleRow;

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Components
+import EditedUnassignedArticleRow from './EditedUnassignedArticleRow';
+import List from '@components/common/list.jsx';
+
+export const EditedUnassignedArticles = ({
+  articles, course, current_user, showArticleId, title, user,
+  fetchArticleDetails
+}) => {
+  const rows = articles.map(article => (
+    <EditedUnassignedArticleRow
+      key={`article-${article.id}`}
+      article={article}
+      course={course}
+      current_user={current_user}
+      fetchArticleDetails={fetchArticleDetails}
+      showArticleId={showArticleId}
+      user={user}
+    />
+  ));
+
+  const options = { desktop_only: false, sortable: false };
+  const keys = {
+    article_name: {
+      label: I18n.t('instructor_view.assignments_table.article_name'),
+      ...options
+    },
+    relevant_links: {
+      label: I18n.t('instructor_view.assignments_table.relevant_links'),
+      ...options
+    }
+  };
+
+  return (
+    <div className="list__wrapper">
+      <h4 className="assignments-list-title">{title}</h4>
+      <List
+        elements={rows}
+        className="table--expandable table--hoverable"
+        keys={keys}
+        table_key="users"
+        stickyHeader={false}
+        sortable={false}
+      />
+    </div>
+  );
+};
+
+EditedUnassignedArticles.propTypes = {
+  articles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  course: PropTypes.object.isRequired,
+  current_user: PropTypes.object,
+  showArticleId: PropTypes.any,
+  title: PropTypes.string.isRequired,
+  user: PropTypes.object.isRequired,
+  fetchArticleDetails: PropTypes.func.isRequired
+};
+
+export default EditedUnassignedArticles;

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
@@ -7,18 +7,22 @@ import AssignmentsList from './AssignmentsList/AssignmentsList.jsx';
 import NoAssignments from './NoAssignments.jsx';
 import StudentExercisesList from './ExercisesList/StudentExercisesList.jsx';
 import StudentRevisionsList from './RevisionsList/StudentRevisionsList.jsx';
+import EditedUnassignedArticles from './EditedUnassignedArticles/EditedUnassignedArticles.jsx';
 
 // Utils
 import { processAssignments } from '@components/overview/my_articles/utils/processAssignments';
+import setUnassignedArticles from '@components/students/utils/setUnassignedArticles';
 
 export const SelectedStudent = ({
-  assignments, course, current_user, fetchArticleDetails, fetchUserRevisions,
-  hasExercisesOrTrainings, openKey, selected, setUploadFilters, sort, sortUsers,
-  toggleUI, trainingStatus, wikidataLabels, userRevisions
+  groupedArticles, assignments, course, current_user, fetchArticleDetails,
+  fetchUserRevisions, hasExercisesOrTrainings, openKey, selected, setUploadFilters,
+  sort, sortUsers, toggleUI, trainingStatus, wikidataLabels, userRevisions
 }) => {
   const {
     assigned, reviewing
   } = processAssignments({ assignments, course, current_user: selected });
+  const unassigned = setUnassignedArticles(groupedArticles, assignments, selected);
+  const showArticleId = Number(location.search.split('showArticle=')[1]);
 
   return (
     <article className="assignments-list">
@@ -73,6 +77,20 @@ export const SelectedStudent = ({
         )
       }
 
+      {
+        !!unassigned.length && (
+          <EditedUnassignedArticles
+            articles={unassigned}
+            course={course}
+            user={selected}
+            current_user={current_user}
+            showArticleId={showArticleId}
+            fetchArticleDetails={fetchArticleDetails}
+            title="Other Edited Articles"
+          />
+        )
+      }
+
       <StudentRevisionsList
         course={course}
         current_user={current_user}
@@ -96,6 +114,7 @@ SelectedStudent.propTypes = {
   current_user: PropTypes.object.isRequired,
   fetchArticleDetails: PropTypes.func.isRequired,
   fetchUserRevisions: PropTypes.func.isRequired,
+  groupedArticles: PropTypes.object.isRequired,
   selected: PropTypes.object.isRequired,
   wikidataLabels: PropTypes.object,
   userRevisions: PropTypes.object,

--- a/app/assets/javascripts/components/students/containers/Articles.jsx
+++ b/app/assets/javascripts/components/students/containers/Articles.jsx
@@ -21,6 +21,7 @@ import { toggleUI } from '~/app/assets/javascripts/actions';
 // Utils
 import { getStudentUsers, getWeeksArray } from '~/app/assets/javascripts/selectors';
 import { getModulesAndBlocksFromWeeks } from '@components/util/helpers';
+import groupArticlesCoursesByUserId from '@components/students/utils/groupArticlesCoursesByUserId';
 
 export class Articles extends React.Component {
   constructor(props) {
@@ -45,7 +46,7 @@ export class Articles extends React.Component {
 
   render() {
     const {
-      assignments, course, current_user, prefix, students, wikidataLabels,
+      articles, assignments, course, current_user, prefix, students, wikidataLabels,
       notify, sortSelect, openKey, sort, trainingStatus, sortUsers, weeks,
       userRevisions
     } = this.props;
@@ -53,6 +54,7 @@ export class Articles extends React.Component {
     const { modules } = getModulesAndBlocksFromWeeks(weeks);
     const hasExercisesOrTrainings = !!modules.length;
 
+    const groupedArticles = groupArticlesCoursesByUserId(articles);
     if (!students.length) return null;
     return (
       <>
@@ -104,6 +106,7 @@ export class Articles extends React.Component {
                         current_user={current_user}
                         fetchArticleDetails={this.props.fetchArticleDetails}
                         fetchUserRevisions={this.props.fetchUserRevisions}
+                        groupedArticles={groupedArticles}
                         hasExercisesOrTrainings={hasExercisesOrTrainings}
                         openKey={openKey}
                         selected={selected}
@@ -134,6 +137,7 @@ export class Articles extends React.Component {
 }
 
 Articles.propTypes = {
+  articles: PropTypes.array.isRequired,
   assignments: PropTypes.array.isRequired,
   course: PropTypes.object.isRequired,
   current_user: PropTypes.object.isRequired,

--- a/app/assets/javascripts/components/students/utils/groupArticlesCoursesByUserId.js
+++ b/app/assets/javascripts/components/students/utils/groupArticlesCoursesByUserId.js
@@ -1,0 +1,15 @@
+// This function organizes the articles data to be sorted by userId first,
+// followed by the articleId.
+export default (articles) => {
+  return articles.reduce((acc, article) => {
+    article.user_ids.forEach((id) => {
+      if (acc[id]) {
+        acc[id].push(article);
+      } else {
+        acc[id] = [article];
+      }
+    });
+
+    return acc;
+  }, {});
+};

--- a/app/assets/javascripts/components/students/utils/setUnassignedArticles.js
+++ b/app/assets/javascripts/components/students/utils/setUnassignedArticles.js
@@ -1,0 +1,9 @@
+export default (articlesById, assignments = [], student) => {
+  const assignmentsByArticleId = assignments.reduce((acc, assignment) => ({
+    ...acc,
+    [assignment.article_id]: assignment
+  }), {});
+
+  const articles = articlesById[student.id] || [];
+  return articles.filter(article => !assignmentsByArticleId[article.id]);
+};

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -65,7 +65,7 @@ class ArticlesCourses < ApplicationRecord
     self.character_sum = revisions.where('characters >= 0').sum(:characters)
     self.references_count = revisions.sum(&:references_added)
     self.view_count = views_since_earliest_revision(revisions)
-    self.details['user_ids'] = associated_user_ids(revisions)
+    details['user_ids'] = associated_user_ids(revisions)
 
     # We use the 'all_revisions' scope so that the dashboard system edits that
     # create sandboxes are not excluded, since those are often wind up being the
@@ -84,7 +84,7 @@ class ArticlesCourses < ApplicationRecord
 
   def associated_user_ids(revisions)
     return [] if revisions.empty?
-    revisions.map { |revision| revision.user_id }.compact.uniq
+    revisions.map(&:user_id).compact.uniq
   end
 
   #################

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -27,6 +27,8 @@ class ArticlesCourses < ApplicationRecord
   scope :tracked, -> { where(tracked: true).distinct }
   scope :not_tracked, -> { where(tracked: false).distinct }
 
+  serialize :details, Hash
+
   ####################
   # Instance methods #
   ####################
@@ -63,6 +65,7 @@ class ArticlesCourses < ApplicationRecord
     self.character_sum = revisions.where('characters >= 0').sum(:characters)
     self.references_count = revisions.sum(&:references_added)
     self.view_count = views_since_earliest_revision(revisions)
+    self.details['user_ids'] = associated_user_ids(revisions)
 
     # We use the 'all_revisions' scope so that the dashboard system edits that
     # create sandboxes are not excluded, since those are often wind up being the
@@ -77,6 +80,11 @@ class ArticlesCourses < ApplicationRecord
     return if article.average_views.nil?
     days = (Time.now.utc.to_date - revisions.order('date ASC').first.date.to_date).to_i
     days * article.average_views
+  end
+
+  def associated_user_ids(revisions)
+    return [] if revisions.empty?
+    revisions.map { |revision| revision.user_id }.compact.uniq
   end
 
   #################

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -27,7 +27,7 @@ class ArticlesCourses < ApplicationRecord
   scope :tracked, -> { where(tracked: true).distinct }
   scope :not_tracked, -> { where(tracked: false).distinct }
 
-  serialize :details, Hash
+  serialize :user_ids, Array # This text field only stores user ids as text
 
   ####################
   # Instance methods #
@@ -65,7 +65,7 @@ class ArticlesCourses < ApplicationRecord
     self.character_sum = revisions.where('characters >= 0').sum(:characters)
     self.references_count = revisions.sum(&:references_added)
     self.view_count = views_since_earliest_revision(revisions)
-    details['user_ids'] = associated_user_ids(revisions)
+    self.user_ids = associated_user_ids(revisions)
 
     # We use the 'all_revisions' scope so that the dashboard system edits that
     # create sandboxes are not excluded, since those are often wind up being the

--- a/app/views/courses/articles.json.jbuilder
+++ b/app/views/courses/articles.json.jbuilder
@@ -11,6 +11,6 @@ json.course do
     json.url article.url
     json.rating_num rating_priority(article.rating)
     json.pretty_rating rating_display(article.rating)
-    json.user_ids ac.details['user_ids']
+    json.user_ids ac.user_ids
   end
 end

--- a/app/views/courses/articles.json.jbuilder
+++ b/app/views/courses/articles.json.jbuilder
@@ -11,5 +11,6 @@ json.course do
     json.url article.url
     json.rating_num rating_priority(article.rating)
     json.pretty_rating rating_display(article.rating)
+    json.user_ids ac.details['user_ids']
   end
 end

--- a/db/migrate/20200421180015_add_details_to_articles_courses.rb
+++ b/db/migrate/20200421180015_add_details_to_articles_courses.rb
@@ -1,5 +1,5 @@
 class AddDetailsToArticlesCourses < ActiveRecord::Migration[6.0]
   def change
-    add_column :articles_courses, :details, :text
+    add_column :articles_courses, :user_ids, :text
   end
 end

--- a/db/migrate/20200421180015_add_details_to_articles_courses.rb
+++ b/db/migrate/20200421180015_add_details_to_articles_courses.rb
@@ -1,0 +1,5 @@
+class AddDetailsToArticlesCourses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles_courses, :details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_27_172134) do
+ActiveRecord::Schema.define(version: 2020_04_21_180015) do
 
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2020_03_27_172134) do
     t.boolean "new_article", default: false
     t.integer "references_count", default: 0
     t.boolean "tracked", default: true
+    t.text "user_ids"
     t.index ["article_id"], name: "index_articles_courses_on_article_id"
     t.index ["course_id"], name: "index_articles_courses_on_course_id"
   end


### PR DESCRIPTION
## What this PR does

This PR adds a new row on the Students > Articles & Exercises page that displays articles that the user has edited but is not assigned to the user. It does so by adding a column to the **ArticlesCourses** model that stores User IDs from associated revisions.

## Screenshots

![image](https://user-images.githubusercontent.com/1316902/79921290-c8a20700-83e6-11ea-81fa-13a63574a24c.png)
