### PR TITLE
Only include edit mode params on MyArticles sandbox links

### DIFF
--- a/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
@@ -22,13 +22,13 @@ const interleaveSeparators = (acc, link, index, collection) => {
   return index < limit ? prefix.concat(<Separator key={index} />) : prefix;
 };
 
-const AssignmentLinks = ({ assignment, courseType, user, project }) => {
+const AssignmentLinks = ({ assignment, courseType, user, project, editMode }) => {
   const { article_url, id, role, editors } = assignment;
   const actions = [];
 
   if ((editors && editors.length) || assignment.role === ASSIGNED_ROLE) {
     actions.push(
-      <SandboxLink key={`sandbox-${id}`} assignment={assignment} />
+      <SandboxLink key={`sandbox-${id}`} assignment={assignment} editMode={editMode} />
     );
   }
 

--- a/app/assets/javascripts/components/common/AssignmentLinks/SandboxLink.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/SandboxLink.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const SandboxLink = ({ assignment }) => {
+export const SandboxLink = ({ assignment, editMode }) => {
   let url = assignment.sandboxUrl || assignment.sandbox_url;
-  if (Features.wikiEd) {
+  if (Features.wikiEd && editMode) {
     url += '?veaction=edit&preload=Template:Dashboard.wikiedu.org_draft_template';
   }
   return (

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/MyArticlesAssignmentLinks.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/MyArticlesAssignmentLinks.jsx
@@ -10,7 +10,7 @@ export const MyArticlesAssignmentLinks = ({ articleTitle, assignment, courseType
         <h4>{articleTitle}</h4>
       </section>
       <section className="editors">
-        <AssignmentLinks assignment={assignment} courseType={courseType} user={current_user} project={project}/>
+        <AssignmentLinks assignment={assignment} courseType={courseType} user={current_user} project={project} editMode={true} />
       </section>
     </section>
   );

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/SandboxLink.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/SandboxLink.spec.jsx
@@ -13,8 +13,8 @@ describe('SandboxLink', () => {
     expect(component.find('a').props().href).toContain('url');
   });
 
-  it('should include a template in the link if the assignment is a new article', () => {
-    const component = shallow(<SandboxLink assignment={{ status: 'new_article' }} />);
+  it('should include a template in the link if the assignment is a new article and editMode is true', () => {
+    const component = shallow(<SandboxLink assignment={{ status: 'new_article' }} editMode={true} />);
     expect(component).toMatchSnapshot();
     expect(component.find('a').props().href).toContain('Template');
   });

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/__snapshots__/SandboxLink.spec.jsx.snap
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Links/__snapshots__/SandboxLink.spec.jsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SandboxLink should include a template in the link if the assignment is a new article 1`] = `ShallowWrapper {}`;
+exports[`SandboxLink should include a template in the link if the assignment is a new article and editMode is true 1`] = `ShallowWrapper {}`;
 
 exports[`SandboxLink should show the link 1`] = `ShallowWrapper {}`;


### PR DESCRIPTION
This will make it easier for instructors to see when sandbox drafts do/don't exist, and also let them follow redirects in cases where a sanbox got moved to Draft space or Mainspace.