### PR TITLE
Create database in setup only if it does not already exist

### DIFF
--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -140,8 +140,8 @@ else
 fi
 
 printf "[*] Creating Databases... \n"
-echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
       exit" | sudo mysql -p && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'

--- a/setup/dnf-setup.sh
+++ b/setup/dnf-setup.sh
@@ -131,8 +131,8 @@ printf '[*] Starting MariaDB... \n'
 sudo service mariadb start
 
 printf "[*] Creating Databases... \n"
-echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
       exit" | sudo mysql && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'

--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -122,8 +122,8 @@ else
 fi
 
 printf "[*] Creating Databases... \n"
-echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
       exit" | sudo mysql && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'

--- a/setup/win-setup.bat
+++ b/setup/win-setup.bat
@@ -50,7 +50,7 @@ start C:\xampp\mysql\bin\mysqld
 echo [+] XAMPP install complete!
 
 echo [*] Creating databases...
-echo CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; exit| C:\xampp\mysql\bin\mysql -u root
+echo CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; exit| C:\xampp\mysql\bin\mysql -u root
 echo [+] Databases created!
 
 echo [*] Creating User for Mysql...


### PR DESCRIPTION
This improves the idempotency of the setup script.

Before:

```
[*] Creating Databases... 
ERROR 1007 (HY000) at line 1: Can't create database 'dashboard'; database exists
```

After:

```
[*] Creating Databases... 
[+] Databases created
```