### PR TITLE
Slide handler to FC

### DIFF
--- a/app/assets/javascripts/training/components/training_slide_handler.jsx
+++ b/app/assets/javascripts/training/components/training_slide_handler.jsx
@@ -88,6 +88,8 @@ const TrainingSlideHandler = () => {
     dispatch(setCurrentSlide(training.previousSlide.slug));
   };
 
+  // runs when the component is first rendered
+  // fetches the initial data and sets the base title
   useEffect(() => {
     setBaseTitle(document.title);
     const slideId = __guard__(routeParams, x => x.slide_id);
@@ -95,6 +97,9 @@ const TrainingSlideHandler = () => {
     dispatch(fetchTrainingModule({ module_id: moduleId(routeParams), slide_id: slideId, user_id: userId }));
   }, []);
 
+  // runs whenever the training from the redux store changes
+  // which means its run essentially when the user goes from one slide to another
+  // changes the page title according to the slide title and updates the event listener
   useEffect(() => {
     const handleKeyPress = (e) => {
       const navParams = { library_id: routeParams.library_id, module_id: routeParams.module_id };
@@ -118,7 +123,7 @@ const TrainingSlideHandler = () => {
     document.title = `${slideTitle} - ${baseTitle}`;
 
     return () => {
-      // cleanup
+      // cleanup. Removes the old event listener
       return window.removeEventListener('keyup', handleKeyPress);
     };
   }, [training]);

--- a/app/assets/javascripts/training/components/training_slide_handler.jsx
+++ b/app/assets/javascripts/training/components/training_slide_handler.jsx
@@ -55,6 +55,7 @@ const TrainingSlideHandler = () => {
 
   const next = () => {
     const nextSlug = training.nextSlide.slug;
+
     dispatch(setCurrentSlide(nextSlug));
     setSlideCompleted_FC(nextSlug);
   };
@@ -82,12 +83,15 @@ const TrainingSlideHandler = () => {
     const slideId = __guard__(routeParams, x => x.slide_id);
     const userId = __guard__(document.getElementById('main'), x => x.getAttribute('data-user-id'));
     dispatch(fetchTrainingModule({ module_id: moduleId(routeParams), slide_id: slideId, user_id: userId }));
+  }, []);
+
+  useEffect(() => {
     window.addEventListener('keyup', handleKeyPress);
 
     return () => {
       return window.removeEventListener('keyup', handleKeyPress);
     };
-  }, []);
+  }, [handleKeyPress]);
 
   if (training.loading === true) {
     return (

--- a/test/components/training/slide_link.spec.jsx
+++ b/test/components/training/slide_link.spec.jsx
@@ -5,7 +5,6 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import '../../testHelper';
-import SlideLink from '../../../app/assets/javascripts/training/components/slide_link.jsx';
 import TrainingSlideHandler from '../../../app/assets/javascripts/training/components/training_slide_handler.jsx';
 
 jest.mock('../../../app/assets/javascripts/components/common/notifications.jsx', () => {
@@ -19,7 +18,7 @@ describe('SlideLink', () => {
   const store = mockStore({
     training: {
       loading: false,
-      currentSlide: { content: 'hello', id: 1 },
+      currentSlide: { content: 'hello', id: 1, buttonText: 'Next Page' },
       slides: ['a'],
       enabledSlides: [],
       nextSlide: { slug: 'foobar' }
@@ -31,20 +30,7 @@ describe('SlideLink', () => {
         <Route
           exact
           path="/training/:library_id/:module_id/:slide_id"
-          render={({ match }) => (
-            <TrainingSlideHandler
-              loading={false}
-            >
-              <SlideLink
-                slideId="foobar"
-                buttonText="Next Page"
-                disabled={false}
-                button={true}
-                onClick={jest.fn()}
-                params={match.params}
-              />
-            </TrainingSlideHandler>
-          )}
+          component={TrainingSlideHandler}
         />
       </MemoryRouter>
     </Provider>


### PR DESCRIPTION
## What this PR does
This PR converts the Training Slide Handler to a functional component. I've also replaced `connect` with the `useSelector` and `useDispatch` hooks. Similarly, I've removed `withRouter` and instead used the `useHistory` and `useParams` hooks. 

The title of the page now changes with each slide change. 
## Open questions and concerns
I'm still not entirely sure about which functions to place inside of the component and which ones outside. Currently, functions which dispatch actions have been included inside of the component.  

Also, since the thunk creator functions(`setSlideCompleted`, `setCurrentSlide`) and the functions which actually call them have the same name, I have simply added `_FC` in the name for those defined inside of the Functional Component. This wasn't a problem before since it was `this.setSlideCompleted` vs `this.props.setSlideCompleted`. Don't know if these are the best names but :shrug: 

And as always, I'm not entirely sure about the format of the title. Here's how it looks currently- 

![titlesPreview](https://user-images.githubusercontent.com/10794178/154688115-3f606c73-d3cc-473c-aba8-046f08b77a79.png)