### PR TITLE
update I18n to version 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
       raabro (~> 1.4)
     fuzzily_reloaded (1.0.1)
       activerecord (>= 5.1)
+    glob (0.3.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     griddler (1.5.2)
@@ -297,8 +298,9 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    i18n-js (3.9.2)
-      i18n (>= 0.6.6)
+    i18n-js (4.0.0)
+      glob
+      i18n
     io-wait (0.2.1)
     ipaddr (1.2.4)
     jbuilder (2.11.5)

--- a/app/assets/javascripts/components/campaign/campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_list.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';

--- a/app/assets/javascripts/components/campaign/detailed_campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/detailed_campaign_list.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React from 'react';
 import CampaignList from './campaign_list';
 import DetailedCampaignRow from './detailed_campaign_row';

--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import OverviewStat from './OverviewStats/overview_stat';
-import I18n from 'i18n-js';
 
 const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
   let containerClass = 'wikidata-stats-container';

--- a/app/assets/javascripts/components/course/searchable_course_list.jsx
+++ b/app/assets/javascripts/components/course/searchable_course_list.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React, { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SearchBar from '../common/search_bar';

--- a/app/assets/javascripts/components/explore/explore.jsx
+++ b/app/assets/javascripts/components/explore/explore.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { getCurrentUser } from '../../selectors';

--- a/app/assets/javascripts/config/i18n.js
+++ b/app/assets/javascripts/config/i18n.js
@@ -1,0 +1,23 @@
+import { I18n } from 'i18n-js';
+
+async function loadTranslations(i18n, locale) {
+  const response = await fetch(`/assets/javascripts/i18n/${locale}.json`);
+  const translations = await response.json();
+  i18n.store(translations);
+}
+
+export default async () => {
+  const i18n = new I18n();
+
+
+  await loadTranslations(i18n, window.locale);
+
+  // all of these are set in app/views/layouts/stats.html.haml and app/views/shared/_head.html.haml
+  i18n.locale = window.locale;
+  i18n.defaultLocale = window.defaultLocale;
+  i18n.availableLocales = window.availableLocales;
+  i18n.enableFallback = true;
+
+  window.I18n = i18n;
+};
+

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -7,16 +7,16 @@
 // core-js/stable and regenerator-runtime/runtime are directly included to polyfill ES features and to use transpiled generator functions respectively, as @babel/polyfill is deprecated.
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import fetchTranslations from './config/i18n';
 
 require('location-origin');
 require('@rails/ujs').start(); // Enables rails-ujs, which adds JavaScript enhancement to some Rails views
 window.List = require('list.js'); // List is used for sorting tables outside of React
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   /* eslint-disable */
-  import('i18n-js').then(({ default: I18n }) => {
-    window.I18n = I18n;
-  });
+
+  await fetchTranslations();
   import('./utils/course.js'); // This adds jquery features for some views outside of React
   
   // This is the main React entry point. It renders the navbar throughout the app, and

--- a/app/assets/javascripts/reducers/wizard.js
+++ b/app/assets/javascripts/reducers/wizard.js
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import {
   RECEIVE_WIZARD_ASSIGNMENT_OPTIONS,
   RECEIVE_WIZARD_PANELS,

--- a/app/assets/javascripts/training/components/training_slide_handler.jsx
+++ b/app/assets/javascripts/training/components/training_slide_handler.jsx
@@ -7,8 +7,6 @@ import SlideLink from './slide_link.jsx';
 import SlideMenu from './slide_menu.jsx';
 import Quiz from './quiz.jsx';
 import Notifications from '../../components/common/notifications.jsx';
-import I18n from 'i18n-js';
-
 
 const md = require('../../utils/markdown_it.js').default({ openLinksExternally: true });
 

--- a/app/views/layouts/stats.html.haml
+++ b/app/views/layouts/stats.html.haml
@@ -10,14 +10,11 @@
   = dashboard_stylesheet_tag("main")
   %script(src="https://unpkg.com/react@16.0.0/umd/react.production.min.js")
   %script(src="https://unpkg.com/react-dom@16.0.0/umd/react-dom.production.min.js")
-
-  = javascript_include_tag '/assets/javascripts/i18n'
-  = i18n_javascript_tag I18n.locale.to_s
   :javascript
-    I18n.defaultLocale = "#{I18n.default_locale}";
-    I18n.locale = "#{I18n.locale}";
-    I18n.availableLocales = #{I18n.available_locales.to_json.html_safe}
-
+    locale = "#{I18n.locale.to_s}"
+    defaultLocale = "#{I18n.default_locale}";
+    availableLocales = #{I18n.available_locales.to_json}
+  :javascript
   %body
     %div
       = yield

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -12,15 +12,14 @@
 
   = content_for :head
 
-  = javascript_include_tag '/assets/javascripts/i18n'
-  = i18n_javascript_tag I18n.locale.to_s
   %meta{name: "data-projects", content: Wiki::PROJECTS.to_json}
   %meta{name: "data-languages", content: Wiki::LANGUAGES.to_json}
   :javascript
-    I18n.defaultLocale = "#{I18n.default_locale}";
-    I18n.locale = "#{I18n.locale}";
-    I18n.availableLocales = #{I18n.available_locales.to_json.html_safe}
-
+    locale = "#{I18n.locale.to_s}"
+    defaultLocale = "#{I18n.default_locale}";
+    availableLocales = #{I18n.available_locales.to_json.html_safe}
+  = hot_javascript_tag "vendors"
+  :javascript
     currentUser = {
       id: "#{current_user&.id || ''}",
       username: "#{current_user&.username || ''}"
@@ -44,8 +43,6 @@
     SentryDsn = "#{ENV['sentry_dsn']}"
     SalesforceServer = "#{ENV['SF_SERVER']}"
     dashboardTitle = "#{title}"
-
-  = hot_javascript_tag "vendors"
   - if Features.sentry?
     = hot_javascript_tag("sentry")
     // Sentry logging

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,4 @@
 Rails.application.configure do
-  config.middleware.use I18n::JS::Middleware
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -37,10 +36,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.i18n.raise_on_missing_translations = true
-
-  # i18n-js
-  # Provides support for localization/translations on the front end utilizing Rails localization.
-  # Uses same translation files, config/
-  # In combination with configuration
-  config.middleware.use I18n::JS::Middleware
 end

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -21,9 +21,7 @@
 # If you're running an old version, you can use something
 # like this:
 #
-fallbacks: :en
-export_i18n_js: "public/assets/javascripts"
 translations:
-  - file: "public/assets/javascripts/i18n/%{locale}.js"
-    only: "*"
-#
+  - file: "public/assets/javascripts/i18n/:locale.json"
+    patterns: 
+      - "*"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.5",
     "fetch-jsonp": "^1.2.1",
-    "i18n-js": "^3.5.1",
+    "i18n-js": "^4.0.2",
     "isomorphic-fetch": "^3.0.0",
     "jeet": "^7.2.0",
     "jest": "^26.0.1",

--- a/prepare.js
+++ b/prepare.js
@@ -17,7 +17,7 @@ console.log('\x1b[33m%s\x1b[0m', `Finished cleaning stale assets after ${elapsed
 
 // export i18n files
 console.log('Started emitting i18n translations');
-execSync('bundle exec rails i18n:js:export');
+execSync('i18n export -c ./config/i18n-js.yml');
 console.log('\x1b[33m%s\x1b[0m', `Finished emitting i18n translations after ${elapsed(process.hrtime(start))} seconds`);
 
 // copies static assets from the source to assets folder

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,7 +146,6 @@ module.exports = (env) => {
     },
     externals: {
       jquery: 'jQuery',
-      'i18n-js': 'I18n'
     },
     devtool,
     stats: env.stats ? 'normal' : 'minimal',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,7 +2738,7 @@ __metadata:
     eslint-plugin-react: ^7.20.5
     eslint-webpack-plugin: ^3.1.1
     fetch-jsonp: ^1.2.1
-    i18n-js: ^3.5.1
+    i18n-js: ^4.0.2
     isomorphic-fetch: ^3.0.0
     jeet: ^7.2.0
     jest: ^26.0.1
@@ -3673,6 +3673,13 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: b89b6e8419b097a8fb4ed2399a1931a68c612bce3cfd5ca8c214b2d017531191070f990598de2fc6f3f993d91c0f08aa82697717f6b3b8732c9731866d233c9e
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:*":
+  version: 9.1.0
+  resolution: "bignumber.js@npm:9.1.0"
+  checksum: 52ec2bb5a3874d7dc1a1018f28f8f7aff4683515ffd09d6c2d93191343c76567ae0ee32cc45149d53afb2b904bc62ed471a307b35764beea7e9db78e56bef6c6
   languageName: node
   linkType: hard
 
@@ -7268,10 +7275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18n-js@npm:^3.5.1":
-  version: 3.9.2
-  resolution: "i18n-js@npm:3.9.2"
-  checksum: b405ad0861dbd57a8757811dcee791e8526a705d67c4a4353e27c924fa2c3422130fba16a21875bd89be871c86ef82f26212b002ba527c09956ff230c47e5026
+"i18n-js@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "i18n-js@npm:4.0.2"
+  dependencies:
+    bignumber.js: "*"
+    lodash: "*"
+  checksum: dae7c264d4d9b047b1cb0b57d7d1e6b0f2dcec45f0d738d30a51a6b07e5b4bc535be0afa27a6c64e5c74d2e8a391c9fde107cb958d2658fd1fb1b9ff55e1a47d
   languageName: node
   linkType: hard
 
@@ -8926,7 +8936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
+"lodash@npm:*, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7


### PR DESCRIPTION
There doesn't seem a way to export JS files now. Instead, the exported files are JSON which must be fetched independently. Because of this, I18n is no longer an external script but is instead handled by webpack.

I've only tried this on the home page but I assume its similar elsewhere so should hopefully work there as well. 