### PR TITLE
[WIP] Orphan lock course update

### DIFF
--- a/app/assets/javascripts/components/overview/statistics_update_modal.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_modal.jsx
@@ -3,13 +3,20 @@ import React from 'react';
 const StatisticsUpdateModal = (props) => {
     const helpMessage = Features.wikiEd ? I18n.t('metrics.wiki_ed_help') : I18n.t('metrics.outreach_help');
 
+    let errorMessage = '';
     const errorCount = props.course.updates.last_update.error_count;
-    const errorMessage = errorCount > 0 ? `${I18n.t('metrics.error_count_message', { error_count: errorCount })} ` : '';
+    if (errorCount && errorCount > 0) {
+      errorMessage = `${I18n.t('metrics.error_count_message', { error_count: errorCount })}`;
+    } else if (props.course.updates.last_update.orphan_lock_failure) {
+      errorMessage = `${I18n.t('metrics.last_update_failed')}`;
+    }
 
     // Update numbers (ids) are stored incrementally as counts in update_logs, so the
     // last update number is the total number of updates till now
     const updateNumbers = Object.keys(props.course.flags.update_logs);
     const totalUpdatesMessage = `${I18n.t('metrics.total_updates')}: ${updateNumbers[updateNumbers.length - 1]}`;
+
+    const updateTimesInformation = props.getUpdateTimesInformation();
 
     return (
       <div className="statistics-update-modal-container">
@@ -19,7 +26,7 @@ const StatisticsUpdateModal = (props) => {
           { errorMessage }
           <ul>
             <li>{ totalUpdatesMessage }</li>
-            <li>{ props.nextUpdateMessage }</li>
+            { updateTimesInformation !== null && <li>{updateTimesInformation[1]}</li> }
           </ul>
           <b>{I18n.t('metrics.missing_data_heading')}</b>
           <br/>

--- a/app/assets/javascripts/components/overview/statistics_update_modal.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_modal.jsx
@@ -3,13 +3,21 @@ import React from 'react';
 const StatisticsUpdateModal = (props) => {
     const helpMessage = Features.wikiEd ? I18n.t('metrics.wiki_ed_help') : I18n.t('metrics.outreach_help');
 
-    let errorMessage = '';
+    let lastUpdateSummary = '';
     const errorCount = props.course.updates.last_update.error_count;
-    if (errorCount && errorCount > 0) {
-      errorMessage = `${I18n.t('metrics.error_count_message', { error_count: errorCount })}`;
+
+    if (errorCount === 0) {
+      lastUpdateSummary = `${I18n.t('metrics.last_update_success')}`;
+    } else if (errorCount > 0) {
+      lastUpdateSummary = `${I18n.t('metrics.error_count_message', { error_count: errorCount })}`;
     } else if (props.course.updates.last_update.orphan_lock_failure) {
-      errorMessage = `${I18n.t('metrics.last_update_failed')}`;
+      lastUpdateSummary = `${I18n.t('metrics.last_update_failed')}`;
     }
+
+    const updateLogs = Object.values(props.course.flags.update_logs);
+    const failureUpdatesCount = updateLogs.filter(log => log.orphan_lock_failure !== undefined).length;
+    const erroredUpdatesCount = updateLogs.filter(log => log.error_count !== undefined && log.error_count > 0).length;
+    const recentUpdatesSummary = I18n.t('metrics.recent_updates_summary', { total: updateLogs.length, failure_count: failureUpdatesCount, error_count: erroredUpdatesCount });
 
     // Update numbers (ids) are stored incrementally as counts in update_logs, so the
     // last update number is the total number of updates till now
@@ -23,8 +31,9 @@ const StatisticsUpdateModal = (props) => {
         <div className="statistics-update-modal">
           <b>{I18n.t('metrics.update_status_heading')}</b>
           <br/>
-          { errorMessage }
+          { lastUpdateSummary }
           <ul>
+            <li>{ recentUpdatesSummary }</li>
             <li>{ totalUpdatesMessage }</li>
             { updateTimesInformation !== null && <li>{updateTimesInformation[1]}</li> }
           </ul>

--- a/app/services/check_course_jobs.rb
+++ b/app/services/check_course_jobs.rb
@@ -76,16 +76,15 @@ class CheckCourseJobs
     # Extracting the latest update end time by getting the last element
     # in the values of update logs which are filtered by no orphan lock logs
     last_update_times_log = update_logs&.values
-                                       &.select { |element| element['orphan_lock_failure'].nil? }
+                                       &.select { |element| element[:orphan_lock_failure].nil? }
                                        &.last
-    last_end_time = last_update_times_log['end_time']
 
-    # If there is no log having update times means all are orphan lock logs
-    return true unless last_end_time.present?
+    # If we cannot find a log having update times means all are orphan lock logs
+    return true unless last_update_times_log.present?
 
-    # Return true only if the last update time is bigger than last update time + one day,
+    # Return true only if the last update end time is bigger than last update time + one day,
     # as currently most update jobs would end in a few minutes at max
-    Time.zone.now > last_end_time + 1.day
+    Time.zone.now > last_update_times_log['end_time'] + 1.day
   end
 
   def find_queued_job

--- a/app/services/check_course_jobs.rb
+++ b/app/services/check_course_jobs.rb
@@ -41,7 +41,7 @@ class CheckCourseJobs
   # among the unique digests
   def expected_digest
     hash = {
-      'class' => 'CourseDataUpdateWorker',
+      'class' => COURSE_DATA_UPDATE_WORKER,
       'queue' => @queue,
       'unique_args' => @worker_args
     }.to_json

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -889,8 +889,10 @@ en:
     missing_data_heading: Missing or unexpected results?
     missing_data_info: Common issues include
     last_update_failed: The last update to this course failed.
+    last_update_success: The last update ran successfully, so the statistics should be up to date.
     outreach_help: Need Help? Refer to 'Report a problem' in the navigation bar.
     per_user: '%{number}/user'
+    recent_updates_summary: Out of the last %{total} updates, %{failure_count} failed and %{error_count} encountered errors.
     revisions: Recent Edits
     references_count: References Added
     references_doc: This is the number of reference tags added to articles, and can include multiple references to the same source. The data comes from the ORES article quality model, and is only available for some languages.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -888,6 +888,7 @@ en:
     last_reviewed: Last Reviewed
     missing_data_heading: Missing or unexpected results?
     missing_data_info: Common issues include
+    last_update_failed: The last update to this course failed.
     outreach_help: Need Help? Refer to 'Report a problem' in the navigation bar.
     per_user: '%{number}/user'
     revisions: Recent Edits

--- a/lib/data_cycle/check_course_jobs_logging.rb
+++ b/lib/data_cycle/check_course_jobs_logging.rb
@@ -6,7 +6,7 @@ module CheckCourseJobsLogging
   def log_orphan_record
     Raven.capture_message('Orphan lock removed',
                           level: 'warn',
-                          extra: { courses: sentry_extra })
+                          extra: sentry_extra)
     return nil
   end
 

--- a/lib/data_cycle/check_course_jobs_logging.rb
+++ b/lib/data_cycle/check_course_jobs_logging.rb
@@ -10,8 +10,8 @@ module CheckCourseJobsLogging
     return nil
   end
 
-  def log_previous_failed_update
-    UpdateLogger.update_course(@course, 'orphan_lock_failure' => true)
+  def log_previous_failed_update(removal_time)
+    UpdateLogger.update_course(@course, 'orphan_lock_failure' => removal_time.to_datetime)
   end
 
   def sentry_extra

--- a/lib/data_cycle/check_course_jobs_logging.rb
+++ b/lib/data_cycle/check_course_jobs_logging.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
+
+module CheckCourseJobsLogging
+  def log_orphan_record
+    Raven.capture_message('Orphan lock removed',
+                          level: 'warn',
+                          extra: { courses: sentry_extra })
+    return nil
+  end
+
+  def log_previous_failed_update
+    UpdateLogger.update_course(@course, 'orphan_lock_failure' => true)
+  end
+
+  def sentry_extra
+    { course: @course.slug, queue: @queue }
+  end
+end

--- a/lib/data_cycle/schedule_course_updates.rb
+++ b/lib/data_cycle/schedule_course_updates.rb
@@ -39,7 +39,7 @@ class ScheduleCourseUpdates
     log_message "Ready to update #{Course.ready_for_update.count} courses"
 
     courses_to_update = Course.ready_for_update
-    CheckCourseJobs.remove_orphan_locks(courses_to_update)
+    orphan_lock_count = CheckCourseJobs.remove_orphan_locks(courses_to_update)
 
     courses_to_update.each do |course|
       CourseDataUpdateWorker.update_course(course_id: course.id, queue: queue_for(course))
@@ -47,6 +47,7 @@ class ScheduleCourseUpdates
     log_message "Short update latency: #{latency('short_update')}"
     log_message "Medium update latency: #{latency('medium_update')}"
     log_message "Long update latency: #{latency('long_update')}"
+    log_message "#{orphan_lock_count} Orphan lock(s) removed"
   end
 
   def conflicting_updates_running?

--- a/lib/data_cycle/schedule_course_updates.rb
+++ b/lib/data_cycle/schedule_course_updates.rb
@@ -3,6 +3,7 @@
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
 require_dependency "#{Rails.root}/app/workers/course_data_update_worker"
+require_dependency "#{Rails.root}/app/services/check_course_jobs"
 
 # Executes all the steps of 'update_constantly' data import task
 class ScheduleCourseUpdates
@@ -36,7 +37,11 @@ class ScheduleCourseUpdates
 
   def enqueue_course_updates
     log_message "Ready to update #{Course.ready_for_update.count} courses"
-    Course.ready_for_update.each do |course|
+
+    courses_to_update = Course.ready_for_update
+    CheckCourseJobs.remove_orphan_locks(courses_to_update)
+
+    courses_to_update.each do |course|
       CourseDataUpdateWorker.update_course(course_id: course.id, queue: queue_for(course))
     end
     log_message "Short update latency: #{latency('short_update')}"

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -26,8 +26,8 @@ class UpdateLogger
   ###########
 
   def self.average_delay(log_hash)
-    return unless log_hash&.length&.> 1
-    end_times = log_hash.values.map { |update| update['end_time'] }
+    end_times = log_hash.values.map { |log| log['end_time'] }.compact
+    return unless end_times&.length&.> 1
     average_delay_in_seconds = (end_times.last.to_f - end_times.first.to_f) / (end_times.count - 1)
     average_delay_in_seconds.to_i
   end

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -36,4 +36,51 @@ describe ScheduleCourseUpdates do
       expect(Raven).to have_received(:capture_message)
     end
   end
+
+  describe 'on calling update workers' do
+    let(:queue) { 'medium_update' }
+
+    context 'a course has no job enqueued' do
+      before do
+        Sidekiq::Testing.disable!
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        slug: 'Medium/Course', needs_update: true)
+      end
+
+      after do
+        # Clearing the queue after the test
+        Sidekiq::Queue.new(queue).clear
+        Sidekiq::Testing.inline!
+      end
+
+      it 'adds the right kind of job, when no orphan lock' do
+        # No job before
+        expect(Sidekiq::Queue.new(queue).size).to eq 0
+        described_class.new
+
+        # 1 job enqueued by ScheduleCourseUpdates
+        expect(Sidekiq::Queue.new(queue).size).to eq 1
+        job = Sidekiq::Queue.new(queue).first
+        expect(job.klass).to eq 'CourseDataUpdateWorker'
+        expect(job.args).to eq [Course.first.id]
+      end
+
+      it 'logs previous update failure and adds job, when orphan lock' do
+        # Adding orphan lock
+        SidekiqUniqueJobs::Locksmith
+          .new({ 'jid' => 1234,
+                 'unique_digest' => CheckCourseJobs.new(Course.first).expected_digest })
+          .lock
+
+        # No job before
+        expect(Sidekiq::Queue.new(queue).size).to eq 0
+        described_class.new
+
+        # 1 job enqueued by ScheduleCourseUpdates
+        expect(Sidekiq::Queue.new(queue).size).to eq 1
+        # Orphan lock  failure is logged
+        expect(Course.first.flags['update_logs'][1]['orphan_lock_failure']).to eq true
+      end
+    end
+  end
 end

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -79,7 +79,7 @@ describe ScheduleCourseUpdates do
         # 1 job enqueued by ScheduleCourseUpdates
         expect(Sidekiq::Queue.new(queue).size).to eq 1
         # Orphan lock  failure is logged
-        expect(Course.first.flags['update_logs'][1]['orphan_lock_failure']).to eq true
+        expect(Course.first.flags['update_logs'][1]['orphan_lock_failure'].present?).to eq true
       end
     end
   end

--- a/spec/services/check_course_jobs_spec.rb
+++ b/spec/services/check_course_jobs_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-require_dependency "#{Rails.root}/lib/data_cycle/schedule_course_updates"
-
 describe CheckCourseJobs do
   let(:course) { create(:course) }
 

--- a/spec/services/check_course_jobs_spec.rb
+++ b/spec/services/check_course_jobs_spec.rb
@@ -119,17 +119,17 @@ describe CheckCourseJobs do
       let(:days_ago_update_log) do
         { 'start_time' => 4.days.ago,
           'end_time' => 3.days.ago,
-          'error_count': 0,
-          'sentry_tag_uuid': 'abcd-12ef' }
+          'error_count' => 0,
+          'sentry_tag_uuid' => 'abcd-12ef' }
       end
       let(:hours_ago_update_log) do
         { 'start_time' => 2.hours.ago,
           'end_time' => 1.hour.ago,
-          'error_count': 0,
-          'sentry_tag_uuid': 'wxyz-34jk' }
+          'error_count' => 0,
+          'sentry_tag_uuid' => 'wxyz-34jk' }
       end
       let(:orphan_lock_update_log) do
-        { 'orphan_lock_failure': true }
+        { 'orphan_lock_failure' => 30.minutes.ago }
       end
       let(:orphan_not_expected) do
         { 'update_logs' => {  1 => days_ago_update_log,

--- a/test/components/overview/statistics_update_info.spec.jsx
+++ b/test/components/overview/statistics_update_info.spec.jsx
@@ -10,6 +10,7 @@ describe('for a mixture of successful and failure update logs', () => {
   const twoHoursAgo = moment().subtract(2, 'hours');
   const fourHoursAgo = moment().subtract(4, 'hours');
   const fiveHoursAgo = moment().subtract(5, 'hours');
+  const sixHoursAgo = moment().subtract(6, 'hours');
 
   const firstSuccessLog = {
     start_time: fiveHoursAgo.toISOString(),
@@ -32,22 +33,21 @@ describe('for a mixture of successful and failure update logs', () => {
     sentry_tag_uuid: '78ij-90kl'
   };
 
-  const failureLog = {
-    orphan_lock_failure: true
-  };
-
   it('renders course update times information correctly if last update is a failure', () => {
+    const firstFailureLog = { orphan_lock_failure: sixHoursAgo.toISOString() };
+    const lastFailureLog = { orphan_lock_failure: current.toISOString() };
+
     const course = {
       flags: {
         update_logs: {
-          1: failureLog,
+          1: firstFailureLog,
           2: firstSuccessLog,
           3: secondSuccessLog,
-          4: failureLog
+          4: lastFailureLog
         }
       },
       updates: {
-        last_update: failureLog,
+        last_update: lastFailureLog,
         average_delay: 3600
       }
     };
@@ -61,6 +61,8 @@ describe('for a mixture of successful and failure update logs', () => {
   });
 
   it('renders course update times information correctly if last update is a success', () => {
+    const failureLog = { orphan_lock_failure: twoHoursAgo.toISOString() };
+
     const course = {
       flags: {
         update_logs: {


### PR DESCRIPTION
## What this PR does
Removing orphan locks occuring in `CourseDataUpdateWorkers`

## Screenshots

### Last 10 Updates: 2 orphan lock failures (none in latest update), no errors in rest of updates, next statistics update before current time (Last update end time + 23961 seconds = 14 hours ago)
### Expectation: To display next estimated only modal, message about successful update, Last 10 updates summary
![Screenshot from 2020-07-16 21-52-06](https://user-images.githubusercontent.com/37243661/87696613-aeda4b00-c7ae-11ea-90b0-5dc1a1a78478.png)
![Screenshot from 2020-07-16 21-52-12](https://user-images.githubusercontent.com/37243661/87696625-b4379580-c7ae-11ea-84de-64cc05fbb546.png)

### Last 10 Updates: 2 orphan lock failures, 1 update with errors (latest update), next estimated statistics update time after current time (last update + 34766 = in 10 hours)
### Expectation: To display next estimated in both places, message about update errors, Last 10 updates summary
![Screenshot from 2020-07-16 21-50-58](https://user-images.githubusercontent.com/37243661/87697027-3aec7280-c7af-11ea-827d-4b4d0a46a43b.png)
![Screenshot from 2020-07-16 21-51-02](https://user-images.githubusercontent.com/37243661/87697046-4049bd00-c7af-11ea-83cf-fa34fb303778.png)


