### PR TITLE
Removed grammatical error from deb-setup.sh

### DIFF
--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -172,4 +172,4 @@ print_success "${CLEAR_LINE}[+] Database migration completed\n"
 printf '[*] Installing node_modules... \n'
 output_line "yarn" && print_success "${CLEAR_LINE}[+] node_modules installed\n"
 
-echo 'Your developmental environment setup is complete. If you there are any errors, please refer to the docs for manual installation, or ask for help.'
+echo 'Your developmental environment setup is complete. If there are any errors, please refer to the docs for manual installation, or ask for help.'

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -172,4 +172,4 @@ print_success "${CLEAR_LINE}[+] Database migration completed\n"
 printf '[*] Installing node_modules... \n'
 output_line "yarn" && print_success "${CLEAR_LINE}[+] node_modules installed\n"
 
-echo 'Your developmental environment setup is complete. If there are any errors, please refer to the docs for manual installation, or ask for help.'
+echo 'Your development environment setup is complete. If there are any errors, please refer to the docs for manual installation, or ask for help.'


### PR DESCRIPTION
## What this PR does
Fixes the typo in the file `deb-setup.sh` by removing the word **you**.

Solves #4351 
