### PR TITLE
Fixes javascript cross site warnings.

### DIFF
--- a/app/assets/javascripts/actions/new_account_actions.js
+++ b/app/assets/javascripts/actions/new_account_actions.js
@@ -5,8 +5,7 @@ import API from '../utils/api.js';
 const _checkAvailability = (newAccount) => {
   return new Promise((res, rej) =>
     $.ajax({
-      dataType: 'jsonp',
-      url: `https://meta.wikimedia.org/w/api.php?action=query&list=users&ususers=${newAccount.username}&usprop=cancreate&format=json`,
+      url: `https://meta.wikimedia.org/w/api.php?action=query&list=users&ususers=${newAccount.username}&usprop=cancreate&format=json&origin=*`,
       success: (data) => {
         const result = data.query.users[0];
         return res(result);

--- a/app/assets/javascripts/actions/wikidata_actions.js
+++ b/app/assets/javascripts/actions/wikidata_actions.js
@@ -3,13 +3,12 @@ import * as types from '../constants';
 import logErrorMessage from '../utils/log_error_message';
 import CourseUtils from '../utils/course_utils';
 
-const wikidataApiBase = 'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json';
+const wikidataApiBase = 'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&origin=*';
 
 const fetchWikidataLabelsPromise = (qNumbers) => {
   const idsParam = _.join(qNumbers, '|');
   return new Promise((res, rej) => {
     return $.ajax({
-      dataType: 'jsonp',
       url: wikidataApiBase,
       data: {
         ids: idsParam,

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -142,11 +142,11 @@ const DiffViewer = createReactClass({
     // eg, "https://en.wikipedia.org/w/api.php?action=query&prop=revisions&revids=139993&rvdiffto=prev&format=json",
     let diffUrl;
     if (this.state.parentRevisionId) {
-      diffUrl = `${queryBase}&revids=${this.state.parentRevisionId}|${lastRevision.mw_rev_id}&rvdiffto=${lastRevision.mw_rev_id}&format=json`;
+      diffUrl = `${queryBase}&revids=${this.state.parentRevisionId}|${lastRevision.mw_rev_id}&rvdiffto=${lastRevision.mw_rev_id}&format=json&origin=*`;
     } else if (firstRevision) {
-      diffUrl = `${queryBase}&revids=${firstRevision.mw_rev_id}|${lastRevision.mw_rev_id}&rvdiffto=${lastRevision.mw_rev_id}&format=json`;
+      diffUrl = `${queryBase}&revids=${firstRevision.mw_rev_id}|${lastRevision.mw_rev_id}&rvdiffto=${lastRevision.mw_rev_id}&format=json&origin=*`;
     } else {
-      diffUrl = `${queryBase}&revids=${lastRevision.mw_rev_id}&rvdiffto=prev&format=json`;
+      diffUrl = `${queryBase}&revids=${lastRevision.mw_rev_id}&rvdiffto=prev&format=json&origin=*`;
     }
 
     return diffUrl;
@@ -168,7 +168,6 @@ const DiffViewer = createReactClass({
     const diffUrl = `${queryBase}&revids=${props.first_revision.mw_rev_id}&format=json`;
     jQuery.ajax(
       {
-        dataType: 'jsonp',
         url: diffUrl,
         success: (data) => {
           const revisionData = data.query.pages[props.first_revision.mw_page_id].revisions[0];
@@ -182,7 +181,6 @@ const DiffViewer = createReactClass({
   fetchDiff(diffUrl) {
     jQuery.ajax(
       {
-        dataType: 'jsonp',
         url: diffUrl,
         success: (data) => {
           let firstRevisionData;


### PR DESCRIPTION
## What this PR does
There are 2 ways to make an API call to another MediaWiki website: 
- JSONP
- CORS

JSONP is more of a hack which turns data into scripts to bypass the cross domain restrictions, it can also cause Cross-Site Scripting issues if the site to which request is being made is compromised.

In CORS, new HTTP headers provide a way to request remote URLs only when they have permission. The server responds appropriately whether or not it wants credentials, after which the actual request is made. In the MediaWiki API case, `origin=*` (unauthenticated requests) responds with `Access-Control-Allow-Credentials: false` , meaning that it will process the request as if logged out.

Also one thing is to be kept in mind that JSONP is an old method now and CORS is a new modern solution. JSONP works with very old browsers nicely whereas CORS can cause some issues. CORS works well with the modern browsers.

Referencing #3998 
Referencing [https://www.mediawiki.org/wiki/API:Cross-site_requests#Unauthenticated_CORS_Requests](https://www.mediawiki.org/wiki/API:Cross-site_requests#Unauthenticated_CORS_Requests)

The error in our case was
![Screenshot from 2020-05-28 03-50-24](https://user-images.githubusercontent.com/37243661/83191392-8ee4be80-a151-11ea-9fae-5c58f6e772f5.png)
