### PR TITLE
Add X-Request-Start header to Apache

### DIFF
--- a/server_config/apache2.conf
+++ b/server_config/apache2.conf
@@ -231,6 +231,6 @@ LoadModule passenger_module /usr/local/rvm/gems/ruby-2.7.1/gems/passenger-6.0.6/
 # Add header to incoming requests, timestamping them with time since the epoch in microseconds
 # This is required for New Relic's request queueing calculation
 <IfModule !mod_headers.c>
-  LoadModule headers_module modules/mod_headers.so
+  LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
 </IfModule>
 RequestHeader set X-Request-Start "%t"

--- a/server_config/apache2.conf
+++ b/server_config/apache2.conf
@@ -227,3 +227,10 @@ LoadModule passenger_module /usr/local/rvm/gems/ruby-2.7.1/gems/passenger-6.0.6/
   PassengerDefaultUser deploy
   PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.7.1/wrappers/ruby
 </IfModule>
+
+# Add header to incoming requests, timestamping them with time since the epoch in microseconds
+# This is required for New Relic's request queueing calculation
+<IfModule !mod_headers.c>
+  LoadModule headers_module modules/mod_headers.so
+</IfModule>
+RequestHeader set X-Request-Start "%t"


### PR DESCRIPTION
Required for New Relic's request queueing calculation to work

I'm not really an Apache wizard - I think this is the correct way to load mod_headers but I'm not sure.
