### PR TITLE
Sidekiq course update debugging utility

### DIFF
--- a/app/services/check_course_jobs.rb
+++ b/app/services/check_course_jobs.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
+
+# Utility for debugging problems with the course update job queue.
+class CheckCourseJobs
+  include CourseQueueSorting
+
+  def initialize(course)
+    @course = course
+    @course_id = course.id
+  end
+
+  def health_report
+    is_locked = SidekiqUniqueJobs::Digests.all.include? expected_digest
+    has_job = find_job.present?
+    pp "locked: #{is_locked}"
+    pp "job in queue: #{has_job}"
+  end
+
+  def delete_unique_lock
+    SidekiqUniqueJobs::Digests.delete_by_digest expected_digest
+  end
+
+  # This is based on the implementation of SidekiqUniqueJobs digest generation
+  # as of version 6.
+  # See SidekiqUniqueJobs::UniqueArgs#create_digest
+  # We want to know the expected hash so that we can look for that digest
+  # among the unique digests
+  def expected_digest
+    hash = {
+      'class' => 'CourseDataUpdateWorker',
+      'queue' => queue_for(@course),
+      'unique_args' => [@course_id]
+    }.to_json
+    digest = OpenSSL::Digest::MD5.hexdigest hash
+    "uniquejobs:#{digest}"
+  end
+
+  def find_job
+    Sidekiq::Queue.all.each do |queue|
+      queue.each do |job|
+        next unless job.klass == 'CourseDataUpdateWorker'
+        next unless job.args == [@course_id]
+        return job
+      end
+    end
+
+    return nil
+  end
+end

--- a/app/services/check_course_jobs.rb
+++ b/app/services/check_course_jobs.rb
@@ -41,8 +41,7 @@ class CheckCourseJobs
     Sidekiq::Queue.all.each do |queue|
       queue.each do |job|
         next unless job.klass == 'CourseDataUpdateWorker'
-        next unless job.args == [@course_id]
-        return job
+        return job if job.args == [@course_id]
       end
     end
 

--- a/lib/data_cycle/course_queue_sorting.rb
+++ b/lib/data_cycle/course_queue_sorting.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CourseQueueSorting
+  def queue_for(course)
+    course_length = course.end - course.start
+    not_ended = Time.zone.now < course.end
+    if course_length < 3.days && not_ended
+      'short_update'
+    elsif course_length < 6.months
+      'medium_update'
+    else
+      'long_update'
+    end
+  end
+end

--- a/lib/data_cycle/schedule_course_updates.rb
+++ b/lib/data_cycle/schedule_course_updates.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
+require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
 require_dependency "#{Rails.root}/app/workers/course_data_update_worker"
 
 # Executes all the steps of 'update_constantly' data import task
 class ScheduleCourseUpdates
   include BatchUpdateLogging
+  include CourseQueueSorting
 
   def initialize
     setup_logger
@@ -45,18 +47,6 @@ class ScheduleCourseUpdates
   def conflicting_updates_running?
     return true if update_running?(:short)
     false
-  end
-
-  def queue_for(course)
-    course_length = course.end - course.start
-    not_ended = Time.zone.now < course.end
-    if course_length < 3.days && not_ended
-      'short_update'
-    elsif course_length < 6.months
-      'medium_update'
-    else
-      'long_update'
-    end
   end
 
   def latency(queue)

--- a/spec/services/check_course_jobs_spec.rb
+++ b/spec/services/check_course_jobs_spec.rb
@@ -22,8 +22,23 @@ describe CheckCourseJobs do
   end
 
   describe '#find_job' do
-    it 'runs without error' do
-      subject.find_job
+    context 'when no update is scheduled' do
+      it 'returns nil' do
+        expect(subject.find_job).to be_nil
+      end
+    end
+
+    context 'when there is an update scheduled' do
+      before do
+        Sidekiq::Testing.disable!
+        CourseDataUpdateWorker.set(queue: 'test').perform_async(course.id)
+      end
+
+      after { Sidekiq::Testing.inline! }
+
+      it 'returns the update job' do
+        expect(subject.find_job).to be_a(Sidekiq::Job)
+      end
     end
   end
 

--- a/spec/services/check_course_jobs_spec.rb
+++ b/spec/services/check_course_jobs_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CheckCourseJobs do
+  let(:course) { create(:course) }
+
+  let(:subject) do
+    described_class.new(course)
+  end
+
+  describe '#health_report' do
+    it 'runs without error' do
+      subject.health_report
+    end
+  end
+
+  describe '#expected_digest' do
+    it 'produces a plausible string' do
+      expect(subject.expected_digest).to match(/uniquejobs/)
+    end
+  end
+
+  describe '#find_job' do
+    it 'runs without error' do
+      subject.find_job
+    end
+  end
+
+  describe '#delete_unique_lock' do
+    it 'runs without error' do
+      subject.delete_unique_lock
+    end
+  end
+end


### PR DESCRIPTION
This adds some code for manually debugging the sidekiq update jobs for a course.

In particular, it can be used to determine whether there's a job in the queue for given course, and also whether there's an orphaned unique lock that needs to be cleared out.

It might be useful later on for automated health checks of the update queue so that we can avoid manual intervention for orphaned locks.