### PR TITLE
Add number_to_human to courses and users count in campaign

### DIFF
--- a/app/views/campaigns/show.json.jbuilder
+++ b/app/views/campaigns/show.json.jbuilder
@@ -9,8 +9,8 @@ if @campaign
     json.template_description @campaign.template_description
     json.default_course_type @campaign.default_course_type
     json.default_passcode @campaign.default_passcode
-    json.courses_count @presenter.courses.count
-    json.user_count @presenter.user_count
+    json.courses_count number_to_human @presenter.courses.count
+    json.user_count number_to_human @presenter.user_count
     json.new_article_count_human number_to_human(@presenter.courses.sum(:new_article_count))
     json.word_count_human number_to_human(@presenter.word_count)
     json.references_count_human number_to_human(@presenter.references_count)

--- a/app/views/courses/_header_stats.html.haml
+++ b/app/views/courses/_header_stats.html.haml
@@ -1,10 +1,10 @@
 .stat-display
   .stat-display__stat
-    .stat-display__value= presenter.courses.count
+    .stat-display__value= number_to_human presenter.courses.count
     %small= t("#{presenter.course_string_prefix}.courses")
   .stat-display__stat.tooltip-trigger
     .stat-display__value
-      = presenter.user_count
+      = number_to_human presenter.user_count
       %img{:src => "/assets/images/info.svg", :alt => "tooltip default logo"}
     %small= t("#{presenter.course_string_prefix}.students")
     .tooltip.dark


### PR DESCRIPTION
Quite unintentionally I found inconsistency in displaying top stats for the campaign, so I fixed it.
These are (before) screenshots from WikiEdu Dashboard:
![image(6)](https://user-images.githubusercontent.com/65791349/155334366-c0d17640-6976-4b25-92e0-e2a7b957a3f6.png)
![stats](https://user-images.githubusercontent.com/65791349/155345603-cd46b145-5938-4c49-ac23-41e1302112de.png)


This is after:
![after](https://user-images.githubusercontent.com/65791349/155334816-5afbe797-35bc-429f-9752-413d21c89829.png)
![afterjson](https://user-images.githubusercontent.com/65791349/155334826-ad344377-fa2e-47cc-9d60-34088d53e932.png)
