### PR TITLE
Improve input matching in WikiSelect

### DIFF
--- a/app/assets/javascripts/components/common/wiki_select.jsx
+++ b/app/assets/javascripts/components/common/wiki_select.jsx
@@ -106,8 +106,8 @@ const WikiSelect = createReactClass({
     };
 
     const options = this.props.options;
-    // Two types of matching for optimizing results.
-    // If the input is less than four characters, it will be matched from the beginning of the string.
+
+    // If the input is less than three characters, it will be matched from the beginning of the string.
 
     const filterOptionsLong = function (val) {
       return options.filter(wiki =>
@@ -115,16 +115,16 @@ const WikiSelect = createReactClass({
       ).slice(0, 10); // limit the options for better performance
     };
 
-  // If the input is less than four characters, it will be matched anywhere in the string
+  // If the input is at least three characters, it will be matched anywhere in the string
 
     const filterOptionsShort = function (val) {
       return options.filter(wiki =>
         wiki.label.toLowerCase().startsWith(val.toLowerCase())
-      ).slice(0, 10); // limit the options for better performance
+      ).slice(0, 10);
     };
 
     const loadOptions = function (inputValue, callback) {
-      if (inputValue.length < 4) {
+      if (inputValue.length < 3) {
         callback(filterOptionsShort(inputValue));
       }
       callback(filterOptionsLong(inputValue));

--- a/app/assets/javascripts/components/common/wiki_select.jsx
+++ b/app/assets/javascripts/components/common/wiki_select.jsx
@@ -107,7 +107,7 @@ const WikiSelect = createReactClass({
     const options = this.props.options;
     const filterOptions = function (val) {
       return options.filter(wiki =>
-        wiki.label.toLowerCase().includes(val.toLowerCase())
+        wiki.label.toLowerCase().startsWith(val.toLowerCase())
       ).slice(0, 10); // limit the options for better performance
     };
 

--- a/app/assets/javascripts/components/common/wiki_select.jsx
+++ b/app/assets/javascripts/components/common/wiki_select.jsx
@@ -104,15 +104,30 @@ const WikiSelect = createReactClass({
         this.props.onChange(this.props.multi ? [] : {});
       }
     };
+
     const options = this.props.options;
-    const filterOptions = function (val) {
+    // Two types of matching for optimizing results.
+    // If the input is less than four characters, it will be matched from the beginning of the string.
+
+    const filterOptionsLong = function (val) {
+      return options.filter(wiki =>
+        wiki.label.toLowerCase().includes(val.toLowerCase())
+      ).slice(0, 10); // limit the options for better performance
+    };
+
+  // If the input is less than four characters, it will be matched anywhere in the string
+
+    const filterOptionsShort = function (val) {
       return options.filter(wiki =>
         wiki.label.toLowerCase().startsWith(val.toLowerCase())
       ).slice(0, 10); // limit the options for better performance
     };
 
     const loadOptions = function (inputValue, callback) {
-      callback(filterOptions(inputValue));
+      if (inputValue.length < 4) {
+        callback(filterOptionsShort(inputValue));
+      }
+      callback(filterOptionsLong(inputValue));
     };
 
     return <AsyncSelect
@@ -130,4 +145,3 @@ const WikiSelect = createReactClass({
 );
 
 export default WikiSelect;
-


### PR DESCRIPTION
Solution for issue  'Improve input matching in WikiSelect component #4681'

For optimizing results in the WikiSelect component I added two types of matching input.

If the input is less than three characters, it will be matched from the beginning of the string. That would enable easy access to some Wikis 
![match1](https://user-images.githubusercontent.com/65791349/144105274-549d35c1-4996-4c5a-9b82-5679b5f24416.png)
![match](https://user-images.githubusercontent.com/65791349/144105282-e8c406c5-5873-483f-9b25-07246e712061.png)

If the input is more than three characters, it will be matched anywhere in the string. That way results like Wikidata wouldn't be missed.
![match2a](https://user-images.githubusercontent.com/65791349/144200946-775e932b-8d18-4d8c-99ac-31cfca6a3d19.png)
![match1b](https://user-images.githubusercontent.com/65791349/144313574-d52f1c9a-8848-4fd2-a8eb-af890bf9e426.png)