### PR TITLE
remove locale files

### DIFF
--- a/js.webpack.js
+++ b/js.webpack.js
@@ -84,8 +84,13 @@ module.exports = (env) => {
     ],
     optimization: {
       splitChunks: {
-        chunks: chunk => !/tinymce|charts/.test(chunk.name),
-        name: 'vendors'
+        cacheGroups: {
+          vendors: {
+            test: /[\\/]node_modules[\\/]((?!(chart)).*)[\\/]/,
+            chunks: chunk => !/tinymce/.test(chunk.name),
+            name: 'vendors'
+          }
+        }
       },
     },
     watch: env.watch_js,

--- a/js.webpack.js
+++ b/js.webpack.js
@@ -2,6 +2,7 @@ const path = require('path');
 const config = require('./config');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const webpack = require('webpack');
 
 const jsSource = `./${config.sourcePath}/${config.jsDirectory}`;
@@ -79,10 +80,11 @@ module.exports = (env) => {
       // Creates smaller Lodash builds by replacing feature sets of modules with noop,
       // identity, or simpler alternatives.
       new LodashModuleReplacementPlugin(config.requiredLodashFeatures),
+      new MomentLocalesPlugin()
     ],
     optimization: {
       splitChunks: {
-        chunks: chunk => !/tinymce|charts|styleguide/.test(chunk.name),
+        chunks: chunk => !/tinymce|charts/.test(chunk.name),
         name: 'vendors'
       },
     },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "mkdirp": "^1.0.4",
     "moment": "2.24.0",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "moment-recur": "^1.0.7",
     "nouislider": "^14.2.0",
     "parsleyjs": "^2.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7134,6 +7134,11 @@ lodash.assign@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
   integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.endswith@^4.0.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.endswith/-/lodash.endswith-4.2.1.tgz#fed59ac1738ed3e236edd7064ec456448b37bc09"
@@ -7587,6 +7592,13 @@ mocha@^5.2.0:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "5.4.0"
+
+moment-locales-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
+  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment-recur@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
Momentjs by default, includes nearly 193 locale files. Those are only used if we use the methods:
```
moment.locale()
moment.tz()
```
or if we import certain locales in the codebase, like, if we were to import Russian locale, it would be
```
require('moment/locales/ru')
```
The locale files combine to form nearly 200KB of the bundle size. We don't use the locale files at all in the codebase, so we wouldn't need them. This PR excludes such unnused locale files, thereby bringing 250KB MomentJS bundle to ~54KB.