### PR TITLE
Fix bug mentioned in Issue #4023, related to articleViewer

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -61,13 +61,26 @@ export class ArticleViewer extends React.Component {
   // fetch the MediaWiki user ids, which are used for coloration. Those can't be
   // fetched until the usernames are available, so 'show' will fetch the usernames
   // first in that case. In that case, componentDidUpdate fetches the
-  // user ids as soon as usernames are avaialable.
+  // user ids as soon as usernames are avaialable. However, the articleViewer will 
+  // contain an extra prop "assignedUsers" when viewed from the Students/Editors tab
+  // which holds all the users extracted from assigned articles in addition to 
+  // the "users" prop, which in this case contains all the usernames that have edited
+  // the article but have not been assigned to it.
   componentDidUpdate(prevProps, prevState) {
+    // checks for the availability of 'assignedUsers' and 'users' props.
+    // This condition will only pass when articleViewer is accessed from the Students/Editors tab 
     if (this.props.assignedUsers && this.props.users) {
+    // checks if usersIds required for coloration have already been fetched or not.
+    // if not, userIds are fetched by passing in an array that contains both 'assignedUsers'
+    // and 'users' as an argument to the fetchUserIds function.
       if (!this.state.userIdsFetched) {
         this.fetchUserIds(union(this.props.assignedUsers, this.props.users));
       }
-    } else if (!prevProps.users && this.props.users) {
+    }
+    // this condition will pass whenever 'assignedUsers' props is not available
+    // and the fetchUserIds inside this branch is invoked when 'users', if not available
+    // previously, have been fetched and passed down as props.
+    else if (!prevProps.users && this.props.users) {
         if (!prevState.userIdsFetched) {
           this.fetchUserIds(this.props.users);
       }

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import OnClickOutside from 'react-onclickoutside';
 
 // Utilities
-import { forEach } from 'lodash-es';
+import { forEach, union } from 'lodash-es';
 import { trunc } from '~/app/assets/javascripts/utils/strings';
 
 // Components
@@ -63,9 +63,13 @@ export class ArticleViewer extends React.Component {
   // first in that case. In that case, componentDidUpdate fetches the
   // user ids as soon as usernames are avaialable.
   componentDidUpdate(prevProps, prevState) {
-    if (!prevProps.users && this.props.users) {
-      if (!prevState.userIdsFetched) {
-        this.fetchUserIds(this.props.users);
+    if (this.props.assignedUsers && this.props.users) {
+      if (!this.state.userIdsFetched) {
+        this.fetchUserIds(union(this.props.assignedUsers, this.props.users));
+      }
+    } else if (!prevProps.users && this.props.users) {
+        if (!prevState.userIdsFetched) {
+          this.fetchUserIds(this.props.users);
       }
     }
   }

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -61,23 +61,19 @@ export class ArticleViewer extends React.Component {
   // fetch the MediaWiki user ids, which are used for coloration. Those can't be
   // fetched until the usernames are available, so 'show' will fetch the usernames
   // first in that case. In that case, componentDidUpdate fetches the
-  // user ids as soon as usernames are avaialable.
+  // user ids as soon as usernames are avaialable. In case the articleViewer is
+  // accessed through the Students/Editors tab, an extra prop called assignedUsers,that
+  // holds all users extracted from assigned articles, will be passed to it in addition to
+  // the users prop, which in this case contains all the users that have edited the article
+  // but not been assigned to it.
   componentDidUpdate(prevProps, prevState) {
-    // checks for the availability of 'assignedUsers' and 'users' props.
-    // This condition will only pass when articleViewer is accessed from the Students/Editors tab
-    if (this.props.assignedUsers && this.props.users) {
-    // checks if usersIds required for coloration have already been fetched or not.
-    // if not, userIds are fetched by passing in an array that contains both 'assignedUsers'
-    // and 'users' as an argument to the fetchUserIds function.
-      if (!this.state.userIdsFetched) {
-        this.fetchUserIds(union(this.props.assignedUsers, this.props.users));
-      }
-    } else if (!prevProps.users && this.props.users) {
-    // the above condition will pass whenever 'assignedUsers' props is not available
-    // and the fetchUserIds inside this branch is invoked when 'users', if not available
-    // previously, have been fetched and passed down as props.
+    // whenever the component updates, the fetchUserIds function is invoked only when the
+    // users prop gets populated with usernames such that userIds, required for coloration,
+    // haven't been fetched yet. In case the assignedUsers prop is available a combination
+    // with users prop is passed to the function, otherwise only the users prop is passed.
+    if (!prevProps.users && this.props.users) {
         if (!prevState.userIdsFetched) {
-          this.fetchUserIds(this.props.users);
+          this.fetchUserIds(union(this.props.assignedUsers || [], this.props.users));
       }
     }
   }
@@ -128,7 +124,13 @@ export class ArticleViewer extends React.Component {
     if (!this.props.users && !this.props.showArticleFinder) {
       this.props.fetchArticleDetails();
     } else if (!this.state.userIdsFetched && !this.props.showArticleFinder) {
-      this.fetchUserIds(this.props.users);
+      // if articleViewer is accessed through Students/Editors tab, a combination
+      // of both assignedUsers and users will be passed to the fetchUserIds function
+      // when show is clicked and the conditions have been satisfied. Otherwise
+      // whenever the articleViewer is accessed through any other tab, e.g Articles tab,
+      // the fetchUserIds function will be invoked with users because
+      // assignedUsers would be undefined.
+      this.fetchUserIds(union(this.props.assignedUsers || [], this.props.users));
     }
     // WhoColor is only available for some languages
     if (!this.state.whocolorFetched && this.isWhocolorLang()) {

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -63,17 +63,14 @@ export class ArticleViewer extends React.Component {
   // first in that case. In that case, componentDidUpdate fetches the
   // user ids as soon as usernames are avaialable. In case the articleViewer is
   // accessed through the Students/Editors tab, an extra prop called assignedUsers,that
-  // holds all users extracted from assigned articles, will be passed to it in addition to
-  // the users prop, which in this case contains all the users that have edited the article
-  // but not been assigned to it.
+  // holds all users extracted from assigned articles, will be passed to the articleViewer in
+  // addition to the users prop, which in this case contains all the users that have edited
+  // the article but not been assigned to it. The assignedUsers prop, if available, is then
+  // used in the fetchUserIds function.
   componentDidUpdate(prevProps, prevState) {
-    // whenever the component updates, the fetchUserIds function is invoked only when the
-    // users prop gets populated with usernames such that userIds, required for coloration,
-    // haven't been fetched yet. In case the assignedUsers prop is available a combination
-    // with users prop is passed to the function, otherwise only the users prop is passed.
     if (!prevProps.users && this.props.users) {
         if (!prevState.userIdsFetched) {
-          this.fetchUserIds(union(this.props.assignedUsers || [], this.props.users));
+          this.fetchUserIds();
       }
     }
   }
@@ -124,13 +121,7 @@ export class ArticleViewer extends React.Component {
     if (!this.props.users && !this.props.showArticleFinder) {
       this.props.fetchArticleDetails();
     } else if (!this.state.userIdsFetched && !this.props.showArticleFinder) {
-      // if articleViewer is accessed through Students/Editors tab, a combination
-      // of both assignedUsers and users will be passed to the fetchUserIds function
-      // when show is clicked and the conditions have been satisfied. Otherwise
-      // whenever the articleViewer is accessed through any other tab, e.g Articles tab,
-      // the fetchUserIds function will be invoked with users because
-      // assignedUsers would be undefined.
-      this.fetchUserIds(union(this.props.assignedUsers || [], this.props.users));
+      this.fetchUserIds();
     }
     // WhoColor is only available for some languages
     if (!this.state.whocolorFetched && this.isWhocolorLang()) {
@@ -220,7 +211,14 @@ export class ArticleViewer extends React.Component {
 
   // These are mediawiki user ids, and don't necessarily match the dashboard
   // database user ids, so we must fetch them by username from the wiki.
-  fetchUserIds(users) {
+  fetchUserIds() {
+    // if articleViewer is accessed through Students/Editors tab, a combination
+    // of both assignedUsers and users will be passed to the URLBuilder, whenever the
+    // fetchUserIds function is called. However, if the articleViewer is accessed
+    // through any other tab, e.g Articles tab, only the users prop will be passed
+    // to the URLBuilder as the assignedUsers prop would be undefined. In this case
+    // the users prop will be combined with an empty array.
+    const users = union(this.props.assignedUsers || [], this.props.users);
     const builder = new URLBuilder({ article: this.props.article, users });
     const api = new ArticleViewerAPI({ builder });
     api.fetchUserIds()

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -61,14 +61,10 @@ export class ArticleViewer extends React.Component {
   // fetch the MediaWiki user ids, which are used for coloration. Those can't be
   // fetched until the usernames are available, so 'show' will fetch the usernames
   // first in that case. In that case, componentDidUpdate fetches the
-  // user ids as soon as usernames are avaialable. However, the articleViewer will 
-  // contain an extra prop "assignedUsers" when viewed from the Students/Editors tab
-  // which holds all the users extracted from assigned articles in addition to 
-  // the "users" prop, which in this case contains all the usernames that have edited
-  // the article but have not been assigned to it.
+  // user ids as soon as usernames are avaialable.
   componentDidUpdate(prevProps, prevState) {
     // checks for the availability of 'assignedUsers' and 'users' props.
-    // This condition will only pass when articleViewer is accessed from the Students/Editors tab 
+    // This condition will only pass when articleViewer is accessed from the Students/Editors tab
     if (this.props.assignedUsers && this.props.users) {
     // checks if usersIds required for coloration have already been fetched or not.
     // if not, userIds are fetched by passing in an array that contains both 'assignedUsers'
@@ -76,11 +72,10 @@ export class ArticleViewer extends React.Component {
       if (!this.state.userIdsFetched) {
         this.fetchUserIds(union(this.props.assignedUsers, this.props.users));
       }
-    }
-    // this condition will pass whenever 'assignedUsers' props is not available
+    } else if (!prevProps.users && this.props.users) {
+    // the above condition will pass whenever 'assignedUsers' props is not available
     // and the fetchUserIds inside this branch is invoked when 'users', if not available
     // previously, have been fetched and passed down as props.
-    else if (!prevProps.users && this.props.users) {
         if (!prevState.userIdsFetched) {
           this.fetchUserIds(this.props.users);
       }

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 // Components
@@ -6,7 +7,7 @@ import CurrentStatus from './CurrentStatus';
 import AssignmentLinks from '@components/common/AssignmentLinks/AssignmentLinks.jsx';
 import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
 
-export const Assignment = ({ assignment, course, current_user, fetchArticleDetails, user }) => {
+export const Assignment = ({ assignment, course, current_user, fetchArticleDetails, user, articleDetails }) => {
   const article = {
     ...assignment,
     course_id: course.id,
@@ -30,6 +31,10 @@ export const Assignment = ({ assignment, course, current_user, fetchArticleDetai
       />
     );
   }
+  const getAllEditors = () => {
+    fetchArticleDetails(article.id, course.id);
+  };
+  const details = articleDetails[article.id] || null;
   return (
     <tr className="article-row">
       <td className="article-title">{assignment.article_title}</td>
@@ -48,8 +53,9 @@ export const Assignment = ({ assignment, course, current_user, fetchArticleDetai
           article={article}
           course={course}
           current_user={current_user}
-          fetchArticleDetails={fetchArticleDetails}
-          users={users}
+          fetchArticleDetails={getAllEditors}
+          users={details && details.editors}
+          assignedUsers={users}
           showOnMount={showArticleId === article.id}
         />
       </td>
@@ -70,4 +76,5 @@ Assignment.propTypes = {
   user: PropTypes.object.isRequired
 };
 
-export default Assignment;
+const mapStateToProps = ({ articleDetails }) => ({ articleDetails: articleDetails });
+export default connect(mapStateToProps)(Assignment);


### PR DESCRIPTION
## What this PR does
This pull request fixes the bug mentioned in issue #4023, wherein, when accessed through the Students tab the articleViewer container did not display all the editors that have edited a particular article, and only displayed those editors that were assigned to that article. 

## Screenshots
Before:
![](https://user-images.githubusercontent.com/62028695/95922670-b27c6e80-0dab-11eb-9dc7-0d9793ae4016.png)

After:
![](https://user-images.githubusercontent.com/62028695/95922700-c4f6a800-0dab-11eb-8a88-bd32081f2f9a.png)
## Open questions and concerns
This bug was addressed in a previous Pull Request #4245, However due to some errors related to rebasing, i decided to delete my old branch and opened a new pull request.