### PR TITLE
Solves Issue #4022 "articles assigned to other students in the class don't show up as other edited articles".

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
@@ -11,7 +11,7 @@ import EditedUnassignedArticles from './EditedUnassignedArticles/EditedUnassigne
 
 // Utils
 import { processAssignments } from '@components/overview/my_articles/utils/processAssignments';
-import setUnassignedArticles from '@components/students/utils/setUnassignedArticles';
+import setOtherEditedArticles from '@components/students/utils/setOtherEditedArticles';
 
 export const SelectedStudent = ({
   groupedArticles, assignments, course, current_user, fetchArticleDetails,
@@ -21,7 +21,7 @@ export const SelectedStudent = ({
   const {
     assigned, reviewing
   } = processAssignments({ assignments, course, current_user: selected });
-  const unassigned = setUnassignedArticles(groupedArticles, assignments, selected);
+  const otherEditedArticles = setOtherEditedArticles(groupedArticles, assignments, selected);
   const showArticleId = Number(location.search.split('showArticle=')[1]);
 
   return (
@@ -78,9 +78,9 @@ export const SelectedStudent = ({
       }
 
       {
-        !!unassigned.length && (
+        !!otherEditedArticles.length && (
           <EditedUnassignedArticles
-            articles={unassigned}
+            articles={otherEditedArticles}
             course={course}
             user={selected}
             current_user={current_user}

--- a/app/assets/javascripts/components/students/utils/groupArticlesCoursesByUserId.js
+++ b/app/assets/javascripts/components/students/utils/groupArticlesCoursesByUserId.js
@@ -9,7 +9,6 @@ export default (articles) => {
         acc[id] = [article];
       }
     });
-
     return acc;
   }, {});
 };

--- a/app/assets/javascripts/components/students/utils/setOtherEditedArticles.js
+++ b/app/assets/javascripts/components/students/utils/setOtherEditedArticles.js
@@ -4,7 +4,8 @@ export default (articlesById, assignments = [], student) => {
   // assignmentsByArticleId holds all the assignments grouped/sorted by articleIds
   // If there are mutiple assignments with the same article/article Id, then only the user_id of the
   // assigned editor is added to the assignees array. However, if no editor is assigned then
-  // it is set to null.
+  // null is added to the assignments array. At a time there can only be 1 null entry in the assignees
+  // array for a particular article as WikiEduDashboard prevent having multiple unassigned assignments.
   const assignmentsByArticleId = assignments.reduce((acc, assignment) => {
     if (acc[assignment.article_id]) {
       return {
@@ -29,8 +30,8 @@ export default (articlesById, assignments = [], student) => {
   const articles = articlesById[student.id] || [];
   // articles array is filtered to include articles edited by a user that aren't present
   // in assignmentsByArticleId. Also if an unassigned editor has edited a particular article
-  // but that article is present,either as an assigned article or an available article yet
-  // to be assigned, in the assignments array then that article is also included.
+  // but that article is present,either as an assigned article to another editor/user or as an
+  // available article yet to be assigned in the assignments array then that article is also included.
   return articles.filter(
     article =>
       !includes(

--- a/app/assets/javascripts/components/students/utils/setOtherEditedArticles.js
+++ b/app/assets/javascripts/components/students/utils/setOtherEditedArticles.js
@@ -4,7 +4,7 @@ export default (articlesById, assignments = [], student) => {
   // assignmentsByArticleId holds all the assignments grouped/sorted by articleIds
   // If there are mutiple assignments with the same article/article Id, then only the user_id of the
   // assigned editor is added to the assignees array. However, if no editor is assigned then
-  // null is added to the assignments array. At a time there can only be 1 null entry in the assignees
+  // null is added to the assignees array. At a time there can only be 1 null entry in the assignees
   // array for a particular article as WikiEduDashboard prevent having multiple unassigned assignments.
   const assignmentsByArticleId = assignments.reduce((acc, assignment) => {
     if (acc[assignment.article_id]) {

--- a/app/assets/javascripts/components/students/utils/setUnassignedArticles.js
+++ b/app/assets/javascripts/components/students/utils/setUnassignedArticles.js
@@ -1,9 +1,42 @@
-export default (articlesById, assignments = [], student) => {
-  const assignmentsByArticleId = assignments.reduce((acc, assignment) => ({
-    ...acc,
-    [assignment.article_id]: assignment
-  }), {});
+import { includes } from 'lodash';
 
+export default (articlesById, assignments = [], student) => {
+  // assignmentsByArticleId holds all the assignments grouped/sorted by articleIds
+  // If there are mutiple assignments with the same article/article Id, then only the user_id of the
+  // assigned editor is added to the assignees array. However, if no editor is assigned then
+  // it is set to null.
+  const assignmentsByArticleId = assignments.reduce((acc, assignment) => {
+    if (acc[assignment.article_id]) {
+      return {
+        ...acc,
+        [assignment.article_id]: {
+          ...acc[assignment.article_id],
+          assignees: [
+            ...acc[assignment.article_id].assignees,
+            assignment.user_id,
+          ],
+        },
+      };
+    }
+    return {
+      ...acc,
+      [assignment.article_id]: {
+        ...assignment,
+        assignees: [assignment.user_id],
+      },
+    };
+  }, {});
   const articles = articlesById[student.id] || [];
-  return articles.filter(article => !assignmentsByArticleId[article.id]);
+  // articles array is filtered to include articles edited by a user that aren't present
+  // in assignmentsByArticleId. Also if an unassigned editor has edited a particular article
+  // but that article is present,either as an assigned article or an available article yet
+  // to be assigned, in the assignments array then that article is also included.
+  return articles.filter(
+    (article) =>
+      !includes(
+        !assignmentsByArticleId[article.id] ||
+          assignmentsByArticleId[article.id].assignees,
+        student.id
+      )
+  );
 };

--- a/app/assets/javascripts/components/students/utils/setUnassignedArticles.js
+++ b/app/assets/javascripts/components/students/utils/setUnassignedArticles.js
@@ -32,10 +32,10 @@ export default (articlesById, assignments = [], student) => {
   // but that article is present,either as an assigned article or an available article yet
   // to be assigned, in the assignments array then that article is also included.
   return articles.filter(
-    (article) =>
+    article =>
       !includes(
-        !assignmentsByArticleId[article.id] ||
-          assignmentsByArticleId[article.id].assignees,
+        !assignmentsByArticleId[article.id]
+          || assignmentsByArticleId[article.id].assignees,
         student.id
       )
   );


### PR DESCRIPTION
## What this PR does
This pull request resolves Issue #4022, wherein articles assigned to other students in the class don't show up as 'other edited articles'.

## Screenshots
Before:
![](https://user-images.githubusercontent.com/848483/81452147-f30bf800-913a-11ea-82f2-e1fad8b2fbfb.png)

After:
![100](https://user-images.githubusercontent.com/62028695/98624961-b77b0200-2306-11eb-9632-baa9bfb62b5d.png)

## Outline of the solution
This Bug was present in the `setUnassignedArticles.js` file. The current implementation of the `setUnassignedArticles` function filtered out any article that was edited by an unassigned editor if the same article was present in the assignments array either as an assigned article to a classmate or as an available article yet to be assigned. While solving this bug I came across five cases which needed to be handled because the assignmets array could contain multiple assignments having the same article and differing only in assignees or existing as an assignment yet to be assigned to an editor. Here are some `console.log` statements that depict the same:
![101](https://user-images.githubusercontent.com/62028695/98625793-41779a80-2308-11eb-87f5-8386efe141db.png)
**The five cases to be handled are:**
**1)** Edited article isn't availabe as an assignment.
**2)** Edited article is available as an assignment but hasn't been assigned to any editor yet.
**3)** Edited article is not available as an assignment but has been assigned to some editors but not all who have edited the article.
**4)** Edited article has been assigned to user/users but is also available as an assignment to other users.
**5)** Edited article has been assigned to all users who have edited the article.

My approach towads the solving the bug includes editing the reducer function of  `assignments.reduce()` such that if multiple assignments had the same `article/articleId` and an assignement with the same `article/articleId` was already present in the `accumulator`, then only the editor assigned to that assignement would be added to the `assignees` property of the article object in the accumulator. If the assignment had no assigned editor then a `null` was added to `assignees`. At a time there can only be 1 unassigned assignment with a particular article. WikiEduDashboard prevents having multiple unassigned assignments with the same article, so there can only be 1 null entry in the `assignees` array.

The assignments array is then reduced to an object - `assignmentsByArticleId` that is sorted/grouped by articleIds, each id referencing its corresponding article.

After this the solution checks if any articles in `assignmentsByArticleId` and "articles edited by an editor" are common and have the same editor. If present those articles are not included. if not they are included in the final array.