### PR TITLE
remove lodash from bundle

### DIFF
--- a/app/assets/javascripts/components/students/utils/setOtherEditedArticles.js
+++ b/app/assets/javascripts/components/students/utils/setOtherEditedArticles.js
@@ -1,4 +1,4 @@
-import { includes } from 'lodash';
+import { includes } from 'lodash-es';
 
 export default (articlesById, assignments = [], student) => {
   // assignmentsByArticleId holds all the assignments grouped/sorted by articleIds

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "list.js": "git+https://github.com/WikiEducationFoundation/list.js.git",
     "location-origin": "^1.1.4",
     "lodash-es": "^4.17.15",
-    "lodash-webpack-plugin": "^0.11.6",
     "markdown-it": "^12.3.2",
     "markdown-it-footnote": "^3.0.2",
     "merge-stream": "^2.0.0",
@@ -120,7 +119,7 @@
     "hot": "node prepare.js && webpack serve --env development --env DISABLE_ESLINT --env memory --client-overlay --client-progress --progress",
     "coverage": "node prepare.js && webpack build --env development --env coverage --progress --node-env test",
     "build": "node prepare.js && webpack build --env production --node-env production --progress",
-    "analyze": "webpack --env production --env stats --profile --json > stats.json && webpack-bundle-analyzer stats.json public/assets/javascripts"
+    "analyze": "node prepare.js && webpack build --env production --node-env production --progress --env analyze"
   },
   "engines": {
     "yarn": ">= 1.0.0"
@@ -132,6 +131,7 @@
     "babel-plugin-root-import": "^6.5.0",
     "eslint-import-resolver-babel-plugin-root-import": "^1.1.1",
     "eslint-webpack-plugin": "^3.1.1",
+    "lodash": "^4.17.21",
     "react-refresh": "^0.14.0",
     "stylus-native-loader": "^1.1.2",
     "webpack-cli": "^4.9.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,11 +3,11 @@ const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RtlCssPlugin = require('rtlcss-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const config = require('./config');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const jsSource = `./${config.sourcePath}/${config.jsDirectory}`;
 const cssSource = `./${config.sourcePath}/${config.cssDirectory}`;
@@ -91,7 +91,6 @@ module.exports = (env) => {
     plugins: [
       // Creates smaller Lodash builds by replacing feature sets of modules with noop,
       // identity, or simpler alternatives.
-      new LodashModuleReplacementPlugin(config.requiredLodashFeatures),
       new MomentLocalesPlugin(),
       !env.DISABLE_ESLINT && new ESLintPlugin({
         files: 'app/assets/javascripts/**/*.{js,jsx}',
@@ -122,7 +121,8 @@ module.exports = (env) => {
       }),
       (env.development && !env.coverage) && new ReactRefreshWebpackPlugin({ overlay: {
         sockPort: 8080
-      } })
+      } }),
+      (env.analyze && new BundleAnalyzerPlugin())
     ].filter(Boolean),
 
     optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,8 +2816,8 @@ __metadata:
     linkifyjs: ^2.1.9
     list.js: "git+https://github.com/WikiEducationFoundation/list.js.git"
     location-origin: ^1.1.4
+    lodash: ^4.17.21
     lodash-es: ^4.17.15
-    lodash-webpack-plugin: ^0.11.6
     markdown-it: ^12.3.2
     markdown-it-footnote: ^3.0.2
     merge-stream: ^2.0.0
@@ -8908,17 +8908,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-webpack-plugin@npm:^0.11.6":
-  version: 0.11.6
-  resolution: "lodash-webpack-plugin@npm:0.11.6"
-  dependencies:
-    lodash: ^4.17.20
-  peerDependencies:
-    webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.1.0
-  checksum: 0ee7ca709592059bc8a83720d7f458efb643a0a538f408efc54a86d72282b325646774d4da90f9e5559b3909a978656077e42fae83697f50e6f9f35fd513a8f5
-  languageName: node
-  linkType: hard
-
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -8996,7 +8985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.7.0":
+"lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7


### PR DESCRIPTION
There was a single occurrence of `lodash` in  `app/assets/javascripts/components/students/utils/setOtherEditedArticles.js` which caused the entire package to be included in the final bundle. This fixes that. 

Lodash is still used by `eslint`, webpack and other development tools so I've listed it as a dev-dependency.

I've also updated the command for `yarn analyze` to make sure it analyzes the production bundle and not the development one. 