### PR TITLE
Added 'macos' keyword option to setup script 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ if platform.platform().lower().find('ubuntu') != -1 \
     deb_setup()
 elif platform.platform().lower().find('fedora') != -1:
     dnf_setup()
-elif platform.platform().lower().find('darwin') != -1:
+elif platform.platform().lower().find('darwin') != -1 \
+        or platform.platform().lower().find('mac') != -1: 
     osx_setup()
 elif platform.platform().lower().find('windows') != -1:
     win_setup()


### PR DESCRIPTION
## What this PR does
When I ran the setup.py script, I kept receiving the error that my operating system is not supported. I'm running macOS Catalina. 

I ran the line 45 of setup.py in my python shell, and confirmed that -1 was the value returned. It seems like platform.system() returns 'Darwin', but platform.platform() returned 'macOS'. 

So, I added an or statement to the script to also check for 'darwin' *or* 'mac' to run osx_setup(). 

## Screenshots
Before, showing my operating system not supported: 
![before_operating_system_not_supported](https://user-images.githubusercontent.com/28582074/81353336-98609680-907d-11ea-9eb4-49bd82ab2ddd.png)

Confirming what platform and system I ran from the shell: 
![platform_check](https://user-images.githubusercontent.com/28582074/81353345-a0b8d180-907d-11ea-8408-3b240e3cf719.png)

After the *or* addition, system found: 
![after_system_found](https://user-images.githubusercontent.com/28582074/81353370-b75f2880-907d-11ea-8219-e0099f94ace3.png)

## Open questions and concerns
There might be other, better workarounds for this, but this change made the script work for me! Shout with any feedback, and thank you!
