### PR TITLE
FAQ system to replace ask.wikiedu.org

### DIFF
--- a/app/assets/javascripts/faq.js
+++ b/app/assets/javascripts/faq.js
@@ -1,0 +1,10 @@
+const toggleAccordian = (id) => {
+  const element = document.getElementById(id);
+  if (element.className.indexOf('collapsed') === -1) {
+    element.className = element.className.replace('expanded', 'collapsed');
+  } else {
+    element.className = element.className.replace('collapsed', 'expanded');
+  }
+};
+
+window.toggleAccordian = toggleAccordian;

--- a/app/assets/stylesheets/modules/_faq.styl
+++ b/app/assets/stylesheets/modules/_faq.styl
@@ -1,3 +1,14 @@
+.faq-header
+  input
+    width 100%
+    max-width 400px
+  button.search
+    right 30px
+    position relative
+    color #888
+  button.search:hover
+    color inherit
+
 .faq
   border-bottom 1px solid #ccc
 

--- a/app/assets/stylesheets/modules/_faq.styl
+++ b/app/assets/stylesheets/modules/_faq.styl
@@ -9,6 +9,14 @@
   button.search:hover
     color inherit
 
+.faq-list
+  width 70%
+  float left
+
+.faq-topic-list
+  width 20%
+  float right
+
 .faq
   border-bottom 1px solid #ccc
 

--- a/app/assets/stylesheets/modules/_faq.styl
+++ b/app/assets/stylesheets/modules/_faq.styl
@@ -1,0 +1,15 @@
+.faq
+  h2
+    font-size 30px
+
+  .edit-link
+    font-size 15px
+    float right
+
+  &.collapsed
+    .faq-content
+      visibility hidden
+
+  &.expanded
+    .faq-content
+      visibility visible

--- a/app/assets/stylesheets/modules/_faq.styl
+++ b/app/assets/stylesheets/modules/_faq.styl
@@ -1,15 +1,42 @@
 .faq
+  border-bottom 1px solid #ccc
+
   h2
+    margin 0
+
+  .icon
     font-size 30px
+    float right
+    transform-origin 50% 45%
 
   .edit-link
     font-size 15px
-    float right
+    float left
+
+  .faq-header
+    padding 12px
+    overflow auto
+    cursor pointer
+
+    .faq-title
+      font-size 30px
+      float left
+
+  .faq-content
+    padding 0 12px
+    overflow hidden
 
   &.collapsed
+    .icon
+      transition transform 0.2s
     .faq-content
-      visibility hidden
+      max-height 0
+      transition max-height 0.1s
 
   &.expanded
+    transition all 0.2s
+    .icon
+      transform rotate(180deg)
     .faq-content
-      visibility visible
+      padding-bottom 20px
+      max-height 1000px

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -28,7 +28,11 @@ class FaqController < ApplicationController
     redirect_to faq_path(@faq)
   end
 
-  def destroy; end
+  def destroy
+    @faq = Faq.find(params[:id])
+    @faq.destroy!
+    redirect_to '/faq'
+  end
 
   private
 

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class FaqController < ApplicationController
+  def index
+    @faqs = Faq.all
+  end
+
+  def show
+    @faq = Faq.find(params[:id])
+  end
+
+  def create; end
+
+  def edit
+    @faq = Faq.find(params[:id])
+  end
+
+  def update
+    @faq = Faq.find(params[:id])
+    @faq.update!(update_params)
+    redirect_to faq_path(@faq)
+  end
+
+  def destroy; end
+
+  private
+
+  def update_params
+    params.require(:faq).permit(:title, :content)
+  end
+end

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -7,12 +7,12 @@ class FaqController < ApplicationController
 
   def index
     @query = params[:search]
-    @topic = params[:topic] || DEFAULT_TOPIC
+    @topic_slug = params[:topic] || DEFAULT_TOPIC
     @faqs = if @query
               Faq.where('lower(title) like ?', "%#{@query}%")
                  .or(Faq.where('lower(content) like ?', "%#{@query}%"))
             else
-              FaqTopic.new(@topic).faqs
+              FaqTopic.new(@topic_slug).faqs
             end
   end
 

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FaqController < ApplicationController
+  before_action :require_admin_permissions, only: [:edit, :update, :destroy, :new, :create]
+
   def index
     @query = params[:search]
     @faqs = if @query

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -3,13 +3,16 @@
 class FaqController < ApplicationController
   before_action :require_admin_permissions, only: [:edit, :update, :destroy, :new, :create]
 
+  DEFAULT_TOPIC = 'top'
+
   def index
     @query = params[:search]
+    @topic = params[:topic] || DEFAULT_TOPIC
     @faqs = if @query
               Faq.where('lower(title) like ?', "%#{@query}%")
                  .or(Faq.where('lower(content) like ?', "%#{@query}%"))
             else
-              Faq.all
+              FaqTopic.new(@topic).faqs
             end
   end
 

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -2,7 +2,14 @@
 
 class FaqController < ApplicationController
   def index
-    @faqs = Faq.all
+    @query = params[:search]
+    @faqs = if @query
+              pp 'wat'
+              Faq.where('lower(title) like ?', "%#{@query}%")
+                 .or(Faq.where('lower(content) like ?', "%#{@query}%"))
+            else
+              Faq.all
+            end
   end
 
   def show

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -4,7 +4,6 @@ class FaqController < ApplicationController
   def index
     @query = params[:search]
     @faqs = if @query
-              pp 'wat'
               Faq.where('lower(title) like ?', "%#{@query}%")
                  .or(Faq.where('lower(content) like ?', "%#{@query}%"))
             else

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -9,7 +9,14 @@ class FaqController < ApplicationController
     @faq = Faq.find(params[:id])
   end
 
-  def create; end
+  def new
+    @faq = Faq.new
+  end
+
+  def create
+    @faq = Faq.create!(update_params)
+    redirect_to faq_path(@faq)
+  end
 
   def edit
     @faq = Faq.find(params[:id])

--- a/app/controllers/faq_topics_controller.rb
+++ b/app/controllers/faq_topics_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class FaqTopicsController < ApplicationController
+  def index
+    @faq_topics = FaqTopic.all
+  end
+
+  def new
+    @topic = FaqTopic.new nil
+  end
+
+  def create
+    FaqTopic.update(slug: params[:slug], name: params[:name], faqs: faq_param)
+  end
+
+  private
+
+  def faq_param
+    params[:faqs].split(',').map(&:to_i)
+  end
+end

--- a/app/controllers/faq_topics_controller.rb
+++ b/app/controllers/faq_topics_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FaqTopicsController < ApplicationController
+  before_action :require_admin_permissions
+
   def index
     @faq_topics = FaqTopic.all
   end
@@ -10,7 +12,21 @@ class FaqTopicsController < ApplicationController
   end
 
   def create
+    update
+  end
+
+  def edit
+    @topic = FaqTopic.new(params[:slug])
+  end
+
+  def update
     FaqTopic.update(slug: params[:slug], name: params[:name], faqs: faq_param)
+    redirect_to '/faq_topics'
+  end
+
+  def delete
+    FaqTopic.delete(slug: params[:slug])
+    redirect_to '/faq_topics'
   end
 
   private

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Faq < ApplicationRecord
+  def self.markdown_renderer
+    @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+  end
+
+  def self.render_markdown(content)
+    markdown_renderer.render(content)
+  end
+
+  def html_content
+    Faq.render_markdown(content)
+  end
+end

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: faqs
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  title      :string(255)      not null
+#  content    :text(65535)
+#
 class Faq < ApplicationRecord
   def self.markdown_renderer
     @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML)

--- a/app/models/faq_topic.rb
+++ b/app/models/faq_topic.rb
@@ -30,7 +30,11 @@ class FaqTopic
     @details[:name]
   end
 
+  def faq_ids
+    @details[:faqs]
+  end
+
   def faqs
-    Faq.where(id: @details[:faqs]).sort_by { |faq| @details[:faqs].index faq.id }
+    Faq.where(id: faq_ids).sort_by { |faq| faq_ids.index faq.id }
   end
 end

--- a/app/models/faq_topic.rb
+++ b/app/models/faq_topic.rb
@@ -31,6 +31,6 @@ class FaqTopic
   end
 
   def faqs
-    Faq.where(id: @details[:faqs] ).sort_by{ |faq| @details[:faqs].index faq.id }
+    Faq.where(id: @details[:faqs]).sort_by { |faq| @details[:faqs].index faq.id }
   end
 end

--- a/app/models/faq_topic.rb
+++ b/app/models/faq_topic.rb
@@ -23,7 +23,7 @@ class FaqTopic
 
   def initialize(slug)
     @slug = slug
-    @details = FaqTopic.setting_record.value[@slug]
+    @details = FaqTopic.setting_record.value[@slug] || {}
   end
 
   def name

--- a/app/models/faq_topic.rb
+++ b/app/models/faq_topic.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class FaqTopic
+  def self.setting_record
+    @setting_record ||= Setting.find_or_create_by(key: 'faq_topics')
+  end
+
+  def self.all
+    setting_record.value.keys.map { |slug| FaqTopic.new(slug) }
+  end
+
+  def self.update(slug:, name:, faqs:)
+    setting_record.value[slug] = { name: name, faqs: faqs }
+    setting_record.save
+  end
+
+  def self.delete(slug:)
+    setting_record.value.delete(slug)
+    setting_record.save
+  end
+
+  attr_reader :slug
+
+  def initialize(slug)
+    @slug = slug
+    @details = FaqTopic.setting_record.value[@slug]
+  end
+
+  def name
+    @details[:name]
+  end
+
+  def faqs
+    Faq.where(id: @details[:faqs] ).sort_by{ |faq| @details[:faqs].index faq.id }
+  end
+end

--- a/app/models/faq_topic.rb
+++ b/app/models/faq_topic.rb
@@ -6,7 +6,7 @@ class FaqTopic
   end
 
   def self.all
-    setting_record.value.keys.map { |slug| FaqTopic.new(slug) }
+    setting_record.value.keys.sort.map { |slug| FaqTopic.new(slug) }
   end
 
   def self.update(slug:, name:, faqs:)

--- a/app/views/faq/_faq.html.haml
+++ b/app/views/faq/_faq.html.haml
@@ -1,6 +1,7 @@
 %div.faq.collapsed{id: "faq-#{faq.id}"}
-  %h2.faq-title{onclick: "toggleAccordian('faq-#{faq.id}')"}
-    =faq.title
+  .faq-header{onclick: "toggleAccordian('faq-#{faq.id}')"}
+    %h2.faq-title=faq.title
     .edit-link= link_to 'edit', edit_faq_path(faq)
+    .icon.icon-arrow
 
   .faq-content= raw faq.html_content

--- a/app/views/faq/_faq.html.haml
+++ b/app/views/faq/_faq.html.haml
@@ -1,7 +1,8 @@
-%div.faq.collapsed{id: "faq-#{faq.id}"}
+%div{class: "faq #{expanded ? 'expanded' : 'collapsed'}" ,id: "faq-#{faq.id}"}
   .faq-header{onclick: "toggleAccordian('faq-#{faq.id}')"}
     %h2.faq-title=faq.title
-    .edit-link= link_to 'edit', edit_faq_path(faq)
+    - if current_user&.admin?
+      .edit-link= link_to 'edit', edit_faq_path(faq)
     .icon.icon-arrow
 
   .faq-content= raw faq.html_content

--- a/app/views/faq/_faq.html.haml
+++ b/app/views/faq/_faq.html.haml
@@ -1,0 +1,6 @@
+%div.faq.collapsed{id: "faq-#{faq.id}"}
+  %h2.faq-title{onclick: "accordianToggle('faq-#{faq.id}')"}
+    =faq.title
+    .edit-link= link_to 'edit', edit_faq_path(faq)
+
+  .faq-content= raw faq.html_content

--- a/app/views/faq/_faq.html.haml
+++ b/app/views/faq/_faq.html.haml
@@ -1,5 +1,5 @@
 %div.faq.collapsed{id: "faq-#{faq.id}"}
-  %h2.faq-title{onclick: "accordianToggle('faq-#{faq.id}')"}
+  %h2.faq-title{onclick: "toggleAccordian('faq-#{faq.id}')"}
     =faq.title
     .edit-link= link_to 'edit', edit_faq_path(faq)
 

--- a/app/views/faq/edit.html.haml
+++ b/app/views/faq/edit.html.haml
@@ -1,0 +1,5 @@
+.container
+  = simple_form_for @faq do |f|
+    = f.input :title
+    = f.input :content
+    = f.button :submit

--- a/app/views/faq/edit.html.haml
+++ b/app/views/faq/edit.html.haml
@@ -3,3 +3,6 @@
     = f.input :title
     = f.input :content
     = f.button :submit
+
+  %hr
+  = button_to 'delete', @faq, method: :delete

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -1,8 +1,12 @@
 = hot_javascript_tag 'faq'
 
 %header
-  .container
-    %h1 Frequenty Asked Questions
+  .container.faq-header
+    %h1 Frequently Asked Questions
+    = form_tag '/faq', method: :get do
+      = text_field_tag(:search, @query, placeholder: 'search')
+      %button.search{type: 'submit'}
+        %i.icon.icon-search
 .container
   - @faqs.each do |faq|
     = render 'faq', faq: faq, expanded: false

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -5,4 +5,4 @@
     %h1 Frequenty Asked Questions
 .container
   - @faqs.each do |faq|
-    = render 'faq', faq: faq
+    = render 'faq', faq: faq, expanded: false

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -1,3 +1,5 @@
+= hot_javascript_tag 'faq'
+
 %header
   .container
     %h1 Frequenty Asked Questions

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -1,0 +1,7 @@
+%header
+  .container
+    %h1 Frequenty Asked Questions
+.container
+  - @faqs.each do |faq|
+    = render 'faq', faq: faq
+    %hr

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -9,4 +9,4 @@
         %i.icon.icon-search
 .container
   - @faqs.each do |faq|
-    = render 'faq', faq: faq, expanded: false
+    = render 'faq', faq: faq, expanded: @query.present?

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -6,4 +6,3 @@
 .container
   - @faqs.each do |faq|
     = render 'faq', faq: faq
-    %hr

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -5,7 +5,7 @@
     %h1 Frequently Asked Questions
     = form_tag '/faq', method: :get do
       = text_field_tag(:search, @query, placeholder: 'search')
-      %button.search{type: 'submit'}
+      %button.search#submit_search{type: 'submit'}
         %i.icon.icon-search
 .container
   - @faqs.each do |faq|

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -8,5 +8,14 @@
       %button.search#submit_search{type: 'submit'}
         %i.icon.icon-search
 .container
-  - @faqs.each do |faq|
-    = render 'faq', faq: faq, expanded: @query.present?
+  .faq-list
+    - @faqs.each do |faq|
+      = render 'faq', faq: faq, expanded: @query.present?
+  .faq-topic-list
+    %h3 Topics
+    - FaqTopic.all.each do |topic|
+      %hr
+      - if topic.slug == @topic_slug
+        = topic.name
+      - else
+        %a.topic-link{href: "/faq?topic=#{topic.slug}"}= topic.name

--- a/app/views/faq/new.html.haml
+++ b/app/views/faq/new.html.haml
@@ -1,0 +1,5 @@
+.container
+  = simple_form_for @faq, url: '/faq' do |f|
+    = f.input :title
+    = f.input :content
+    = f.button :submit

--- a/app/views/faq/show.html.haml
+++ b/app/views/faq/show.html.haml
@@ -1,2 +1,4 @@
+= hot_javascript_tag 'faq'
+
 .container
-  = render 'faq', faq: @faq
+  = render 'faq', faq: @faq, expanded: true

--- a/app/views/faq/show.html.haml
+++ b/app/views/faq/show.html.haml
@@ -1,0 +1,2 @@
+.container
+  = render 'faq', faq: @faq

--- a/app/views/faq_topics/edit.html.haml
+++ b/app/views/faq_topics/edit.html.haml
@@ -1,0 +1,11 @@
+.container
+  %h2= "Editing topic: #{@topic.slug}" 
+  = form_with url: "/faq_topics/#{@topic.slug}", method: :update do
+    = label_tag :name, 'Name'
+    = text_field_tag :name, @topic.name
+    = label_tag :faqs, 'IDs of FAQs included'
+    = text_field_tag :faqs, @topic.faq_ids.join(',')
+    = submit_tag 'Update FAQ Topic'
+
+  %hr
+  = button_to 'delete', "/faq_topics/#{@topic.slug}", method: :delete

--- a/app/views/faq_topics/index.html.haml
+++ b/app/views/faq_topics/index.html.haml
@@ -1,0 +1,6 @@
+.container
+  %h2 FAQ Topics
+  - @faq_topics.each do |topic|
+    = topic.name
+    = topic.slug
+    = topic.faqs.map(&:title)

--- a/app/views/faq_topics/index.html.haml
+++ b/app/views/faq_topics/index.html.haml
@@ -1,6 +1,18 @@
 .container
-  %h2 FAQ Topics
+  %h1 FAQ Topics
+  %a.button{href: '/faq_topics/new'} New Topic
+
   - @faq_topics.each do |topic|
-    = topic.name
-    = topic.slug
-    = topic.faqs.map(&:title)
+    .faq
+      %h3
+        = topic.name
+        - if current_user&.admin?
+          .edit-link= link_to 'edit', "/faq_topics/#{topic.slug}/edit"
+      %div
+        Slug:
+        = topic.slug
+        %ul
+          - topic.faqs.each do |faq|
+            %li
+              %a{href: "/faq/#{faq.id}"}= faq.title
+        

--- a/app/views/faq_topics/new.html.haml
+++ b/app/views/faq_topics/new.html.haml
@@ -1,0 +1,9 @@
+.container
+  = form_with url: '/faq_topics', method: :create do
+    = label_tag :slug, 'Slug'
+    = text_field_tag :slug
+    = label_tag :name, 'Name'
+    = text_field_tag :name
+    = label_tag :faqs, 'IDs of FAQs included'
+    = text_field_tag :faqs
+    = submit_tag 'Create FAQ Topic'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,9 @@ Rails.application.routes.draw do
   # ask.wikiedu.org search box
   get 'ask' => 'ask#search'
 
+  # frequenty asked questions
+  resources :faq
+
   # Authenticated users root to the courses dashboard
   authenticated :user do
     root to: "dashboard#index", as: :courses_dashboard

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,7 +301,12 @@ Rails.application.routes.draw do
 
   # frequenty asked questions
   resources :faq
-  resources :faq_topics
+  get '/faq_topics' => 'faq_topics#index'
+  get '/faq_topics/new' => 'faq_topics#new'
+  post '/faq_topics' => 'faq_topics#create'
+  get '/faq_topics/:slug/edit' => 'faq_topics#edit'
+  post '/faq_topics/:slug' => 'faq_topics#update'
+  delete '/faq_topics/:slug' => 'faq_topics#delete'
 
   # Authenticated users root to the courses dashboard
   authenticated :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,6 +301,7 @@ Rails.application.routes.draw do
 
   # frequenty asked questions
   resources :faq
+  resources :faq_topics
 
   # Authenticated users root to the courses dashboard
   authenticated :user do

--- a/config/wizard/researchwrite/wizard.yml
+++ b/config/wizard/researchwrite/wizard.yml
@@ -448,3 +448,67 @@
       blurb: The Wiki Ed team can provide advice and support to high-achieving students who are interested in the Good Article process.
       tag: dyk_and_ga
       logic: good_article_nominations
+
+-
+  key: assignment_expectations
+  title: Assignment expectations
+  description: |
+    What types of contributions do you expect your students to make to Wikipedia?
+  type: 1 # single choice
+  minimum: 1
+  options:
+    -
+      title: I would like my students to substantially contribute to Wikipedia either by considerably expanding existing articles or creating new articles.
+      tag: expected_contributions_large
+    -
+      title: I expect that my students will make small edits to Wikipedia, such as adding a few sentences to an article.
+      tag: expected_contributions_small
+    -
+      title: I don't know how much content my students will contribute to Wikipedia.
+      tag: expected_contributions_unknown
+
+-
+  key: other_assignments
+  title: Other assignments
+  description: |
+    What portion of your course will the Wikipedia assignment comprise?
+  type: 1 # single choice
+  minimum: 1
+  options:
+    -
+      title: The Wikipedia assignment will be the only assignment.
+      tag: assignment_portion_only
+    -
+      title: The Wikipedia assignment is a major assignment.
+      tag: assignment_portion_major
+    -
+      title: The Wikipedia assignment is a minor assignment.
+      tag: assignment_portion_minor
+    -
+      title: I don't know.
+      tag: assignment_portion_unknown
+
+-
+  key: staying_in_sandboxes
+  title: Staying in sandboxes
+  description: |
+    In Fall 2020, we will be asking many classes to leave student work in draft spaces ("sandboxes") on Wikipedia,
+    rather than making edits to live articles. Wiki Education staff would then evaluate and move good student work
+    live in the weeks following the conclusion of the term. This measure will greatly help us support more courses
+    as we deal with a high demand for support in Fall 2020. How do you feel about this for your class?
+  type: 1 # single choice
+  minimum: 1
+  options:
+    -
+      title: I would only be comfortable doing this assignment if my students worked on live articles.
+      tag: sandboxes_unacceptable
+    -
+      title: I would prefer they worked on live articles, but it would be acceptable to leave work in sandboxes if that's what it takes to participate in the program this term.
+      tag: sandboxes_not_preferred
+    -
+      title: I would prefer my students' work stays in sandboxes until it can be evaluated by a Wiki Education staff person.
+      tag: sandboxes_preferred
+    -
+      title: I don't know.
+      tag: sandboxes_unknown
+      

--- a/db/migrate/20200616162237_add_faq.rb
+++ b/db/migrate/20200616162237_add_faq.rb
@@ -1,0 +1,9 @@
+class AddFaq < ActiveRecord::Migration[6.0]
+  def change
+    create_table :faq do |t|
+      t.timestamps
+      t.string :title, null: false
+      t.text :content
+    end
+  end
+end

--- a/db/migrate/20200616162237_add_faq.rb
+++ b/db/migrate/20200616162237_add_faq.rb
@@ -1,6 +1,6 @@
 class AddFaq < ActiveRecord::Migration[6.0]
   def change
-    create_table :faq do |t|
+    create_table :faqs do |t|
       t.timestamps
       t.string :title, null: false
       t.text :content

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -260,7 +260,7 @@ ActiveRecord::Schema.define(version: 2020_06_16_162237) do
     t.index ["wiki_id"], name: "index_courses_wikis_on_wiki_id"
   end
 
-  create_table "faq", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "faqs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "title", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_180015) do
+ActiveRecord::Schema.define(version: 2020_06_16_162237) do
 
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
@@ -258,6 +258,13 @@ ActiveRecord::Schema.define(version: 2020_04_21_180015) do
     t.index ["course_id", "wiki_id"], name: "index_courses_wikis_on_course_id_and_wiki_id", unique: true
     t.index ["course_id"], name: "index_courses_wikis_on_course_id"
     t.index ["wiki_id"], name: "index_courses_wikis_on_wiki_id"
+  end
+
+  create_table "faq", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "title", null: false
+    t.text "content"
   end
 
   create_table "feedback_form_responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/js.webpack.js
+++ b/js.webpack.js
@@ -17,6 +17,7 @@ const entry = {
   charts: [`${jsSource}/charts.js`],
   tinymce: [`${jsSource}/tinymce.js`],
   embed_course_stats: [`${jsSource}/embed_course_stats.js`],
+  faq: [`${jsSource}/faq.js`]
 };
 
 module.exports = (env) => {

--- a/spec/factories/faq.rb
+++ b/spec/factories/faq.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :faq do
+  end
+end

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -84,6 +84,22 @@ def go_through_researchwrite_wizard
   click_button 'Next' # No DYK/GA
   sleep 1
 
+  ####################################
+  # Fall 2020 supplemental questions #
+  ####################################
+  # contribute substantially
+  omniclick find('.wizard__option', match: :first).find('button', match: :first)
+  click_button 'Next'
+  sleep 1
+  # only assignment
+  omniclick find('.wizard__option', match: :first).find('button', match: :first)
+  click_button 'Next'
+  sleep 1
+  # sandboxes unacceptable
+  omniclick find('.wizard__option', match: :first).find('button', match: :first)
+  click_button 'Next'
+  sleep 1
+
   click_button 'Generate Timeline'
   sleep 1
 end

--- a/spec/features/faq_spec.rb
+++ b/spec/features/faq_spec.rb
@@ -11,10 +11,9 @@ describe 'FAQs', type: :feature, js: true do
   describe 'INDEX page' do
     it 'has search working search' do
       visit '/faq'
-      expect(page).to have_content 'It works'
-      fill_in 'search', with: 'how do i begin?'
+      fill_in 'search', with: 'how does'
       click_button 'submit_search'
-      expect(page).not_to have_content 'It works'
+      expect(page).to have_content 'How does this work?'
     end
   end
 

--- a/spec/features/faq_spec.rb
+++ b/spec/features/faq_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 describe 'FAQs', type: :feature, js: true do
   let!(:faq) { create(:faq, title: 'How does this work?', content: 'It works.') }
+  let(:admin) { create(:admin) }
+
+  before { login_as admin }
 
   describe 'INDEX page' do
     it 'has search working search' do

--- a/spec/features/faq_spec.rb
+++ b/spec/features/faq_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'FAQs', type: :feature, js: true do
+  let!(:faq) { create(:faq, title: 'How does this work?', content: 'It works.') }
+
+  describe 'INDEX page' do
+    it 'has search working search' do
+      visit '/faq'
+      expect(page).to have_content 'It works'
+      fill_in 'search', with: 'how do i begin?'
+      click_button 'submit_search'
+      expect(page).not_to have_content 'It works'
+    end
+  end
+
+  describe 'SHOW page' do
+    it 'includes title and content' do
+      visit "/faq/#{faq.id}"
+      expect(page).to have_content 'How does this work?'
+      expect(page).to have_content 'It works'
+    end
+  end
+
+  describe 'EDIT page' do
+    it 'redirects to SHOW page after saving' do
+      visit "/faq/#{faq.id}/edit"
+      fill_in 'faq_content', with: 'It just works'
+      click_button 'Update Faq'
+      expect(page).to have_current_path("/faq/#{faq.id}")
+      expect(page).to have_content 'It just works'
+    end
+
+    it 'redirects to FAQ INDEX after deleting' do
+      visit "/faq/#{faq.id}/edit"
+      click_button 'delete'
+      expect(page).to have_current_path('/faq')
+      expect(Faq.count).to eq(0)
+    end
+  end
+
+  describe 'NEW page' do
+    it 'redirects to SHOW after creating' do
+      visit '/faq/new'
+      fill_in 'faq_title', with: 'new question'
+      fill_in 'faq_content', with: 'new answer'
+      click_button 'Create Faq'
+      expect(Faq.count).to eq(2)
+      expect(page).to have_current_path("/faq/#{Faq.last.id}")
+      expect(page).to have_content 'new answer'
+    end
+  end
+end

--- a/spec/features/faq_topics_spec.rb
+++ b/spec/features/faq_topics_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'FAQ topics', type: :feature, js: true do
+  let!(:faq) { create(:faq, title: 'How does this work?', content: 'It works.') }
+  let(:admin) { create(:admin) }
+
+  before { login_as admin }
+
+  it 'lets an admin create, update and delete topics' do
+    visit '/faq_topics'
+
+    # Create an FAQ Topic
+    click_link 'New Topic'
+    fill_in 'slug', with: 'cool_new_topic'
+    fill_in 'name', with: 'Topical Name'
+    fill_in 'faqs', with: faq.id
+    click_button 'Create FAQ Topic'
+    expect(page).to have_content('Topical Name')
+    expect(page).to have_content(faq.title)
+
+    # Edit the topic
+    click_link 'edit'
+    fill_in 'name', with: 'Updated name'
+    fill_in 'faqs', with: '1,2,3,4'
+    click_button 'Update FAQ Topic'
+    expect(page).to have_content('Updated name')
+
+    # Delete the topic
+    click_link 'edit'
+    click_button 'delete'
+    expect(page).to have_current_path('/faq_topics')
+    expect(page).not_to have_content('Updated name')
+  end
+end


### PR DESCRIPTION
This PR will implement a minimal system for maintaining a searchable FAQ within the dashboard.

The idea is to replace ask.wikiedu.org, which does not have working login anymore, with a more basic, admin-written FAQ system to collect the most valuable questions/answers.

It's intended to have a relatively limited number of curated collections of topics, as a simple alternative to tags. These "FAQ Topics" are stored via a Setting record (rather than implementing a full topics table and a join table between topics and FAQ questions, which would be necessary to support large numbers of topics).