### PR TITLE
Silent javascript error when a course search returns no results

### DIFF
--- a/app/assets/javascripts/utils/course.js
+++ b/app/assets/javascripts/utils/course.js
@@ -27,6 +27,19 @@ $(() => {
     });
   }
 
+  // Course Results sorting
+  // only sort if there are tables to sort
+  let courseResultList;
+  if ($('#course_results table').length) {
+    courseResultList = new List('course_results', {
+      page: 500,
+      valueNames: [
+        'title', 'school', 'revisions', 'characters', 'references', 'average-words', 'views',
+        'reviewed', 'students', 'creation-date', 'ungreeted', 'untrained'
+      ]
+    });
+  }
+
   // Campaign sorting
   // only sort if there are tables to sort
   let campaignList;
@@ -78,6 +91,7 @@ $(() => {
     const list = (() => {
       switch ($(this).attr('rel')) {
         case 'courses': return courseList;
+        case 'course_results': return courseResultList;
         case 'campaigns': return campaignList;
         case 'campaign-articles': return articlesList;
         case 'users': return studentsList;

--- a/app/views/explore/_search.html.haml
+++ b/app/views/explore/_search.html.haml
@@ -1,9 +1,9 @@
 - if query.present?
-  %section#courses
+  %section#course_results
     -if results.present?
       .section-header
         .sort-select
-          %select.sorts{rel: 'courses'}
+          %select.sorts{rel: 'course_results'}
             %option{rel: 'asc', value: 'title'}
               = t("courses.title")
             %option{rel: 'asc', value: 'school'}


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This commit solve #4680 

To fix silent error, I change `id value from courses to course_results` in `_search.html.haml` And add logic for new id in `course.js`. So after the PR applied there is will be different `id value` in one html page.

## Open questions and concerns
- The code in `course.js` is redundant because section `course` and `course_results` absolutely doing same logic (see line 21 and 34)