### PR TITLE
Fuller translation capabilities for TrainingLibrary pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,7 @@ Metrics/ClassLength:
     - 'lib/importers/revision_score_importer.rb'
     - 'lib/wizard_timeline_manager.rb'
     - 'lib/wiki_course_edits.rb'
+    - 'lib/training/wiki_slide_parser.rb'
 
 Metrics/AbcSize:
   Max: 23 # We should bring this down, ideally to the default of 15

--- a/app/models/training_library.rb
+++ b/app/models/training_library.rb
@@ -63,7 +63,7 @@ class TrainingLibrary < ApplicationRecord
     training_library.introduction = content['introduction'] || content[:introduction]
     training_library.translations = content['translations']
     training_library.wiki_page = wiki_page
-    training_library.categories = content['categories']
+    training_library.categories = content['categories'] || content[:categories]
     training_library.exclude_from_index = content['exclude_from_index']
     TrainingLibrary.save_if_valid(training_library, slug)
   rescue StandardError, TypeError => e # rubocop:disable Lint/ShadowedException
@@ -81,6 +81,10 @@ class TrainingLibrary < ApplicationRecord
 
   def translated_introduction
     translated(:introduction) || introduction
+  end
+
+  def translated_categories
+    translated(:categories) || categories
   end
 
   def translated(key)

--- a/app/views/training/show.html.haml
+++ b/app/views/training/show.html.haml
@@ -7,7 +7,7 @@
     %p
       = @library.translated_introduction
   %ul.training__categories
-    - @library.categories.each do |lib_category|
+    - @library.translated_categories.each do |lib_category|
       - lib_category = lib_category.to_hashugar
       %li
         .training__category__header

--- a/lib/training/wiki_training_loader.rb
+++ b/lib/training/wiki_training_loader.rb
@@ -136,7 +136,7 @@ class WikiTrainingLoader
     when 'TrainingModule'
       { name: parser.title, description: parser.content }
     when 'TrainingLibrary'
-      { name: parser.title, introduction: parser.content }
+      { name: parser.title, introduction: parser.content, categories: parser.categories }
     end
   end
 

--- a/spec/lib/training/wiki_slide_parser_spec.rb
+++ b/spec/lib/training/wiki_slide_parser_spec.rb
@@ -182,6 +182,30 @@ describe WikiSlideParser do
     WIKISLIDE
   end
 
+  # https://meta.wikimedia.org/wiki/Training_modules/editathons/library
+  let(:editathons_library_wikitext) do
+    <<~WIKITEXT
+      <noinclude><languages /></noinclude>
+      <translate>== Running Editathons and other Editing Events == <!--T:1--></translate>
+
+      <translate><!--T:2--> This set of modules focuses on the development of editathons and other editing events.</translate>
+
+      {{Training module category
+      | title = <translate><!--T:3--> Running Editathons</translate>
+      | description = <translate><!--T:4--> Training modules for running an editathon or other similar editing events. The training takes about 1.5-2 hours, and is in three parts.</translate>
+      | module_name_1 = <translate><!--T:5--> Module 1: Defining your event</translate>
+      | module_slug_1 = defining-your-event
+      | module_description_1 = <translate><!--T:6--> What decisions do you need to make to identify and create and editing event?</translate>
+      | module_name_2 =<translate> <!--T:7--> Module 2: Planning well before the Editathon</translate>
+      | module_slug_2 = planning-well-before-the-event
+      | module_description_2 = <translate><!--T:8--> Logistics, decisions and outreach that can be done well before editing events — including Venue logistics, Communications plans and preparing contribution topics.</translate>
+      | module_name_3 = <translate><!--T:9--> Module 3: Planning leading up to the event</translate>
+      | module_slug_3 = planning-leading-up-to-the-event
+      | module_description_3 = <translate><!--T:10--> Logistics, preparation and concerns that might arise in the final weeks before the event and during the event.</translate>
+      }}
+    WIKITEXT
+  end
+
   describe '#title' do
     it 'extracts title from translation-enabled source wikitext' do
       output = described_class.new(source_wikitext.dup).title
@@ -206,6 +230,11 @@ describe WikiSlideParser do
     it 'extracts the title from translated wikitext with leading whitespace' do
       output = described_class.new(translated_wikitext_with_leading_whitespace.dup).title
       expect(output).to eq('Edizio ekintzei buruzko sarrera')
+    end
+
+    it 'works for training libraries' do
+      output = described_class.new(editathons_library_wikitext.dup).title
+      expect(output).to eq('Running Editathons and other Editing Events')
     end
   end
 
@@ -257,6 +286,19 @@ describe WikiSlideParser do
       output = described_class.new(quiz_wikitext.dup).quiz
       expect(output[:correct_answer_id]).to eq(1)
       expect(output[:answers].count).to eq(2)
+    end
+  end
+
+  describe '#categories' do
+    it 'extracts an array of category hashes from a wiki template' do
+      output = described_class.new(editathons_library_wikitext.dup).categories
+      expect(output.count).to eq(1)
+      expect(output.first['modules'].count).to eq(3)
+      expect(output.first['modules'].first['slug']).to eq('defining-your-event')
+      expect(output.first['modules'].second['name'])
+        .to eq('Module 2: Planning well before the Editathon')
+      expect(output.first['modules'].third['description'])
+        .to include('Logistics, preparation and concerns that might arise')
     end
   end
 end

--- a/spec/lib/training/wiki_training_loader_spec.rb
+++ b/spec/lib/training/wiki_training_loader_spec.rb
@@ -156,7 +156,8 @@ describe WikiTrainingLoader do
       it 'loads translated content' do
         VCR.use_cassette 'training/load_from_wiki' do
           content_class.load
-          expect(content_class.last.translations.key?('de')).to eq(true)
+          # https://meta.wikimedia.org/wiki/User:Ragesoss/dashboard_libraries/editing-wikipedia-dev.json
+          expect(content_class.find(10002).translations.key?('de')).to eq(true)
         end
       end
     end


### PR DESCRIPTION
Adds support for translations of TrainingLibrary categories, via pages like this: https://meta.wikimedia.org/wiki/Training_modules/editathons/library