### PR TITLE
Add Alerts for "de-userfying" edits

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -39,6 +39,7 @@ class Alert < ApplicationRecord
     BlockedUserAlert
     ContinuedCourseActivityAlert
     DeletedUploadsAlert
+    DeUserfyingAlert
     DiscretionarySanctionsAssignmentAlert
     DiscretionarySanctionsEditAlert
     DYKNominationAlert

--- a/app/models/alert_types/de_userfying_alert.rb
+++ b/app/models/alert_types/de_userfying_alert.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id             :integer          not null, primary key
+#  course_id      :integer
+#  user_id        :integer
+#  article_id     :integer
+#  revision_id    :integer
+#  type           :string(255)
+#  email_sent_at  :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  message        :text(65535)
+#  target_user_id :integer
+#  subject_id     :integer
+#  resolved       :boolean          default(FALSE)
+#  details        :text(65535)
+#
+
+# Alert for when a new user move a sandbox into mainspace on Wikipedia,
+# the edits are automatically tagged de-userfying.
+class DeUserfyingAlert < Alert
+  def main_subject
+    "#{user.username} moved article #{article.title} from sandbox into mainspace"
+  end
+
+  def url
+    article.url
+  end
+end

--- a/app/models/alert_types/de_userfying_alert.rb
+++ b/app/models/alert_types/de_userfying_alert.rb
@@ -28,6 +28,6 @@ class DeUserfyingAlert < Alert
   end
 
   def url
-    article.url
+    article&.url
   end
 end

--- a/lib/alerts/de_userfying_edit_alert_monitor.rb
+++ b/lib/alerts/de_userfying_edit_alert_monitor.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# This class identifies articles that have been moved from
+# their use space by users
+# Tag: de-userfying
+# Cf. https://en.wikipedia.org/wiki/MediaWiki:Tag-de-userfying
+class DeUserfyingEditAlertMonitor
+  def self.create_alerts_for_deuserfying_edits
+    new.create_alerts
+  end
+
+  def initialize
+    @wiki = Wiki.find_by(language: 'en', project: 'wikipedia')
+  end
+
+  def create_alerts
+    student_edits = edits_made_by_students(edits, current_students)
+    student_edits.each do |edit|
+      article = Article.find_by(mw_page_id: edit['pageid'])
+      user = User.find_by(username: edit['user'])
+      course_id = ArticlesCourses
+                  .where(article_id: article.id)
+                  .joins(course: [:users])
+                  .find_by(users: { id: user.id })
+                  .course_id
+      create_alert(user.id, course_id, article.id, edit['revid'])
+    end
+  end
+
+  def edits
+    api = WikiApi.new @wiki
+    query_params = {
+      list: 'recentchanges',
+      rcprop: 'title|ids|flags|user|tags|loginfo',
+      rctag: 'de-userfying',
+      rcshow: '!bot'
+    }
+    res = api.query(query_params)
+    res.data['recentchanges'].map { |change| change.slice('user', 'revid', 'pageid', 'logparams') }
+  end
+
+  # Those enrolled in at least one course. Multiple enrolled are counted only once.
+  def current_students
+    CoursesUsers
+      .select(:user_id, 'users.username')
+      .joins(:user)
+      .where(role: CoursesUsers::Roles::STUDENT_ROLE)
+      .distinct(:user_id)
+  end
+
+  def edits_made_by_students(edits, students)
+    usernames = students.map(&:username)
+    edits.filter { |edit| usernames.include?(edit['user']) }
+  end
+
+  def create_alert(user_id, course_id, article_id, revision_id)
+    return if alert_already_exists?(course_id, article_id, revision_id)
+    alert = Alert.create!(type: 'DeUserfyingAlert',
+                          user_id: user_id,
+                          course_id: course_id,
+                          article_id: article_id,
+                          revision_id: revision_id)
+    alert.email_content_expert
+  end
+
+  def alert_already_exists?(course_id, article_id, revision_id)
+    Alert.exists?(type: 'DeUserfyingAlert',
+                  course_id: course_id,
+                  article_id: article_id,
+                  revision_id: revision_id)
+  end
+end

--- a/lib/alerts/de_userfying_edit_alert_monitor.rb
+++ b/lib/alerts/de_userfying_edit_alert_monitor.rb
@@ -18,12 +18,10 @@ class DeUserfyingEditAlertMonitor
     student_edits.each do |edit|
       article = Article.find_by(mw_page_id: edit['pageid'])
       user = User.find_by(username: edit['user'])
-      course_id = ArticlesCourses
-                  .where(article_id: article.id)
-                  .joins(course: [:users])
-                  .find_by(users: { id: user.id })
-                  .course_id
-      create_alert(user.id, course_id, article.id, edit['revid'])
+      course_ids = courses_for_a_student(user.id)
+      course_ids.each do |course_id|
+        create_alert(user.id, course_id, article.id, edit['revid'])
+      end
     end
   end
 
@@ -68,5 +66,13 @@ class DeUserfyingEditAlertMonitor
                   course_id: course_id,
                   article_id: article_id,
                   revision_id: revision_id)
+  end
+
+  def courses_for_a_student(id)
+    student = CoursesUsers::Roles::STUDENT_ROLE
+    CoursesUsers
+      .joins(:user)
+      .where(role: student, user_id: id)
+      .pluck(:course_id)
   end
 end

--- a/lib/data_cycle/update_cycle_alert_generator.rb
+++ b/lib/data_cycle/update_cycle_alert_generator.rb
@@ -9,6 +9,7 @@ require_dependency "#{Rails.root}/lib/alerts/discretionary_sanctions_monitor"
 require_dependency "#{Rails.root}/lib/alerts/high_quality_article_monitor"
 require_dependency "#{Rails.root}/lib/alerts/protected_article_monitor"
 require_dependency "#{Rails.root}/lib/alerts/blocked_user_monitor"
+require "#{Rails.root}/lib/alerts/de_userfying_edit_alert_monitor"
 
 module UpdateCycleAlertGenerator
   # rubocop:disable Metrics/MethodLength

--- a/lib/data_cycle/update_cycle_alert_generator.rb
+++ b/lib/data_cycle/update_cycle_alert_generator.rb
@@ -39,6 +39,9 @@ module UpdateCycleAlertGenerator
 
     log_message 'Generate blocked user alerts'
     BlockedUserMonitor.create_alerts_for_recently_blocked_users
+
+    log_message 'Generate de-userfying edits alerts'
+    DeUserfyingEditAlertMonitor.create_alerts_for_deuserfying_edits
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
+++ b/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
@@ -17,6 +17,15 @@ describe DeUserfyingEditAlertMonitor do
   let(:article1) { create(:article, title: 'my title 1', mw_page_id: 111) }
   let(:article2) { create(:article, title: 'my title 2', mw_page_id: 222) }
   let(:content_expert) { create(:user, greeter: true) }
+  let!(:student_role) { CoursesUsers::Roles::STUDENT_ROLE }
+  let(:courses_users) do
+    [
+      { course_id: course1.id, user_id: student1.id, role: student_role },
+      { course_id: course1.id, user_id: student3.id, role: student_role },
+      { course_id: course2.id, user_id: student2.id, role: student_role },
+      { course_id: course2.id, user_id: student3.id, role: student_role }
+    ]
+  end
 
   before do
     populate_students
@@ -73,18 +82,20 @@ describe DeUserfyingEditAlertMonitor do
     end
   end
 
+  describe '.courses_for_a_student' do
+    it 'checks course(s) for a given student' do
+      expect(mntor.courses_for_a_student(student1))
+        .to eq courses_users
+          .filter { |cu| cu[:user_id] == student1.id }
+          .pluck(:course_id)
+    end
+  end
+
   private
 
   # Some students should be enrolled in multiple courses to make
   # the test effective.
   def populate_students
-    student = CoursesUsers::Roles::STUDENT_ROLE
-    courses_users = [
-      { course_id: course1.id, user_id: student1.id, role: student },
-      { course_id: course1.id, user_id: student3.id, role: student },
-      { course_id: course2.id, user_id: student2.id, role: student },
-      { course_id: course2.id, user_id: student3.id, role: student }
-    ]
     CoursesUsers.create(courses_users)
   end
 

--- a/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
+++ b/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/alerts/de_userfying_edit_alert_monitor"
+
+def mock_mailer
+  OpenStruct.new(deliver_now: true)
+end
+
+describe DeUserfyingEditAlertMonitor do
+  let(:mntor) { described_class.new }
+  let(:course1) { create(:course, slug: 'slug-one') }
+  let(:course2) { create(:course, slug: 'slug-two') }
+  let(:student1) { create(:user, username: 'alice', email: 'student1@example.edu') }
+  let(:student2) { create(:user, username: 'bob', email: 'student2@example.edu') }
+  let(:student3) { create(:user, username: 'carol', email: 'student3@example.edu') }
+  let(:article1) { create(:article, title: 'my title 1', mw_page_id: 111) }
+  let(:article2) { create(:article, title: 'my title 2', mw_page_id: 222) }
+  let(:content_expert) { create(:user, greeter: true) }
+
+  before do
+    populate_students
+  end
+
+  describe '.edits' do
+    it 'checks keys' do
+      VCR.use_cassette 'recent_changes' do
+        fedits = mntor.edits.first
+        expect(fedits.dig('logparams', 'target_title')).not_to be_nil
+        expect(fedits.dig('user')).not_to be_nil
+        expect(fedits.dig('revid')).not_to be_nil
+        expect(fedits.dig('pageid')).not_to be_nil
+      end
+    end
+  end
+
+  describe '.current_students' do
+    it 'checks distinct enrolled students' do
+      expect(mntor.current_students.count).to eq 3
+    end
+  end
+
+  describe '.edits_made_by_students' do
+    it 'filters students that de-userfyed their page' do
+      allow(mntor).to receive(:edits).and_return(editsfeed)
+      edits = mntor.edits
+      students = mntor.current_students
+      expect(mntor.edits_made_by_students(edits, students).count).to eq editsfeed.count
+    end
+  end
+
+  describe '.create_alerts' do
+    before do
+      populate_content_expert
+      populate_articles_courses
+      allow(mntor).to receive(:edits).and_return(editsfeed)
+      allow_any_instance_of(AlertMailer).to receive(:alert).and_return(mock_mailer)
+    end
+
+    it 'emails a content expert per edit' do
+      mntor.create_alerts
+      expect(Alert.all.pluck(:email_sent_at).compact.count).to eq editsfeed.count
+    end
+
+    it 'does not create a third Alert' do
+      Alert.create(type: 'DeUserfyingAlert',
+                   course_id: course1.id,
+                   article_id: article1.id,
+                   revision_id: editsfeed.first['revid'])
+      expect(Alert.count).to eq(1)
+      mntor.create_alerts
+      expect(Alert.count).to eq editsfeed.count
+    end
+  end
+
+  private
+
+  # Some students should be enrolled in multiple courses to make
+  # the test effective.
+  def populate_students
+    student = CoursesUsers::Roles::STUDENT_ROLE
+    courses_users = [
+      { course_id: course1.id, user_id: student1.id, role: student },
+      { course_id: course1.id, user_id: student3.id, role: student },
+      { course_id: course2.id, user_id: student2.id, role: student },
+      { course_id: course2.id, user_id: student3.id, role: student }
+    ]
+    CoursesUsers.create(courses_users)
+  end
+
+  def editsfeed
+    [{ 'user' => 'alice', 'revid' => 12, 'pageid' => 111,
+       'logparams' => { 'target_title' => 'my title 1' } },
+     { 'user' => 'bob', 'revid' => 447, 'pageid' => 222,
+       'logparams' => { 'target_title' => 'my title 2' } }]
+  end
+
+  def populate_content_expert
+    create(:courses_user,
+           user_id: content_expert.id,
+           course_id: course1.id,
+           role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+    create(:courses_user,
+           user_id: content_expert.id,
+           course_id: course2.id,
+           role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+  end
+
+  def populate_articles_courses
+    create(:articles_course, article_id: article1.id, course_id: course1.id)
+    create(:articles_course, article_id: article2.id, course_id: course2.id)
+  end
+end

--- a/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
+++ b/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
@@ -35,11 +35,13 @@ describe DeUserfyingEditAlertMonitor do
   describe '.edits' do
     it 'checks keys' do
       VCR.use_cassette 'recent_changes' do
-        fedits = mntor.edits.first
-        expect(fedits.dig('logparams', 'target_title')).not_to be_nil
-        expect(fedits.dig('user')).not_to be_nil
-        expect(fedits.dig('revid')).not_to be_nil
-        expect(fedits.dig('pageid')).not_to be_nil
+        fedit = mntor.edits.first
+        expect(fedit.dig('logparams', 'target_title')).not_to be_nil
+        expect(fedit.dig('user')).not_to be_nil
+        expect(fedit.dig('revid')).not_to be_nil
+        expect(fedit.dig('pageid')).not_to be_nil
+        expect(fedit.dig('logid')).not_to be_nil
+        expect(fedit.dig('timestamp')).not_to be_nil
       end
     end
   end
@@ -81,6 +83,14 @@ describe DeUserfyingEditAlertMonitor do
       mntor.create_alerts
       expect(Alert.count).to eq editsfeed.count
     end
+
+    context 'When neither article fetch or created' do
+      it 'creates an alert with nil article' do
+        allow(mntor).to receive(:article_by_mw_page_id)
+        mntor.create_alerts
+        expect(Alert.first.article_id).to eq nil
+      end
+    end
   end
 
   describe '.courses_for_a_student' do
@@ -100,7 +110,7 @@ describe DeUserfyingEditAlertMonitor do
 
       let(:importer) { instance_double(ArticleImporter) }
 
-      it 'imports from wikipedia' do
+      it 'tries to import from wikipedia' do
         expect(importer).to receive(:import_articles).with([7777])
         mntor.article_by_mw_page_id(7777)
       end

--- a/spec/lib/data_cycle/constant_update_spec.rb
+++ b/spec/lib/data_cycle/constant_update_spec.rb
@@ -21,6 +21,7 @@ describe ConstantUpdate do
       expect(DYKNominationMonitor).to receive(:create_alerts_for_course_articles)
       expect(GANominationMonitor).to receive(:create_alerts_for_course_articles)
       expect(BlockedUserMonitor).to receive(:create_alerts_for_recently_blocked_users)
+      expect(DeUserfyingEditAlertMonitor).to receive(:create_alerts_for_deuserfying_edits)
       expect_any_instance_of(CourseAlertManager).to receive(:create_no_students_alerts)
       expect_any_instance_of(CourseAlertManager).to receive(:create_untrained_students_alerts)
       expect_any_instance_of(CourseAlertManager).to receive(:create_productive_course_alerts)

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-#= Preview all emails at http://localhost:3000/rails/mailers/survey_mailer
-class AlertPreview < ActionMailer::Preview
+#= Preview all emails at http://localhost:3000/rails/mailers/alert_mailer
+class AlertMailerPreview < ActionMailer::Preview
   def articles_for_deletion_alert
     AlertMailer.alert(example_alert(type: 'ArticlesForDeletionAlert'), example_user)
   end
@@ -26,10 +26,18 @@ class AlertPreview < ActionMailer::Preview
     AlertMailer.alert(example_alert, example_user)
   end
 
+  def de_userfying_alert
+    AlertMailer.alert(example_de_userfying_alert, example_user)
+  end
+
   private
 
   def example_user
     User.new(email: 'sage@example.com', username: 'Ragesoss', permissions: 1)
+  end
+
+  def example_student
+    User.new(email: 'nospam@nospam.com', username: 'nospam', permissions: 0)
   end
 
   def example_course
@@ -48,5 +56,10 @@ class AlertPreview < ActionMailer::Preview
   def example_alert(type: 'HighQualityArticleEditAlert')
     Alert.new(type: type, article: example_article,
               course: example_course, id: 9)
+  end
+
+  def example_de_userfying_alert
+    Alert.new(type: 'DeUserfyingAlert', article: example_article,
+              course: example_course, id: 9, user: example_student)
   end
 end

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -60,6 +60,7 @@ class AlertMailerPreview < ActionMailer::Preview
 
   def example_de_userfying_alert
     Alert.new(type: 'DeUserfyingAlert', article: example_article,
-              course: example_course, id: 9, user: example_student)
+              course: example_course, id: 9, user: example_student,
+              details: { logid: 125126035, timestamp: '2021-12-16T08:10:56Z' })
   end
 end


### PR DESCRIPTION
## What this PR does
References issue #4677 (Add Alerts for "de-userfying")
This PR to create and handle a new "de-userfying" alert

By: 
- adding a new AlertMonitor object
- adding a new sub type of Alert
- adding the matching specs
- adding to the list of alerts
- adding to the list of mailer previews




