### PR TITLE
fix #4359 - Student's list of trainings and exercises should be ordered by due date, and divided by already-due vs not-yet-due 

### DIFF
--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
@@ -16,31 +16,46 @@ const ExerciseStatusCell = ({ status, sandboxUrl }) => {
 // Helper Functions
 const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);
 
-const generateRow = () => (exercise) => {
-  const dueDate = moment(exercise.due_date).format('MMM Do, YYYY');
+// This function returns the status of exercise
+// returns status as unread/complete/incomplete depending on the deadline status and flags if any
+const getExerciseStatus = (exercise) => {
   const isComplete = exercise.deadline_status === 'complete';
   const flags = exercise.flags || {};
-  let exercise_status = '';
+  let status = '';
   if (isComplete && flags.marked_complete) {
-    exercise_status = 'complete';
+    status = 'complete';
   } else if (isComplete) {
-    exercise_status = 'incomplete';
+    status = 'incomplete';
   } else {
-    exercise_status = 'unread';
+    status = 'unread';
   }
+  return status;
+};
+
+// This function compares exercise's due date with current date
+// returns true if the current date has not passed the training's due date
+const isExerciseDue = (exercise) => {
+  const currentDate = new Date();
+  const exerciseDueDate = new Date(Date.parse(exercise.due_date.replace(/-/g, ' ')));
+  return exerciseDueDate >= currentDate;
+};
+
+const generateRow = () => (exercise) => {
+  const dueDate = moment(exercise.due_date).format('MMM Do, YYYY');
+  const exerciseStatus = getExerciseStatus(exercise);
   return (
-    <tr className={exercise.overdue ? 'student-training-module overdue' : 'student-training-module'} key={exercise.id}>
+    <tr className={isExerciseDue(exercise) ? 'student-training-module due-training' : 'student-training-module'} key={exercise.id}>
       <td>{exercise.name} <small>Due by {dueDate}</small></td>
-      <ExerciseStatusCell status={exercise_status} sandboxUrl={exercise.sandbox_url}/>
+      <ExerciseStatusCell status={exerciseStatus} sandboxUrl={exercise.sandbox_url}/>
     </tr>
   );
 };
 
 export const ExerciseRows = ({ exercises }) => {
   const { unread, incomplete, complete } = exercises;
-  const all_exercises = [...unread, ...incomplete, ...complete];
+  const allExercises = [...unread, ...incomplete, ...complete];
   return [
-    all_exercises.sort(orderByDueDate).map(generateRow()),
+    allExercises.sort(orderByDueDate).map(generateRow()),
   ];
 };
 

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
@@ -16,22 +16,31 @@ const ExerciseStatusCell = ({ status, sandboxUrl }) => {
 // Helper Functions
 const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);
 
-const generateRow = status => (exercise) => {
+const generateRow = () => (exercise) => {
   const dueDate = moment(exercise.due_date).format('MMM Do, YYYY');
+  const isComplete = exercise.deadline_status === 'complete';
+  const flags = exercise.flags || {};
+  let exercise_status = '';
+  if (isComplete && flags.marked_complete) {
+    exercise_status = 'complete';
+  } else if (isComplete) {
+    exercise_status = 'incomplete';
+  } else {
+    exercise_status = 'unread';
+  }
   return (
-    <tr className="student-training-module" key={exercise.id}>
+    <tr className={exercise.overdue ? 'student-training-module overdue' : 'student-training-module'} key={exercise.id}>
       <td>{exercise.name} <small>Due by {dueDate}</small></td>
-      <ExerciseStatusCell status={status} sandboxUrl={exercise.sandbox_url}/>
+      <ExerciseStatusCell status={exercise_status} sandboxUrl={exercise.sandbox_url}/>
     </tr>
   );
 };
 
 export const ExerciseRows = ({ exercises }) => {
   const { unread, incomplete, complete } = exercises;
+  const all_exercises = [...unread, ...incomplete, ...complete];
   return [
-    unread.sort(orderByDueDate).map(generateRow('unread')),
-    incomplete.sort(orderByDueDate).map(generateRow('incomplete')),
-    complete.sort(orderByDueDate).map(generateRow('complete'))
+    all_exercises.sort(orderByDueDate).map(generateRow()),
   ];
 };
 

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { capitalize } from 'lodash-es';
 import moment from 'moment';
 
+// Helper Functions
+import { getExerciseStatus, isTrainingDue, orderByDueDate } from '@components/students/utils/trainingHelperFunctions';
+
 // Helper Components
 const ExerciseStatusCell = ({ status, sandboxUrl }) => {
   let exerciseLink;
@@ -13,38 +16,11 @@ const ExerciseStatusCell = ({ status, sandboxUrl }) => {
   return <td className={`exercise-status ${status}`}>{capitalize(status)} {exerciseLink}</td>;
 };
 
-// Helper Functions
-const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);
-
-// This function returns the status of exercise
-// returns status as unread/complete/incomplete depending on the deadline status and flags if any
-const getExerciseStatus = (exercise) => {
-  const isComplete = exercise.deadline_status === 'complete';
-  const flags = exercise.flags || {};
-  let status = '';
-  if (isComplete && flags.marked_complete) {
-    status = 'complete';
-  } else if (isComplete) {
-    status = 'incomplete';
-  } else {
-    status = 'unread';
-  }
-  return status;
-};
-
-// This function compares exercise's due date with current date
-// returns true if the current date has not passed the training's due date
-const isExerciseDue = (date) => {
-  const currentDate = new Date();
-  const exerciseDueDate = new Date(Date.parse(date.replace(/-/g, ' ')));
-  return exerciseDueDate >= currentDate;
-};
-
 const generateRow = () => (exercise) => {
   const dueDate = moment(exercise.due_date).format('MMM Do, YYYY');
   const exerciseStatus = getExerciseStatus(exercise);
   return (
-    <tr className={exercise.due_date && isExerciseDue(exercise.due_date) ? 'student-training-module due-training' : 'student-training-module'} key={exercise.id}>
+    <tr className={exercise.due_date && isTrainingDue(exercise.due_date) ? 'student-training-module due-training' : 'student-training-module'} key={exercise.id}>
       <td>{exercise.name} <small>Due by {dueDate}</small></td>
       <ExerciseStatusCell status={exerciseStatus} sandboxUrl={exercise.sandbox_url}/>
     </tr>

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
@@ -34,9 +34,9 @@ const getExerciseStatus = (exercise) => {
 
 // This function compares exercise's due date with current date
 // returns true if the current date has not passed the training's due date
-const isExerciseDue = (exercise) => {
+const isExerciseDue = (date) => {
   const currentDate = new Date();
-  const exerciseDueDate = new Date(Date.parse(exercise.due_date.replace(/-/g, ' ')));
+  const exerciseDueDate = new Date(Date.parse(date.replace(/-/g, ' ')));
   return exerciseDueDate >= currentDate;
 };
 
@@ -44,7 +44,7 @@ const generateRow = () => (exercise) => {
   const dueDate = moment(exercise.due_date).format('MMM Do, YYYY');
   const exerciseStatus = getExerciseStatus(exercise);
   return (
-    <tr className={isExerciseDue(exercise) ? 'student-training-module due-training' : 'student-training-module'} key={exercise.id}>
+    <tr className={exercise.due_date && isExerciseDue(exercise.due_date) ? 'student-training-module due-training' : 'student-training-module'} key={exercise.id}>
       <td>{exercise.name} <small>Due by {dueDate}</small></td>
       <ExerciseStatusCell status={exerciseStatus} sandboxUrl={exercise.sandbox_url}/>
     </tr>

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -2,7 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+// Helper functions
 const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);
+
+// This function compares training's due date with current date
+// returns true if the current date has not passed the training's due date
+const isTrainingDue = (training) => {
+  const currentDate = new Date();
+  const trainingDueDate = new Date(Date.parse(training.due_date.replace(/-/g, ' ')));
+  return trainingDueDate >= currentDate;
+};
 
 export const TrainingModuleRows = ({ trainings }) => {
   trainings.sort(orderByDueDate);
@@ -10,7 +19,6 @@ export const TrainingModuleRows = ({ trainings }) => {
     const momentDueDate = moment(trainingModule.due_date);
     const dueDate = momentDueDate.format('MMM Do, YYYY');
     const overdue = trainingModule.overdue || momentDueDate.endOf('day').isBefore(trainingModule.completion_date);
-
     let moduleStatus;
     if (trainingModule.completion_date) {
       let completionTime = '';
@@ -42,7 +50,7 @@ export const TrainingModuleRows = ({ trainings }) => {
 
 
     return (
-      <tr className={trainingModule.overdue ? 'student-training-module overdue' : 'student-training-module'} key={trainingModule.id}>
+      <tr className={isTrainingDue(trainingModule) ? 'student-training-module due-training' : 'student-training-module'} key={trainingModule.id}>
         <td>{trainingModule.module_name} <small>Due by { dueDate }</small></td>
         <td>
           { moduleStatus }

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -7,9 +7,9 @@ const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 :
 
 // This function compares training's due date with current date
 // returns true if the current date has not passed the training's due date
-const isTrainingDue = (training) => {
+const isTrainingDue = (date) => {
   const currentDate = new Date();
-  const trainingDueDate = new Date(Date.parse(training.due_date.replace(/-/g, ' ')));
+  const trainingDueDate = new Date(Date.parse(date.replace(/-/g, ' ')));
   return trainingDueDate >= currentDate;
 };
 
@@ -50,7 +50,7 @@ export const TrainingModuleRows = ({ trainings }) => {
 
 
     return (
-      <tr className={isTrainingDue(trainingModule) ? 'student-training-module due-training' : 'student-training-module'} key={trainingModule.id}>
+      <tr className={trainingModule.due_date && isTrainingDue(trainingModule.due_date) ? 'student-training-module due-training' : 'student-training-module'} key={trainingModule.id}>
         <td>{trainingModule.module_name} <small>Due by { dueDate }</small></td>
         <td>
           { moduleStatus }

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
+const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);
+
 export const TrainingModuleRows = ({ trainings }) => {
+  trainings.sort(orderByDueDate);
   return trainings.map((trainingModule) => {
     const momentDueDate = moment(trainingModule.due_date);
     const dueDate = momentDueDate.format('MMM Do, YYYY');
@@ -39,7 +42,7 @@ export const TrainingModuleRows = ({ trainings }) => {
 
 
     return (
-      <tr className="student-training-module" key={trainingModule.id}>
+      <tr className={trainingModule.overdue ? 'student-training-module overdue' : 'student-training-module'} key={trainingModule.id}>
         <td>{trainingModule.module_name} <small>Due by { dueDate }</small></td>
         <td>
           { moduleStatus }

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingModuleRows.jsx
@@ -2,16 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-// Helper functions
-const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);
-
-// This function compares training's due date with current date
-// returns true if the current date has not passed the training's due date
-const isTrainingDue = (date) => {
-  const currentDate = new Date();
-  const trainingDueDate = new Date(Date.parse(date.replace(/-/g, ' ')));
-  return trainingDueDate >= currentDate;
-};
+// Helper Functions
+import { isTrainingDue, orderByDueDate } from '@components/students/utils/trainingHelperFunctions';
 
 export const TrainingModuleRows = ({ trainings }) => {
   trainings.sort(orderByDueDate);

--- a/app/assets/javascripts/components/students/utils/trainingHelperFunctions.js
+++ b/app/assets/javascripts/components/students/utils/trainingHelperFunctions.js
@@ -1,0 +1,29 @@
+import { Date } from 'core-js';
+import moment from 'moment';
+
+// This function returns the status of exercise
+// returns status as unread/complete/incomplete depending on the deadline status and flags if any
+export const getExerciseStatus = (exercise) => {
+  const isComplete = exercise.deadline_status === 'complete';
+  const flags = exercise.flags || {};
+  let status = '';
+  if (isComplete && flags.marked_complete) {
+    status = 'complete';
+  } else if (isComplete) {
+    status = 'incomplete';
+  } else {
+    status = 'unread';
+  }
+  return status;
+};
+
+// This function compares training's due date with current date
+// returns true if the current date has not passed the training's due date
+export const isTrainingDue = (date) => {
+  const currentDate = new Date();
+  const trainingDueDate = new Date(Date.parse(date.replace(/-/g, ' ')));
+  return trainingDueDate >= currentDate;
+};
+
+// This is a sorting function that returns the earlier training of the two inputs
+export const orderByDueDate = (a, b) => (moment(a.due_date).isBefore(b.due_date) ? -1 : 1);

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -225,8 +225,8 @@
 
   // Give nested tables darker row colors
   > tbody
-    > tr
-      background-color #F9F9F9
+    > tr.overdue
+      background-color #f0f0f0
 
   &:first-child
     margin-bottom 0

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -225,7 +225,7 @@
 
   // Give nested tables darker row colors
   > tbody
-    > tr.overdue
+    > tr.due-training
       background-color #f0f0f0
 
   &:first-child


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >
fix #4359 

1. Exercises and trainings should be sorted by due date.
2. Exercises/Training with overdue property true should be shown with different background color.

## Screenshots
Before:
< add a screenshot of the UI before your change >
![unsorted_trainings](https://user-images.githubusercontent.com/56123141/110696241-d59f3300-8210-11eb-9d14-d6a01d5a3aef.png)


After:
< add a screenshot of the UI after your change >
![sorted_trainings_and_overdue_color_change](https://user-images.githubusercontent.com/56123141/110696271-dfc13180-8210-11eb-9e80-c7d65a660da2.png)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
