### PR TITLE
Check for enrollment page, before showing 'Join course' button

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -106,6 +106,8 @@ const AvailableActions = createReactClass({
     const course = this.props.course;
     const controls = [];
     const user = this.props.current_user;
+    const urlParams = new URLSearchParams(window.location.search);
+    const isEnrollmentURL = urlParams.has('enroll');
     // If user has a role in the course or is an admin
     if ((user.isEnrolled) || user.admin || user.isAdvancedRole) {
       // If user is a student, show the 'leave' button.
@@ -132,23 +134,17 @@ const AvailableActions = createReactClass({
           <div key="needs_update" className="available-action"><button className="button" onClick={this.needsUpdate}>{I18n.t('courses.needs_update')}</button></div>
         ));
       }
-    // If user has no role or is logged out
-    } else if (!course.ended) {
-
-      //If it's enrollment page, don't show 'Join course' button in Actions to avoid confusion
-      const urlParams = new URLSearchParams(window.location.search);
-      const isEnrollmentURL = urlParams.has('enroll');
-
-      if (!isEnrollmentURL) {
+    // If user has no role or is logged out, and if he is not on enrollment page, show 'Join course' button.
+    // On enrollment page, 'Join course' button is not shown in Actions component to avoid confusion.
+    } else if (!course.ended && !isEnrollmentURL) {
+      controls.push(
+        <div key="join" className="available-action"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', course.string_prefix)}</button></div>
+      );
+      // On P&E Dashboard, offer option to join as online volunteer
+      if (!Features.wikiEd && course.online_volunteers_enabled) {
         controls.push(
-          <div key="join" className="available-action"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', course.string_prefix)}</button></div>
+          <div key="volunteer" className="available-action"><button onClick={() => this.join('online_volunteer')} className="button">{CourseUtils.i18n('join_course_as_volunteer', course.string_prefix)}</button></div>
         );
-        // On P&E Dashboard, offer option to join as online volunteer
-        if (!Features.wikiEd && course.online_volunteers_enabled) {
-          controls.push(
-            <div key="volunteer" className="available-action"><button onClick={() => this.join('online_volunteer')} className="button">{CourseUtils.i18n('join_course_as_volunteer', course.string_prefix)}</button></div>
-          );
-        }
       }
     }
     // If the user is enrolled in the course or admin, and the course type is editathon and not finished, show a manual stats update button

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -134,14 +134,21 @@ const AvailableActions = createReactClass({
       }
     // If user has no role or is logged out
     } else if (!course.ended) {
-      controls.push(
-        <div key="join" className="available-action"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', course.string_prefix)}</button></div>
-      );
-      // On P&E Dashboard, offer option to join as online volunteer
-      if (!Features.wikiEd && course.online_volunteers_enabled) {
+
+      //If it's enrollment page, don't show 'Join course' button in Actions to avoid confusion
+      const urlParams = new URLSearchParams(window.location.search);
+      const isEnrollmentURL = urlParams.has('enroll');
+
+      if (!isEnrollmentURL) {
         controls.push(
-          <div key="volunteer" className="available-action"><button onClick={() => this.join('online_volunteer')} className="button">{CourseUtils.i18n('join_course_as_volunteer', course.string_prefix)}</button></div>
+          <div key="join" className="available-action"><button onClick={this.join} className="button">{CourseUtils.i18n('join_course', course.string_prefix)}</button></div>
         );
+        // On P&E Dashboard, offer option to join as online volunteer
+        if (!Features.wikiEd && course.online_volunteers_enabled) {
+          controls.push(
+            <div key="volunteer" className="available-action"><button onClick={() => this.join('online_volunteer')} className="button">{CourseUtils.i18n('join_course_as_volunteer', course.string_prefix)}</button></div>
+          );
+        }
       }
     }
     // If the user is enrolled in the course or admin, and the course type is editathon and not finished, show a manual stats update button


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This PR tries to resolve the issue - #4752. Basically, it adds an extra check before rendering buttons in Actions section. If the current url is enrollment url, it does not show button to join the course.
## Screenshots
Before:
![Screenshot (117)](https://user-images.githubusercontent.com/56690165/151853863-83e6693f-3353-4174-ba19-d594575ae4d1.png)


After:
![Screenshot (116)](https://user-images.githubusercontent.com/56690165/151853887-383735d4-527e-4572-8d4d-445763d1afe8.png)
Enrollment page

![Screenshot (118)](https://user-images.githubusercontent.com/56690165/151854132-e241e497-48a1-48c6-976a-af41a5c933f8.png)
Normal page
