### PR TITLE
Fix jump in page content when scrolling

### DIFF
--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -294,6 +294,7 @@ nav.ham-nav
 
 .course-nav__wrapper,
 .campaign-nav__wrapper
+  height: $nav_height
   +below(desktop)
     margin-top 50px
 

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -294,7 +294,7 @@ nav.ham-nav
 
 .course-nav__wrapper,
 .campaign-nav__wrapper
-  height: $nav_height
+  height $nav_height
   +below(desktop)
     margin-top 50px
 


### PR DESCRIPTION
## What this PR does
Fixes a content jump due to the sticky nav being removed from the flow of the page when its position is set to fixed. The fix is achieved by giving the sticky nav wrapper the same height as the sticky nav itself.

## Screenshots
Before:

Jittering on scroll:
![before_1](https://user-images.githubusercontent.com/3844911/81561352-10baa680-9361-11ea-8a8f-d6d64921b802.gif)

Visible content jump when scrolling:
![before_2](https://user-images.githubusercontent.com/3844911/81561381-17491e00-9361-11ea-9f41-b16d57694698.gif)


After:

No longer jittering (can actually scroll to the bottom of the page!):
![after_1](https://user-images.githubusercontent.com/3844911/81561431-2c25b180-9361-11ea-8d60-7b8eb6b8084c.gif)

No content jump when scrolling:
![after_2](https://user-images.githubusercontent.com/3844911/81561467-3647b000-9361-11ea-809f-9dc37b68768b.gif)