### PR TITLE
Hide progress bar when there are no users

### DIFF
--- a/app/assets/javascripts/actions/revisions_actions.js
+++ b/app/assets/javascripts/actions/revisions_actions.js
@@ -5,7 +5,9 @@ import {
   RECEIVE_COURSE_SCOPED_REVISIONS,
   COURSE_SCOPED_REVISIONS_LOADING,
   SORT_REVISIONS,
-  API_FAIL
+  API_FAIL,
+  RECEIVE_ASSESSMENTS,
+  RECEIVE_REFERENCES
 } from '../constants';
 import { fetchWikidataLabelsForRevisions } from './wikidata_actions';
 import logErrorMessage from '../utils/log_error_message';
@@ -45,6 +47,14 @@ export const fetchRevisions = course => async (dispatch, getState) => {
     dispatch({
       type: RECEIVE_REVISIONS,
       data: { course },
+    });
+    dispatch({
+      type: RECEIVE_REFERENCES,
+      data: { },
+    });
+    dispatch({
+      type: RECEIVE_ASSESSMENTS,
+      data: { },
     });
     return;
   }


### PR DESCRIPTION
Just dispatched the relevant actions for receiving references and page assessments. 

Presently, the loading bar just spins infinitely if there are no users