### PR TITLE
Instead of using the jsonp dataType, use origin=* on article finder requests

### DIFF
--- a/app/assets/javascripts/actions/article_finder_action.js
+++ b/app/assets/javascripts/actions/article_finder_action.js
@@ -6,9 +6,9 @@ import { ORESSupportedWiki, PageAssessmentSupportedWiki } from '../utils/article
 
 const mediawikiApiBase = (language, project) => {
   if (project === 'wikidata') {
-    return `https://${project}.org/w/api.php?action=query&format=json`;
+    return `https://${project}.org/w/api.php?action=query&format=json&origin=*`;
   }
-  return `https://${language}.${project}.org/w/api.php?action=query&format=json`;
+  return `https://${language}.${project}.org/w/api.php?action=query&format=json&origin=*`;
 };
 
 const oresApiBase = (language, project) => {

--- a/app/assets/javascripts/utils/article_finder_utils.js
+++ b/app/assets/javascripts/utils/article_finder_utils.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
 import logErrorMessage from './log_error_message';
 
-export const queryUrl = (url, query = {}, dataType = 'jsonp') => {
+export const queryUrl = (url, query = {}) => {
   return new Promise((res, rej) => {
     return $.ajax({
-      dataType: dataType,
       url: url,
       data: query,
       success: (data) => {


### PR DESCRIPTION
## What this PR does

This PR updates the `queryUrl` function to stop using `jsonp` and instead adds the `origin=*` query key-value pair to the relevant queries. This should remove a warning that shows up when running tests.