### PR TITLE
FIXED : Trailing whitespace in i18n messages

### DIFF
--- a/app/assets/javascripts/components/common/AssignCell/AssignCell.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignCell.jsx
@@ -20,7 +20,7 @@ const ArticleLink = ({ content, href, prefix }) => {
 
   return (
     <span>
-      { prefix }{ content }
+      { prefix }&nbsp;{ content }
     </span>
   );
 };

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -63,7 +63,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
 
   return (
     <div className="user-legend-wrap">
-      <div className="user-legend">{I18n.t('users.edits_by')} </div>
+      <div className="user-legend">{I18n.t('users.edits_by')}&nbsp;</div>
       {userLinks}
       {usersStatus}
     </div>

--- a/app/assets/javascripts/components/common/enroll_button.jsx
+++ b/app/assets/javascripts/components/common/enroll_button.jsx
@@ -152,7 +152,7 @@ const EnrollButton = createReactClass({
       editRows.push(
         <tr className="edit" key="enroll_students">
           <td>
-            <p>{I18n.t('users.course_passcode')}<b>{this.props.course.passcode}</b></p>
+            <p>{I18n.t('users.course_passcode')}&nbsp;<b>{this.props.course.passcode}</b></p>
             <p>{I18n.t('users.enroll_url')}</p>
             <input type="text" readOnly={true} value={enrollUrl} style={{ width: '100%' }} />
             {massEnrollmentLink}

--- a/app/assets/javascripts/components/common/feedback.jsx
+++ b/app/assets/javascripts/components/common/feedback.jsx
@@ -186,7 +186,7 @@ const Feedback = createReactClass({
           <div className="feedback-body">
             {titleElement}
             <hr />
-            <h5>{I18n.t('courses.rating_feedback') + rating}</h5>
+            <h5>{I18n.t('courses.rating_feedback') + ' ' + rating}</h5>
             <p className="rating-description">
               {I18n.t(`articles.rating_docs.${rating.toLowerCase() || '?'}`, { class: rating.toLowerCase() || '' })}
             </p>

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -247,7 +247,7 @@ const DiffViewer = createReactClass({
   authorsHTML() {
     return (
       <div className="user-legend-wrap">
-        <div className="user-legend">{I18n.t('users.edits_by')}</div>
+        <div className="user-legend">{I18n.t('users.edits_by')}&nbsp;</div>
         <div className="user-legend">{this.props.editors.join(', ')}</div>
       </div>
     );

--- a/app/assets/javascripts/components/students/components/Overview/Controls/EnrollButton.jsx
+++ b/app/assets/javascripts/components/students/components/Overview/Controls/EnrollButton.jsx
@@ -144,7 +144,7 @@ export class EnrollButton extends React.Component {
       editRows.push(
         <tr className="edit" key="enroll_students">
           <td>
-            <p>{I18n.t('users.course_passcode')}<b>{this.props.course.passcode}</b></p>
+            <p>{I18n.t('users.course_passcode')}&nbsp;<b>{this.props.course.passcode}</b></p>
             <p>{I18n.t('users.enroll_url')}</p>
             <input type="text" readOnly={true} value={enrollUrl} style={{ width: '100%' }} />
             {massEnrollmentLink}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,7 +405,7 @@ en:
       select_meeting_days: Select the days of the week on which your class meets.
     cancel: 'Cancel'
     character_doc: The sum of characters added to mainspace articles by the course's students during the course term
-    campaigns: 'Campaigns: '
+    campaigns: 'Campaigns:'
     campaign_articles: '%{title} Articles'
     campaign_courses: '%{title} Courses'
     campaign_select: 'Select a campaign'
@@ -635,7 +635,7 @@ en:
     please_log_in: "Please log in."
     private: Private
     published: "Your course has been published! Students may enroll in the course by visiting the following URL:"
-    rating_feedback: "Predicted rating for the article is: "
+    rating_feedback: "Predicted rating for the article is:"
     requested_accounts: Requested accounts
     requested_accounts_alert:
       one: '%{count} requested account pending.'
@@ -681,7 +681,7 @@ en:
     submitted: Submitted
     submitted_at: Submitted at
     tag_select: 'Select or create a tag'
-    tags: 'Tags: '
+    tags: 'Tags:'
     term: Term
     timeline: Assignment Details
     timeline_enabled: Timeline enabled
@@ -749,7 +749,7 @@ en:
     course: Program
     courses: Programs
     courses_taught: Programs Taught
-    campaigns: 'Campaigns: '
+    campaigns: 'Campaigns:'
     campaign_courses: '%{title} Programs'
     creator:
       assignment_end: Event end
@@ -1074,9 +1074,9 @@ en:
     edit_titles: Edit Week Titles
     edit_titles_info: Edit week titles in timeline. Only weeks with scheduled meetings can be given custom titles. If any custom titles are used, weeks with no meetings will be dated instead of numbered.
     # FIXME: lego message. This one is hard to work around because it has inline components.
-    empty_week_1: 'To get started, '
+    empty_week_1: 'To get started,'
     empty_week_2: start editing this week
-    empty_week_3: ' or '
+    empty_week_3: 'or'
     empty_week_4: use the assignment wizard to create a timeline.
     first_week_title: First Active Week
     gradeable_value: Value
@@ -1162,10 +1162,10 @@ en:
     contributions_history_full: View full contribution history
     contributions_more: View More Contributions
     contribution_statistics: Contribution Statistics
-    course_passcode: 'Passcode: '
+    course_passcode: 'Passcode:'
     editors: Editors
     edits: edits
-    edits_by: 'Edits by: '
+    edits_by: 'Edits by:'
     enroll_confirmation: Are you sure you want to add %{username}?
     enroll_url: 'Users may join by visiting this URL:'
     enrolled_success: '%{username} was added successfully!'
@@ -1181,8 +1181,8 @@ en:
     characters_added_userspace: Characters Added (user)
     characters_added_draftspace: Characters Added (draft)
     references_count: References Added
-    my_assigned: "Assigned: "
-    my_reviewing: "Reviewing: "
+    my_assigned: "Assigned:"
+    my_reviewing: "Reviewing:"
     name: Name
     none: There are no participants.
     no_articles: No articles

--- a/spec/features/article_viewer_spec.rb
+++ b/spec/features/article_viewer_spec.rb
@@ -17,7 +17,7 @@ describe 'Article Viewer', type: :feature, js: true do
   it 'shows list of students who edited the article' do
     visit "/courses/#{course.slug}/articles"
     find('button.icon-article-viewer').click
-    expect(page).to have_content("Edits by:\nRagesoss")
+    expect(page).to have_content("Edits by: \nRagesoss")
     within(:css, '.user-legend.user-highlight-1', wait: 20) do # once authorship date loads
       find('img.user-legend-hover').click # click to scroll to next highlight
     end


### PR DESCRIPTION
As per the error defined in the issue: Trailing whitespace in i18n messages #4332, I have made some changes in config/locales/en.yml.
Earlier                                 Now
'Campaigns: '        |        'Campaigns:'                          
'Predicted rating for the article is:  | 'Predicted rating for the article is:'
'Tags: '                   |           'Tags:'                               
'Campaigns: '        |        'Campaigns:'                          
'To get started, '    |       'To get started,'                     
' or '                       |           'or'                                 
'Passcode: '          |        'Passcode:'                           
'Edits by: '             |         'Edits by:'                           
'Assigned: '           |         'Assigned:'                           
'Reviewing: '         |         'Reviewing:'  
Please review the changes.


