### PR TITLE
Removing method CourseUploadImporter.update_courses not used anymore

### DIFF
--- a/lib/importers/course_upload_importer.rb
+++ b/lib/importers/course_upload_importer.rb
@@ -4,12 +4,6 @@ require_dependency "#{Rails.root}/lib/importers/upload_importer"
 
 #= Imports uploads by students during a course
 class CourseUploadImporter
-  def self.update_courses(courses)
-    courses.each do |course|
-      new(course).run
-    end
-  end
-
   def initialize(course)
     @course = course
     @start = course.start

--- a/spec/lib/importers/course_upload_importer_spec.rb
+++ b/spec/lib/importers/course_upload_importer_spec.rb
@@ -13,10 +13,10 @@ describe CourseUploadImporter do
     create(:courses_user, user: user, course: course)
   end
 
-  describe '.update_courses' do
-    it 'imports uploads with thumburls and usage counts for the courses' do
+  describe '.run' do
+    it 'imports uploads with thumburls and usage counts for the course' do
       VCR.use_cassette 'course_upload_importer/kippleboy' do
-        described_class.update_courses([course])
+        described_class.new(course).run
         expect(course.reload.uploads.count).to eq(5)
         # https://commons.wikimedia.org/wiki/File%3AVaga_feminista_8M_2018_a_Sabadell_02.jpg
         upload = course.uploads.third


### PR DESCRIPTION
## What this PR does
This method was used earlier. It basically runs the `run` method for a list of courses. Its usage was removed in [this commit](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/5552ee88775c008044233b5643a4baead1134413#diff-29d3b72a735e3bc19cae145d06eba504)
