### PR TITLE
Add service to update namespace stats.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -283,7 +283,7 @@ class Course < ApplicationRecord
   end
 
   def tracked_namespaces
-    return ['0']
+    return [0]
   end
 
   def suspected_plagiarism

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -282,6 +282,10 @@ class Course < ApplicationRecord
              .where(wiki_id: wiki_ids)
   end
 
+  def tracked_namespaces
+    return ['0']
+  end
+
   def suspected_plagiarism
     revisions.suspected_plagiarism
   end

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -100,7 +100,8 @@ class ArticlesCourses < ApplicationRecord
 
   def self.update_from_course(course)
     course_article_ids = course.articles.where(wiki: course.wikis).pluck(:id)
-    revision_article_ids = get_mainspace_revisions(course.revisions).distinct.pluck(:article_id)
+    revision_article_ids = get_revisions_by_namespaces(course.tracked_namespaces,
+                                                       course.revisions).distinct.pluck(:article_id)
 
     # Remove all the ArticlesCourses that do not correspond to course revisions.
     # That may happen if the course dates changed, so some revisions are no
@@ -128,7 +129,7 @@ class ArticlesCourses < ApplicationRecord
     end
   end
 
-  def self.get_mainspace_revisions(revisions)
-    revisions.joins(:article).where(articles: { namespace: '0' })
+  def self.get_revisions_by_namespaces(namespaces, revisions)
+    revisions.joins(:article).where(articles: { namespace: namespaces })
   end
 end

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -31,6 +31,7 @@ class Revision < ApplicationRecord
   scope :live, -> { where(deleted: false) }
   scope :user, -> { where(system: false) }
   scope :suspected_plagiarism, -> { where.not(ithenticate_id: nil) }
+  scope :namespace, -> (ns) { joins(:article).where(articles: { namespace: ns }) }
 
   # Helps with importing data
   alias_attribute :rev_id, :mw_rev_id

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -31,7 +31,7 @@ class Revision < ApplicationRecord
   scope :live, -> { where(deleted: false) }
   scope :user, -> { where(system: false) }
   scope :suspected_plagiarism, -> { where.not(ithenticate_id: nil) }
-  scope :namespace, -> (ns) { joins(:article).where(articles: { namespace: ns }) }
+  scope :namespace, ->(ns) { joins(:article).where(articles: { namespace: ns }) }
 
   # Helps with importing data
   alias_attribute :rev_id, :mw_rev_id

--- a/app/services/update_wiki_namespace_stats.rb
+++ b/app/services/update_wiki_namespace_stats.rb
@@ -11,13 +11,13 @@ class UpdateWikiNamespaceStats
   def update_stats
     stat_key = "#{@wiki.domain}-namespace-#{@namespace}"
     stats = {
-      'edited_count': edited_articles_count,
-      'new_count': new_articles_count,
-      'revision_count': revision_count,
-      'user_count': user_count,
-      'word_count': word_count,
-      'reference_count': reference_count,
-      'view_count': view_count
+      edited_count: edited_articles_count,
+      new_count: new_articles_count,
+      revision_count: revision_count,
+      user_count: user_count,
+      word_count: word_count,
+      reference_count: reference_count,
+      view_count: view_count
     }
     course_stats = CourseStat.find_or_create_by(course_id: @course.id)
     course_stats.stats_hash[stat_key] = stats
@@ -27,20 +27,20 @@ class UpdateWikiNamespaceStats
   # live, tracked course revisions filtered by wiki and namespace
   def revisions_filtered_by_wiki_namespace
     @course.revisions.where.not(article_id: @course.articles_courses.not_tracked.pluck(:article_id))
-                     .where(wiki_id: @wiki.id)
-                     .namespace(@namespace).live
+           .where(wiki_id: @wiki.id)
+           .namespace(@namespace).live
   end
 
   # live, tracked articles filtered by wiki and namespace
   def articles_filtered_by_wiki_namespace
     @course.articles_courses.joins(:article).where(articles: { wiki: @wiki, namespace: @namespace })
-                                            .tracked.live
+           .tracked.live
   end
 
   def edited_articles_count
     articles = articles_filtered_by_wiki_namespace
     articles.count
-	end
+  end
 
   def new_articles_count
     articles = articles_filtered_by_wiki_namespace

--- a/app/services/update_wiki_namespace_stats.rb
+++ b/app/services/update_wiki_namespace_stats.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class UpdateWikiNamespaceStats
+  def initialize(course, wiki, namespace)
+    @course = course
+    @wiki = wiki
+    @namespace = namespace
+    update_stats
+  end
+
+  def update_stats
+    stat_key = "#{@wiki.domain}-namespace-#{@namespace}"
+    stats = {
+      'edited_count': edited_articles_count,
+      'new_count': new_articles_count,
+      'revision_count': revision_count,
+      'user_count': user_count,
+      'word_count': word_count,
+      'reference_count': reference_count,
+      'view_count': view_count
+    }
+    course_stats = CourseStat.find_or_create_by(course_id: @course.id)
+    course_stats.stats_hash[stat_key] = stats
+    course_stats.save
+  end
+
+  # live, tracked course revisions filtered by wiki and namespace
+  def revisions_filtered_by_wiki_namespace
+    @course.revisions.where.not(article_id: @course.articles_courses.not_tracked.pluck(:article_id))
+                     .where(wiki_id: @wiki.id)
+                     .namespace(@namespace).live
+  end
+
+  # live, tracked articles filtered by wiki and namespace
+  def articles_filtered_by_wiki_namespace
+    @course.articles_courses.joins(:article).where(articles: { wiki: @wiki, namespace: @namespace })
+                                            .tracked.live
+  end
+
+  def edited_articles_count
+    articles = articles_filtered_by_wiki_namespace
+    articles.count
+	end
+
+  def new_articles_count
+    articles = articles_filtered_by_wiki_namespace
+    articles.new_article.count
+  end
+
+  def revision_count
+    revisions = revisions_filtered_by_wiki_namespace
+    revisions.size
+  end
+
+  def user_count
+    revisions = revisions_filtered_by_wiki_namespace
+    revisions.distinct.pluck(:user_id).count
+  end
+
+  def word_count
+    revisions = revisions_filtered_by_wiki_namespace
+    character_sum = revisions.where('characters >= 0').sum(:characters) || 0
+    WordCount.from_characters(character_sum)
+  end
+
+  def reference_count
+    revisions = revisions_filtered_by_wiki_namespace
+    revisions.sum(&:references_added)
+  end
+
+  def view_count
+    articles = articles_filtered_by_wiki_namespace
+    articles.sum(:view_count)
+  end
+end

--- a/spec/services/update_wiki_namespace_stats_spec.rb
+++ b/spec/services/update_wiki_namespace_stats_spec.rb
@@ -51,4 +51,16 @@ describe UpdateWikiNamespaceStats do
     expect(stats).to have_key(:reference_count)
     expect(stats).to have_key(:view_count)
   end
+
+  it 'updates the wiki-namespace stats correctly' do
+    stats = course.course_stat.stats_hash['en.wikibooks.org-namespace-102']
+
+    expect(stats[:edited_count]).to eq 1
+    expect(stats[:new_count]).to eq 1
+    expect(stats[:revision_count]).to eq 4
+    expect(stats[:user_count]).to eq 1
+    expect(stats[:word_count]).to eq 262
+    expect(stats[:reference_count]).to eq 0
+    expect(stats[:view_count]).to eq 0
+  end
 end

--- a/spec/services/update_wiki_namespace_stats_spec.rb
+++ b/spec/services/update_wiki_namespace_stats_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdateWikiNamespaceStats do
+  let(:course) { create(:course, start: Date.new(2022, 8, 1), end: Date.new(2022, 8, 2)) }
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikibooks') }
+  let(:namespace) { 102 }
+  let(:user1) { create(:user, username: 'Jamzze') } # user with cookbook edits
+  let(:user2) { create(:user, username: 'FieldMarine') } # user with other namespace edits
+
+  before do
+    stub_wiki_validation
+    course.campaigns << Campaign.first
+    course.wikis << wiki
+    JoinCourse.new(course: course, user: user1, role: 0)
+    JoinCourse.new(course: course, user: user2, role: 0)
+    allow_any_instance_of(Course).to receive(:tracked_namespaces).and_return([0, 102])
+    VCR.use_cassette 'course_update' do
+      UpdateCourseStats.new(course)
+    end
+    described_class.new(course, wiki, namespace)
+  end
+
+  it 'adds articles with only tracked namespaces to article_courses' do
+    # namespaces of all the fetched revisions of course users
+    fetched_namespaces = course.revisions.joins(:article).distinct.pluck('articles.namespace')
+    # namespaces of article_courses
+    article_namespaces = course.articles.distinct.pluck(:namespace)
+
+    expect(fetched_namespaces).to include(0, 2, 3, 102)
+    expect(article_namespaces).to include(0, 102)
+    expect(article_namespaces).not_to include(2, 3)
+  end
+
+  it 'updates course_stat record with appropriate wiki-namespace key' do
+    expect(course.course_stat).not_to be_nil
+
+    stats = course.course_stat.stats_hash
+    expect(stats).to have_key('en.wikibooks.org-namespace-102')
+  end
+
+  it 'updates wiki-namespace stats with appropriate keys' do
+    stats = course.course_stat.stats_hash['en.wikibooks.org-namespace-102']
+
+    expect(stats).to have_key(:edited_count)
+    expect(stats).to have_key(:new_count)
+    expect(stats).to have_key(:revision_count)
+    expect(stats).to have_key(:user_count)
+    expect(stats).to have_key(:word_count)
+    expect(stats).to have_key(:reference_count)
+    expect(stats).to have_key(:view_count)
+  end
+end


### PR DESCRIPTION
## What this PR does
Defines a service to generate/update namespace stats to CourseStats.

## Steps to reproduce for cookbook namespace

1.  Copy/ Import the course -https://outreachdashboard.wmflabs.org/courses/Edriiic/Nigerian_Cuisine
2.  In rails console, 
```
course = Course.find_by(title: "Nigerian Cuisine");
wiki = course.wikis.find_by(project: "wikibooks");
```
3.  Update revisions with `UpdateCourseStats.new(course)`
4.  Update namespace stats with `UpdateWikiNamespaceStats.new(course, wiki, 102)`

