### PR TITLE
Add Wikidata stats to campaign#show

### DIFF
--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -159,6 +159,13 @@ class CoursesPresenter
     100 * trained_count.to_f / user_count
   end
 
+  def wikidata_stats
+    stats ||= courses.joins(:course_stat).where.not(course_stats: nil).map do |course|
+      course.course_stat.stats_hash['www.wikidata.org']
+    end
+    return { 'www.wikidata.org' => stats.inject { |a, b| a.merge(b) { |_, x, y| x + y } } }
+  end
+
   def creation_date
     I18n.l campaign.created_at.to_date
   end

--- a/app/views/campaigns/show.json.jbuilder
+++ b/app/views/campaigns/show.json.jbuilder
@@ -29,5 +29,9 @@ if @campaign
     json.start @campaign.start
     json.end @campaign.end
     json.created_at @campaign.created_at
+
+    if @presenter.wikidata_stats['www.wikidata.org']
+      json.course_stats format_wikidata_stats(@presenter.wikidata_stats)
+    end
   end
 end


### PR DESCRIPTION
Course (Wikidata) stats are added to a campaign.json in the same format as in course.json.

This is the new campaign.json:
![wikidatacampaign](https://user-images.githubusercontent.com/65791349/155226873-361215c1-9c03-44ec-8e6a-c83296605c5c.png)

That is a sum of this two course's:

![course1](https://user-images.githubusercontent.com/65791349/155226924-04e1f06c-1f3d-4456-a765-c3c64907d7d5.png)
![course2](https://user-images.githubusercontent.com/65791349/155226930-a0e1acc9-9be2-4d3d-b45a-8266832a2417.png)

A campaign without Wikidata stats is the same as before:
![nowikidatacampaign](https://user-images.githubusercontent.com/65791349/155227059-f452211e-38e0-439b-b7e0-22714a38fa70.png)

