### PR TITLE
Make 'Available Articles' work for group assignments

### DIFF
--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -49,7 +49,7 @@ export const deleteAssignment = assignment => (dispatch) => {
     .catch(response => dispatch({ type: types.API_FAIL, data: response }));
 };
 
-export const updateAssignment = assignment => (dispatch) => {
+export const claimAssignment = assignment => (dispatch) => {
   return API.updateAssignment(assignment)
     .then(resp => dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp }))
     .catch(response => dispatch({ type: types.API_FAIL, data: response }));

--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -49,8 +49,25 @@ export const deleteAssignment = assignment => (dispatch) => {
     .catch(response => dispatch({ type: types.API_FAIL, data: response }));
 };
 
+const claimAssignmentPromise = (assignment) => {
+  return request(`/assignments/${assignment.id}/claim`, {
+    method: 'PUT',
+    body: JSON.stringify(assignment)
+  })
+  .then((res) => {
+    if (res.ok && res.status === 200) {
+      return res.json();
+    }
+    return Promise.reject(res);
+  })
+  .catch((error) => {
+    logErrorMessage(error);
+    return error;
+  });
+};
+
 export const claimAssignment = assignment => (dispatch) => {
-  return API.updateAssignment(assignment)
+  return claimAssignmentPromise(assignment)
     .then(resp => dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp }))
     .catch(response => dispatch({ type: types.API_FAIL, data: response }));
 };

--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -59,10 +59,6 @@ const claimAssignmentPromise = (assignment) => {
       return res.json();
     }
     return Promise.reject(res);
-  })
-  .catch((error) => {
-    logErrorMessage(error);
-    return error;
   });
 };
 

--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -64,7 +64,7 @@ export const claimAssignment = (assignment, successNotification) => (dispatch) =
   return claimAssignmentPromise(assignment)
     .then((resp) => {
       if (resp.assignment) {
-        dispatch(addNotification(successNotification));
+        if (successNotification) { dispatch(addNotification(successNotification)); }
         dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp });
       } else {
         dispatch({ type: types.API_FAIL, data: resp });

--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -2,6 +2,9 @@ import API from '../utils/api.js';
 import * as types from '../constants';
 import logErrorMessage from '../utils/log_error_message';
 import request from '../utils/request';
+import { addNotification } from './notification_actions.js';
+
+
 
 const fetchAssignmentsPromise = (courseSlug) => {
   return request(`/courses/${courseSlug}/assignments.json`)
@@ -54,17 +57,19 @@ const claimAssignmentPromise = (assignment) => {
     method: 'PUT',
     body: JSON.stringify(assignment)
   })
-  .then((res) => {
-    if (res.ok && res.status === 200) {
-      return res.json();
-    }
-    return Promise.reject(res);
-  });
+  .then(res => res.json());
 };
 
-export const claimAssignment = assignment => (dispatch) => {
+export const claimAssignment = (assignment, successNotification) => (dispatch) => {
   return claimAssignmentPromise(assignment)
-    .then(resp => dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp }))
+    .then((resp) => {
+      if (resp.assignment) {
+        dispatch(addNotification(successNotification));
+        dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp });
+      } else {
+        dispatch({ type: types.API_FAIL, data: resp });
+      }
+    })
     .catch(response => dispatch({ type: types.API_FAIL, data: response }));
 };
 

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import CourseUtils from '../../utils/course_utils.js';
-import { deleteAssignment, updateAssignment } from '../../actions/assignment_actions.js';
+import { deleteAssignment, claimAssignment } from '../../actions/assignment_actions.js';
 import { addNotification } from '../../actions/notification_actions.js';
 
 export const AvailableArticle = createReactClass({
@@ -16,7 +16,7 @@ export const AvailableArticle = createReactClass({
     course: PropTypes.object,
     addNotification: PropTypes.func,
     deleteAssignment: PropTypes.func,
-    updateAssignment: PropTypes.func
+    claimAssignment: PropTypes.func
   },
 
   onSelectHandler() {
@@ -33,7 +33,7 @@ export const AvailableArticle = createReactClass({
       type: 'success'
     });
 
-    return this.props.updateAssignment(assignment);
+    return this.props.claimAssignment(assignment);
   },
 
   onRemoveHandler(e) {
@@ -102,7 +102,7 @@ export const AvailableArticle = createReactClass({
 const mapDispatchToProps = {
   addNotification,
   deleteAssignment,
-  updateAssignment
+  claimAssignment
 };
 
 export default connect(null, mapDispatchToProps)(AvailableArticle);

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -14,7 +14,8 @@ export const AvailableArticle = createReactClass({
     current_user: PropTypes.object,
     course: PropTypes.object,
     deleteAssignment: PropTypes.func,
-    claimAssignment: PropTypes.func
+    claimAssignment: PropTypes.func,
+    selectable: PropTypes.func
   },
 
   onSelectHandler() {
@@ -60,7 +61,7 @@ export const AvailableArticle = createReactClass({
 
     let actionSelect;
     let actionRemove;
-    if (this.props.current_user.isStudent) {
+    if (this.props.current_user.isStudent && this.props.selectable) {
       actionSelect = (
         <button className="button dark" onClick={this.onSelectHandler}>{I18n.t('assignments.select')}</button>
       );

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -15,7 +15,7 @@ export const AvailableArticle = createReactClass({
     course: PropTypes.object,
     deleteAssignment: PropTypes.func,
     claimAssignment: PropTypes.func,
-    selectable: PropTypes.func
+    selectable: PropTypes.bool
   },
 
   onSelectHandler() {

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 
 import CourseUtils from '../../utils/course_utils.js';
 import { deleteAssignment, claimAssignment } from '../../actions/assignment_actions.js';
-import { addNotification } from '../../actions/notification_actions.js';
 
 export const AvailableArticle = createReactClass({
   displayName: 'AvailableArticle',
@@ -14,7 +13,6 @@ export const AvailableArticle = createReactClass({
     assignment: PropTypes.object,
     current_user: PropTypes.object,
     course: PropTypes.object,
-    addNotification: PropTypes.func,
     deleteAssignment: PropTypes.func,
     claimAssignment: PropTypes.func
   },
@@ -27,13 +25,13 @@ export const AvailableArticle = createReactClass({
     };
 
     const title = this.props.assignment.article_title;
-    this.props.addNotification({
+    const successNotification = {
       message: I18n.t('assignments.article', { title }),
       closable: true,
       type: 'success'
-    });
+    };
 
-    return this.props.claimAssignment(assignment);
+    return this.props.claimAssignment(assignment, successNotification);
   },
 
   onRemoveHandler(e) {
@@ -100,7 +98,6 @@ export const AvailableArticle = createReactClass({
 );
 
 const mapDispatchToProps = {
-  addNotification,
   deleteAssignment,
   claimAssignment
 };

--- a/app/assets/javascripts/components/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/articles/available_articles.jsx
@@ -28,6 +28,16 @@ const AvailableArticles = createReactClass({
     let findingArticlesTraining;
     const { assignments, course, course_id, current_user } = this.props;
 
+    const { assigned } = processAssignments(this.props);
+    const isWikidataCourse = course.home_wiki && course.home_wiki.project === 'wikidata';
+    const showMyArticlesSection = assigned.length && current_user.isStudent && !isWikidataCourse;
+    let myArticles;
+    if (showMyArticlesSection) {
+      myArticles = (
+        <MyArticlesContainer current_user={current_user} />
+      );
+    }
+
     if (Features.wikiEd && current_user.isAdvancedRole) {
       findingArticlesTraining = (
         <a href="/training/instructors/finding-articles" target="_blank" className="button ghost-button small">
@@ -37,11 +47,13 @@ const AvailableArticles = createReactClass({
     }
 
     if (assignments.length > 0) {
+      const assignedUrls = assigned.map(assignment => assignment.article_url);
       elements = assignments.map((assignment) => {
         if (assignment.user_id === null) {
           return (
             <ConnectedAvailableArticle
               {...this.props}
+              selectable={!assignedUrls.includes(assignment.article_url)}
               assignment={assignment}
               key={assignment.id}
             />
@@ -64,16 +76,6 @@ const AvailableArticles = createReactClass({
           assignments={[]}
           prefix={I18n.t('users.my_assigned')}
         />
-      );
-    }
-
-    const { assigned } = processAssignments(this.props);
-    const isWikidataCourse = course.home_wiki && course.home_wiki.project === 'wikidata';
-    const showMyArticlesSection = assigned.length && current_user.isStudent && !isWikidataCourse;
-    let myArticles;
-    if (showMyArticlesSection) {
-      myArticles = (
-        <MyArticlesContainer current_user={current_user} />
       );
     }
 

--- a/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import PopoverExpandable from '../../high_order/popover_expandable.jsx';
 import Popover from '../popover.jsx';
 import { initiateConfirm } from '../../../actions/confirm_actions';
-import { addAssignment, deleteAssignment, updateAssignment } from '../../../actions/assignment_actions';
+import { addAssignment, deleteAssignment, claimAssignment } from '../../../actions/assignment_actions';
 import CourseUtils from '../../../utils/course_utils.js';
 import AddAvailableArticles from '../../articles/add_available_articles';
 import NewAssignmentInput from '../../assignments/new_assignment_input';
@@ -351,7 +351,7 @@ export class AssignButton extends React.Component {
     e.preventDefault();
 
     return this._onConfirmHandler({
-      action: this.props.updateAssignment,
+      action: this.props.claimAssignment,
       assignment: {
         id: assignment.id,
         role: this.props.role
@@ -524,7 +524,7 @@ const mapDispatchToProps = {
   addAssignment,
   deleteAssignment,
   initiateConfirm,
-  updateAssignment
+  claimAssignment
 };
 
 export default connect(null, mapDispatchToProps)(

--- a/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
@@ -517,7 +517,8 @@ AssignButton.propTypes = {
 
   addAssignment: PropTypes.func,
   initiateConfirm: PropTypes.func,
-  deleteAssignment: PropTypes.func
+  deleteAssignment: PropTypes.func,
+  unassigned: PropTypes.array
 };
 
 const mapDispatchToProps = {

--- a/app/assets/javascripts/components/common/get_help_button.jsx
+++ b/app/assets/javascripts/components/common/get_help_button.jsx
@@ -203,7 +203,7 @@ const GetHelpButton = createReactClass({
           <form target="_blank" action="/faq" acceptCharset="UTF-8" method="get">
             <input name="utf8" type="hidden" defaultValue="✓" />
             <input name="source" type="hidden" defaultValue="get_help_button" />
-            <input type="text" name="search" id="search" defaultValue="" placeholder="Search Help Forum" />
+            <input type="text" name="search" id="get_help_search" defaultValue="" placeholder="Search Help Forum" />
             <button type="submit">
               <i className="icon icon-search" />
             </button>

--- a/app/assets/javascripts/components/nav/hamburger_menu.jsx
+++ b/app/assets/javascripts/components/nav/hamburger_menu.jsx
@@ -69,7 +69,7 @@ const HamburgerMenu = createReactClass({
           <li>
             <form className="top-nav__faq-search" target="_blank" action="/faq" acceptCharset="UTF-8" method="get">
               <input name="utf8" type="hidden" defaultValue="✓" />
-              <input type="text" name="search" id="search" defaultValue="" placeholder={I18n.t('application.search')} />
+              <input type="text" name="search" id="hamburger_search" defaultValue="" placeholder={I18n.t('application.search')} />
               <input name="source" type="hidden" defaultValue="nav_ask_form" />
               <button type="submit">
                 <i className="icon icon-search" />

--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -114,7 +114,7 @@ const Nav = createReactClass({
           <div className="top-nav__faq-search">
             <form target="_blank" action="/faq" acceptCharset="UTF-8" method="get">
               <input name="utf8" type="hidden" defaultValue="✓" />
-              <input type="text" name="search" id="search" defaultValue="" placeholder={I18n.t('application.search')} />
+              <input type="text" name="search" id="nav_search" defaultValue="" placeholder={I18n.t('application.search')} />
               <input name="source" type="hidden" defaultValue="nav_ask_form" />
               <button type="submit">
                 <i className="icon icon-search" />

--- a/app/assets/javascripts/components/overview/my_articles/containers/index.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/containers/index.jsx
@@ -28,8 +28,8 @@ export class MyArticlesContainer extends React.Component {
     const {
       assigned,
       reviewing,
-      unassigned,
       reviewable,
+      assignable,
       all
     } = processAssignments(this.props);
 
@@ -52,7 +52,7 @@ export class MyArticlesContainer extends React.Component {
             current_user={current_user}
             reviewable={reviewable}
             reviewing={reviewing}
-            unassigned={unassigned}
+            unassigned={assignable}
             wikidataLabels={wikidataLabels}
           />
           <MyArticlesCategories

--- a/app/assets/javascripts/components/overview/my_articles/utils/processAssignments.js
+++ b/app/assets/javascripts/components/overview/my_articles/utils/processAssignments.js
@@ -102,7 +102,7 @@ export const processAssignments = ({ assignments, course, current_user }) => {
 
   const {
     assigned, reviewing,
-    unassigned, reviewable
+    unassigned, reviewable, assignable
   } = groupByAssignmentType(assignments, userId);
 
   const all = assigned.concat(reviewing).map(addAssignmentCategory);
@@ -112,6 +112,7 @@ export const processAssignments = ({ assignments, course, current_user }) => {
     reviewing,
     unassigned,
     reviewable,
+    assignable,
     all
   };
 };

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/Header.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/Header.jsx
@@ -17,7 +17,7 @@ export const Header = ({
 }) => {
   const {
     assigned, reviewing,
-    unassigned, reviewable
+    reviewable, assignable
   } = groupByAssignmentType(assignments, selected.id);
 
   return (
@@ -43,7 +43,7 @@ export const Header = ({
           role={ASSIGNED_ROLE}
           student={selected}
           tooltip_message={I18n.t('assignments.assign_tooltip')}
-          unassigned={unassigned}
+          unassigned={assignable}
           wikidataLabels={wikidataLabels}
         />
         <AssignCell

--- a/app/assets/javascripts/components/util/helpers.js
+++ b/app/assets/javascripts/components/util/helpers.js
@@ -28,6 +28,12 @@ export const groupByAssignmentType = (assignments, user_id) => {
   const assignOptions = { user_id, role: ASSIGNED_ROLE };
   const assigned = getFiltered(assignments, assignOptions);
 
+  // Assignable to the current user: unassigned, and the current user
+  // isn't already assigned the same one
+  const pluckArticleUrl = pluck('article_url');
+  const assignedArticleUrls = assigned.map(pluckArticleUrl);
+  const assignable = unassigned.filter(assignment => !assignedArticleUrls.includes(assignment.article_url));
+
   // The current user is reviewing
   const reviewOptions = { user_id, role: REVIEWING_ROLE };
   const reviewing = getFiltered(assignments, reviewOptions);
@@ -64,7 +70,7 @@ export const groupByAssignmentType = (assignments, user_id) => {
   });
 
   const reviewable = uniqBy(reviewableDuplicates, 'article_url');
-  return { assigned, reviewing, unassigned, reviewable };
+  return { assigned, reviewing, unassigned, reviewable, assignable };
 };
 
 export const getModulesAndBlocksFromWeeks = (weeks) => {

--- a/app/assets/javascripts/reducers/notifications.js
+++ b/app/assets/javascripts/reducers/notifications.js
@@ -30,7 +30,7 @@ const handleErrorNotification = function (data) {
     if (!notification.message) { notification.message = data.responseJSON.error; }
   }
 
-  if (!notification.message) { notification.message = data.statusText; }
+  if (!notification.message) { notification.message = data.errors || data.message || data.statusText; }
   if (isEmpty(data)) {
     console.error('Error: ', data); // eslint-disable-line no-console
     console.log(data); // eslint-disable-line no-console

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -290,23 +290,6 @@ const API = {
     );
   },
 
-  updateAssignment(opts) {
-    const queryString = $.param(opts);
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: `/assignments/${opts.id}.json?${queryString}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
-  },
-
   fetch(courseId, endpoint) {
     return request(`/courses/${courseId}/${endpoint}.json`, {
       credentials: "include"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,9 +66,7 @@ class ApplicationController < ActionController::Base
   def require_participating_user
     require_signed_in
     course = Course.find_by(slug: params[:id])
-    # Course roles for non-students are greater than STUDENT_ROLE.
-    # Non-participating users have the VISITOR_ROLE, which is below STUDENT_ROLE.
-    return if current_user.role(course) >= CoursesUsers::Roles::STUDENT_ROLE
+    return if current_user.nonvisitor?(course)
     raise ParticipatingUserError
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -59,6 +59,9 @@ class AssignmentsController < ApplicationController
       claim_assignment # sets @assignment
       render partial: 'updated_assignment', locals: { assignment: @assignment }
     end
+  rescue AssignmentManager::DuplicateAssignmentError => e
+    render json: { errors: e, message: I18n.t('assignments.already_exists') },
+                   status: :conflict
   end
 
   def update_status

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -394,6 +394,10 @@ class Course < ApplicationRecord
     flags[:stay_in_sandbox].present?
   end
 
+  def retain_available_articles?
+    flags[:retain_available_articles].present?
+  end
+
   # Overridden for some course types
   def cloneable?
     !tag?('no_clone')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,6 +159,10 @@ class User < ApplicationRecord
     @course_student ||= courses_users.exists?(role: CoursesUsers::Roles::STUDENT_ROLE)
   end
 
+  def nonvisitor?(course)
+    role(course) != CoursesUsers::Roles::VISITOR_ROLE
+  end
+
   def role(course)
     # If this is a new course, grant permissions.
     return CoursesUsers::Roles::INSTRUCTOR_ROLE if course.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
     patch '/status' => 'assignments#update_status'
     resources :assignment_suggestions
   end
+  put '/assignments/:assignment_id/claim' => 'assignments#claim'
   post '/assignments/assign_reviewers_randomly' => 'assignments#assign_reviewers_randomly'
 
   get 'mass_enrollment/:course_id'  => 'mass_enrollment#index',

--- a/lib/assignment_manager.rb
+++ b/lib/assignment_manager.rb
@@ -42,6 +42,18 @@ class AssignmentManager
     raise DuplicateAssignmentError, "#{@clean_title} is already assigned to this user."
   end
 
+  def claim_assignment(claimed_assignment)
+    @wiki = claimed_assignment.wiki
+    @title = claimed_assignment.article_title
+    @role = Assignment::Roles::ASSIGNED_ROLE
+    if @course.retain_available_articles?
+      create_assignment
+    else
+      claimed_assignment.update(user_id: @user_id)
+      claimed_assignment
+    end
+  end
+
   private
 
   def assigned_titles

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -187,7 +187,8 @@ class WizardTimelineManager
   FLAG_LOGIC = {
     '1_peer_reviewers' => { peer_review_count: 1 },
     '2_peer_reviewers' => { peer_review_count: 2 },
-    '3_peer_reviewers' => { peer_review_count: 3 }
+    '3_peer_reviewers' => { peer_review_count: 3 },
+    'working_in_groups' => { retain_available_articles: true }
   }.freeze
   def add_flags
     FLAG_LOGIC.each_key do |logic_key|

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -330,32 +330,45 @@ describe AssignmentsController, type: :request do
     end
   end
 
-  describe 'PATCH #update' do
+  describe 'PUT #claim' do
     let(:assignment) { create(:assignment, course_id: course.id, role: 0) }
     let(:request_params) do
       { course_id: course.id, id: assignment.id, user_id: user.id, format: :json }
     end
 
-    context 'when the update succeeds' do
+    context 'when the claim succeeds' do
+      before { create(:courses_user, course: course, user: user) }
+
       it 'renders a 200' do
-        put "/assignments/#{assignment.id}", params: request_params
+        put "/assignments/#{assignment.id}/claim", params: request_params
         expect(response.status).to eq(200)
       end
     end
 
     context 'when the article is already assigned to a user' do
+      before { create(:courses_user, course: course, user: user) }
+
       it 'renders a 409' do
         assignment.update(user_id: 1)
-        put "/assignments/#{assignment.id}", params: request_params
+        put "/assignments/#{assignment.id}/claim", params: request_params
         expect(response.status).to eq(409)
       end
     end
 
-    context 'when the update fails' do
+    context 'when the claim fails' do
+      before { create(:courses_user, course: course, user: user) }
+
       it 'renders a 500' do
         allow_any_instance_of(Assignment).to receive(:save).and_return(false)
-        put "/assignments/#{assignment.id}", params: request_params
+        put "/assignments/#{assignment.id}/claim", params: request_params
         expect(response.status).to eq(500)
+      end
+    end
+
+    context 'when the user is not in the course' do
+      it 'renders a 401' do
+        put "/assignments/#{assignment.id}/claim", params: request_params
+        expect(response.status).to eq(401)
       end
     end
   end

--- a/test/components/articles/available_article.spec.jsx
+++ b/test/components/articles/available_article.spec.jsx
@@ -26,14 +26,14 @@ describe('AvailableArticle', () => {
 
   it('notify when an article is selected', () => {
     const notificationSpy = jest.fn();
-    const updateAssignmentSpy = jest.fn();
+    const claimAssignmentSpy = jest.fn();
     const TestDom = ReactTestUtils.renderIntoDocument(
       <table>
         <tbody>
           <AvailableArticle
             {...props}
             addNotification={notificationSpy}
-            updateAssignment={updateAssignmentSpy}
+            claimAssignment={claimAssignmentSpy}
           />
         </tbody>
       </table>
@@ -43,6 +43,6 @@ describe('AvailableArticle', () => {
     ReactTestUtils.Simulate.click(select);
 
     expect(notificationSpy.mock.calls.length).toEqual(1);
-    expect(updateAssignmentSpy.mock.calls.length).toEqual(1);
+    expect(claimAssignmentSpy.mock.calls.length).toEqual(1);
   });
 });

--- a/test/components/articles/available_article.spec.jsx
+++ b/test/components/articles/available_article.spec.jsx
@@ -24,15 +24,14 @@ describe('AvailableArticle', () => {
     expect(TestDom.textContent).toContain('two');
   });
 
-  it('notify when an article is selected', () => {
-    const notificationSpy = jest.fn();
+  it('claims an article when Select button is clicked', () => {
     const claimAssignmentSpy = jest.fn();
     const TestDom = ReactTestUtils.renderIntoDocument(
       <table>
         <tbody>
           <AvailableArticle
             {...props}
-            addNotification={notificationSpy}
+            selectable={true}
             claimAssignment={claimAssignmentSpy}
           />
         </tbody>
@@ -42,7 +41,6 @@ describe('AvailableArticle', () => {
     const select = TestDom.querySelector('button');
     ReactTestUtils.Simulate.click(select);
 
-    expect(notificationSpy.mock.calls.length).toEqual(1);
     expect(claimAssignmentSpy.mock.calls.length).toEqual(1);
   });
 });

--- a/test/components/common/get_help_button.spec.jsx
+++ b/test/components/common/get_help_button.spec.jsx
@@ -35,7 +35,7 @@ describe('GetHelpButton', () => {
     });
 
     it('has an ask search field', () => {
-      const searchField = popContainer.find('input#search');
+      const searchField = popContainer.find('input#get_help_search');
       expect(searchField.length).toEqual(1);
       expect(searchField.prop('placeholder')).toEqual('Search Help Forum');
     });


### PR DESCRIPTION
This adds new behavior to Available Articles for courses that select to work in groups: an Available Article won't leave the list after it is selected, and will remain so tha another classmate can choose the same one.