### PR TITLE
Made the filter selectors in sync with the redux store

### DIFF
--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -12,6 +12,8 @@ import articleListKeys from './article_list_keys';
 import ArticleUtils from '../../utils/article_utils.js';
 import { parse, stringify } from 'query-string';
 
+const defaults_params = { wiki: 'all', tracked: 'tracked', newness: 'both' };
+
 const ArticleList = createReactClass({
   displayName: 'ArticleList',
 
@@ -99,7 +101,14 @@ const ArticleList = createReactClass({
     const history = this.props.history;
 
     const params = parse(search);
-    params[filter] = value;
+
+    // don't add the search param if the value is equal to the default value
+    if (defaults_params[filter] === value) {
+      // delete the existing key
+      delete params[filter];
+    } else {
+      params[filter] = value;
+    }
 
     history.push({
       search: stringify(params)

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -32,30 +32,39 @@ const ArticleList = createReactClass({
 
     // filter by "wiki"
     if (wiki !== undefined) {
+      // wiki is passed as a search param
       const value = wiki.split('.');
       if (value.length > 1) {
         this.props.filterArticles({ language: value[0], project: value[1] });
       } else {
         this.props.filterArticles({ language: null, project: value[0] });
       }
+    } else {
+      // since the wiki search param is absent, set the URL using the previous
+      // filter in the redux store
+      const wikiFilterValue = this.wikiObjectToString(this.props.wikiFilter);
+      this.updateParams('wiki', wikiFilterValue);
     }
 
     // filter by "newness"
     if (newness !== undefined) {
+      // newness is passed as a search param
       this.props.filterNewness(newness);
+    } else {
+      // absent, so setting newness from the redux store
+      this.updateParams('newness', this.props.newnessFilter);
     }
 
     // filter by "tracked"
     if (tracked !== undefined) {
+      // tracked is passed as a search param
       this.props.filterTrackedStatus(tracked);
+    } else {
+      // absent, so setting tracked from the redux store
+      this.updateParams('tracked', this.props.trackedStatusFilter);
     }
 
-    // there is no need to return tracked, since there already exists a prop for that
-    // - trackedStatusFilter, which gets changed whenever filterTrackedStatus is called
-    // wiki and newness don't have any such props, which is why store them as state
     return {
-      wiki: wiki || 'all',
-      newness: newness || 'both',
       selectedIndex: -1,
     };
   },
@@ -86,7 +95,7 @@ const ArticleList = createReactClass({
   },
 
   updateParams(filter, value) {
-    const search = this.props.location.search;
+    const search = this.props.history.location.search;
     const history = this.props.history;
 
     const params = parse(search);
@@ -109,6 +118,17 @@ const ArticleList = createReactClass({
 
   sortSelect(e) {
     return this.props.sortArticles(e.target.value);
+  },
+
+  wikiObjectToString(wikiFilter) {
+    let wikiFilterValue;
+
+    if (wikiFilter.language) {
+      wikiFilterValue = `${wikiFilter.language}.${wikiFilter.project}`;
+    } else {
+      wikiFilterValue = `${wikiFilter.project}`;
+    }
+    return wikiFilterValue;
   },
 
   render() {
@@ -169,6 +189,8 @@ const ArticleList = createReactClass({
     }
 
     let filterWikis;
+    const wikiFilterValue = this.wikiObjectToString(this.props.wikiFilter);
+
     if (this.props.wikis.length > 1) {
       const wikiOptions = this.props.wikis.map((wiki) => {
         const wikiString = `${wiki.language ? `${wiki.language}.` : ''}${wiki.project}`;
@@ -178,7 +200,7 @@ const ArticleList = createReactClass({
       filterWikis = (
         <select
           onChange={this.onChangeFilter}
-          defaultValue={this.state.wiki}
+          value={wikiFilterValue}
         >
           <option value="all">{I18n.t('articles.filter.wiki_all')}</option>
           {wikiOptions}
@@ -191,7 +213,7 @@ const ArticleList = createReactClass({
       filterArticlesSelect = (
         <select
           className="filter-articles"
-          defaultValue={this.state.newness}
+          value={this.props.newnessFilter}
           onChange={this.onNewnessChange}
         >
           <option value="new">{I18n.t('articles.filter.new')}</option>

--- a/app/assets/javascripts/components/articles/articles_handler.jsx
+++ b/app/assets/javascripts/components/articles/articles_handler.jsx
@@ -127,7 +127,9 @@ const mapStateToProps = state => ({
   loadingAssignments: state.assignments.loading,
   newnessFilterEnabled: state.articles.newnessFilterEnabled,
   trackedStatusFilterEnabled: state.articles.trackedStatusFilterEnabled,
-  trackedStatusFilter: state.articles.trackedStatusFilter
+  trackedStatusFilter: state.articles.trackedStatusFilter,
+  wikiFilter: state.articles.wikiFilter,
+  newnessFilter: state.articles.newnessFilter
 });
 
 const mapDispatchToProps = {

--- a/app/assets/javascripts/reducers/articles.js
+++ b/app/assets/javascripts/reducers/articles.js
@@ -18,8 +18,8 @@ const initialState = {
     sortKey: null
   },
   wikis: [],
-  wikiFilter: null,
-  newnessFilter: null,
+  wikiFilter: { project: 'all' },
+  newnessFilter: 'both',
   trackedStatusFilter: 'tracked',
   loading: true,
   newnessFilterEnabled: false,
@@ -99,7 +99,7 @@ export default function articles(state = initialState, action) {
 
     case SET_PROJECT_FILTER: {
       if (action.wiki.project === 'all') {
-        return { ...state, wikiFilter: null };
+        return { ...state, wikiFilter: { project: 'all' } };
       }
       return { ...state, wikiFilter: action.wiki };
     }

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -95,7 +95,7 @@ export const getCloneableCourses = createSelector(
 
 export const getWikiArticles = createSelector(
   [getAllEditedArticles, getWikiFilter], (editedArticles, wikiFilter) => {
-    if (wikiFilter === null) {
+    if (wikiFilter.project === 'all') {
       return editedArticles;
     }
     return getFiltered(editedArticles, { ...wikiFilter });

--- a/test/reducers/articles.spec.js
+++ b/test/reducers/articles.spec.js
@@ -44,8 +44,8 @@ describe('articles reducer', () => {
       expect(newState.sort.key).toBeNull();
       expect(newState.sort.sortKey).toBeNull();
       expect(Array.isArray(newState.wikis)).toBe(true);
-      expect(newState.wikiFilter).toBeNull();
-      expect(newState.newnessFilter).toBeNull();
+      expect(newState.wikiFilter).toMatchObject({ project: 'all' });
+      expect(newState.newnessFilter).toBe('both');
       expect(newState.loading).toBe(true);
       expect(newState.newnessFilterEnabled).toBe(false);
     }
@@ -99,7 +99,8 @@ describe('articles reducer', () => {
     };
 
     const state = articles(initialState, mockedAction);
-    expect(state.wikiFilter).toBeNull();
+    expect(state.wikiFilter).toMatchObject({ project: 'all' });
+
 
     const newMockedAction = {
       type: SET_PROJECT_FILTER,


### PR DESCRIPTION
## What this PR does

Addresses #4805 

For convenience, I have changed the default value of `wikiFilter` and `newnessFilter` to the default values in the drop downs instead of `null`. For example, `newnessFilter` now has a default value of `both` since that matches with the dropdown and thus makes it easier to map. 

For `wikiFilter`, the new default value is `{project:"all"}`. This is also mostly for convenience - it means I don't have to have another if condition to check whether its `null`

Now if the user visits `/courses/Southwestern_University/Biochemistry_(Fall)/articles/edited`, the url is changed to `/courses/Southwestern_University/Biochemistry_(Fall)/articles/edited?newness=both&tracked=tracked&wiki=all` since those are the default values of the redux store. 

If the user changes a filter and goes to another tab, and comes back, the URL is changed appropriately. 

![gif](https://user-images.githubusercontent.com/10794178/155738086-512c66ae-c92b-4893-b11c-e42f0f52f734.gif)
