### PR TITLE
Fixed dotted outline styling on navbar links

### DIFF
--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -26,9 +26,9 @@ nav.top-nav
     font-size 15px
     &:hover, &.active
       color $brand_primary
-      border none !important
+      border none 
       border-bottom 3px solid $brand_primary
-      outline none !important
+      outline none 
 
 
   .container
@@ -148,14 +148,14 @@ nav.top-nav
   justify-content flex-start
   margin 0
   padding 0
-  outline: none !important
+  outline: none 
   
   li
     margin-left 25px
-    outline none !important
+    outline none 
   a
     margin 0
-    outline none !important
+    outline none 
   span
     display inherit
 .top-nav__site-logo

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -26,7 +26,9 @@ nav.top-nav
     font-size 15px
     &:hover, &.active
       color $brand_primary
+      border none !important
       border-bottom 3px solid $brand_primary
+      outline none !important
 
 
   .container
@@ -146,10 +148,14 @@ nav.top-nav
   justify-content flex-start
   margin 0
   padding 0
+  outline: none !important
+  
   li
     margin-left 25px
+    outline none !important
   a
     margin 0
+    outline none !important
   span
     display inherit
 .top-nav__site-logo


### PR DESCRIPTION
## What this PR does
Removes outline on focus on the navbar components


## Screenshots
Before:
![Screenshot from 2021-02-25 04-22-09](https://user-images.githubusercontent.com/47888725/109080555-9ce85f80-7722-11eb-8731-a98a43baee88.png)

After:
![Screenshot from 2021-02-25 04-22-44](https://user-images.githubusercontent.com/47888725/109080561-a376d700-7722-11eb-929b-02a8f381bc78.png)

## Open questions and concerns
This feature has been tested both on chrome and firefox 