### PR TITLE
update_course_detail_view

### DIFF
--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -66,7 +66,7 @@
 
     .course-term
       color $text_med_header
-      margin-left auto
+      margin-left 100px
       margin-right 20px
 
   .course-details
@@ -74,6 +74,12 @@
 
     .col
       margin-right 40px
+      &:first-child
+        width: 300px
+      &:nth-child(2)
+        width: 150px
+      &:nth-child(3)
+        width: 100px
       &:last-child
         margin-right 0
 


### PR DESCRIPTION

## What this PR does
- [x] In WikiEduDashboard User course detail page some attributes(School, Term, No of student and role)  are not aligned->(you can see in the screenshoot given below).
- [x]  updated _course.styl component for the above problem.
- [x] Now all the attributes are aligned beautifully in vertical line->(you can see in the screenshoot given below) .

## Screenshots
#### Before:

<img width="1131" alt="Screenshot 2022-04-12 at 1 48 16 PM" src="https://user-images.githubusercontent.com/76791320/163023327-222a83ff-196c-46f1-8080-edd5ab9149b7.png">

#### After:

<img width="1131" alt="Screenshot 2022-04-12 at 8 29 31 PM" src="https://user-images.githubusercontent.com/76791320/163023551-0b6596b8-c3ed-41fc-9abc-05a7ac12e6d5.png">

