### PR TITLE
Fix item terminology for edited items tab in wiki education

### DIFF
--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -106,7 +106,7 @@ const ArticleList = createReactClass({
 
     let header;
     if (Features.wikiEd) {
-      header = <h3 className="article tooltip-trigger">{I18n.t('metrics.articles_edited')}</h3>;
+      header = <h3 className="article tooltip-trigger">{ArticleUtils.I18n('edited', project)}</h3>;
     } else {
       header = (
         <h3 className="article tooltip-trigger">{ArticleUtils.I18n('edited', project)}


### PR DESCRIPTION
A fix for a headline in the Edited Items tab in Wiki Education.
![fix](https://user-images.githubusercontent.com/65791349/146610697-f9bdb81d-3aeb-4f2b-ae0f-ca6bdd0fb84d.png)

Before:
![before](https://user-images.githubusercontent.com/65791349/146610691-25ebf785-5724-4b78-a4f2-b16c1b879c4d.png)

