### PR TITLE
Fix DOM nesting error in Uploads list

### DIFF
--- a/app/assets/javascripts/components/common/list.jsx
+++ b/app/assets/javascripts/components/common/list.jsx
@@ -61,7 +61,7 @@ const List = createReactClass({
 
   render() {
     const { keys, sortable, table_key, className, none_message, sortBy, loading, stickyHeader } = this.props;
-    const { elements } = this.props;
+    let { elements } = this.props;
     const headers = [];
     const iterable = Object.keys(keys);
 
@@ -111,10 +111,8 @@ const List = createReactClass({
     // Handle the case of no elements:
     // Show a none message if data is already loaded, or
     // show the Loading spinner if data is not yet loaded.
-    let emptyMessage;
-    let tbody = true;
     if (elements.length === 0) {
-      tbody = false;
+      let emptyMessage;
       if (!loading) {
         // eslint-disable-next-line
         let noneMessage = none_message;
@@ -122,10 +120,17 @@ const List = createReactClass({
           // eslint-disable-next-line
           noneMessage = I18n.t(`${table_key}.none`);
         }
-        emptyMessage = <div className="none, text-center"><p>{noneMessage}</p></div>;
+        emptyMessage = <span>{noneMessage}</span>;
       } else {
         emptyMessage = <Loading />;
       }
+      elements = (
+        <tr className="disabled">
+          <td colSpan={headers.length + 1} className="text-center">
+            {emptyMessage}
+          </td>
+        </tr>
+      );
     }
     let fixedHeader;
     let fixedArea;
@@ -137,8 +142,7 @@ const List = createReactClass({
     }
     return (
       <div className={fixedArea}>
-        {/* eslint-disable */}
-        {tbody && <table className={defaultClassName}>
+        <table className={defaultClassName}>
           <thead className={fixedHeader}>
             <tr>
               {headers}
@@ -147,9 +151,7 @@ const List = createReactClass({
           <tbody>
             {elements}
           </tbody>
-        </table> }
-        {/* eslint-enable */}
-        {!tbody && emptyMessage}
+        </table>
       </div>
     );
   }

--- a/app/assets/javascripts/components/common/list.jsx
+++ b/app/assets/javascripts/components/common/list.jsx
@@ -61,7 +61,7 @@ const List = createReactClass({
 
   render() {
     const { keys, sortable, table_key, className, none_message, sortBy, loading, stickyHeader } = this.props;
-    let { elements } = this.props;
+    const { elements } = this.props;
     const headers = [];
     const iterable = Object.keys(keys);
 
@@ -111,8 +111,10 @@ const List = createReactClass({
     // Handle the case of no elements:
     // Show a none message if data is already loaded, or
     // show the Loading spinner if data is not yet loaded.
+    let emptyMessage;
+    let tbody = true;
     if (elements.length === 0) {
-      let emptyMessage;
+      tbody = false;
       if (!loading) {
         // eslint-disable-next-line
         let noneMessage = none_message;
@@ -120,17 +122,10 @@ const List = createReactClass({
           // eslint-disable-next-line
           noneMessage = I18n.t(`${table_key}.none`);
         }
-        emptyMessage = <span>{noneMessage}</span>;
+        emptyMessage = <div className="none, text-center"><p>{noneMessage}</p></div>;
       } else {
         emptyMessage = <Loading />;
       }
-      elements = (
-        <tr className="disabled">
-          <td colSpan={headers.length + 1} className="text-center">
-            {emptyMessage}
-          </td>
-        </tr>
-      );
     }
     let fixedHeader;
     let fixedArea;
@@ -142,7 +137,8 @@ const List = createReactClass({
     }
     return (
       <div className={fixedArea}>
-        <table className={defaultClassName}>
+        {/* eslint-disable */}
+        {tbody && <table className={defaultClassName}>
           <thead className={fixedHeader}>
             <tr>
               {headers}
@@ -151,7 +147,9 @@ const List = createReactClass({
           <tbody>
             {elements}
           </tbody>
-        </table>
+        </table> }
+        {/* eslint-enable */}
+        {!tbody && emptyMessage}
       </div>
     );
   }

--- a/app/assets/javascripts/components/uploads/upload_list.jsx
+++ b/app/assets/javascripts/components/uploads/upload_list.jsx
@@ -73,17 +73,19 @@ const UploadList = createReactClass({
     }
 
     if (this.props.view === LIST_VIEW) {
-      uploadsView = (
-        <div className="list-view">
-          <List
-            elements={elements}
-            keys={keys}
-            table_key="uploads"
-            sortBy={this.props.sortBy}
-            none_message={I18n.t('courses_generic.uploads_none')}
-          />
-        </div>
-      );
+      if (elements.length && elements.length > 0) {
+        uploadsView = (
+          <div className="list-view">
+            <List
+              elements={elements}
+              keys={keys}
+              table_key="uploads"
+              sortBy={this.props.sortBy}
+            />
+          </div>);
+      } else {
+          uploadsView = (<div className="list-view">{noUploadsMessage}</div>);
+        }
     }
 
     if (this.props.view === TILE_VIEW) {

--- a/app/assets/javascripts/components/uploads/upload_list.jsx
+++ b/app/assets/javascripts/components/uploads/upload_list.jsx
@@ -65,15 +65,11 @@ const UploadList = createReactClass({
     let uploadsView;
 
     if (this.props.view === GALLERY_VIEW) {
-      if (elements.length === 0) {
-        uploadsView = (<div className="list-view">{noUploadsMessage}</div>);
-      } else {
-        uploadsView = (<div className="gallery-view"> {elements} </div>);
-      }
+      uploadsView = elements.length === 0 ? (<div className="list-view">{noUploadsMessage}</div>) : (<div className="gallery-view"> {elements} </div>);
     }
 
     if (this.props.view === LIST_VIEW) {
-      if (elements.length && elements.length > 0) {
+      if (elements.length > 0) {
         uploadsView = (
           <div className="list-view">
             <List
@@ -91,8 +87,7 @@ const UploadList = createReactClass({
     if (this.props.view === TILE_VIEW) {
       uploadsView = (
         <div className="tile-view">
-          {uploads.length > 0 && elements}
-          {uploads.length === 0 && noUploadsMessage}
+          {uploads.length > 0 ? elements : noUploadsMessage}
         </div>
       );
     }

--- a/app/assets/javascripts/components/uploads/upload_list.jsx
+++ b/app/assets/javascripts/components/uploads/upload_list.jsx
@@ -18,14 +18,17 @@ const UploadList = createReactClass({
   render() {
     const uploads = this.props.uploads;
     let elements;
+    let noUploadsMessage;
     if (uploads.length > 0) {
       elements = uploads.map((upload) => {
         return <Upload upload={upload} view={this.props.view} key={upload.id} linkUsername={true} />;
       });
     } else if (!this.props.loadingUploads && this.props.totalUploadsCount > 0 && uploads.length === 0) {
-      elements = (<div className="none"><p>{I18n.t('courses_generic.user_uploads_none')}</p></div>);
+      elements = [];
+      noUploadsMessage = (<div className="none text-center"><p>{I18n.t('courses_generic.user_uploads_none')}</p></div>);
     } else if (!this.props.loadingUploads && uploads.length === 0) {
-      elements = (<div className="none"><p>{I18n.t('courses_generic.uploads_none')}</p></div>);
+      elements = [];
+      noUploadsMessage = (<div className="none text-center"><p>{I18n.t('courses_generic.uploads_none')}</p></div>);
     } else {
       elements = (<div style={{ width: '100%' }}><Loading /></div>);
     }
@@ -62,11 +65,11 @@ const UploadList = createReactClass({
     let uploadsView;
 
     if (this.props.view === GALLERY_VIEW) {
-      uploadsView = (
-        <div className="gallery-view">
-          {elements}
-        </div>
-      );
+      if (elements.length === 0) {
+        uploadsView = (<div className="list-view">{noUploadsMessage}</div>);
+      } else {
+        uploadsView = (<div className="gallery-view"> {elements} </div>);
+      }
     }
 
     if (this.props.view === LIST_VIEW) {
@@ -86,7 +89,8 @@ const UploadList = createReactClass({
     if (this.props.view === TILE_VIEW) {
       uploadsView = (
         <div className="tile-view">
-          {elements}
+          {uploads.length > 0 && elements}
+          {uploads.length === 0 && noUploadsMessage}
         </div>
       );
     }

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -477,6 +477,25 @@ describe 'the course page', type: :feature, js: true do
     end
   end
 
+  describe 'uploads view when no uploads' do
+    it 'displays a message when there are no uploads in gallery view' do
+      visit "/courses/#{slug}/uploads"
+      expect(page).to have_content 'This project has not contributed any images or other media'
+    end
+
+    it 'displays a message when there are no uploads in list view' do
+      visit "/courses/#{slug}/uploads"
+      find('button#list-view').click
+      expect(page).to have_content 'This project has not contributed any images or other media'
+    end
+
+    it 'displays a message when there are no uploads in tile view' do
+      visit "/courses/#{slug}/uploads"
+      find('button#tile-view').click
+      expect(page).to have_content 'This project has not contributed any images or other media'
+    end
+  end
+
   describe '/manual_update' do
     it 'updates the course cache' do
       user = create(:user)


### PR DESCRIPTION
UploadsList and List are refactored not to render no uploads message inside of tbody HTML element.

Before, in the List and Tile view, an HTML table was generated even if there were no updates with a message (in div tags) inside. Having a div as a child element of tbody was causing an error and sometimes tests were failing because of it (screenshot).
![Screenshot from 2022-02-06 22-05-57](https://user-images.githubusercontent.com/65791349/152701341-9b141177-d35a-4e69-b286-48d938875a28.png)

I removed the no-updates message from the table and added tests for no uploads situation.

The design is slightly changed and no uploads message looks the same for all three views.

After:
![gallery](https://user-images.githubusercontent.com/65791349/152515389-cf3d5418-9367-4f90-9669-d094c9531b66.png)
![list](https://user-images.githubusercontent.com/65791349/152515402-02197aed-448c-4f43-ba08-6e3070bdb3b8.png)
![tile](https://user-images.githubusercontent.com/65791349/152515423-30d0a5a4-cc8a-43dd-9e3e-1a8b41346d2f.png)

Before:
![gallery-before](https://user-images.githubusercontent.com/65791349/152515458-1a519b4c-e99f-4f98-9c83-3f3adb7b3d68.png)
![list-before](https://user-images.githubusercontent.com/65791349/152515473-ffb944a2-1168-49a7-9901-35c1b4c9bd08.png)
![tile-before](https://user-images.githubusercontent.com/65791349/152515480-9521e36d-a498-46b0-9563-6b0988969713.png)

