### PR TITLE
Tracking category talk page categories and talk template categories

### DIFF
--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -58,7 +58,7 @@ class Category < ApplicationRecord
   def title_list_from_wiki
     case source
     when 'category'
-      CategoryImporter.new(wiki).page_titles_for_category(name_with_prefix, depth)
+      CategoryImporter.new(wiki).mainspace_page_titles_for_category(name_with_prefix, depth)
     when 'psid'
       PetScanApi.new.page_titles_for_psid(name)
     when 'pileid'

--- a/lib/category_utils.rb
+++ b/lib/category_utils.rb
@@ -8,6 +8,7 @@ class CategoryUtils
   #     "ns": 0,
   #     "title": "Andorra"
   # }
+
   # Removing prefixes for pages outside mainspace
   # Everything till (and including) the first semicolon(:) is removed
   def self.get_titles_without_prefixes(pages)
@@ -15,5 +16,9 @@ class CategoryUtils
       title = page['title']
       page['ns'] == Article::Namespaces::MAINSPACE ? title : title[(title.index(':') + 1)..-1]
     end
+  end
+
+  def self.get_titles(pages)
+    pages.map { |page| page['title'] }
   end
 end

--- a/lib/category_utils.rb
+++ b/lib/category_utils.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class CategoryUtils
+  # API Documentation: https://en.wikipedia.org/w/api.php?action=query&prop=transcludedin&titles=Template:Cn
+  # A page object here looks like:
+  # {
+  #     "pageid": 600,
+  #     "ns": 0,
+  #     "title": "Andorra"
+  # }
   # Removing prefixes for pages outside mainspace
   # Everything till (and including) the first semicolon(:) is removed
   def self.get_titles_without_prefixes(pages)

--- a/lib/category_utils.rb
+++ b/lib/category_utils.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CategoryUtils
+  def self.get_titles_without_prefixes(pages)
+    pages.map do |page|
+      title = page['title']
+      page['ns'] == Article::Namespaces::MAINSPACE ? title : title[(title.index(':') + 1)..-1]
+    end
+  end
+end

--- a/lib/category_utils.rb
+++ b/lib/category_utils.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CategoryUtils
+  # Removing prefixes for pages outside mainspace
+  # Everything till (and including) the first semicolon(:) is removed
   def self.get_titles_without_prefixes(pages)
     pages.map do |page|
       title = page['title']

--- a/lib/importers/category_importer.rb
+++ b/lib/importers/category_importer.rb
@@ -49,7 +49,8 @@ class CategoryImporter
       cat_response = WikiApi.new(@wiki).query query
       page_data = cat_response.data['categorymembers']
       page_data.each do |page|
-        data_values << property.present? ? page[property] : page
+        data = property.present? ? page[property] : page
+        data_values << data
       end
 
       continue = cat_response['continue']

--- a/lib/importers/transclusion_importer.rb
+++ b/lib/importers/transclusion_importer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/category_utils"
 require_dependency "#{Rails.root}/lib/wiki_api"
 
 # Fetches data about which wiki pages transclude a given page
@@ -11,13 +12,7 @@ class TransclusionImporter
   end
 
   def transcluded_titles
-    all_transcluded_pages.map do |page|
-      title = page['title']
-      # Remove "Talk:" prefix if present
-      # TODO: Support for prefixes in other languages.
-      # Until then, talk page templates are only supported on English Wikipedia.
-      title.gsub(/Talk:/, '')
-    end
+    CategoryUtils.get_titles_without_prefixes all_transcluded_pages
   end
 
   private

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Category, type: :model do
              wiki: pt_wiki, source: 'category')
     end
     # English language template-source category with several 'Talk:' in prefixes
-    let(:category2) { create(:category, name: 'Cn', wiki: Wiki.find(1), source: 'template') }
+    let(:category2) { create(:category, name: 'WikiProject Punjab', wiki: Wiki.find(1), source: 'template') }
 
     it 'does not include Discussão: prefix in titles' do
       VCR.use_cassette 'categories' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -169,4 +169,29 @@ RSpec.describe Category, type: :model do
       end
     end
   end
+
+  describe '.refresh_titles' do
+    let(:pt_wiki) { create(:wiki, language: 'pt', project: 'wikipedia') }
+    # Portuguese language category with 'Discussão:' in prefixes
+    let(:category1) do
+      create(:category, name: '!Artigos de importância 1 sobre Museu Paulista',
+             wiki: pt_wiki, source: 'category')
+    end
+    # English language template-source category with several 'Talk:' in prefixes
+    let(:category2) { create(:category, name: 'Cn', wiki: Wiki.find(1), source: 'template') }
+
+    it 'does not include Discussão: prefix in titles' do
+      VCR.use_cassette 'categories' do
+        category1.refresh_titles
+        expect(category1.article_titles.select { |title| title.include? 'Discussão:' }).to eq([])
+      end
+    end
+
+    it 'does not include Talk: prefix in titles' do
+      VCR.use_cassette 'categories' do
+        category2.refresh_titles
+        expect(category2.article_titles.select { |title| title.include? 'Talk:' }).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -178,7 +178,9 @@ RSpec.describe Category, type: :model do
              wiki: pt_wiki, source: 'category')
     end
     # English language template-source category with several 'Talk:' in prefixes
-    let(:category2) { create(:category, name: 'WikiProject Punjab', wiki: Wiki.find(1), source: 'template') }
+    let(:category2) do
+      create(:category, name: 'WikiProject Punjab', wiki: Wiki.find(1), source: 'template')
+    end
 
     it 'does not include Discussão: prefix in titles' do
       VCR.use_cassette 'categories' do


### PR DESCRIPTION
## What this PR does
Fixes #3762

Putting here the difference between `properties` and `data`:
Data is the result which comes from the API, refers to the items inside "transcludein"
[https://en.wikipedia.org/w/api.php?action=query&prop=transcludedin&titles=Template:Cn](https://en.wikipedia.org/w/api.php?action=query&prop=transcludedin&titles=Template:Cn)
`{ "pageid": 12345, "ns": 0, "title": "ABC Title"}`

<del>The difference I made here was that I made `property` parameter(which was used earlier) optional for `CategoryImporter`, so that we can get only the `"title"` keys from the result (or any other `property`). But for removing prefixes we want to know the `"ns"` (namespace) also, which is why I added support for getting all the key/value pairs in json for the page. </del>

All data passes though, filtering done by CategoryUtils.

Removing prefixes requires us to know the namespace, which if 0, should be as they are, and when not 0, the prefix (for e.g., `Talk:`) should be removed.