### PR TITLE
Add choice of course format (in-person vs online) to CourseCreator

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_form.jsx
+++ b/app/assets/javascripts/components/course_creator/course_form.jsx
@@ -3,6 +3,7 @@ import TextAreaInput from '../common/text_area_input.jsx';
 import CreatableInput from '../common/creatable_input.jsx';
 import TextInput from '../common/text_input.jsx';
 import CourseLevelSelector from './course_level_selector.jsx';
+import CourseFormatSelector from './course_format_selector.jsx';
 import CourseSubjectSelector from './course_subject_selector.jsx';
 import CourseUtils from '../../utils/course_utils.js';
 import selectStyles from '../../styles/select';
@@ -38,6 +39,7 @@ const CourseForm = (props) => {
   let courseSubject;
   let expectedStudents;
   let courseLevel;
+  let courseFormat;
   let roleDescription;
   let academic_system;
 
@@ -68,6 +70,12 @@ const CourseForm = (props) => {
     courseLevel = (
       <CourseLevelSelector
         level={props.course.level}
+        updateCourse={props.updateCourseAction}
+      />
+    );
+    courseFormat = (
+      <CourseFormatSelector
+        format={props.course.format}
         updateCourse={props.updateCourseAction}
       />
     );
@@ -224,10 +232,11 @@ const CourseForm = (props) => {
         {home_wiki}
         {multi_wiki}
         {backButton}
-        <p className="tempCourseIdText">{props.tempCourseId}</p>
+        <p className="tempCourseIdText">{props.tempCourseId || '\xa0'}</p>
       </div>
       <div className="column">
         {courseLevel}
+        {courseFormat}
         <span className="text-input-component__label">
           <strong>
             {CourseUtils.i18n('creator.course_description', props.stringPrefix)}

--- a/app/assets/javascripts/components/course_creator/course_format_selector.jsx
+++ b/app/assets/javascripts/components/course_creator/course_format_selector.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+import selectStyles from '../../styles/single_select';
+
+const CourseFormatSelector = ({ format, updateCourse }) => {
+  let selectedOption = { value: format, label: format };
+  const handleChange = (option) => {
+    const courseLevel = option.value;
+    selectedOption = option;
+    updateCourse('format', courseLevel);
+  };
+  const options = [
+    { value: '', label: '— select one —' },
+    { value: 'In-person', label: 'In-person' },
+    { value: 'Online', label: 'Online' },
+    { value: 'Mixed', label: 'Mixed' },
+  ];
+  return (
+    <div className="form-group">
+      <label htmlFor="course_format">Course format:</label>
+      <Select
+        id="course_format"
+        value={options.find(option => option.value === selectedOption.value)}
+        onChange={handleChange}
+        options={options}
+        simpleValue
+        styles={selectStyles}
+      />
+    </div>
+  );
+};
+
+CourseFormatSelector.propTypes = {
+  format: PropTypes.string,
+  updateCourse: PropTypes.func
+};
+
+export default CourseFormatSelector;

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -20,7 +20,8 @@ import OnlineVolunteersToggle from './online_volunteers_toggle.jsx';
 
 import WikiEditsToggle from './wiki_edits_toggle';
 import EditSettingsToggle from './edit_settings_toggle';
-import CourseLevelSelector from '../course_creator/course_level_selector.jsx';
+import CourseLevelSelector from '../course_creator/course_level_selector';
+import CourseFormatSelector from '../course_creator/course_format_selector';
 import selectStyles from '../../styles/select';
 import WikiSelect from '../common/wiki_select.jsx';
 import Modal from '../common/modal.jsx';
@@ -287,6 +288,7 @@ const Details = createReactClass({
     let submittedSelector;
     let privacySelector;
     let courseLevelSelector;
+    let courseFormatSelector;
     let timelineToggle;
     let onlineVolunteersToggle;
     let wikiEditsToggle;
@@ -355,6 +357,12 @@ const Details = createReactClass({
       courseLevelSelector = (
         <CourseLevelSelector
           level={this.props.course.level}
+          updateCourse={this.updateDetails}
+        />
+      );
+      courseFormatSelector = (
+        <CourseFormatSelector
+          format={this.props.course.format}
           updateCourse={this.updateDetails}
         />
       );
@@ -498,6 +506,7 @@ const Details = createReactClass({
               {timelineEnd}
               {subject}
               {courseLevelSelector}
+              {courseFormatSelector}
               {tags}
               {courseTypeSelector}
               {submittedSelector}

--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -25,6 +25,7 @@ const initialState = {
   level: '',
   subject: '',
   expected_students: '0',
+  format: '',
   start: null,
   end: null,
   timeline_start: null,

--- a/app/assets/stylesheets/modules/_wizard.styl
+++ b/app/assets/stylesheets/modules/_wizard.styl
@@ -112,6 +112,7 @@ wizard-width = 860px
             width 20px
 
     .tempCourseIdText
+      margin-top 16px
       display inline-block
       margin-left 10px
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -33,6 +33,7 @@ class CoursesController < ApplicationController
     @course = course_creation_manager.create
     update_courses_wikis
     update_academic_system
+    update_course_format
   end
 
   def update
@@ -261,6 +262,7 @@ class CoursesController < ApplicationController
     update_boolean_flag :online_volunteers_enabled
     update_edit_settings
     update_academic_system
+    update_course_format
     update_last_reviewed
   end
 
@@ -289,6 +291,11 @@ class CoursesController < ApplicationController
 
   def update_academic_system
     @course.flags['academic_system'] = params.dig(:course, 'academic_system')
+    @course.save
+  end
+
+  def update_course_format
+    @course.flags['format'] = params.dig(:course, 'format')
     @course.save
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -341,6 +341,10 @@ class Course < ApplicationRecord
     flags['academic_system']
   end
 
+  def format
+    flags['format']
+  end
+
   def edit_settings_present?
     flags.key?('edit_settings')
   end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -8,8 +8,8 @@ json.course do
             :timeline_end, :day_exceptions, :weekdays, :no_day_exceptions,
             :updated_at, :string_prefix, :use_start_and_end_times, :type,
             :home_wiki, :character_sum,  :upload_count, :uploads_in_use_count,
-            :upload_usages_count, :cloned_status, :flags, :level, :private, :closed?,
-            :training_library_slug, :peer_review_count, :withdrawn)
+            :upload_usages_count, :cloned_status, :flags, :level, :format, :private,
+            :closed?, :training_library_slug, :peer_review_count, :withdrawn)
 
   json.wikis @course.wikis, :language, :project
   json.timeline_enabled @course.timeline_enabled?


### PR DESCRIPTION
This adds a new 'format' flag to ClassroomProgramCourse-type courses. It also includes a tweak to the way the course slug is displayed to that the Next button doesn't overlap with the now-bigger right column of the creator form, and it improves the course creation spec to check for the values of the course level, format, and subject. (It also removes some dead code in that spec.)