### PR TITLE
/training should display some documentation

### DIFF
--- a/app/controllers/training_controller.rb
+++ b/app/controllers/training_controller.rb
@@ -11,6 +11,7 @@ class TrainingController < ApplicationController
     @libraries = TrainingLibrary.all.sort_by do |library|
       library.slug == @focused_library_slug ? 0 : 1
     end
+    render 'no_training_module' if @libraries.empty?
   end
 
   def show

--- a/app/views/training/index.html.haml
+++ b/app/views/training/index.html.haml
@@ -3,27 +3,20 @@
   %h1 Training Libraries
   %ul.training-libraries.no-bullets.no-margin
     - defocus_class = @focused_library_slug ? 'training-library-defocus' : ''
-    - unless @libraries.empty?
-      - @libraries.each do |library|
-        - next if library.exclude_from_index?
-        - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
-        %li{class: "training-libraries__individual-library no-left-margin #{focus_class}"}
-          %a.action-card.action-card-index{href: "/training/#{library.slug}"}
-            %header.action-card-header
-              %h3.action-card-title
-                = library.translated_name
-              %span.icon-container
-                %i.action-card-icon.icon.icon-rt_arrow
-          .action-card-text
-            %h3 Included Modules:
-            %ul
-              - library.categories.pluck('modules').flatten.each do |training_module|
-                %li
-                  %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
-                    = training_module['name']
-    - else
-      - if Features.wiki_ed?
-        = sanitize t("training.no_training_library_records_wiki_ed_mode", url: '/reload_trainings?module=all')
-      - else
-        = t("training.no_training_library_records_non_wiki_ed_mode")
-
+    - @libraries.each do |library|
+      - next if library.exclude_from_index?
+      - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
+      %li{class: "training-libraries__individual-library no-left-margin #{focus_class}"}
+        %a.action-card.action-card-index{href: "/training/#{library.slug}"}
+          %header.action-card-header
+            %h3.action-card-title
+              = library.translated_name
+            %span.icon-container
+              %i.action-card-icon.icon.icon-rt_arrow
+        .action-card-text
+          %h3 Included Modules:
+          %ul
+            - library.categories.pluck('modules').flatten.each do |training_module|
+              %li
+                %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
+                  = training_module['name']

--- a/app/views/training/index.html.haml
+++ b/app/views/training/index.html.haml
@@ -3,20 +3,27 @@
   %h1 Training Libraries
   %ul.training-libraries.no-bullets.no-margin
     - defocus_class = @focused_library_slug ? 'training-library-defocus' : ''
-    - @libraries.each do |library|
-      - next if library.exclude_from_index?
-      - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
-      %li{class: "training-libraries__individual-library no-left-margin #{focus_class}"}
-        %a.action-card.action-card-index{href: "/training/#{library.slug}"}
-          %header.action-card-header
-            %h3.action-card-title
-              = library.translated_name
-            %span.icon-container
-              %i.action-card-icon.icon.icon-rt_arrow
-        .action-card-text
-          %h3 Included Modules:
-          %ul
-            - library.categories.pluck('modules').flatten.each do |training_module|
-              %li
-                %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
-                  = training_module['name']
+    - unless @libraries.empty?
+      - @libraries.each do |library|
+        - next if library.exclude_from_index?
+        - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
+        %li{class: "training-libraries__individual-library no-left-margin #{focus_class}"}
+          %a.action-card.action-card-index{href: "/training/#{library.slug}"}
+            %header.action-card-header
+              %h3.action-card-title
+                = library.translated_name
+              %span.icon-container
+                %i.action-card-icon.icon.icon-rt_arrow
+          .action-card-text
+            %h3 Included Modules:
+            %ul
+              - library.categories.pluck('modules').flatten.each do |training_module|
+                %li
+                  %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
+                    = training_module['name']
+    - else
+      - if Features.wiki_ed?
+        = sanitize t("training.no_training_library_records_wiki_ed_mode", url: '/reload_trainings?module=all')
+      - else
+        = t("training.no_training_library_records_non_wiki_ed_mode")
+

--- a/app/views/training/no_training_module.html.haml
+++ b/app/views/training/no_training_module.html.haml
@@ -1,0 +1,4 @@
+- if Features.wiki_ed?
+  = sanitize t("training.no_training_library_records_wiki_ed_mode", url: '/reload_trainings?module=all')
+- else
+  = t("training.no_training_library_records_non_wiki_ed_mode")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1271,6 +1271,8 @@ en:
       exercise: Exercise
       discussion: Discussion
       training: Training
+    no_training_library_records_wiki_ed_mode: There are no TrainingLibrary records in the database. Click <a href="%{url}"> here</a> to load training data from the training_content/ yaml files.
+    no_training_library_records_non_wiki_ed_mode: There are no TrainingLibrary records in the database.
 
   uploads:
     credit: Credit

--- a/spec/features/training_tool_spec.rb
+++ b/spec/features/training_tool_spec.rb
@@ -146,7 +146,7 @@ describe 'Training', type: :feature, js: true do
       let(:url) { '/reload_trainings?module=all' }
 
       before do
-        ENV['wiki_education'] = 'true'
+        allow(Features).to receive(:wiki_ed?).and_return(true)
         TrainingLibrary.delete_all
         visit '/training'
       end
@@ -164,7 +164,7 @@ describe 'Training', type: :feature, js: true do
 
     context 'when in non wiki_education mode' do
       before do
-        ENV['wiki_education'] = 'false'
+        allow(Features).to receive(:wiki_ed?).and_return(false)
         TrainingLibrary.delete_all
         visit '/training'
       end

--- a/spec/features/training_tool_spec.rb
+++ b/spec/features/training_tool_spec.rb
@@ -141,6 +141,41 @@ describe 'Training', type: :feature, js: true do
     end
   end
 
+  describe 'display message if none available' do
+    context 'when wiki_education mode' do
+      let(:url) { '/reload_trainings?module=all' }
+
+      before do
+        ENV['wiki_education'] = 'true'
+        TrainingLibrary.delete_all
+        visit '/training'
+      end
+
+      it 'displays proper message in wiki_ed mode' do
+        expect(page.html)
+          .to include(I18n.t('training.no_training_library_records_wiki_ed_mode',
+                             url:))
+      end
+
+      it 'includes a link' do
+        expect(page).to have_link(href: url)
+      end
+    end
+
+    context 'when in non wiki_education mode' do
+      before do
+        ENV['wiki_education'] = 'false'
+        TrainingLibrary.delete_all
+        visit '/training'
+      end
+
+      it 'displays proper message in non wiki_ed mode' do
+        expect(page.html)
+          .to include(I18n.t('training.no_training_library_records_non_wiki_ed_mode'))
+      end
+    end
+  end
+
   describe 'finish module button' do
     context 'logged in user' do
       it 'redirects to their dashboard' do


### PR DESCRIPTION
- altered view to handle the no library case
- added localized text
- added tests for the 2 modes


When there is no library in the DB, some text is displayed stating there is no library yet.
In wiki_education mode, a link to /reload_trainings?module=all is also displayed.

Issue #5094 
