### PR TITLE
Bump react-dropzone to v10.2.2 #2602

### DIFF
--- a/app/assets/javascripts/components/overview/syllabus-upload.jsx
+++ b/app/assets/javascripts/components/overview/syllabus-upload.jsx
@@ -22,13 +22,13 @@ class SyllabusUpload extends React.Component {
     const cancelButton = <button className="link-button" onClick={this.props.toggleEditingSyllabus}>cancel</button>;
     const loadingAnimation = <Loading message={false} />;
     const dropzone = (
-      <Dropzone onDrop={this.onDrop} multiple={false} className="course-syllabus__uploader">
+      <Dropzone onDrop={this.onDrop} multiple={false}>
         {({ getRootProps, getInputProps }) => (
-          <div {...getRootProps()}>
+          <div {...getRootProps()} className="course-syllabus__uploader">
             <input {...getInputProps()} />
-            <p>
+            <div>
               Drag and Drop or <button id="browse_files" className="link-button">Browse Files</button>
-            </p>
+            </div>
           </div>
         )}
       </Dropzone>

--- a/app/assets/javascripts/components/overview/syllabus-upload.jsx
+++ b/app/assets/javascripts/components/overview/syllabus-upload.jsx
@@ -23,7 +23,14 @@ class SyllabusUpload extends React.Component {
     const loadingAnimation = <Loading message={false} />;
     const dropzone = (
       <Dropzone onDrop={this.onDrop} multiple={false} className="course-syllabus__uploader">
-        <div>Drag and Drop or <button id="browse_files" className="link-button">Browse Files</button></div>
+        {({ getRootProps, getInputProps }) => (
+          <div {...getRootProps()}>
+            <input {...getInputProps()} />
+            <p>
+              Drag and Drop or <button id="browse_files" className="link-button">Browse Files</button>
+            </p>
+          </div>
+        )}
       </Dropzone>
     );
     return (

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react-dnd-html5-backend": "^5.0.1",
     "react-dnd-touch-backend": "^0.3.15",
     "react-dom": "^16.13.1",
-    "react-dropzone": "^7.0.1",
+    "react-dropzone": "10.2.2",
     "react-input-range": "^1.3.0",
     "react-motion": "^0.5.2",
     "react-onclickoutside": "^6.9.0",

--- a/spec/features/syllabus_upload_spec.rb
+++ b/spec/features/syllabus_upload_spec.rb
@@ -29,8 +29,8 @@ describe 'syllabus upload', type: :feature, js: true do
       expect(page).to have_content course.title
       expect(page).to have_content 'Syllabus'
       click_button 'edit'
-      find('input[type="file"]', :visible => false).attach_file "#{Rails.root}/spec/fixtures/syllabus.pdf",
-                                             make_visible: true
+      find('input[type="file"]', visible: false)
+        .attach_file "#{Rails.root}/spec/fixtures/syllabus.pdf", make_visible: true
       click_link 'save'
       expect(page).not_to have_content 'Syllabus'
       expect(course.reload.syllabus_file_name).to eq('syllabus.pdf')

--- a/spec/features/syllabus_upload_spec.rb
+++ b/spec/features/syllabus_upload_spec.rb
@@ -29,7 +29,7 @@ describe 'syllabus upload', type: :feature, js: true do
       expect(page).to have_content course.title
       expect(page).to have_content 'Syllabus'
       click_button 'edit'
-      find('input[type="file"]').attach_file "#{Rails.root}/spec/fixtures/syllabus.pdf",
+      find('input[type="file"]', :visible => false).attach_file "#{Rails.root}/spec/fixtures/syllabus.pdf",
                                              make_visible: true
       click_link 'save'
       expect(page).not_to have_content 'Syllabus'

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,7 +905,6 @@
 
 "@bower_components/jquery@jquery/jquery-dist#3.5.0":
   version "3.5.0"
-  uid "1fd78cd729742aa26f64783f9188e169e41f194e"
   resolved "https://codeload.github.com/jquery/jquery-dist/tar.gz/1fd78cd729742aa26f64783f9188e169e41f194e"
 
 "@cnakazawa/watch@^1.0.3":
@@ -2152,12 +2151,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-attr-accept@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
-  integrity sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==
-  dependencies:
-    core-js "^2.5.0"
+attr-accept@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.1.0.tgz#a231a854385d36ff7a99647bb77b33c8a5175aee"
+  integrity sha512-sLzVM3zCCmmDtDNhI0i96k6PUztkotSOXqE4kDGQt/6iDi5M+H0srjeF+QC6jN581l4X/Zq3Zu/tgcErEssavg==
 
 autobind-decorator@^1.3.4:
   version "1.4.3"
@@ -3528,7 +3525,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.6.5:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
@@ -5447,6 +5444,13 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-selector@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.12.tgz#fe726547be219a787a9dcc640575a04a032b1fd0"
+  integrity sha512-Kx7RTzxyQipHuiqyZGf+Nz4vY9R1XGxuQl/hLoJwq+J4avk/9wxxgZyHKtbyIPJmbD4A66DWGYfyykWNpcYutQ==
+  dependencies:
+    tslib "^1.9.0"
 
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
@@ -10941,13 +10945,14 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dropzone@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-7.0.1.tgz#bc76bc1686fb47ed0c8301f968fffa6aecdff47b"
-  integrity sha512-J4rbzhFZPVW7k7K9CVb0OcwSOJGLWa0y+0rvtB4rBLVkvq0agH/o3kPJ0DCkd6ZVzL2K1NFqIOvtQkwQKpmJBA==
+react-dropzone@10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.2.tgz#67b4db7459589a42c3b891a82eaf9ade7650b815"
+  integrity sha512-U5EKckXVt6IrEyhMMsgmHQiWTGLudhajPPG77KFSvgsMqNEHSyGpqWvOMc5+DhEah/vH4E1n+J5weBNLd5VtyA==
   dependencies:
-    attr-accept "^1.1.3"
-    prop-types "^15.6.2"
+    attr-accept "^2.0.0"
+    file-selector "^0.1.12"
+    prop-types "^15.7.2"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
## What this PR does
Upgrades react-dropzone to v10.2.2 (highest version before 11)

## Screenshots
Before:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/2396455/80599435-35428480-8a2b-11ea-8d18-1cdced097b1b.png">

After:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/2396455/80599447-3bd0fc00-8a2b-11ea-8e2c-4acea7716a31.png">


## Open questions and concerns
Note: alignment of cancel/save buttons were present before any changes. Is this noted?
