### PR TITLE
Added nested directory daily_update/ inside app/workers/ for autoloading.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module WikiEduDashboard
   class Application < Rails::Application
     config.autoload_paths += Dir[Rails.root.join("app", "models", "{*/}")]
+    config.autoload_paths += Dir[Rails.root.join("app", "workers", "{*/}")]
 
     config.generators do |g|
       g.test_framework :rspec,


### PR DESCRIPTION
## What this PR does
In my development environment, I was getting `NameError`s relating to each worker inside `app/workers/daily_update` on running `rails batch:update_daily`. They were not getting autoloaded as they were inside the nested directory. The difference can be seen using the command `puts ActiveSupport::Dependencies.autoload_paths`. Added `*` to include all nested directories in future also.
Putting the error log of one such worker here:
```
2020-07-28T20:06:33.927Z pid=21034 tid=gssgzvuli WARN: {"context":"Job raised exception","job":{"retry":true,"queue":"daily_update","unique":"until_executed","args":[],"class":"FindAssignmentsWorker","jid":"0c658b29197a28457ea2eab8","created_at":1595966792.626286,"lock_timeout":0,"lock_expiration":null,"unique_prefix":"uniquejobs","unique_args":[],"unique_digest":"uniquejobs:9d48b6d34fb898e86b684045aa6f072a","newrelic":{},"enqueued_at":1595966792.6272924},"jobstr":"{\"retry\":true,\"queue\":\"daily_update\",\"unique\":\"until_executed\",\"args\":[],\"class\":\"FindAssignmentsWorker\",\"jid\":\"0c658b29197a28457ea2eab8\",\"created_at\":1595966792.626286,\"lock_timeout\":0,\"lock_expiration\":null,\"unique_prefix\":\"uniquejobs\",\"unique_args\":[],\"unique_digest\":\"uniquejobs:9d48b6d34fb898e86b684045aa6f072a\",\"newrelic\":{},\"enqueued_at\":1595966792.6272924}"}
2020-07-28T20:06:33.927Z pid=21034 tid=gssgzvuli WARN: NameError: uninitialized constant FindAssignmentsWorker
```

## Screenshots
### Before
![Screenshot from 2020-07-29 01-46-12](https://user-images.githubusercontent.com/37243661/88716884-5ce5dd80-d13d-11ea-90d4-6b3f3c92902b.png)
![Screenshot from 2020-07-29 01-52-40](https://user-images.githubusercontent.com/37243661/88717514-4724e800-d13e-11ea-92d9-516a2650232d.png)

### After
![Screenshot from 2020-07-29 01-39-35](https://user-images.githubusercontent.com/37243661/88716917-666f4580-d13d-11ea-82d5-9028e0b913dd.png)
![Screenshot from 2020-07-29 01-52-23](https://user-images.githubusercontent.com/37243661/88717534-4c823280-d13e-11ea-899d-f79d5854e834.png)


