### PR TITLE
Made footer adapt to the number of users

### DIFF
--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -1,4 +1,7 @@
 .article-viewer
+  display grid
+  grid-template-rows max-content 1fr max-content
+  max-height calc(100vh - 140px)
   background-color white
   position fixed
   top 70px
@@ -46,12 +49,13 @@
 .article-footer
   border-top 1px solid mischka !important
   font-size 90%
+  max-height: calc((100vh - 140px) * 0.2)
   overflow-y auto
   overflow-x hidden
-  max-height 92px
   width 100%
   div
     float left
+    overflow hidden
 
 .article-viewer-button
   margin 10px
@@ -63,7 +67,6 @@
   color $warning_text
 
 .user-legend-wrap
-  position: absolute
   width 90%
   background white
 


### PR DESCRIPTION
# What this PR does

Addresses #4795. Now, the height of the modal is always `100vh - 140px`. The `140px` is distributed evenly above and below the modal. 

The footer now takes up at most 20% of that modal height. The rest is given to the article content. 

# Before

![image](https://user-images.githubusercontent.com/10794178/158671371-64151aa2-7ef0-4fad-879c-ec6349974050.png)


# After 

![image](https://user-images.githubusercontent.com/10794178/158671003-b467e16f-93b7-4e51-9a9b-c27a83bee0d5.png)

When the 20% limit is breached, the footer becomes scrollable. 

![image](https://user-images.githubusercontent.com/10794178/158671896-ecb8ca85-fe44-4cbc-bc80-a547285187e3.png)

