### PR TITLE
Select only tracked wikis

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -17,7 +17,7 @@ import { fetchCategoryResults, fetchKeywordResults, updateFields, sortArticleFin
 import { fetchAssignments, addAssignment, deleteAssignment } from '../../actions/assignment_actions.js';
 import { getFilteredArticleFinder } from '../../selectors';
 
-import { formatOption } from '../../utils/wiki_utils';
+import { trackedWikisMaker } from '../../utils/wiki_utils';
 
 const ArticleFinder = createReactClass({
   getDefaultProps() {
@@ -376,13 +376,7 @@ const ArticleFinder = createReactClass({
       );
     }
 
-    let trackedWikis = [];
-    if (this.props.course.wikis) {
-      trackedWikis = this.props.course.wikis.map((wiki) => {
-        wiki.language = wiki.language || 'www'; // for multilingual wikis language is null
-        return formatOption(wiki);
-      });
-    }
+    const trackedWikis = trackedWikisMaker(this.props.course);
 
     const options = (
       <SelectedWikiOption

--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -17,6 +17,8 @@ import { fetchCategoryResults, fetchKeywordResults, updateFields, sortArticleFin
 import { fetchAssignments, addAssignment, deleteAssignment } from '../../actions/assignment_actions.js';
 import { getFilteredArticleFinder } from '../../selectors';
 
+import { formatOption } from '../../utils/wiki_utils';
+
 const ArticleFinder = createReactClass({
   getDefaultProps() {
     return {
@@ -374,13 +376,24 @@ const ArticleFinder = createReactClass({
       );
     }
 
+    let trackedWikis = [];
+    if (this.props.course.wikis) {
+      trackedWikis = this.props.course.wikis.map((wiki) => {
+        wiki.language = wiki.language || 'www'; // for multilingual wikis language is null
+        return formatOption(wiki);
+      });
+    }
+
     const options = (
       <SelectedWikiOption
         language={this.props.home_wiki.language}
         project={this.props.home_wiki.project}
         handleWikiChange={this.handleWikiChange}
+        trackedWikis={trackedWikis}
       />
     );
+
+
 
     return (
       <div className="container">

--- a/app/assets/javascripts/components/assignments/new_assignment_input.jsx
+++ b/app/assets/javascripts/components/assignments/new_assignment_input.jsx
@@ -3,7 +3,7 @@ import SelectedWikiOption from '../common/selected_wiki_option';
 
 const NewAssignmentInput = ({
   language, project, title,
-  assign, handleChangeTitle, handleWikiChange
+  assign, handleChangeTitle, handleWikiChange, trackedWikis
 }) => (
   <form onSubmit={assign}>
     <input
@@ -17,6 +17,7 @@ const NewAssignmentInput = ({
       language={language}
       project={project}
       handleWikiChange={handleWikiChange}
+      trackedWikis={trackedWikis}
     />
   </form>
 );

--- a/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
@@ -12,7 +12,7 @@ import AddAvailableArticles from '../../articles/add_available_articles';
 import NewAssignmentInput from '../../assignments/new_assignment_input';
 import { ASSIGNED_ROLE, REVIEWING_ROLE } from '~/app/assets/javascripts/constants';
 import SelectedWikiOption from '../selected_wiki_option';
-import { formatOption } from '../../../utils/wiki_utils';
+import { trackedWikisMaker } from '../../../utils/wiki_utils';
 
 // Helper Components
 // Button to show the static list
@@ -409,13 +409,7 @@ export class AssignButton extends React.Component {
       );
     }
 
-    let trackedWikis = [];
-    if (this.props.course.wikis) {
-     trackedWikis = this.props.course.wikis.map((wiki) => {
-        wiki.language = wiki.language || 'www'; // for multilingual wikis language is null
-        return formatOption(wiki);
-      });
-    }
+    const trackedWikis = trackedWikisMaker(this.props.course);
 
     let editRow;
     if (permitted) {

--- a/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
@@ -12,6 +12,7 @@ import AddAvailableArticles from '../../articles/add_available_articles';
 import NewAssignmentInput from '../../assignments/new_assignment_input';
 import { ASSIGNED_ROLE, REVIEWING_ROLE } from '~/app/assets/javascripts/constants';
 import SelectedWikiOption from '../selected_wiki_option';
+import { formatOption } from '../../../utils/wiki_utils';
 
 // Helper Components
 // Button to show the static list
@@ -408,6 +409,14 @@ export class AssignButton extends React.Component {
       );
     }
 
+    let trackedWikis = [];
+    if (this.props.course.wikis) {
+     trackedWikis = this.props.course.wikis.map((wiki) => {
+        wiki.language = wiki.language || 'www'; // for multilingual wikis language is null
+        return formatOption(wiki);
+      });
+    }
+
     let editRow;
     if (permitted) {
       let assignmentInput;
@@ -419,6 +428,7 @@ export class AssignButton extends React.Component {
             <br />
             <SelectedWikiOption
               language={this.state.language}
+              trackedWikis={trackedWikis}
               project={this.state.project}
               handleWikiChange={this.handleWikiChange.bind(this)}
             />
@@ -433,6 +443,7 @@ export class AssignButton extends React.Component {
               project={this.state.project}
               title={this.state.title}
               assign={this.assign.bind(this)}
+              trackedWikis={trackedWikis}
               handleChangeTitle={this.handleChangeTitle.bind(this)}
               handleWikiChange={this.handleWikiChange.bind(this)}
             />

--- a/app/assets/javascripts/components/common/selected_wiki_option.jsx
+++ b/app/assets/javascripts/components/common/selected_wiki_option.jsx
@@ -11,13 +11,14 @@ const SelectedWikiOption = (props) => {
     setShow(true);
   };
 
-  const { language, project } = props;
+  const { language, project, trackedWikis } = props;
   if (show) {
     return (
       <div className="wiki-select">
         <WikiSelect
           wikis={[{ language, project }]}
           onChange={props.handleWikiChange}
+          options={trackedWikis}
           multi={false}
           styles={{ ...selectStyles, singleValue: null }}
         />

--- a/app/assets/javascripts/components/common/wiki_select.jsx
+++ b/app/assets/javascripts/components/common/wiki_select.jsx
@@ -4,7 +4,6 @@ import AsyncSelect from 'react-select/async';
 import PropTypes from 'prop-types';
 import { map } from 'lodash-es';
 import ArrayUtils from '../../utils/array_utils';
-import WIKI_OPTIONS from '../../utils/wiki_options';
 
 
 /**
@@ -37,6 +36,12 @@ const WikiSelect = createReactClass({
      *  Should the Wikis be read-only
      */
     readOnly: PropTypes.bool,
+    /**
+     * Wikis for options, in article finder (through selected_wiki_options)
+     * and assign button (through new assigment input and selected wiki options)  tracked Wikis,
+     * in details and couse_form all Wikis
+    */
+    options: PropTypes.array
   },
 
   formatOption(wiki) {
@@ -99,9 +104,9 @@ const WikiSelect = createReactClass({
         this.props.onChange(this.props.multi ? [] : {});
       }
     };
-
+    const options = this.props.options;
     const filterOptions = function (val) {
-      return WIKI_OPTIONS.filter(wiki =>
+      return options.filter(wiki =>
         wiki.label.toLowerCase().includes(val.toLowerCase())
       ).slice(0, 10); // limit the options for better performance
     };

--- a/app/assets/javascripts/components/course_creator/course_form.jsx
+++ b/app/assets/javascripts/components/course_creator/course_form.jsx
@@ -9,6 +9,7 @@ import CourseUtils from '../../utils/course_utils.js';
 import selectStyles from '../../styles/select';
 import WikiSelect from '../common/wiki_select.jsx';
 import AcademicSystem from '../common/academic_system.jsx';
+import WIKI_OPTIONS from '../../utils/wiki_options';
 
 const CourseForm = (props) => {
   const updateCoursePrivacy = (e) => {
@@ -146,6 +147,7 @@ const CourseForm = (props) => {
         <WikiSelect
           wikis={[{ ...props.course.home_wiki }]}
           onChange={handleWikiChange}
+          options={WIKI_OPTIONS}
           multi={false}
           styles={{ ...selectStyles, singleValue: null }}
         />

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -34,9 +34,12 @@ import Notifications from '../common/notifications.jsx';
 
 import DatePicker from '../common/date_picker.jsx';
 
+import WIKI_OPTIONS from '../../utils/wiki_options';
 import CourseUtils from '../../utils/course_utils.js';
 import CourseDateUtils from '../../utils/course_date_utils.js';
 import AcademicSystem from '../common/academic_system.jsx';
+
+
 
 const POLL_INTERVAL = 60000; // 1 minute
 const MAX_UPDATE_COUNT = 60 * 12; // 12 hours of updates
@@ -459,6 +462,7 @@ const Details = createReactClass({
             }
             readOnly={!this.props.editable}
             onChange={this.handleWikiChange}
+            options={WIKI_OPTIONS}
             multi={false}
             styles={{ ...selectStyles, singleValue: null }}
           />
@@ -475,6 +479,7 @@ const Details = createReactClass({
             wikis={this.props.course.wikis}
             homeWiki={home_wiki}
             readOnly={!this.props.editable}
+            options={WIKI_OPTIONS}
             onChange={this.handleMultiWikiChange}
             multi={true}
             styles={{ ...selectStyles, singleValue: null }}

--- a/app/assets/javascripts/utils/wiki_utils.js
+++ b/app/assets/javascripts/utils/wiki_utils.js
@@ -10,4 +10,14 @@ const formatOption = (wiki) => {
   };
 };
 
-export { formatOption, url };
+const trackedWikisMaker = (course) => {
+  let trackedWikis = [];
+  if (course.wikis) {
+    trackedWikis = course.wikis.map((wiki) => {
+      wiki.language = wiki.language || 'www'; // for multilingual wikis language is null
+      return formatOption(wiki);
+    });
+  }
+  return trackedWikis;
+};
+export { trackedWikisMaker, formatOption, url };

--- a/app/assets/javascripts/utils/wiki_utils.js
+++ b/app/assets/javascripts/utils/wiki_utils.js
@@ -10,4 +10,4 @@ const formatOption = (wiki) => {
   };
 };
 
-export { formatOption };
+export { formatOption, url };

--- a/app/assets/javascripts/utils/wiki_utils.js
+++ b/app/assets/javascripts/utils/wiki_utils.js
@@ -1,0 +1,13 @@
+const url = (wiki) => {
+  const subdomain = wiki.language || 'www';
+  return `${subdomain}.${wiki.project}.org`;
+};
+
+const formatOption = (wiki) => {
+  return {
+    value: JSON.stringify(wiki),
+    label: url(wiki)
+  };
+};
+
+export { formatOption };

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -45,38 +45,6 @@ describe 'multiwiki assignments', type: :feature, js: true do
     end
   end
 
-  it 'creates a valid assignment from an article and an alternative project and language' do
-    VCR.use_cassette 'multiwiki_assignment' do
-      visit "/courses/#{course.slug}/students/articles"
-      first('.student-selection .student').click
-
-      button = first('.assign-button')
-      expect(button).to have_content 'Assign an article'
-      button.click
-
-      within('#users') do
-        find('input', visible: true).set('No le des prisa, dolor')
-        click_link 'Change'
-        find('div.wiki-select').click
-        within('.wiki-select') do
-          find('input').send_keys('es.wikisource', :enter)
-        end
-      end
-
-      click_button 'Assign'
-      click_button 'OK'
-
-      visit "/courses/#{course.slug}/students/articles"
-      first('.student-selection .student').click
-
-      within('#users') do
-        expect(page).to have_content 'No le des prisa'
-        link = first('.assignment-links a')
-        expect(link[:href]).to include('es.wikisource')
-      end
-    end
-  end
-
   it 'will create a valid assignment for multilingual wikisource projects' do
     VCR.use_cassette 'multiwiki_assignment' do
       visit "/courses/#{course.slug}/students/articles"

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -1,5 +1,5 @@
 import '../testHelper';
-import { formatOption, url } from '../../app/assets/javascripts/utils/wiki_utils';
+import { formatOption, url, trackedWikisMaker } from '../../app/assets/javascripts/utils/wiki_utils';
 
 
 describe('formatOption', () => {
@@ -37,6 +37,33 @@ describe('url', () => {
       };
       const result = url(wikiData);
       expect(result).toStrictEqual('www.wikipedia.org');
+    }
+  );
+});
+
+describe('trackedWikisMaker', () => {
+  test(
+    'if course includes wikis data, creates an array of tracked Wikis objects',
+    () => {
+      const course = {
+        wikis: [{
+          language: 'en',
+          project: 'wikipedia'
+        }, {
+          language: null,
+          project: 'wikipedia'
+        }]
+      };
+  const result = trackedWikisMaker(course);
+  expect(result).toStrictEqual([{ label: 'en.wikipedia.org', value: '{"language":"en","project":"wikipedia"}' }, { label: 'www.wikipedia.org', value: '{"language":"www","project":"wikipedia"}' }]);
+    }
+  );
+  test(
+    'if course does not include wikis data, returns an empty array',
+    () => {
+      const course = 'no Wikis here';
+      const result = trackedWikisMaker(course);
+      expect(result).toStrictEqual([]);
     }
   );
 });

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -7,11 +7,11 @@ describe('formatOption', () => {
     'formats wiki data',
     () => {
       const wikiData = {
-        "language": "en",
-        "project": "wikipedia"
+        language: 'en',
+        project: 'wikipedia'
       };
       const result = formatOption(wikiData);
-      expect(result).toStrictEqual( {"label": "en.wikipedia.org", "value": "{\"language\":\"en\",\"project\":\"wikipedia\"}"});
+      expect(result).toStrictEqual({ label: 'en.wikipedia.org', value: '{"language":"en","project":"wikipedia"}' });
     }
   );
 });
@@ -21,22 +21,22 @@ describe('url', () => {
     'returns url format',
     () => {
       const wikiData = {
-        "language": "en",
-        "project": "wikipedia"
+        language: 'en',
+        project: 'wikipedia'
       };
       const result = url(wikiData);
-      expect(result).toStrictEqual("en.wikipedia.org");
+      expect(result).toStrictEqual('en.wikipedia.org');
     }
   );
   test(
     'if no language specified, returns www subdomain',
     () => {
       const wikiData = {
-        "language": null,
-        "project": "wikipedia"
+        language: null,
+        project: 'wikipedia'
       };
       const result = url(wikiData);
-      expect(result).toStrictEqual("www.wikipedia.org");
+      expect(result).toStrictEqual('www.wikipedia.org');
     }
   );
 });

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -1,0 +1,42 @@
+import '../testHelper';
+import { formatOption, url } from '../../app/assets/javascripts/utils/wiki_utils';
+
+
+describe('formatOption', () => {
+  test(
+    'formats wiki data',
+    () => {
+      const wikiData = {
+        "language": "en",
+        "project": "wikipedia"
+      };
+      const result = formatOption(wikiData);
+      expect(result).toStrictEqual( {"label": "en.wikipedia.org", "value": "{\"language\":\"en\",\"project\":\"wikipedia\"}"});
+    }
+  );
+});
+
+describe('url', () => {
+  test(
+    'returns url format',
+    () => {
+      const wikiData = {
+        "language": "en",
+        "project": "wikipedia"
+      };
+      const result = url(wikiData);
+      expect(result).toStrictEqual("en.wikipedia.org");
+    }
+  );
+  test(
+    'if no language specified, returns www subdomain',
+    () => {
+      const wikiData = {
+        "language": null,
+        "project": "wikipedia"
+      };
+      const result = url(wikiData);
+      expect(result).toStrictEqual("www.wikipedia.org");
+    }
+  );
+});


### PR DESCRIPTION
This PR should solve issue #4526 (Wiki select for assigning articles lets you choose untracked wikis). While adding articles and assigning students to articles, all Wikis list was displayed instead of tracked Wikis list.

I added a new prop to WikiSelect, and now this component can take a list of all or tracked Wikis or something else, if needed.

I needed to use some functions a few times, so I moved them from the WikiSelect component to the wiki_utils file in utils and created tests for them. 

I updated the test for the successful creation of an assignment to an article to work with tracked Wikis only.



Tracked Wikis lists (before here was all Wikis list):
![tracked](https://user-images.githubusercontent.com/65791349/139968130-a1746922-8ffc-47df-add3-c964db6b4032.png)
![tracked1](https://user-images.githubusercontent.com/65791349/139968133-5564ae94-2915-444c-a396-dffb2fbe7426.png)
![tracked2](https://user-images.githubusercontent.com/65791349/139968145-f27a2efd-b399-4042-875d-6a3f03efad67.png)

All Wikis lists (same as before):
![all](https://user-images.githubusercontent.com/65791349/139968010-1a78fb31-4de0-44bc-842f-87f7d6020940.png)
![all1](https://user-images.githubusercontent.com/65791349/139968022-d6312db0-2e96-42a8-a065-9d84dfa92251.png)
