### PR TITLE
Convert ajax to fetch

### DIFF
--- a/app/assets/javascripts/actions/campaign_actions.js
+++ b/app/assets/javascripts/actions/campaign_actions.js
@@ -1,20 +1,15 @@
 import { RECEIVE_CAMPAIGNS, SORT_CAMPAIGNS, DELETE_CAMPAIGN, API_FAIL, RECEIVE_ALL_CAMPAIGNS, ADD_CAMPAIGN } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
 
-const fetchCampaignsPromise = (courseId) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: `/courses/${courseId}/campaigns.json`,
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      });
-  });
+const fetchCampaignsPromise = async (courseId) => {
+  const response = await request(`/courses/${courseId}/campaigns.json`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const fetchCampaigns = courseId => (dispatch) => {
@@ -32,21 +27,17 @@ export const fetchCampaigns = courseId => (dispatch) => {
 
 export const sortCampaigns = key => ({ type: SORT_CAMPAIGNS, key: key });
 
-const removeCampaignsPromise = (courseId, campaignId) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'DELETE',
-      url: `/courses/${courseId}/campaign.json`,
-      data: { campaign: { title: campaignId } },
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      });
+const removeCampaignsPromise = async (courseId, campaignId) => {
+  const response = await request(`/courses/${courseId}/campaign.json`, {
+    method: 'DELETE',
+    body: JSON.stringify({ campaign: { title: campaignId } })
   });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const removeCampaign = (courseId, campaignId) => (dispatch) => {
@@ -62,21 +53,17 @@ export const removeCampaign = (courseId, campaignId) => (dispatch) => {
   );
 };
 
-const addCampaignsPromise = (courseId, campaignId) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'POST',
-      url: `/courses/${courseId}/campaign.json`,
-      data: { campaign: { title: campaignId } },
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      });
+const addCampaignsPromise = async (courseId, campaignId) => {
+  const response = await request(`/courses/${courseId}/campaign.json`, {
+    method: 'POST',
+    body: JSON.stringify({ campaign: { title: campaignId } })
   });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const addCampaign = (courseId, campaignId) => (dispatch) => {
@@ -92,20 +79,14 @@ export const addCampaign = (courseId, campaignId) => (dispatch) => {
   );
 };
 
-const fetchAllCampaignsPromise = () => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: '/lookups/campaign.json',
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      });
-  });
+const fetchAllCampaignsPromise = async () => {
+  const response = await request('/lookups/campaign.json');
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const fetchAllCampaigns = () => (dispatch) => {

--- a/app/assets/javascripts/actions/campaign_actions.js
+++ b/app/assets/javascripts/actions/campaign_actions.js
@@ -7,7 +7,7 @@ const fetchCampaignsPromise = async (courseId) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -35,7 +35,7 @@ const removeCampaignsPromise = async (courseId, campaignId) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -61,7 +61,7 @@ const addCampaignsPromise = async (courseId, campaignId) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -84,7 +84,7 @@ const fetchAllCampaignsPromise = async () => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/category_actions.js
+++ b/app/assets/javascripts/actions/category_actions.js
@@ -8,7 +8,7 @@ const fetchCategoriesPromise = async (courseSlug) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -42,7 +42,7 @@ const addCategoryPromise = async ({ category, source, project, language, depth, 
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -72,7 +72,7 @@ const removeCategoryPromise = async (course_id, category_id) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/category_actions.js
+++ b/app/assets/javascripts/actions/category_actions.js
@@ -1,21 +1,16 @@
 import { RECEIVE_CATEGORIES, ADD_CATEGORY, DELETE_CATEGORY, API_FAIL } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
+import { stringify } from 'query-string';
 
-const fetchCategoriesPromise = (courseSlug) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: `/courses/${courseSlug}/categories.json`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
+const fetchCategoriesPromise = async (courseSlug) => {
+  const response = await request(`/courses/${courseSlug}/categories.json`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
   }
-  );
+  return response.json();
 };
 
 export const fetchCategories = courseSlug => (dispatch) => {
@@ -30,21 +25,26 @@ export const fetchCategories = courseSlug => (dispatch) => {
   );
 };
 
-const addCategoryPromise = ({ category, source, project, language, depth, course }) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'POST',
-      url: `/categories.json?category_name=${category}&depth=${depth}&course_id=${course.id}&project=${project}&language=${language}&source=${source}`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
+const addCategoryPromise = async ({ category, source, project, language, depth, course }) => {
+  const params = {
+    category_name: category,
+    depth,
+    course_id: course.id,
+    project,
+    language,
+    source
+  };
+
+  const response = await request(`/categories.json?${stringify(params)}`, {
+    method: 'POST'
+  });
+
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
   }
-  );
+  return response.json();
 };
 
 export const addCategory = categoryCourse => (dispatch) => {
@@ -59,21 +59,22 @@ export const addCategory = categoryCourse => (dispatch) => {
   );
 };
 
-const removeCategoryPromise = (courseId, categoryId) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'DELETE',
-      url: `/categories.json?category_id=${categoryId}&course_id=${courseId}`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
+const removeCategoryPromise = async (course_id, category_id) => {
+  const params = {
+    category_id,
+    course_id
+  };
+
+  const response = await request(`/categories.json?${stringify(params)}`, {
+    method: 'DELETE'
+  });
+
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
   }
-  );
+  return response.json();
 };
 
 export const removeCategory = (courseId, categoryId) => (dispatch) => {

--- a/app/assets/javascripts/actions/course_creation_actions.js
+++ b/app/assets/javascripts/actions/course_creation_actions.js
@@ -9,7 +9,7 @@ const fetchCampaignPromise = async (slug) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/course_creation_actions.js
+++ b/app/assets/javascripts/actions/course_creation_actions.js
@@ -1,17 +1,17 @@
 import API from '../utils/api.js';
+import request from '../utils/request';
+import logErrorMessage from '../utils/log_error_message';
+
 import { RECEIVE_INITIAL_CAMPAIGN, CREATED_COURSE, RECEIVE_COURSE_CLONE, API_FAIL } from '../constants';
 
-const fetchCampaignPromise = (slug) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'GET',
-      url: `/campaigns/${slug}.json`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail(obj => rej(obj))
-  );
+const fetchCampaignPromise = async (slug) => {
+  const response = await request(`/campaigns/${slug}.json`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const fetchCampaign = slug => (dispatch) => {

--- a/app/assets/javascripts/actions/new_account_actions.js
+++ b/app/assets/javascripts/actions/new_account_actions.js
@@ -8,7 +8,7 @@ const _checkAvailability = async (newAccount) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/new_account_actions.js
+++ b/app/assets/javascripts/actions/new_account_actions.js
@@ -1,20 +1,16 @@
 import * as types from '../constants';
 import logErrorMessage from '../utils/log_error_message';
 import API from '../utils/api.js';
+import request from '../utils/request';
 
-const _checkAvailability = (newAccount) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      url: `https://meta.wikimedia.org/w/api.php?action=query&list=users&ususers=${newAccount.username}&usprop=cancreate&format=json&origin=*`,
-      success: (data) => {
-        const result = data.query.users[0];
-        return res(result);
-      }
-    }).fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    })
-  );
+const _checkAvailability = async (newAccount) => {
+  const response = await request(`https://meta.wikimedia.org/w/api.php?action=query&list=users&ususers=${newAccount.username}&usprop=cancreate&format=json&origin=*`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const setNewAccountUsername = (_, username) => ({

--- a/app/assets/javascripts/actions/recent_edits_actions.js
+++ b/app/assets/javascripts/actions/recent_edits_actions.js
@@ -1,21 +1,16 @@
 import { RECEIVE_RECENT_EDITS, SORT_RECENT_EDITS, API_FAIL } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
 
-const _fetchRecentEdits = (opts = {}) => {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/revision_analytics/recent_edits.json?scoped=${opts.scoped || false}`,
-        success(data) {
-          return res(data);
-        }
-      })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      })
-    );
-  };
+const _fetchRecentEdits = async (opts = {}) => {
+  const response = await request(`/revision_analytics/recent_edits.json?scoped=${opts.scoped || false}`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
+};
 
 export const fetchRecentEdits = (opts = {}) => (dispatch) => {
   return (

--- a/app/assets/javascripts/actions/recent_edits_actions.js
+++ b/app/assets/javascripts/actions/recent_edits_actions.js
@@ -7,7 +7,7 @@ const _fetchRecentEdits = async (opts = {}) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/revisions_actions.js
+++ b/app/assets/javascripts/actions/revisions_actions.js
@@ -15,7 +15,7 @@ const fetchRevisionsPromise = async (courseId, limit, isCourseScoped) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/revisions_actions.js
+++ b/app/assets/javascripts/actions/revisions_actions.js
@@ -8,21 +8,16 @@ import {
 } from '../constants';
 import { fetchWikidataLabelsForRevisions } from './wikidata_actions';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
 
-const fetchRevisionsPromise = (courseId, limit, isCourseScoped) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: `/courses/${courseId}/revisions.json?limit=${limit}&course_scoped=${isCourseScoped}`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
-  });
+const fetchRevisionsPromise = async (courseId, limit, isCourseScoped) => {
+  const response = await request(`/courses/${courseId}/revisions.json?limit=${limit}&course_scoped=${isCourseScoped}`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const fetchRevisions = (courseId, limit, isCourseScoped = false) => (dispatch) => {

--- a/app/assets/javascripts/actions/settings_actions.js
+++ b/app/assets/javascripts/actions/settings_actions.js
@@ -16,7 +16,7 @@ const fetchAdminUsersPromise = async () => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -26,7 +26,7 @@ const fetchSpecialUsersPromise = async () => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -45,7 +45,7 @@ const grantAdminPromise = async (username, upgrade) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -59,7 +59,7 @@ const grantSpecialUserPromise = async (username, upgrade, position) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -314,7 +314,7 @@ const updateSalesforceCredentialsPromise = async (password, token) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -330,7 +330,7 @@ const fetchCourseCreationSettingsPromise = async () => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -359,7 +359,7 @@ const updateCourseCreationSettingsPromise = async (settings) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -380,7 +380,7 @@ const fetchDefaultCamapignPromise = async () => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -409,7 +409,7 @@ const updateDefaultCampaignPromise = async (campaignSlug) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/tag_actions.js
+++ b/app/assets/javascripts/actions/tag_actions.js
@@ -1,20 +1,15 @@
 import { RECEIVE_TAGS, RECEIVE_ALL_TAGS, ADD_TAG, REMOVE_TAG, API_FAIL } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
 
-const fetchTagsPromise = (courseId) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: `/courses/${courseId}/tags.json`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
-  });
+const fetchTagsPromise = async (courseId) => {
+  const response = await request(`/courses/${courseId}/tags.json`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const fetchTags = courseId => (dispatch) => {
@@ -30,20 +25,14 @@ export const fetchTags = courseId => (dispatch) => {
   );
 };
 
-const fetchAllTagsPromise = () => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: '/lookups/tag.json',
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
-  });
+const fetchAllTagsPromise = async () => {
+  const response = await request('/lookups/tag.json');
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const fetchAllTags = () => (dispatch) => {
@@ -52,21 +41,17 @@ export const fetchAllTags = () => (dispatch) => {
     .catch(response => (dispatch({ type: API_FAIL, data: response })));
 };
 
-const addTagPromise = (courseId, tag) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'POST',
-      url: `/courses/${courseId}/tag.json`,
-      data: { tag: { tag } },
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
+const addTagPromise = async (courseId, tag) => {
+  const response = await request(`/courses/${courseId}/tag.json`, {
+    method: 'POST',
+    body: JSON.stringify({ tag: { tag } })
   });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const addTag = (courseId, tag) => (dispatch) => {
@@ -82,21 +67,17 @@ export const addTag = (courseId, tag) => (dispatch) => {
   );
 };
 
-const removeTagPromise = (courseId, tag) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'DELETE',
-      url: `/courses/${courseId}/tag.json`,
-      data: { tag: { tag } },
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
+const removeTagPromise = async (courseId, tag) => {
+  const response = await request(`/courses/${courseId}/tag.json`, {
+    method: 'DELETE',
+    body: JSON.stringify({ tag: { tag } })
   });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const removeTag = (courseId, tag) => (dispatch) => {

--- a/app/assets/javascripts/actions/tag_actions.js
+++ b/app/assets/javascripts/actions/tag_actions.js
@@ -7,7 +7,7 @@ const fetchTagsPromise = async (courseId) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -30,7 +30,7 @@ const fetchAllTagsPromise = async () => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -49,7 +49,7 @@ const addTagPromise = async (courseId, tag) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };
@@ -75,7 +75,7 @@ const removeTagPromise = async (courseId, tag) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/tickets_actions.js
+++ b/app/assets/javascripts/actions/tickets_actions.js
@@ -159,7 +159,7 @@ export const deleteNotePromise = async (id) => {
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();
-    throw new Error(data.message);
+    throw data;
   }
   return response.json();
 };

--- a/app/assets/javascripts/actions/tickets_actions.js
+++ b/app/assets/javascripts/actions/tickets_actions.js
@@ -152,20 +152,16 @@ export const deleteTicket = id => async (dispatch) => {
 };
 
 
-export const deleteNotePromise = (id) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'DELETE',
-      url: `/td/tickets/replies/${id}`,
-      success: function (data) {
-        return res(data);
-      }
-    })
-    .fail((err) => {
-      logErrorMessage(err);
-      return rej(err);
-    });
+export const deleteNotePromise = async (id) => {
+  const response = await request(`/td/tickets/replies/${id}`, {
+    method: 'DELETE'
   });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw new Error(data.message);
+  }
+  return response.json();
 };
 
 export const deleteNote = id => (dispatch) => {

--- a/app/assets/javascripts/actions/timeline_actions.js
+++ b/app/assets/javascripts/actions/timeline_actions.js
@@ -19,21 +19,16 @@ import {
 } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
 import { fetchCourse } from './course_actions';
+import request from '../utils/request';
 
-const fetchTimelinePromise = (courseSlug) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'GET',
-      url: `/courses/${courseSlug}/timeline.json`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    })
-  );
+const fetchTimelinePromise = async (courseSlug) => {
+  const response = await request(`/courses/${courseSlug}/timeline.json`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 export const fetchTimeline = courseSlug => (dispatch) => {

--- a/app/assets/javascripts/actions/training_actions.js
+++ b/app/assets/javascripts/actions/training_actions.js
@@ -6,56 +6,43 @@ import {
 } from '../constants';
 import request from '../utils/request';
 import logErrorMessage from '../utils/log_error_message';
+import { stringify } from 'query-string';
 
-const fetchAllTrainingModulesPromise = () => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'GET',
-      url: '/training_modules.json',
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      })
-  );
+const fetchAllTrainingModulesPromise = async () => {
+  const response = await request('/training_modules.json');
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
-const fetchTrainingModulePromise = (opts) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'GET',
-      url: `/training_module.json?module_id=${opts.module_id}`,
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      })
-  );
+const fetchTrainingModulePromise = async (opts) => {
+  const response = await request(`/training_module.json?module_id=${opts.module_id}`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
-const setSlideCompletedPromise = (opts) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'POST',
-      url: `/training_modules_users.json?\
-module_id=${opts.module_id}&\
-user_id=${opts.user_id}&\
-slide_id=${opts.slide_id}`,
-      success(data) {
-        return res(data);
-      }
-    })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      })
-  );
+const setSlideCompletedPromise = async (opts) => {
+  const params = {
+    module_id: opts.module_id,
+    user_id: opts.user_id,
+    slide_id: opts.slide_id
+  };
+  const response = await request(`/training_modules_users.json?${stringify(params)}`, {
+    method: 'POST'
+  });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 export const fetchAllTrainingModules = () => (dispatch) => {

--- a/app/assets/javascripts/actions/training_status_actions.js
+++ b/app/assets/javascripts/actions/training_status_actions.js
@@ -1,38 +1,26 @@
 import { RECEIVE_TRAINING_STATUS, RECEIVE_USER_TRAINING_STATUS, API_FAIL } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
 
-const fetchTrainingStatusPromise = (userId, courseId) => {
-  return new Promise((res, rej) => {
-    const url = `/training_status.json?user_id=${userId}&course_id=${courseId}`;
-    return $.ajax({
-      type: 'GET',
-      url,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
-  });
+
+const fetchTrainingStatusPromise = async (userId, courseId) => {
+  const response = await request(`/training_status.json?user_id=${userId}&course_id=${courseId}`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
-const fetchUserTrainingStatusPromise = (username) => {
-  return new Promise((res, rej) => {
-    const url = `/user_training_status.json?username=${username}`;
-    return $.ajax({
-      type: 'GET',
-      url,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
-  });
+const fetchUserTrainingStatusPromise = async (username) => {
+  const response = await request(`/user_training_status.json?username=${username}`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 

--- a/app/assets/javascripts/actions/user_revisions_actions.js
+++ b/app/assets/javascripts/actions/user_revisions_actions.js
@@ -1,20 +1,16 @@
 import { RECEIVE_USER_REVISIONS, API_FAIL } from '../constants';
 import logErrorMessage from '../utils/log_error_message';
+import request from '../utils/request';
 
-const fetchUserRevisionsPromise = (courseId, userId) => {
-  return new Promise((res, rej) => {
-    return $.ajax({
-      type: 'GET',
-      url: `/revisions.json?user_id=${userId}&course_id=${courseId}`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    });
-  });
+
+const fetchUserRevisionsPromise = async (courseId, userId) => {
+  const response = await request(`/revisions.json?user_id=${userId}&course_id=${courseId}`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 export const fetchUserRevisions = (courseId, userId) => (dispatch, getState) => {

--- a/app/assets/javascripts/actions/wikidata_actions.js
+++ b/app/assets/javascripts/actions/wikidata_actions.js
@@ -2,28 +2,27 @@ import { chunk, map, join, filter } from 'lodash-es';
 import * as types from '../constants';
 import logErrorMessage from '../utils/log_error_message';
 import CourseUtils from '../utils/course_utils';
+import request from '../utils/request';
+
 
 const wikidataApiBase = 'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&origin=*';
 
-const fetchWikidataLabelsPromise = (qNumbers) => {
+const fetchWikidataLabelsPromise = async (qNumbers) => {
   const idsParam = join(qNumbers, '|');
-  return new Promise((res, rej) => {
-    return $.ajax({
-      url: wikidataApiBase,
-      data: {
-        ids: idsParam,
-        props: 'labels',
-        languages: `${I18n.locale}|en`
-      },
-      success: (data) => {
-        return res(data);
-      },
+  const response = await request(wikidataApiBase, {
+    method: 'POST',
+    body: JSON.stringify({
+      ids: idsParam,
+      props: 'labels',
+      languages: `${I18n.locale}|en`
     })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      });
   });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 // This takes a Wikidata page title and checks whether it looks like

--- a/app/assets/javascripts/actions/wikidata_actions.js
+++ b/app/assets/javascripts/actions/wikidata_actions.js
@@ -3,20 +3,18 @@ import * as types from '../constants';
 import logErrorMessage from '../utils/log_error_message';
 import CourseUtils from '../utils/course_utils';
 import request from '../utils/request';
-
+import { stringify } from 'query-string';
 
 const wikidataApiBase = 'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&origin=*';
 
 const fetchWikidataLabelsPromise = async (qNumbers) => {
   const idsParam = join(qNumbers, '|');
-  const response = await request(wikidataApiBase, {
-    method: 'POST',
-    body: JSON.stringify({
-      ids: idsParam,
-      props: 'labels',
-      languages: `${I18n.locale}|en`
-    })
-  });
+  const query = {
+    ids: idsParam,
+    props: 'labels',
+    languages: `${I18n.locale}|en`
+  };
+  const response = await request(`${wikidataApiBase}&${stringify(query)}`);
   if (!response.ok) {
     logErrorMessage(response);
     const data = await response.json();

--- a/app/assets/javascripts/actions/wizard_actions.js
+++ b/app/assets/javascripts/actions/wizard_actions.js
@@ -14,23 +14,18 @@ import {
 } from '../constants';
 import { fetchCourse } from './course_actions';
 import { fetchTimeline } from './timeline_actions';
+import request from '../utils/request';
 
 import logErrorMessage from '../utils/log_error_message';
 
-const fetchWizardIndexPromise = () => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'GET',
-      url: '/wizards.json',
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    })
-  );
+const fetchWizardIndexPromise = async () => {
+  const response = await request('/wizards.json');
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 export const fetchWizardIndex = () => (dispatch) => {
@@ -42,20 +37,14 @@ export const fetchWizardIndex = () => (dispatch) => {
 };
 
 
-const fetchWizardPanelsPromise = (wizardId) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'GET',
-      url: `/wizards/${wizardId}.json`,
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj);
-      return rej(obj);
-    })
-  );
+const fetchWizardPanelsPromise = async (wizardId) => {
+  const response = await request(`/wizards/${wizardId}.json`);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 export const fetchWizardPanels = wizardId => (dispatch) => {
@@ -116,22 +105,17 @@ export const disableSummaryMode = () => {
   return { type: WIZARD_DISABLE_SUMMARY_MODE };
 };
 
-const submitWizardPromise = (courseSlug, wizardId, wizardOutput) => {
-  return new Promise((res, rej) =>
-    $.ajax({
-      type: 'POST',
-      url: `/courses/${courseSlug}/wizard/${wizardId}.json`,
-      contentType: 'application/json',
-      data: JSON.stringify({ wizard_output: wizardOutput }),
-      success(data) {
-        return res(data);
-      }
-    })
-    .fail((obj) => {
-      logErrorMessage(obj, 'Couldn\'t submit wizard answers! ');
-      return rej(obj);
-    })
-  );
+const submitWizardPromise = async (courseSlug, wizardId, wizardOutput) => {
+  const response = await request(`/courses/${courseSlug}/wizard/${wizardId}.json`, {
+    method: 'POST',
+    body: JSON.stringify({ wizard_output: wizardOutput })
+  });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    throw data;
+  }
+  return response.json();
 };
 
 const getWizardKey = (state) => {

--- a/app/assets/javascripts/components/articles/article_graphs.jsx
+++ b/app/assets/javascripts/components/articles/article_graphs.jsx
@@ -5,6 +5,8 @@ import OnClickOutside from 'react-onclickoutside';
 import Wp10Graph from './wp10_graph.jsx';
 import EditSizeGraph from './edit_size_graph.jsx';
 import Loading from '../common/loading.jsx';
+import request from '../../utils/request';
+
 
 const ArticleGraphs = createReactClass({
   displayName: 'ArticleGraphs',
@@ -26,15 +28,10 @@ const ArticleGraphs = createReactClass({
 
     const articleId = this.props.article.id;
     const articledataUrl = `/articles/article_data.json?article_id=${articleId}`;
-    $.ajax(
-      {
-        dataType: 'json',
-        url: articledataUrl,
-        success: (data) => {
-          this.setState({
-            articleData: data
-          });
-        }
+    request(articledataUrl)
+      .then(resp => resp.json())
+      .then((data) => {
+        this.setState({ articleData: data });
       });
   },
 

--- a/app/assets/javascripts/components/articles/course_ores_plot.jsx
+++ b/app/assets/javascripts/components/articles/course_ores_plot.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Loading from '../common/loading.jsx';
 import CourseQualityProgressGraph from './course_quality_progress_graph';
 import { ORESSupportedWiki } from '../../utils/article_finder_language_mappings';
+import request from '../../utils/request';
 
 const CourseOresPlot = createReactClass({
   displayName: 'CourseOresPlot',
@@ -51,21 +52,19 @@ const CourseOresPlot = createReactClass({
   },
 
   fetchFile() {
-    $.ajax({
-      url: `/courses/${this.props.course.slug}/refresh_ores_data.json`,
-      success: (data) => {
+    request(`/courses/${this.props.course.slug}/refresh_ores_data.json`)
+      .then(resp => resp.json())
+      .then((data) => {
         this.setState({ refreshedData: data.ores_plot, loading: false });
-      }
-    });
+      });
   },
 
   fetchFilePath() {
-    $.ajax({
-      url: `/courses/${this.props.course.slug}/ores_plot.json`,
-      success: (data) => {
+    request(`/courses/${this.props.course.slug}/ores_plot.json`)
+      .then(resp => resp.json())
+      .then((data) => {
         this.setState({ articleData: data.ores_plot, loading: false });
-      }
-    });
+      });
   },
 
   displayGraph(data) {

--- a/app/assets/javascripts/components/campaign/campaign_ores_plot.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_ores_plot.jsx
@@ -3,6 +3,7 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Loading from '../common/loading.jsx';
 import CourseQualityProgressGraph from '../articles/course_quality_progress_graph';
+import request from '../../utils/request';
 
 const CampaignOresPlot = createReactClass({
   displayName: 'CampaignOresPlot',
@@ -51,12 +52,11 @@ const CampaignOresPlot = createReactClass({
   },
 
   fetchFilePath() {
-    $.ajax({
-      url: `/campaigns/${this.props.match.params.campaign_slug}/ores_data.json`,
-      success: (data) => {
+    request(`/campaigns/${this.props.match.params.campaign_slug}/ores_data.json`)
+      .then(resp => resp.json())
+      .then((data) => {
         this.setState({ articleData: data.ores_plot, loading: false });
-      }
-    });
+      });
   },
 
   render() {

--- a/app/assets/javascripts/components/user_profiles/user_profile.jsx
+++ b/app/assets/javascripts/components/user_profiles/user_profile.jsx
@@ -9,6 +9,7 @@ import { fetchStats } from '../../actions/user_profile_actions.js';
 import { fetchUserTrainingStatus } from '../../actions/training_status_actions';
 import Loading from '../common/loading.jsx';
 import UserTrainingStatus from './user_training_status.jsx';
+import request from '../../utils/request';
 
 const UserProfile = createReactClass({
   propTypes: {
@@ -33,15 +34,11 @@ const UserProfile = createReactClass({
   getData() {
     const username = encodeURIComponent(this.props.match.params.username);
     const statsdataUrl = `/stats_graphs.json?username=${username}`;
-    $.ajax(
-      {
-        dataType: 'json',
-        url: statsdataUrl,
-        success: (data) => {
-          this.setState({
-            statsGraphsData: data
-          });
-        }
+
+    request(statsdataUrl)
+      .then(resp => resp.json())
+      .then((data) => {
+        this.setState({ statsGraphsData: data });
       });
   },
 

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -1,6 +1,7 @@
 import { capitalize } from './strings';
 import logErrorMessage from './log_error_message';
 import request from './request';
+import { stringify } from 'query-string';
 
 const SentryLogger = {};
 
@@ -44,234 +45,180 @@ const API = {
       });
   },
 
-  createCustomFeedback(assignmentId, text, userId) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'POST',
-        url: `/assignments/${assignmentId}/assignment_suggestions`,
-        data: { feedback: { text: text, assignment_id: assignmentId, user_id: userId } },
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
-  },
-
-  destroyCustomFeedback(assignmentId, id) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'DELETE',
-        url: `/assignments/${assignmentId}/assignment_suggestions/${id}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
-  },
-
-  fetchUserProfileStats(username) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/user_stats.json?username=${username}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
-  },
-
-  updateArticleTrackedStatus(articleId, courseId, tracked) {
-    return new Promise((res, rej) => {
-      const url = `/articles/status.json?article_id=${articleId}&tracked=${tracked}&course_id=${courseId}`;
-      return $.ajax({
-        type: 'POST',
-        url,
-        success(data) {
-          return res(data);
-        }
-      }).fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      });
+  async createCustomFeedback(assignmentId, text, userId) {
+    const response = await request(`/assignments/${assignmentId}/assignment_suggestions`, {
+      method: 'POST',
+      body: JSON.stringify({ feedback: { text: text, assignment_id: assignmentId, user_id: userId } })
     });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  fetchArticleDetails(articleId, courseId) {
-    return new Promise((res, rej) => {
-      const url = `/articles/details.json?article_id=${articleId}&course_id=${courseId}`;
-      return $.ajax({
-        type: 'GET',
-        url,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        });
+  async destroyCustomFeedback(assignmentId, id) {
+    const response = await request(`/assignments/${assignmentId}/assignment_suggestions/${id}`, {
+      method: 'DELETE',
     });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  fetchDykArticles(opts = {}) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/revision_analytics/dyk_eligible.json?scoped=${opts.scoped || false}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async fetchUserProfileStats(username) {
+    const response = await request(`/user_stats.json?username=${username}`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  fetchSuspectedPlagiarism(opts = {}) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/revision_analytics/suspected_plagiarism.json?scoped=${opts.scoped || false}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async updateArticleTrackedStatus(article_id, course_id, tracked) {
+    const params = {
+      article_id,course_id, tracked
+    }
+    const response = await request(`/articles/status.json?${stringify(params)}`, {
+      method: 'POST'
+    });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  fetchSuspectedCoursePlagiarism(course_id) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/courses/${course_id}/suspected_plagiarism.json`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    )
+  async fetchArticleDetails(articleId, courseId) {
+    const response = await request(`/articles/details.json?article_id=${articleId}&course_id=${courseId}`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  fetchRecentUploads(opts = {}) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/revision_analytics/recent_uploads.json?scoped=${opts.scoped || false}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async fetchDykArticles(opts = {}) {
+    const response = await request(`/revision_analytics/dyk_eligible.json?scoped=${opts.scoped || false}`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  cloneCourse(id, campaign) {
+  async fetchSuspectedPlagiarism(opts = {}) {
+    const response = await request(`/revision_analytics/suspected_plagiarism.json?scoped=${opts.scoped || false}`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
+  },
+
+  async fetchSuspectedCoursePlagiarism(course_id) {
+    const response = await request(`/courses/${course_id}/suspected_plagiarism.json`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
+  },
+
+  async fetchRecentUploads(opts = {}) {
+    const response = await request(`/revision_analytics/recent_uploads.json?scoped=${opts.scoped || false}`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
+  },
+
+  async cloneCourse(id, campaign) {
     const campaignQueryParam = campaign ? `?campaign_slug=${campaign}` : ''
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'POST',
-        url: `/clone_course/${id}${campaignQueryParam}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+    const response = await request(`/clone_course/${id}${campaignQueryParam}`, {
+      method: 'POST'
+    });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  fetchUserCourses(userId) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/courses_users.json?user_id=${userId}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async fetchUserCourses(userId) {
+    const response = await request(`/courses_users.json?user_id=${userId}`);
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  deleteAssignment(assignment) {
+  async deleteAssignment(assignment) {
     const queryString = $.param(assignment);
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'DELETE',
-        url: `/assignments/${assignment.id}?${queryString}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+    const response = await request(`/assignments/${assignment.id}?${queryString}`, {
+      method: 'DELETE'
+    });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  createAssignment(opts) {
+  async createAssignment(opts) {
     const queryString = $.param(opts);
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'POST',
-        url: `/assignments.json?${queryString}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+    const response = await request(`/assignments.json?${queryString}`, {
+      method: 'POST'
+    });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  createRandomPeerAssignments(opts) {
+  async createRandomPeerAssignments(opts) {
     const queryString = $.param(opts);
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'POST',
-        url: `/assignments/assign_reviewers_randomly?${queryString}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+    const response = await request(`/assignments/assign_reviewers_randomly?${queryString}`, {
+      method: 'POST'
+    });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
   fetch(courseId, endpoint) {
@@ -393,123 +340,90 @@ const API = {
       .fail(() => console.error('Couldn\'t delete course'));
   },
 
-  deleteBlock(block_id) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'DELETE',
-        url: `/blocks/${block_id}.json`,
-        success(data) {
-          return res({ block_id });
-        }
-      })
-        .fail((obj) => {
-          console.error('Couldn\'t delete block');
-          return rej(obj);
-        })
-    );
+  async deleteBlock(block_id) {
+    const response = await request(`/blocks/${block_id}.json`, {
+      method: 'DELETE'
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return {block_id};
   },
 
-  deleteWeek(week_id) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'DELETE',
-        url: `/weeks/${week_id}.json`,
-        success(data) {
-          return res({ week_id });
-        }
-      })
-        .fail((obj) => {
-          console.error('Couldn\'t delete week');
-          return rej(obj);
-        })
-    );
+  async deleteWeek(week_id) {
+    const response = await request(`/weeks/${week_id}.json`, {
+      method: 'DELETE'
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return { week_id };
   },
 
-  deleteAllWeeks(course_id) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'DELETE',
-        url: `/courses/${course_id}/delete_all_weeks.json`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          console.error('Couldn\'t delete all weeks');
-          return rej(obj);
-        })
-    );
+  async deleteAllWeeks(course_id) {
+    const response = await request(`/courses/${course_id}/delete_all_weeks.json`, {
+      method: 'DELETE'
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  notifyOverdue(courseSlug) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'GET',
-        url: `/courses/${courseSlug}/notify_untrained.json`,
-        success(data) {
-          alert('Students with overdue trainings notified!');
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj, 'Couldn\'t notify students! ');
-          return rej(obj);
-        })
-    );
+  async notifyOverdue(courseSlug) {
+    const response = await request(`/courses/${courseSlug}/notify_untrained.json`);
+    if (!response.ok) {
+      logErrorMessage(response, 'Couldn\'t notify students! ');
+      const data = await response.json();
+      throw data;
+    }
+    alert('Students with overdue trainings notified!');
+    return response.json();
   },
 
-  greetStudents(courseId) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: `/greeting?course_id=${courseId}`,
-        success(data) {
-          alert('Student greetings added to the queue.');
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj, 'There was an error with the greetings! ');
-          return rej(obj);
-        })
-    );
+  async greetStudents(courseId) {
+    const response = await request(`/greeting?course_id=${courseId}`, {
+      method: 'PUT',
+    });
+    if (!response.ok) {
+      logErrorMessage(response, 'There was an error with the greetings! ');
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  modify(model, courseSlug, data, add) {
+  async modify(model, courseSlug, data, add) {
     const verb = add ? 'added' : 'removed';
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: (add ? 'POST' : 'DELETE'),
-        url: `/courses/${courseSlug}/${model}.json`,
-        contentType: 'application/json',
-        data: JSON.stringify(data),
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj, `${capitalize(model)} not ${verb}: `);
-          return rej(obj);
-        })
-    );
+    const response = await request(`/courses/${courseSlug}/${model}.json`, {
+      method: (add ? 'POST' : 'DELETE'),
+      body: JSON.stringify(data)
+    });
+    if (!response.ok) {
+      logErrorMessage(response, `${capitalize(model)} not ${verb}: `);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  dismissNotification(id) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: '/survey_notification',
-        dataType: 'json',
-        data: { survey_notification: { id, dismissed: true } },
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async dismissNotification(id) {
+    const response = await request('/survey_notification', {
+      method: 'PUT',
+      body: JSON.stringify( { survey_notification: { id, dismissed: true } })
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
   uploadSyllabus({ courseId, file }) {
@@ -534,103 +448,79 @@ const API = {
     });
   },
 
-  createBadWorkAlert(opts) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'POST',
-        url: '/alerts',
-        data: { ...opts, alert_type: 'BadWorkAlert' },
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
-  },
-
-  createNeedHelpAlert(opts) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'POST',
-        url: '/alerts',
-        data: { ...opts, alert_type: 'NeedHelpAlert' },
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
-  },
-
-  requestNewAccount(passcode, courseSlug, username, email, createAccountNow) {
-    return new Promise((res, rej) => {
-      $.ajax({
-        type: 'PUT',
-        url: '/requested_accounts',
-        data: { passcode, course_slug: courseSlug, username, email, create_account_now: createAccountNow },
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
+  async createBadWorkAlert(opts) {
+    const response = await request('/alerts', {
+      method: 'POST',
+      body: JSON.stringify( { ...opts, alert_type: 'BadWorkAlert' })
     });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  enableAccountRequests(courseSlug) {
-    return new Promise((res, rej) => {
-      $.ajax({
-        type: 'GET',
-        url: `/requested_accounts/${courseSlug}/enable_account_requests`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
+  async createNeedHelpAlert(opts) {
+    const response = await request('/alerts', {
+      method: 'POST',
+      body: JSON.stringify( { ...opts, alert_type: 'NeedHelpAlert' })
     });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  linkToSalesforce(courseId, salesforceId) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: `/salesforce/link/${courseId}.json?salesforce_id=${salesforceId}`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async requestNewAccount(passcode, courseSlug, username, email, createAccountNow) {
+    const response = await request('/requested_accounts', {
+      method: 'PUT',
+      body: JSON.stringify(  
+        { passcode, course_slug: courseSlug, username, email, create_account_now: createAccountNow }
+      )
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  updateSalesforceRecord(courseId) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: `/salesforce/update/${courseId}.json`,
-        success(data) {
-          return res(data);
-        }
-      })
-        .fail((obj) => {
-          logErrorMessage(obj);
-          return rej(obj);
-        })
-    );
+  async enableAccountRequests(courseSlug) {
+    const response = await request(`/requested_accounts/${courseSlug}/enable_account_requests`);
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
+  },
+
+  async linkToSalesforce(courseId, salesforceId) {
+    const response = await request(`/salesforce/link/${courseId}.json?salesforce_id=${salesforceId}`, {
+      method: 'PUT'
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
+  },
+
+  async updateSalesforceRecord(courseId) {
+    const response = await request(`/salesforce/update/${courseId}.json`, {
+      method: 'PUT'
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 };
 

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -373,7 +373,7 @@ const API = {
       const data = await response.json();
       throw data;
     }
-    return response.json();
+    return response.text();
   },
 
   async notifyOverdue(courseSlug) {

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -391,6 +391,7 @@ const API = {
       const data = await response.json();
       throw data;
     }
+    alert('Student greetings added to the queue.');
     return response.json();
   },
 

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -70,7 +70,7 @@ const API = {
       const data = await response.json();
       throw data;
     }
-    return response.json();
+    return response.text();
   },
 
   async fetchUserProfileStats(username) {

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -491,7 +491,7 @@ const API = {
       const data = await response.json();
       throw data;
     }
-    return response.json();
+    return response.text();
   },
 
   async linkToSalesforce(courseId, salesforceId) {

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -180,7 +180,7 @@ const API = {
   },
 
   async deleteAssignment(assignment) {
-    const queryString = $.param(assignment);
+    const queryString = stringify(assignment);
     const response = await request(`/assignments/${assignment.id}?${queryString}`, {
       method: 'DELETE'
     });
@@ -194,7 +194,7 @@ const API = {
   },
 
   async createAssignment(opts) {
-    const queryString = $.param(opts);
+    const queryString = stringify(opts);
     const response = await request(`/assignments.json?${queryString}`, {
       method: 'POST'
     });
@@ -208,7 +208,7 @@ const API = {
   },
 
   async createRandomPeerAssignments(opts) {
-    const queryString = $.param(opts);
+    const queryString = stringify(opts);
     const response = await request(`/assignments/assign_reviewers_randomly?${queryString}`, {
       method: 'POST'
     });

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -300,7 +300,7 @@ const API = {
     this.obj = null;
     this.status = null;
     const response = await request(`/courses${append}.json`, {
-      method: 'PUT',
+      method: type,
       body: JSON.stringify(req_data)
     });
 
@@ -321,19 +321,18 @@ const API = {
     // return promise;
   },
 
-  deleteCourse(courseId) {
-    request(`/courses/${courseId}.json`, {
+  async deleteCourse(courseId) {
+    console.log("deleting")
+    const response = await request(`/courses/${courseId}.json`, {
       method: 'DELETE'
-    }).then((resp)=>{
-      if(!resp.ok){
-        throw 'Couldn\'t delete course';
-      }
-      return resp.json();
-    }).then(()=>{
-      return window.location = '/';
-    }).catch((err)=>{
-      console.error(err);
-    })
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    window.location = '/';
+    return response.json();
   },
 
   async deleteBlock(block_id) {

--- a/app/assets/javascripts/utils/onboarding_utils.js
+++ b/app/assets/javascripts/utils/onboarding_utils.js
@@ -1,42 +1,33 @@
 import logErrorMessage from './log_error_message';
+import request from '../utils/request';
 
 const OnboardAPI = {
   // /  GETTERS
 
-  onboard(args) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: '/onboarding/onboard',
-        contentType: 'application/json',
-        data: JSON.stringify(args),
-        success(data) {
-          return res(data);
-        }
-      })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      })
-    );
+  async onboard(args) {
+    const response = await request('/onboarding/onboard', {
+      method: 'PUT',
+      body: JSON.stringify(args)
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   },
 
-  supplement(args) {
-    return new Promise((res, rej) =>
-      $.ajax({
-        type: 'PUT',
-        url: '/onboarding/supplementary',
-        contentType: 'application/json',
-        data: JSON.stringify(args),
-        success(data) {
-          return res(data);
-        }
-      })
-      .fail((obj) => {
-        logErrorMessage(obj);
-        return rej(obj);
-      })
-    );
+  async supplement(args) {
+    const response = await request('/onboarding/supplementary', {
+      method: 'PUT',
+      body: JSON.stringify(args)
+    });
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.json();
+      throw data;
+    }
+    return response.json();
   }
 };
 

--- a/app/assets/javascripts/utils/onboarding_utils.js
+++ b/app/assets/javascripts/utils/onboarding_utils.js
@@ -11,10 +11,10 @@ const OnboardAPI = {
     });
     if (!response.ok) {
       logErrorMessage(response);
-      const data = await response.json();
+      const data = await response.text();
       throw data;
     }
-    return response.json();
+    return response.text();
   },
 
   async supplement(args) {
@@ -24,10 +24,10 @@ const OnboardAPI = {
     });
     if (!response.ok) {
       logErrorMessage(response);
-      const data = await response.json();
+      const data = await response.text();
       throw data;
     }
-    return response.json();
+    return response.text();
   }
 };
 

--- a/app/assets/javascripts/utils/request.js
+++ b/app/assets/javascripts/utils/request.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import Rails from '@rails/ujs';
 
-const isRelativePath = path => !path.match(/http(s?)/g);
+// it is a relative path if it doesn't start with http or https
+const isRelativePath = path => !path.match(/^http(s?)/);
 
 export default (path, { method = 'GET', body = null } = {}) => {
   const options = {
@@ -10,7 +11,6 @@ export default (path, { method = 'GET', body = null } = {}) => {
     },
     method
   };
-
   // If the path is an internal request, include the CSRF Token
   if (isRelativePath(path)) options.headers['X-CSRF-Token'] = Rails.csrfToken();
   return fetch(path, body ? { body, ...options } : options);

--- a/test/actions/assignment_actions.spec.js
+++ b/test/actions/assignment_actions.spec.js
@@ -1,10 +1,14 @@
 import '../testHelper';
 import { addAssignment, deleteAssignment } from '../../app/assets/javascripts/actions/assignment_actions.js';
+import * as requestModule from '../../app/assets/javascripts/utils/request';
+
 
 describe('AssignmentActions', () => {
   const testAssignment = { article_title: 'Foo', user_id: 1, id: 4 };
   const initialAssignments = [];
-  sinon.stub($, 'ajax').yieldsTo('success', testAssignment);
+  sinon.stub(requestModule, 'default').resolves(
+    { status: 200, ok: true, json: sinon.fake.returns(testAssignment) }
+  );
   test(
     '.addAssignment sets a new assignment and .deleteAssignment removes one',
     (done) => {
@@ -19,9 +23,11 @@ describe('AssignmentActions', () => {
         .then(() => {
           const updatedAssignments = reduxStore.getState().assignments.assignments;
           const deletionResponse = { assignmentId: updatedAssignments[0].id };
-          $.ajax.restore();
-          sinon.stub($, 'ajax').yieldsTo('success', deletionResponse);
-          deleteAssignment(updatedAssignments[0])(reduxStore.dispatch);
+          requestModule.default.restore();
+          sinon.stub(requestModule, 'default').resolves(
+            { status: 200, ok: true, json: sinon.fake.returns({ ...deletionResponse }) }
+          );
+          return deleteAssignment(updatedAssignments[0])(reduxStore.dispatch);
         })
         .then(() => {
           const assignmentsAfterDelete = reduxStore.getState().assignments.assignments;

--- a/test/actions/course_actions.spec.js
+++ b/test/actions/course_actions.spec.js
@@ -1,12 +1,15 @@
 import '../testHelper';
 import { updateCourse, persistCourse } from '../../app/assets/javascripts/actions/course_actions.js';
+import * as requestModule from '../../app/assets/javascripts/utils/request';
 
 describe('CourseActions', () => {
   beforeEach(() => {
-    sinon.stub($, 'ajax').yieldsTo('success', { course: { title: 'Bar' } });
+    sinon.stub(requestModule, 'default').resolves(
+      { status: 200, ok: true, json: sinon.fake.returns({ course: { title: 'Bar' } }) }
+    );
   });
   afterEach(() => {
-    $.ajax.restore();
+    requestModule.default.restore();
   });
 
   test('.updateCourse sets course data in the store', () => {

--- a/test/actions/settings_actions.spec.js
+++ b/test/actions/settings_actions.spec.js
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import '../testHelper';
 import { REVOKING_ADMIN, SET_ADMIN_USERS } from '../../app/assets/javascripts/constants';
 import { downgradeAdmin, fetchAdminUsers, upgradeAdmin } from '../../app/assets/javascripts/actions/settings_actions';
+import * as requestModule from '../../app/assets/javascripts/utils/request';
 
 
 const middlewares = [thunk];
@@ -15,11 +16,13 @@ describe('SettingsActions', () => {
   // or this: https://github.com/reactjs/redux/blob/master/docs/recipes/WritingTests.md#async-action-creators
 
   beforeEach(() => {
-    sinon.stub($, 'ajax').yieldsTo('success', { spam: 'eggs' });
+    sinon.stub(requestModule, 'default').resolves(
+      { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
+      );
   });
 
   afterEach(() => {
-    $.ajax.restore();
+    requestModule.default.restore();
   });
 
   test('dispatches to SET_ADMIN_USERS', () => {
@@ -38,13 +41,17 @@ describe('upgradeAdmin', () => {
   let cannedResponse;
   beforeEach(() => {
     cannedResponse = { spam: 'eggs' };
-    sinon.stub($, 'ajax')
-      .onCall(0).yieldsTo('success', {})
-      .onCall(1).yieldsTo('success', { spam: 'eggs' });
+    sinon.stub(requestModule, 'default')
+      .onCall(0).resolves(
+        { status: 200, ok: true, json: sinon.fake.returns({}) }
+        )
+      .onCall(1).resolves(
+        { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
+        );
   });
 
   afterEach(() => {
-    $.ajax.restore();
+    requestModule.default.restore();
   });
 
   test('dispatches to SUBMITTING_NEW_ADMIN', () => {
@@ -86,13 +93,17 @@ describe('downgradeAdmin', () => {
   let cannedResponse;
   beforeEach(() => {
     cannedResponse = { spam: 'eggs' };
-    sinon.stub($, 'ajax')
-      .onCall(0).yieldsTo('success', {})
-      .onCall(1).yieldsTo('success', { spam: 'eggs' });
+    sinon.stub(requestModule, 'default')
+    .onCall(0).resolves(
+      { status: 200, ok: true, json: sinon.fake.returns({}) }
+      )
+    .onCall(1).resolves(
+      { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
+      );
   });
 
   afterEach(() => {
-    $.ajax.restore();
+    requestModule.default.restore();
   });
 
   test('dispatches correctly', () => {


### PR DESCRIPTION
## What this PR does

Addresses #4684 

The coverage report indicates that there are currently 12 requests which haven't been tested. 

1. [`fetchWikidataLabelsPromise`](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/4818/files#diff-7db6e393e6f74dbb08ce544acb55415ad34735fc73d58a5da18b9ba53fee4886)
2. [`article_graphs.jsx`](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/4818/files#diff-4fd0bc428b65148d07c6dbae3f39b909dcb827e52951dd7e4a2685cb0cd0f3c0)
3. [`updateSalesforceCredentialsPromise`](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/4818/files#diff-7ced3f635bf09bb5c531ecd01903b936ca5143a641f9dcfed64f8ab520940354)
4. [`grantAdminPromise`](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/4818/files#diff-7ced3f635bf09bb5c531ecd01903b936ca5143a641f9dcfed64f8ab520940354)
5. `createCustomFeedback`, `destroyCustomFeedback`, `greetStudents`, `dismissNotification`, `createBadWorkAlert`, `requestNewAccount`, `enableAccountRequests`, and `updateSalesforceRecord` all in [`api.js`](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/4818/commits/36d0df0f52bae1750ff88e5414879ea57e7cd6d7#diff-fe52ddf568c7cec6e7f56bc61c464f5b923852485bb723f0bb3fc3328c06e34e)

Apart from these, I haven't been able to test whether the `SentryLogger` works as expected. Its used in 2 places - `saveTimeline` and `saveCourse`, both of them in `api.js`