### PR TITLE
Tracking course update errors downwards

### DIFF
--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -34,7 +34,7 @@ class UpdateCourseStats
 
   def fetch_data
     log_update_progress :start
-    CourseRevisionUpdater.import_revisions(@course, all_time: @full_update)
+    CourseRevisionUpdater.import_revisions(@course, all_time: @full_update, update_service: self)
     log_update_progress :revisions_imported
 
     RevisionScoreImporter.update_revision_scores_for_course(@course)

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -7,9 +7,12 @@ require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/importers/average_views_importer"
+require_dependency "#{Rails.root}/lib/errors/update_service_error_helper"
 
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats
+  include UpdateServiceErrorHelper
+
   def initialize(course, full: false)
     @course = course
     # If the upate was explicitly requested by a user,
@@ -27,7 +30,9 @@ class UpdateCourseStats
     @course.update(needs_update: false)
     @end_time = Time.zone.now
     UpdateLogger.update_course(@course, 'start_time' => @start_time.to_datetime,
-                                        'end_time' => @end_time.to_datetime)
+                                        'end_time' => @end_time.to_datetime,
+                                        'sentry_tag_uuid' => sentry_tag_uuid,
+                                        'error_count' => error_count)
   end
 
   private

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -37,7 +37,7 @@ class UpdateCourseStats
     CourseRevisionUpdater.import_revisions(@course, all_time: @full_update, update_service: self)
     log_update_progress :revisions_imported
 
-    RevisionScoreImporter.update_revision_scores_for_course(@course)
+    RevisionScoreImporter.update_revision_scores_for_course(@course, update_service: self)
     log_update_progress :revision_scores_imported
 
     CourseUploadImporter.new(@course).run

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -40,7 +40,7 @@ class UpdateCourseStats
     RevisionScoreImporter.update_revision_scores_for_course(@course, update_service: self)
     log_update_progress :revision_scores_imported
 
-    CourseUploadImporter.new(@course).run
+    CourseUploadImporter.new(@course, update_service: self).run
     log_update_progress :uploads_imported
   end
 

--- a/lib/commons.rb
+++ b/lib/commons.rb
@@ -5,24 +5,25 @@ require_dependency "#{Rails.root}/lib/wiki_api"
 
 #= This class is for getting data directly from the Wikimedia Commons API.
 class Commons
-  def initialize(query)
+  def initialize(query, update_service = nil)
     @query = query
+    @update_service = update_service
   end
   ###################
   # Request methods #
   ###################
 
   # Get user contribution data that corresponds to new file uploads.
-  def self.get_uploads(users, start_date: nil, end_date: nil)
+  def self.get_uploads(users, start_date: nil, end_date: nil, update_service: nil)
     upload_query = build_upload_query(users, start_date, end_date)
-    uploads = new(upload_query).fetch_all_uploads
+    uploads = new(upload_query, update_service).fetch_all_uploads
     uploads
   end
 
   # Get data about how files are being used across Wikimedia sites.
-  def self.get_usages(commons_uploads)
+  def self.get_usages(commons_uploads, update_service: nil)
     usage_query = build_usage_query commons_uploads
-    usages = new(usage_query).get_image_data('globalusage', 'gucontinue')
+    usages = new(usage_query, update_service).get_image_data('globalusage', 'gucontinue')
     usages
   end
 
@@ -34,9 +35,9 @@ class Commons
     commons_uploads.select { |file| missing_page_ids.include? file.id }
   end
 
-  def self.get_urls(commons_uploads)
+  def self.get_urls(commons_uploads, update_service: nil)
     url_query = build_url_query commons_uploads
-    file_urls = new(url_query).get_image_data('imageinfo', 'iicontinue')
+    file_urls = new(url_query, update_service).get_image_data('imageinfo', 'iicontinue')
     file_urls
   end
 
@@ -138,6 +139,6 @@ class Commons
   private
 
   def api_get
-    WikiApi.new(CommonsWiki.new).query(@query)
+    WikiApi.new(CommonsWiki.new, @update_service).query(@query)
   end
 end

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -7,19 +7,20 @@ class CourseRevisionUpdater
   ###############
   # Entry point #
   ###############
-  def self.import_revisions(course, all_time:)
+  def self.import_revisions(course, all_time:, update_service: nil)
     return if course.students.empty?
-    new(course).update_revisions_for_relevant_wikis(all_time)
+    new(course, update_service: update_service).update_revisions_for_relevant_wikis(all_time)
     ArticlesCourses.update_from_course(course)
   end
 
-  def initialize(course)
+  def initialize(course, update_service: nil)
     @course = course
+    @update_service = update_service
   end
 
   def update_revisions_for_relevant_wikis(all_time)
     @course.wikis.each do |wiki|
-      RevisionImporter.new(wiki, @course).import_revisions_for_course(all_time: all_time)
+      RevisionImporter.new(wiki, @course, update_service: @update_service).import_revisions_for_course(all_time: all_time)
     end
   end
 end

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -20,7 +20,8 @@ class CourseRevisionUpdater
 
   def update_revisions_for_relevant_wikis(all_time)
     @course.wikis.each do |wiki|
-      RevisionImporter.new(wiki, @course, update_service: @update_service).import_revisions_for_course(all_time: all_time)
+      RevisionImporter.new(wiki, @course, update_service: @update_service)
+                      .import_revisions_for_course(all_time: all_time)
     end
   end
 end

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -4,9 +4,9 @@ class UpdateLogger
   ################
   # Entry points #
   ################
-  def self.update_course(course, times)
+  def self.update_course(course, hash_info)
     logs = course.flags['update_logs']
-    new_logs = new(logs).update(times)
+    new_logs = new(logs).update(hash_info)
     course.flags['update_logs'] = new_logs
     course.flags['average_update_delay'] = average_delay(new_logs)
     course.save
@@ -40,9 +40,9 @@ class UpdateLogger
     @last_update_number = @log_hash.keys.max || 0
   end
 
-  def update(times)
+  def update(hash_info)
     @update_number = @last_update_number + 1
-    @log_hash[@update_number] = times
+    @log_hash[@update_number] = hash_info
     @log_hash.delete(@log_hash.keys.min) until @log_hash.count <= MAX_UPDATES
     @log_hash
   end

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -4,11 +4,11 @@ class UpdateLogger
   ################
   # Entry points #
   ################
-  def self.update_course(course, hash_info)
+  def self.update_course(course, new_logs)
     logs = course.flags['update_logs']
-    new_logs = new(logs).update(hash_info)
-    course.flags['update_logs'] = new_logs
-    course.flags['average_update_delay'] = average_delay(new_logs)
+    updated_logs = new(logs).update(new_logs)
+    course.flags['update_logs'] = updated_logs
+    course.flags['average_update_delay'] = average_delay(updated_logs)
     course.save
   end
 
@@ -40,9 +40,9 @@ class UpdateLogger
     @last_update_number = @log_hash.keys.max || 0
   end
 
-  def update(hash_info)
+  def update(new_logs)
     @update_number = @last_update_number + 1
-    @log_hash[@update_number] = hash_info
+    @log_hash[@update_number] = new_logs
     @log_hash.delete(@log_hash.keys.min) until @log_hash.count <= MAX_UPDATES
     @log_hash
   end

--- a/lib/errors/api_error_handling.rb
+++ b/lib/errors/api_error_handling.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ApiErrorHandling
+  def log_error(error, update_service: nil, sentry_extra:)
+    Rails.logger.info "Caught #{error}"
+    sentry_tags = nil
+    if update_service.present?
+      update_service.update_error_stats
+      sentry_tags = update_service.sentry_tags
+    end
+    Raven.capture_exception(error,
+                            level: error_level(error),
+                            extra: sentry_extra,
+                            tags: sentry_tags)
+    return nil
+  end
+
+  def error_level(error)
+    self.class.const_get(:TYPICAL_ERRORS).include?(error.class) ? 'warning' : 'error'
+  end
+end

--- a/lib/errors/update_service_error_helper.rb
+++ b/lib/errors/update_service_error_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module UpdateServiceErrorHelper
+  def sentry_tag_uuid
+    @sentry_tag_uuid ||= SecureRandom.uuid
+  end
+
+  def error_count
+    @error_count ||= 0
+  end
+
+  def update_error_stats
+    @error_count = error_count + 1
+  end
+
+  def sentry_tags
+    { update_service_id: sentry_tag_uuid, course: @course.slug }
+  end
+end

--- a/lib/importers/course_upload_importer.rb
+++ b/lib/importers/course_upload_importer.rb
@@ -4,8 +4,9 @@ require_dependency "#{Rails.root}/lib/importers/upload_importer"
 
 #= Imports uploads by students during a course
 class CourseUploadImporter
-  def initialize(course)
+  def initialize(course, update_service: nil)
     @course = course
+    @update_service = update_service
     @start = course.start
     @end = course.end + Course::UPDATE_LENGTH
   end
@@ -25,14 +26,15 @@ class CourseUploadImporter
   end
 
   def import_thumbnail_urls
-    UploadImporter.import_urls_in_batches @course.uploads.where(thumburl: nil, deleted: false)
+    UploadImporter.import_urls_in_batches(@course.uploads.where(thumburl: nil, deleted: false),
+                                          update_service: @update_service)
   end
 
   def update_usage
-    UploadImporter.update_usage_count(@course.uploads)
+    UploadImporter.update_usage_count(@course.uploads, update_service: @update_service)
   end
 
   def uploads_data(users)
-    Commons.get_uploads(users, start_date: @start, end_date: @end)
+    Commons.get_uploads(users, start_date: @start, end_date: @end, update_service: @update_service)
   end
 end

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -6,9 +6,10 @@ require_dependency "#{Rails.root}/lib/importers/article_importer"
 
 #= Imports and updates revisions from Wikipedia into the dashboard database
 class RevisionImporter
-  def initialize(wiki, course)
+  def initialize(wiki, course, update_service: nil)
     @wiki = wiki
     @course = course
+    @update_service = update_service
   end
 
   def import_revisions_for_course(all_time:)
@@ -67,7 +68,7 @@ class RevisionImporter
   # Get revisions made by a set of users between two dates.
   def get_revisions(users, start, end_date)
     Utils.chunk_requests(users, 40) do |block|
-      Replica.new(@wiki).get_revisions block, start, end_date
+      Replica.new(@wiki, @update_service).get_revisions block, start, end_date
     end
   end
 

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -18,18 +18,21 @@ class RevisionScoreImporter
     new(language: nil, project: 'wikidata').update_previous_revision_scores
   end
 
-  def self.update_revision_scores_for_course(course)
+  def self.update_revision_scores_for_course(course, update_service: nil)
     course.wikis.each do |wiki|
       next unless OresApi.valid_wiki?(wiki)
-      new(wiki: wiki, course: course).update_revision_scores
-      new(wiki: wiki, course: course).update_previous_revision_scores
+      new(wiki: wiki, course: course, update_service: update_service)
+        .update_revision_scores
+      new(wiki: wiki, course: course, update_service: update_service)
+        .update_previous_revision_scores
     end
   end
 
-  def initialize(language: 'en', project: 'wikipedia', wiki: nil, course: nil)
+  def initialize(language: 'en', project: 'wikipedia', wiki: nil, course: nil, update_service: nil)
     @course = course
+    @update_service = update_service
     @wiki = wiki || Wiki.get_or_create(language: language, project: project)
-    @ores_api = OresApi.new(@wiki)
+    @ores_api = OresApi.new(@wiki, @update_service)
   end
 
   # assumes a mediawiki rev_id from the correct Wikipedia
@@ -127,7 +130,7 @@ class RevisionScoreImporter
   def get_parent_revisions(rev_batch)
     revisions = {}
     rev_query = parent_revisions_query rev_batch.map(&:mw_rev_id)
-    response = WikiApi.new(@wiki).query rev_query
+    response = WikiApi.new(@wiki, @update_service).query rev_query
     return unless response.data['pages']
     response.data['pages'].each do |_page_id, page_data|
       rev_data = page_data['revisions']

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -131,7 +131,7 @@ class RevisionScoreImporter
     revisions = {}
     rev_query = parent_revisions_query rev_batch.map(&:mw_rev_id)
     response = WikiApi.new(@wiki, @update_service).query rev_query
-    return unless response.data['pages']
+    return unless response.present? && response.data['pages']
     response.data['pages'].each do |_page_id, page_data|
       rev_data = page_data['revisions']
       next unless rev_data

--- a/lib/importers/upload_importer.rb
+++ b/lib/importers/upload_importer.rb
@@ -26,9 +26,9 @@ class UploadImporter
     end
   end
 
-  def self.update_usage_count(commons_uploads)
+  def self.update_usage_count(commons_uploads, update_service: nil)
     commons_uploads.in_groups_of(50, false) do |file_batch|
-      usages = Commons.get_usages file_batch
+      usages = Commons.get_usages(file_batch, update_service: update_service)
       import_usages usages
     end
   end
@@ -54,10 +54,10 @@ class UploadImporter
   ################
   # Data methods #
   ################
-  def self.import_urls_in_batches(commons_uploads)
+  def self.import_urls_in_batches(commons_uploads, update_service: nil)
     # Larger values (50) per batch choke the MediaWiki API on this query.
     commons_uploads.in_groups_of(10, false) do |file_batch|
-      file_urls = Commons.get_urls file_batch
+      file_urls = Commons.get_urls(file_batch, update_service: update_service)
       import_urls file_urls
     end
   end

--- a/lib/ores_api.rb
+++ b/lib/ores_api.rb
@@ -43,7 +43,6 @@ class OresApi
     log_error(e, update_service: @update_service,
               sentry_extra: { url: url, response_body: response_body,
                               project_code: @project_code, project_model: @project_model })
-    raise e unless TYPICAL_ERRORS.include?(e.class)
     return {}
   end
 

--- a/lib/ores_api.rb
+++ b/lib/ores_api.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/errors/api_error_handling"
+
 # Gets data from ORES — Objective Revision Evaluation Service
 # https://meta.wikimedia.org/wiki/Objective_Revision_Evaluation_Service
 class OresApi
+  include ApiErrorHandling
+
   # This is the maximum number of concurrent requests the app should make.
   # As of 2018-09-19, ORES policy is a max of 4 parallel connections per IP:
   # https://lists.wikimedia.org/pipermail/wikitech-l/2018-September/090835.html
@@ -36,6 +40,9 @@ class OresApi
     ores_data
   rescue StandardError => e
     url = ORES_SERVER_URL + url_query
+    log_error(e, update_service: @update_service,
+              sentry_extra: { url: url, response_body: response_body,
+                              project_code: @project_code, project_model: @project_model })
     raise e unless TYPICAL_ERRORS.include?(e.class)
     return {}
   end

--- a/lib/ores_api.rb
+++ b/lib/ores_api.rb
@@ -9,6 +9,7 @@ class OresApi
   # Use this if we need to make parallel threaded requests.
   # CONCURRENCY = 4
 
+  ORES_SERVER_URL = 'https://ores.wikimedia.org'
   REVS_PER_REQUEST = 50
 
   # All the wikis with an articlequality model as of 2018-09-18
@@ -28,10 +29,13 @@ class OresApi
   end
 
   def get_revision_data(rev_ids)
-    response = ores_server.get query_url(rev_ids)
-    ores_data = Oj.load(response.body)
+    url_query = query_url(rev_ids)
+    response = ores_server.get(url_query)
+    response_body = response.body
+    ores_data = Oj.load(response_body)
     ores_data
   rescue StandardError => e
+    url = ORES_SERVER_URL + url_query
     raise e unless TYPICAL_ERRORS.include?(e.class)
     return {}
   end
@@ -58,7 +62,7 @@ class OresApi
   end
 
   def ores_server
-    conn = Faraday.new(url: 'https://ores.wikimedia.org')
+    conn = Faraday.new(url: ORES_SERVER_URL)
     conn.headers['User-Agent'] = ENV['dashboard_url'] + ' ' + Rails.env
     conn
   end

--- a/lib/ores_api.rb
+++ b/lib/ores_api.rb
@@ -20,10 +20,11 @@ class OresApi
     wiki.project == 'wikipedia' && AVAILABLE_WIKIPEDIAS.include?(wiki.language)
   end
 
-  def initialize(wiki)
+  def initialize(wiki, update_service = nil)
     raise InvalidProjectError unless OresApi.valid_wiki?(wiki)
     @project_code = wiki.project == 'wikidata' ? 'wikidata' + 'wiki' : wiki.language + 'wiki'
     @project_model = wiki.project == 'wikidata' ? 'itemquality' : 'articlequality'
+    @update_service = update_service
   end
 
   def get_revision_data(rev_ids)

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -119,7 +119,8 @@ class Replica
     tries ||= 3
     response = do_query(endpoint, query)
     return if response.empty?
-    parsed = Oj.load(response.to_s)
+    response_body = response.to_s
+    parsed = Oj.load(response_body)
     return unless parsed['success']
     parsed['data']
   rescue StandardError => e

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -7,8 +7,9 @@ require_dependency "#{Rails.root}/lib/revision_data_parser"
 #= For what's going on at the other end, see:
 #=   https://github.com/WikiEducationFoundation/WikiEduDashboardTools
 class Replica
-  def initialize(wiki)
+  def initialize(wiki, update_service = nil)
     @wiki = wiki
+    @update_service = update_service
   end
 
   # This is the maximum number of concurrent queries the system should run

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -6,9 +6,10 @@ require_dependency "#{Rails.root}/lib/article_rating_extractor.rb"
 
 #= This class is for getting data directly from the MediaWiki API.
 class WikiApi
-  def initialize(wiki = nil)
+  def initialize(wiki = nil, update_service = nil)
     wiki ||= Wiki.default_wiki
     @api_url = wiki.api_url
+    @update_service = update_service
   end
 
   ################

--- a/spec/lib/commons_spec.rb
+++ b/spec/lib/commons_spec.rb
@@ -169,14 +169,5 @@ describe Commons do
       response = described_class.get_urls(CommonsUpload.all)
       expect(response.empty?).to be true
     end
-
-    it 'raises unexpected errors' do
-      stub_request(:get, /.*commons.wikimedia.org.*/).to_raise(StandardError)
-      create(:commons_upload,
-             id: 541408,
-             file_name: 'File:Haeckel Stephoidea.jpg')
-      expect { described_class.get_urls(CommonsUpload.all) }
-        .to raise_error(StandardError)
-    end
   end
 end

--- a/spec/lib/ores_api_spec.rb
+++ b/spec/lib/ores_api_spec.rb
@@ -57,4 +57,26 @@ describe OresApi do
       end
     end
   end
+
+  describe 'error handling and calls ApiErrorHandling method' do
+    let(:course) { create(:course, start: '2013-12-31', end: '2015-01-01') }
+    let(:rev_ids) { [641962088, 12345] }
+    let(:subject) do
+      described_class.new(Wiki.find(1), course).get_revision_data(rev_ids)
+    end
+
+    it 'handles timeout errors' do
+      stub_request(:any, %r{https://ores.wikimedia.org/.*})
+        .to_raise(Errno::ETIMEDOUT)
+      expect_any_instance_of(described_class).to receive(:log_error).once
+      expect(subject).to be_empty
+    end
+
+    it 'handles connection refused errors' do
+      stub_request(:any, %r{https://ores.wikimedia.org/.*})
+        .to_raise(Faraday::ConnectionFailed)
+      expect_any_instance_of(described_class).to receive(:log_error).once
+      expect(subject).to be_empty
+    end
+  end
 end

--- a/spec/lib/ores_api_spec.rb
+++ b/spec/lib/ores_api_spec.rb
@@ -59,10 +59,9 @@ describe OresApi do
   end
 
   describe 'error handling and calls ApiErrorHandling method' do
-    let(:course) { create(:course, start: '2013-12-31', end: '2015-01-01') }
     let(:rev_ids) { [641962088, 12345] }
     let(:subject) do
-      described_class.new(Wiki.find(1), course).get_revision_data(rev_ids)
+      described_class.new(Wiki.find(1)).get_revision_data(rev_ids)
     end
 
     it 'handles timeout errors' do

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -181,7 +181,7 @@ describe Replica do
     end
   end
 
-  describe 'error handling' do
+  describe 'error handling and calls ApiErrorHandling method' do
     let(:all_users) do
       [build(:user, username: 'ELE427'),
        build(:user, username: 'Ragesoss'),
@@ -194,25 +194,28 @@ describe Replica do
     it 'handles timeout errors' do
       stub_request(:any, %r{https://tools.wmflabs.org/.*})
         .to_raise(Errno::ETIMEDOUT)
+      expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles connection refused errors' do
       stub_request(:any, %r{https://tools.wmflabs.org/.*})
         .to_raise(Errno::ECONNREFUSED)
-
+      expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles failed queries' do
       stub_request(:any, %r{https://tools.wmflabs.org/.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
+      expect_any_instance_of(described_class).not_to receive(:log_error)
       expect(subject).to be_empty
     end
 
     it 'handles successful empty responses' do
       stub_request(:any, %r{https://tools.wmflabs.org/.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
+      expect_any_instance_of(described_class).not_to receive(:log_error)
       expect(subject).to be_empty
     end
   end

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -6,7 +6,7 @@ require "#{Rails.root}/lib/wiki_api"
 class UnexpectedError < StandardError; end
 
 describe WikiApi do
-  describe 'error handling' do
+  describe 'error handling and calls ApiErrorHandling method' do
     let(:subject) { described_class.new.get_page_content('Ragesoss') }
 
     it 'handles mediawiki 503 errors gracefully' do
@@ -17,18 +17,21 @@ describe WikiApi do
     it 'handles timeout errors gracefully' do
       allow_any_instance_of(MediawikiApi::Client).to receive(:send)
         .and_raise(Faraday::TimeoutError)
+      expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to eq(nil)
     end
 
     it 'handles API errors gracefully' do
       allow_any_instance_of(MediawikiApi::Client).to receive(:send)
         .and_raise(MediawikiApi::ApiError)
+      expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to eq(nil)
     end
 
     it 'handles HTTP errors gracefully' do
       allow_any_instance_of(MediawikiApi::Client).to receive(:send)
         .and_raise(MediawikiApi::HttpError, '')
+      expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to eq(nil)
     end
   end

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -31,12 +31,6 @@ describe WikiApi do
         .and_raise(MediawikiApi::HttpError, '')
       expect(subject).to eq(nil)
     end
-
-    it 're-raises unexpected errors' do
-      allow_any_instance_of(MediawikiApi::Client).to receive(:send)
-        .and_raise(UnexpectedError)
-      expect { subject }.to raise_error(UnexpectedError)
-    end
   end
 
   describe '#get_page_content' do


### PR DESCRIPTION
## What this PR does
Implementing tracking of course update errors by passing update service `UpdateCourseStats` downwards to APIs and keeping track of errors with the help of Sentry and error count with the help of `UpdateLogger` and `course.flags`.