### PR TITLE
Fix debian setup shell script

### DIFF
--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -117,7 +117,7 @@ else
 fi
 
 printf '[*] Updating bundler... \n'
-if ruby should_update_rubygems.rb
+if ruby setup/should_update_rubygems.rb; then
   gem update --system
   printf '[+] Bundler updated\n'
 else


### PR DESCRIPTION
## What this PR does
It fixes a typo in the `setup/deb-setup.sh` file preventing debian-based system to run it properly.
and it changes a path of a .rb file which is 

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/36356746/81116416-4f7cd680-8ef3-11ea-904f-7a7dce69f8ed.png)

After fixing the typo:
![image](https://user-images.githubusercontent.com/36356746/81116641-bdc19900-8ef3-11ea-8f50-eea52e971744.png)
## Open questions and concerns
I didn't know that the filepaths given in the shell script are relative to the python file that calls it.

I have read the [CONTRIBUTING.md](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process) and I know that I'm maybe not conform to the instructions, however I believe that this small fix, given that it's not on the project's content, didn't need to be rebased, and that it didn't need another branch only for this one line. If it causes problem, tell me and I will do what's needed to conform to every points of the [CONTRIBUTING.md](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process)