### PR TITLE
Resolved Wikipedia redlinks parse bug and added neccessary tests

### DIFF
--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -93,6 +93,19 @@ export default class CourseUtils {
       };
     }
 
+    const wikiRedLinkUrlParts = /([a-z-]+)\.(?:m\.)?(wik[a-z]+)\.org\/w\/index\.php\?title=([\w%]*)[^a-zA-Z0-9%](?:[^#]*)/.exec(articleTitle);
+    if (wikiRedLinkUrlParts) {
+        const title = decodeURIComponent(wikiRedLinkUrlParts[3]).replace(/_/g, ' ');
+        const project = wikiRedLinkUrlParts[2];
+        const language = wikiRedLinkUrlParts[1];
+        return {
+          title: title,
+          project: project,
+          language: language,
+           article_url: articleTitle,
+        };
+      }
+
     return {
       title: articleTitleInput,
       project: null,

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -93,11 +93,11 @@ export default class CourseUtils {
       };
     }
 
-    const wikiRedLinkUrlParts = /([a-z-]+)\.(?:m\.)?(wik[a-z]+)\.org\/w\/index\.php\?title=([\w%]*)[^a-zA-Z0-9%](?:[^#]*)/.exec(articleTitle);
-    if (wikiRedLinkUrlParts) {
-        const title = decodeURIComponent(wikiRedLinkUrlParts[3]).replace(/_/g, ' ');
-        const project = wikiRedLinkUrlParts[2];
-        const language = wikiRedLinkUrlParts[1];
+    const indexphpFormatUrlParts = /([a-z-]+)\.(?:m\.)?(wik[a-z]+)\.org\/w\/index\.php\?title=([\w%]*)[^a-zA-Z0-9%](?:[^#]*)/.exec(articleTitle);
+    if (indexphpFormatUrlParts) {
+        const title = decodeURIComponent(indexphpFormatUrlParts[3]).replace(/_/g, ' ');
+        const project = indexphpFormatUrlParts[2];
+        const language = indexphpFormatUrlParts[1];
         return {
           title: title,
           project: project,

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -90,6 +90,7 @@ describe('courseUtils.i18n', () => {
 });
 
 describe('courseUtils.articleFromTitleInput', () => {
+
   test('replaces underscores', () => {
     const input = 'Robot_selfie';
     const output = courseUtils.articleFromTitleInput(input);
@@ -99,7 +100,6 @@ describe('courseUtils.articleFromTitleInput', () => {
   test('converts Wikipedia urls into titles', () => {
     const input = 'https://en.wikipedia.org/wiki/Robot_selfie';
     const output = courseUtils.articleFromTitleInput(input);
-
     expect(output.title).toBe('Robot selfie');
     expect(output.project).toBe('wikipedia');
     expect(output.language).toBe('en');
@@ -109,7 +109,6 @@ describe('courseUtils.articleFromTitleInput', () => {
   test('handles mobile urls correctly', () => {
     const input = 'https://en.m.wikipedia.org/wiki/Robot_selfie';
     const output = courseUtils.articleFromTitleInput(input);
-
     expect(output.title).toBe('Robot selfie');
     expect(output.project).toBe('wikipedia');
     expect(output.language).toBe('en');
@@ -223,7 +222,6 @@ describe('courseUtils.articleFromTitleInput', () => {
     expect(output.language).toBe('en');
     expect(output.article_url).toBe(input);
   });
-  
 });
 
 describe('courseUtils.articleFromAssignment', () => {

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -142,6 +142,88 @@ describe('courseUtils.articleFromTitleInput', () => {
     expect(output.language).toBe('es');
     expect(output.article_url).toBe(input);
   });
+
+  test('correctly parses Wikipedia redlinks', () => {
+    const input = 'https://en.wikipedia.org/w/index.php?title=Redlink&action=edit&redlink=1';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Redlink');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('correctly parses wikipedia redlinks (variation: The edit link for an older revision)', () => {
+    const input = 'https://en.wikipedia.org/w/index.php?title=72nd_Primetime_Emmy_Awards&oldid=980777920&action=edit';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('72nd Primetime Emmy Awards');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('correctly parses wikipedia redlinks (variation: Section edit link)', () => {
+    const input = 'https://en.wikipedia.org/w/index.php?title=Sweetwater_Formation&action=edit&section=2';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Sweetwater Formation');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('correctly parses wikipedia redlinks (variation: Old version of page)', () => {
+    const input = 'https://en.wikipedia.org/w/index.php?title=Smedsb%C3%B6le_Radio_Mast&oldid=479392613';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Smedsböle Radio Mast');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('correctly parses wikipedia redlinks (variation: Old version edit link using VisualEditor)', () => {
+    const input = ' https://en.wikipedia.org/w/index.php?title=Christian_Social_Party_of_Obwalden&oldid=886780353&veaction=editsource';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Christian Social Party of Obwalden');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('correctly parses mobile Wikipedia redlinks', () => {
+    const input = 'https://en.m.wikipedia.org/w/index.php?title=Red_link&action=edit&redlink=1';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Red link');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('correctly parses Wikimedia redlinks', () => {
+    const input = 'https://incubator.wikimedia.org/w/index.php?title=Redlink&action=edit&redlink=1';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Redlink');
+    expect(output.project).toBe('wikimedia');
+    expect(output.language).toBe('incubator');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('handles url-encoded characters in Wikipedia redlinks -- #1', () => {
+    const input = 'https://en.wikipedia.org/w/index.php?title=Jalape%C3%B1o&action=edit&redlink=1';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Jalapeño');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+
+  test('handles url-encoded characters in Wikipedia redlinks -- #2', () => {
+    const input = 'https://en.wikipedia.org/w/index.php?title=Mesut%20%C3%96zil:REDLINK&redirect=no';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Mesut Özil');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(input);
+  });
+  
 });
 
 describe('courseUtils.articleFromAssignment', () => {

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -90,7 +90,6 @@ describe('courseUtils.i18n', () => {
 });
 
 describe('courseUtils.articleFromTitleInput', () => {
-
   test('replaces underscores', () => {
     const input = 'Robot_selfie';
     const output = courseUtils.articleFromTitleInput(input);


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
Fixes Issue #4213: Wikipedia URLs for nonexistent articles are not handled properly. 
Redlink URL's are now parsed properly by `articleFromTitleInput` function in `course_utils.js`. Appropriate tests have also been added in the `course_utils.spec.js` file.

## Screenshots
### Before:
**1)**
![Screenshot from 2020-09-28 23-30-52](https://user-images.githubusercontent.com/62028695/94494184-74e1e800-01e6-11eb-9d22-1714d871a035.png)
**2)**
![Screenshot from 2020-09-28 23-30-59](https://user-images.githubusercontent.com/62028695/94494913-436a1c00-01e8-11eb-85db-ca42f55627f0.png)


### After:
**1)**
![Screenshot from 2020-09-28 23-30-52](https://user-images.githubusercontent.com/62028695/94494184-74e1e800-01e6-11eb-9d22-1714d871a035.png)
**2)**
![Screenshot from 2020-09-28 23-52-20](https://user-images.githubusercontent.com/62028695/94495031-90e68900-01e8-11eb-9d90-a7db5f1d9d54.png)