### PR TITLE
Add wikidata stats to campaign

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign.jsx
+++ b/app/assets/javascripts/components/campaign/campaign.jsx
@@ -10,6 +10,7 @@ import CampaignOresPlot from './campaign_ores_plot.jsx';
 import CampaignOverviewHandler from './campaign_overview_handler';
 import CampaignNavbar from '../common/campaign_navbar';
 import CampaignStats from './campaign_stats';
+import WikidataOverviewStats from '../common/wikidata_overview_stats';
 
 export const Campaign = createReactClass({
   displayName: 'Campaign',
@@ -48,6 +49,9 @@ export const Campaign = createReactClass({
         <div className="container campaign_main">
           <section className="overview container">
             <CampaignStats campaign={this.props.campaign} />
+            {this.props.campaign.course_stats && <WikidataOverviewStats
+              statistics={this.props.campaign.course_stats['www.wikidata.org']}
+            />}
           </section>
           {campaignHandler}
           <Switch>

--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -1,28 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import OverviewStat from '../common/OverviewStats/overview_stat';
+import OverviewStat from './OverviewStats/overview_stat';
 import I18n from 'i18n-js';
 
 const WikidataOverviewStats = ({ statistics }) => {
-  // const total = Object.values(statistics).reduce((a, b) => a + b);
-  let total;
-  if (statistics['total revisions']) {
-    total = <OverviewStat
-      id="total-revisions"
-      className="stat-display__value-small"
-      stat={statistics['total revisions']}
-      statMsg={I18n.t('metrics.total_revisions')}
-      renderZero={true}
-    />;
-  }
-
   return (
     <div className="wikidata-stats-container">
       <h2 className="wikidata-stats-title">Wikidata stats</h2>
       <div className="wikidata-display">
-
         <div className="single-stat">
-          {total}
+          <OverviewStat
+            id="total-revisions"
+            className="stat-display__value-small"
+            stat={statistics['total revisions']}
+            statMsg={I18n.t('metrics.total_revisions')}
+            renderZero={true}
+          />
         </div>
         <div className="stat-display__row">
           <h5 className="stats-label">{I18n.t('items.items')}</h5>

--- a/app/assets/javascripts/components/overview/overview_handler.jsx
+++ b/app/assets/javascripts/components/overview/overview_handler.jsx
@@ -24,7 +24,7 @@ import { fetchOnboardingAlert } from '../../actions/course_alert_actions';
 import { fetchTags } from '../../actions/tag_actions';
 import { addValidation, setValid, setInvalid, activateValidations } from '../../actions/validation_actions';
 import { getStudentUsers, getWeeksArray, firstValidationErrorMessage, isValid } from '../../selectors';
-import WikidataOverviewStats from './wikidata_overview_stats';
+import WikidataOverviewStats from '../common/wikidata_overview_stats';
 
 const Overview = createReactClass({
   displayName: 'Overview',

--- a/app/assets/stylesheets/modules/_campaign.styl
+++ b/app/assets/stylesheets/modules/_campaign.styl
@@ -75,18 +75,28 @@
 
 .high-modal
   position absolute
-  top 265px
-  right 17%
+  top 540px
+  right 18%
+
+  +below(1090px)
+    top 620px
+    right 17%
 
   +below(desktop)
-    top 680px
+    top 1050px
     left 2%
 
+  +below(836px)
+    top 1120px
+
+  +below(584px)
+    top 1270px
+
   +below(420px)
-    top 720px
+    top 1400px
     left 3%
 
   +above(1300px)
-    top 260px
+    top 530px
     right 18%
 


### PR DESCRIPTION
Wikidata stats are added to a campaign.
![wikidatastats](https://user-images.githubusercontent.com/65791349/156886411-ec6ff7bb-b374-413f-8338-7e650450e9fc.png)

I moved the WikidataOverviewStats component to a common folder and removed the conditional display of total revisions (I guess that all Wikidata stats records include this stat by now).