### PR TITLE
Remove ratings for Items Edited, Assigned and Available tabs

### DIFF
--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -44,7 +44,6 @@ const Article = createReactClass({
   render() {
     const ratingClass = `rating ${this.props.article.rating}`;
     const ratingMobileClass = `${ratingClass} tablet-only`;
-    const isArticle = project !== 'wikidata';
 
     // Uses Course Utils Helper
     const formattedTitle = CourseUtils.formattedArticleTitle(this.props.article, this.props.course.home_wiki, this.props.wikidataLabel);
@@ -74,19 +73,21 @@ const Article = createReactClass({
     if (project === 'wikidata') language = 'www';
     const pageviewUrl = `https://pageviews.toolforge.org/?project=${language}.${project}.org&platform=all-access&agent=user&range=latest-90&pages=${title}`;
 
+    const isWikipedia = project === 'wikipedia';
+
     return (
       <tr className="article">
         <td className="tooltip-trigger desktop-only-tc">
-          {isArticle && <p className="rating_num hidden">{this.props.article.rating_num}</p>}
-          {isArticle && <div className={ratingClass}><p>{this.props.article.pretty_rating || '-'}</p></div>}
-          {isArticle && <div className="tooltip dark">
+          {isWikipedia && <p className="rating_num hidden">{this.props.article.rating_num}</p>}
+          {isWikipedia && <div className={ratingClass}><p>{this.props.article.pretty_rating || '-'}</p></div>}
+          {isWikipedia && <div className="tooltip dark">
             <p>{I18n.t(`articles.rating_docs.${this.props.article.rating || '?'}`, { class: this.props.article.rating || '' })}</p>
             {/* eslint-disable-next-line */}
           </div>}
         </td>
         <td>
-          {isArticle && <div className={ratingMobileClass}><p>{this.props.article.pretty_rating || '-'}</p></div>}
-          {!isArticle && <div />}
+          {isWikipedia && <div className={ratingMobileClass}><p>{this.props.article.pretty_rating || '-'}</p></div>}
+          {isWikipedia && <div />}
           <div className="title">
             <a href={this.props.article.url} target="_blank" className="inline">{formattedTitle} {(this.props.article.new_article ? ` ${I18n.t('articles.new')}` : '')}</a>
             <br />

--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -44,6 +44,7 @@ const Article = createReactClass({
   render() {
     const ratingClass = `rating ${this.props.article.rating}`;
     const ratingMobileClass = `${ratingClass} tablet-only`;
+    const isArticle = project !== 'wikidata';
 
     // Uses Course Utils Helper
     const formattedTitle = CourseUtils.formattedArticleTitle(this.props.article, this.props.course.home_wiki, this.props.wikidataLabel);
@@ -76,14 +77,16 @@ const Article = createReactClass({
     return (
       <tr className="article">
         <td className="tooltip-trigger desktop-only-tc">
-          <p className="rating_num hidden">{this.props.article.rating_num}</p>
-          <div className={ratingClass}><p>{this.props.article.pretty_rating || '-'}</p></div>
-          <div className="tooltip dark">
+          {isArticle && <p className="rating_num hidden">{this.props.article.rating_num}</p>}
+          {isArticle && <div className={ratingClass}><p>{this.props.article.pretty_rating || '-'}</p></div>}
+          {isArticle && <div className="tooltip dark">
             <p>{I18n.t(`articles.rating_docs.${this.props.article.rating || '?'}`, { class: this.props.article.rating || '' })}</p>
-          </div>
+            {/* eslint-disable-next-line */}
+          </div>}
         </td>
         <td>
-          <div className={ratingMobileClass}><p>{this.props.article.pretty_rating || '-'}</p></div>
+          {isArticle && <div className={ratingMobileClass}><p>{this.props.article.pretty_rating || '-'}</p></div>}
+          {!isArticle && <div />}
           <div className="title">
             <a href={this.props.article.url} target="_blank" className="inline">{formattedTitle} {(this.props.article.new_article ? ` ${I18n.t('articles.new')}` : '')}</a>
             <br />

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -106,7 +106,7 @@ const ArticleList = createReactClass({
 
     let header;
     if (Features.wikiEd) {
-      header = <h3 className="article tooltip-trigger">{I18n.t('metrics.articles_edited')}</h3>;
+      header = <h3 className="article tooltip-trigger">{ArticleUtils.I18n('edited', project)}</h3>;
     } else {
       header = (
         <h3 className="article tooltip-trigger">{ArticleUtils.I18n('edited', project)}

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -54,11 +54,12 @@ export const AvailableArticle = createReactClass({
   render() {
     const className = 'assignment';
     const { assignment } = this.props;
+
     const article = CourseUtils.articleFromAssignment(assignment, this.props.course.home_wiki);
     const ratingClass = `rating ${assignment.article_rating}`;
     const ratingMobileClass = `${ratingClass} tablet-only`;
     const articleLink = <a onClick={this.stop} href={article.url} target="_blank" className="inline">{article.formatted_title}</a>;
-    const isArticle = this.props.course.home_wiki.project !== 'wikidata';
+    const isWikipedia = article.project === 'wikipedia';
 
     let actionSelect;
     let actionRemove;
@@ -77,15 +78,15 @@ export const AvailableArticle = createReactClass({
     return (
       <tr className={className}>
         <td className="tooltip-trigger desktop-only-tc">
-          {isArticle && <p className="rating_num hidden">{article.rating_num}</p>}
-          {isArticle && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
-          {isArticle && <div className="tooltip dark">
+          {isWikipedia && <p className="rating_num hidden">{article.rating_num}</p>}
+          {isWikipedia && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
+          {isWikipedia && <div className="tooltip dark">
             <p>{I18n.t(`articles.rating_docs.${assignment.article_rating || '?'}`, { class: assignment.article_rating || '' })}</p>
             {/* eslint-disable-next-line */}
           </div>}
         </td>
         <td>
-          {isArticle && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
+          {isWikipedia && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
           <p className="title">
             {articleLink}
           </p>

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -58,6 +58,7 @@ export const AvailableArticle = createReactClass({
     const ratingClass = `rating ${assignment.article_rating}`;
     const ratingMobileClass = `${ratingClass} tablet-only`;
     const articleLink = <a onClick={this.stop} href={article.url} target="_blank" className="inline">{article.formatted_title}</a>;
+    const isArticle = this.props.course.home_wiki.project !== 'wikidata';
 
     let actionSelect;
     let actionRemove;
@@ -76,14 +77,15 @@ export const AvailableArticle = createReactClass({
     return (
       <tr className={className}>
         <td className="tooltip-trigger desktop-only-tc">
-          <p className="rating_num hidden">{article.rating_num}</p>
-          <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>
-          <div className="tooltip dark">
+          {isArticle && <p className="rating_num hidden">{article.rating_num}</p>}
+          {isArticle && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
+          {isArticle && <div className="tooltip dark">
             <p>{I18n.t(`articles.rating_docs.${assignment.article_rating || '?'}`, { class: assignment.article_rating || '' })}</p>
-          </div>
+            {/* eslint-disable-next-line */}
+          </div>}
         </td>
         <td>
-          <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>
+          {isArticle && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
           <p className="title">
             {articleLink}
           </p>

--- a/app/assets/javascripts/components/assignments/assignment.jsx
+++ b/app/assets/javascripts/components/assignments/assignment.jsx
@@ -24,6 +24,8 @@ const Assignment = createReactClass({
     wikidataLabel: PropTypes.string
   },
   render() {
+    const isArticle = this.props.course.home_wiki.project !== 'wikidata';
+
     if (!this.props.course.home_wiki) { return <div />; }
     const article = this.props.article || CourseUtils.articleFromAssignment(this.props.assignmentGroup[0], this.props.course.home_wiki);
     if (!article.formatted_title) {
@@ -65,14 +67,15 @@ const Assignment = createReactClass({
     return (
       <tr className={className}>
         <td className="tooltip-trigger desktop-only-tc">
-          <p className="rating_num hidden">{article.rating_num}</p>
-          <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>
-          <div className="tooltip dark">
+          {isArticle && <p className="rating_num hidden">{article.rating_num}</p>}
+          {isArticle && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
+          {isArticle && <div className="tooltip dark">
             <p>{I18n.t(`articles.rating_docs.${article.rating || '?'}`, { class: article.rating || '' })}</p>
-          </div>
+            {/* eslint-disable-next-line */}
+          </div>}
         </td>
         <td>
-          <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>
+          {isArticle && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
           <p className="title">
             {articleLink}
           </p>

--- a/app/assets/javascripts/components/assignments/assignment.jsx
+++ b/app/assets/javascripts/components/assignments/assignment.jsx
@@ -24,8 +24,6 @@ const Assignment = createReactClass({
     wikidataLabel: PropTypes.string
   },
   render() {
-    const isArticle = this.props.course.home_wiki.project !== 'wikidata';
-
     if (!this.props.course.home_wiki) { return <div />; }
     const article = this.props.article || CourseUtils.articleFromAssignment(this.props.assignmentGroup[0], this.props.course.home_wiki);
     if (!article.formatted_title) {
@@ -38,6 +36,7 @@ const Assignment = createReactClass({
     const assignees = [];
     const reviewers = [];
     const iterable = sortBy(this.props.assignmentGroup, 'username');
+    const isWikipedia = article.project === 'wikipedia';
     for (let i = 0; i < iterable.length; i += 1) {
       const assignment = iterable[i];
       if (assignment.role === 0 && assignment.user_id && assignment.username) {
@@ -67,15 +66,15 @@ const Assignment = createReactClass({
     return (
       <tr className={className}>
         <td className="tooltip-trigger desktop-only-tc">
-          {isArticle && <p className="rating_num hidden">{article.rating_num}</p>}
-          {isArticle && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
-          {isArticle && <div className="tooltip dark">
+          {isWikipedia && <p className="rating_num hidden">{article.rating_num}</p>}
+          {isWikipedia && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
+          {isWikipedia && <div className="tooltip dark">
             <p>{I18n.t(`articles.rating_docs.${article.rating || '?'}`, { class: article.rating || '' })}</p>
             {/* eslint-disable-next-line */}
           </div>}
         </td>
         <td>
-          {isArticle && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
+          {isWikipedia && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
           <p className="title">
             {articleLink}
           </p>

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -77,7 +77,7 @@ describe 'the course page', type: :feature, js: true do
     end
 
     ratings = ['fl', 'fa', 'a', 'ga', 'b', 'c', 'start', 'stub', 'list', nil]
-    (1...article_count/2).each do |i|
+    (1...article_count / 2).each do |i|
       create(:article,
              id: i,
              title: "Article #{i}",
@@ -85,7 +85,7 @@ describe 'the course page', type: :feature, js: true do
              wiki_id:  home_wiki.id,
              rating: ratings[(i + 5) % 10])
     end
-    (article_count/2..article_count).each do |i|
+    (article_count / 2..article_count).each do |i|
       create(:article,
              id: i,
              title: "Article #{i}",

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -77,7 +77,15 @@ describe 'the course page', type: :feature, js: true do
     end
 
     ratings = ['fl', 'fa', 'a', 'ga', 'b', 'c', 'start', 'stub', 'list', nil]
-    (1..article_count).each do |i|
+    (1...article_count/2).each do |i|
+      create(:article,
+             id: i,
+             title: "Article #{i}",
+             namespace: 0,
+             wiki_id:  home_wiki.id,
+             rating: ratings[(i + 5) % 10])
+    end
+    (article_count/2..article_count).each do |i|
       create(:article,
              id: i,
              title: "Article #{i}",
@@ -246,12 +254,15 @@ describe 'the course page', type: :feature, js: true do
   describe 'articles edited view' do
     it 'displays a list of articles, and sort articles by class' do
       js_visit "/courses/#{slug}/articles"
-      # List of articles
       sleep 1
       rows = page.all('tr.article').count
       expect(rows).to eq(article_count)
+    end
 
-      # Sorting
+    it 'sorts Wikipedia articles by class' do
+      js_visit "/courses/#{slug}/articles"
+      sleep 1
+
       # first click on the Class sorting should sort high to low
       find('th.sortable', text: 'Class').click
       first_rating = page.find(:css, 'table.articles', match: :first).first('td .rating p')
@@ -262,6 +273,14 @@ describe 'the course page', type: :feature, js: true do
       expect(new_first_rating).to have_content '-'
       title = page.find(:css, 'table.articles', match: :first).first('td .title')
       expect(title).to have_content 'es:wiktionary:Article'
+    end
+
+    it 'does not show ratings for non Wikipedia articles' do
+      js_visit "/courses/#{slug}/articles"
+      sleep 1
+      rows = page.all('tr.article').count
+      ratings = page.all('.rating').count
+      expect(rows).to be > ratings
     end
 
     it 'includes a list of available articles' do


### PR DESCRIPTION
Ratings are removed for Items, for desktop and mobile versions.
![1](https://user-images.githubusercontent.com/65791349/146641396-6f0b582f-fba9-4f44-b7ab-f8ee00cd59e3.png)
![2m](https://user-images.githubusercontent.com/65791349/146641398-4c4e8f36-03b2-4339-b3f2-055afca85f61.png)

I'm not sure what I did in the edited tab here, because I don't know how to add edited items, but it should be fine.
![3?](https://user-images.githubusercontent.com/65791349/146641430-61afd510-774c-45e9-ae58-388991321dce.png)

Articles are the same as before.
![4a](https://user-images.githubusercontent.com/65791349/146641400-be83ab50-d866-4ee7-92ea-acbf15dc7a12.png)

