### PR TITLE
Fix #4363

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/IconOpener.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/IconOpener.jsx
@@ -1,19 +1,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const IconOpener = ({ showArticle, showButtonClass, showButtonLabel }) => (
-  <div className={`tooltip-trigger ${showButtonClass}`}>
-    <button onClick={showArticle} aria-label="Open Article Viewer" className="icon icon-article-viewer" />
-    <div className="tooltip tooltip-center dark large">
-      <p>{showButtonLabel()}</p>
-    </div>
-  </div>
+export const IconOpener = ({ showArticle, showButtonClass, showButtonLabel, article }) => (
+    article.id ? (
+      <div className={`tooltip-trigger ${showButtonClass}`}>
+        <button
+          onClick={showArticle}
+          aria-label="Open Article Viewer"
+          className="icon icon-article-viewer"
+        />
+        <div className="tooltip tooltip-center dark large">
+          <p>{showButtonLabel()}</p>
+        </div>
+      </div>
+    ) : (
+      <div className={`tooltip-trigger ${showButtonClass}`}>
+        <button
+          aria-label="Open Article Viewer"
+          className="icon icon-article-viewer-disabled"
+          disabled
+        />
+        <div className="tooltip tooltip-center dark large">
+          <p>{I18n.t('articles.article_not_found')}</p>
+        </div>
+      </div>
+    )
 );
 
 IconOpener.propTypes = {
   showArticle: PropTypes.func.isRequired,
   showButtonClass: PropTypes.string,
-  showButtonLabel: PropTypes.func.isRequired
+  showButtonLabel: PropTypes.func.isRequired,
+  article: PropTypes.shape({
+    id: PropTypes.number,
+    language: PropTypes.string.isRequired,
+    project: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  }),
 };
 
 export default IconOpener;

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -276,6 +276,7 @@ export class ArticleViewer extends React.Component {
           showArticle={this.showArticle}
           showButtonClass={showButtonClass}
           showButtonLabel={this.showButtonLabel}
+          article={this.props.article}
         />
       );
     }

--- a/app/assets/stylesheets/_icons.styl
+++ b/app/assets/stylesheets/_icons.styl
@@ -65,6 +65,15 @@
     background url('../images/article-viewer.svg') center no-repeat
     background-size 60px
 
+
+.icon-article-viewer-disabled
+  background url('../images/article-viewer-grey.svg') center no-repeat
+  background-size 60px
+  padding 24px
+  left calc(50% - 12px)
+  cursor: not-allowed
+
+
 .icon-diff-viewer
   background url('../images/diff-viewer-grey.svg') center no-repeat
   background-size 60px

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,7 @@ en:
     label: Activity
 
   articles:
+    article_not_found: 'This article has not been created yet.'
     article_development: (article development)
     articles_shown: 'Showing %{count} of %{total}'
     assigned: Assigned Articles


### PR DESCRIPTION
disable Article Viewer button if the article doesn't exist.

Fix article viewer button error

Disable the article viewer button when the article is not valid

Add Style for Article Viewer Disabled Button

clean syntax

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
* Disable Article Viewer button when the article dosen't exist.
* Add styling for disabled viewer button

## Screenshots
Before:


After:
<img width="1252" alt="Screenshot 2021-03-03 at 6 25 27 PM" src="https://user-images.githubusercontent.com/48797475/109809051-dc94d700-7c4d-11eb-8983-60d67b20a789.png">

## Open questions and concerns
* right now the string "Article Dosen't Exist" is hardcoded into the IconOpener component, Is there any other place where i 
place that string?
