### PR TITLE
Add Items terminology to user profile

### DIFF
--- a/app/assets/javascripts/components/assignments/new_assignment_input.jsx
+++ b/app/assets/javascripts/components/assignments/new_assignment_input.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SelectedWikiOption from '../common/selected_wiki_option';
+import ArticleUtils from '../../utils/article_utils';
 
 const NewAssignmentInput = ({
   language, project, title,
@@ -7,7 +8,7 @@ const NewAssignmentInput = ({
 }) => (
   <form onSubmit={assign}>
     <input
-      placeholder={I18n.t('articles.title_example')}
+      placeholder={ArticleUtils.I18n('title_example', project)}
       value={title}
       onSubmit={assign}
       onChange={handleChangeTitle}

--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/BadWorkAlert.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/BadWorkAlert.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import ArticleUtils from '../../../../../utils/article_utils';
 // Components
 import SubmitIssuePanel from '@components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx';
 
@@ -30,7 +30,7 @@ export class BadWorkAlert extends React.Component {
     return (
       <section className="article-alert">
         <article className="learn-more">
-          <p>{ I18n.t('instructor_view.bad_work.learn_more') }</p>
+          <p>{ I18n.t(`instructor_view.bad_work.${ArticleUtils.projectSuffix(this.props.project, 'learn_more')}`) }</p>
           <a target="_blank" className="button dark" href="/training/instructors/fixing-bad-articles/instructors-role-in-cleanup">
             {I18n.t('instructor_view.bad_work.learn_more_button')}
           </a>
@@ -41,6 +41,7 @@ export class BadWorkAlert extends React.Component {
           handleSubmit={this.handleSubmit}
           isSubmitting={isSubmitting}
           message={message}
+          project={this.props.project}
         />
       </section>
     );
@@ -50,6 +51,7 @@ BadWorkAlert.propTypes = {
   alertStatus: PropTypes.shape({
     created: PropTypes.bool.isRequired
   }).isRequired,
+  project: PropTypes.string.isRequired,
   submitBadWorkAlert: PropTypes.func.isRequired
 };
 

--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ArticleUtils from '../../../../../utils/article_utils';
 
 // Components
 import TextAreaInput from '@components/common/text_area_input.jsx';
 
-export const SubmitIssuePanel = ({ alertStatus, handleChange, handleSubmit, isSubmitting, message }) => {
+export const SubmitIssuePanel = ({ alertStatus, handleChange, handleSubmit, isSubmitting, message, project }) => {
   if (alertStatus.created) {
     return (
       <article className="submit-alert">
@@ -15,7 +16,7 @@ export const SubmitIssuePanel = ({ alertStatus, handleChange, handleSubmit, isSu
 
   return (
     <article className="submit-alert">
-      <p>{I18n.t('instructor_view.bad_work.submit_issue')}</p>
+      <p>{I18n.t(`instructor_view.bad_work.${ArticleUtils.projectSuffix(project, 'submit_issue')}`)}</p>
       <form onSubmit={handleSubmit}>
         <TextAreaInput
           id="submit-bad-work-alert"
@@ -41,7 +42,8 @@ SubmitIssuePanel.propTypes = {
   }).isRequired,
   handleChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
-  message: PropTypes.string.isRequired
+  message: PropTypes.string.isRequired,
+  project: PropTypes.string.isRequired
 };
 
 export default SubmitIssuePanel;

--- a/app/assets/javascripts/components/common/ArticleViewer/components/IconOpener.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/IconOpener.jsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ArticleUtils from '../../../../utils/article_utils';
 
 export const IconOpener = ({ showArticle, showButtonClass, showButtonLabel, article }) => (
-    article.id ? (
-      <div className={`tooltip-trigger ${showButtonClass}`}>
-        <button
-          onClick={showArticle}
-          aria-label="Open Article Viewer"
-          className="icon icon-article-viewer"
-        />
-        <div className="tooltip tooltip-center dark large">
-          <p>{showButtonLabel()}</p>
-        </div>
+  article.id ? (
+    <div className={`tooltip-trigger ${showButtonClass}`}>
+      <button
+        onClick={showArticle}
+        aria-label="Open Article Viewer"
+        className="icon icon-article-viewer"
+      />
+      <div className="tooltip tooltip-center dark large">
+        <p>{showButtonLabel()}</p>
       </div>
+    </div>
     ) : (
       <div className={`tooltip-trigger ${showButtonClass}`}>
         <button
@@ -21,7 +22,7 @@ export const IconOpener = ({ showArticle, showButtonClass, showButtonLabel, arti
           disabled
         />
         <div className="tooltip tooltip-center dark large">
-          <p>{I18n.t('articles.article_not_found')}</p>
+          <p>{ArticleUtils.I18n('article_not_found', article.project)}</p>
         </div>
       </div>
     )
@@ -33,7 +34,7 @@ IconOpener.propTypes = {
   showButtonLabel: PropTypes.func.isRequired,
   article: PropTypes.shape({
     id: PropTypes.number,
-    language: PropTypes.string.isRequired,
+    language: PropTypes.string,
     project: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -6,6 +6,7 @@ import OnClickOutside from 'react-onclickoutside';
 // Utilities
 import { forEach, union } from 'lodash-es';
 import { trunc } from '~/app/assets/javascripts/utils/strings';
+import ArticleUtils from '~/app/assets/javascripts/utils/article_utils';
 
 // Components
 import Loading from '@components/common/loading.jsx';
@@ -85,7 +86,7 @@ export class ArticleViewer extends React.Component {
 
   showButtonLabel() {
     const { showArticleFinder, showButtonLabel } = this.props;
-    if (showArticleFinder) return 'Brief preview of Article';
+    if (showArticleFinder) return ArticleUtils.I18n('preview', this.props.article.project);
     if (showButtonLabel) return showButtonLabel;
     if (this.isWhocolorLang()) {
       return I18n.t('articles.show_current_version_with_authorship_highlighting');

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -303,6 +303,7 @@ export class ArticleViewer extends React.Component {
             showBadArticleAlert && (
               <BadWorkAlert
                 alertStatus={alertStatus}
+                project={this.props.article.project}
                 submitBadWorkAlert={this.submitBadWorkAlert}
               />
             )

--- a/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
@@ -137,7 +137,7 @@ const PotentialAssignmentRows = ({
 
   const text = role === ASSIGNED_ROLE
     ? I18n.t(`courses.assignment_headings.${ArticleUtils.projectSuffix(project, 'available_articles')}`)
-    : CourseUtils.i18n(`assignment_headings.${ArticleUtils.projectSuffix(project, ' available_reviews')}`, course.string_prefix);
+    : CourseUtils.i18n(`assignment_headings.${ArticleUtils.projectSuffix(project, 'available_reviews')}`, course.string_prefix);
   const title = (
     <tr key="available" className="assignment-section-header">
       <td>

--- a/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
@@ -9,6 +9,7 @@ import GroupMembersLink from './GroupMembersLink';
 import PeerReviewLink from './PeerReviewLink';
 import AllPeerReviewLinks from './AllPeerReviewLinks';
 import Separator from '@components/overview/my_articles/common/Separator.jsx';
+import ArticleUtils from '../../../utils/article_utils';
 
 // constants
 import { ASSIGNED_ROLE, REVIEWING_ROLE } from '~/app/assets/javascripts/constants/assignments';
@@ -21,7 +22,7 @@ const interleaveSeparators = (acc, link, index, collection) => {
   return index < limit ? prefix.concat(<Separator key={index} />) : prefix;
 };
 
-const AssignmentLinks = ({ assignment, courseType, user }) => {
+const AssignmentLinks = ({ assignment, courseType, user, project }) => {
   const { article_url, id, role, editors } = assignment;
   const actions = [];
 
@@ -44,7 +45,7 @@ const AssignmentLinks = ({ assignment, courseType, user }) => {
   }
 
   const article = (
-    <a key={`article-${id}`} href={article_url} target="_blank">{I18n.t('assignments.article_link')}</a>
+    <a key={`article-${id}`} href={article_url} target="_blank">{I18n.t(`assignments.${ArticleUtils.projectSuffix(project, 'article_link')}`)}</a>
   );
 
   let groupMembers;
@@ -84,6 +85,7 @@ AssignmentLinks.propTypes = {
     reviewers: PropTypes.array,
     role: PropTypes.number.isRequired
   }),
+  project: PropTypes.string,
   courseType: PropTypes.string.isRequired,
   user: PropTypes.object.isRequired
 };

--- a/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
@@ -85,7 +85,7 @@ AssignmentLinks.propTypes = {
     reviewers: PropTypes.array,
     role: PropTypes.number.isRequired
   }),
-  project: PropTypes.string,
+  project: PropTypes.string.isRequired,
   courseType: PropTypes.string.isRequired,
   user: PropTypes.object.isRequired
 };

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import ArticleUtils from '../../utils/article_utils.js';
-
-
 import UserUtils from '../../utils/user_utils.js';
 // import Scroll from 'react-scroll';
 
@@ -36,7 +33,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
         } else if (user.activeRevision === true) {
           res = <div key={`legend-${user.name}`} className={`user-legend ${colors[i]}`}><a href={userLink} title={realName} target="_blank">{user.name}</a><img className="user-legend-hover" style={{ color: 'transparent' }} src="/assets/images/arrow.svg" alt="scroll to users revisions" width="30px" height="20px" onClick={() => Scroller.scrollTo(user.name, scrollBox)} /></div >;
         } else {
-          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip dark large'}>{I18n.t(`users.${ArticleUtils.projectSuffix(article.project, 'no_highlighting')}`)}</p><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
+          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip dark large'}>{I18n.t('users.no_highlighting')}</p><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
         }
 
         return res;

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import ArticleUtils from '../../utils/article_utils.js';
 
 
 import UserUtils from '../../utils/user_utils.js';
@@ -35,7 +36,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
         } else if (user.activeRevision === true) {
           res = <div key={`legend-${user.name}`} className={`user-legend ${colors[i]}`}><a href={userLink} title={realName} target="_blank">{user.name}</a><img className="user-legend-hover" style={{ color: 'transparent' }} src="/assets/images/arrow.svg" alt="scroll to users revisions" width="30px" height="20px" onClick={() => Scroller.scrollTo(user.name, scrollBox)} /></div >;
         } else {
-          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip dark large'}>{I18n.t('users.no_highlighting')}</p><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
+          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip dark large'}>{I18n.t(`users.${ArticleUtils.projectSuffix(article.project, 'no_highlighting')}`)}</p><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
         }
 
         return res;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/Categories.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/Categories.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   IMPROVING_ARTICLE, NEW_ARTICLE, REVIEWING_ARTICLE
 } from '~/app/assets/javascripts/constants/assignments';
+import ArticleUtils from '../../../../../utils/article_utils';
 
 import CourseUtils from '~/app/assets/javascripts/utils/course_utils.js';
 
@@ -26,17 +27,17 @@ export const Categories = ({ assignments, course, current_user, wikidataLabels }
     <>
       {
         articles.new.length
-          ? <List {...listProps} assignments={articles.new} title={CourseUtils.i18n('articles_i_will_create', course.string_prefix)} />
+          ? <List {...listProps} assignments={articles.new} title={CourseUtils.i18n(ArticleUtils.projectSuffix(course.home_wiki.project, 'articles_i_will_create'), course.string_prefix)} />
           : null
       }
       {
         articles.improving.length
-          ? <List {...listProps} assignments={articles.improving} title={CourseUtils.i18n('articles_i_am_updating', course.string_prefix)} />
+          ? <List {...listProps} assignments={articles.improving} title={CourseUtils.i18n(ArticleUtils.projectSuffix(course.home_wiki.project, 'articles_i_am_updating'), course.string_prefix)} />
           : null
       }
       {
         articles.reviewing.length
-          ? <List {...listProps} assignments={articles.reviewing} title={CourseUtils.i18n('articles_i_am_reviewing', course.string_prefix)} />
+          ? <List {...listProps} assignments={articles.reviewing} title={CourseUtils.i18n(ArticleUtils.projectSuffix(course.home_wiki.project, 'articles_i_am_reviewing'), course.string_prefix)} />
           : null
       }
     </>

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
@@ -41,6 +41,7 @@ export const Header = ({
   <header aria-label={`${articleTitle} assignment`} className="header-wrapper">
     <MyArticlesAssignmentLinks
       articleTitle={articleTitle}
+      project={article.project}
       assignment={assignment}
       courseType={course.type}
       current_user={current_user}

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/MyArticlesAssignmentLinks.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/MyArticlesAssignmentLinks.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 
 import AssignmentLinks from '@components/common/AssignmentLinks/AssignmentLinks.jsx';
 
-export const MyArticlesAssignmentLinks = ({ articleTitle, assignment, courseType, current_user }) => {
+export const MyArticlesAssignmentLinks = ({ articleTitle, assignment, courseType, current_user, project }) => {
   return (
     <section className="header">
       <section className="title">
         <h4>{articleTitle}</h4>
       </section>
       <section className="editors">
-        <AssignmentLinks assignment={assignment} courseType={courseType} user={current_user} />
+        <AssignmentLinks assignment={assignment} courseType={courseType} user={current_user} project={project}/>
       </section>
     </section>
   );
@@ -19,6 +19,7 @@ export const MyArticlesAssignmentLinks = ({ articleTitle, assignment, courseType
 MyArticlesAssignmentLinks.propTypes = {
   // props
   articleTitle: PropTypes.string.isRequired,
+  project: PropTypes.string.isRequired,
   assignment: PropTypes.object.isRequired,
   courseType: PropTypes.string.isRequired,
   current_user: PropTypes.object.isRequired,

--- a/app/assets/javascripts/components/overview/my_articles/components/Header.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import assignmentPropTypes from '../utils/assignmentPropTypes';
+import ArticleUtils from '../../../../utils/article_utils';
 
 // components
 import AssignCell from '@components/common/AssignCell/AssignCell.jsx';
@@ -15,7 +16,7 @@ export const Header = ({
   assigned, course, current_user, reviewable, reviewing, unassigned, wikidataLabels
 }) => (
   <div className="section-header my-articles-header">
-    <h3>{I18n.t('courses.my_articles')}</h3>
+    <h3>{I18n.t(`courses.${ArticleUtils.projectSuffix(course.home_wiki.project, 'my_articles')}`)}</h3>
     <div className="controls">
       <AssignCell
         assignments={assigned}
@@ -27,7 +28,7 @@ export const Header = ({
         prefix={I18n.t('users.my_assigned')}
         role={ASSIGNED_ROLE}
         student={current_user}
-        tooltip_message={I18n.t('assignments.assign_tooltip')}
+        tooltip_message={I18n.t(`assignments.${ArticleUtils.projectSuffix(course.home_wiki.project, 'assign_tooltip')}`)}
         unassigned={unassigned}
         wikidataLabels={wikidataLabels}
       />
@@ -41,12 +42,12 @@ export const Header = ({
         prefix={I18n.t('users.my_reviewing')}
         role={REVIEWING_ROLE}
         student={current_user}
-        tooltip_message={I18n.t('assignments.review_tooltip')}
+        tooltip_message={I18n.t(`assignments.${ArticleUtils.projectSuffix(course.home_wiki.project, 'review_tooltip')}`)}
         unassigned={reviewable}
         wikidataLabels={wikidataLabels}
       />
       <Link to={`/courses/${course.slug}/article_finder`}>
-        <button className="button border small assign-button link">Find Articles</button>
+        <button className="button border small assign-button link">{ArticleUtils.I18n('find', course.home_wiki.project)}</button>
       </Link>
     </div>
   </div>

--- a/app/assets/javascripts/components/overview/overview_handler.jsx
+++ b/app/assets/javascripts/components/overview/overview_handler.jsx
@@ -121,8 +121,8 @@ const Overview = createReactClass({
     );
 
     let userArticles;
-    const isWikidataCourse = course.home_wiki && course.home_wiki.project === 'wikidata';
-    if (this.props.current_user.isEnrolled && course.id && !isWikidataCourse) {
+    // const isWikidataCourse = course.home_wiki && course.home_wiki.project === 'wikidata';
+    if (this.props.current_user.isEnrolled && course.id) {
       userArticles = (
         <>
           <MyExercises trainingLibrarySlug={this.props.course.training_library_slug} />

--- a/app/assets/javascripts/components/students/components/Articles/NoSelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/NoSelectedStudent.jsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ArticleUtils from '../../../../utils/article_utils';
 
 // Utils
 import CourseUtils from '~/app/assets/javascripts/utils/course_utils.js';
 
-export const NoSelectedStudent = ({ string_prefix }) => {
+export const NoSelectedStudent = ({ string_prefix, project }) => {
   const prefix = CourseUtils.i18n('student', string_prefix);
   return (
     <div className="no-selected-student">
       <h4>{ I18n.t('instructor_view.select_student.title', { prefix }) }</h4>
-      <p>{ I18n.t('instructor_view.select_student.content') }</p>
+      <p>{ I18n.t(`instructor_view.select_student.${ArticleUtils.projectSuffix(project, 'content')}`) }</p>
     </div>
   );
 };
 
 
 NoSelectedStudent.propTypes = {
-  string_prefix: PropTypes.string.isRequired
+  string_prefix: PropTypes.string.isRequired,
+  project: PropTypes.string.isRequired
 };
 
 export default NoSelectedStudent;

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
@@ -43,6 +43,7 @@ export const Assignment = ({ assignment, course, current_user, fetchArticleDetai
           assignment={assignment}
           courseType={course.type}
           user={user}
+          project={course.home_wiki.project}
         />
       </td>
       <td className="current-status">

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/AssignmentsList.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/AssignmentsList.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 // Components
 import Assignment from './Assignment/Assignment.jsx';
 import List from '@components/common/list.jsx';
+import ArticleUtils from '../../../../../../utils/article_utils.js';
 
 export const AssignmentsList = ({ assignments, course, current_user, fetchArticleDetails, title, user }) => {
   const options = { desktop_only: false, sortable: false };
@@ -21,7 +22,7 @@ export const AssignmentsList = ({ assignments, course, current_user, fetchArticl
       ...options
     },
     article_viewer: {
-      label: I18n.t('courses.article_viewer'),
+      label: I18n.t(`courses.${ArticleUtils.projectSuffix(course.home_wiki.project, 'article_viewer')}`),
       ...options
     }
   };

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/Header.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/Header.jsx
@@ -6,6 +6,7 @@ import AssignCell from '@components/common/AssignCell/AssignCell.jsx';
 
 // Helper Functions
 import { groupByAssignmentType } from '@components/util/helpers';
+import ArticleUtils from '../../../../../utils/article_utils.js';
 
 // Constants
 import {
@@ -42,7 +43,7 @@ export const Header = ({
           prefix={I18n.t('users.my_assigned')}
           role={ASSIGNED_ROLE}
           student={selected}
-          tooltip_message={I18n.t('assignments.assign_tooltip')}
+          tooltip_message={I18n.t(`assignments.${ArticleUtils.projectSuffix(course.home_wiki.project, 'assign_tooltip')}`)}
           unassigned={assignable}
           wikidataLabels={wikidataLabels}
         />
@@ -55,7 +56,7 @@ export const Header = ({
           prefix={I18n.t('users.my_reviewing')}
           role={REVIEWING_ROLE}
           student={selected}
-          tooltip_message={I18n.t('assignments.review_tooltip')}
+          tooltip_message={I18n.t(`assignments.${ArticleUtils.projectSuffix(course.home_wiki.project, 'review_tooltip')}`)}
           unassigned={reviewable}
           wikidataLabels={wikidataLabels}
         />

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/NoAssignments.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/NoAssignments.jsx
@@ -1,16 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import ArticleUtils from '../../../../../utils/article_utils';
 
-export const NoAssignments = () => {
+export const NoAssignments = ({ project }) => {
   return (
     <div className="list__wrapper">
       <h4 className="assignments-list-title">
         {I18n.t('articles.assigned')}
       </h4>
       <section className="no-assignments">
-        <p>{ I18n.t('instructor_view.no_assignments') }</p>
+        <p>{ I18n.t(`instructor_view.${ArticleUtils.projectSuffix(project, 'no_assignments')}`) }</p>
       </section>
     </div>
   );
+};
+
+NoAssignments.propTypes = {
+  project: PropTypes.string.isRequired
 };
 
 export default NoAssignments;

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
@@ -58,7 +58,7 @@ export const SelectedStudent = ({
       }
 
       {
-        !assigned.length && !reviewing.length && <NoAssignments />
+        !assigned.length && !reviewing.length && <NoAssignments project={course.home_wiki.project} />
       }
 
       {

--- a/app/assets/javascripts/components/students/components/RandomPeerAssignButton.jsx
+++ b/app/assets/javascripts/components/students/components/RandomPeerAssignButton.jsx
@@ -6,6 +6,7 @@ import createReactClass from 'create-react-class';
 import { initiateConfirm } from '../../../actions/confirm_actions';
 import { randomPeerAssignments } from '../../../actions/assignment_actions';
 import { REVIEWING_ROLE } from '../../../constants';
+import ArticleUtils from '../../../utils/article_utils';
 
 const RandomPeerAssignButton = createReactClass({
   displayName: 'RandomPeerAssignButton',
@@ -25,10 +26,10 @@ const RandomPeerAssignButton = createReactClass({
     let confirmMessage;
     let onConfirm;
     if (randomAssignmentsCount <= 0) {
-      confirmMessage = I18n.t('assignments.random_peer_review.limit_exceeded', { maximum: peerReviewCount });
+      confirmMessage = I18n.t(`assignments.random_peer_review.${ArticleUtils.projectSuffix(this.props.course.home_wiki.project, 'limit_exceeded')}`, { maximum: peerReviewCount });
       onConfirm = () => {};
     } else {
-      confirmMessage = I18n.t('assignments.random_peer_review.confirm_addition', { count: randomAssignmentsCount, maximum: peerReviewCount });
+      confirmMessage = I18n.t(`assignments.random_peer_review.${ArticleUtils.projectSuffix(this.props.course.home_wiki.project, 'confirm_addition')}`, { count: randomAssignmentsCount, maximum: peerReviewCount });
       onConfirm = () => this.props.randomPeerAssignments({ course_slug: this.props.course.slug });
     }
 
@@ -47,7 +48,7 @@ const RandomPeerAssignButton = createReactClass({
         </button>
         <div className="tooltip">
           <p>
-            {I18n.t('assignments.random_peer_review.tooltip_message')}
+            {I18n.t(`assignments.random_peer_review.${ArticleUtils.projectSuffix(this.props.course.home_wiki.project, 'tooltip_message')}`)}
           </p>
         </div>
       </div>

--- a/app/assets/javascripts/components/students/containers/Articles.jsx
+++ b/app/assets/javascripts/components/students/containers/Articles.jsx
@@ -125,7 +125,7 @@ export class Articles extends React.Component {
                 <Route
                   exact
                   path="/courses/:course_school/:course_title/students/articles"
-                  render={() => <NoSelectedStudent string_prefix={course.string_prefix} />}
+                  render={() => <NoSelectedStudent string_prefix={course.string_prefix} project={course.home_wiki.project} />}
                 />
               </Switch>
             </section>

--- a/app/assets/javascripts/components/students/shared/StudentList/student_list_keys.js
+++ b/app/assets/javascripts/components/students/shared/StudentList/student_list_keys.js
@@ -1,10 +1,12 @@
 import ArticleUtils from '../../../../utils/article_utils';
 
-const charactersAddedKey = {
-  label: I18n.t('users.chars_added'),
-  desktop_only: true,
-  sortable: true,
-  info_key: 'users.character_doc'
+const charactersAddedKey = (project) => {
+  return {
+    label: I18n.t(`users.${ArticleUtils.projectSuffix(project, 'chars_added')}`),
+    desktop_only: true,
+    sortable: true,
+    info_key: 'users.character_doc'
+  };
 };
 
 const wordsAddedKey = {
@@ -15,7 +17,7 @@ const wordsAddedKey = {
 };
 
 const studentListKeys = (course) => {
-  const contentAddedKey = course.home_wiki_bytes_per_word ? wordsAddedKey : charactersAddedKey;
+  const contentAddedKey = course.home_wiki_bytes_per_word ? wordsAddedKey : charactersAddedKey(course.home_wiki.project);
 
   return {
     username: {

--- a/app/assets/javascripts/components/students/shared/StudentList/student_list_keys.js
+++ b/app/assets/javascripts/components/students/shared/StudentList/student_list_keys.js
@@ -1,3 +1,5 @@
+import ArticleUtils from '../../../../utils/article_utils';
+
 const charactersAddedKey = {
   label: I18n.t('users.chars_added'),
   desktop_only: true,
@@ -22,7 +24,7 @@ const studentListKeys = (course) => {
       sortable: true,
     },
     assignment_title: {
-      label: I18n.t('users.assigned'),
+      label: I18n.t(`users.${ArticleUtils.projectSuffix(course.home_wiki.project, 'assigned')}`),
       desktop_only: true,
       sortable: false
     },
@@ -42,7 +44,7 @@ const studentListKeys = (course) => {
       label: I18n.t('users.references_count'),
       desktop_only: true,
       sortable: true,
-      info_key: 'metrics.references_doc'
+      info_key: `metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'references_doc')}`
     },
     total_uploads: {
       label: I18n.t('users.total_uploads'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,7 @@ en:
 
   items:
     items: Items
+    article_not_found: "This item has not been created yet."
     assigned: Assigned Items
     assignments_none: There are no assigned items yet.
     available: Available Items
@@ -893,23 +894,29 @@ en:
   instructor_view:
     article_assignments: "%{prefix} Assignments"
     assignments_table:
-      article_name: Article Name
+      article_name: Name
       current_stage: Current Stage
       relevant_links: Relevant Links
     assigned_articles: Assigned Articles
+    assigned_articles_wikidata: Assigned Articles
     bad_work:
       learn_more: "If student work made the article worse, we encourage you to edit it yourself. Otherwise, let us know about the problems so that we can fix them later on."
+      learn_more_wikidata: "If student work made the item worse, we encourage you to edit it yourself. Otherwise, let us know about the problems so that we can fix them later on."
       learn_more_button: "Learn More"
       submit_issue: "What are the significant problems with this article?"
+      submit_issue_wikidata: "What are the significant problems with this item?"
       submit_issue_placeholder: "The more expert perspective and detail you can provide, the better."
       thank_you: "Thank you! Contact your Wiki Expert if you have additional questions."
     exercises_and_trainings: "%{prefix} Exercises & Trainings"
     no_assignments: "This student currently has no assigned articles. You can assign an article by using the buttons above."
+    no_assignments_wikidata: "This student currently has no assigned itemss. You can assign an item by using the buttons above."
     overview: "%{prefix} Overview"
     reviewing_articles: Reviewing Articles
+    reviewing_articles: Reviewing Items
     select_student:
       title: "Select %{prefix}"
       content: to assign and view article assignments
+      content_wikidata: to assign and view article assignments
 
   metrics:
     label: Course Activity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
     loading: Loading articles...
     new: (new)
     none: This course has not edited any articles.
+    preview: Brief preview of Article
     rating: Class
     rating_doc: The rating an article has been assigned by WikiProjects on Wikipedia. These ratings may corresponds to much older versions, so they are just a rough indicator of article maturity.
     rating_docs:
@@ -237,6 +238,7 @@ en:
     does_not_exist: The Item doesn't exist. Create a Sandbox page and assign yourself to that to receive suggestions.
     edited: Items Edited
     edited_none: There are no edited items yet.
+    preview: Brief preview of Item
     search: Search Wikidata for an Item
     tracked_doc: Only tracked items contribute to the the statistics for this program. When items are marked as untracked, they will be removed from the statistics during the next data update.
     view_doc: The estimated views to each item since it was first edited, through the most recent stats update. You can use pageviews.toolforge.org to see the exact numbers.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
   assignments:
     article: The article %{title} is now assigned to you.
     article_link: Article
+    article_link_wikidata: Item
     already_exists: This assignment already exists!
     title_too_large: The title shouldn't exceed 255 characters
     assignees: Assignee(s)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -303,7 +303,7 @@ en:
       tooltip_message: Assigns random articles (with peer review count as the maximum number) to each student.
       tooltip_message_wikidata: Assigns random items (with peer review count as the maximum number) to each student.
       limit_exceeded: Each student is already reviewing at least %{maximum} articles(s).
-      limit_exceeded_wikidata: Each student is already reviewing at least %{maximum} articles(s).
+      limit_exceeded_wikidata: Each student is already reviewing at least %{maximum} item(s).
     remove: Remove
     reviewers: Reviewer(s)
     review_other: Assign/remove a peer review

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1225,7 +1225,8 @@ en:
       increased page size. This number doesn't necessarily reflect the
       amount of new content the user added. Restoring removed content
       will also increase this total.
-    chars_added: Characters Added<br>(item | user | draft)
+    chars_added: Characters Added<br>(article | user | draft)
+    chars_added_wikidata: Characters Added<br>(item | user | draft)
     contributions: User Contributions
     contributions_history_full: View full contribution history
     contributions_more: View More Contributions
@@ -1257,7 +1258,6 @@ en:
     no_articles_wikidata: No items
     no_revisions: This editor has made no revisions.
     no_highlighting: "No text from the current version of the article is attributed to this editor. Check the page history to see their edits."
-    no_highlighting_wikidata: "No text from the current version of the item is attributed to this editor. Check the page history to see their edits."
     number_of_articles:
       one: "%{count} article"
       other: "%{count} articles"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1189,8 +1189,10 @@ en:
   users:
     already_enrolled: That user is already enrolled!
     assign_articles: Assign Articles
+    assign_articles_wikidata: Assign Items
     assign_articles_done: Done
     assigned: Assigned Articles
+    assigned_wikidata: Assigned Items
     assignees: Assignee(s)
     loading_authorship_data: loading authorship data
     authorship_data_not_fetched: could not fetch authorship data
@@ -1200,7 +1202,7 @@ en:
       increased page size. This number doesn't necessarily reflect the
       amount of new content the user added. Restoring removed content
       will also increase this total.
-    chars_added: Characters Added<br>(article | user | draft)
+    chars_added: Characters Added<br>(item | user | draft)
     contributions: User Contributions
     contributions_history_full: View full contribution history
     contributions_more: View More Contributions
@@ -1220,10 +1222,10 @@ en:
     last_name: Last name
     loading: Loading users...
     characters_added_mainspace: Characters Added (article)
+    characters_added_mainspace_wikidata: Characters Added (item)
     characters_added_short: "MS: %{mainspace}, US: %{userspace}"
     characters_added_userspace: Characters Added (user)
     characters_added_draftspace: Characters Added (draft)
-    references_count: References Added
     my_assigned: "Assigned:"
     my_reviewing: "Reviewing:"
     name: Name
@@ -1232,6 +1234,7 @@ en:
     no_articles_wikidata: No items
     no_revisions: This editor has made no revisions.
     no_highlighting: "No text from the current version of the article is attributed to this editor. Check the page history to see their edits."
+    no_highlighting_wikidata: "No text from the current version of the item is attributed to this editor. Check the page history to see their edits."
     number_of_articles:
       one: "%{count} article"
       other: "%{count} articles"
@@ -1240,6 +1243,7 @@ en:
       other: "%{count} items"
     profile: profile
     recent_revisions: Recent Edits
+    references_count: References Added
     remove_confirmation: Are you sure you want to remove %{username}?
     request_confirmation: Are you sure you want to request this account?
     requested_account_status:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,7 @@ en:
     search: Search Wikidata for an Item
     tracked_doc: Only tracked items contribute to the the statistics for this program. When items are marked as untracked, they will be removed from the statistics during the next data update.
     view_doc: The estimated views to each item since it was first edited, through the most recent stats update. You can use pageviews.toolforge.org to see the exact numbers.
+    title_example: Item title
 
   articles_wikidata:
     articles_short: Items

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,9 +435,12 @@ en:
     articles: Articles
     article_viewer: Article Viewer
     article_viewer_wikidata: Item Viewer
+    articles_i_am_reviewing_wikidata: Items I'm peer reviewing
     articles_i_am_reviewing: Articles I'm peer reviewing
     articles_i_will_create: Articles I will create
+    articles_i_will_create_wikidata: Items I will create
     articles_i_am_updating: Articles I'm updating
+    articles_i_am_updating_wikidata: Items I'm updating
     assignment_headings:
       assigned_articles: Assigned Articles
       assigned_articles_wikidata: Assigned Items

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,6 +173,7 @@ en:
       tracked: Tracked
       untracked: Untracked
       tracked_and_untracked: Tracked and Untracked
+    find: Find Articles
     hide: Hide
     history: (history)
     label: Articles
@@ -238,6 +239,7 @@ en:
     does_not_exist: The Item doesn't exist. Create a Sandbox page and assign yourself to that to receive suggestions.
     edited: Items Edited
     edited_none: There are no edited items yet.
+    find: Find Items
     preview: Brief preview of Item
     search: Search Wikidata for an Item
     tracked_doc: Only tracked items contribute to the the statistics for this program. When items are marked as untracked, they will be removed from the statistics during the next data update.
@@ -266,6 +268,7 @@ en:
     assign_self: Assign myself an article
     assign_self_wikidata: Assign myself an item
     assign_tooltip: An assigned article is one that you plan to create or improve.
+    assign_tooltip_wikidata: An assigned item is one that you plan to create or improve.
     bibliography: Bibliography
     clone: Clone
     confirm_add_available: Are you sure you want to add %{title}?
@@ -306,6 +309,7 @@ en:
     review_self: Review an article
     review_self_wikidata: Review an item
     review_tooltip: This is for article(s) you plan to peer review or provide feedback on.
+    review_tooltip_wikidata: This is for item(s) you plan to peer review or provide feedback on.
     sandbox_draft_link: Sandbox Draft
     select: Select
     warning_untracked_wiki: >
@@ -637,6 +641,7 @@ en:
     loading: Loading…
     milestones_none: This course does not currently have any milestones.
     my_articles: My Articles
+    my_articles_wikidata: My Items
     needs_update: Schedule Data Update
     new_week: Add New Week
     new_account_check_username: Check username availability
@@ -918,7 +923,7 @@ en:
     select_student:
       title: "Select %{prefix}"
       content: to assign and view article assignments
-      content_wikidata: to assign and view article assignments
+      content_wikidata: to assign and view item assignments
 
   metrics:
     label: Course Activity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,9 +286,17 @@ en:
         you can manually assign peer reviews by clicking a student's row and then using "Assign/remove a peer review" button.
         Clicking "OK" will assign a total of %{count} additional peer review(s), with a maximum of %{maximum} for each student,
         chosen from among their classmates' articles.
+      confirm_addition_wikidata: >
+        In most cases, you should only use this after all students have been assigned their main items.
+        Alternatively, you can ask your students to choose their own peer reviews or
+        you can manually assign peer reviews by clicking a student's row and then using "Assign/remove a peer review" button.
+        Clicking "OK" will assign a total of %{count} additional peer review(s), with a maximum of %{maximum} for each student,
+        chosen from among their classmates' items.
       heading: Assign random peer reviews
       tooltip_message: Assigns random articles (with peer review count as the maximum number) to each student.
+      tooltip_message_wikidata: Assigns random items (with peer review count as the maximum number) to each student.
       limit_exceeded: Each student is already reviewing at least %{maximum} articles(s).
+      limit_exceeded_wikidata: Each student is already reviewing at least %{maximum} articles(s).
     remove: Remove
     reviewers: Reviewer(s)
     review_other: Assign/remove a peer review

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -433,6 +433,7 @@ en:
     actions: Actions
     articles: Articles
     article_viewer: Article Viewer
+    article_viewer_wikidata: Item Viewer
     articles_i_am_reviewing: Articles I'm peer reviewing
     articles_i_will_create: Articles I will create
     articles_i_am_updating: Articles I'm updating
@@ -917,7 +918,7 @@ en:
       thank_you: "Thank you! Contact your Wiki Expert if you have additional questions."
     exercises_and_trainings: "%{prefix} Exercises & Trainings"
     no_assignments: "This student currently has no assigned articles. You can assign an article by using the buttons above."
-    no_assignments_wikidata: "This student currently has no assigned itemss. You can assign an item by using the buttons above."
+    no_assignments_wikidata: "This student currently has no assigned items. You can assign an item by using the buttons above."
     overview: "%{prefix} Overview"
     reviewing_articles: Reviewing Articles
     reviewing_articles: Reviewing Items

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/index.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/index.spec.jsx
@@ -9,7 +9,8 @@ describe('MyArticlesAssignmentLinks', () => {
     articleTitle: 'title',
     assignment: { id: 1, article_url: 'url', role: 0 },
     courseType: 'ClassroomProgramCourse',
-    current_user: { id: 99, username: 'user' }
+    current_user: { id: 99, username: 'user' },
+    project: 'wikipedia'
   };
 
   it('should show the default links', () => {

--- a/test/components/overview/my_articles/components/Categories/index.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/index.spec.jsx
@@ -7,9 +7,10 @@ import Categories from '@components/overview/my_articles/components/Categories/C
 describe('Categories', () => {
   const props = {
     assignments: [],
-    course: {},
+    course: { home_wiki: { project: 'wikipedia' } },
     current_user: {},
     wikidataLabels: {}
+
   };
 
   it('should show articles the user is creating', () => {

--- a/test/components/overview/my_articles/components/Header.spec.jsx
+++ b/test/components/overview/my_articles/components/Header.spec.jsx
@@ -7,7 +7,7 @@ import Header from '../../../../../app/assets/javascripts/components/overview/my
 describe('Header', () => {
   const props = {
     assigned: [],
-    course: { slug: 'course/slug', home_wiki: {project: 'wikipedia'} },
+    course: { slug: 'course/slug', home_wiki: { project: 'wikipedia' } },
     current_user: {},
     reviewable: [],
     reviewing: [],

--- a/test/components/overview/my_articles/components/Header.spec.jsx
+++ b/test/components/overview/my_articles/components/Header.spec.jsx
@@ -7,7 +7,7 @@ import Header from '../../../../../app/assets/javascripts/components/overview/my
 describe('Header', () => {
   const props = {
     assigned: [],
-    course: { slug: 'course/slug' },
+    course: { slug: 'course/slug', home_wiki: {project: 'wikipedia'} },
     current_user: {},
     reviewable: [],
     reviewing: [],


### PR DESCRIPTION
Users profile tab is rendering based on max home wiki occurrences. 

If Wikidata is most frequent, Items terminology is displayed: 
![profile](https://user-images.githubusercontent.com/65791349/147980068-3f3e478a-f700-48d0-a5c8-fafcaa7f035c.png)

In other cases, it is Articles terminology as before:
![profile1](https://user-images.githubusercontent.com/65791349/147980125-de1f86ac-82bf-45f9-a01f-3660acb5e66e.png)


