### PR TITLE
Fixed urls and errors on settings page

### DIFF
--- a/app/assets/javascripts/actions/settings_actions.js
+++ b/app/assets/javascripts/actions/settings_actions.js
@@ -152,10 +152,12 @@ export const upgradeSpecialUser = (username, position) => (dispatch) => {
           submitting: false
         },
       });
-
+      if (response.responseJSON === undefined) {
+        response.responseJSON = { message: response.responseText };
+      }
       dispatch(addNotification({
         type: 'error',
-        message: response.statusText,
+        message: response.responseJSON.message,
         closable: true
       })
       );
@@ -211,9 +213,12 @@ export const downgradeSpecialUser = (username, position) => (dispatch) => {
         },
       });
 
+      if (response.responseJSON === undefined) {
+        response.responseJSON = { message: response.responseText };
+      }
       dispatch(addNotification({
         type: 'error',
-        message: response.statusText,
+        message: response.responseJSON.message,
         closable: true
       })
       );
@@ -260,10 +265,12 @@ export const upgradeAdmin = username => (dispatch) => {
           submitting: false
         },
       });
-
+      if (response.responseJSON === undefined) {
+        response.responseJSON = { message: response.responseText };
+      }
       dispatch(addNotification({
         type: 'error',
-        message: response.statusText,
+        message: response.responseJSON.message,
         closable: true
       })
       );

--- a/app/assets/javascripts/actions/settings_actions.js
+++ b/app/assets/javascripts/actions/settings_actions.js
@@ -14,7 +14,7 @@ const fetchAdminUsersPromise = () => {
   return new Promise((accept, reject) => {
     return $.ajax({
       type: 'GET',
-      url: 'settings/all_admins',
+      url: '/settings/all_admins',
       success(data) {
         return accept(data);
       }
@@ -30,7 +30,7 @@ const fetchSpecialUsersPromise = () => {
   return new Promise((accept, reject) => {
     return $.ajax({
       type: 'GET',
-      url: 'settings/special_users',
+      url: '/settings/special_users',
       success(data) {
         return accept(data);
       }
@@ -155,7 +155,7 @@ export const upgradeSpecialUser = (username, position) => (dispatch) => {
 
       dispatch(addNotification({
         type: 'error',
-        message: response.responseJSON.message,
+        message: response.statusText,
         closable: true
       })
       );
@@ -213,7 +213,7 @@ export const downgradeSpecialUser = (username, position) => (dispatch) => {
 
       dispatch(addNotification({
         type: 'error',
-        message: response.responseJSON.message,
+        message: response.statusText,
         closable: true
       })
       );
@@ -263,7 +263,7 @@ export const upgradeAdmin = username => (dispatch) => {
 
       dispatch(addNotification({
         type: 'error',
-        message: response.responseJSON.message,
+        message: response.statusText,
         closable: true
       })
       );

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -72,7 +72,7 @@ class SettingsController < ApplicationController # rubocop:disable Metrics/Class
       format.json do
         @user = User.find_by(username: special_user_params[:username])
         @position = special_user_params[:position]
-        ensure_user_exists(params[:username]) { return }
+        ensure_user_exists(special_user_params[:username]) { return }
         unless SpecialUsers.respond_to? @position
           return render json: { message: 'position is invalid' },
                         status: :unprocessable_entity
@@ -127,7 +127,7 @@ class SettingsController < ApplicationController # rubocop:disable Metrics/Class
     respond_to do |format|
       format.json do
         @user = User.find_by username: username_param[:username]
-        ensure_user_exists(params[:username]) { return }
+        ensure_user_exists(username_param[:username]) { return }
         yield
       end
     end


### PR DESCRIPTION
## What this PR does

This PR does multiple things. 

~~Firstly, it converts the ajax calls with the fetch API. This wasn't required really, but I was in the middle of doing exactly this when I found the other bugs  so :shrug:~~ Nvm ajax was being mocked in the tests. Prolly best to do this later lol

Secondly, it fixes the URLs of the requests, which were nonexistent, resulting in the following error 

![image](https://user-images.githubusercontent.com/10794178/155896755-b6faba64-bcbc-4f5b-ad21-b384c3a9cb19.png)

And thirdly, I've removed the undefined property access. It occurs when the user is not a super admin and tries to add an admin, special user, etc. 

![ksnip_20220228-004835](https://user-images.githubusercontent.com/10794178/155896820-7e64b470-0848-4a13-9166-94036fd533f6.png)

Now, as is expected, a notification pops up, showing the error message. 

![ksnip_20220228-005211](https://user-images.githubusercontent.com/10794178/155896876-73369be2-fa51-4de3-9049-aa414e94aeb9.png)

