### PR TITLE
Resolved issue ArticleViewer only shows edits by assigned group members #4023

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -68,12 +68,10 @@ export class ArticleViewer extends React.Component {
     if (this.props.users !== null) {
       if (this.props.articleDetails[`${this.props.article.id}`] !== undefined) {
         if (Object.keys(prevProps.articleDetails).length === 0 && Object.keys(this.props.articleDetails).length === 1) {
-            console.log('updating upper');
             const users = Array.from(new Set(this.props.users.concat(this.props.articleDetails[`${this.props.article.id}`].editors)));
             this.fetchUserIds(users);
         }
         if (this.state.users.length === 0 && Object.keys(prevProps.articleDetails).length !== 0 && Object.keys(this.props.articleDetails).length !== 0) {
-            console.log('updating lower');
             const users = Array.from(new Set(this.props.users.concat(this.props.articleDetails[`${this.props.article.id}`].editors)));
             this.fetchUserIds(users);
         }

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -53,6 +53,8 @@ export class ArticleViewer extends React.Component {
   componentDidMount() {
     if (this.props.showOnMount) {
       this.showArticle();
+    } else {
+      this.props.fetchArticleDetails();
     }
   }
 
@@ -63,6 +65,20 @@ export class ArticleViewer extends React.Component {
   // first in that case. In that case, componentDidUpdate fetches the
   // user ids as soon as usernames are avaialable.
   componentDidUpdate(prevProps, prevState) {
+    if (this.props.users !== null) {
+      if (this.props.articleDetails[`${this.props.article.id}`] !== undefined) {
+        if (Object.keys(prevProps.articleDetails).length === 0 && Object.keys(this.props.articleDetails).length === 1) {
+            console.log('updating upper');
+            const users = Array.from(new Set(this.props.users.concat(this.props.articleDetails[`${this.props.article.id}`].editors)));
+            this.fetchUserIds(users);
+        }
+        if (this.state.users.length === 0 && Object.keys(prevProps.articleDetails).length !== 0 && Object.keys(this.props.articleDetails).length !== 0) {
+            console.log('updating lower');
+            const users = Array.from(new Set(this.props.users.concat(this.props.articleDetails[`${this.props.article.id}`].editors)));
+            this.fetchUserIds(users);
+        }
+      }
+    }
     if (!prevProps.users && this.props.users) {
       if (!prevState.userIdsFetched) {
         this.fetchUserIds(this.props.users);

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -53,7 +53,7 @@ export class ArticleViewer extends React.Component {
   componentDidMount() {
     if (this.props.showOnMount) {
       this.showArticle();
-    } else {
+    } else if (this.props.fetchArticleDetails) {
       this.props.fetchArticleDetails();
     }
   }

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -354,7 +354,7 @@ ArticleViewer.propTypes = {
 };
 
 const clickOutsideComponent = OnClickOutside(ArticleViewer);
-const mapStateToProps = ({ needHelpAlert }) => ({ alertStatus: needHelpAlert });
+const mapStateToProps = ({ articleDetails, needHelpAlert }) => ({ alertStatus: needHelpAlert, articleDetails: articleDetails });
 const mapDispatchToProps = {
   resetNeedHelpAlert,
   submitBadWorkAlert

--- a/app/assets/javascripts/components/course/articles/add_available_articles.jsx
+++ b/app/assets/javascripts/components/course/articles/add_available_articles.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import TextAreaInput from '../common/text_area_input';
+import CourseUtils from '../../utils/course_utils.js';
+
+const AddAvailableArticles = createReactClass({
+  displayName: 'AddAvailableArticles',
+
+  propTypes: {
+    course_id: PropTypes.string,
+    course: PropTypes.object,
+    role: PropTypes.number.isRequired,
+    current_user: PropTypes.object,
+    assignments: PropTypes.array,
+    project: PropTypes.string,
+    language: PropTypes.string,
+    addAssignment: PropTypes.func,
+    open: PropTypes.func // closes popover
+  },
+
+  getInitialState() {
+    return { assignments: '' };
+  },
+
+  updateInput(_key, value) {
+    return this.setState({ assignments: value });
+  },
+
+  resetInput() {
+    this.setState({ assignments: '' });
+    this.props.open();
+  },
+
+  chainSubmissions(assignments, promise) {
+    const assignment = assignments.shift();
+    if (assignment === undefined) { return promise; }
+    let extendedPromise;
+    if (promise) {
+      extendedPromise = promise.then(() => this.props.addAssignment(assignment));
+    } else {
+      extendedPromise = this.props.addAssignment(assignment);
+    }
+    return this.chainSubmissions(assignments, extendedPromise);
+  },
+
+  submit() {
+    // turn multipline input into an array of lines
+    const inputLines = this.state.assignments.match(/[^\r\n]+/g);
+    const assignments = inputLines.map((assignmentString) => {
+      const assignment = CourseUtils.articleFromTitleInput(assignmentString);
+      const language = assignment.language ? assignment.language : this.props.language;
+      const project = assignment.project ? assignment.project : this.props.project;
+      return {
+        title: assignment.title,
+        project,
+        language,
+        course_slug: this.props.course_id,
+        role: this.props.role
+      };
+    });
+    return this.chainSubmissions(assignments)
+      .then(() => this.resetInput());
+  },
+
+  render() {
+    return (
+      <div className="pop__padded-content">
+        <TextAreaInput
+          id="add_available_articles"
+          onChange={this.updateInput}
+          value={this.state.assignments}
+          value_key="assignments"
+          editable
+          placeholder={I18n.t('assignments.add_available_placeholder')}
+        />
+        <button className="button border pull-right" onClick={this.submit}>{I18n.t('assignments.add_available_submit')}</button>
+      </div>
+    );
+  }
+});
+
+export default AddAvailableArticles;

--- a/app/assets/javascripts/components/course/articles/article.jsx
+++ b/app/assets/javascripts/components/course/articles/article.jsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import CourseUtils from '../../utils/course_utils.js';
+import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
+import DiffViewer from '../revisions/diff_viewer.jsx';
+import ArticleGraphs from './article_graphs.jsx';
+import Switch from 'react-switch';
+
+const Article = createReactClass({
+  displayName: 'Article',
+
+  propTypes: {
+    article: PropTypes.object.isRequired,
+    index: PropTypes.number,
+    course: PropTypes.object.isRequired,
+    fetchArticleDetails: PropTypes.func.isRequired,
+    updateArticleTrackedStatus: PropTypes.func,
+    articleDetails: PropTypes.object,
+    wikidataLabel: PropTypes.string,
+    showOnMount: PropTypes.bool,
+    setSelectedIndex: PropTypes.func,
+    lastIndex: PropTypes.number,
+    selectedIndex: PropTypes.number
+  },
+
+  getInitialState() {
+    return {
+      tracked: this.props.article.tracked
+    };
+  },
+
+  fetchArticleDetails() {
+    if (!this.props.articleDetails) {
+      this.props.fetchArticleDetails(this.props.article.id, this.props.course.id);
+    }
+  },
+
+  handleTrackedChange(tracked) {
+    this.props.updateArticleTrackedStatus(this.props.article.id, this.props.course.id, tracked);
+    this.setState({ tracked });
+  },
+
+  render() {
+    const ratingClass = `rating ${this.props.article.rating}`;
+    const ratingMobileClass = `${ratingClass} tablet-only`;
+
+    // Uses Course Utils Helper
+    const formattedTitle = CourseUtils.formattedArticleTitle(this.props.article, this.props.course.home_wiki, this.props.wikidataLabel);
+    const historyUrl = `${this.props.article.url}?action=history`;
+
+    const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
+
+    let tracked;
+    if (this.props.course.type !== 'ClassroomProgramCourse' && trackedEditable) {
+      tracked = (
+        <td className="tracking">
+          <Switch onChange={this.handleTrackedChange} checked={this.state.tracked} onColor="#676eb4" />
+        </td>
+      );
+    }
+
+    let contentAdded;
+    if (this.props.course.home_wiki_bytes_per_word) {
+      const wordsAdded = Math.round(this.props.article.character_sum / this.props.course.home_wiki_bytes_per_word);
+      contentAdded = <td className="desktop-only-tc">{wordsAdded}</td>;
+    } else {
+      contentAdded = <td className="desktop-only-tc">{this.props.article.character_sum}</td>;
+    }
+
+    const { project, title } = this.props.article;
+    let { language } = this.props.article;
+    if (project === 'wikidata') language = 'www';
+    const pageviewUrl = `https://pageviews.toolforge.org/?project=${language}.${project}.org&platform=all-access&agent=user&range=latest-90&pages=${title}`;
+
+    return (
+      <tr className="article">
+        <td className="tooltip-trigger desktop-only-tc">
+          <p className="rating_num hidden">{this.props.article.rating_num}</p>
+          <div className={ratingClass}><p>{this.props.article.pretty_rating || '-'}</p></div>
+          <div className="tooltip dark">
+            <p>{I18n.t(`articles.rating_docs.${this.props.article.rating || '?'}`, { class: this.props.article.rating || '' })}</p>
+          </div>
+        </td>
+        <td>
+          <div className={ratingMobileClass}><p>{this.props.article.pretty_rating || '-'}</p></div>
+          <div className="title">
+            <a href={this.props.article.url} target="_blank" className="inline">{formattedTitle} {(this.props.article.new_article ? ` ${I18n.t('articles.new')}` : '')}</a>
+            <br />
+            <small>
+              <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a> | <ArticleGraphs article={this.props.article} />
+            </small>
+          </div>
+        </td>
+        {contentAdded}
+        <td className="desktop-only-tc">{this.props.article.references_count || ''}</td>
+        <td className="desktop-only-tc">
+          <a href={pageviewUrl} target="_blank" className="inline">{this.props.article.view_count}</a>
+        </td>
+        <td>
+          <ArticleViewer
+            article={this.props.article}
+            course={this.props.course}
+            current_user={this.props.current_user}
+            users={this.props.articleDetails && this.props.articleDetails.editors}
+            fetchArticleDetails={this.fetchArticleDetails}
+            showButtonClass="pull-left"
+            showOnMount={this.props.showOnMount}
+          />
+          <DiffViewer
+            fetchArticleDetails={this.fetchArticleDetails}
+            index={this.props.index}
+            revision={this.props.articleDetails && this.props.articleDetails.last_revision}
+            first_revision={this.props.articleDetails && this.props.articleDetails.first_revision}
+            showButtonLabel={I18n.t('articles.show_cumulative_changes')}
+            showButtonClass="pull-right"
+            editors={this.props.articleDetails && this.props.articleDetails.editors}
+            showSalesforceButton={Boolean(Features.wikiEd && this.props.current_user.admin)}
+            course={this.props.course}
+            article={this.props.article}
+            articleTitle={this.props.article.title}
+            setSelectedIndex={this.props.setSelectedIndex}
+            lastIndex={this.props.lastIndex}
+            selectedIndex={this.props.selectedIndex}
+          />
+        </td>
+        {tracked}
+      </tr>
+    );
+  }
+});
+
+export default Article;

--- a/app/assets/javascripts/components/course/articles/article_graphs.jsx
+++ b/app/assets/javascripts/components/course/articles/article_graphs.jsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import OnClickOutside from 'react-onclickoutside';
+import Wp10Graph from './wp10_graph.jsx';
+import EditSizeGraph from './edit_size_graph.jsx';
+import Loading from '../common/loading.jsx';
+
+const ArticleGraphs = createReactClass({
+  displayName: 'ArticleGraphs',
+
+  propTypes: {
+    article: PropTypes.object
+  },
+
+  getInitialState() {
+    return {
+      showGraph: false,
+      selectedRadio: 'wp10_score',
+      articleData: null
+    };
+  },
+
+  getData() {
+    if (this.state.articleData) { return; }
+
+    const articleId = this.props.article.id;
+    const articledataUrl = `/articles/article_data.json?article_id=${articleId}`;
+    $.ajax(
+      {
+        dataType: 'json',
+        url: articledataUrl,
+        success: (data) => {
+          this.setState({
+            articleData: data
+          });
+        }
+      });
+  },
+
+  showGraph() {
+    this.getData();
+    this.setState({ showGraph: true });
+  },
+
+  handleRadioChange(event) {
+    this.setState({
+      selectedRadio: event.currentTarget.value
+    });
+  },
+
+  hideGraph() {
+    this.state.articleData = null;
+    this.setState({ showGraph: false });
+  },
+
+  handleClickOutside() {
+    this.hideGraph();
+  },
+
+  graphId() {
+    return `vega-graph-${this.props.article.id}`;
+  },
+
+  render() {
+    let style = 'hidden';
+    if (this.state.showGraph) {
+      style = '';
+    }
+
+    let graph;
+    let editSize;
+    let radioInput;
+    const graphWidth = 500;
+    const graphHeight = 300;
+    const className = `vega-graph ${style}`;
+
+    if (this.state.articleData != null) {
+      // Only render the wp10 graph radio button if the data includes wp10 / article completeness scores
+      if (this.state.articleData[0].wp10) {
+        radioInput = (
+          <div>
+            <div className="input-row">
+              <input
+                type="radio"
+                name="wp10_score"
+                value="wp10_score"
+                checked={this.state.selectedRadio === 'wp10_score'}
+                onChange={this.handleRadioChange}
+              />
+              <label htmlFor="wp10_score">{I18n.t('articles.wp10')}</label>
+            </div>
+            <div className="input-row">
+              <input
+                type="radio"
+                name="edit_size"
+                value="edit_size"
+                checked={this.state.selectedRadio === 'edit_size'}
+                onChange={this.handleRadioChange}
+              />
+              <label htmlFor="edit_size">{I18n.t('articles.edit_size')}</label>
+            </div>
+          </div>
+        );
+        if (this.state.selectedRadio === 'wp10_score') {
+          graph = (
+            <Wp10Graph
+              graphid = {this.graphId()}
+              graphWidth = {graphWidth}
+              graphHeight = {graphHeight}
+              articleData = {this.state.articleData}
+            />
+          );
+        } else {
+          graph = (
+            <EditSizeGraph
+              graphid ={this.graphId()}
+              graphWidth = {graphWidth}
+              graphHeight = {graphHeight}
+              articleData = {this.state.articleData}
+            />
+          );
+        }
+      } else {
+        editSize = (
+          <p>{I18n.t('articles.edit_size')}</p>
+        );
+        graph = (
+          <EditSizeGraph
+            graphid ={this.graphId()}
+            graphWidth = {graphWidth}
+            graphHeight = {graphHeight}
+            articleData = {this.state.articleData}
+          />
+        );
+      } // Display the loading element if articleData is not available
+     } else {
+      graph = <Loading />;
+    }
+
+    return (
+      <a onClick={this.showGraph} className="inline">
+        {I18n.t('articles.article_development')}
+        <div className={className}>
+          <div className="radio-row">
+            {radioInput}
+            {editSize}
+          </div>
+          {graph}
+        </div>
+      </a>
+    );
+  }
+});
+
+export default OnClickOutside(ArticleGraphs);

--- a/app/assets/javascripts/components/course/articles/article_list.jsx
+++ b/app/assets/javascripts/components/course/articles/article_list.jsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import * as ArticleActions from '../../actions/article_actions';
+import List from '../common/list.jsx';
+import Article from './article.jsx';
+import CourseOresPlot from './course_ores_plot.jsx';
+import articleListKeys from './article_list_keys';
+import CourseUtils from '../../utils/course_utils.js';
+
+const ArticleList = createReactClass({
+  displayName: 'ArticleList',
+
+  propTypes: {
+    articles: PropTypes.array,
+    course: PropTypes.object,
+    current_user: PropTypes.object,
+    actions: PropTypes.object,
+    articleDetails: PropTypes.object,
+    sortArticles: PropTypes.func,
+    wikidataLabels: PropTypes.object,
+    sort: PropTypes.object
+  },
+
+  getInitialState() {
+    return {
+      selectedIndex: -1,
+    };
+  },
+
+  onChangeFilter(e) {
+    const value = e.target.value.split('.');
+    if (value.length > 1) {
+      return this.props.filterArticles({ language: value[0], project: value[1] });
+    }
+    return this.props.filterArticles({ language: null, project: value[0] });
+  },
+
+  onNewnessChange(e) {
+    return this.props.filterNewness(e.target.value);
+  },
+
+  onTrackedFilterChange(e) {
+    return this.props.filterTrackedStatus(e.target.value);
+  },
+
+  showDiff(index) {
+    this.setState({
+      selectedIndex: index
+    });
+  },
+
+  showMore() {
+    return this.props.fetchArticles(this.props.course_id, this.props.limit + 500);
+  },
+
+  sortSelect(e) {
+    return this.props.sortArticles(e.target.value);
+  },
+
+  render() {
+    const keys = articleListKeys(this.props.course);
+
+    const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
+
+    if (this.props.course.type !== 'ClassroomProgramCourse' && trackedEditable) {
+      keys.tracked = {
+        label: I18n.t('articles.tracked'),
+        desktop_only: true,
+        sortable: false,
+        info_key: 'articles.tracked_doc'
+      };
+    }
+
+    const sort = this.props.sort;
+    if (sort.key) {
+      const order = (sort.sortKey) ? 'asc' : 'desc';
+      keys[sort.key].order = order;
+    }
+
+    // If a parameter like ?showArticle=123 is present,
+    // the ArticleViewer should go into show mode immediately.
+    // this allows for links to directly view a specific article.
+    const showArticleId = Number(location.search.split('showArticle=')[1]);
+    const articleElements = this.props.articles.map((article, index) => (
+      <Article
+        article={article}
+        index={index}
+        showOnMount={showArticleId === article.id}
+        course={this.props.course}
+        key={article.id}
+        wikidataLabel={this.props.wikidataLabels[article.title]}
+        // eslint-disable-next-line
+        current_user={this.props.current_user}
+        fetchArticleDetails={this.props.actions.fetchArticleDetails}
+        updateArticleTrackedStatus={this.props.actions.updateArticleTrackedStatus}
+        articleDetails={this.props.articleDetails[article.id] || null}
+        setSelectedIndex={this.showDiff}
+        lastIndex={this.props.articles.length}
+        selectedIndex={this.state.selectedIndex}
+      />
+    ));
+
+    let header;
+    if (Features.wikiEd) {
+      header = <h3 className="article tooltip-trigger">{I18n.t('metrics.articles_edited')}</h3>;
+    } else {
+      header = (
+        <h3 className="article tooltip-trigger">{I18n.t('metrics.articles_edited')}
+          <span className="tooltip-indicator" />
+          <div className="tooltip dark">
+            <p>{I18n.t('articles.cross_wiki_tracking')}</p>
+          </div>
+        </h3>
+      );
+    }
+
+    let filterWikis;
+    if (this.props.wikis.length > 1) {
+      const wikiOptions = this.props.wikis.map((wiki) => {
+        const wikiString = `${wiki.language ? `${wiki.language}.` : ''}${wiki.project}`;
+        return (<option value={wikiString} key={wikiString}>{wikiString}</option>);
+      });
+
+      filterWikis = (
+        <select onChange={this.onChangeFilter}>
+          <option value="all">{I18n.t('articles.filter.wiki_all')}</option>
+          {wikiOptions}
+        </select>
+      );
+    }
+
+    let filterArticlesSelect;
+    if (this.props.newnessFilterEnabled) {
+      filterArticlesSelect = (
+        <select className="filter-articles" defaultValue="both" onChange={this.onNewnessChange}>
+          <option value="new">{I18n.t('articles.filter.new')}</option>
+          <option value="existing">{I18n.t('articles.filter.existing')}</option>
+          <option value="both">{I18n.t('articles.filter.new_and_existing')}</option>
+        </select>
+      );
+    }
+
+    let filterTracked;
+    if (this.props.trackedStatusFilterEnabled) {
+      filterTracked = (
+        <select className="filter-articles" value={this.props.trackedStatusFilter} onChange={this.onTrackedFilterChange}>
+          <option value="tracked">{I18n.t('articles.filter.tracked')}</option>
+          <option value="untracked">{I18n.t('articles.filter.untracked')}</option>
+          <option value="both">{I18n.t('articles.filter.tracked_and_untracked')}</option>
+        </select>
+      );
+    }
+
+    let filterLabel;
+    if (!!filterWikis || !!filterArticlesSelect || !!filterTracked) {
+      filterLabel = <b>Filters:</b>;
+    }
+
+    const articleSort = (
+      <div className="article-sort">
+        <select className="sorts" name="sorts" onChange={this.sortSelect}>
+          <option value="rating_num">{I18n.t('articles.rating')}</option>
+          <option value="title">{I18n.t('articles.title')}</option>
+          <option value="character_sum">{I18n.t('metrics.char_added')}</option>
+          <option value="references_count">{I18n.t('metrics.references_count')}</option>
+          <option value="view_count">{I18n.t('metrics.view')}</option>
+        </select>
+      </div>
+    );
+
+    const sectionHeader = (
+      <div className="section-header">
+        {header}
+        <CourseOresPlot course={this.props.course} />
+        <div className="wrap-filters">
+          {filterLabel}
+          {filterTracked}
+          {filterArticlesSelect}
+          {filterWikis}
+          {articleSort}
+        </div>
+      </div>
+    );
+
+    let showMoreSection;
+    if (!this.props.limitReached) {
+      showMoreSection = (
+        <div className="see-more">
+          <button className="button ghost" onClick={this.showMore}>{I18n.t('articles.see_more')}</button>
+          <p>{I18n.t('articles.articles_shown', { count: articleElements.length, total: this.props.course.edited_count })}</p>
+        </div>
+      );
+    }
+
+    return (
+      <div id="articles" className="mt4">
+        {sectionHeader}
+        {showMoreSection}
+        <List
+          elements={articleElements}
+          keys={keys}
+          sortable={true}
+          table_key="articles"
+          className="table--expandable table--hoverable"
+          none_message={CourseUtils.i18n('articles_none', this.props.course.string_prefix)}
+          sortBy={this.props.sortArticles}
+        />
+      </div>
+    );
+  }
+});
+
+const mapStateToProps = state => ({
+  articleDetails: state.articleDetails,
+  sort: state.articles.sort,
+});
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators({ ...ArticleActions }, dispatch)
+});
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(ArticleList);

--- a/app/assets/javascripts/components/course/articles/article_list_keys.js
+++ b/app/assets/javascripts/components/course/articles/article_list_keys.js
@@ -1,0 +1,46 @@
+const contentAddedKey = (course) => {
+  if (course.home_wiki_bytes_per_word) {
+    return {
+      label: I18n.t('metrics.word_count'),
+      desktop_only: true,
+      info_key: `${course.string_prefix}.word_count_doc`
+    };
+  }
+  return {
+    label: I18n.t('metrics.char_added'),
+    desktop_only: true,
+    info_key: 'articles.character_doc'
+  };
+};
+
+const articleListKeys = (course) => {
+  return {
+    rating_num: {
+      label: I18n.t('articles.rating'),
+      desktop_only: true,
+      info_key: 'articles.rating_doc'
+    },
+    title: {
+      label: I18n.t('articles.title'),
+      desktop_only: false
+    },
+    character_sum: contentAddedKey(course),
+    references_count: {
+      label: I18n.t('metrics.references_count'),
+      desktop_only: true,
+      info_key: 'metrics.references_doc'
+    },
+    view_count: {
+      label: I18n.t('metrics.view'),
+      desktop_only: true,
+      info_key: 'articles.view_doc'
+    },
+    tools: {
+      label: I18n.t('articles.tools'),
+      desktop_only: false,
+      sortable: false
+    },
+  };
+};
+
+export default articleListKeys;

--- a/app/assets/javascripts/components/course/articles/articles_handler.jsx
+++ b/app/assets/javascripts/components/course/articles/articles_handler.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import { Redirect, Route, Switch } from 'react-router-dom';
+
+import Loading from '../common/loading.jsx';
+import SubNavigation from '../common/sub_navigation.jsx';
+import ArticleList from './article_list.jsx';
+import AssignmentList from '../assignments/assignment_list.jsx';
+import AvailableArticles from '../articles/available_articles.jsx';
+import CategoryHandler from '../categories/category_handler.jsx';
+import { fetchArticles, sortArticles, filterArticles, filterNewness, filterTrackedStatus } from '../../actions/articles_actions.js';
+import { fetchAssignments } from '../../actions/assignment_actions';
+import { getArticlesByTrackedStatus } from '../../selectors';
+import { delayFetchAssignmentsAndArticles } from '../util/helpers';
+
+export const ArticlesHandler = createReactClass({
+  displayName: 'ArticlesHandler',
+
+  propTypes: {
+    course_id: PropTypes.string,
+    current_user: PropTypes.object,
+    course: PropTypes.object,
+    fetchArticles: PropTypes.func,
+    limitReached: PropTypes.bool,
+    limit: PropTypes.number,
+    articles: PropTypes.array,
+    loadingArticles: PropTypes.bool,
+    assignments: PropTypes.array,
+    loadingAssignments: PropTypes.bool
+  },
+
+  getInitialState() {
+    return {
+      loading: true
+    };
+  },
+
+  componentDidMount() {
+    delayFetchAssignmentsAndArticles(this.props, () => this.setState({ loading: false }));
+  },
+
+  hideAssignments() {
+    const user = this.props.current_user;
+    const assignments = this.props.assignments;
+    const noAssignments = !assignments.filter(assignment => !assignment.user_id).length;
+    const isAdminOrInstructor = user.admin || user.isAdvancedRole;
+
+    return noAssignments && !isAdminOrInstructor;
+  },
+
+  render() {
+    // FIXME: These props should be required, and this component should not be
+    // mounted in the first place if they are not available.
+    if (!this.props.course || !this.props.course.home_wiki) { return <div />; }
+
+    let categories;
+    if (this.props.course.type === 'ArticleScopedProgram') {
+      categories = <CategoryHandler course={this.props.course} current_user={this.props.current_user} />;
+    }
+
+    const links = [
+      {
+        href: `/courses/${this.props.course.slug}/articles/edited`,
+        text: I18n.t('articles.edited')
+      },
+      {
+        href: `/courses/${this.props.course.slug}/articles/assigned`,
+        text: I18n.t('articles.assigned')
+      }
+    ];
+
+    if (this.state.loading) return <Loading />;
+    // If there are assignments or the user is an admin, show the Articles Available button
+    if (!this.hideAssignments()) {
+      links.push({
+        href: `/courses/${this.props.course.slug}/articles/available`,
+        text: I18n.t('articles.available')
+      });
+    }
+    return (
+      <div className="articles-view">
+        <SubNavigation links={links} />
+
+        <Switch>
+          <Route exact path="/courses/:course_school/:course_title/articles/edited" render={() => <ArticleList {...this.props} />} />
+          <Route exact path="/courses/:course_school/:course_title/articles/assigned" render={() => <AssignmentList {...this.props} />} />
+          <Route
+            exact
+            path="/courses/:course_school/:course_title/articles/available"
+            render={() => {
+              // If at any point there are no available articles, redirect the user
+              if (!this.state.loading && this.hideAssignments()) {
+                return <Redirect to={`/courses/${this.props.course.slug}`} />;
+              }
+
+              return <AvailableArticles {...this.props} />;
+            }}
+          />
+          <Redirect
+            to={{
+              pathname: '/courses/:course_school/:course_title/articles/edited',
+              search: this.props.location.search
+            }}
+          />
+        </Switch>
+
+        {categories}
+      </div>
+    );
+  }
+});
+
+const mapStateToProps = state => ({
+  limit: state.articles.limit,
+  articles: getArticlesByTrackedStatus(state),
+  limitReached: state.articles.limitReached,
+  wikis: state.articles.wikis,
+  wikidataLabels: state.wikidataLabels.labels,
+  loadingArticles: state.articles.loading,
+  assignments: state.assignments.assignments,
+  loadingAssignments: state.assignments.loading,
+  newnessFilterEnabled: state.articles.newnessFilterEnabled,
+  trackedStatusFilterEnabled: state.articles.trackedStatusFilterEnabled,
+  trackedStatusFilter: state.articles.trackedStatusFilter
+});
+
+const mapDispatchToProps = {
+  fetchArticles,
+  sortArticles,
+  filterArticles,
+  filterNewness,
+  filterTrackedStatus,
+  fetchAssignments
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+const component = connector(ArticlesHandler);
+export default withRouter(component);

--- a/app/assets/javascripts/components/course/articles/available_article.jsx
+++ b/app/assets/javascripts/components/course/articles/available_article.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import CourseUtils from '../../utils/course_utils.js';
+import { deleteAssignment, updateAssignment } from '../../actions/assignment_actions.js';
+import { addNotification } from '../../actions/notification_actions.js';
+
+export const AvailableArticle = createReactClass({
+  displayName: 'AvailableArticle',
+
+  propTypes: {
+    assignment: PropTypes.object,
+    current_user: PropTypes.object,
+    course: PropTypes.object,
+    addNotification: PropTypes.func,
+    deleteAssignment: PropTypes.func,
+    updateAssignment: PropTypes.func
+  },
+
+  onSelectHandler() {
+    const assignment = {
+      id: this.props.assignment.id,
+      user_id: this.props.current_user.id,
+      role: 0
+    };
+
+    const title = this.props.assignment.article_title;
+    this.props.addNotification({
+      message: I18n.t('assignments.article', { title }),
+      closable: true,
+      type: 'success'
+    });
+
+    return this.props.updateAssignment(assignment);
+  },
+
+  onRemoveHandler(e) {
+    e.preventDefault();
+
+    const assignment = {
+      id: this.props.assignment.id,
+      course_slug: this.props.course.slug,
+      language: this.props.assignment.language,
+      project: this.props.assignment.project,
+      article_title: this.props.assignment.article_title,
+      role: 0
+    };
+
+    if (!confirm(I18n.t('assignments.confirm_deletion'))) { return; }
+    return this.props.deleteAssignment(assignment);
+  },
+
+  render() {
+    const className = 'assignment';
+    const { assignment } = this.props;
+    const article = CourseUtils.articleFromAssignment(assignment, this.props.course.home_wiki);
+    const ratingClass = `rating ${assignment.article_rating}`;
+    const ratingMobileClass = `${ratingClass} tablet-only`;
+    const articleLink = <a onClick={this.stop} href={article.url} target="_blank" className="inline">{article.formatted_title}</a>;
+
+    let actionSelect;
+    let actionRemove;
+    if (this.props.current_user.isStudent) {
+      actionSelect = (
+        <button className="button dark" onClick={this.onSelectHandler}>{I18n.t('assignments.select')}</button>
+      );
+    }
+
+    if (this.props.current_user.isAdvancedRole) {
+      actionRemove = (
+        <button className="button dark" onClick={this.onRemoveHandler}>{I18n.t('assignments.remove')}</button>
+      );
+    }
+
+    return (
+      <tr className={className}>
+        <td className="tooltip-trigger desktop-only-tc">
+          <p className="rating_num hidden">{article.rating_num}</p>
+          <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>
+          <div className="tooltip dark">
+            <p>{I18n.t(`articles.rating_docs.${assignment.article_rating || '?'}`, { class: assignment.article_rating || '' })}</p>
+          </div>
+        </td>
+        <td>
+          <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>
+          <p className="title">
+            {articleLink}
+          </p>
+        </td>
+        <td className="table-action-cell">
+          {actionSelect}
+          {actionRemove}
+        </td>
+      </tr>
+    );
+  }
+}
+);
+
+const mapDispatchToProps = {
+  addNotification,
+  deleteAssignment,
+  updateAssignment
+};
+
+export default connect(null, mapDispatchToProps)(AvailableArticle);

--- a/app/assets/javascripts/components/course/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/course/articles/available_articles.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { compact } from 'lodash-es';
+import { Link } from 'react-router-dom';
+
+import AssignCell from '@components/common/AssignCell/AssignCell.jsx';
+import ConnectedAvailableArticle from './available_article.jsx';
+import AvailableArticlesList from '../articles/available_articles_list.jsx';
+import MyArticlesContainer from '../overview/my_articles/containers';
+import { ASSIGNED_ROLE } from '../../constants';
+import { processAssignments } from '../overview/my_articles/utils/processAssignments';
+
+const AvailableArticles = createReactClass({
+  displayName: 'AvailableArticles',
+
+  propTypes: {
+    course_id: PropTypes.string,
+    course: PropTypes.object,
+    current_user: PropTypes.object,
+    assignments: PropTypes.array
+  },
+
+  render() {
+    let assignCell;
+    let availableArticles;
+    let elements = [];
+    let findingArticlesTraining;
+    const { assignments, course, course_id, current_user } = this.props;
+
+    if (Features.wikiEd && current_user.isAdvancedRole) {
+      findingArticlesTraining = (
+        <a href="/training/instructors/finding-articles" target="_blank" className="button ghost-button small">
+          How to find articles
+        </a>
+      );
+    }
+
+    if (assignments.length > 0) {
+      elements = assignments.map((assignment) => {
+        if (assignment.user_id === null) {
+          return (
+            <ConnectedAvailableArticle
+              {...this.props}
+              assignment={assignment}
+              key={assignment.id}
+            />
+          );
+        }
+        return null;
+      });
+      elements = compact(elements);
+    }
+
+    if (course.id) {
+      assignCell = (
+        <AssignCell
+          course={course}
+          role={ASSIGNED_ROLE}
+          editable
+          allowMultipleArticles={true}
+          course_id={course_id}
+          current_user={current_user}
+          assignments={[]}
+          prefix={I18n.t('users.my_assigned')}
+        />
+      );
+    }
+
+    const { assigned } = processAssignments(this.props);
+    const isWikidataCourse = course.home_wiki && course.home_wiki.project === 'wikidata';
+    const showMyArticlesSection = assigned.length && current_user.isStudent && !isWikidataCourse;
+    let myArticles;
+    if (showMyArticlesSection) {
+      myArticles = (
+        <MyArticlesContainer current_user={current_user} />
+      );
+    }
+
+    const showAvailableArticles = elements.length > 0 || current_user.isAdvancedRole;
+    if (showAvailableArticles) {
+      availableArticles = (
+        <div id="available-articles" className="mt4">
+          <div className="section-header">
+            <h3>{I18n.t('articles.available')}</h3>
+            <div className="section-header__actions">
+              {findingArticlesTraining}
+              {assignCell}
+              <Link to={`/courses/${course_id}/article_finder`}><button className="button border small ml2">Find Articles</button></Link>
+            </div>
+          </div>
+          <AvailableArticlesList {...this.props} elements={elements} />
+        </div>
+      );
+    } else {
+      availableArticles = null;
+    }
+
+    return (
+      <>
+        {myArticles}
+        {availableArticles}
+      </>
+    );
+  }
+});
+
+export default AvailableArticles;

--- a/app/assets/javascripts/components/course/articles/available_articles_list.jsx
+++ b/app/assets/javascripts/components/course/articles/available_articles_list.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import List from '../common/list.jsx';
+import CourseUtils from '../../utils/course_utils.js';
+
+const AvailableArticlesList = ({ elements }) => {
+  const keys = {
+    rating_num: {
+      label: I18n.t('articles.rating'),
+      desktop_only: true
+    },
+    title: {
+      label: I18n.t('articles.title'),
+      desktop_only: false
+    }
+  };
+
+  return (
+    <List
+      elements={elements}
+      keys={keys}
+      table_key="articles"
+      none_message={CourseUtils.i18n('no_available', 'assignments')}
+      sortable={false}
+    />
+  );
+};
+
+AvailableArticlesList.propTypes = {
+  elements: PropTypes.array
+};
+
+export default AvailableArticlesList;

--- a/app/assets/javascripts/components/course/articles/course_ores_plot.jsx
+++ b/app/assets/javascripts/components/course/articles/course_ores_plot.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import Loading from '../common/loading.jsx';
+import CourseQualityProgressGraph from './course_quality_progress_graph';
+import { ORESSupportedWiki } from '../../utils/article_finder_language_mappings';
+
+const CourseOresPlot = createReactClass({
+  displayName: 'CourseOresPlot',
+
+  propTypes: {
+    course: PropTypes.object
+  },
+
+  getInitialState() {
+    return {
+      show: false,
+      articleData: null,
+      refreshedData: null,
+      loading: true,
+      refresh: false
+    };
+  },
+
+  show() {
+    if (!this.state.filePath) {
+      this.fetchFilePath();
+    }
+    return this.setState({ show: true });
+  },
+
+  refresh() {
+    this.setState({ refreshedData: null });
+    this.fetchFile();
+    return this.setState({ show: false, refresh: true });
+  },
+
+  hide() {
+    return this.setState({ show: false });
+  },
+
+  isSupportedWiki() {
+    const wiki = this.props.course.home_wiki;
+    if (!wiki) { return false; }
+    return ORESSupportedWiki.languages.includes(wiki.language) && wiki.project === 'wikipedia';
+  },
+
+  shouldShowButton() {
+    // Do not show it if there are zero articles edited, or it's not an en-wiki course.
+    return this.isSupportedWiki() && this.props.course.edited_count !== '0';
+  },
+
+  fetchFile() {
+    $.ajax({
+      url: `/courses/${this.props.course.slug}/refresh_ores_data.json`,
+      success: (data) => {
+        this.setState({ refreshedData: data.ores_plot, loading: false });
+      }
+    });
+  },
+
+  fetchFilePath() {
+    $.ajax({
+      url: `/courses/${this.props.course.slug}/ores_plot.json`,
+      success: (data) => {
+        this.setState({ articleData: data.ores_plot, loading: false });
+      }
+    });
+  },
+
+  displayGraph(data) {
+    return (
+      <div className="ores-plot">
+        <CourseQualityProgressGraph graphid={'vega-graph-ores-plot'} graphWidth={1000} graphHeight={200} articleData={data} />
+        <p>
+          This graph visualizes, in aggregate, how much articles developed from
+          before students first edited them until their most recent edits. The <em>Structural Completeness </em>
+          rating is based on a machine learning project (<a href="https://www.mediawiki.org/wiki/ORES/FAQ" target="_blank">ORES</a>)
+          that estimates an article&apos;s quality rating based on the amount of
+          prose, the number of wikilinks, images and section headers, and other features. (<a href="#" onClick={this.refresh}>Refresh Cached Data</a>)
+        </p>
+      </div>
+    );
+  },
+
+  loadgraph() {
+    if (this.state.loading) {
+      return <div onClick={this.hide}><Loading /></div>;
+    }
+    return <div>No Structural Completeness data available</div>;
+  },
+
+  render() {
+    if (!this.shouldShowButton()) { return <div />; }
+
+    if (this.state.refresh) {
+      if (this.state.refreshedData) {
+        return (
+          this.displayGraph(this.state.refreshedData)
+        );
+      }
+      this.loadgraph();
+    }
+
+    if (this.state.show) {
+      if (this.state.articleData) {
+        return (
+          this.displayGraph(this.state.articleData)
+        );
+      }
+      this.loadgraph();
+    }
+    return (<button className="button small" onClick={this.show}>Change in Structural Completeness</button>);
+  }
+});
+
+export default CourseOresPlot;

--- a/app/assets/javascripts/components/course/articles/course_quality_progress_graph.jsx
+++ b/app/assets/javascripts/components/course/articles/course_quality_progress_graph.jsx
@@ -1,0 +1,338 @@
+/* global vegaEmbed */
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+
+const CourseQualityProgressGraph = createReactClass({
+  displayName: 'CourseQualityProgressGraph',
+
+  propTypes: {
+    graphid: PropTypes.string,
+    graphWidth: PropTypes.number,
+    graphHeight: PropTypes.number,
+    articleData: PropTypes.array
+  },
+
+  componentDidMount() {
+    this.renderGraph();
+  },
+
+  renderGraph() {
+    if (this.props.articleData.length === 0) {
+      return;
+    }
+
+    const max_bytes_added = Math.max(
+      ...this.props.articleData.map(o => o.bytes_added),
+      0
+    );
+    const max_score = Math.max(
+      ...this.props.articleData.map(o => o.ores_after - o.ores_before),
+      0
+    );
+    const vegaSpec = {
+      width: this.props.graphWidth,
+      height: this.props.graphHeight,
+      padding: 5,
+      signals: [
+        { name: 'bandwidth', value: 1 },
+        { name: 'steps', value: 1000 },
+        { name: 'method', value: 'pdf' },
+        {
+          name: 'articles',
+          value: 'both',
+          bind: {
+            input: 'radio',
+            options: ['new', 'existing', 'both'],
+            name: 'Articles:'
+          }
+        },
+        {
+          name: 'bytes_added',
+          value: 0,
+          bind: {
+            input: 'range',
+            min: 0,
+            max: max_bytes_added,
+            name: 'Minimum bytes added:'
+          }
+        },
+        {
+          name: 'score',
+          value: 0,
+          bind: {
+            input: 'range',
+            min: 0,
+            max: max_score,
+            name: 'Minimum change in score:'
+          }
+        },
+        {
+          name: 'articleCount',
+          value: 0,
+          update: "'Article count: ' + data('points').length"
+        },
+        {
+          name: 'mean_ores_before',
+          value: 0,
+          update:
+            "'Mean score before: ' + format(data('mean_before')[0].mean_ores_before, '.1f')"
+        },
+        {
+          name: 'mean_ores_after',
+          value: 0,
+          update:
+            "'Mean score after: ' + format(data('mean_after')[0].mean_ores_after, '.1f')"
+        }
+      ],
+
+      data: [
+        {
+          name: 'points',
+          values: this.props.articleData,
+          transform: [
+            { // Filter based on the [new / existing / both] selection
+              type: 'filter',
+              expr:
+                "(articles === 'both') ? true : (articles === 'new' ? (datum.ores_before === 0) : (datum.ores_before > 0))"
+            },
+            { // Filter based on the 'Minimum bytes added' slider. The minimum bytes added is zero, so by default no articles are filtered out.
+              type: 'filter',
+              expr: 'datum.bytes_added >= bytes_added'
+            },
+            { // Filter based on the 'Minimum change in score' slider. This can be negative, so we treat the default 0 position as no filter.
+              type: 'filter',
+              expr: '(score === 0) ? true : (datum.ores_after - datum.ores_before) >= score'
+            }
+          ]
+        },
+        {
+          name: 'mean_before',
+          source: 'points',
+          transform: [
+            {
+              type: 'aggregate',
+              fields: ['ores_before'],
+              ops: ['mean']
+            }
+          ]
+        },
+        {
+          name: 'mean_after',
+          source: 'points',
+          transform: [
+            {
+              type: 'aggregate',
+              fields: ['ores_after'],
+              ops: ['mean']
+            }
+          ]
+        },
+        {
+          name: 'before',
+          source: 'points',
+          transform: [
+            {
+              type: 'aggregate',
+              fields: ['ores_before', 'ores_before'],
+              ops: ['mean', 'stdev'],
+              as: ['mean', 'stdev']
+            }
+          ]
+        },
+        {
+          name: 'after',
+          source: 'points',
+          transform: [
+            {
+              type: 'aggregate',
+              fields: ['ores_after', 'ores_after'],
+              ops: ['mean', 'stdev'],
+              as: ['mean', 'stdev']
+            }
+          ]
+        },
+        {
+          name: 'density',
+          source: 'points',
+          transform: [
+            {
+              type: 'density',
+              extent: { signal: "domain('xscale')" },
+              steps: { signal: 'steps' },
+              method: { signal: 'method' },
+              distribution: {
+                function: 'kde',
+                field: 'ores_before',
+                bandwidth: { signal: 'bandwidth' }
+              }
+            }
+          ]
+        },
+        {
+          name: 'density_after',
+          source: 'points',
+          transform: [
+            {
+              type: 'density',
+              extent: { signal: "domain('xscale')" },
+              steps: { signal: 'steps' },
+              method: { signal: 'method' },
+              distribution: {
+                function: 'kde',
+                field: 'ores_after',
+                bandwidth: { signal: 'bandwidth' }
+              }
+            }
+          ]
+        },
+        {
+          name: 'normal',
+          transform: [
+            {
+              type: 'density',
+              extent: { signal: "domain('xscale')" },
+              steps: { signal: 'steps' },
+              method: { signal: 'method' },
+              distribution: {
+                function: 'normal',
+                mean: { signal: "data('before')[0] && data('before')[0].mean" },
+                stdev: {
+                  signal: "data('before')[0] && data('before')[0].stdev"
+                }
+              }
+            }
+          ]
+        }
+      ],
+
+      scales: [
+        {
+          name: 'xscale',
+          type: 'linear',
+          range: 'width',
+          domain: [0, 100],
+          nice: true
+        },
+        {
+          name: 'yscale',
+          type: 'linear',
+          range: 'height',
+          round: true,
+          domain: {
+            fields: [
+              { data: 'density', field: 'density' },
+              { data: 'density', field: 'density_after' }
+            ]
+          }
+        },
+        {
+          name: 'color',
+          type: 'ordinal',
+          domain: ['before', 'after'],
+          range: ['#676eb4', '#359178']
+        }
+      ],
+
+      axes: [{ orient: 'bottom', scale: 'xscale', zindex: 1 }],
+
+      legends: [
+        { orient: 'right', fill: 'color', offset: 0, zindex: 1 },
+        {
+          orient: 'right',
+          fill: 'color',
+          offset: -15,
+          zindex: 1,
+          values: [
+            {
+              signal: 'articleCount'
+            },
+            {
+              signal: 'mean_ores_before'
+            },
+            {
+              signal: 'mean_ores_after'
+            }
+          ]
+        }
+      ],
+
+      marks: [
+        {
+          type: 'area',
+          from: { data: 'density' },
+          encode: {
+            update: {
+              x: { scale: 'xscale', field: 'value' },
+              y: { scale: 'yscale', field: 'density' },
+              y2: { scale: 'yscale', value: 0 },
+              fill: { signal: "scale('color', 'before')" },
+              fillOpacity: { value: 0.5 }
+            }
+          }
+        },
+        {
+          type: 'area',
+          from: { data: 'density_after' },
+          encode: {
+            update: {
+              x: { scale: 'xscale', field: 'value' },
+              y: { scale: 'yscale', field: 'density' },
+              y2: { scale: 'yscale', value: 0 },
+              fill: { signal: "scale('color', 'after')" },
+              fillOpacity: { value: 0.5 }
+            }
+          }
+        },
+        {
+          type: 'symbol',
+          from: { data: 'points' },
+          encode: {
+            enter: {
+              shape: { value: 'circle' },
+              x: { scale: 'xscale', field: 'ores_before' },
+              size: { value: 200 },
+              y: { value: 25, offset: { signal: 'height' } },
+              height: { value: 5 },
+              fill: { signal: "scale('color', 'before')" },
+              fillOpacity: { value: 0.4 },
+              stroke: { signal: "scale('color', 'before')" },
+              tooltip: { signal: "{'Before': datum.article_title}" }
+            }
+          }
+        },
+        {
+          type: 'symbol',
+          from: { data: 'points' },
+          encode: {
+            enter: {
+              shape: { value: 'circle' },
+              x: { scale: 'xscale', field: 'ores_after' },
+              size: { value: 200 },
+              y: { value: 25, offset: { signal: 'height' } },
+              height: { value: 5 },
+              fill: { signal: "scale('color', 'after')" },
+              fillOpacity: { value: 0.4 },
+              stroke: { signal: "scale('color', 'after')" },
+              tooltip: { signal: "{'After': datum.article_title}" }
+            }
+          }
+        }
+      ]
+    };
+    vegaEmbed(`#${this.props.graphid}`, vegaSpec, {
+      defaultStyle: true,
+      actions: { source: false }
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <div id={this.props.graphid} />
+      </div>
+    );
+  }
+});
+
+export default CourseQualityProgressGraph;

--- a/app/assets/javascripts/components/course/articles/edit_size_graph.jsx
+++ b/app/assets/javascripts/components/course/articles/edit_size_graph.jsx
@@ -1,0 +1,170 @@
+/* global vegaEmbed */
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+
+const EditSizeGraph = createReactClass({
+  displayName: 'EditSizeGraph',
+
+  propTypes: {
+    graphid: PropTypes.string,
+    graphWidth: PropTypes.number,
+    graphHeight: PropTypes.number,
+    articleData: PropTypes.array
+  },
+
+  componentDidMount() {
+    this.renderGraph();
+  },
+
+  renderGraph() {
+    const vegaSpec = {
+      width: this.props.graphWidth,
+      height: this.props.graphHeight,
+      padding: 5,
+      // //////////////////
+      // Scales and Axes //
+      // //////////////////
+      scales: [
+        {
+          name: 'x',
+          type: 'time',
+          domain: {
+            data: 'characters_edited',
+            field: 'date',
+            sort: { field: 'date', op: 'min' }
+          },
+          range: [0, this.props.graphWidth],
+          round: true
+        },
+        {
+          name: 'y',
+          type: 'linear',
+          domain: {
+            data: 'characters_edited',
+            field: 'characters'
+          },
+          range: [this.props.graphHeight, 0],
+          round: true,
+          nice: true,
+          zero: true
+        }
+      ],
+      axes: [
+        {
+          orient: 'bottom',
+          scale: 'x',
+          grid: true,
+          ticks: true,
+          title: 'Date'
+        },
+        {
+          orient: 'left',
+          scale: 'y',
+          format: 's',
+          grid: true,
+          offset: 10,
+          title: I18n.t('metrics.characters')
+        }
+      ],
+      // ///////////////
+      // Data Sources //
+      // ///////////////
+      data: [
+        {
+          name: 'characters_edited',
+          values: this.props.articleData,
+          format: { type: 'json', parse: { date: 'date', characters: 'number' } },
+          transform: [{
+            type: 'filter',
+            expr: 'datum.date !== null && !isNaN(datum.date) && datum.characters!== null && !isNaN(datum.characters) && datum.characters !== 0'
+          }
+          ]
+        }
+      ],
+      // //////////////
+      // Mark layers //
+      // //////////////
+      marks: [
+        {
+          type: 'rule',
+          encode: {
+            update: {
+              x: { value: 0 },
+              x2: { value: this.props.graphWidth },
+              y: { scale: 'y', value: 0 },
+              stroke: { value: '#000000' },
+              strokeWidth: { value: 1 },
+              strokeOpacity: { value: 0.5 }
+            }
+          }
+        },
+        {
+          type: 'rule',
+          from: {
+            data: 'characters_edited',
+            transform: [{ type: 'sort', by: '-date' }]
+          },
+          encode:
+          {
+            update: {
+              x: { scale: 'x', field: 'date' },
+              y: { scale: 'y', field: 'characters' },
+              y2: { scale: 'y', value: 0 },
+              strokeWidth: { value: 2 },
+              strokeOpacity: { value: 0.3 },
+              stroke: [
+                {
+                  test: 'datum.characters > 0',
+                  value: '#0000ff'
+                },
+                { value: '#ff0000' }
+              ]
+            }
+          }
+        },
+        {
+          name: 'circle_marks',
+          type: 'symbol',
+          from: {
+            data: 'characters_edited',
+            transform: [{ type: 'sort', by: '-date' }]
+          },
+          encode: { enter: {
+            orient: { value: 'vertical' },
+            opacity: { value: 0.5 }
+          },
+            update: {
+              x: { scale: 'x', field: 'date' },
+              y: { scale: 'y', field: 'characters' },
+              y2: { scale: 'y' },
+              size: { value: 100 },
+              shape: { value: 'circle' },
+              fill: [
+                {
+                  test: 'datum.characters > 0',
+                  value: '#0000ff'
+                },
+                { value: '#ff0000' }
+              ]
+            }
+          }
+        }
+      ]
+    };
+
+    // emded the visualization in the container with id vega-graph-article_id
+    vegaEmbed(`#${this.props.graphid}`, vegaSpec, { defaultStyle: true, actions: { source: false } });
+  },
+
+
+  render() {
+    return (
+      <div>
+        <div id={this.props.graphid} />
+      </div>
+    );
+  }
+});
+
+export default EditSizeGraph;

--- a/app/assets/javascripts/components/course/articles/salesforce_media_buttons.jsx
+++ b/app/assets/javascripts/components/course/articles/salesforce_media_buttons.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SalesforceMediaButtons = ({
+  article,
+  course,
+  editors,
+  before_rev_id,
+  after_rev_id
+}) => {
+  const salesforceMediaUrlRoot = '/salesforce/create_media?';
+  const courseParam = `course_id=${course.id}`;
+  const articleParam = `&article_id=${article.id}`;
+  // eslint-disable-next-line
+  const diffParams = `&before_rev_id=${before_rev_id}&after_rev_id=${after_rev_id}`;
+  const urlWithoutUsername = salesforceMediaUrlRoot + courseParam + articleParam + diffParams;
+
+  const salesforceButtons = editors.map((username) => {
+    const usernameParam = `&username=${username}`;
+    const completeUrl = urlWithoutUsername + usernameParam;
+    return (
+      <a
+        href={completeUrl}
+        target="_blank"
+        className="button dark small"
+        key={`salesforce-media-${username}`}
+      >
+        {username}
+      </a>
+    );
+  });
+
+  return (
+    <div>
+      <p>
+        Create a new Salesforce &quot;Media&quot; record for this article, credited to:
+      </p>
+      {salesforceButtons}
+    </div>
+  );
+};
+
+SalesforceMediaButtons.propTypes = {
+  article: PropTypes.object,
+  course: PropTypes.object,
+  editors: PropTypes.array,
+  before_rev_id: PropTypes.number,
+  after_rev_id: PropTypes.number
+};
+
+export default SalesforceMediaButtons;

--- a/app/assets/javascripts/components/course/articles/wp10_graph.jsx
+++ b/app/assets/javascripts/components/course/articles/wp10_graph.jsx
@@ -1,0 +1,143 @@
+/* global vegaEmbed */
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+
+const Wp10Graph = createReactClass({
+  displayName: 'Wp10Graph',
+
+  propTypes: {
+    graphid: PropTypes.string,
+    graphWidth: PropTypes.number,
+    graphHeight: PropTypes.number,
+    articleData: PropTypes.array
+  },
+
+  componentDidMount() {
+    this.renderGraph();
+  },
+
+  renderGraph() {
+    const vegaSpec = {
+      width: this.props.graphWidth,
+      height: this.props.graphHeight,
+      padding: 5,
+      // //////////////////
+      // Scales and Axes //
+      // //////////////////
+      scales: [
+        {
+          name: 'x',
+          type: 'time',
+          domain: {
+            data: 'wp10_scores',
+            field: 'date',
+            sort: { field: 'date', op: 'min' }
+          },
+          range: 'width',
+          round: true
+        },
+        {
+          name: 'y',
+          type: 'linear',
+          domain: [0, 100, 0, 100],
+          range: 'height',
+          round: true,
+          nice: true,
+          zero: false
+        }
+      ],
+      axes: [
+        {
+          orient: 'bottom',
+          scale: 'x',
+          grid: true,
+          ticks: true,
+          title: 'Date'
+        },
+        {
+          orient: 'left',
+          scale: 'y',
+          format: 's',
+          grid: true,
+          offset: 10,
+          title: I18n.t('articles.wp10')
+        }
+      ],
+      // ///////////////
+      // Data Sources //
+      // ///////////////
+      data: [
+        {
+          name: 'wp10_scores',
+          values: this.props.articleData,
+          format: { type: 'json', parse: { date: 'date', wp10: 'number' } },
+          transform: [{
+            type: 'filter',
+            expr: 'datum.date !== null && !isNaN(datum.date) && datum.wp10 !== null && !isNaN(datum.wp10)'
+          }]
+        }
+      ],
+      // //////////////
+      // Mark layers //
+      // //////////////
+      marks: [
+        // Step graph fill area below scores
+        {
+          name: 'area_marks',
+          type: 'area',
+          from: {
+            data: 'wp10_scores'
+          },
+          encode: { enter: {
+            orient: { value: 'vertical' },
+            x: { scale: 'x', field: 'date' },
+            y: { scale: 'y', field: 'wp10' },
+            y2: { scale: 'y', value: 0 },
+            fill: { value: '#676EB4' },
+            opacity: { value: 0.7 },
+            interpolate: { value: 'step-after' }
+          } }
+        },
+        // Revision point marks
+        {
+          name: 'circle_marks',
+          type: 'symbol',
+          from: {
+            data: 'wp10_scores'
+          },
+          encode: {
+            enter: {
+              x: { scale: 'x', field: 'date' },
+              y: { scale: 'y', field: 'wp10' },
+              size: { value: 100 },
+              shape: { value: 'circle' },
+              fill: { value: '#359178' },
+              opacity: { value: 0.7 },
+              tooltip: { field: 'username' }
+            },
+            hover: { fill: { value: '#333' }, opacity: { value: 1 } },
+            update: {
+              fill: { value: '#359178' },
+              opacity: { value: 0.7 }
+            }
+          }
+        },
+
+      ],
+
+    };
+
+    vegaEmbed(`#${this.props.graphid}`, vegaSpec, { defaultStyle: true, actions: { source: false } });
+  },
+
+  render() {
+    return (
+      <div>
+        <div id={this.props.graphid} />
+      </div>
+    );
+  }
+});
+
+export default Wp10Graph;

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
@@ -48,7 +48,7 @@ export const Assignment = ({ assignment, course, current_user, fetchArticleDetai
           article={article}
           course={course}
           current_user={current_user}
-          fetchArticleDetails={fetchArticleDetails}
+          fetchArticleDetails={() => { fetchArticleDetails(article.id, course.id); }}
           users={users}
           showOnMount={showArticleId === article.id}
         />

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticleRow.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticleRow.jsx
@@ -21,7 +21,7 @@ export const EditedUnassignedArticleRow = ({
         article={article}
         course={course}
         current_user={current_user}
-        fetchArticleDetails={fetchArticleDetails}
+        fetchArticleDetails={() => { fetchArticleDetails(article.id, course.id); }}
         users={[user.username]}
         showOnMount={showArticleId === article.id}
       />


### PR DESCRIPTION
## What this PR does
Fixes the bug mentioned in issue #4023, wherein, when invoked from the student's tab the `articleViewer` container only displayed editors that were assigned to that article, even if edits were made by other unassigned editors.

## Screenshots
Before:
![94878069-3ea9a000-0454-11eb-9c99-0d57562878ed](https://user-images.githubusercontent.com/62028695/95800618-b2b73400-0cef-11eb-9ebf-194a6fdf6194.png)


After:
![Screenshot from 2020-10-13 00-54-08 (1)](https://user-images.githubusercontent.com/62028695/95800805-3a9d3e00-0cf0-11eb-859a-438dc7e9553e.png)

## Open questions and concerns
My current approach towards solving this bug involves replicating the process of extracting editors when the `ArticleViewer` container is viewed from the `Articles` tab, wherein the `fetchArticleDetails` function is supplied with neccessary argumets and called within the `ArticleViewer` component, which then updates the `redux-store` with `articleDetails`. The editors are then extracted from the `articleDetails` object. However, my current approach involves altering the data in the `redux-store` and i was wondering if there was a better way to approach this bug?
