### PR TITLE
Fix missing keyboard focus on nav items

### DIFF
--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -226,7 +226,6 @@ nav
     +above(desktop)
       padding-top 13px
   .nav__item
-    overflow hidden
     padding 0
     width 30%
     display inline-block


### PR DESCRIPTION
## What this PR does
This PR fixes an accessibility problem, which is that keyboard focus on items in the nav bar is not visible. The cause of the missing keyboard focus is hidden overflow. Removing `overflow hidden` from the `nav__item` class makes the keyboard focus visible.

## Screenshots
Tabbing through the nav items before:
![no_keyboard_focus](https://user-images.githubusercontent.com/3844911/81627865-21a10180-93cd-11ea-861d-05c518e85721.gif)

Tabbing through the nav items after:
![keyboard_focus](https://user-images.githubusercontent.com/3844911/81627899-31b8e100-93cd-11ea-868b-4abf7386b653.gif)

