### PR TITLE
Make Sentry logging of routine updates more selective

### DIFF
--- a/lib/data_cycle/constant_update.rb
+++ b/lib/data_cycle/constant_update.rb
@@ -34,7 +34,7 @@ class ConstantUpdate
     update_new_article_ratings
     update_status_of_ungreeted_students if Features.wiki_ed?
     generate_alerts # from UpdateCycleAlertGenerator
-    log_end_of_update 'Constant update finished.'
+    sparse_log_end_of_update 'Constant update finished.', UpdateLogger.number_of_constant_updates
   # rubocop:disable Lint/RescueException
   rescue Exception => e
     log_end_of_update 'Constant update failed.'

--- a/lib/data_cycle/schedule_course_updates.rb
+++ b/lib/data_cycle/schedule_course_updates.rb
@@ -22,7 +22,9 @@ class ScheduleCourseUpdates
   def run_update
     log_start_of_update 'Schedule course updates starting.'
     enqueue_course_updates
-    log_end_of_update 'Schedule course updates finished.'
+  # These are very reliable, so no need to log the successful ones.
+  # log_end_of_update 'Schedule course updates finished.'
+
   # rubocop:disable Lint/RescueException
   rescue Exception => e
     log_end_of_update 'Schedule course updates failed.'

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -21,6 +21,12 @@ class UpdateLogger
     setting.save
   end
 
+  def self.number_of_constant_updates
+    setting = Setting.find_or_create_by(key: 'metrics_update')
+    logs = setting.value['constant_update']
+    logs.keys.max || 0
+  end
+
   ###########
   # Helpers #
   ###########

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -24,7 +24,7 @@ class UpdateLogger
   def self.number_of_constant_updates
     setting = Setting.find_or_create_by(key: 'metrics_update')
     logs = setting.value['constant_update']
-    logs.keys.max || 0
+    logs&.keys&.max || 0
   end
 
   ###########

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -38,7 +38,6 @@ describe ScheduleCourseUpdates do
 
     it 'calls the revisions and articles updates on courses currently taking place' do
       expect(UpdateCourseStats).to receive(:new).exactly(7).times
-      expect(Sentry).to receive(:capture_message).and_call_original
       update = described_class.new
       sentry_logs = update.instance_variable_get(:@sentry_logs)
       expect(sentry_logs.grep(/Short update latency/).any?).to eq(true)


### PR DESCRIPTION
We've now switched to sentry.io SaaS instead of running our own Sentry server, since sentry.wikiedu.org was getting less reliable after recent updates. I'd like to switch over both dashboard.wikiedu.org (already done) and outreachdashboard.wmflabs.org (not done yet) to use sentry.io, but I want to stay under the monthly limit of our current plan, 50k captures per month. When running smoothly, ScheduleCourseUpdates and ConstantUpdate log about 30k per month. Here, I'm removing the routine logging of the very-reliable ScheduleCourseUpdates (which is easy to recognize if problems arise, by inspect the Sidekiq queues). I'm also introducing "sparse" logging for ConstantUpdate, so that it only sends the heartbeat-type log for successful updates one-tenth of the time. That should provide plenty of headroom to switch P&E Dashboard over to use sentry.io as well.