### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
 # Run all tests in job 2
 - TEST_SUITE='~type:foo' AFTER_SUCCESS='' CC_TEST_REPORTER_ID=f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
 language: ruby
-rvm: 2.5.0
+rvm: 2.7.1
 sudo: required
 dist: xenial
 cache:
@@ -20,7 +20,7 @@ services:
   - mysql
   - redis-server
 before_install:
-- rvm --default use 2.5.0
+- rvm --default use 2.7.1
 - nvm install # use Node version specified in .nvmrc
 - export PATH=$PATH:`yarn global bin`
 - export DB=test

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.0'
+ruby '2.7.1'
 
 ### Basic Framework
 gem 'rails', '6.0.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,6 +513,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
     validates_email_format_of (1.6.3)
       i18n
@@ -630,7 +631,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.5.0p0
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/app/mailers/ticket_notification_mailer.rb
+++ b/app/mailers/ticket_notification_mailer.rb
@@ -5,12 +5,12 @@ class TicketNotificationMailer < ApplicationMailer
 
   def self.notify_of_message(opts)
     return unless Features.email?
-    notify(opts).deliver_now
+    notify(**opts).deliver_now
   end
 
   def self.notify_of_open_tickets(opts)
     return unless Features.email?
-    open_tickets_notify(opts).deliver_now
+    open_tickets_notify(**opts).deliver_now
   end
 
   def notify(course:, message:, recipient:, sender:, bcc_to_salesforce:)

--- a/docs/WMFLABS_DEPLOYMENT.md
+++ b/docs/WMFLABS_DEPLOYMENT.md
@@ -52,9 +52,9 @@ ON THE SERVER
   - $ `source /home/deploy/.rvm/scripts/rvm`
   - $ `sudo usermod -a -G rvm <username>`
   - logout and back in again so that these settings take effect
-  - $ `rvm install 2.5.0`
+  - $ `rvm install 2.7.1`
     - This will probably report that ruby is already installed, but we do this just in case.
-  - $ `rvm --default use 2.5.0`
+  - $ `rvm --default use 2.7.``
 
 - Install Phusion Passenger module for Apache
   - $ `gem install passenger`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,7 @@ We have a script to automate the process of setting up your developmental enviro
 There are some basic requirements for the script to work:
 - git (to clone the repository)
 - python 3.5 or newer
-- ruby 2.5.0
+- ruby 2.7.1
 - apt (debian) or homebrew (MacOS)
 
 ## Instructions
@@ -65,7 +65,7 @@ If you know your way around Rails, here's the very short version. Some additiona
 * copy `config/application.example.yml` to `config/application.yml`
 * copy `config/database.example.yml` to `config/database.yml`
 * create a MySQL database, `dashboard`
-* install ruby 2.5.0 and nodejs
+* install ruby 2.7.1 and nodejs
 * `bundle install`
 * `rake db:migrate`
 * install yarn
@@ -87,10 +87,10 @@ If you know your way around Rails, here's the very short version. Some additiona
 - Fork this repo, so that you can make changes and push them freely to GitHub.
 - Clone the new WikiEduDashboard repo and enter that directory.
 - On OSX/Debian, make sure you are in the "sudo" group.
-- Install Ruby 2.5.0 (RVM is documented here; rbenv also works fine.)
+- Install Ruby 2.7.1 (RVM is documented here; rbenv also works fine.)
     - OSX/Debian:
        - From the WikiEduDashboard directory, run the curl script from [rvm.io](https://rvm.io/)
-       - `rvm install ruby-2.5.0`
+       - `rvm install ruby-2.7.1`
     - Windows:
        - Use [RailsInstaller](http://railsinstaller.org/en)
        - Install [Ruby DevKit](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit)

--- a/docs/upgrade_dependencies.md
+++ b/docs/upgrade_dependencies.md
@@ -27,10 +27,10 @@ On the server where the dashboard is already running, in `/var/www/dashboard/cur
 Passenger should now be ready. Copy the output for updating the apache config.
 It will be something like this:
 ```
-LoadModule passenger_module /usr/local/rvm/gems/ruby-2.5.0/gems/passenger-5.1.12/buildout/apache2/mod_passenger.so
+LoadModule passenger_module /usr/local/rvm/gems/ruby-2.7.1/gems/passenger-5.1.12/buildout/apache2/mod_passenger.so
 <IfModule mod_passenger.c>
-  PassengerRoot /usr/local/rvm/gems/ruby-2.5.0/gems/passenger-5.1.12
-  PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.5.0/wrappers/ruby
+  PassengerRoot /usr/local/rvm/gems/ruby-2.7.1/gems/passenger-5.1.12
+  PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.7.1/wrappers/ruby
 </IfModule>
 ```
 

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -23,7 +23,7 @@ class WikiCourseEdits
     @dashboard_url = ENV['dashboard_url']
     @current_user = current_user
     @templates = @home_wiki.edit_templates
-    send(action, opts)
+    send(action, **opts)
   end
 
   # Updates the on-wiki version of a course to reflect the latest

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ print ("WARNING! This is a work in progress script. It has been tested to work f
   The logs can be found in the setup directory. If you can help improve this script, \
   We would love your contributions.")
 
-print ("Please install ruby-2.5.0 before running this script.")
+print ("Please install ruby-2.7.1 before running this script.")
 
 def deb_setup():
     print ("Your system is found to be debian-based.")

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -37,12 +37,12 @@ echo '[+] Creating log file...'
 touch setup/log.txt
 print_success '[+] Log File created'
 
-printf '[*] Checking for Ruby-2.5.0...\n'
-if ruby -v | grep "ruby 2.5.0" >/dev/null; then
+printf '[*] Checking for Ruby-2.7.1...\n'
+if ruby -v | grep "ruby 2.7.1" >/dev/null; then
   printf "${CLEAR_LINE}Ruby already installed\n"
 else
-  print_error "Ruby-2.5.0 not found. Please install ruby-2.5.0 and run this script again."
-  echo "One way to install ruby-2.5.0 is through RVM, Visit: https://rvm.io/"
+  print_error "Ruby-2.7.1 not found. Please install ruby-2.7.1 and run this script again."
+  echo "One way to install ruby-2.7.1 is through RVM, Visit: https://rvm.io/"
   exit 0;
 fi
 

--- a/setup/dnf-setup.sh
+++ b/setup/dnf-setup.sh
@@ -37,12 +37,12 @@ echo '[+] Creating log file...'
 touch setup/log.txt
 print_success '[+] Log File created'
 
-printf '[*] Checking for Ruby-2.5.0...\n'
-if ruby -v | grep "ruby 2.5.0" >/dev/null; then
+printf '[*] Checking for Ruby-2.7.1...\n'
+if ruby -v | grep "ruby 2.7.1" >/dev/null; then
   printf "${CLEAR_LINE}Ruby already installed\n"
 else
-  print_error "Ruby-2.5.0 not found. Please install ruby-2.5.0 and run this script again."
-  echo "One way to install ruby-2.5.0 is through RVM, Visit: https://rvm.io/"
+  print_error "Ruby-2.7.1 not found. Please install ruby-2.7.1 and run this script again."
+  echo "One way to install ruby-2.7.1 is through RVM, Visit: https://rvm.io/"
   exit 0;
 fi
 

--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -37,12 +37,12 @@ echo '[+] Creating log file...'
 touch setup/log.txt
 echo '[+] Log File created'
 
-printf '[*] Checking for Ruby-2.5.0...\n'
-if ruby -v | grep "ruby 2.5.0" >/dev/null; then
+printf '[*] Checking for Ruby-2.7.1...\n'
+if ruby -v | grep "ruby 2.7.1" >/dev/null; then
   printf "${CLEAR_LINE}Ruby already installed\n"
 else
-  print_error "Ruby-2.5.0 not found. Please install ruby-2.5.0 and run this script again."
-  echo "One way to install ruby-2.5.0 is through RVM, Visit: https://rvm.io/"
+  print_error "Ruby-2.7.1 not found. Please install ruby-2.7.1 and run this script again."
+  echo "One way to install ruby-2.7.1 is through RVM, Visit: https://rvm.io/"
   exit 0;
 fi
 


### PR DESCRIPTION
There are a few deprecation warnings for using single hash as the last argument to pass an unspecified set of keyword parameters to a method, but I think the remaining warnings are all from gem code rather than our code. There should be plenty of time for those gems to get the deprecations sorted before Ruby 2.8 or whenever that deprecated behavior actually changes.