### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #   - docker build -t wiki-edu-dashboard .
 #   - docker run -p 3000:3000 -it wiki-edu-dashboard
 
-FROM ruby:2.5.0
+FROM ruby:2.7.1
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Error: While trying to setup project using Docker 
Your Ruby version is 2.5.1, but your Gemfile specified 2.7.1
can be resolved by changing the version in the Docker file to **FROM ruby:2.7.1**

