### PR TITLE
Add queue latency for Sidekiq jobs in NR

### DIFF
--- a/config/initializers/nr_sidekiq_queue_latency.rb
+++ b/config/initializers/nr_sidekiq_queue_latency.rb
@@ -1,0 +1,13 @@
+class NewRelicQueueLatencyLogger
+  def call(worker, job, queue)
+    queue_latency = Time.now.utc - Time.at(job["enqueued_at"], in: "+00:00")
+    ::NewRelic::Agent.add_custom_attributes({ queue_latency: queue_latency, queue: queue })
+    yield
+  end
+end
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add NewRelicQueueLatencyLogger
+  end
+end


### PR DESCRIPTION
I'm not sure if this or New Relic "custom metrics" is the best way to go, but we'll see.

Tested locally, jobs run without any problem 👍 

This is part of my plan for understanding and addressing queue configuration.