### PR TITLE
Scroll to top when a student is selected in the Students Tab

### DIFF
--- a/app/assets/javascripts/components/students/containers/Articles.jsx
+++ b/app/assets/javascripts/components/students/containers/Articles.jsx
@@ -22,7 +22,7 @@ import { toggleUI } from '~/app/assets/javascripts/actions';
 import { getStudentUsers, getWeeksArray } from '~/app/assets/javascripts/selectors';
 import { getModulesAndBlocksFromWeeks } from '@components/util/helpers';
 import groupArticlesCoursesByUserId from '@components/students/utils/groupArticlesCoursesByUserId';
-import ScrollToTop from '../../util/ScrollToTop';
+import ScrollToTopOnMount from '../../util/ScrollToTopOnMount';
 
 export class Articles extends React.Component {
   constructor(props) {
@@ -73,7 +73,7 @@ export class Articles extends React.Component {
     );
     return (
       <>
-        <ScrollToTop />
+        <ScrollToTopOnMount />
         <StudentsSubNavigation
           course={course}
           heading={I18n.t('instructor_view.article_assignments', { prefix })}

--- a/app/assets/javascripts/components/students/containers/Articles.jsx
+++ b/app/assets/javascripts/components/students/containers/Articles.jsx
@@ -22,6 +22,7 @@ import { toggleUI } from '~/app/assets/javascripts/actions';
 import { getStudentUsers, getWeeksArray } from '~/app/assets/javascripts/selectors';
 import { getModulesAndBlocksFromWeeks } from '@components/util/helpers';
 import groupArticlesCoursesByUserId from '@components/students/utils/groupArticlesCoursesByUserId';
+import ScrollToTop from '../../util/ScrollToTop';
 
 export class Articles extends React.Component {
   constructor(props) {
@@ -61,8 +62,18 @@ export class Articles extends React.Component {
     const hasExercisesOrTrainings = !!modules.length;
     const groupedArticles = groupArticlesCoursesByUserId(articles);
     if (!students.length) return null;
+    const studentSelection = (
+      <StudentSelection
+        articlesUrl={this.generateArticlesUrl(course)}
+        course={course}
+        selected={this.state.selected}
+        selectStudent={this.selectStudent}
+        students={students}
+      />
+    );
     return (
       <>
+        <ScrollToTop />
         <StudentsSubNavigation
           course={course}
           heading={I18n.t('instructor_view.article_assignments', { prefix })}
@@ -83,13 +94,14 @@ export class Articles extends React.Component {
         }
         <section className="users-articles">
           <aside className="student-selection">
-            <StudentSelection
-              articlesUrl={this.generateArticlesUrl(course)}
-              course={course}
-              selected={this.state.selected}
-              selectStudent={this.selectStudent}
-              students={students}
-            />
+            <Routes>
+              <Route
+                path=":username" element={studentSelection}
+              />
+              <Route
+                path="*" element={studentSelection}
+              />
+            </Routes>
           </aside>
           <article className="student-details">
             <section className="assignments">

--- a/app/assets/javascripts/components/util/ScrollToTop.jsx
+++ b/app/assets/javascripts/components/util/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+const ScrollToTop = () => {
+  useEffect(() => {
+      window.scrollTo(0, 0);
+    },
+   []);
+  return null;
+};
+
+
+export default ScrollToTop;

--- a/app/assets/javascripts/components/util/ScrollToTopOnMount.jsx
+++ b/app/assets/javascripts/components/util/ScrollToTopOnMount.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-const ScrollToTop = () => {
+const ScrollToTopOnMount = () => {
   useEffect(() => {
       window.scrollTo(0, 0);
     },
@@ -9,4 +9,4 @@ const ScrollToTop = () => {
 };
 
 
-export default ScrollToTop;
+export default ScrollToTopOnMount;


### PR DESCRIPTION
This also fixes the issue where the selected user wasn't being highlighted. 

I've had to duplicate a route for `studentSelection` since that component is rendered both when a user isn't selected and when it is. 