### PR TITLE
Edit Count is reversed for Student's Table

### DIFF
--- a/app/views/campaigns/users.html.haml
+++ b/app/views/campaigns/users.html.haml
@@ -21,7 +21,7 @@
           %th.sort.sortable.asc{"data-default-order" => "asc", "data-sort" => "username"}
             = t('users.username')
             %span.sortable-indicator
-          %th.sort.sortable{"data-default-order" => "asc", "data-sort" => "revision-count"}
+          %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "revision-count"}
             = t('courses.edit_count')
             %span.sortable-indicator
           %th.sort.sortable{"data-default-order" => "asc", "data-sort" => "title"}


### PR DESCRIPTION
## What this PR does?
Deals with the issue #4887. In this PR we solve the issue where the `edit count` sorts the `students` table low to high on the first click, so this action is reversed.

The file which was dealt with `app/views/campaigns/users.html.haml` where `revision-count` has its `data-default-order` changed to `desc`.

## Screenshots
![solved issue](https://user-images.githubusercontent.com/40771676/160680378-39da90a7-afc8-4c1d-b37b-1a8721c4aa77.gif)





