### PR TITLE
Include number of articles edited, and number of articles created, for each user in Editors CSV

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -269,10 +269,6 @@ class Course < ApplicationRecord
              .where(wiki_id: wiki_ids)
   end
 
-  def tracked_articles
-    articles.where.not(id: articles_courses.not_tracked.pluck(:article_id))
-  end
-
   def scoped_article_ids
     assigned_article_ids + category_article_ids
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -311,12 +311,16 @@ class Course < ApplicationRecord
     "#{home_wiki.base_url}/wiki/#{wiki_title}"
   end
 
-  def new_articles
-    articles_courses.tracked.live.new_article.joins(:article).where('articles.namespace = 0')
+  def edited_articles_courses
+    articles_courses.tracked.live
+  end
+
+  def new_articles_courses
+    edited_articles_courses.new_article
   end
 
   def new_articles_on(wiki)
-    new_articles.where("articles.wiki_id = #{wiki.id}")
+    new_articles_courses.where("articles.wiki_id = #{wiki.id}")
   end
 
   def uploads_in_use

--- a/lib/analytics/course_students_csv_builder.rb
+++ b/lib/analytics/course_students_csv_builder.rb
@@ -5,6 +5,8 @@ require 'csv'
 class CourseStudentsCsvBuilder
   def initialize(course)
     @course = course
+    @created_articles = course.new_articles.select(:article_id, :user_ids).to_a
+    @edited_articles = course.new_articles.select(:article_id, :user_ids).unscope(where: :new_article).to_a
   end
 
   def generate_csv
@@ -31,6 +33,8 @@ class CourseStudentsCsvBuilder
     draft_space_bytes_added
     references_added
     registered_during_project
+    total_articles_created
+    total_articles_edited
   ].freeze
   def row(courses_user)
     row = [courses_user.user.username]
@@ -42,9 +46,19 @@ class CourseStudentsCsvBuilder
     row << courses_user.character_sum_draft
     row << courses_user.references_count
     row << newbie?(courses_user.user)
+    row << total_articles_created(courses_user.user_id)
+    row << total_articles_edited(courses_user.user_id)
   end
 
   def newbie?(user)
     (@course.start..@course.end).cover? user.registered_at
+  end
+
+  def total_articles_created(user_id)
+    @created_articles.count {|a| a[:user_ids].include?(user_id)}
+  end
+
+  def total_articles_edited(user_id)
+    @edited_articles.count {|a| a[:user_ids].include?(user_id)}
   end
 end

--- a/lib/analytics/course_students_csv_builder.rb
+++ b/lib/analytics/course_students_csv_builder.rb
@@ -7,10 +7,11 @@ class CourseStudentsCsvBuilder
     @course = course
     @created_articles = Hash.new(0)
     @edited_articles = Hash.new(0)
-    @revisions = @course.all_revisions.where(new_article: true).pluck(:article_id, :user_id).to_h
   end
 
   def generate_csv
+    @new_article_revisions = @course.all_revisions.where(new_article: true)
+                                    .pluck(:article_id, :user_id).to_h
     populate_created_articles
     populate_edited_articles
     csv_data = [CSV_HEADERS]
@@ -34,7 +35,7 @@ class CourseStudentsCsvBuilder
   end
 
   def article_creator?(article_id, user_id)
-    @revisions[article_id] == user_id
+    @new_article_revisions[article_id] == user_id
   end
 
   def populate_edited_articles
@@ -61,6 +62,7 @@ class CourseStudentsCsvBuilder
     total_articles_created
     total_articles_edited
   ].freeze
+  # rubocop:disable Metrics/AbcSize
   def row(courses_user)
     row = [courses_user.user.username]
     row << courses_user.created_at
@@ -74,6 +76,7 @@ class CourseStudentsCsvBuilder
     row << @created_articles[courses_user.user_id]
     row << @edited_articles[courses_user.user_id]
   end
+  # rubocop:enable Metrics/AbcSize
 
   def newbie?(user)
     (@course.start..@course.end).cover? user.registered_at

--- a/lib/course_cache_manager.rb
+++ b/lib/course_cache_manager.rb
@@ -75,11 +75,11 @@ class CourseCacheManager
   end
 
   def update_article_count
-    @course.article_count = @course.tracked_articles.namespace(0).live.size
+    @course.article_count = @course.edited_articles_courses.count
   end
 
   def update_new_article_count
-    @course.new_article_count = @course.new_articles.count
+    @course.new_article_count = @course.new_articles_courses.count
   end
 
   def update_upload_count

--- a/spec/lib/analytics/course_students_csv_builder_spec.rb
+++ b/spec/lib/analytics/course_students_csv_builder_spec.rb
@@ -5,14 +5,40 @@ require "#{Rails.root}/lib/analytics/course_students_csv_builder"
 
 describe CourseStudentsCsvBuilder do
   let(:course) { create(:course) }
-  let(:user) { create(:user, registered_at: course.start + 1.minute) }
-  let!(:courses_user) { create(:courses_user, course: course, user: user) }
+  let(:user1) { create(:user, registered_at: course.start + 1.minute, username: 'first_user') }
+  let(:user2) { create(:user, registered_at: course.start + 2.minute, username: 'second_user') }
+  let(:user3) { create(:user, registered_at: course.start + 3.minute, username: 'third_user') }
+  let!(:courses_user1) { create(:courses_user, course: course, user: user1) }
+  let!(:courses_user2) { create(:courses_user, course: course, user: user2) }
+  let!(:courses_user3) { create(:courses_user, course: course, user: user3) }
+  let(:article) { create(:article, created_at: course.start + 10.minute, namespace: 0, deleted: false) }
+  let!(:articles_course1) {
+    create(:articles_course, article: article, course: course, user_ids: [user1.id], new_article: true, tracked: true)
+  }
+  let!(:articles_course2) {
+    create(:articles_course, article: article, course: course, user_ids: [user2.id], new_article: false, tracked: true)
+  }
   let(:subject) { described_class.new(course).generate_csv }
 
   it 'creates a CSV with a header and a row of data for each student' do
-    expect(subject.split("\n").count).to eq(2)
-    # last column is 'registered_during_project', which should be true
-    # for the test user.
-    expect(subject[-5..]).to eq("true\n")
+    lines = subject.split("\n")
+    expect(lines.count).to eq(4)
+
+    lines.shift # Remove headers
+
+    expected_result = {
+      'first_user' => { created: '1', updated: '1' },
+      'second_user' => { created: '0', updated: '1' },
+      'third_user' => { created: '0', updated: '0' }
+    }
+
+    lines.each do |line|
+      columns = line.split(',')
+      user_result = expected_result[columns[0]]
+      # column 9 is 'registered_during_project', which should be true
+      expect(columns[8]).to eq('true')
+      expect(columns[9]).to eq(user_result[:created])
+      expect(columns[10]).to eq(user_result[:updated])
+    end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -297,7 +297,6 @@ describe Course, type: :model do
       # non-mainspace page
       sandbox = create(:article, namespace: Article::Namespaces::TALK)
       create(:revision, article_id: sandbox.id, user_id: student.id)
-      create(:articles_course, article_id: sandbox.id, course_id: course.id)
 
       course.update_cache
       expect(course.article_count).to eq(1)
@@ -319,8 +318,6 @@ describe Course, type: :model do
       # non-mainspace page
       sandbox = create(:article, namespace: Article::Namespaces::TALK)
       create(:revision, article_id: sandbox.id, user_id: student.id)
-      create(:articles_course, article_id: sandbox.id, course_id: course.id,
-                               new_article: true)
 
       course.update_cache
       expect(course.new_article_count).to eq(1)


### PR DESCRIPTION
## What this PR does
This PR implements the desired behavior requested in issue #4217

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/24531739/103376350-52f14d80-4ad4-11eb-85b1-77d33717ed9e.png)

After:
![image](https://user-images.githubusercontent.com/24531739/103376371-60a6d300-4ad4-11eb-9c47-ef2ea4a2a1ee.png)


## Open questions and concerns

The solution for both created and edited was based off how course.new_article_count is updated in course_cache_manager (line 82).

For the edit part I've unscoped the filter on new_article.

I've chosen to hit the database only twice to get the values for all employees and then loop through the result for each employee as I assume this will be faster than 2 SQL queries per employee, but I'm not sure this is correct.