### PR TITLE
Surfacing to UI future course update information and some css fixes

### DIFF
--- a/app/assets/javascripts/components/overview/statistics_update_modal.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_modal.jsx
@@ -1,27 +1,29 @@
 import React from 'react';
 
 const StatisticsUpdateModal = (props) => {
+    const course = props.course;
     const helpMessage = Features.wikiEd ? I18n.t('metrics.wiki_ed_help') : I18n.t('metrics.outreach_help');
+    const futureUpdatesMessage = course.update_in_future ? I18n.t('metrics.future_updates_remaining.true') : I18n.t('metrics.future_updates_remaining.false');
 
     let lastUpdateSummary = '';
-    const errorCount = props.course.updates.last_update.error_count;
+    const errorCount = course.updates.last_update.error_count;
 
     if (errorCount === 0) {
       lastUpdateSummary = `${I18n.t('metrics.last_update_success')}`;
     } else if (errorCount > 0) {
       lastUpdateSummary = `${I18n.t('metrics.error_count_message', { error_count: errorCount })}`;
-    } else if (props.course.updates.last_update.orphan_lock_failure) {
+    } else if (course.updates.last_update.orphan_lock_failure) {
       lastUpdateSummary = `${I18n.t('metrics.last_update_failed')}`;
     }
 
-    const updateLogs = Object.values(props.course.flags.update_logs);
+    const updateLogs = Object.values(course.flags.update_logs);
     const failureUpdatesCount = updateLogs.filter(log => log.orphan_lock_failure !== undefined).length;
     const erroredUpdatesCount = updateLogs.filter(log => log.error_count !== undefined && log.error_count > 0).length;
     const recentUpdatesSummary = I18n.t('metrics.recent_updates_summary', { total: updateLogs.length, failure_count: failureUpdatesCount, error_count: erroredUpdatesCount });
 
     // Update numbers (ids) are stored incrementally as counts in update_logs, so the
     // last update number is the total number of updates till now
-    const updateNumbers = Object.keys(props.course.flags.update_logs);
+    const updateNumbers = Object.keys(course.flags.update_logs);
     const totalUpdatesMessage = `${I18n.t('metrics.total_updates')}: ${updateNumbers[updateNumbers.length - 1]}`;
 
     const updateTimesInformation = props.getUpdateTimesInformation();
@@ -36,13 +38,14 @@ const StatisticsUpdateModal = (props) => {
             <li>{ recentUpdatesSummary }</li>
             <li>{ totalUpdatesMessage }</li>
             { updateTimesInformation !== null && <li>{updateTimesInformation[1]}</li> }
+            <li>{ futureUpdatesMessage }</li>
           </ul>
           <b>{I18n.t('metrics.missing_data_heading')}</b>
           <br/>
           { I18n.t('metrics.missing_data_info') }:
           <ul>
             <li>{ I18n.t('metrics.replag_info') }<a href="https://replag.toolforge.org/" target="_blank">{I18n.t('metrics.replag_link')}</a></li>
-            { props.course.type === 'ArticleScopedProgram' && <li>{ I18n.t('metrics.article_scoped_program_info') }</li> }
+            { course.type === 'ArticleScopedProgram' && <li>{ I18n.t('metrics.article_scoped_program_info') }</li> }
           </ul>
           <small>{ helpMessage }</small>
           <br/>

--- a/app/assets/javascripts/components/overview/statistics_update_modal.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_modal.jsx
@@ -4,7 +4,10 @@ import moment from 'moment';
 const StatisticsUpdateModal = (props) => {
     const course = props.course;
     const helpMessage = Features.wikiEd ? I18n.t('metrics.wiki_ed_help') : I18n.t('metrics.outreach_help');
-    const futureUpdatesMessage = moment.utc(course.update_until).isAfter() ? I18n.t('metrics.future_updates_remaining.true') : I18n.t('metrics.future_updates_remaining.false');
+    const updatesEndMoment = moment.utc(course.update_until);
+    const futureUpdatesRemaining = updatesEndMoment.isAfter();
+    const futureUpdatesMessage = futureUpdatesRemaining ? I18n.t('metrics.future_updates_remaining.true', { date: updatesEndMoment.format('MMMM Do YYYY') }) : I18n.t('metrics.future_updates_remaining.false');
+    const additionalUpdateMessage = course.needs_update ? I18n.t('metrics.non_updating_course_update') : '';
 
     let lastUpdateSummary = '';
     const errorCount = course.updates.last_update.error_count;
@@ -38,9 +41,8 @@ const StatisticsUpdateModal = (props) => {
           <ul>
             <li>{ recentUpdatesSummary }</li>
             <li>{ totalUpdatesMessage }</li>
-            { updateTimesInformation !== null && <li>{updateTimesInformation[1]}</li> }
-            <li>{ futureUpdatesMessage }</li>
-            { course.needs_update && <li>{I18n.t('metrics.non_updating_course_update')}</li> }
+            { (updateTimesInformation !== null && futureUpdatesRemaining) && <li>{updateTimesInformation[1]}</li> }
+            <li>{futureUpdatesMessage} {additionalUpdateMessage}</li>
           </ul>
           <b>{I18n.t('metrics.missing_data_heading')}</b>
           <br/>

--- a/app/assets/javascripts/components/overview/statistics_update_modal.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_modal.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import moment from 'moment';
 
 const StatisticsUpdateModal = (props) => {
     const course = props.course;
     const helpMessage = Features.wikiEd ? I18n.t('metrics.wiki_ed_help') : I18n.t('metrics.outreach_help');
-    const futureUpdatesMessage = course.update_in_future ? I18n.t('metrics.future_updates_remaining.true') : I18n.t('metrics.future_updates_remaining.false');
+    const futureUpdatesMessage = moment.utc(course.update_until).isAfter() ? I18n.t('metrics.future_updates_remaining.true') : I18n.t('metrics.future_updates_remaining.false');
 
     let lastUpdateSummary = '';
     const errorCount = course.updates.last_update.error_count;
@@ -39,6 +40,7 @@ const StatisticsUpdateModal = (props) => {
             <li>{ totalUpdatesMessage }</li>
             { updateTimesInformation !== null && <li>{updateTimesInformation[1]}</li> }
             <li>{ futureUpdatesMessage }</li>
+            { course.needs_update && <li>{I18n.t('metrics.non_updating_course_update')}</li> }
           </ul>
           <b>{I18n.t('metrics.missing_data_heading')}</b>
           <br/>

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -192,7 +192,7 @@ rating(color)
   .details-form
     display flex
 
-@media only screen and (max-width: 920px)
+@media only screen and (max-width: 919px)
   .course_main,
   .campaign_main
     margin-top 163px

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -138,7 +138,7 @@ rating(color)
   width 90%
   @media only screen and (min-width: 920px)
     width 700px
-    margin-top 100px
+    margin-top 200px
 
 .rating
   round-placeholder(23)

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -323,7 +323,9 @@ nav.ham-nav
       text-decoration none
       text-align center
       +above(desktop)
-        max-width 370px
+        max-width 290px
+        @media only screen and (min-width: 1000px)
+          max-width 370px
         margin-right 20px
         padding-right 40px
         text-align left

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -295,7 +295,7 @@ nav.ham-nav
 .course-nav__wrapper,
 .campaign-nav__wrapper
   height $nav_height
-  +below(desktop)
+  +below(desktop - 1)
     margin-top 50px
 
 .course_navigation,

--- a/app/assets/stylesheets/modules/_stats.styl
+++ b/app/assets/stylesheets/modules/_stats.styl
@@ -84,7 +84,7 @@
       .stat-display__stat
         margin 0 20px 0 20px
 
-@media only screen and (max-width: 920px)
+@media only screen and (max-width: 919px)
   .stat-display
     .stat-display__value
       img

--- a/app/assets/stylesheets/modules/_stats.styl
+++ b/app/assets/stylesheets/modules/_stats.styl
@@ -84,7 +84,7 @@
       .stat-display__stat
         margin 0 20px 0 20px
 
-@media only screen and (max-width: 910px)
+@media only screen and (max-width: 920px)
   .stat-display
     .stat-display__value
       img

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -250,6 +250,11 @@ class Course < ApplicationRecord
     flags[:closed_date].present?
   end
 
+  def current_and_future?
+    current_time = Time.zone.now
+    current_time > start && current_time - UPDATE_LENGTH < self.end
+  end
+
   def tag?(query_tag)
     tags.pluck(:tag).include? query_tag
   end
@@ -286,8 +291,7 @@ class Course < ApplicationRecord
   end
 
   def update_in_future?
-    current_time = Time.zone.now
-    needs_update || (current_time > start && current_time - UPDATE_LENGTH < self.end)
+    needs_update || current_and_future?
   end
 
   def wiki_page?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -285,6 +285,11 @@ class Course < ApplicationRecord
     categories.inject([]) { |ids, cat| ids + cat.article_ids }
   end
 
+  def update_in_future?
+    current_time = Time.zone.now
+    needs_update || (current_time > start && current_time - UPDATE_LENGTH < self.end)
+  end
+
   def wiki_page?
     wiki_course_page_enabled? && home_wiki.edits_enabled?
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -250,11 +250,6 @@ class Course < ApplicationRecord
     flags[:closed_date].present?
   end
 
-  def current_and_future?
-    current_time = Time.zone.now
-    current_time > start && current_time - UPDATE_LENGTH < self.end
-  end
-
   def tag?(query_tag)
     tags.pluck(:tag).include? query_tag
   end
@@ -290,8 +285,8 @@ class Course < ApplicationRecord
     categories.inject([]) { |ids, cat| ids + cat.article_ids }
   end
 
-  def update_in_future?
-    needs_update || current_and_future?
+  def update_until
+    self.end + UPDATE_LENGTH
   end
 
   def wiki_page?

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -43,6 +43,7 @@ json.course do
   json.syllabus @course.syllabus.url if @course.syllabus.file?
   json.updates average_delay: @course.flags['average_update_delay'],
                last_update: @course.flags['update_logs']&.values&.last
+  json.update_in_future @course.update_in_future?
 
   if user_role.zero? # student role
     json.incomplete_assigned_modules @course.training_progress_manager

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -9,7 +9,8 @@ json.course do
             :updated_at, :string_prefix, :use_start_and_end_times, :type,
             :home_wiki, :character_sum,  :upload_count, :uploads_in_use_count,
             :upload_usages_count, :cloned_status, :flags, :level, :format, :private,
-            :closed?, :training_library_slug, :peer_review_count, :withdrawn)
+            :closed?, :training_library_slug, :peer_review_count, :needs_update,
+            :update_until, :withdrawn)
 
   json.wikis @course.wikis, :language, :project
   json.timeline_enabled @course.timeline_enabled?
@@ -43,7 +44,6 @@ json.course do
   json.syllabus @course.syllabus.url if @course.syllabus.file?
   json.updates average_delay: @course.flags['average_update_delay'],
                last_update: @course.flags['update_logs']&.values&.last
-  json.update_in_future @course.update_in_future?
 
   if user_role.zero? # student role
     json.incomplete_assigned_modules @course.training_progress_manager

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -891,6 +891,7 @@ en:
     last_reviewed: Last Reviewed
     missing_data_heading: Missing or unexpected results?
     missing_data_info: Common issues include
+    non_updating_course_update: An additional update has been scheduled for this course.
     last_update_failed: The last update to this course failed.
     last_update_success: The last update ran successfully, so the statistics should be up to date.
     outreach_help: Need Help? Refer to 'Report a problem' in the navigation bar.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -885,6 +885,9 @@ en:
     date_time: Date/Time
     edit_count_description: Total Edits
     error_count_message: The dashboard encountered %{error_count} error(s) during the most recent update.
+    future_updates_remaining:
+      true: This course will be updated in future.
+      false: This course will not be updated in future.
     last_reviewed: Last Reviewed
     missing_data_heading: Missing or unexpected results?
     missing_data_info: Common issues include

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -886,12 +886,12 @@ en:
     edit_count_description: Total Edits
     error_count_message: The dashboard encountered %{error_count} error(s) during the most recent update.
     future_updates_remaining:
-      true: This course will be updated in future.
-      false: This course will not be updated in future.
+      true: The stats will continue to be updated until %{date}.
+      false: The stats for this program are no longer being updated regularly.
     last_reviewed: Last Reviewed
     missing_data_heading: Missing or unexpected results?
     missing_data_info: Common issues include
-    non_updating_course_update: An additional update has been scheduled for this course.
+    non_updating_course_update: It has been scheduled for a one-time update, which should take place soon.
     last_update_failed: The last update to this course failed.
     last_update_success: The last update ran successfully, so the statistics should be up to date.
     outreach_help: Need Help? Refer to 'Report a problem' in the navigation bar.

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -863,4 +863,19 @@ describe Course, type: :model do
       expect(course.pages_edited).not_to include(article2)
     end
   end
+
+  describe '#current_and_future?' do
+    let(:course1) { create(:course) }
+    let(:course2) do
+      create(:course, slug: 'foo/2', start: Time.zone.now - 2.months, end: Time.zone.now + 2.months)
+    end
+
+    it 'returns false for earlier course' do
+      expect(course1.current_and_future?).to eq false
+    end
+
+    it 'returns true for current and future course' do
+      expect(course2.current_and_future?).to eq true
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -863,19 +863,4 @@ describe Course, type: :model do
       expect(course.pages_edited).not_to include(article2)
     end
   end
-
-  describe '#current_and_future?' do
-    let(:course1) { create(:course) }
-    let(:course2) do
-      create(:course, slug: 'foo/2', start: Time.zone.now - 2.months, end: Time.zone.now + 2.months)
-    end
-
-    it 'returns false for earlier course' do
-      expect(course1.current_and_future?).to eq false
-    end
-
-    it 'returns true for current and future course' do
-      expect(course2.current_and_future?).to eq true
-    end
-  end
 end


### PR DESCRIPTION
## What this PR does
Surfaces following information to UI:
- Future update date
- Whether or not one-time additional update is scheduled
- Also, includes some CSS fixes
## Screenshots
### Before
![Screenshot from 2020-07-22 01-36-25](https://user-images.githubusercontent.com/37243661/88101692-fcdebc80-cbbb-11ea-8f6d-e90b1222fc91.png)
![Screenshot from 2020-07-22 01-36-12](https://user-images.githubusercontent.com/37243661/88101701-00724380-cbbc-11ea-8efe-fbaa91130aa4.png)

### After
#### Regularly updated
![Screenshot from 2020-08-01 00-29-31](https://user-images.githubusercontent.com/37243661/89081123-498a7a80-d3a8-11ea-84d5-b9f7bbf1b95e.png)
#### No longer updated, but one-time update scheduled
![Screenshot from 2020-08-01 00-30-47](https://user-images.githubusercontent.com/37243661/89081054-2069ea00-d3a8-11ea-9ecf-8022c28b3d08.png)
#### No longer updated
![Screenshot from 2020-08-01 00-29-43](https://user-images.githubusercontent.com/37243661/89081081-2eb80600-d3a8-11ea-8b9f-ce69b6fa94d8.png)




## Additionally includes CSS Fixes of :
### Before and After
![Peek 2020-07-31 03-56](https://user-images.githubusercontent.com/37243661/89073151-91ed6c80-d397-11ea-91b6-3c3461c41d81.gif)
![Peek 2020-08-01 01-57](https://user-images.githubusercontent.com/37243661/89074686-69b33d00-d39a-11ea-9edc-981f2f18e0a3.gif)
### Before and After
![Screenshot from 2020-08-01 01-35-08](https://user-images.githubusercontent.com/37243661/89073070-62d6fb00-d397-11ea-9409-5071fb075e99.png)
![Peek 2020-08-01 01-54](https://user-images.githubusercontent.com/37243661/89074620-47212400-d39a-11ea-8db6-665d26d360dc.gif)
### Before and After
![Peek 2020-08-01 01-32](https://user-images.githubusercontent.com/37243661/89074127-6e2b2600-d399-11ea-89a1-98ca836d312b.gif)
![Screenshot from 2020-08-01 01-52-08](https://user-images.githubusercontent.com/37243661/89075160-2dcca780-d39b-11ea-81b3-2ad41ce1ea5c.png)




