### PR TITLE
changing subject selector to dropdown in the edit screen (#2499)

### DIFF
--- a/app/assets/javascripts/components/common/creatable_input.jsx
+++ b/app/assets/javascripts/components/common/creatable_input.jsx
@@ -20,7 +20,7 @@ class CreatableInput extends React.Component {
   }
 
   render() {
-    const { label, id, options, placeholder } = this.props;
+    const { label, id, options, placeholder, selected } = this.props;
 
     return (
       <div>
@@ -33,7 +33,7 @@ class CreatableInput extends React.Component {
           onBlur={element => this.onModify({ value: element.target.value })}
           options={options}
           placeholder={placeholder}
-          value={this.state.selected}
+          value={this.state.selected || selected}
           styles={{ ...selectStyles, singleValue: null }}
         />
       </div>

--- a/app/assets/javascripts/components/course_creator/course_subject_selector.jsx
+++ b/app/assets/javascripts/components/course_creator/course_subject_selector.jsx
@@ -1,55 +1,72 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import CreatableInput from '../common/creatable_input.jsx';
+import TextInput from '../common/text_input.jsx';
 import request from '../../utils/request';
 
-const CourseSubjectSelector = ({ updateCourse }) => {
+const CourseSubjectSelector = ({ updateCourse, subject, editable }) => {
   const [options, setOptions] = useState();
+  const [selected, setSelected] = useState(null);
+  if (typeof editable !== 'boolean') editable = true;
 
   useEffect(() => {
-    // Will contain an array of subjects in the required object format
-    const opts = [];
+    if (editable) {
+      // Will contain an array of subjects in the required object format
+      const opts = [];
 
-    request('/wizards/researchwrite.json')
-      .then(resp => resp.json())
-      .then((data) => {
-        const jsonObj = data;
-        // Exctracting the 5th index of researchwrite.json that contains all the subjects
-        const subjectOptions = jsonObj[5].options;
-        Object.keys(subjectOptions).forEach((key) => {
-          if (subjectOptions.hasOwnProperty(key)) {
-            opts.push({
-              value: subjectOptions[key].title,
-              label: subjectOptions[key].title
-            });
+      request('/wizards/researchwrite.json')
+        .then(resp => resp.json())
+        .then((data) => {
+          const jsonObj = data;
+          // Exctracting the 5th index of researchwrite.json that contains all the subjects
+          const subjectOptions = jsonObj[5].options;
+          Object.keys(subjectOptions).forEach((key) => {
+            if (subjectOptions.hasOwnProperty(key)) {
+              opts.push({
+                value: subjectOptions[key].title,
+                label: subjectOptions[key].title
+              });
+            }
+          });
+          if (subject.length > 0) {
+            const sel = { value: subject, label: subject };
+            setSelected(sel);
+            opts.push(sel);
           }
+          setOptions(opts);
         });
-        setOptions(opts);
-      });
-  }, []);
+    }
+  }, [editable]);
 
-  return (
+  return (editable) ? (
     <div className="form-group">
       <CreatableInput
         id="course_subject"
         onChange={({ value }) =>
           updateCourse('subject', value)
         }
-        label={'Course Subject:'}
-        placeholder={'Subject'}
+        selected={selected}
+        label={I18n.t('courses.subject')}
+        placeholder={I18n.t('courses.subject')}
         options={options}
       />
     </div>
+  ) : (
+    <TextInput
+      value={subject}
+      value_key="courseSubject"
+      editable={editable}
+      type="text"
+      label={I18n.t('courses.subject')}
+    />
   );
 };
 
 CourseSubjectSelector.propTypes = {
   subject: PropTypes.string,
-  updateCourse: PropTypes.func
+  updateCourse: PropTypes.func,
+  editable: PropTypes.bool
 };
 
 export default CourseSubjectSelector;
-
-
-
 

--- a/app/assets/javascripts/components/course_creator/course_subject_selector.jsx
+++ b/app/assets/javascripts/components/course_creator/course_subject_selector.jsx
@@ -4,10 +4,9 @@ import CreatableInput from '../common/creatable_input.jsx';
 import TextInput from '../common/text_input.jsx';
 import request from '../../utils/request';
 
-const CourseSubjectSelector = ({ updateCourse, subject, editable }) => {
+const CourseSubjectSelector = ({ updateCourse, subject = '', editable = true }) => {
   const [options, setOptions] = useState();
   const [selected, setSelected] = useState(null);
-  if (typeof editable !== 'boolean') editable = true;
 
   useEffect(() => {
     if (editable) {

--- a/app/assets/javascripts/components/course_creator/course_subject_selector.jsx
+++ b/app/assets/javascripts/components/course_creator/course_subject_selector.jsx
@@ -27,7 +27,7 @@ const CourseSubjectSelector = ({ updateCourse, subject = '', editable = true }) 
               });
             }
           });
-          if (subject.length > 0) {
+          if (subject !== '') {
             const sel = { value: subject, label: subject };
             setSelected(sel);
             opts.push(sel);

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -21,6 +21,7 @@ import OnlineVolunteersToggle from './online_volunteers_toggle.jsx';
 import WikiEditsToggle from './wiki_edits_toggle';
 import EditSettingsToggle from './edit_settings_toggle';
 import CourseLevelSelector from '../course_creator/course_level_selector.jsx';
+import CourseSubjectSelector from '../course_creator/course_subject_selector.jsx';
 import selectStyles from '../../styles/select';
 import WikiSelect from '../common/wiki_select.jsx';
 import Modal from '../common/modal.jsx';
@@ -281,7 +282,7 @@ const Details = createReactClass({
         {campaignEditable}
       </span>
     );
-    let subject;
+    let courseSubject;
     let tags;
     let courseTypeSelector;
     let submittedSelector;
@@ -296,14 +297,11 @@ const Details = createReactClass({
     let multiWikiSelector;
 
     if (this.props.current_user.admin) {
-      subject = (
-        <TextInput
-          onChange={this.updateDetails}
-          value={this.props.course.subject}
-          value_key="subject"
+      courseSubject = (
+        <CourseSubjectSelector
           editable={this.props.editable}
-          type="text"
-          label={I18n.t('courses.subject')}
+          updateCourse={this.updateDetails}
+          subject={this.props.course.subject}
         />
       );
       tags = (
@@ -496,7 +494,7 @@ const Details = createReactClass({
             <div className="group-right">
               {timelineStart}
               {timelineEnd}
-              {subject}
+              {courseSubject}
               {courseLevelSelector}
               {tags}
               {courseTypeSelector}


### PR DESCRIPTION
## What this PR does
Changed the subject field of the edit screen to the drop down as requested in #2499

## Screenshots
Before:
![Screenshot from 2020-05-06 21-20-19](https://user-images.githubusercontent.com/36356746/81244608-e96e7d00-8fe0-11ea-86f8-a3ae4c91f255.png)

After:
![Screenshot from 2020-05-06 21-24-05](https://user-images.githubusercontent.com/36356746/81244632-f55a3f00-8fe0-11ea-9835-ae3697039210.png)

## Open questions and concerns
I haven't found anywhere else to change it. I hope this is the right way to do what I intended. I'd love to hear feedback. Thanks !
I believe the custom subjects do not persist, and I would need help about the strategy to accomplish this.

EDIT: Also changed it in the cloned view
