### PR TITLE
split bundles based on routes

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -408,6 +408,6 @@ const mapDispatchToProps = ({
 });
 
 // exporting two difference ways as a testing hack.
-export const ConnectedCourseCreator = connect(mapStateToProps, mapDispatchToProps)(CourseCreator);
+export default connect(mapStateToProps, mapDispatchToProps)(CourseCreator);
 
-export default CourseCreator;
+export { CourseCreator };

--- a/app/assets/javascripts/components/util/routes.jsx
+++ b/app/assets/javascripts/components/util/routes.jsx
@@ -1,49 +1,51 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import Loading from '../common/loading.jsx';
 
-import Course from '../course/course.jsx';
-import Onboarding from '../onboarding/index.jsx';
-import { ConnectedCourseCreator } from '../course_creator/course_creator.jsx';
-import ArticleFinder from '../article_finder/article_finder.jsx';
-import AdminAlerts from '../alerts/admin_alerts.jsx';
-import RecentActivityHandler from '../activity/recent_activity_handler.jsx';
-import TrainingApp from '../../training/components/training_app.jsx';
-import UserProfile from '../user_profiles/user_profile.jsx';
-import SettingsHandler from '../settings/settings_handler.jsx';
-import TicketsHandler from '../tickets/tickets_handler.jsx';
-import TicketShowHandler from '../tickets/ticket_show_handler.jsx';
-import TaggedCourseAlerts from '../alerts/tagged_course_alerts.jsx';
-import CampaignsHandler from '../campaign/campaigns_handler.jsx';
-import DetailedCampaignList from '../campaign/detailed_campaign_list';
-import Explore from '../explore/explore.jsx';
-import ActiveCoursesHandler from '../active_courses/active_courses_handler.jsx';
-import CoursesByWikiHandler from '../courses_by_wiki/courses_by_wiki_handler.jsx';
+const Course = lazy(() => import('../course/course.jsx'));
+const Onboarding = lazy(() => import('../onboarding/index.jsx'));
+const ConnectedCourseCreator = lazy(() => import('../course_creator/course_creator.jsx'));
+const ArticleFinder = lazy(() => import('../article_finder/article_finder.jsx'));
+const AdminAlerts = lazy(() => import('../alerts/admin_alerts.jsx'));
+const RecentActivityHandler = lazy(() => import('../activity/recent_activity_handler.jsx'));
+const UserProfile = lazy(() => import('../user_profiles/user_profile.jsx'));
+const SettingsHandler = lazy(() => import('../settings/settings_handler.jsx'));
+const TicketsHandler = lazy(() => import('../tickets/tickets_handler.jsx'));
+const TicketShowHandler = lazy(() => import('../tickets/ticket_show_handler.jsx'));
+const TaggedCourseAlerts = lazy(() => import('../alerts/tagged_course_alerts.jsx'));
+const CampaignsHandler = lazy(() => import('../campaign/campaigns_handler.jsx'));
+const DetailedCampaignList = lazy(() => import('../campaign/detailed_campaign_list'));
+const Explore = lazy(() => import('../explore/explore.jsx'));
+const TrainingApp = lazy(() => import('../../training/components/training_app.jsx'));
+const ActiveCoursesHandler = lazy(() => import('../active_courses/active_courses_handler.jsx'));
+const CoursesByWikiHandler = lazy(() => import('../courses_by_wiki/courses_by_wiki_handler.jsx'));
 
 const routes = (
-  <Routes>
-    <Route path="/onboarding/*" element={<Onboarding />} />
-    <Route path="/recent-activity/*" element={<RecentActivityHandler />} />
-    <Route path="/courses/:course_school/:course_title/*" element={<Course />} />
-    <Route path="/course_creator" element={<ConnectedCourseCreator />} />
-    <Route path="/users/:username" element={<UserProfile />} />
-    <Route path="/alerts_list" element={<AdminAlerts />} />
-    <Route path="/settings" element={<SettingsHandler />} />
-    <Route path="/article_finder" element={<ArticleFinder />} />
-    <Route path="/training/*" element={<TrainingApp />} />
-    <Route path="/tickets/dashboard" element={<TicketsHandler />} />
-    <Route path="/tickets/dashboard/:id" element={<TicketShowHandler />} />
-    <Route path="/campaigns/*" element={<CampaignsHandler />} />
-    <Route path="/tagged_courses/:tag/alerts" element={<TaggedCourseAlerts />} />
-    <Route index element={<DetailedCampaignList headerText={I18n.t('campaign.campaigns')} userOnly={true}/>} />
-    <Route path="/dashboard" element={<DetailedCampaignList headerText={I18n.t('campaign.campaigns')} userOnly={true}/>} />
-    <Route path="/explore" element={<Explore dashboardTitle={window.dashboardTitle}/>} />
-    <Route path="/active_courses" element={<ActiveCoursesHandler dashboardTitle={window.dashboardTitle}/>}/>
-    <Route path="/courses_by_wiki/:wiki_url" element={<CoursesByWikiHandler />}/>
+  <Suspense fallback={<Loading />}>
+    <Routes>
+      <Route path="/onboarding/*" element={<Onboarding />} />
+      <Route path="/recent-activity/*" element={<RecentActivityHandler />} />
+      <Route path="/courses/:course_school/:course_title/*" element={<Course />} />
+      <Route path="/course_creator" element={<ConnectedCourseCreator />} />
+      <Route path="/users/:username" element={<UserProfile />} />
+      <Route path="/alerts_list" element={<AdminAlerts />} />
+      <Route path="/settings" element={<SettingsHandler />} />
+      <Route path="/article_finder" element={<ArticleFinder />} />
+      <Route path="/training/*" element={<TrainingApp />} />
+      <Route path="/tickets/dashboard" element={<TicketsHandler />} />
+      <Route path="/tickets/dashboard/:id" element={<TicketShowHandler />} />
+      <Route path="/campaigns/*" element={<CampaignsHandler />} />
+      <Route path="/tagged_courses/:tag/alerts" element={<TaggedCourseAlerts />} />
+      <Route index element={<DetailedCampaignList headerText={I18n.t('campaign.campaigns')} userOnly={true}/>} />
+      <Route path="/dashboard" element={<DetailedCampaignList headerText={I18n.t('campaign.campaigns')} userOnly={true}/>} />
+      <Route path="/explore" element={<Explore dashboardTitle={window.dashboardTitle}/>} />
+      <Route path="/active_courses" element={<ActiveCoursesHandler dashboardTitle={window.dashboardTitle}/>}/>
+      <Route path="/courses_by_wiki/:wiki_url" element={<CoursesByWikiHandler />}/>
 
-
-    {/* this prevents the "route not found" warning for pages which are server rendered */}
-    <Route path="*" element={<div style={{ display: 'none' }}/>} />
-  </Routes>
+      {/* this prevents the "route not found" warning for pages which are server rendered */}
+      <Route path="*" element={<div style={{ display: 'none' }}/>} />
+    </Routes>
+  </Suspense>
 );
 
 export default routes;

--- a/test/components/course_creator/course_creator.spec.jsx
+++ b/test/components/course_creator/course_creator.spec.jsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import '../../testHelper';
-import CourseCreator from '../../../app/assets/javascripts/components/course_creator/course_creator.jsx';
+import { CourseCreator } from '../../../app/assets/javascripts/components/course_creator/course_creator.jsx';
 
 describe('CourseCreator', () => {
   describe('render', () => {


### PR DESCRIPTION
This is [one of the recommendations on the official documentation](https://reactjs.org/docs/code-splitting.html#route-based-code-splitting). It means that the user only downloads the code of the routes they actually visit.

I've also had to change the default export in the course creator file because dynamic imports don't support named exports.