### PR TITLE
fixed reference added bug in articles table

### DIFF
--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -4,7 +4,7 @@
     = t('articles.deleted') if article.deleted
   %td.char_added
     = article_course.character_sum
-  %td.references_count
+  %td.references
     = article_course.references_count
   %td.views
     = article_course.view_count


### PR DESCRIPTION
## What this PR does?
Deals with the issue #4889. In this PR we solve the issue where the `references added` isn't able to sort the `articles` table. 

The file which was dealt with `app/views/campaigns/_article_row.html.haml` where `references_count` is changed to `references`. It was initially unable to render the article row cause it was referring to the wrong class. 

## Screenshots
![solved1](https://user-images.githubusercontent.com/40771676/160685286-31ec37bc-3144-43a3-97f3-4ca0648febc9.gif)

