### PR TITLE
Add links to the sandbox for 'evaluate-wikipedia' exercise

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -127,6 +127,7 @@ export class ArticleViewer extends React.Component {
   }
 
   hideArticle(e) {
+    if (!this.state.showArticle) { return; }
     this.hideBadArticleAlert();
     this.setState({ showArticle: false });
     this.props.resetNeedHelpAlert();

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
@@ -4,8 +4,13 @@ import { capitalize } from 'lodash-es';
 import moment from 'moment';
 
 // Helper Components
-const ExerciseStatusCell = ({ status }) => {
-  return <td className={`exercise-status ${status}`}>{capitalize(status)}</td>;
+const ExerciseStatusCell = ({ status, sandboxUrl }) => {
+  let exerciseLink;
+  if (sandboxUrl && status === 'complete') {
+    exerciseLink = <> &nbsp; &nbsp; <a className="assignment-links" target="_blank" href={sandboxUrl}>Exercise Sandbox</a></>;
+  }
+
+  return <td className={`exercise-status ${status}`}>{capitalize(status)} {exerciseLink}</td>;
 };
 
 // Helper Functions
@@ -16,7 +21,7 @@ const generateRow = status => (exercise) => {
   return (
     <tr className="student-training-module" key={exercise.id}>
       <td>{exercise.name} <small>Due by {dueDate}</small></td>
-      <ExerciseStatusCell status={status} />
+      <ExerciseStatusCell status={status} sandboxUrl={exercise.sandbox_url}/>
     </tr>
   );
 };

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -2,12 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import {
-  TRAINING_MODULE_KIND
-} from '~/app/assets/javascripts/constants';
-
-export const TrainingModuleRows = ({ trainingModules }) => {
-  const trainings = trainingModules.filter(({ kind }) => kind === TRAINING_MODULE_KIND);
+export const TrainingModuleRows = ({ trainings }) => {
   return trainings.map((trainingModule) => {
     const momentDueDate = moment(trainingModule.due_date);
     const dueDate = momentDueDate.format('MMM Do, YYYY');
@@ -55,7 +50,7 @@ export const TrainingModuleRows = ({ trainingModules }) => {
 };
 
 TrainingModuleRows.propTypes = {
-  trainingModules: PropTypes.arrayOf(
+  trainings: PropTypes.arrayOf(
     PropTypes.shape({
       completion_date: PropTypes.string,
       id: PropTypes.number.isRequired,

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx
@@ -5,6 +5,10 @@ import PropTypes from 'prop-types';
 import TrainingModuleRows from './TrainingModuleRows';
 import ExerciseRows from './ExerciseRows';
 
+import {
+  TRAINING_MODULE_KIND
+} from '~/app/assets/javascripts/constants';
+
 const TrainingStatus = ({ exercises, trainingModules }) => {
   if (!trainingModules.length) return <div />;
 
@@ -22,7 +26,9 @@ const TrainingStatus = ({ exercises, trainingModules }) => {
     </table>
   );
 
-  const trainingModuleTable = (
+  const trainings = trainingModules.filter(({ kind }) => kind === TRAINING_MODULE_KIND);
+
+  const trainingModuleTable = !!trainings.length && (
     <table className="table">
       <thead>
         <tr>
@@ -31,7 +37,7 @@ const TrainingStatus = ({ exercises, trainingModules }) => {
         </tr>
       </thead>
       <tbody>
-        <TrainingModuleRows trainingModules={trainingModules} />
+        <TrainingModuleRows trainings={trainings} />
       </tbody>
     </table>
   );

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -24,6 +24,7 @@ class TrainingModule < ApplicationRecord
 
   serialize :slide_slugs, Array
   serialize :translations, Hash
+  serialize :settings, Hash
 
   validates_uniqueness_of :slug, case_sensitive: false
 
@@ -77,6 +78,7 @@ class TrainingModule < ApplicationRecord
     training_module.description = content['description'] || content[:description]
     training_module.estimated_ttc = content['estimated_ttc']
     training_module.translations = content['translations']
+    training_module.settings = content['settings']
     training_module.wiki_page = wiki_page
     training_module.slide_slugs = content['slides'].pluck('slug')
     training_module.kind = training_module_kind(content['kind'])
@@ -138,6 +140,10 @@ class TrainingModule < ApplicationRecord
 
   def translated(key)
     translations.dig(I18n.locale.to_s, key)
+  end
+
+  def sandbox_location
+    settings['sandbox_location']
   end
 
   class ModuleNotFound < StandardError; end

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -14,6 +14,7 @@
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  kind          :integer          default(0)
+#  settings      :text(65535)
 #
 
 require_dependency "#{Rails.root}/lib/training/training_base"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,10 @@ class User < ApplicationRecord
     CGI.escape(username.tr(' ', '_'))
   end
 
+  def userpage_url(course)
+    "#{course.home_wiki.base_url}/wiki/User:#{url_encoded_username}"
+  end
+
   def admin?
     [Permissions::ADMIN, Permissions::SUPER_ADMIN].include? permissions
   end

--- a/app/views/courses/_block.json.jbuilder
+++ b/app/views/courses/_block.json.jbuilder
@@ -20,6 +20,7 @@ if block.training_module_ids.present?
     json.overdue due_date_manager.overdue?
     json.deadline_status due_date_manager.deadline_status
     json.flags due_date_manager.flags(course.id)
+    json.sandbox_url due_date_manager.sandbox_url
     json.block_id block.id
   end
 end

--- a/app/views/training_status/show.json.jbuilder
+++ b/app/views/training_status/show.json.jbuilder
@@ -18,6 +18,8 @@ json.course do
     json.due_date due_date_manager.computed_due_date
     json.deadline_status due_date_manager.deadline_status
 
+    json.sandbox_url due_date_manager.sandbox_url
+
     json.completion_date training_progress_manager.completion_date
     json.completion_time training_progress_manager.completion_time
   end

--- a/db/migrate/20201007191933_add_settings_to_training_modules.rb
+++ b/db/migrate/20201007191933_add_settings_to_training_modules.rb
@@ -1,0 +1,5 @@
+class AddSettingsToTrainingModules < ActiveRecord::Migration[6.0]
+  def change
+    add_column :training_modules, :settings, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_150005) do
+ActiveRecord::Schema.define(version: 2020_10_07_191933) do
 
   create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "course_id"
@@ -483,6 +483,7 @@ ActiveRecord::Schema.define(version: 2020_07_09_150005) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "kind", limit: 1, default: 0
+    t.text "settings"
     t.index ["slug"], name: "index_training_modules_on_slug", unique: true
   end
 

--- a/lib/training_module_due_date_manager.rb
+++ b/lib/training_module_due_date_manager.rb
@@ -56,6 +56,11 @@ class TrainingModuleDueDateManager
     end
   end
 
+  def sandbox_url
+    return unless @training_module.sandbox_location && @user
+    "#{@user.userpage_url(@course)}/#{@training_module.sandbox_location}"
+  end
+
   private
 
   def blocks_with_training_modules_for_user

--- a/spec/features/assigned_exercise_spec.rb
+++ b/spec/features/assigned_exercise_spec.rb
@@ -40,7 +40,7 @@ describe 'students with assigned exercise modules', type: :feature, js: true do
   context 'when there are multiple incomplete exercises' do
     let(:assigned_ids) { [evaluate_exercise_id, presentation_exercise_id] }
 
-    it 'see the next incomplete exercise after complete one' do
+    it 'shows the next incomplete exercise after complete one' do
       visit "/courses/#{course.slug}"
 
       within '.my-exercises' do
@@ -54,6 +54,31 @@ describe 'students with assigned exercise modules', type: :feature, js: true do
         expect(page).not_to have_content 'Evaluate Wikipedia'
         expect(page).to have_content 'In-class presentation'
       end
+    end
+  end
+
+  context 'shows a link to the sandbox of an completed exercise' do
+    let(:assigned_ids) { [evaluate_exercise_id] }
+
+    it 'shows the next incomplete exercise after complete one' do
+      visit "/courses/#{course.slug}"
+
+      within '.my-exercises' do
+        click_button 'Mark Complete'
+        expect(page).not_to have_content 'Evaluate Wikipedia'
+      end
+
+      click_link 'Students'
+      within '#users' do
+        expect(page).to have_content student.username
+        page.find('.name').click
+      end
+
+      within 'tr.students-exercise' do
+        page.find('button').click
+      end
+
+      expect(page).to have_link 'Exercise Sandbox'
     end
   end
 end

--- a/training_content/wiki_ed/modules/evaluate-wikipedia-exercise.yml
+++ b/training_content/wiki_ed/modules/evaluate-wikipedia-exercise.yml
@@ -11,3 +11,5 @@ slides:
   - slug: evaluating-sources #3405
   - slug: checking-talk-page #3406
   - slug: option-activity #3407
+settings:
+  sandbox_location: 'Evaluate_an_Article'


### PR DESCRIPTION
This adds a link to the student's sandbox in the Selected Student view, if an exercise is completed and has a standard sandbox link defined for it.

Also fixes display of the training status drawer when there are exercises but no trainings.

## Before

![exercise links before](https://user-images.githubusercontent.com/848483/95497710-a3cf2b00-0957-11eb-82ca-2ff1c6804db9.png)

## After

![exercise link after](https://user-images.githubusercontent.com/848483/95497726-a9c50c00-0957-11eb-904b-9f18c5275bdb.png)
