### PR TITLE
Dynamic tinymce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 .idea/
 .vscode/
 /dump.rdb
-
+/public/skins
 *.rbc
 capybara-*.html
 .rspec

--- a/app/assets/javascripts/components/common/text_area_input.jsx
+++ b/app/assets/javascripts/components/common/text_area_input.jsx
@@ -29,6 +29,20 @@ const TextAreaInput = createReactClass({
     clearOnSubmit: PropTypes.bool
   },
 
+  getInitialState() {
+    return { tinymceLoaded: false };
+  },
+
+  componentDidMount() {
+    if (this.props.wysiwyg) {
+      import(/* webpackIgnore: true */ document.getElementById('tiny-mce-url').innerText).then(() => {
+        this.setState({
+          tinymceLoaded: true
+        });
+      });
+    }
+  },
+
   handleRichTextEditorChange(e) {
     this.props.onChange(
       { target: { value: e.target.getContent() } },
@@ -56,7 +70,7 @@ const TextAreaInput = createReactClass({
       }
 
       // Use TinyMCE if props.wysiwyg, otherwise, use a basic textarea.
-      if (this.props.wysiwyg) {
+      if (this.props.wysiwyg && this.state.tinymceLoaded) {
         inputElement = (
           <Editor
             initialValue={this.props.value}
@@ -64,16 +78,16 @@ const TextAreaInput = createReactClass({
             onSubmit={this.handleSubmit}
             className={inputClass}
             init={{
-               setup: (editor) => { this.setState({ activeEditor: editor }); },
-               inline: true,
-               convert_urls: false,
-               plugins: 'lists link code',
-               toolbar: [
-                 'undo redo | styleselect | bold italic',
-                 'alignleft aligncenter alignright alignleft',
-                 'bullist numlist outdent indent',
-                 'link'
-               ],
+              setup: (editor) => { this.setState({ activeEditor: editor }); },
+              inline: true,
+              convert_urls: false,
+              plugins: 'lists link code',
+              toolbar: [
+                'undo redo | styleselect | bold italic',
+                'alignleft aligncenter alignright alignleft',
+                'bullist numlist outdent indent',
+                'link'
+              ],
             }}
           />
         );

--- a/app/assets/javascripts/components/common/text_area_input.jsx
+++ b/app/assets/javascripts/components/common/text_area_input.jsx
@@ -35,12 +35,23 @@ const TextAreaInput = createReactClass({
 
   componentDidMount() {
     if (this.props.wysiwyg) {
-      import(/* webpackIgnore: true */ document.getElementById('tiny-mce-url').innerText).then(() => {
-        this.setState({
-          tinymceLoaded: true
-        });
-      });
+      this.loadTinyMCE();
     }
+  },
+
+  loadTinyMCE() {
+    // dynamically add the script tag
+    // import() doesn't work because
+    // the skins are loaded relative to the current url which results in 500
+    const script = document.createElement('script');
+    script.onload = () => {
+      // tinymce is loaded at this point
+      this.setState({
+        tinymceLoaded: true
+      });
+    };
+    script.src = document.getElementById('tiny-mce-url').innerText;
+    document.head.appendChild(script);
   },
 
   handleRichTextEditorChange(e) {

--- a/app/assets/javascripts/components/common/text_area_input.jsx
+++ b/app/assets/javascripts/components/common/text_area_input.jsx
@@ -6,6 +6,9 @@ import InputHOC from '../high_order/input_hoc.jsx';
 
 const md = require('../../utils/markdown_it.js').default({ openLinksExternally: true });
 
+const TINY_MCE_URL = 'tiny-mce-url';
+const TINY_MCE_SCRIPT = 'tiny-mce-script';
+
 // This is a flexible text input box. It switches between edit and read mode,
 // and can either provide a wysiwyg editor or a plain text editor.
 const TextAreaInput = createReactClass({
@@ -34,6 +37,14 @@ const TextAreaInput = createReactClass({
   },
 
   componentDidMount() {
+    // check if tinymce is already loaded
+    let tinyMCEScript = document.getElementById(TINY_MCE_SCRIPT);
+    if(tinyMCEScript != null) {
+      this.setState({
+        tinymceLoaded: true
+      });
+      return;
+    }
     if (this.props.wysiwyg) {
       this.loadTinyMCE();
     }
@@ -43,15 +54,19 @@ const TextAreaInput = createReactClass({
     // dynamically add the script tag
     // import() doesn't work because
     // the skins are loaded relative to the current url which results in 500
-    const script = document.createElement('script');
-    script.onload = () => {
-      // tinymce is loaded at this point
-      this.setState({
-        tinymceLoaded: true
-      });
-    };
-    script.src = document.getElementById('tiny-mce-url').innerText;
-    document.head.appendChild(script);
+    const tinyMCEPath = document.getElementById(TINY_MCE_URL).innerText;
+    if (tinyMCEPath.trim() != "") { // path is empty when logged out
+      const script = document.createElement('script');
+      script.id = TINY_MCE_SCRIPT;
+      script.onload = () => {
+        // tinymce is loaded at this point
+        this.setState({
+          tinymceLoaded: true
+        });
+      };
+      script.src = tinyMCEPath;
+      document.head.appendChild(script);
+    }
   },
 
   handleRichTextEditorChange(e) {

--- a/app/assets/javascripts/components/common/text_area_input.jsx
+++ b/app/assets/javascripts/components/common/text_area_input.jsx
@@ -38,8 +38,8 @@ const TextAreaInput = createReactClass({
 
   componentDidMount() {
     // check if tinymce is already loaded
-    let tinyMCEScript = document.getElementById(TINY_MCE_SCRIPT);
-    if(tinyMCEScript != null) {
+    const tinyMCEScript = document.getElementById(TINY_MCE_SCRIPT);
+    if (tinyMCEScript !== null) {
       this.setState({
         tinymceLoaded: true
       });
@@ -55,7 +55,7 @@ const TextAreaInput = createReactClass({
     // import() doesn't work because
     // the skins are loaded relative to the current url which results in 500
     const tinyMCEPath = document.getElementById(TINY_MCE_URL).innerText;
-    if (tinyMCEPath.trim() != "") { // path is empty when logged out
+    if (tinyMCEPath.trim() !== '') { // path is empty when logged out
       const script = document.createElement('script');
       script.id = TINY_MCE_SCRIPT;
       script.onload = () => {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -12,16 +12,18 @@ require('@rails/ujs').start(); // Enables rails-ujs, which adds JavaScript enhan
 
 document.addEventListener('DOMContentLoaded', () => {
   window.List = require('list.js'); // List is used for sorting tables outside of React
-  require.ensure(
-    ['i18n-js', './utils/course.js', './components/app.jsx', 'events', './utils/editable.js', './utils/users_profile.js'],
-    (require) => {
-      window.I18n = require('i18n-js');
-      require('./utils/course.js'); // This adds jquery features for some views outside of React
-      // This is the main React entry point. It renders the navbar throughout the app, and
-      // renders other components depending on the route.
-      require('./components/app.jsx');
-      require('events').EventEmitter.defaultMaxListeners = 30;
-      require('./utils/editable.js');
-      require('./utils/users_profile.js');
-    });
+  import('i18n-js').then(({ default: I18n }) => {
+    window.I18n = I18n;
+  });
+  /* eslint-disable */
+  import('./utils/course.js'); // This adds jquery features for some views outside of React
+  // This is the main React entry point. It renders the navbar throughout the app, and
+  // renders other components depending on the route.
+  import('./components/app.jsx');
+  import('events').then(({default: events}) => {
+    events.EventEmitter.defaultMaxListeners = 30;
+  });
+  import('./utils/editable.js');
+  import('./utils/users_profile.js');
+  /* eslint-enable */
 });

--- a/app/assets/stylesheets/main.styl
+++ b/app/assets/stylesheets/main.styl
@@ -13,3 +13,7 @@ Author: team@wintr.us
 @import "_base"
 @import "modules/*"
 @import "home"
+
+#tiny-mce-url {
+  display: none;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,11 +49,12 @@ module ApplicationHelper
   end
 
   def hot_javascript_tag(filename)
-    if Features.hot_loading?
-      javascript_include_tag "http://localhost:8080/#{filename}.js"
-    else
-      javascript_include_tag fingerprinted('/assets/javascripts/', filename)
-    end
+    javascript_include_tag hot_javascript_path(filename)
+  end
+
+  def hot_javascript_path(filename)
+    return "http://localhost:8080/#{filename}.js" if Features.hot_loading?
+    fingerprinted('/assets/javascripts/', filename)
   end
 
   def fingerprinted(path, filename, file_prefix = nil)

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -48,6 +48,8 @@
     Sentry.setContext(currentUser);
 
 = javascript_include_tag '/assets/javascripts/jquery.min.js'
-%p#tiny-mce-url=hot_javascript_path("tinymce")
+// The following path will be only available when a user is logged in
+// and is used to load tinymce dynamically.
+%p#tiny-mce-url=user_signed_in? ? hot_javascript_path("tinymce") : ""
 = content_for :javascripts
 = csrf_meta_tags

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -48,6 +48,6 @@
     Sentry.setContext(currentUser);
 
 = javascript_include_tag '/assets/javascripts/jquery.min.js'
-= hot_javascript_tag("tinymce")
+%p#tiny-mce-url=hot_javascript_path("tinymce")
 = content_for :javascripts
 = csrf_meta_tags

--- a/js.webpack.js
+++ b/js.webpack.js
@@ -58,7 +58,8 @@ module.exports = (env) => {
           loader: 'eslint-loader',
           options: {
             cache: true,
-            failOnError: !!env.production
+            failOnError: !!env.production,
+            parser: 'babel-eslint'
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tinymce/tinymce-react": "^3.6.0",
     "autosize": "^4.0.2",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.1",
     "babel-loader": "^8.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",

--- a/prepare.js
+++ b/prepare.js
@@ -32,7 +32,7 @@ const copyPaths = [{
   to: `${config.outputPath}/${config.fontsDirectory}`,
 }, {
   from: './node_modules/tinymce/skins',
-  to: `${config.publicPath}/skins`, // tinymce skins resolve to public path
+  to: `${config.outputPath}/${config.jsDirectory}/skins`,
 }];
 copyPaths.forEach((entry, idx) => {
   switch (idx) {
@@ -51,4 +51,3 @@ copyPaths.forEach((entry, idx) => {
     default: console.log('\x1b[33m%s\x1b[0m', `Finished copying static assets after ${elapsed(process.hrtime(start))} seconds`); break;
   }
 });
-

--- a/prepare.js
+++ b/prepare.js
@@ -32,7 +32,7 @@ const copyPaths = [{
   to: `${config.outputPath}/${config.fontsDirectory}`,
 }, {
   from: './node_modules/tinymce/skins',
-  to: `${config.outputPath}/${config.jsDirectory}/skins`,
+  to: `${config.publicPath}/skins`, // tinymce skins resolve to public path
 }];
 copyPaths.forEach((entry, idx) => {
   switch (idx) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.10.1"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.8.6", "@babel/compat-data@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.0.tgz#04815556fc90b0c174abd2c0c1bb966faa036a6c"
@@ -46,6 +53,16 @@
   integrity sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
   dependencies:
     "@babel/types" "^7.10.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.4.tgz#e49eeed9fe114b62fa5b181856a43a5e32f5f243"
+  integrity sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==
+  dependencies:
+    "@babel/types" "^7.10.4"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -136,6 +153,15 @@
     "@babel/template" "^7.10.1"
     "@babel/types" "^7.10.1"
 
+"@babel/helper-function-name@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -160,6 +186,13 @@
   integrity sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==
   dependencies:
     "@babel/types" "^7.10.1"
+
+"@babel/helper-get-function-arity@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+  dependencies:
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -306,6 +339,13 @@
   dependencies:
     "@babel/types" "^7.10.1"
 
+"@babel/helper-split-export-declaration@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz#2c70576eaa3b5609b24cb99db2888cc3fc4251d1"
+  integrity sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
@@ -317,6 +357,11 @@
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
   integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -346,10 +391,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.10.1", "@babel/parser@^7.10.2", "@babel/parser@^7.7.5":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
+
+"@babel/parser@^7.10.4", "@babel/parser@^7.7.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.4.tgz#9eedf27e1998d87739fb5028a5120557c06a1a64"
+  integrity sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -936,6 +995,15 @@
     "@babel/parser" "^7.10.1"
     "@babel/types" "^7.10.1"
 
+"@babel/template@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.1", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.1.tgz#bbcef3031e4152a6c0b50147f4958df54ca0dd27"
@@ -951,12 +1019,36 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.4.tgz#e642e5395a3b09cc95c8e74a27432b484b697818"
+  integrity sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.10.4"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
   integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.1"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.4", "@babel/types@^7.7.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.4.tgz#369517188352e18219981efd156bfdb199fff1ee"
+  integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -2153,6 +2245,18 @@ babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
+
+babel-eslint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-jest@^26.0.1:
   version "26.0.1"
@@ -4489,6 +4593,11 @@ eslint-utils@^2.0.0:
   integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Imports Tinymce only when needed, aka, when `<TextAreaInput wysiwyg={true} />`

This PR also adds babel-eslint which lets us use dynamic `import()` statements.

`import()` doesn't work for tinymce since the tinymce loads the skins relative to the current URL which leads to 404/500.