### PR TITLE
Add total articles created and edited in CSV

### DIFF
--- a/spec/lib/analytics/course_students_csv_builder_spec.rb
+++ b/spec/lib/analytics/course_students_csv_builder_spec.rb
@@ -11,8 +11,8 @@ describe CourseStudentsCsvBuilder do
 
   it 'creates a CSV with a header and a row of data for each student' do
     expect(subject.split("\n").count).to eq(2)
-    # last column is 'registered_during_project', which should be true
+    # last column is 'total_articles_created', which should be 0
     # for the test user.
-    expect(subject[-5..-1]).to eq("true\n")
+    expect(subject[-2..-1]).to eq("0\n")
   end
 end


### PR DESCRIPTION
## What this PR does
- Adds the total number of articles edited or created by editors in the editors CSV
- The [issue](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/4217)

## Screenshots
Before:
<img width="911" alt="Screenshot 2020-10-14 at 19 35 38" src="https://user-images.githubusercontent.com/7622875/96018957-8b2dac00-0e54-11eb-8dca-540971bf2072.png">

After:
<img width="1144" alt="Screenshot 2020-10-14 at 19 29 49" src="https://user-images.githubusercontent.com/7622875/96018240-aba93680-0e53-11eb-9825-3473f183a4a8.png">

## Open questions and concerns
- The build is failing because of  [50 and 51](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/4248/files#diff-6c15f159a652c018e981d3e09825dbf1b0623f0b08b4573c4b4f66345659a31fR50-R51) in the CSV builder. 
- I can create a separate method to fix this unless we don't need to worry about this issue in favour of readability.