### PR TITLE
Table indicators fixed.

### DIFF
--- a/app/views/campaigns/_campaigns.html.haml
+++ b/app/views/campaigns/_campaigns.html.haml
@@ -17,10 +17,10 @@
   %table.table.table--hoverable.table--sortable
     %thead
       %tr
-        %th.sort.sortable.asc{"data-default-order" => "asc", "data-sort" => "title"}
+        %th.sort.sortable{"data-default-order" => "asc", "data-sort" => "title"}
           = t('campaign.campaigns')
           %span.sortable-indicator
-        %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "num-courses", style: "width: 150px"}
+        %th.sort.sortable.desc{"data-default-order" => "desc", "data-sort" => "num-courses", style: "width: 150px"}
           .tooltip-trigger
             = t("#{Features.default_course_string_prefix}.courses")
             %span.sortable-indicator

--- a/app/views/campaigns/articles.html.haml
+++ b/app/views/campaigns/articles.html.haml
@@ -28,10 +28,10 @@
     %table.table.table--hoverable.table--sortable
       %thead
         %tr
-          %th.sort.sortable.asc{'data-default-order' => 'asc', 'data-sort' => 'title'}
+          %th.sort.sortable{'data-default-order' => 'asc', 'data-sort' => 'title'}
             = t('articles.title')
             %span.sortable-indicator
-          %th.sort.sortable{'data-default-order' => 'desc', 'data-sort' => 'char_added'}
+          %th.sort.sortable.desc{'data-default-order' => 'desc', 'data-sort' => 'char_added'}
             .tooltip-trigger
               = t('metrics.char_added')
               %span.sortable-indicator

--- a/app/views/campaigns/programs.html.haml
+++ b/app/views/campaigns/programs.html.haml
@@ -34,7 +34,7 @@
     %table.table.table--hoverable.table--sortable
       %thead
         %tr
-          %th.sort.sortable.asc{'data-default-order' => 'asc', 'data-sort' => 'title'}
+          %th.sort.sortable{'data-default-order' => 'asc', 'data-sort' => 'title'}
             = t("#{@presenter.course_string_prefix}.courses")
             %span.sortable-indicator
           %th.sort.sortable{style: 'width: 200px;', 'data-default-order' => 'asc', 'data-sort' => 'school'}
@@ -42,7 +42,7 @@
             %span.sortable-indicator
           - if Features.wiki_ed?
             %th Instructor
-          %th.sort.sortable{style: 'width: 165px;', 'data-default-order' => 'desc', 'data-sort' => 'revisions'}
+          %th.sort.sortable.desc{style: 'width: 165px;', 'data-default-order' => 'desc', 'data-sort' => 'revisions'}
             .tooltip-trigger
               = t('metrics.revisions')
               %span.sortable-indicator

--- a/app/views/campaigns/users.html.haml
+++ b/app/views/campaigns/users.html.haml
@@ -18,10 +18,10 @@
     %table.table.table--hoverable.table--sortable
       %thead
         %tr
-          %th.sort.sortable.asc{"data-default-order" => "asc", "data-sort" => "username"}
+          %th.sort.sortable{"data-default-order" => "asc", "data-sort" => "username"}
             = t('users.username')
             %span.sortable-indicator
-          %th.sort.sortable{"data-default-order" => "desc", "data-sort" => "revision-count"}
+          %th.sort.sortable.desc{"data-default-order" => "desc", "data-sort" => "revision-count"}
             = t('courses.edit_count')
             %span.sortable-indicator
           %th.sort.sortable{"data-default-order" => "asc", "data-sort" => "title"}


### PR DESCRIPTION
## What this PR does?
This PR deals with the issue #4891. Here the class of `.asc` or `.desc` is added to the respective column. 

- In the case of `Active Campaign`, the sorting takes place with respect to `Courses` or `num_courses`, which has been modified in `app/views/campaigns/_campaigns.html.haml` by adding `.desc` to the correct column.
- For `Students`, the sorting takes place with respect to `Edit Count`, which has been modified in `app/views/campaigns/users.html.haml` by adding `.desc` to the respective column.
- `Articles` had it's sorting take place with `Chars Added`, hence `app/views/campaigns/articles.html.haml` was modified.
- `Courses` had it's sorting take place with `Recent Edits` hence `app/views/campaigns/programs.html.haml` was modified.


## Screenshots
For Active Campaign 
![image](https://user-images.githubusercontent.com/40771676/160728414-53aad061-1a73-432f-81dd-a79130d3874e.png)
For Students
![image](https://user-images.githubusercontent.com/40771676/160728482-2e098709-9cd9-4bcc-98ec-ae55f6ae4e80.png)
For Articles
![image](https://user-images.githubusercontent.com/40771676/160728534-ca915c9d-d52b-4244-adf1-9f6df0341fcf.png)
For Courses
![image](https://user-images.githubusercontent.com/40771676/160728581-2fee0dae-a6ea-48ca-9715-4c69a9f3bfdc.png)
