### PR TITLE
Course Advice Emails

### DIFF
--- a/app/mailers/course_advice_mailer.rb
+++ b/app/mailers/course_advice_mailer.rb
@@ -10,20 +10,21 @@ class CourseAdviceMailer < ApplicationMailer
   end
 
   SUBJECT_LINES = {
-    'preliminary_work' => 'SUBJECT 1',
-    'drafting_and_moving' => 'SUBJECT 2',
-    'peer_review' => 'SUBJECT 3',
-    'assessing_contributions' => 'SUBJECT 4'
+    'preliminary_work' => 'Tips for navigating the early weeks of your Wikipedia assignment',
+    'drafting_and_moving' => 'Tips for drafting work and moving it into the article main space',
+    'peer_review' => 'Tips for peer review',
+    'assessing_contributions' => 'How to find and assess student contributions'
   }.freeze
 
   def email(course, stage, staffer)
     @course = course
     @instructors = @course.instructors
+    @staffer = staffer
     @greeted_users = @instructors.map { |user| user.real_name || user.username }.to_sentence
     @course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
 
     mail(to: @instructors.pluck(:email),
-         reply_to: staffer.email,
+         reply_to: @staffer.email,
          subject: SUBJECT_LINES[stage],
          template_name: stage)
   end

--- a/app/mailers/course_advice_mailer.rb
+++ b/app/mailers/course_advice_mailer.rb
@@ -20,6 +20,7 @@ class CourseAdviceMailer < ApplicationMailer
     @course = course
     @instructors = @course.instructors
     @staffer = staffer
+    @group_work = @course.tag? 'working_in_groups'
     @greeted_users = @instructors.map { |user| user.real_name || user.username }.to_sentence
     @course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
 

--- a/app/mailers/course_advice_mailer.rb
+++ b/app/mailers/course_advice_mailer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CourseAdviceMailer < ApplicationMailer
+  def self.send_email(course:, stage:)
+    return unless Features.email?
+    return unless course.instructors.pluck(:email).any?
+
+    staffer = SpecialUsers.classroom_program_manager
+    email(course, stage, staffer).deliver_now
+  end
+
+  SUBJECT_LINES = {
+    'preliminary_work' => 'SUBJECT 1',
+    'drafting_and_moving' => 'SUBJECT 2',
+    'peer_review' => 'SUBJECT 3',
+    'assessing_contributions' => 'SUBJECT 4'
+  }
+
+  def email(course, stage, staffer)
+    @course = course
+    @instructors = @course.instructors
+    @greeted_users = @instructors.map { |user| user.real_name || user.username }.to_sentence
+    @course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
+
+    mail(to: @instructors.pluck(:email),
+         reply_to: staffer.email,
+         subject: SUBJECT_LINES[stage],
+         template_name: stage)
+  end
+end

--- a/app/mailers/course_advice_mailer.rb
+++ b/app/mailers/course_advice_mailer.rb
@@ -14,7 +14,7 @@ class CourseAdviceMailer < ApplicationMailer
     'drafting_and_moving' => 'SUBJECT 2',
     'peer_review' => 'SUBJECT 3',
     'assessing_contributions' => 'SUBJECT 4'
-  }
+  }.freeze
 
   def email(course, stage, staffer)
     @course = course

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -254,6 +254,12 @@ class Course < ApplicationRecord
     tags.pluck(:tag).include? query_tag
   end
 
+  # title can be a string or a Regexp
+  def find_block_by_title(title)
+    title_matcher = Regexp.new(title)
+    blocks.find { |block| block.title =~ title_matcher }
+  end
+
   def training_modules
     @training_modules ||= TrainingModule.all.select { |tm| training_module_ids.include?(tm.id) }
   end

--- a/app/services/push_course_to_salesforce.rb
+++ b/app/services/push_course_to_salesforce.rb
@@ -90,13 +90,12 @@ class PushCourseToSalesforce
   end
 
   def editing_in_sandbox_block
-    title_matcher = Regexp.union [/Draft your article/, /Start drafting your/]
-    @sandbox_block ||= @course.blocks.find { |block| block.title =~ title_matcher }
+    title_matcher = Regexp.union('Draft your article', 'Start drafting your')
+    @sandbox_block ||= @course.find_block_by_title(title_matcher)
   end
 
   def editing_in_mainspace_block
-    title_matcher = /Begin moving your work to Wikipedia/
-    @mainspace_block ||= @course.blocks.find { |block| block.title =~ title_matcher }
+    @mainspace_block ||= @course.find_block_by_title('Begin moving your work to Wikipedia')
   end
 
   def assignment_date_for(block)

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -13,7 +13,7 @@ class ScheduleCourseAdviceEmails
     return unless @course.tag?('research_write_assignment')
 
     schedule_preliminary_work_email
-    schedule_drafting_and_moving_email
+    schedule_drafting_and_moving_email unless @course.stay_in_sandbox?
     schedule_peer_review_email
     schedule_assessing_contributions_email
   end

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -22,7 +22,7 @@ class ScheduleCourseAdviceEmails
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
       stage: 'preliminary_work',
-      send_at: course.timeline_start
+      send_at: @course.timeline_start
     )
   end
 
@@ -33,7 +33,7 @@ class ScheduleCourseAdviceEmails
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
       stage: 'drafting_and_moving',
-      send_at: block.calculated_date
+      send_at: block.calculated_date.to_datetime
     )
   end
 
@@ -44,7 +44,7 @@ class ScheduleCourseAdviceEmails
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
       stage: 'peer_review',
-      send_at: block.calculated_date
+      send_at: block.calculated_date.to_datetime
     )
   end
 
@@ -55,7 +55,7 @@ class ScheduleCourseAdviceEmails
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
       stage: 'assessing_contributions',
-      send_at: block.calculated_date
+      send_at: block.calculated_date.to_datetime
     )
   end
 end

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -21,7 +21,7 @@ class ScheduleCourseAdviceEmails
   def schedule_preliminary_work_email
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
-      stage: 'drafting_and_moving',
+      stage: 'preliminary_work',
       send_at: course.timeline_start
     )
   end

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -19,28 +19,43 @@ class ScheduleCourseAdviceEmails
   end
 
   def schedule_preliminary_work_email
-    # find timeline start
-    # send
+    CourseAdviceEmailWorker.schedule_email(
+      course: @course,
+      stage: 'drafting_and_moving',
+      send_at: course.timeline_start
+    )
   end
 
   def schedule_drafting_and_moving_email
     block = @course.find_block_by_title 'Start drafting your'
     return unless block
 
-    # send
+    CourseAdviceEmailWorker.schedule_email(
+      course: @course,
+      stage: 'drafting_and_moving',
+      send_at: block.calculated_date
+    )
   end
 
   def schedule_peer_review_email
     block = @course.find_block_by_title 'Peer review'
     return unless block
 
-    # send
+    CourseAdviceEmailWorker.schedule_email(
+      course: @course,
+      stage: 'peer_review',
+      send_at: block.calculated_date
+    )
   end
 
   def schedule_assessing_contributions_email
     block = @course.find_block_by_title 'Final article'
     return unless block
 
-    # send
+    CourseAdviceEmailWorker.schedule_email(
+      course: @course,
+      stage: 'assessing_contributions',
+      send_at: block.calculated_date
+    )
   end
 end

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -13,7 +13,7 @@ class ScheduleCourseAdviceEmails
     return unless @course.tag?('research_write_assignment')
 
     schedule_preliminary_work_email
-    schedule_drafting_and_moving_email unless @course.stay_in_sandbox?
+    schedule_drafting_and_moving_email
     schedule_peer_review_email
     schedule_assessing_contributions_email
   end

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#= Schedules a series of drip emails for advice, based on course timeline
+class ScheduleCourseAdviceEmails
+  def initialize(course)
+    @course = course
+    schedule_emails
+  end
+
+  private
+
+  def schedule_emails
+    return unless @course.tag?('research_write_assignment')
+
+    schedule_preliminary_work_email
+    schedule_drafting_and_moving_email
+    schedule_peer_review_email
+    schedule_assessing_contributions_email
+  end
+
+  def schedule_preliminary_work_email
+    # find timeline start
+    # send
+  end
+
+  def schedule_drafting_and_moving_email
+    block = @course.find_block_by_title 'Start drafting your'
+    return unless block
+
+    # send
+  end
+
+  def schedule_peer_review_email
+    block = @course.find_block_by_title 'Peer review'
+    return unless block
+
+    # send
+  end
+
+  def schedule_assessing_contributions_email
+    block = @course.find_block_by_title 'Final article'
+    return unless block
+
+    # send
+  end
+end

--- a/app/views/course_advice_mailer/assessing_contributions.html.haml
+++ b/app/views/course_advice_mailer/assessing_contributions.html.haml
@@ -30,8 +30,9 @@
                   Here's a guide on
                   %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} how to use the dashboard to see your student contributions.
                 %li
-                  Remember, never base grades based on what sticks, and when it
-                  comes to the Wikipedia assignment, quality is far more important than quantity.
+                  Remember, never base grades on whether student work remains on Wikipedia; instead, assess the quality of their contribution.
+                  If their work has been removed, it will still be available via the Wikipedia page's 'View history' tab in most cases.
+                  If you run into trouble, reach out to your Wikipedia Expert.
               %p.paragraph.center — — —
               %p.paragraph
                 You can always refer to our

--- a/app/views/course_advice_mailer/assessing_contributions.html.haml
+++ b/app/views/course_advice_mailer/assessing_contributions.html.haml
@@ -1,0 +1,10 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@greeted_users},"

--- a/app/views/course_advice_mailer/assessing_contributions.html.haml
+++ b/app/views/course_advice_mailer/assessing_contributions.html.haml
@@ -8,3 +8,49 @@
             %td.main-content
               %p.paragraph
                 = "Dear #{@greeted_users},"
+              %p.paragraph
+                - if @course.stay_in_sandbox?
+                  As your students put the finishing touches on their final contributions,
+                  we want to make sure you know how to find and assess those contributions.
+                - else
+                  As your students move their work into the article main space and put the
+                  finishing touches on their final contributions, we want to make sure you
+                  know how to find and assess those contributions.
+              %ul.paragraph
+                %li
+                  Here are some
+                  %a.link{href: 'https://wikiedu.org/blog/2017/11/15/tips-for-grading-a-wikipedia-assignment/'} general tips for grading and assessing student work.
+                %li
+                  You may wish to use our sample grading rubric. (
+                  %a.link{href: 'https://wikiedu.org/wp-content/uploads/2020/07/Example-grading-rubric-for-a-Wikipedia-assignment.docx'} .doc
+                  ,
+                  %a.link{href: 'https://commons.wikimedia.org/wiki/File:Wiki_Education_Classroom_Program_example_grading_rubric.pdf'} PDF  
+                  )
+                %li
+                  Here's a guide on
+                  %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} how to use the dashboard to see your student contributions.
+                %li
+                  Remember, never base grades based on what sticks, and when it
+                  comes to the Wikipedia assignment, quality is far more important than quantity.
+              %p.paragraph.center — — —
+              %p.paragraph
+                You can always refer to our
+                %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
+                for more information.
+              %p.paragraph
+                Good luck!
+              %p.paragraph
+                %br
+                %em
+                  =@staffer.real_name
+                %br
+                %em Senior Program Manager
+                %br
+                %em Wiki Education
+                %br
+                %br
+              %p.info
+                This is an automated email from Wiki Education intended to help you with assessing student work for your Wikipedia assignment.
+                If you have thoughts about it — anything you found confusing or important things that are missing — you can let us know
+                by replying, or
+                %a.link{href: 'https://dashboard.wikiedu.org/feedback?subject=Assessing-Contributions-Advice-email'} leave feedback here.

--- a/app/views/course_advice_mailer/assessing_contributions.html.haml
+++ b/app/views/course_advice_mailer/assessing_contributions.html.haml
@@ -33,6 +33,13 @@
                   Remember, never base grades on whether student work remains on Wikipedia; instead, assess the quality of their contribution.
                   If their work has been removed, it will still be available via the Wikipedia page's 'View history' tab in most cases.
                   If you run into trouble, reach out to your Wikipedia Expert.
+                %li
+                  Ideally you'll be able to use the Dashboard's
+                  %a.link{href: "#{@course_link}/students/articles"} Students Assignments view
+                  to find each student's contributions, but in case their work isn't where the Dashboard expects it to be, the most useful
+                  tools for tracking down a student's contributions are a student's 'sandboxes' link — which goes to a page listing every
+                  sandbox page associated with their username — and the 'edits' link, which goes to the full list of every they've made on
+                  Wikipedia.
               %p.paragraph.center — — —
               %p.paragraph
                 You can always refer to our

--- a/app/views/course_advice_mailer/assessing_contributions.html.haml
+++ b/app/views/course_advice_mailer/assessing_contributions.html.haml
@@ -38,7 +38,7 @@
                   %a.link{href: "#{@course_link}/students/articles"} Students Assignments view
                   to find each student's contributions, but in case their work isn't where the Dashboard expects it to be, the most useful
                   tools for tracking down a student's contributions are a student's 'sandboxes' link — which goes to a page listing every
-                  sandbox page associated with their username — and the 'edits' link, which goes to the full list of every they've made on
+                  sandbox page associated with their username — and the 'edits' link, which goes to the full list of every edit they've made on
                   Wikipedia.
               %p.paragraph.center — — —
               %p.paragraph

--- a/app/views/course_advice_mailer/drafting_and_moving.html.haml
+++ b/app/views/course_advice_mailer/drafting_and_moving.html.haml
@@ -26,6 +26,10 @@
                 %a.link{href: "#{@course_link}/students/articles"} Students Assignments view
                 when you select an individual student.
               %p.paragraph
+                Sometimes students end up doing work in a place other than where the Dashboard recommends. You can see a
+                list of any student's sandbox pages by navigating to the Students tab of your course page and clicking
+                on the 'sandboxes' link for their account.
+              %p.paragraph
                 A few things to remember:
                 %ul.paragraph
                   %li
@@ -52,11 +56,15 @@
                   A few critical points:
                   %ul.paragraph
                     %li
-                      After students move their work, they should be sure to pay attention to any feedback from community members. They are now members of the Wikipedia community and have a responsibility toward that community.
+                      After students move their work, they should be sure to pay attention to any feedback from community members.
+                      They are now members of the Wikipedia community and have a responsibility toward that community.
                     %li
-                      If student work is reverted, students should reach out to the editor that reverted the work to try and understand why and how they can improve it. They should NEVER just put the work back into the article. This type of activity may lead them to getting blocked.
+                      If student work is removed, students should reach out to the editor who removed the work to try
+                      to understand why, and how they can improve it. They should NEVER just put the work back
+                      into the article without discussion. This type of activity — an "edit war" — may lead them to getting blocked.
                     %li
-                      Stress to your students that their grade is not dependent on whether the work remains on Wikipedia and that you will always be able to see their contributions in their edit history.
+                      Stress to your students that their grade is not dependent on whether the work remains on Wikipedia
+                      and that you will always be able to see their contributions in their edit history.
                     %li
                       %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} Here are the various ways you can use the dashboard to keep track of your students' contributions.
               %p.paragraph.center — — —

--- a/app/views/course_advice_mailer/drafting_and_moving.html.haml
+++ b/app/views/course_advice_mailer/drafting_and_moving.html.haml
@@ -8,3 +8,74 @@
             %td.main-content
               %p.paragraph
                 = "Dear #{@greeted_users},"
+              %p.paragraph
+                Once your students have selected an article to work on and have gathered sources to
+                improve their chosen topic, it will be time to begin drafting their main contribution!
+              %h2.headline Drafting in the sandbox
+              %p.paragraph
+                Students should take the training module on
+                - if @group_work
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/drafting-in-sandbox-group'} 'Drafting as a group'
+                - else
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/drafting-in-sandbox'} Drafting in the sandbox
+                for guidance on the best way to draft their contribution.
+              %p.paragraph
+                Once students have assigned themselves their main article(s), the Dashboard will provide links to the
+                specific sandbox page where each article's draft should be prepared. Students can find these links in
+                My Articles section of the Home tab, and you can find them under 'Assigned Articles' in the
+                %a.link{href: "#{@course_link}/students/articles"} Students Assignments view
+                when you select an individual student.
+              %p.paragraph
+                A few things to remember:
+                %ul.paragraph
+                  %li
+                    Sandboxes are considered draft spaces on Wikipedia, but they are still publicly accessible like all
+                    Wikipedia pages. Students must adhere to Wikipedia policies in their sandboxes.
+                  %li
+                    If students are working on existing articles, they should not copy over the whole article into their
+                    sandbox. Rather, they should only copy over the section(s) they're working on.
+                  %li
+                    While the sandbox is a great place to experiment and get your draft ready, students shouldn't spend
+                    too long there. A few weeks should be enough for them to get their contribution up and ready for
+                    Wikipedia's live article space.
+              %h2.headline Moving work out of the sandbox
+              %p.paragraph
+                When students are ready to move their work into the article main space, they should take the
+                - if @group_work
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/moving-to-mainspace-group'} 'Moving group work live'
+                - else
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/moving-to-mainspace'} 'Moving work out of the sandbox'
+                training module.
+              %p.paragraph
+                A few critical points:
+                %ul.paragraph
+                  %li
+                    After students move their work, they should be sure to pay attention to any feedback from community members. They are now members of the Wikipedia community and have a responsibility toward that community.
+                  %li
+                    If student work is reverted, students should reach out to the editor that reverted the work to try and understand why and how they can improve it. They should NEVER just put the work back into the article. This type of activity may lead them to getting blocked.
+                  %li
+                    Stress to your students that their grade is not dependent on whether the work remains on Wikipedia and that you will always be able to see their contributions in their edit history.
+                  %li
+                    %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} Here are the various ways you can use the dashboard to keep track of your students' contributions.
+              %p.paragraph.center — — —
+              %p.paragraph
+                Remember, you can always refer to our
+                %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
+                for more information.
+              %p.paragraph
+                Good luck!
+              %p.paragraph
+                %br
+                %em
+                  =@staffer.real_name
+                %br
+                %em Senior Program Manager
+                %br
+                %em Wiki Education
+                %br
+                %br
+              %p.info
+                This is an automated email from Wiki Education intended to help you with the main article development stages of your Wikipedia assignment.
+                If you have thoughts about it — anything you found confusing or important things that are missing — you can let us know
+                by replying, or
+                %a.link{href: 'https://dashboard.wikiedu.org/feedback?subject=Drafting-and-Moving-Advice-email'} leave feedback here.

--- a/app/views/course_advice_mailer/drafting_and_moving.html.haml
+++ b/app/views/course_advice_mailer/drafting_and_moving.html.haml
@@ -1,0 +1,10 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@greeted_users},"

--- a/app/views/course_advice_mailer/drafting_and_moving.html.haml
+++ b/app/views/course_advice_mailer/drafting_and_moving.html.haml
@@ -17,7 +17,7 @@
                 - if @group_work
                   %a.link{href: 'https://dashboard.wikiedu.org/training/students/drafting-in-sandbox-group'} 'Drafting as a group'
                 - else
-                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/drafting-in-sandbox'} Drafting in the sandbox
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/drafting-in-sandbox'} 'Drafting in the sandbox'
                 for guidance on the best way to draft their contribution.
               %p.paragraph
                 Once students have assigned themselves their main article(s), the Dashboard will provide links to the

--- a/app/views/course_advice_mailer/drafting_and_moving.html.haml
+++ b/app/views/course_advice_mailer/drafting_and_moving.html.haml
@@ -34,29 +34,31 @@
                   %li
                     If students are working on existing articles, they should not copy over the whole article into their
                     sandbox. Rather, they should only copy over the section(s) they're working on.
-                  %li
-                    While the sandbox is a great place to experiment and get your draft ready, students shouldn't spend
-                    too long there. A few weeks should be enough for them to get their contribution up and ready for
-                    Wikipedia's live article space.
-              %h2.headline Moving work out of the sandbox
-              %p.paragraph
-                When students are ready to move their work into the article main space, they should take the
-                - if @group_work
-                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/moving-to-mainspace-group'} 'Moving group work live'
-                - else
-                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/moving-to-mainspace'} 'Moving work out of the sandbox'
-                training module.
-              %p.paragraph
-                A few critical points:
-                %ul.paragraph
-                  %li
-                    After students move their work, they should be sure to pay attention to any feedback from community members. They are now members of the Wikipedia community and have a responsibility toward that community.
-                  %li
-                    If student work is reverted, students should reach out to the editor that reverted the work to try and understand why and how they can improve it. They should NEVER just put the work back into the article. This type of activity may lead them to getting blocked.
-                  %li
-                    Stress to your students that their grade is not dependent on whether the work remains on Wikipedia and that you will always be able to see their contributions in their edit history.
-                  %li
-                    %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} Here are the various ways you can use the dashboard to keep track of your students' contributions.
+                  - unless @course.stay_in_sandbox?
+                    %li
+                      While the sandbox is a great place to experiment and get your draft ready, students shouldn't spend
+                      too long there. A few weeks should be enough for them to get their contribution up and ready for
+                      Wikipedia's live article space.
+              - unless @course.stay_in_sandbox?
+                %h2.headline Moving work out of the sandbox
+                %p.paragraph
+                  When students are ready to move their work into the article main space, they should take the
+                  - if @group_work
+                    %a.link{href: 'https://dashboard.wikiedu.org/training/students/moving-to-mainspace-group'} 'Moving group work live'
+                  - else
+                    %a.link{href: 'https://dashboard.wikiedu.org/training/students/moving-to-mainspace'} 'Moving work out of the sandbox'
+                  training module.
+                %p.paragraph
+                  A few critical points:
+                  %ul.paragraph
+                    %li
+                      After students move their work, they should be sure to pay attention to any feedback from community members. They are now members of the Wikipedia community and have a responsibility toward that community.
+                    %li
+                      If student work is reverted, students should reach out to the editor that reverted the work to try and understand why and how they can improve it. They should NEVER just put the work back into the article. This type of activity may lead them to getting blocked.
+                    %li
+                      Stress to your students that their grade is not dependent on whether the work remains on Wikipedia and that you will always be able to see their contributions in their edit history.
+                    %li
+                      %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} Here are the various ways you can use the dashboard to keep track of your students' contributions.
               %p.paragraph.center — — —
               %p.paragraph
                 Remember, you can always refer to our

--- a/app/views/course_advice_mailer/drafting_and_moving.html.haml
+++ b/app/views/course_advice_mailer/drafting_and_moving.html.haml
@@ -61,7 +61,7 @@
                       %a.link{href: 'https://dashboard.wikiedu.org/faq/1/'} Here are the various ways you can use the dashboard to keep track of your students' contributions.
               %p.paragraph.center — — —
               %p.paragraph
-                Remember, you can always refer to our
+                You can always refer to our
                 %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
                 for more information.
               %p.paragraph

--- a/app/views/course_advice_mailer/peer_review.html.haml
+++ b/app/views/course_advice_mailer/peer_review.html.haml
@@ -22,7 +22,7 @@
                 of your course page click on the "Assign random peer reviews" button. Alternatively, students can select
                 for themselves which classmates' articles to review under the My Articles section.
               %p.paragraph
-                Once a review is assigned, the My Articles secton of the Dashboard will provide a link to the
+                Once a review is assigned, the My Articles section of the Dashboard will provide a link to the
                 sandbox page where the student can compose their review. As long as they are signed in on Wikipedia,
                 the link will also prepopulate the review page with a template of guiding questions and considerations,
                 %a.link{href: 'https://en.wikipedia.org/wiki/Template:Dashboard.wikiedu.org_peer_review'}like this.
@@ -30,6 +30,10 @@
                 You can find these reviews, once completed, by going to the Students tab and navigating to the
                 'Assignments & Exercises' section. See also our
                 %a.link{href: 'https://dashboard.wikiedu.org/faq/15/'}FAQ about the peer review process.
+              %p.paragraph
+                Sometimes students post their peer reviews in a place other than where the Dashboard recommends.
+                You can see a list of any student's sandbox pages by navigating to the Students tab of
+                your course page and clicking on the 'sandboxes' link for their account.
               %p.paragraph.center — — —
               %p.paragraph
                 You can always refer to our

--- a/app/views/course_advice_mailer/peer_review.html.haml
+++ b/app/views/course_advice_mailer/peer_review.html.haml
@@ -1,0 +1,10 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@greeted_users},"

--- a/app/views/course_advice_mailer/peer_review.html.haml
+++ b/app/views/course_advice_mailer/peer_review.html.haml
@@ -8,3 +8,47 @@
             %td.main-content
               %p.paragraph
                 = "Dear #{@greeted_users},"
+              %p.paragraph
+                We recommend that all students review at least one of their peer's contributions, and
+                the Dashboard has the infrastructure to support peer review.
+              %p.paragraph
+                When students are ready for the peer review portion of the project, they should launch the
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/peer-review'} 'Peer review'
+                training module. This will provide them with tips on how to craft their reviews, how to select an article
+                to review using the Dashboard, and where to complete them.
+              %p.paragraph
+                As the instructor, you can randomly assign your students articles to review. To do this, go to the
+                %a.link{href: "#{@course_link}/students"} Students tab
+                of your course page click on the "Assign random peer reviews" button. Alternatively, students can select
+                for themselves which classmates' articles to review under the My Articles section.
+              %p.paragraph
+                Once a review is assigned, the My Articles secton of the Dashboard will provide a link to the
+                sandbox page where the student can compose their review. As long as they are signed in on Wikipedia,
+                the link will also prepopulate the review page with a template of guiding questions and considerations,
+                %a.link{href: 'https://en.wikipedia.org/wiki/Template:Dashboard.wikiedu.org_peer_review'}like this.
+              %p.paragraph
+                You can find these reviews, once completed, by going to the Students tab and navigating to the
+                'Assignments & Exercises' section. See also our
+                %a.link{href: 'https://dashboard.wikiedu.org/faq/15/'}FAQ about the peer review process.
+              %p.paragraph.center — — —
+              %p.paragraph
+                Remember, you can always refer to our
+                %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
+                for more information.
+              %p.paragraph
+                Good luck!
+              %p.paragraph
+                %br
+                %em
+                  =@staffer.real_name
+                %br
+                %em Senior Program Manager
+                %br
+                %em Wiki Education
+                %br
+                %br
+              %p.info
+                This is an automated email from Wiki Education intended to help you with the peer review of your Wikipedia assignment.
+                If you have thoughts about it — anything you found confusing or important things that are missing — you can let us know
+                by replying, or
+                %a.link{href: 'https://dashboard.wikiedu.org/feedback?subject=Peer-Review-Advice-email'} leave feedback here.

--- a/app/views/course_advice_mailer/peer_review.html.haml
+++ b/app/views/course_advice_mailer/peer_review.html.haml
@@ -32,7 +32,7 @@
                 %a.link{href: 'https://dashboard.wikiedu.org/faq/15/'}FAQ about the peer review process.
               %p.paragraph.center — — —
               %p.paragraph
-                Remember, you can always refer to our
+                You can always refer to our
                 %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
                 for more information.
               %p.paragraph

--- a/app/views/course_advice_mailer/preliminary_work.html.haml
+++ b/app/views/course_advice_mailer/preliminary_work.html.haml
@@ -62,7 +62,7 @@
                 compile their bibliography and where they should begin drafting. They can find these pages under the My Articles section.
               %p.paragraph.center — — —
               %p.paragraph
-                Remember, you can always refer to our
+                You can always refer to our
                 %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
                 for more information.
               %p.paragraph

--- a/app/views/course_advice_mailer/preliminary_work.html.haml
+++ b/app/views/course_advice_mailer/preliminary_work.html.haml
@@ -1,0 +1,10 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@greeted_users},"

--- a/app/views/course_advice_mailer/preliminary_work.html.haml
+++ b/app/views/course_advice_mailer/preliminary_work.html.haml
@@ -8,3 +8,77 @@
             %td.main-content
               %p.paragraph
                 = "Dear #{@greeted_users},"
+              %p.paragraph
+                Before your students begin drafting their work, they'll go through a series of
+                preliminary activities to prepare them for their final contributions. Below are
+                some tips for helping them with these early exercises.
+              %h2.headline Evaluate an article
+              %p.paragraph
+                A critical part of learning how to contribute to Wikipedia is learning how to
+                evaluate an article's quality. In
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/evaluate-wikipedia-exercise'}this exercise
+                students will be asked to write up their evaluation of a Wikipedia article. When they launch
+                the exercise from the dashboard, they will be prompted to begin their article evaluation,
+                and the dashboard will create a page for them in their userspace where they should
+                complete this evaluation. The page will look like
+                %a.link{href: 'https://en.wikipedia.org/wiki/Template:Dashboard.wikiedu.org_evaluate_article'}this.
+                (Students will need to be logged in both on the Dashboard and on Wikipedia for this to work properly.)
+              %p.paragraph
+                Once completed, you'll be able to find their article evaluations by choosing a student in the
+                %a.link{href: "#{@course_link}/students/articles"} Students Assignments view
+                of your course page, clicking the "Exercises & Trainings" table, then following the "Exercise Sandbox"
+                link.
+              %h2.headline Early edits
+              %p.paragraph
+                Making that first live edit on Wikipedia can be daunting, which is why we've designed a few exercises
+                that get students over this hurdle before starting on their main contribution. Depending on your
+                selections during the assignment design process, you may have assigned exercises to
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/add-to-article-exercise'}add to an article
+                and/or
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/copyedit-exercise'}copyedit an article.
+              %p.paragraph
+                In either case, students will add a very small amount of content to a live article. The
+                %a.link{href: "#{@course_link}/students/overview"}Students Overview
+                can show you who has been active recently, and how much content they've added to live articles and
+                sandbox pages ("userspace"). You can click a student to see exactly which articles they've edited,
+                and activate the
+                %strong Article Viewer
+                to see what the article currently looks like. Once the Authorship Highlighting data loads, you'll be able to
+                see the students' contributions in the context of the rest of the article.
+              %h2.headline Choosing an article
+              %p.paragraph
+                With its millions of entries, finding an article to work on can seem overwhelming. To learn how to best approach
+                this, students should go through the
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/finding-your-article'}"Finding articles"
+                training module and the
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/choose-topic-exercise'}"Choose your article"
+                exercise.
+              %p.paragraph
+                Once students have selected an article to work on, they'll assign themselves this article on the Dashboard
+                on the My Articles portion of the home tab. Only students have the My Articles section. To see what this look,
+                %a.link{href: 'https://dashboard.wikiedu.org/training/students/keeping-track-of-your-work'}click here.
+              %p.paragraph
+                Once a student assigns themself an article, the Dashboard will link to dedicated sandbox pages where they can
+                compile their bibliography and where they should begin drafting. They can find these pages under the My Articles section.
+              %p.paragraph.center — — —
+              %p.paragraph
+                Remember, you can always refer to our
+                %a.link{href: 'https://dashboard.wikiedu.org/faq?topic=instructor_faq'}Instructor FAQs
+                for more information.
+              %p.paragraph
+                Good luck!
+              %p.paragraph
+                %br
+                %em
+                  =@staffer.real_name
+                %br
+                %em Senior Program Manager
+                %br
+                %em Wiki Education
+                %br
+                %br
+              %p.info
+                This is an automated email from Wiki Education intended to help you with the early stages of your Wikipedia assignment.
+                If you have thoughts about it — anything you found confusing or important things that are missing — you can let us know
+                by replying, or
+                %a.link{href: 'https://dashboard.wikiedu.org/feedback?subject=Preliminary-Work-Advice-email'} leave feedback here.

--- a/app/views/course_advice_mailer/preliminary_work.html.haml
+++ b/app/views/course_advice_mailer/preliminary_work.html.haml
@@ -55,7 +55,7 @@
                 exercise.
               %p.paragraph
                 Once students have selected an article to work on, they'll assign themselves this article on the Dashboard
-                on the My Articles portion of the home tab. Only students have the My Articles section. To see what this look,
+                on the My Articles portion of the home tab. Only students have the My Articles section. To see what this looks like,
                 %a.link{href: 'https://dashboard.wikiedu.org/training/students/keeping-track-of-your-work'}click here.
               %p.paragraph
                 Once a student assigns themself an article, the Dashboard will link to dedicated sandbox pages where they can

--- a/app/views/course_advice_mailer/preliminary_work.html.haml
+++ b/app/views/course_advice_mailer/preliminary_work.html.haml
@@ -60,6 +60,10 @@
               %p.paragraph
                 Once a student assigns themself an article, the Dashboard will link to dedicated sandbox pages where they can
                 compile their bibliography and where they should begin drafting. They can find these pages under the My Articles section.
+                (In case a student ends up working in a place other than where the Dashboard recommends, you can also see a full list of
+                their sandbox pages by navigating to the
+                %a.link{href: "#{@course_link}/students/articles"} Students tab
+                and clicking on the 'sandboxes' link for their account.)
               %p.paragraph.center — — —
               %p.paragraph
                 You can always refer to our

--- a/app/workers/course_advice_email_worker.rb
+++ b/app/workers/course_advice_email_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CourseAdviceEmailWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def self.schedule_email(course:, stage:, send_at:)
+    perform_at(send_at, course.id, stage)
+  end
+
+  def perform(course_id, stage)
+    course = Course.find(course_id)
+    CourseAdviceMailer.send_email(course: course, stage: stage)
+  end
+end

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -97,6 +97,7 @@ class CourseCloneManager
     tricky_topic_areas
     working_individually
     working_in_groups
+    research_write_assignment
   ].freeze
   def tag_course
     tag_manager = TagManager.new(@clone)

--- a/lib/list_course_manager.rb
+++ b/lib/list_course_manager.rb
@@ -56,5 +56,6 @@ class ListCourseManager
     @course.instructors.each do |user|
       CourseApprovalFollowupWorker.schedule_followup_email(course: @course, instructor: user)
     end
+    ScheduleCourseAdviceEmails.new(@course)
   end
 end

--- a/lib/list_course_manager.rb
+++ b/lib/list_course_manager.rb
@@ -17,7 +17,7 @@ class ListCourseManager
 
     # Tasks for when a course is initially approved
     add_instructor_real_names if Features.wiki_ed?
-    send_approval_notification_emails
+    send_approval_notification_emails if Features.wiki_ed?
     add_classroom_program_manager_if_exists if Features.wiki_ed?
   end
 

--- a/public/mailer.css
+++ b/public/mailer.css
@@ -50,6 +50,10 @@ section.message, section.message p, .paragraph {
   text-decoration: underline;
 }
 
+.center {
+  text-align: center;
+}
+
 .button_link {
   padding: 15px 20px;
   max-width: 600px;

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -476,7 +476,7 @@ describe CoursesController, type: :request do
     let(:course_type) { 'ClassroomProgramCourse' }
     let(:campaign) { Campaign.last }
     let(:user) { create(:admin, email: 'user@example.edu') }
-    let(:teaching_assistant) { create(:user, username: 'TeachingAssistant', email: 'ta@example.com') }
+    let(:teaching_assistant) { create(:user, username: 'TA', email: 'ta@example.com') }
     let(:week) { create(:week) }
     let!(:drafting_block) { create(:block, title: 'Start drafting your contributions', week: week) }
     let!(:peer_review_block) { create(:block, title: 'Peer review', week: week) }

--- a/spec/mailers/previews/course_advice_mailer_preview.rb
+++ b/spec/mailers/previews/course_advice_mailer_preview.rb
@@ -9,6 +9,10 @@ class CourseAdviceMailerPreview < ActionMailer::Preview
     CourseAdviceMailer.email(example_course, 'drafting_and_moving', example_staffer)
   end
 
+  def drafting_sandbox_only
+    CourseAdviceMailer.email(sandbox_only_course, 'drafting_and_moving', example_staffer)
+  end
+
   def peer_review
     CourseAdviceMailer.email(example_course, 'peer_review', example_staffer)
   end
@@ -21,6 +25,12 @@ class CourseAdviceMailerPreview < ActionMailer::Preview
 
   def example_course
     Course.last
+  end
+
+  def sandbox_only_course
+    course = example_course
+    course.define_singleton_method(:stay_in_sandbox?) { true }
+    course
   end
 
   def example_staffer

--- a/spec/mailers/previews/course_advice_mailer_preview.rb
+++ b/spec/mailers/previews/course_advice_mailer_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CourseAdviceMailerPreview < ActionMailer::Preview
+  def preliminary_work
+    CourseAdviceMailer.email(example_course, 'preliminary_work', example_staffer)
+  end
+
+  def drafting_and_moving
+    CourseAdviceMailer.email(example_course, 'drafting_and_moving', example_staffer)
+  end
+
+  def peer_review
+    CourseAdviceMailer.email(example_course, 'peer_review', example_staffer)
+  end
+
+  def assessing_contributions
+    CourseAdviceMailer.email(example_course, 'assessing_contributions', example_staffer)
+  end
+
+  private
+
+  def example_course
+    Course.last
+  end
+
+  def example_staffer
+    User.new(email: 'sage@example.com', username: 'Sage (Wiki Ed)', real_name: 'Sage Ross')
+  end
+end


### PR DESCRIPTION
This adds a suite of automated emails, scheduled at the time of course approval, that go out to instructors at various points in their timeline.

Preview here: https://dashboard-testing.wikiedu.org/rails/mailers/course_advice_mailer