### PR TITLE
Fix eslint plugin config

### DIFF
--- a/app/assets/javascripts/components/alerts/alerts_handler.jsx
+++ b/app/assets/javascripts/components/alerts/alerts_handler.jsx
@@ -75,7 +75,7 @@ const AlertsHandler = createReactClass({
     }
     return (
       <div>{alertList}</div>
-      );
+    );
     }
 });
 

--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -189,7 +189,8 @@ const ArticleFinderRow = createReactClass({
           {pageviews}
         </td>
         {button}
-      </tr>);
+      </tr>
+    );
   }
 });
 

--- a/app/assets/javascripts/components/timeline/orderable_block.jsx
+++ b/app/assets/javascripts/components/timeline/orderable_block.jsx
@@ -31,7 +31,8 @@ const OrderableBlock = createReactClass({
         <button onClick={this.props.onMoveUp} className="button border" aria-label={I18n.t('timeline.move_block_up')} disabled={this.props.disableUp}>
           <i className="icon icon-arrow-up" />
         </button>
-      </div>);
+      </div>
+    );
   }
 });
 

--- a/app/assets/javascripts/surveys/components/RangeGraph.jsx
+++ b/app/assets/javascripts/surveys/components/RangeGraph.jsx
@@ -43,7 +43,8 @@ export default class RangeGraph extends Component {
                   onMouseLeave={() => { this.showValue(null); }}
                   style={{ position: 'absolute', display: 'block', width: 10, left: -10, bottom: 0, height: (increment * answers[key]) }}
                 />
-              </div>);
+              </div>
+            );
           })}
           <span className="results__range-graph__max">{max}</span>
         </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ const outputPath = path.resolve(`${config.outputPath}`);
 
 module.exports = (env) => {
   const mode = env.development ? 'development' : 'production';
+  const isProductionOrCI = env.production || env.coverage;
   let devtool = 'eval-cheap-source-map';
   // see https://webpack.js.org/configuration/devtool/ for the detailed descriptions of these
   if (env.production) {
@@ -94,10 +95,10 @@ module.exports = (env) => {
       new MomentLocalesPlugin(),
       !env.DISABLE_ESLINT && new ESLintPlugin({
         files: 'app/assets/javascripts/**/*.{js,jsx}',
-        failOnError: !!env.production,
-        threads: !!env.production,
-        lintDirtyModulesOnly: true,
-        cache: true
+        failOnError: isProductionOrCI,
+        threads: isProductionOrCI,
+        lintDirtyModulesOnly: !isProductionOrCI,
+        cache: !isProductionOrCI
       }),
 
       new MiniCssExtractPlugin({


### PR DESCRIPTION
Because `lintDirtyModulesOnly` was set to `true` during `yarn build` and `yarn coverage` as well, the build would never fail since there would be no dirty modules. 