### PR TITLE
Replaces deprecated @babel/polyfill module 

### DIFF
--- a/app/assets/javascripts/main-coverage.js
+++ b/app/assets/javascripts/main-coverage.js
@@ -18,8 +18,9 @@
 // and other static (from a JavaScript perspective) data objects.
 
 
-// Polyfill
-import '@babel/polyfill';
+// core-js/stable and regenerator-runtime/runtime are directly included to polyfill ES features and to use transpiled generator functions respectively, as @babel/polyfill is deprecated.
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 require('location-origin');
 require('@rails/ujs').start(); // Enables rails-ujs, which adds JavaScript enhancement to some Rails views

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -4,8 +4,9 @@
 // and other static (from a JavaScript perspective) data objects.
 
 
-// Polyfill
-import '@babel/polyfill';
+// core-js/stable and regenerator-runtime/runtime are directly included to polyfill ES features and to use transpiled generator functions respectively, as @babel/polyfill is deprecated.
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 require('location-origin');
 require('@rails/ujs').start(); // Enables rails-ujs, which adds JavaScript enhancement to some Rails views

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@babel/core": "^7.17.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.17.3",
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-    "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/register": "^7.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,14 +1056,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.16.7"
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/polyfill@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
-  integrity sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@^7.16.11":
   version "7.16.11"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.11.tgz#5dd88fd885fae36f88fd7c8342475c9f0abe2982"
@@ -3690,11 +3682,6 @@ core-js-pure@^3.0.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.12.1.tgz#934da8b9b7221e2a2443dc71dfa5bd77a7ea00b8"
   integrity sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==
-
-core-js@^2.6.5:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.6.5:
   version "3.12.1"


### PR DESCRIPTION
## What this PR does?
As mentioned in discussion #4825, this PR is updating the `app/assets/javascripts/main.js` where `@babel/polyfill` was being used and replaced with individual imports of `core-js/stable` and `regenerator-runtime/runtime`. 

1. `@babel/polyfill` is a wrapper package that only includes imports of stable `core-js` features and `regenerator-runtime/runtime`, needed by transpiled generators and async functions. 
2. One needs to note that `@babel/polyfill`  was deprecated cause this package doesn't make it possible to provide a smooth migration path from core-js@2 to core-js@3. 

The changes have been made with respect to the following docs. 

1. [https://www.npmjs.com/package/@babel/polyfill](https://www.npmjs.com/package/@babel/polyfill)
2. [Introduction to core-js@3](https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md)