### PR TITLE
Add unknown to other wikidata updates

### DIFF
--- a/app/assets/javascripts/components/overview/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/wikidata_overview_stats.jsx
@@ -173,8 +173,6 @@ const WikidataOverviewStats = ({ statistics }) => {
               stat={statistics['redirects created']}
               statMsg={I18n.t('metrics.redirects_created')}
               renderZero={true}
-              info={I18n.t('metrics.redirects_info')}
-              infoId="redirects-info"
             />
             <OverviewStat
               id="reverts-performed"
@@ -202,13 +200,6 @@ const WikidataOverviewStats = ({ statistics }) => {
               className="stat-display__value-small"
               stat={statistics['other updates']}
               statMsg={I18n.t('metrics.other_updates')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="unknown"
-              className="stat-display__value-small"
-              stat={statistics.unknown}
-              statMsg={I18n.t('metrics.unknown')}
               renderZero={true}
             />
           </div>

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -28,4 +28,15 @@ module CourseHelper
     string_prefix ||= Features.default_course_string_prefix
     I18n.t("#{string_prefix}.#{message_key}")
   end
+
+  def format_wikidata_stats(course_stats)
+    course_stats['www.wikidata.org']['other updates'] += course_stats['www.wikidata.org']['unknown']
+    course_stats['www.wikidata.org'].reject! { |k, _v| k == 'unknown' }
+    course_stats.each_value do |stat|
+      stat.each do |key, value|
+        stat[key] = number_to_human(value)
+      end
+    end
+    course_stats
+  end
 end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -34,11 +34,7 @@ json.course do
   json.wiki_string_prefix @course.home_wiki.string_prefix
 
   if @course.course_stat
-    @course.course_stat.stats_hash.each_value do |stat|
-      stat.each do |key, value|
-        stat[key] = number_to_human(value)
-      end
-    end
+    @course.course_stat.stats_hash = format_wikidata_stats(@course.course_stat.stats_hash)
     json.course_stats @course.course_stat, :id, :stats_hash
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1027,7 +1027,6 @@ en:
     redirects_created: Redirects created
     restorations_performed: Restorations performed
     reverts_performed: Reverts performed
-    unknown: Unknown
 
   namespace:
     main: Mainspace


### PR DESCRIPTION
The Sum of other and unknown updates is displayed as Other updates in the course.json and WikidataOverviewStats component.
I added a views helper method for adding unknown to other updates and removing from stats hash. The plan is to use that method for Wikidata stats in campaigns also.

The info is removed from Redirects created.

After:
![other](https://user-images.githubusercontent.com/65791349/154373486-1c982e75-563c-47a1-bc37-2c733e9777f0.png)
![otherjson](https://user-images.githubusercontent.com/65791349/154480769-38b69a13-1106-485b-8001-45fac0b4cda5.png)
Before:
![otherjsonbefore](https://user-images.githubusercontent.com/65791349/154480818-b716d869-9e7e-4ad1-99d2-ed242d699eee.png)
![otherbefore](https://user-images.githubusercontent.com/65791349/154373544-5da6dba4-74d5-4d5c-a125-99aa13417eec.png)

