### PR TITLE
Add rack-mini-profiler in development and production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,10 @@ gem 'rb-readline', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'griddler'
 gem 'griddler-mailgun'
 
+### Performance
+gem 'rack-mini-profiler'
+gem 'stackprof'
+
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller', platforms: [:mri_21]
@@ -105,6 +109,7 @@ group :development do
   gem 'rails-erd'
   gem 'annotate' # Generates automatic schema notations on model files
   gem 'faker', require: false # Generates random data for example records
+  gem 'memory_profiler' # Unsafe for production use
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,7 @@ GEM
       rest-client (~> 2.0.2)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    memory_profiler (1.0.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -350,6 +351,8 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-mini-profiler (2.3.1)
+      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.4)
@@ -508,6 +511,7 @@ GEM
     sshkit (1.21.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.16)
     temple (0.8.2)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
@@ -521,6 +525,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
     validates_email_format_of (1.6.3)
       i18n
@@ -588,6 +593,7 @@ DEPENDENCIES
   jbuilder
   mailgun-ruby
   mediawiki_api!
+  memory_profiler
   mysql2
   newrelic_rpm
   nokogiri
@@ -602,6 +608,7 @@ DEPENDENCIES
   pry-rails
   puma
   rack-cors
+  rack-mini-profiler
   rails (= 6.0.3.4)
   rails-controller-testing
   rails-erd
@@ -628,6 +635,7 @@ DEPENDENCIES
   simple_form
   simplecov
   skylight
+  stackprof
   ticket_dispenser!
   tzinfo-data
   validates_email_format_of

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
   before_action :check_onboarded
   before_action :set_locale
   before_action :set_paper_trail_whodunnit
+  before_action :authorize_rmp
 
   def after_sign_out_path_for(_resource_or_scope)
     '/'
@@ -81,6 +82,12 @@ class ApplicationController < ActionController::Base
   def check_for_unsupported_browser
     supported = !browser.ie?
     flash[:notice] = t('error.unsupported_browser.explanation') unless supported
+  end
+
+  def authorize_rmp
+    if current_user && current_user.super_admin?
+      Rack::MiniProfiler.authorize_request
+    end
   end
 
   def course_slug_path(slug, args={})

--- a/config/initializers/rmp.rb
+++ b/config/initializers/rmp.rb
@@ -1,0 +1,6 @@
+if Rails.env.production?
+  Rack::MiniProfiler.config.storage_options = { url: "localhost:11211" }
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemcacheStore
+else
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore
+end


### PR DESCRIPTION
This could be improved by adding [a call to the RMP javascript when React changes routes](https://github.com/MiniProfiler/rack-mini-profiler#using-in-spa-applications) but I'm not experienced enough w/React to figure that out.

If you find this annoying in production, [you can disable it's visibility with the `start_hidden` option.](https://github.com/MiniProfiler/rack-mini-profiler#configuration-options)