### PR TITLE
Add Survey/Question group to survey response alert

### DIFF
--- a/lib/alerts/survey_response_alert_manager.rb
+++ b/lib/alerts/survey_response_alert_manager.rb
@@ -9,19 +9,31 @@ class SurveyResponseAlertManager
     @answers.each do |answer|
       next unless answer_meets_alert_conditions?(answer)
       next if alert_already_exists?(answer)
-      details = {
-        question: answer.question.question_text,
-        answer: answer.answer_text,
-        followup: answer.follow_up_answer_text
-      }
       alert = Alert.create(type: 'SurveyResponseAlert',
                            message: alert_message(answer),
                            user_id: answer.user.id,
                            subject_id: answer.question.id,
-                           details: details,
+                           details: details(answer),
                            target_user_id: alert_recipient&.id)
       alert.email_target_user
     end
+  end
+
+  def details(answer)
+    {
+      question: answer.question.question_text,
+      answer: answer.answer_text,
+      followup: answer.follow_up_answer_text,
+      source: self.class.source(answer)
+    }
+  end
+
+  def self.source(answer)
+    question_group = answer.answer_group.question_group
+    survey_names = question_group.surveys.map(&:name).join(' .')
+
+    format('Question group: %<qg>s, Survey(s): %<s>s ',
+           { qg: question_group.name, s: survey_names })
   end
 
   private

--- a/spec/mailers/previews/alert_mailer_preview.rb
+++ b/spec/mailers/previews/alert_mailer_preview.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "#{Rails.root}/lib/alerts/survey_response_alert_manager"
+
 #= Preview all emails at http://localhost:3000/rails/mailers/alert_mailer
 class AlertMailerPreview < ActionMailer::Preview
   def articles_for_deletion_alert
@@ -34,6 +36,10 @@ class AlertMailerPreview < ActionMailer::Preview
     AlertMailer.alert(example_no_med_training_for_course, example_user)
   end
 
+  def survey_response_alert
+    AlertMailer.alert(example_survey_response_alert, example_user)
+  end
+
   private
 
   def example_user
@@ -41,7 +47,7 @@ class AlertMailerPreview < ActionMailer::Preview
   end
 
   def example_student
-    User.new(email: 'nospam@nospam.com', username: 'nospam', permissions: 0)
+    User.new(email: 'nospam@nospam.com', username: 'Me_student', permissions: 0)
   end
 
   def example_course
@@ -72,5 +78,50 @@ class AlertMailerPreview < ActionMailer::Preview
     Alert.new(type: 'NoMedTrainingForCourseAlert',
               article: example_article,
               course: example_course)
+  end
+
+  def example_survey_response_alert
+    clean_up_answer
+    answer = create_answer
+    details =
+      {
+        question: answer.question.question_text,
+        answer: answer.answer_text,
+        followup: answer.follow_up_answer_text,
+        source: SurveyResponseAlertManager.source(answer)
+      }
+
+    Alert.new(type: 'SurveyResponseAlert',
+              user: answer.user,
+              subject_id: answer.question.id,
+              details: details)
+  end
+
+  def create_answer
+    survey = Survey.new(name: 'Test survey')
+    question_group = Rapidfire::QuestionGroup.new(id: 999999, name: 'Test question group')
+    survey.rapidfire_question_groups << question_group
+    question_group.surveys << survey
+    answer_group = Rapidfire::AnswerGroup
+                   .new(id: 999999,
+                        question_group: question_group,
+                        user: example_student)
+    question = Rapidfire::Question
+               .create!(id: 999999,
+                        question_text: 'What are you studying ?',
+                        question_group: question_group)
+    answer = Rapidfire::Answer
+             .new(answer_text: 'Physics',
+                  follow_up_answer_text: 'Really ?',
+                  answer_group: answer_group,
+                  question: question)
+    answer.user = example_student
+    answer
+  end
+
+  def clean_up_answer
+    PaperTrail::Version.destroy_by(item_id: 999999)
+    Rapidfire::QuestionGroup.destroy_by(id: 999999)
+    Rapidfire::Question.destroy_by(id: 999999)
   end
 end


### PR DESCRIPTION
Add survey(s)/question group to the SurveyResponseAlert email 
Issue #4650

- update survey response manager to include alert source
- add alert mailer to alerts list

