### PR TITLE
dynamic load on DOMContentLoaded

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -11,13 +11,17 @@ require('location-origin');
 require('@rails/ujs').start(); // Enables rails-ujs, which adds JavaScript enhancement to some Rails views
 
 document.addEventListener('DOMContentLoaded', () => {
-  window.I18n = require('i18n-js');
-  window.List = require('list.js'); // List is used for sorting tables outside of React
-  require('./utils/course.js'); // This adds jquery features for some views outside of React
-  // This is the main React entry point. It renders the navbar throughout the app, and
-  // renders other components depending on the route.
-  require('./components/app.jsx');
-  require('events').EventEmitter.defaultMaxListeners = 30;
-  require('./utils/editable.js');
-  require('./utils/users_profile.js');
+  require.ensure(
+    ['i18n-js', 'list.js', './utils/course.js', './components/app.jsx', 'events', './utils/editable.js', './utils/users_profile.js'],
+    (require) => {
+      window.I18n = require('i18n-js');
+      window.List = require('list.js'); // List is used for sorting tables outside of React
+      require('./utils/course.js'); // This adds jquery features for some views outside of React
+      // This is the main React entry point. It renders the navbar throughout the app, and
+      // renders other components depending on the route.
+      require('./components/app.jsx');
+      require('events').EventEmitter.defaultMaxListeners = 30;
+      require('./utils/editable.js');
+      require('./utils/users_profile.js');
+    });
 });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -11,11 +11,11 @@ require('location-origin');
 require('@rails/ujs').start(); // Enables rails-ujs, which adds JavaScript enhancement to some Rails views
 
 document.addEventListener('DOMContentLoaded', () => {
+  window.List = require('list.js'); // List is used for sorting tables outside of React
   require.ensure(
-    ['i18n-js', 'list.js', './utils/course.js', './components/app.jsx', 'events', './utils/editable.js', './utils/users_profile.js'],
+    ['i18n-js', './utils/course.js', './components/app.jsx', 'events', './utils/editable.js', './utils/users_profile.js'],
     (require) => {
       window.I18n = require('i18n-js');
-      window.List = require('list.js'); // List is used for sorting tables outside of React
       require('./utils/course.js'); // This adds jquery features for some views outside of React
       // This is the main React entry point. It renders the navbar throughout the app, and
       // renders other components depending on the route.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,7 +59,7 @@ module ApplicationHelper
   def fingerprinted(path, filename, file_prefix = nil)
     manifest_path = "#{Rails.root}/public/#{path}/js-manifest.json"
     manifest = Oj.load(File.read(File.expand_path(manifest_path, __FILE__)))
-    "#{path}#{file_prefix}#{manifest[filename + '.js']}"
+    "#{file_prefix}#{manifest[filename + '.js']}"
   end
 
   def css_fingerprinted(filename, file_prefix = '')

--- a/js.webpack.js
+++ b/js.webpack.js
@@ -34,7 +34,7 @@ module.exports = (env) => {
     output: {
       path: outputPath,
       filename: doHot ? '[name].js' : '[name].[chunkhash].js',
-      publicPath: '/',
+      publicPath: '/assets/javascripts/',
     },
     resolve: {
       extensions: ['.js', '.jsx'],
@@ -65,7 +65,7 @@ module.exports = (env) => {
     },
     externals: {
       jquery: 'jQuery',
-      'i18n-js': 'I18n',
+      'i18n-js': 'I18n'
     },
     plugins: [
       // manifest file


### PR DESCRIPTION
The `DOMContentReady` listener in `main.js` is supposed to load a bunch of dependencies upon page load. But what currently happens is, Webpack just sees the `require('...')` and includes them right in the `main.js`

So, the event handler is noop. This PR rectifies that so `main.js` actually dynamically loads the dependencies when the actual DOMContentReady event is fired.

This drastically reduces the amount of resources that is loaded initially.
