### PR TITLE
Move Campaign CSV generation to background workers

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -182,13 +182,15 @@ class CampaignsController < ApplicationController
     csv_for_role(:instructors)
   end
 
+  CSV_PUBLIC_PATH = '/system/analytics'
+
   def courses
     filename = "#{@campaign.slug}-courses-#{Time.zone.today}.csv"
-    respond_to do |format|
-      format.csv do
-        send_data CampaignCsvBuilder.new(@campaign).courses_to_csv,
-                  filename: filename
-      end
+    if File.exist? "public/#{CSV_PUBLIC_PATH}/#{filename}"
+      redirect_to "#{CSV_PUBLIC_PATH}/#{filename}"
+    else
+      CampaignCsvWorker.generate_csv(campaign: @campaign, filename: filename, type: 'courses')
+      render plain: 'This file is being generated. Please try back in a few minutes.', status: :ok
     end
   end
 

--- a/app/workers/campaign_csv_worker.rb
+++ b/app/workers/campaign_csv_worker.rb
@@ -6,14 +6,18 @@ class CampaignCsvWorker
   include Sidekiq::Worker
   sidekiq_options unique: :until_executed
 
-  def self.generate_csv(campaign:, filename:, type:)
-    perform_async(campaign.id, filename, type)
+  def self.generate_csv(campaign:, filename:, type:, include_course:)
+    perform_async(campaign.id, filename, type, include_course)
   end
 
-  def perform(campaign_id, filename, type)
+  def perform(campaign_id, filename, type, include_course)
     campaign = Campaign.find(campaign_id)
     builder = CampaignCsvBuilder.new(campaign)
     data = case type
+           when 'instructors'
+             campaign.users_to_csv(:instructors, course: include_course)
+           when 'students'
+             campaign.users_to_csv(:students, course: include_course)
            when 'courses'
              builder.courses_to_csv
            when 'articles'

--- a/app/workers/campaign_csv_worker.rb
+++ b/app/workers/campaign_csv_worker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require_dependency "#{Rails.root}/lib/analytics/campaign_csv_builder"
+
+class CampaignCsvWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def self.generate_csv(campaign:, filename:, type:)
+    perform_async(campaign.id, filename, type)
+  end
+
+  CSV_PATH = 'public/system/analytics'
+
+  def perform(campaign_id, filename, type)
+    campaign = Campaign.find(campaign_id)
+    builder = CampaignCsvBuilder.new(campaign)
+    data = case type
+           when 'courses'
+             builder.courses_to_csv
+           when 'articles'
+             builder.articles_to_csv
+           when 'revisions'
+             builder.revisions_to_csv
+           end
+
+    File.write "#{CSV_PATH}/#{filename}", data
+    # TODO: schedule deletion of file 1 week later
+  end
+end

--- a/app/workers/campaign_csv_worker.rb
+++ b/app/workers/campaign_csv_worker.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_dependency "#{Rails.root}/lib/analytics/campaign_csv_builder"
+require_dependency "#{Rails.root}/app/workers/csv_cleanup_worker"
 
 class CampaignCsvWorker
   include Sidekiq::Worker
@@ -8,8 +9,6 @@ class CampaignCsvWorker
   def self.generate_csv(campaign:, filename:, type:)
     perform_async(campaign.id, filename, type)
   end
-
-  CSV_PATH = 'public/system/analytics'
 
   def perform(campaign_id, filename, type)
     campaign = Campaign.find(campaign_id)
@@ -23,7 +22,8 @@ class CampaignCsvWorker
              builder.revisions_to_csv
            end
 
-    File.write "#{CSV_PATH}/#{filename}", data
-    # TODO: schedule deletion of file 1 week later
+    File.write "public#{CampaignsController::CSV_PATH}/#{filename}", data
+
+    CsvCleanupWorker.perform_at(1.week.from_now, filename)
   end
 end

--- a/app/workers/campaign_csv_worker.rb
+++ b/app/workers/campaign_csv_worker.rb
@@ -26,8 +26,14 @@ class CampaignCsvWorker
              builder.revisions_to_csv
            end
 
-    File.write "public#{CampaignsController::CSV_PATH}/#{filename}", data
-
+    write_csv(filename, data)
     CsvCleanupWorker.perform_at(1.week.from_now, filename)
+  end
+
+  private
+
+  def write_csv(filename, data)
+    FileUtils.mkdir_p "public#{CampaignsController::CSV_PATH}"
+    File.write "public#{CampaignsController::CSV_PATH}/#{filename}", data
   end
 end

--- a/app/workers/csv_cleanup_worker.rb
+++ b/app/workers/csv_cleanup_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CsvCleanupWorker
+  include Sidekiq::Worker
+
+  def perform(filename)
+    File.delete "public#{CampaignsController::CSV_PATH}/#{filename}"
+  end
+end

--- a/lib/analytics/campaign_csv_builder.rb
+++ b/lib/analytics/campaign_csv_builder.rb
@@ -4,6 +4,7 @@ require 'csv'
 require_dependency "#{Rails.root}/lib/analytics/course_csv_builder"
 require_dependency "#{Rails.root}/lib/analytics/course_articles_csv_builder"
 require_dependency "#{Rails.root}/lib/analytics/course_revisions_csv_builder"
+require_dependency "#{Rails.root}/app/workers/campaign_csv_worker"
 
 class CampaignCsvBuilder
   def initialize(campaign)


### PR DESCRIPTION
@nateberkopec discovered that generating CSVs for campaigns was the likely main cause of the Apache queue filling up today, causing Programs & Events Dashboard to be briefly unavailable until I reset the server.

<img width="589" alt="Screen Shot 2021-03-11 at 12 09 52 PM" src="https://user-images.githubusercontent.com/848483/110885729-3c1d6300-829c-11eb-995e-411980908426.png">

This change pushes those expensive operations to a Sidekiq queue, directing the user to check back soon if the file hasn't been generated yet.

We'll need to monitor this to make sure it's behaving well in production and the files are eventually getting deleted.