### PR TITLE
Removed option for adding follow ups from text-type questions

### DIFF
--- a/app/views/rapidfire/questions/_form.html.haml
+++ b/app/views/rapidfire/questions/_form.html.haml
@@ -73,7 +73,7 @@
             = f.label :placeholder_text, "Placeholder text for dropdown input"
             %br/
             = f.text_area :placeholder_text, rows: 1
-        %div
+        %div{"data-question-type-options" => "Radio, Checkbox, Select, Numeric, RangeInput, Date, Long,Short"}
           %label
             <input type='checkbox' #{question_form_has_follow_up_question(@question_form) ? "checked" : ""} data-follow-up-question-checkbox />
             Add follow up question


### PR DESCRIPTION
I removed follow-ups from text questions with one line of code to fix minor bug  #4592 (On Survey Results view, follow-up answers to Text-type questions are not shown).

I deleted the previously created branch and pull request because it was easier to start over than to return ymls and schema to the original state.

Before:
![flw](https://user-images.githubusercontent.com/65791349/137200241-70bd7300-8219-48bc-89a4-5d3e8c01f1e7.png)

After:
![flw1](https://user-images.githubusercontent.com/65791349/137200314-e56cfe08-9d0c-49d1-8632-c3a287d4d96b.png)

For the other types of questions, Data, for example, follow-ups are displayed
![flw2](https://user-images.githubusercontent.com/65791349/137200322-66fc48a5-e36c-4f4e-a1e8-8d988afa3ced.png)
: