### PR TITLE
Attempting to split the message courses.active_courses for issue #4342

### DIFF
--- a/app/views/courses/_campaign_courses.html.haml
+++ b/app/views/courses/_campaign_courses.html.haml
@@ -1,8 +1,7 @@
 %section#courses
   .section-header
     %h3
-      = t("courses.active_courses", course_type: t("#{presenter.course_string_prefix}.courses")) + ': ' + presenter.campaign.title
-    .sort-select
+      = t("courses.active_courses") + ': ' + presenter.campaign.title
       %select.sorts{:rel => "courses"}
         %option{:rel => "asc", :value => "title"}= t("courses.title")
         %option{:rel => "desc", :value => "revisions"}= t("metrics.revisions")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,7 +425,7 @@ en:
       program participants at the same time.
     accounts_generation_confirm_message: Are you sure you want to enable account requests?
     activity: Activity
-    active_courses: Active %{course_type}
+    active_courses: Active Courses
     add_trainings: Please add student trainings to your assignment timeline. Assigning training modules is an essential part of Wiki Ed's best practices.
     alerts: Alerts
     all_courses: All Courses

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -242,6 +242,8 @@ qqq:
     milestones:
       title: Label for the Milestone section of a course page (Wiki Ed only)
   campaign:
+    active_campaigns: |-
+      Heading for the list of active campaigns
     add_organizer: Button to add an organizer
     all_campaigns: Button to view the list of all campaigns
     already_exists: Error shown when a new campaign has the same name or slug of another
@@ -296,12 +298,7 @@ qqq:
   courses:
     activity: Label for link to the 'recent activity' list for a course
     active_courses: |-
-      Heading for the list of active courses. 'course_type' is one of these messages:
-      * {{msg-wm|Wikiedudashboard-courses.courses}}
-      * {{msg-wm|Wikiedudashboard-campaign.campaigns}}
-
-      So in English, the message would say either 'Active Courses' or 'Active Campaigns'.
-      {{Identical|Active}}
+      Heading for the list of active courses
     all_courses: Button to view the list of all courses
     already_enrolled: Message displayed when the user attempts to enroll in a course
       they have already joined.


### PR DESCRIPTION
Hello I just resubmitted the PR cause the previous one wasn't clean and was dynamically changing the file which didn't have to be dealt with.

## What this PR does
This PR is trying to solve the issue #4342 
In **config/locales/en.yml** the value was changed 
to `active_courses: Active Courses` 
from `active_courses: Active %{course_type}` where the `%{course_type}` was referencing `courses: Courses`  hence didn't serve the purpose, hence now the action is similar to what active_campaign does.

## Screenshots
Element dealt with
![image](https://user-images.githubusercontent.com/40771676/155191034-8f120ae8-0e64-4ac2-933d-369702e57a1f.png)
