### PR TITLE
Disable email for course

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -17,6 +17,7 @@ import PrivacySelector from './privacy_selector.jsx';
 import WithdrawnSelector from './withdrawn_selector.jsx';
 import TimelineToggle from './timeline_toggle.jsx';
 import OnlineVolunteersToggle from './online_volunteers_toggle.jsx';
+import DisableStudentEmailsToggle from './disable_student_emails.jsx';
 import StayInSandboxToggle from './stay_in_sandbox_toggle';
 import RetainAvailableArticlesToggle from './retain_available_articles_toggle';
 
@@ -310,6 +311,7 @@ const Details = createReactClass({
     let courseFormatSelector;
     let timelineToggle;
     let onlineVolunteersToggle;
+    let disableStudentEmailsToggle;
     let wikiEditsToggle;
     let editSettingsToggle;
     let withdrawnSelector;
@@ -407,6 +409,17 @@ const Details = createReactClass({
     if (canRename && !isClassroomProgramType) {
       timelineToggle = (
         <TimelineToggle
+          course={this.props.course}
+          editable={this.props.editable}
+          updateCourse={this.props.updateCourse}
+        />
+      );
+    }
+
+    // Users who can rename a course are also allowed to toggle the student email on/off.
+    if (canRename && !isClassroomProgramType) {
+      disableStudentEmailsToggle = (
+        <DisableStudentEmailsToggle
           course={this.props.course}
           editable={this.props.editable}
           updateCourse={this.props.updateCourse}
@@ -552,6 +565,7 @@ const Details = createReactClass({
               {privacySelector}
               {timelineToggle}
               {onlineVolunteersToggle}
+              {disableStudentEmailsToggle}
               {wikiEditsToggle}
               {editSettingsToggle}
               {withdrawnSelector}

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -417,7 +417,7 @@ const Details = createReactClass({
     }
 
     // Users who can rename a course are also allowed to toggle the student email on/off.
-    if (canRename && !isClassroomProgramType) {
+    if (canRename) {
       disableStudentEmailsToggle = (
         <DisableStudentEmailsToggle
           course={this.props.course}

--- a/app/assets/javascripts/components/overview/disable_student_emails.jsx
+++ b/app/assets/javascripts/components/overview/disable_student_emails.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import YesNoSelector from './yes_no_selector';
+
+const DisableStudentEmailsToggle = ({ course, editable, updateCourse }) => {
+  return (
+    <YesNoSelector
+      courseProperty="disable_student_emails"
+      label={I18n.t('courses.disable_student_emails')}
+      tooltip={I18n.t('courses.disable_student_emails_tooltip')}
+      course={course}
+      editable={editable}
+      updateCourse={updateCourse}
+    />
+  );
+};
+
+export default DisableStudentEmailsToggle;

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -279,6 +279,7 @@ class CoursesController < ApplicationController
     update_boolean_flag :timeline_enabled
     update_boolean_flag :wiki_edits_enabled
     update_boolean_flag :online_volunteers_enabled
+    update_boolean_flag :disable_student_emails
     update_boolean_flag :stay_in_sandbox
     update_boolean_flag :retain_available_articles
     update_edit_settings

--- a/app/models/alert_types/overdue_training_alert.rb
+++ b/app/models/alert_types/overdue_training_alert.rb
@@ -39,6 +39,7 @@ class OverdueTrainingAlert < Alert
   def send_email
     return if emails_disabled?
     return if opted_out?
+    return if course.disable_student_emails?
     OverdueTrainingAlertMailer.send_email(self)
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -415,6 +415,10 @@ class Course < ApplicationRecord
     flags[:retain_available_articles].present?
   end
 
+  def disable_student_emails?
+    flags[:disable_student_emails].present?
+  end
+
   # Overridden for some course types
   def cloneable?
     !tag?('no_clone')

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -14,6 +14,7 @@ json.course do
 
   json.wikis @course.wikis, :language, :project
   json.timeline_enabled @course.timeline_enabled?
+  json.disable_student_emails @course.disable_student_emails?
   json.academic_system @course.academic_system
   json.home_wiki_bytes_per_word @course.home_wiki.bytes_per_word
   json.home_wiki_edits_enabled @course.home_wiki.edits_enabled?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,7 +591,7 @@ en:
     delete_suggestion: Delete
     delete_course_instructions: You may delete this page if all campaigns are removed first.
     disable_student_emails: Disable Student Emails
-    disable_student_emails_tooltip: Disabling student email will stop all email being sent to students associated with this course.
+    disable_student_emails_tooltip: Disabling student email will stop some notification emails from being sent to students for this course.
     dismiss_survey: Dismiss
     dismiss_survey_confirm: Are you sure you want to permanently dismiss this survey?
     download_stats_data: Download stats

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -590,6 +590,8 @@ en:
     delete_course: Delete course
     delete_suggestion: Delete
     delete_course_instructions: You may delete this page if all campaigns are removed first.
+    disable_student_emails: Disable Student Emails
+    disable_student_emails_tooltip: Disabling student email will stop all email being sent to students associated with this course.
     dismiss_survey: Dismiss
     dismiss_survey_confirm: Are you sure you want to permanently dismiss this survey?
     download_stats_data: Download stats

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -220,14 +220,14 @@ describe CoursesController, type: :request do
 
     describe 'toggling disable student emails' do
       it 'sets the disable student emails flag to true' do
-        expect(course.flags[:disable_student_emails]).to be_nil
+        expect(course.disable_student_emails?).to be false
         params = { id: course.slug, course: { disable_student_emails: true } }
         put "/courses/#{course.slug}", params: params, as: :json
         expect(course.reload.flags[:disable_student_emails]).to eq(true)
       end
 
       it 'sets the disable student emails flag to false' do
-        expect(course.flags[:disable_student_emails]).to be_nil
+        expect(course.disable_student_emails?).to be false
         params = { id: course.slug, course: { disable_student_emails: false } }
         put "/courses/#{course.slug}", params: params, as: :json
         expect(course.reload.flags[:disable_student_emails]).to eq(false)

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -218,6 +218,22 @@ describe CoursesController, type: :request do
       end
     end
 
+    describe 'toggling disable student emails' do
+      it 'sets the disable student emails flag to true' do
+        expect(course.flags[:disable_student_emails]).to be_nil
+        params = { id: course.slug, course: { disable_student_emails: true } }
+        put "/courses/#{course.slug}", params: params, as: :json
+        expect(course.reload.flags[:disable_student_emails]).to eq(true)
+      end
+
+      it 'sets the disable student emails flag to false' do
+        expect(course.flags[:disable_student_emails]).to be_nil
+        params = { id: course.slug, course: { disable_student_emails: false } }
+        put "/courses/#{course.slug}", params: params, as: :json
+        expect(course.reload.flags[:disable_student_emails]).to eq(false)
+      end
+    end
+
     describe 'updating "last_reviewed"' do
       it 'sets the timestamp and reviewer' do
         expect(course.flags['last_reviewed']).to be_nil


### PR DESCRIPTION
## What this PR does
https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/3259 Wiring that adds a flag to course (serialized) for disabling student email for an individual course and also toggle in course details page.

## Screenshots
After:

![image](https://user-images.githubusercontent.com/505198/164452585-7494b1b9-c4db-44a8-970f-4b8ef255a47f.png)

## Open questions and concerns
Only added a single check for the flag in app/models/alert_types/overdue_training_alert.rb but should also add to other alerts where we would want this to apply
