### PR TITLE
View count human readable form

### DIFF
--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -3,7 +3,7 @@
     = link_to article.full_title, article.url
     = t('articles.deleted') if article.deleted
   %td.char_added
-    = number_to_human article_course.character_sum/7
+    = article_course.character_sum
   %td.references
     = article_course.references_count
   %td.views

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -3,11 +3,11 @@
     = link_to article.full_title, article.url
     = t('articles.deleted') if article.deleted
   %td.char_added
-    = article_course.character_sum
+    = number_to_human article_course.character_sum/5.175
   %td.references
     = article_course.references_count
   %td.views
-    = article_course.view_count
+    = number_to_human article_course.view_count
   %td.lang_project
     %small
       = "#{article.wiki.language}.#{article.wiki.project}"

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -3,7 +3,7 @@
     = link_to article.full_title, article.url
     = t('articles.deleted') if article.deleted
   %td.char_added
-    = number_to_human article_course.character_sum/5.175
+    = article_course.character_sum
   %td.references
     = article_course.references_count
   %td.views

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -3,7 +3,7 @@
     = link_to article.full_title, article.url
     = t('articles.deleted') if article.deleted
   %td.char_added
-    = article_course.character_sum
+    = number_to_human article_course.character_sum/7
   %td.references
     = article_course.references_count
   %td.views


### PR DESCRIPTION
## It is solving the issue :
 in campaign article page View count is converted into human readable form  ==> (47997 == 47.997k)

## What this PR does
- [x] big numbers  of views is not relevant here.
- [x] so converting big number of views to  human readable form.
- [x] I changed the number of views to human readable form-->(47997 == 47.997k)

## Screenshots
Before:
<img width="1170" alt="Screenshot 2022-04-15 at 7 30 25 PM" src="https://user-images.githubusercontent.com/76791320/163580540-f6ff162a-ceeb-4b59-aadd-627684c048b3.png">

After:
<img width="1170" alt="Screenshot 2022-04-16 at 10 34 43 PM" src="https://user-images.githubusercontent.com/76791320/163684739-574a0283-3fcd-4cd1-8838-837a73308600.png">





