### PR TITLE
Remove ratings for items on Recent Activity tab and add item terminology

### DIFF
--- a/app/assets/javascripts/components/articles/article_list_keys.js
+++ b/app/assets/javascripts/components/articles/article_list_keys.js
@@ -5,7 +5,7 @@ const contentAddedKey = (course, articlesOrItems) => {
     return {
       label: I18n.t('metrics.word_count'),
       desktop_only: true,
-      info_key: `${course.string_prefix}.word_count_doc_separated.${articlesOrItems}`
+      info_key: `${course.string_prefix}.${ArticleUtils.chooseMsg(course.home_wiki.project, 'word_count_doc')}`
     };
   }
   return {
@@ -31,7 +31,7 @@ const articleListKeys = (course) => {
     references_count: {
       label: I18n.t('metrics.references_count'),
       desktop_only: true,
-      info_key: `metrics.references_doc_separated.${articlesOrItems}`
+      info_key: `metrics.${ArticleUtils.chooseMsg(course.home_wiki.project, 'references_doc')}`
     },
     view_count: {
       label: I18n.t('metrics.view'),

--- a/app/assets/javascripts/components/articles/article_list_keys.js
+++ b/app/assets/javascripts/components/articles/article_list_keys.js
@@ -5,7 +5,7 @@ const contentAddedKey = (course, articlesOrItems) => {
     return {
       label: I18n.t('metrics.word_count'),
       desktop_only: true,
-      info_key: `${course.string_prefix}.${ArticleUtils.chooseMsg(course.home_wiki.project, 'word_count_doc')}`
+      info_key: `${course.string_prefix}.${ArticleUtils.projectSuffix(course.home_wiki.project, 'word_count_doc')}`
     };
   }
   return {
@@ -31,7 +31,7 @@ const articleListKeys = (course) => {
     references_count: {
       label: I18n.t('metrics.references_count'),
       desktop_only: true,
-      info_key: `metrics.${ArticleUtils.chooseMsg(course.home_wiki.project, 'references_doc')}`
+      info_key: `metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'references_doc')}`
     },
     view_count: {
       label: I18n.t('metrics.view'),

--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -9,20 +9,20 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
   const ratingMobileClass = `${ratingClass} tablet-only`;
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
-  const isArticle = course.home_wiki.project !== 'wikidata';
+  const isWikipedia = revision.wiki.project === 'wikipedia';
 
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
-        {isArticle && <p className="rating_num hidden">{revision.rating_num}</p>}
-        {isArticle && <div className={ratingClass}><p>{revision.pretty_rating || '-'}</p></div>}
-        {isArticle && <div className="tooltip dark">
+        {isWikipedia && <p className="rating_num hidden">{revision.rating_num}</p>}
+        {isWikipedia && <div className={ratingClass}><p>{revision.pretty_rating || '-'}</p></div>}
+        {isWikipedia && <div className="tooltip dark">
           <p>{I18n.t(`articles.rating_docs.${revision.rating || '?'}`, { class: revision.rating || '' })}</p>
           {/* eslint-disable-next-line */}
         </div>}
       </td>
       <td>
-        {isArticle && <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>}
+        {isWikipedia && <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>}
         <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}&nbsp;<small>{subtitle}</small></p></a>
       </td>
       <td className="desktop-only-tc">{revision.revisor}</td>

--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -9,17 +9,20 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
   const ratingMobileClass = `${ratingClass} tablet-only`;
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
+  const isArticle = course.home_wiki.project !== 'wikidata';
+
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
-        <p className="rating_num hidden">{revision.rating_num}</p>
-        <div className={ratingClass}><p>{revision.pretty_rating || '-'}</p></div>
-        <div className="tooltip dark">
+        {isArticle && <p className="rating_num hidden">{revision.rating_num}</p>}
+        {isArticle && <div className={ratingClass}><p>{revision.pretty_rating || '-'}</p></div>}
+        {isArticle && <div className="tooltip dark">
           <p>{I18n.t(`articles.rating_docs.${revision.rating || '?'}`, { class: revision.rating || '' })}</p>
-        </div>
+          {/* eslint-disable-next-line */}
+        </div>}
       </td>
       <td>
-        <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>
+        {isArticle && <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>}
         <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}&nbsp;<small>{subtitle}</small></p></a>
       </td>
       <td className="desktop-only-tc">{revision.revisor}</td>

--- a/app/assets/javascripts/components/revisions/revision_list.jsx
+++ b/app/assets/javascripts/components/revisions/revision_list.jsx
@@ -63,7 +63,7 @@ const RevisionList = createReactClass({
       references: {
         label: I18n.t('revisions.references'),
         desktop_only: true,
-        info_key: `metrics.references_doc_separated.${ArticleUtils.articlesOrItems(this.props.course.home_wiki.project)}`
+        info_key: `metrics.${ArticleUtils.chooseMsg(this.props.course.home_wiki.project, 'references_doc')}`
       },
       date: {
         label: I18n.t('revisions.date_time'),

--- a/app/assets/javascripts/components/revisions/revision_list.jsx
+++ b/app/assets/javascripts/components/revisions/revision_list.jsx
@@ -4,6 +4,7 @@ import List from '../common/list.jsx';
 import Revision from './revision.jsx';
 import CourseUtils from '../../utils/course_utils.js';
 import createReactClass from 'create-react-class';
+import ArticleUtils from '../../utils/article_utils.js';
 
 const RevisionList = createReactClass({
   displayName: 'RevisionList',
@@ -62,7 +63,7 @@ const RevisionList = createReactClass({
       references: {
         label: I18n.t('revisions.references'),
         desktop_only: true,
-        info_key: 'metrics.references_doc'
+        info_key: `metrics.references_doc_separated.${ArticleUtils.articlesOrItems(this.props.course.home_wiki.project)}`
       },
       date: {
         label: I18n.t('revisions.date_time'),

--- a/app/assets/javascripts/components/revisions/revision_list.jsx
+++ b/app/assets/javascripts/components/revisions/revision_list.jsx
@@ -63,7 +63,7 @@ const RevisionList = createReactClass({
       references: {
         label: I18n.t('revisions.references'),
         desktop_only: true,
-        info_key: `metrics.${ArticleUtils.chooseMsg(this.props.course.home_wiki.project, 'references_doc')}`
+        info_key: `metrics.${ArticleUtils.projectSuffix(this.props.course.home_wiki.project, 'references_doc')}`
       },
       date: {
         label: I18n.t('revisions.date_time'),

--- a/app/assets/javascripts/utils/article_utils.js
+++ b/app/assets/javascripts/utils/article_utils.js
@@ -17,7 +17,7 @@ export default class ArticleUtils {
     return ArticleUtils.articlesOrItemsMsg(messageKey, articlesOrItems);
   }
 
-  static chooseMsg(project, msg) {
-    return project === 'wikidata' ? `${msg}_wikidata` : msg;
+  static projectSuffix(project, messageKey) {
+    return project === 'wikidata' ? `${messageKey}_wikidata` : messageKey;
   }
 }

--- a/app/assets/javascripts/utils/article_utils.js
+++ b/app/assets/javascripts/utils/article_utils.js
@@ -1,19 +1,23 @@
 export default class ArticleUtils {
-// Returns article or item, based on home Wiki project.
+  // Returns article or item, based on home Wiki project.
   static articlesOrItems(project) {
     return project === 'wikidata' ? 'items' : 'articles';
   }
 
-// Returns article or item message, based on articles or items keyword.
+  // Returns article or item message, based on articles or items keyword.
   static articlesOrItemsMsg(messageKey, articlesOrItems, defaultarticlesOrItems = 'articles') {
     return I18n.t(`${articlesOrItems}.${messageKey}`, {
       defaults: [{ scope: `${defaultarticlesOrItems}.${messageKey}` }]
     });
   }
 
-// Returns article or item message, based on home Wiki project.
-static I18n(messageKey, project) {
-  const articlesOrItems = ArticleUtils.articlesOrItems(project);
-  return ArticleUtils.articlesOrItemsMsg(messageKey, articlesOrItems);
-}
+  // Returns article or item message, based on home Wiki project.
+  static I18n(messageKey, project) {
+    const articlesOrItems = ArticleUtils.articlesOrItems(project);
+    return ArticleUtils.articlesOrItemsMsg(messageKey, articlesOrItems);
+  }
+
+  static chooseMsg(project, msg) {
+    return project === 'wikidata' ? `${msg}_wikidata` : msg;
+  }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -760,10 +760,8 @@ en:
       if you don't want templates added to user pages, the talk pages of assigned articles, etc.
     wiki_staff: Wiki Education Staff
     withdrawn: Did not do assignment
-    word_count_doc_separated:
-      articles: An estimate of the number of words added to mainspace articles by the course's students during the course term
-      items: An estimate of the number of words added to mainspace items by the course's students during the course term
     word_count_doc: An estimate of the number of words added to mainspace articles by the course's students during the course term
+    word_count_doc_wikidata: An estimate of the number of words added to mainspace items by the course's students during the course term
     yourcourses: Your Courses
     survey:
       notification_message: Take our survey for this course.
@@ -868,10 +866,8 @@ en:
     user_uploads_none: Selected users have not contributed any images or other media files to this project.
     view_other: View other campaigns
     view_page: View Program Page
-    word_count_doc_separated:
-      items: An estimate of the number of words added to mainspace items by the program's editors during the program term
-      articles: An estimate of the number of words added to mainspace articles by the program's editors during the program term
     word_count_doc: An estimate of the number of words added to mainspace articles by the program's editors during the program term
+    word_count_doc_wikidata: An estimate of the number of words added to mainspace items by the program's editors during the program term
     yourcourses: Your Programs
 
   editable:
@@ -945,10 +941,9 @@ en:
     recent_updates_summary: Out of the last %{total} updates, %{failure_count} failed and %{error_count} encountered errors.
     revisions: Recent Edits
     references_count: References Added
-    references_doc_separated:
-      articles: This is the number of reference tags added to articles, and can include multiple references to the same source. The data comes from the ORES article quality model, and is only available for some languages.
-      items: This is the number of reference tags added to items, and can include multiple references to the same source. The data comes from the ORES item quality model, and is only available for some languages.
     references_doc: This is the number of reference tags added to articles, and can include multiple references to the same source. The data comes from the ORES article quality model, and is only available for some languages.
+    references_doc_wikidata: This is the number of reference tags added to items, and can include multiple references to the same source. The data comes from the ORES item quality model, and is only available for some languages.
+
     replag_info: >
       The Dashboard retrieves edit data from WMF Cloud replica databases. Sometimes these databases are missing the most recent edits
       because of replication lag (replag). When this is the case, the missing edits will show up later on.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -980,7 +980,7 @@ en:
 
   recent_activity:
     active_courses: Article is active in
-    article_title: Article Title
+    article_title: Title
     datetime: Date/Time
     did_you_know_eligible: Did You Know Eligible
     image: Image


### PR DESCRIPTION
Ratings for items are removed from the Recent Activity tab.
![111](https://user-images.githubusercontent.com/65791349/146684408-fd29dc89-2fde-47d4-ba4c-515da2295020.png)

Articles are the same as before.
![222](https://user-images.githubusercontent.com/65791349/146684439-f8137c34-71aa-4e34-a4f0-f339b19e4abe.png)
