### PR TITLE
Use strings instead of symbols for data that goes through Sidekiq

### DIFF
--- a/app/controllers/self_enrollment_controller.rb
+++ b/app/controllers/self_enrollment_controller.rb
@@ -72,16 +72,16 @@ class SelfEnrollmentController < ApplicationController
   end
 
   def redirect_if_enrollment_failed
-    return unless @result[:failure]
+    return unless @result['failure']
     respond_to do |format|
       format.html do
         redirect_to course_slug_path(@course.slug,
                                      enrolled: false,
-                                     failure_reason: @result[:failure])
+                                     failure_reason: @result['failure'])
       end
       format.json do
         render json: {
-          message: I18n.t("courses.join_failure_details.#{@result[:failure]}")
+          message: I18n.t("courses.join_failure_details.#{@result['failure']}")
         },
                status: :bad_request
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,8 +105,8 @@ class UsersController < ApplicationController
   end
 
   def ensure_enrollment_success
-    return unless @result[:failure]
-    message = I18n.t("courses.join_failure_details.#{@result[:failure]}")
+    return unless @result['failure']
+    message = I18n.t("courses.join_failure_details.#{@result['failure']}")
     render json: { message: message }, status: :not_found
     yield
   end

--- a/app/services/add_users.rb
+++ b/app/services/add_users.rb
@@ -29,7 +29,8 @@ class AddUsers
     user ||= UserImporter.new_from_username(username, @course.home_wiki)
     return user if user.present?
 
-    @results[username] = { failure: 'Not an existing user.' }
+    # This needs to use string keys because it is used in Sidekiq arguments.
+    @results[username] = { 'failure' => 'Not an existing user.' }
     yield
   end
 end

--- a/app/services/join_course.rb
+++ b/app/services/join_course.rb
@@ -21,16 +21,17 @@ class JoinCourse
     validate_request { return }
     create_courses_user
     update_course_user_count
-    @result = { success: 'User added to course.' }
+    # This needs to use string keys because it is used in Sidekiq arguments.
+    @result = { 'success' => 'User added to course.' }
   end
 
   def validate_request
     if user_already_enrolled?
-      @result = { failure: :cannot_join_twice }
+      @result = { 'failure' => 'cannot_join_twice' }
     elsif course_withdrawn?
-      @result = { failure: :withdrawn }
+      @result = { 'failure' => 'withdrawn' }
     elsif student_joining_before_approval?
-      @result = { failure: :not_yet_approved }
+      @result = { 'failure' => 'not_yet_approved' }
     else
       return
     end

--- a/spec/services/add_users_spec.rb
+++ b/spec/services/add_users_spec.rb
@@ -24,9 +24,9 @@ describe AddUsers do
     VCR.use_cassette 'add_users' do
       result = subject.add_all_at_once
       expect(result.size).to eq(usernames_list.size)
-      expect(result['Ursos clio herodoto']).to have_key(:success)
+      expect(result['Ursos clio herodoto']).to have_key('success')
       expect(result[nonnormalized_username]).to be_nil
-      expect(result[nonexistent_username]).to have_key(:failure)
+      expect(result[nonexistent_username]).to have_key('failure')
     end
   end
 end

--- a/spec/services/join_course_spec.rb
+++ b/spec/services/join_course_spec.rb
@@ -35,8 +35,8 @@ describe JoinCourse do
 
     it 'allows a course to be joined' do
       result = subject.result
-      expect(result[:failure]).to be_nil
-      expect(result[:success]).not_to be_nil
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
     end
   end
 
@@ -50,8 +50,8 @@ describe JoinCourse do
 
     it 'allows a course to be joined' do
       result = subject.result
-      expect(result[:failure]).to be_nil
-      expect(result[:success]).not_to be_nil
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
     end
   end
 
@@ -60,8 +60,8 @@ describe JoinCourse do
 
     it 'does not allow joining with multiple roles' do
       result = subject.result
-      expect(result[:failure]).not_to be_nil
-      expect(result[:success]).to be_nil
+      expect(result['failure']).not_to be_nil
+      expect(result['success']).to be_nil
     end
   end
 
@@ -70,8 +70,8 @@ describe JoinCourse do
 
     it 'does not allow joining with multiple roles' do
       result = subject.result
-      expect(result[:failure]).not_to be_nil
-      expect(result[:success]).to be_nil
+      expect(result['failure']).not_to be_nil
+      expect(result['success']).to be_nil
     end
   end
 
@@ -80,8 +80,8 @@ describe JoinCourse do
 
     it 'allows joining with multiple roles' do
       result = subject.result
-      expect(result[:failure]).to be_nil
-      expect(result[:success]).not_to be_nil
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
     end
   end
 
@@ -90,8 +90,8 @@ describe JoinCourse do
 
     it 'allows joining with multiple roles' do
       result = subject.result
-      expect(result[:failure]).to be_nil
-      expect(result[:success]).not_to be_nil
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
     end
   end
 
@@ -100,8 +100,8 @@ describe JoinCourse do
 
     it 'allows joining with multiple roles' do
       result = subject.result
-      expect(result[:failure]).to be_nil
-      expect(result[:success]).not_to be_nil
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
     end
   end
 
@@ -110,8 +110,8 @@ describe JoinCourse do
 
     it 'allows joining with multiple roles' do
       result = subject.result
-      expect(result[:failure]).to be_nil
-      expect(result[:success]).not_to be_nil
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
This fixes some warnings about JSON serialization, which would error on Sidekiq 7.0.