### PR TITLE
Prevent assignment banners for unsubmitted courses

### DIFF
--- a/lib/wiki_assignment_output.rb
+++ b/lib/wiki_assignment_output.rb
@@ -28,6 +28,9 @@ class WikiAssignmentOutput
   # Main routine #
   ################
   def build_talk_page_update
+    # If a course changed state so that it has no on-wiki course page, don't post.
+    return nil if @course_page.nil?
+
     initial_page_content = WikiApi.new(@wiki).get_page_content(@talk_title)
     # This indicates an API failure, which may happen because of rate-limiting.
     # A nonexistent page will return empty string instead of nil.

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -11,7 +11,8 @@ describe WikiAssignmentOutput do
            title: 'Language in Hawaiʻi and the Pacific',
            school: 'University of Hawaiʻi at Mānoa',
            term: 'Fall 2016',
-           slug: 'University_of_Hawaiʻi_at_Mānoa/Language_in_Hawaiʻi_and_the_Pacific_(Fall_2016)')
+           slug: 'University_of_Hawaiʻi_at_Mānoa/Language_in_Hawaiʻi_and_the_Pacific_(Fall_2016)',
+           submitted: true)
     create(:assignment,
            id: 1,
            user_id: 3,
@@ -184,6 +185,15 @@ describe WikiAssignmentOutput do
           page_content = wiki_assignment_output.build_talk_page_update
           expect(page_content).to include('{{dashboard.wikiedu.org assignment | course = ')
         end
+      end
+    end
+
+    context 'when the course is not submitted' do
+      let(:course) { create(:course, submitted: false) }
+
+      it 'returns nil' do
+        page_content = wiki_assignment_output.build_talk_page_update
+        expect(page_content).to be_nil
       end
     end
 


### PR DESCRIPTION
See the problem I cleaned up here: https://en.wikipedia.org/w/index.php?title=Talk:Islamic_feminism&type=revision&diff=963232768&oldid=963200530&diffmode=source

If a course is not submitted, it has no on-wiki course page, which results in buggy and duplicated article talk page banners.

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process
