### PR TITLE
First pass at implementing Wikidata stats design

### DIFF
--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -8,14 +8,31 @@ const WikidataOverviewStats = ({ statistics }) => {
     <div className="wikidata-stats-container">
       <h2 className="wikidata-stats-title">Wikidata stats</h2>
       <div className="wikidata-display">
-        <div className="single-stat">
-          <OverviewStat
-            id="total-revisions"
-            className="stat-display__value-small"
-            stat={statistics['total revisions']}
-            statMsg={I18n.t('metrics.total_revisions')}
-            renderZero={true}
-          />
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.general')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="total-revisions"
+              className="stat-display__value-small"
+              stat={statistics['total revisions']}
+              statMsg={I18n.t('metrics.total_revisions')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="merged"
+              className="stat-display__value-small"
+              stat = {statistics['merged to']}
+              statMsg={I18n.t('metrics.merged')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="interwiki-links"
+              className="stat-display__value-small"
+              stat = {statistics['interwiki links added']}
+              statMsg={I18n.t('metrics.interwiki_links_added')}
+              renderZero={true}
+            />
+          </div>
         </div>
         <div className="stat-display__row">
           <h5 className="stats-label">{I18n.t('items.items')}</h5>
@@ -114,24 +131,6 @@ const WikidataOverviewStats = ({ statistics }) => {
             />
           </div>
         </div>
-        <div className="single-stat">
-          <OverviewStat
-            id="merged"
-            className="stat-display__value-small"
-            stat = {statistics['merged to']}
-            statMsg={I18n.t('metrics.merged')}
-            renderZero={true}
-          />
-        </div>
-        <div className="single-stat">
-          <OverviewStat
-            id="interwiki-links"
-            className="stat-display__value-small"
-            stat = {statistics['interwiki links added']}
-            statMsg={I18n.t('metrics.interwiki_links_added')}
-            renderZero={true}
-          />
-        </div>
         <div className="stat-display__row">
           <h5 className="stats-label">Aliases</h5>
           <div className="stat-display__value-group">
@@ -158,9 +157,9 @@ const WikidataOverviewStats = ({ statistics }) => {
             />
           </div>
         </div>
-        <div className="stat-display__row">
+        <div className="stat-display__row double-row">
           <h5 className="stats-label">Other</h5>
-          <div className="stat-display__value-group">
+          <div className="stat-display__value-group double">
             <OverviewStat
               id="redirects-created"
               className="stat-display__value-small"
@@ -182,6 +181,8 @@ const WikidataOverviewStats = ({ statistics }) => {
               statMsg={I18n.t('metrics.restorations_performed')}
               renderZero={true} i
             />
+          </div>
+          <div className="stat-display__value-group double">
             <OverviewStat
               id="qualifiers-added"
               className="stat-display__value-small"

--- a/app/assets/stylesheets/modules/_stats.styl
+++ b/app/assets/stylesheets/modules/_stats.styl
@@ -86,32 +86,39 @@
     flex-flow wrap
 
     .stat-display__row
-      width: auto
-      margin: 0 15px
+      width: 25%
+      padding: 0 15px 18px 0
+
+      &.double-row
+        width: 50%
 
       .stat-display__value-group
-        display flex
-        justify-content space-between
+        justify-content left
         gap 10px
 
+        &.double
+          width: 50%
+          float: left
+
     .stat-display__stat
-          text-align center
-          width: auto
+          width: 100%
+          line-height: 1.4
+          padding: 2px 0
 
           .stat-display__value-small
             font-family inherit
             color $brand_primary
-            font-size 18px
+            font-size 22px
             font-weight 300
-            text-align center
-            padding-right 15px
+            padding-left 15px
+            float left
 
           small
             color #666
             font-size 15px
             line-height 1
-            max-width 80px
-            margin 0 5px 10px 5px
+            margin 0 10px
+            vertical-align bottom
 
           img
             width 8px
@@ -137,7 +144,7 @@
         margin 0 20px 0 20px
 
 .stats-label
-  text-align center
+  padding-left 18px
   margin-bottom 5px
   color #666
   background-color: #F5F5F5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1011,6 +1011,7 @@ en:
     wiki_ed_help: Use the 'Get Help' button to report a problem.
     word_count: Words Added
     word_count_average: Average Word Count
+    general: General
     total_revisions: Total revisions
     claims: Claims
     aliases: Aliases


### PR DESCRIPTION
This is based on Toqa's redesign for the Wikidata stats component.

## Screenshots
Before:
![before](https://user-images.githubusercontent.com/848483/158440181-17b76df6-01ce-43c8-ab51-30e0e79433f2.png)

After:
![after](https://user-images.githubusercontent.com/848483/158440235-998711c4-20a0-4977-8018-e95cc286ce53.png)

