### PR TITLE
fix #4171

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleViewerAPI.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleViewerAPI.js
@@ -109,7 +109,10 @@ export class ArticleViewerAPI {
           attempts += 1;
           if (attempts <= MAX_RETRY_ATTEMPTS) return colorURLRequest.call(this, attempts);
 
-          const err = `Request failed after ${MAX_RETRY_ATTEMPTS} attempts. Please try again.`;
+          // Handle the case when the key 'info' is not present in response.
+          let info = response.info ? response.info : ''
+
+          const err = `Request failed after ${MAX_RETRY_ATTEMPTS} attempts. ${info}`;
           throw new Error(err);
         });
     }


### PR DESCRIPTION
show clear message to explain that authorship highlighting is not
available for redirected pages

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
Fix #4171 
Show clear message to explain that authorship highlighting is not available from redirected pages,

It might so happen that the status code for response is 200 but `success: false`
for example - 
`{"info":"Requested revision (947629440) is detected as vandalism by WikiWho.","success":false,"rev_id":947629440,"page_title":"Medical use of MDMA"}`
in this case we would like to show proper information in ArticleViewer Footer

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns

