### PR TITLE
Fix number to human bug

### DIFF
--- a/app/assets/javascripts/components/overview/overview_stat.jsx
+++ b/app/assets/javascripts/components/overview/overview_stat.jsx
@@ -27,7 +27,8 @@ OverviewStat.propTypes = {
   id: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   stat: PropTypes.oneOfType([
-    PropTypes.number
+    PropTypes.number,
+    PropTypes.string
   ]),
   statMsg: PropTypes.string.isRequired,
   renderZero: PropTypes.bool.isRequired,

--- a/app/assets/javascripts/components/overview/overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/overview_stats.jsx
@@ -32,7 +32,7 @@ const OverviewStats = ({ course }) => {
     articlesCreated = <OverviewStat
       id="articles-created"
       className={valueClass('articles-created')}
-      stat={parseInt(course.created_count)}
+      stat={course.created_count}
       statMsg={createdLabel}
       renderZero={false}
     />;
@@ -44,7 +44,7 @@ const OverviewStats = ({ course }) => {
     contentCount = <OverviewStat
       id="word-count"
       className={valueClass('word-count')}
-      stat={parseInt(course.word_count)}
+      stat={course.word_count}
       statMsg={I18n.t('metrics.word_count')}
       renderZero={true}
     />;
@@ -52,7 +52,7 @@ const OverviewStats = ({ course }) => {
     contentCount = <OverviewStat
       id="bytes-added"
       className={valueClass('bytes-added')}
-      stat={parseInt(course.character_sum_human)}
+      stat={course.character_sum_human}
       statMsg={I18n.t('metrics.bytes_added')}
       renderZero={true}
     />;
@@ -108,14 +108,14 @@ const OverviewStats = ({ course }) => {
       <OverviewStat
         id="articles-edited"
         className={valueClass('edited_count')}
-        stat={parseInt(course.edited_count)}
+        stat={course.edited_count}
         statMsg={editedLabel}
         renderZero={true}
       />
       <OverviewStat
         id="total-edits"
         className={valueClass('edited_count')}
-        stat={parseInt(course.edit_count)}
+        stat={course.edit_count}
         statMsg={I18n.t('metrics.edit_count_description')}
         renderZero={true}
       />
@@ -124,7 +124,7 @@ const OverviewStats = ({ course }) => {
       <OverviewStat
         id="references-count"
         className={valueClass('references-count')}
-        stat={parseInt(course.references_count)}
+        stat={course.references_count}
         statMsg={I18n.t('metrics.references_count')}
         renderZero={false}
         info={I18n.t(`metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'references_doc')}`)}
@@ -133,7 +133,7 @@ const OverviewStats = ({ course }) => {
       <OverviewStat
         id="view-count"
         className={valueClass('view_count')}
-        stat={parseInt(course.view_count)}
+        stat={course.view_count}
         statMsg={I18n.t(`metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'view_count_description')}`)}
         renderZero={false}
       />

--- a/app/assets/javascripts/components/overview/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/wikidata_overview_stats.jsx
@@ -4,7 +4,17 @@ import OverviewStat from './overview_stat';
 import I18n from 'i18n-js';
 
 const WikidataOverviewStats = ({ statistics }) => {
-  const total = Object.values(statistics).reduce((a, b) => a + b);
+  // const total = Object.values(statistics).reduce((a, b) => a + b);
+  let total;
+  if (statistics.total) {
+    total = <OverviewStat
+      id="total-revisions"
+      className="stat-display__value-small"
+      stat={total}
+      statMsg={I18n.t('metrics.total_revisions')}
+      renderZero={true}
+    />;
+  }
 
   return (
     <div className="wikidata-stats-container">
@@ -12,13 +22,7 @@ const WikidataOverviewStats = ({ statistics }) => {
       <div className="wikidata-display">
 
         <div className="single-stat">
-          <OverviewStat
-            id="total-revisions"
-            className="stat-display__value-small"
-            stat={total}
-            statMsg={I18n.t('metrics.total_revisions')}
-            renderZero={true}
-          />
+          {total}
         </div>
         <div className="stat-display__row">
           <h5 className="stats-label">{I18n.t('items.items')}</h5>

--- a/app/assets/javascripts/components/overview/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/wikidata_overview_stats.jsx
@@ -6,11 +6,11 @@ import I18n from 'i18n-js';
 const WikidataOverviewStats = ({ statistics }) => {
   // const total = Object.values(statistics).reduce((a, b) => a + b);
   let total;
-  if (statistics.total) {
+  if (statistics['total revisions']) {
     total = <OverviewStat
       id="total-revisions"
       className="stat-display__value-small"
-      stat={total}
+      stat={statistics['total revisions']}
       statMsg={I18n.t('metrics.total_revisions')}
       renderZero={true}
     />;

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -33,7 +33,14 @@ json.course do
   json.enroll_url "#{request.base_url}#{course_slug_path(@course.slug)}/enroll/"
   json.wiki_string_prefix @course.home_wiki.string_prefix
 
-  json.course_stats @course.course_stat, :id, :stats_hash if @course.course_stat
+  if @course.course_stat
+    @course.course_stat.stats_hash.each_value do |stat|
+      stat.each do |key, value|
+        stat[key] = number_to_human(value)
+      end
+    end
+    json.course_stats @course.course_stat, :id, :stats_hash
+  end
 
   json.created_count number_to_human @course.new_article_count
   json.edited_count number_to_human @course.article_count

--- a/lib/wikidata_summary_parser.rb
+++ b/lib/wikidata_summary_parser.rb
@@ -38,6 +38,7 @@ class WikidataSummaryParser
     REVISION_CLASSIFICATIONS.each do |label, method|
       stats[label] = revisions.count { |r| new(r.summary).send(method) }
     end
+    stats['total revisions'] = stats.values.sum
     stats
   end
 


### PR DESCRIPTION

OverviewStat component is refactored to take strings as a prop in addition to numbers,  (because numbers greater than 1000 are transformed to strings by number_to_human in course.json).
Total revisions are added to stats_hash in CourseStat. If there are no total revisions (before the next update) that stat would not be displayed.
Number_to_human is added to stats_hash values in course.json.
As a result, top and Wikidata stats are displayed the same way in the course overview tab (first screenshot) and course.json (second screenshot).
![tab](https://user-images.githubusercontent.com/65791349/153731868-2633a00b-6021-4b5a-94fa-18c7f6b57e7e.png)
![json](https://user-images.githubusercontent.com/65791349/153731981-703f5f59-36e7-43e1-993d-1135f7e8d2fd.png)

