### PR TITLE
Speed up UpdateCourseStats by 12-30%

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ gem 'rack-mini-profiler'
 gem 'stackprof'
 
 group :development do
+  gem 'stackprof'
   gem 'better_errors'
   gem 'binding_of_caller', platforms: [:mri_21]
   gem 'guard-bundler'

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -82,7 +82,7 @@ class ArticlesCourses < ApplicationRecord
   def views_since_earliest_revision(revisions)
     return if revisions.blank?
     return if article.average_views.nil?
-    days = (Time.now.utc.to_date - revisions.min { |a,b| a.date <=> b.date }.date.to_date).to_i
+    days = (Time.now.utc.to_date - revisions.min_by(&:date).date.to_date).to_i
     days * article.average_views
   end
 

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -64,9 +64,9 @@ class ArticlesCourses < ApplicationRecord
   end
 
   def update_cache
-    revisions = live_manual_revisions
+    revisions = live_manual_revisions.load
 
-    self.character_sum = revisions.where('characters >= 0').sum(:characters)
+    self.character_sum = revisions.select { |r| r.characters >= 0 }.sum(&:characters)
     self.references_count = revisions.sum(&:references_added)
     self.view_count = views_since_earliest_revision(revisions)
     self.user_ids = associated_user_ids(revisions)
@@ -80,14 +80,14 @@ class ArticlesCourses < ApplicationRecord
   end
 
   def views_since_earliest_revision(revisions)
-    return if revisions.empty?
+    return if revisions.blank?
     return if article.average_views.nil?
-    days = (Time.now.utc.to_date - revisions.order('date ASC').first.date.to_date).to_i
+    days = (Time.now.utc.to_date - revisions.min { |a,b| a.date <=> b.date }.date.to_date).to_i
     days * article.average_views
   end
 
   def associated_user_ids(revisions)
-    return [] if revisions.empty?
+    return [] if revisions.blank?
     revisions.map(&:user_id).compact.uniq
   end
 

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -66,7 +66,7 @@ class ArticlesCourses < ApplicationRecord
   def update_cache
     revisions = live_manual_revisions.load
 
-    self.character_sum = revisions.select { |r| r.characters >= 0 }.sum(&:characters)
+    self.character_sum = revisions.sum { |r| r.characters >= 0 ? r.characters : 0 }
     self.references_count = revisions.sum(&:references_added)
     self.view_count = views_since_earliest_revision(revisions)
     self.user_ids = associated_user_ids(revisions)

--- a/benchmarks/cuwbench.rb
+++ b/benchmarks/cuwbench.rb
@@ -1,34 +1,35 @@
 #!/usr/bin/env rails runner
+# frozen_string_literal: true
 
 puts "This benchmark WILL WIPE YOUR DATABASE. You must enter 'WIPE' to continue."
 input = gets.chomp
-exit(1) unless input == "WIPE"
+exit(1) unless input == 'WIPE'
 
 WikiEduDashboard::Application.load_tasks
-Rake::Task["db:reset"].invoke
+Rake::Task['db:reset'].invoke
 
 require "#{Rails.root}/setup/populate_dashboard"
-puts "Copying benchmark course..."
-make_copy_of "https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wikidata_Taster_(Saturday_6th_March_2021)"
+puts 'Copying benchmark course...'
+make_copy_of 'https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wikidata_Taster_(Saturday_6th_March_2021)'
 @course = Course.first
-puts "Warmup..."
+
+puts 'Warmup...'
 ActiveRecord::Base.transaction do
   # Warmup
   UpdateCourseStats.new(@course)
   raise ActiveRecord::Rollback
 end
 
-
-puts "### GC state"
+puts '### GC state'
 
 puts GC.stat
 
-raise unless Article.count == 0
+raise unless Article.count.zero?
 
-puts "### Cold Database"
+puts '### Cold Database'
 result = Benchmark.measure do
   10.times do
-    printf(".")
+    printf('.')
     ActiveRecord::Base.transaction do
       UpdateCourseStats.new(@course)
       raise ActiveRecord::Rollback
@@ -37,20 +38,19 @@ result = Benchmark.measure do
 end
 puts result
 
-raise unless Article.count == 0
+raise unless Article.count.zero?
 
-puts "### Hot Database"
+puts '### Hot Database'
 
 ActiveRecord::Base.transaction do
   UpdateCourseStats.new(@course)
 
   result = Benchmark.measure do
     10.times do
-      printf(".")
+      printf('.')
       UpdateCourseStats.new(@course)
     end
   end
   puts result
   raise ActiveRecord::Rollback
 end
-

--- a/benchmarks/cuwbench.rb
+++ b/benchmarks/cuwbench.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env rails runner
+
+puts "This benchmark WILL WIPE YOUR DATABASE. You must enter 'WIPE' to continue."
+input = gets.chomp
+exit(1) unless input == "WIPE"
+
+WikiEduDashboard::Application.load_tasks
+Rake::Task["db:reset"].invoke
+
+require "#{Rails.root}/setup/populate_dashboard"
+puts "Copying benchmark course..."
+make_copy_of "https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wikidata_Taster_(Saturday_6th_March_2021)"
+@course = Course.first
+puts "Warmup..."
+ActiveRecord::Base.transaction do
+  # Warmup
+  UpdateCourseStats.new(@course)
+  raise ActiveRecord::Rollback
+end
+
+
+puts "### GC state"
+
+puts GC.stat
+
+raise unless Article.count == 0
+
+puts "### Cold Database"
+result = Benchmark.measure do
+  10.times do
+    printf(".")
+    ActiveRecord::Base.transaction do
+      UpdateCourseStats.new(@course)
+      raise ActiveRecord::Rollback
+    end
+  end
+end
+puts result
+
+raise unless Article.count == 0
+
+puts "### Hot Database"
+
+ActiveRecord::Base.transaction do
+  UpdateCourseStats.new(@course)
+
+  result = Benchmark.measure do
+    10.times do
+      printf(".")
+      UpdateCourseStats.new(@course)
+    end
+  end
+  puts result
+  raise ActiveRecord::Rollback
+end
+

--- a/benchmarks/cuwprofile.rb
+++ b/benchmarks/cuwprofile.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env rails runner
+
+puts "This profile WILL WIPE YOUR DATABASE. You must enter 'WIPE' to continue."
+input = gets.chomp
+exit(1) unless input == "WIPE"
+
+WikiEduDashboard::Application.load_tasks
+Rake::Task["db:reset"].invoke
+
+require "#{Rails.root}/setup/populate_dashboard"
+puts "Copying benchmark course..."
+make_copy_of "https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wikidata_Taster_(Saturday_6th_March_2021)"
+@course = Course.first
+
+profile = StackProf.run(mode: :wall, raw: true, interval: 10000) do
+  UpdateCourseStats.new(@course)
+end
+
+# Drag this file into https://speedscope.app
+File.open("profile.json", 'w') { |f| f.puts(JSON.dump(profile)) }

--- a/benchmarks/cuwprofile.rb
+++ b/benchmarks/cuwprofile.rb
@@ -1,15 +1,16 @@
 #!/usr/bin/env rails runner
+# frozen_string_literal: true
 
 puts "This profile WILL WIPE YOUR DATABASE. You must enter 'WIPE' to continue."
 input = gets.chomp
-exit(1) unless input == "WIPE"
+exit(1) unless input == 'WIPE'
 
 WikiEduDashboard::Application.load_tasks
-Rake::Task["db:reset"].invoke
+Rake::Task['db:reset'].invoke
 
 require "#{Rails.root}/setup/populate_dashboard"
-puts "Copying benchmark course..."
-make_copy_of "https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wikidata_Taster_(Saturday_6th_March_2021)"
+puts 'Copying benchmark course...'
+make_copy_of 'https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wikidata_Taster_(Saturday_6th_March_2021)'
 @course = Course.first
 
 profile = StackProf.run(mode: :wall, raw: true, interval: 10000) do
@@ -17,4 +18,4 @@ profile = StackProf.run(mode: :wall, raw: true, interval: 10000) do
 end
 
 # Drag this file into https://speedscope.app
-File.open("profile.json", 'w') { |f| f.puts(JSON.dump(profile)) }
+File.open('profile.json', 'w') { |f| f.puts(JSON.dump(profile)) }

--- a/lib/importers/average_views_importer.rb
+++ b/lib/importers/average_views_importer.rb
@@ -11,35 +11,28 @@ class AverageViewsImporter
     update_average_views(to_update)
   end
 
-  # We get some 429 / too many requests errors with 8 per batch.
-  ARTICLES_PER_BATCH = 3
+  # We get some 429 / too many requests errors with 8
+  MAX_HTTP_CONCURRENCY = 3
   def self.update_average_views(articles)
-    article_batches = articles.includes(:wiki).each_slice(ARTICLES_PER_BATCH)
-    article_batches.each do |batch|
-      update_average_views_for_batch batch
+    pool = Concurrent::FixedThreadPool.new(MAX_HTTP_CONCURRENCY)
+    average_views = Concurrent::Hash.new
+    time = Time.zone.today
+
+    # Get the average views data and put it into a concurrency-safe datastructure
+    articles.includes(:wiki).each do |article|
+      pool.post { update_average_views_for_batch(article, average_views, time) }
     end
+
+    pool.shutdown && pool.wait_for_termination # Block here until pool is done.
+
+    # Now, take all the average views and save them to the DB in one fell swoop!
+    Article.update(average_views.keys, average_views.values)
   end
 
-  def self.update_average_views_for_batch(articles)
-    average_views = {}
-    threads = articles.each_with_index.map do |article, i|
-      Thread.new(i) do
-        average_views[article.id] = WikiPageviews.new(article).average_views
-      end
-    end
-    threads.each(&:join)
-
-    datestamp = Time.zone.today
-    save_updated_average_views(articles, average_views, datestamp)
-  end
-
-  def self.save_updated_average_views(articles, average_views, average_views_updated_at)
-    Article.transaction do
-      articles.each do |article|
-        article.average_views_updated_at = average_views_updated_at
-        article.average_views = average_views[article.id]
-        article.save
-      end
-    end
+  def self.update_average_views_for_batch(article, average_views, time)
+    average_views[article.id] = {
+      average_views: WikiPageviews.new(article).average_views,
+      average_views_updated_at: time
+    }
   end
 end

--- a/lib/importers/average_views_importer.rb
+++ b/lib/importers/average_views_importer.rb
@@ -20,7 +20,7 @@ class AverageViewsImporter
 
     # Get the average views data and put it into a concurrency-safe datastructure
     articles.includes(:wiki).each do |article|
-      pool.post { update_average_views_for_batch(article, average_views, time) }
+      pool.post { update_average_views_for_article(article, average_views, time) }
     end
 
     pool.shutdown && pool.wait_for_termination # Block here until pool is done.
@@ -29,7 +29,7 @@ class AverageViewsImporter
     Article.update(average_views.keys, average_views.values)
   end
 
-  def self.update_average_views_for_batch(article, average_views, time)
+  def self.update_average_views_for_article(article, average_views, time)
     average_views[article.id] = {
       average_views: WikiPageviews.new(article).average_views,
       average_views_updated_at: time

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -95,43 +95,18 @@ class RevisionImporter
   def import_revisions_slice(sub_data)
     @articles, @revisions = [], []
 
-    # Extract all article data from the slice
-    articles = sub_data.map do |_a_id, article_data|
-      {
-        "mw_page_id" => article_data['article']['mw_page_id'],
-        "wiki_id" => @wiki.id,
-        "title" => sanitize_4_byte_titles(article_data['article']['title']),
-        "namespace" => article_data['article']['namespace'],
-      }
-    end
-    Article.import articles, on_duplicate_key_update: [:title, :namespace] # We rely on the unique index here
-    @articles = Article.where(mw_page_id: articles.map { |a| a["mw_page_id"]})
+    # Extract all article data from the slice. Outputs a hash with article attrs.
+    articles = sub_data_to_article_attributes(sub_data)
+
+    # We rely on the unique index here
+    Article.import articles, on_duplicate_key_update: [:title, :namespace]
+    @articles = Article.where(mw_page_id: articles.map { |a| a['mw_page_id'] })
 
     # Prep: get a user dictionary for all users referred to by revisions.
-    users = sub_data.map do |_a_id, article_data|
-      article_data['revisions'].map { |rev_data| rev_data["username"] }
-    end
-    users.flatten!
-    users.uniq!
-    users = User.where(username: users)
+    users = user_dict_from_sub_data(sub_data)
 
     # Now get all the revisions
-    revisions = sub_data.map do |_a_id, article_data|
-      article_data['revisions'].map { |rev_data|
-        mw_page_id = rev_data["mw_page_id"].to_i
-        {
-          mw_rev_id: rev_data['mw_rev_id'],
-          date: rev_data['date'],
-          characters: rev_data['characters'],
-          article_id: @articles.find { |a| a.mw_page_id == mw_page_id}&.id,
-          mw_page_id: rev_data['mw_page_id'],
-          user_id: users.find { |u| u.username == rev_data["username"]}&.id,
-          new_article: string_to_boolean(rev_data['new_article']),
-          system: string_to_boolean(rev_data['system']),
-          wiki_id: rev_data['wiki_id']
-        }
-      }
-    end
+    revisions = sub_data_to_revision_attributes(sub_data, users)
     revisions.flatten!
     Revision.import revisions, on_duplicate_key_ignore: true
 
@@ -148,10 +123,49 @@ class RevisionImporter
   end
 
   def sanitize_4_byte_titles(title)
-    if title.chars.any? {|c| c.bytes.count >= 4 }
+    if title.chars.any? { |c| c.bytes.count >= 4 }
       CGI.escape(title)
     else
       title
+    end
+  end
+
+  def sub_data_to_article_attributes(sub_data)
+    sub_data.map do |_a_id, article_data|
+      {
+        'mw_page_id' => article_data['article']['mw_page_id'],
+        'wiki_id' => @wiki.id,
+        'title' => sanitize_4_byte_titles(article_data['article']['title']),
+        'namespace' => article_data['article']['namespace']
+      }
+    end
+  end
+
+  def user_dict_from_sub_data(sub_data)
+    sub_data.map do |_a_id, article_data|
+      article_data['revisions'].map { |rev_data| rev_data['username'] }
+    end
+    users.flatten!
+    users.uniq!
+    User.where(username: users)
+  end
+
+  def sub_data_to_revision_attributes(sub_data, users)
+    sub_data.map do |_a_id, article_data|
+      article_data['revisions'].map do |rev_data|
+        mw_page_id = rev_data['mw_page_id'].to_i
+        {
+          mw_rev_id: rev_data['mw_rev_id'],
+          date: rev_data['date'],
+          characters: rev_data['characters'],
+          article_id: @articles.find { |a| a.mw_page_id == mw_page_id }&.id,
+          mw_page_id: mw_page_id,
+          user_id: users.find { |u| u.username == rev_data['username'] }&.id,
+          new_article: string_to_boolean(rev_data['new_article']),
+          system: string_to_boolean(rev_data['system']),
+          wiki_id: rev_data['wiki_id']
+        }
+      end
     end
   end
 end

--- a/lib/importers/revision_importer.rb
+++ b/lib/importers/revision_importer.rb
@@ -142,7 +142,7 @@ class RevisionImporter
   end
 
   def user_dict_from_sub_data(sub_data)
-    sub_data.map do |_a_id, article_data|
+    users = sub_data.map do |_a_id, article_data|
       article_data['revisions'].map { |rev_data| rev_data['username'] }
     end
     users.flatten!


### PR DESCRIPTION
## What this PR does

As identified earlier, UpdateCourseStats is a major generator of load on Wiki Ed servers. Speeding it up has the potential to decrease load on Wiki Ed servers, or at least to increase throughput of the CourseUpdateWorker job so that courses can be updated more frequently.

In addition, this pull request greatly reduces database load by translating many N+1s into single queries, primarily updating or inserting many rows at once.

There are three improvements:

1. Improving concurrency of average view update by using a `FixedThreadPool`.
2. Fixing an N+1 with Articles/Revisions/Users, and batching them into bigger updates.
3. Fixing an N+1 with ArticleCourses, which went to the Revisions table multiple times (now it only goes once).

## Results

Speed increase of 12-30% depending on scenario. Peak memory usage is unaffected.

Before:
```
### GC state
{:count=>57, :heap_allocated_pages=>1526, :heap_sorted_length=>1526, :heap_allocatable_pages=>0, :heap_available_slots=>621987, :heap_live_slots=>621336, :heap_free_slots=>651, :heap_final_slots=>0, :heap_marked_slots=>473255, :heap_eden_pages=>1526, :heap_tomb_pages=>0, :total_allocated_pages=>1526, :total_freed_pages=>0, :total_allocated_objects=>3899135, :total_freed_objects=>3277799, :malloc_increase_bytes=>156704, :malloc_increase_bytes_limit=>22404975, :minor_gc_count=>48, :major_gc_count=>9, :compact_count=>0, :remembered_wb_unprotected_objects=>5018, :remembered_wb_unprotected_objects_limit=>7568, :old_objects=>464894, :old_objects_limit=>725014, :oldmalloc_increase_bytes=>6939056, :oldmalloc_increase_bytes_limit=>22765743}
### Cold Database
.......... 26.341452   1.252287  27.593739 (195.683865)
### Hot Database
..........  7.663174   0.415003   8.078177 ( 24.650678)
```

After:

```
### GC state
{:count=>54, :heap_allocated_pages=>1537, :heap_sorted_length=>1537, :heap_allocatable_pages=>0, :heap_available_slots=>626487, :heap_live_slots=>625600, :heap_free_slots=>887, :heap_final_slots=>0, :heap_marked_slots=>456201, :heap_eden_pages=>1537, :heap_tomb_pages=>0, :total_allocated_pages=>1537, :total_freed_pages=>0, :total_allocated_objects=>3541208, :total_freed_objects=>2915608, :malloc_increase_bytes=>211984, :malloc_increase_bytes_limit=>16777216, :minor_gc_count=>45, :major_gc_count=>9, :compact_count=>0, :remembered_wb_unprotected_objects=>4622, :remembered_wb_unprotected_objects_limit=>7740, :old_objects=>448328, :old_objects_limit=>729816, :oldmalloc_increase_bytes=>6810416, :oldmalloc_increase_bytes_limit=>22765743}
### Cold Database
.......... 21.863503   0.948639  22.812142 (136.959312)
### Hot Database
..........  6.106491   0.249173   6.355664 ( 21.941323)
```

## Open questions and concerns

Speedscope profiler output afterward:

<img width="1411" alt="Screen Shot 2021-03-11 at 3 38 11 PM" src="https://user-images.githubusercontent.com/845662/110864808-dcb15a00-827f-11eb-8975-c4ae6cf07da2.png">

After this PR, this task spends ~10% of total on importing revisions, 60% on revision score updating, 20% on average views, 5% updating caches and 5% on other.

Further improvements to this job would probably be:

1. Moving the revision score updating into its own job and queue. This queue would be serviced by a single Sidekiq process with `concurrency: 4`. This will ensure maximum throughput while not exceeding the ORES API concurrency limit of 4.
2. Doing the same with average views updating, though probably with far more aggressive concurrency.
3. Refactoring this process into many smaller jobs, which then updates the cache at the end. Perhaps a Sidekiq Batch? This would allow us to parallelize parts of the task that can be parallelized. Multinode is probably a higher priority than this though, because for now, at least on global, CPU is maxed out, so parallelizing does not buy additional throughput.
