### PR TITLE
Training resources should have a search feature

### DIFF
--- a/app/assets/stylesheets/training_modules/_layout.styl
+++ b/app/assets/stylesheets/training_modules/_layout.styl
@@ -6,7 +6,7 @@ body > .container
   clearfix()
   max-width 1100px
   margin 0 auto
-  padding 0 10px
+  padding 0
   .container
     padding 0
 

--- a/app/controllers/training_controller.rb
+++ b/app/controllers/training_controller.rb
@@ -9,7 +9,8 @@ class TrainingController < ApplicationController
 
   def index
     @search = params[:search_training]
-    @focused_library_slug, @libraries = TrainingResourceQueryObject.find_libraries(@search, current_user)
+    @focused_library_slug, @libraries = TrainingResourceQueryObject
+                                        .find_libraries(@search, current_user)
 
     unless @search
       render 'no_training_module' if @libraries.empty?

--- a/app/controllers/training_controller.rb
+++ b/app/controllers/training_controller.rb
@@ -6,13 +6,14 @@ require_dependency "#{Rails.root}/lib/training/training_resource_query_object"
 
 class TrainingController < ApplicationController
   layout 'training'
+  before_action :init_query_object, only: :index
 
   def index
-    @search = params[:search_training]
-    @focused_library_slug, @libraries = TrainingResourceQueryObject
-                                        .find_libraries(@search, current_user)
+    if @search
+      @slides = @query_object.selected_slides_and_excerpt
+    else
+      @focused_library_slug, @libraries = @query_object.all_libraries
 
-    unless @search
       render 'no_training_module' if @libraries.empty?
     end
   end
@@ -83,5 +84,10 @@ class TrainingController < ApplicationController
   def fail_if_entity_not_found(entity, finder)
     return if entity.find_by(slug: finder).present?
     raise ActionController::RoutingError, 'not found'
+  end
+
+  def init_query_object
+    @search = params[:search_training]
+    @query_object = TrainingResourceQueryObject.new(current_user, @search)
   end
 end

--- a/app/controllers/training_controller.rb
+++ b/app/controllers/training_controller.rb
@@ -2,16 +2,18 @@
 
 require_dependency "#{Rails.root}/lib/training_progress_manager"
 require_dependency "#{Rails.root}/lib/data_cycle/training_update"
+require_dependency "#{Rails.root}/lib/training/training_resource_query_object"
 
 class TrainingController < ApplicationController
   layout 'training'
 
   def index
-    @focused_library_slug = current_user&.courses&.last&.training_library_slug
-    @libraries = TrainingLibrary.all.sort_by do |library|
-      library.slug == @focused_library_slug ? 0 : 1
+    @search = params[:search_training]
+    @focused_library_slug, @libraries = TrainingResourceQueryObject.find_libraries(@search, current_user)
+
+    unless @search
+      render 'no_training_module' if @libraries.empty?
     end
-    render 'no_training_module' if @libraries.empty?
   end
 
   def show

--- a/app/views/training/_all_modules.html.haml
+++ b/app/views/training/_all_modules.html.haml
@@ -1,0 +1,19 @@
+%ul.training-libraries.no-bullets.no-margin
+  - defocus_class = @focused_library_slug ? 'training-library-defocus' : ''
+  - @libraries.each do |library|
+    - next if library.exclude_from_index?
+    - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
+    %li{class: "training-libraries__individual-library no-left-margin #{focus_class}"}
+      %a.action-card.action-card-index{href: "/training/#{library.slug}"}
+        %header.action-card-header
+          %h3.action-card-title
+            = library.translated_name
+          %span.icon-container
+            %i.action-card-icon.icon.icon-rt_arrow
+      .action-card-text
+        %h3 Included Modules:
+        %ul
+          - library.categories.pluck('modules').flatten.each do |training_module|
+            %li
+              %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
+                = training_module['name']

--- a/app/views/training/_search_results.html.haml
+++ b/app/views/training/_search_results.html.haml
@@ -1,0 +1,11 @@
+%ul.training-libraries.no-bullets.no-margin.action-card-text
+  - @slides.each do |slide|
+    %li
+      %a{href: "/training/#{slide[:path]}", target: "_blank"}
+        = slide[:title]
+      (
+      %a{href: "/training/#{slide[:module]}", target: "_blank"}      
+        = slide[:module_name]
+      )
+      %br
+      = sanitize(slide[:excerpt], tags: ['mark'])

--- a/app/views/training/_search_results.html.haml
+++ b/app/views/training/_search_results.html.haml
@@ -1,11 +1,14 @@
 %ul.training-libraries.no-bullets.no-margin.action-card-text
-  - @slides.each do |slide|
-    %li
-      %a{href: "/training/#{slide[:path]}", target: "_blank"}
-        = slide[:title]
-      (
-      %a{href: "/training/#{slide[:module]}", target: "_blank"}      
-        = slide[:module_name]
-      )
-      %br
-      = sanitize(slide[:excerpt], tags: ['mark'])
+  - unless @slides.empty?
+    - @slides.each do |slide|
+      %li
+        %a{href: "/training/#{slide[:path]}", target: "_blank"}
+          = sanitize(slide[:title], tags: ['mark'])
+        (
+        %a{href: "/training/#{slide[:module]}", target: "_blank"}      
+          = slide[:module_name]
+        )
+        %br
+        = sanitize(slide[:excerpt], tags: ['mark'])
+  - else
+    = t('training.no_training_resource_match_your_search')

--- a/app/views/training/index.html.haml
+++ b/app/views/training/index.html.haml
@@ -4,7 +4,7 @@
   .search-bar{style: 'position:relative'}
     = form_tag("/training", method: "get") do
       = text_field_tag(:search_training, '', placeholder: t('training.search_training_resources'), style: 'width: 100%; height: 3rem;font-size: 15px')
-      %button{type: 'submit', style: 'position: absolute; right: 20px; top: 10px'}
+      %button{type: 'submit', id: 'training_search_button', style: 'position: absolute; right: 20px; top: 10px'}
         %i.icon.icon-search
   - if @search
     = render 'search_results'

--- a/app/views/training/index.html.haml
+++ b/app/views/training/index.html.haml
@@ -1,6 +1,11 @@
 - content_for :before_title, "Training Libraries - "
 .container.training
   %h1 Training Libraries
+  .search-bar{style: 'position:relative'}
+    = form_tag("/training", method: "get") do
+      = text_field_tag(:search_training, '', placeholder: t('training.search_training_resources'), style: 'width: 100%; height: 3rem;font-size: 15px')
+      %button{type: 'submit', name: 'glass_training', style: 'position: absolute; right: 20px'}
+        %i.icon.icon-search
   %ul.training-libraries.no-bullets.no-margin
     - defocus_class = @focused_library_slug ? 'training-library-defocus' : ''
     - @libraries.each do |library|

--- a/app/views/training/index.html.haml
+++ b/app/views/training/index.html.haml
@@ -4,7 +4,7 @@
   .search-bar{style: 'position:relative'}
     = form_tag("/training", method: "get") do
       = text_field_tag(:search_training, '', placeholder: t('training.search_training_resources'), style: 'width: 100%; height: 3rem;font-size: 15px')
-      %button{type: 'submit', name: 'glass_training', style: 'position: absolute; right: 20px; top: 10px'}
+      %button{type: 'submit', style: 'position: absolute; right: 20px; top: 10px'}
         %i.icon.icon-search
   - if @search
     = render 'search_results'

--- a/app/views/training/index.html.haml
+++ b/app/views/training/index.html.haml
@@ -4,24 +4,9 @@
   .search-bar{style: 'position:relative'}
     = form_tag("/training", method: "get") do
       = text_field_tag(:search_training, '', placeholder: t('training.search_training_resources'), style: 'width: 100%; height: 3rem;font-size: 15px')
-      %button{type: 'submit', name: 'glass_training', style: 'position: absolute; right: 20px'}
+      %button{type: 'submit', name: 'glass_training', style: 'position: absolute; right: 20px; top: 10px'}
         %i.icon.icon-search
-  %ul.training-libraries.no-bullets.no-margin
-    - defocus_class = @focused_library_slug ? 'training-library-defocus' : ''
-    - @libraries.each do |library|
-      - next if library.exclude_from_index?
-      - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
-      %li{class: "training-libraries__individual-library no-left-margin #{focus_class}"}
-        %a.action-card.action-card-index{href: "/training/#{library.slug}"}
-          %header.action-card-header
-            %h3.action-card-title
-              = library.translated_name
-            %span.icon-container
-              %i.action-card-icon.icon.icon-rt_arrow
-        .action-card-text
-          %h3 Included Modules:
-          %ul
-            - library.categories.pluck('modules').flatten.each do |training_module|
-              %li
-                %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
-                  = training_module['name']
+  - if @search
+    = render 'search_results'
+  - else
+    = render 'all_modules'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1279,6 +1279,7 @@ en:
     no_training_library_records_wiki_ed_mode: There are no TrainingLibrary records in the database. Click <a href="%{url}"> here</a> to load training data from the training_content/ yaml files.
     no_training_library_records_non_wiki_ed_mode: There are no TrainingLibrary records in the database.
     search_training_resources: Search for training resources
+    no_training_resource_match_your_search: No training resource matches your search
   uploads:
     credit: Credit
     file_name: File Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1278,7 +1278,7 @@ en:
       training: Training
     no_training_library_records_wiki_ed_mode: There are no TrainingLibrary records in the database. Click <a href="%{url}"> here</a> to load training data from the training_content/ yaml files.
     no_training_library_records_non_wiki_ed_mode: There are no TrainingLibrary records in the database.
-
+    search_training_resources: Search for training resources
   uploads:
     credit: Credit
     file_name: File Name

--- a/lib/training/training_resource_query_object.rb
+++ b/lib/training/training_resource_query_object.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class TrainingResourceQueryObject
+  def self.find_libraries(...)
+    new(...).find_libraries
+  end
+
+  def initialize(search, current_user)
+    @search = search
+    @current_user = current_user
+  end
+
+  def find_libraries
+    if @search
+      search_for_libraries
+    else
+      all_libraries
+    end
+  end
+
+  private
+
+  def all_libraries
+    libraries = TrainingLibrary.all.sort_by do |library|
+      library.slug == focused_library_slug ? 0 : 1
+    end
+
+    [focused_library_slug, libraries]
+  end
+
+  def search_for_libraries
+    library_ids, category_slugs = find_libraries_from_modules
+    libraries = TrainingLibrary.where(id: library_ids)
+    libraries.each do |lib|
+      lib.categories = ['modules' => []]
+    end
+    category_slugs.each do |lib_id, modules|
+      libraries.find { |l| l.id == lib_id }.categories.first['modules'] = modules
+    end
+
+    [focused_library_slug, libraries]
+  end
+
+  def focused_library_slug
+    @current_user&.courses&.last&.training_library_slug
+  end
+
+  def search_content_in_slides
+    srch = "%#{@search}%"
+    TrainingSlide
+      .where('content LIKE ? or title LIKE ?', srch, srch)
+      .map(&:slug)
+  end
+
+  def find_modules_slugs_from_content
+    module_slugs = []
+    search_content_in_slides.each do |slug|
+      tr_module = TrainingModule.all.find { |mod| mod.slide_slugs.include?(slug) }
+      module_slugs << tr_module.slug unless tr_module.nil?
+    end
+    TrainingModule.where(slug: module_slugs).pluck(:slug)
+  end
+
+  def find_libraries_from_modules
+    ids_libraries = []
+    cat_slugs = {}
+    cat_slugs.default = []
+    module_slugs = find_modules_slugs_from_content
+    module_slugs.each do |mdl|
+      TrainingLibrary.all.each do |lib|
+        md = lib.categories.pluck('modules').flatten.select { |o| o['slug'] == mdl }
+        unless md.empty?
+          ids_libraries << lib.id
+          cat_slugs[lib.id] += md
+        end
+      end
+    end
+
+    [ids_libraries, cat_slugs]
+  end
+end

--- a/lib/utils/string_utils.rb
+++ b/lib/utils/string_utils.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class StringUtils
+  class << self
+    def excerpt(text, kword, length)
+      txt = text.tr "\n", ''
+      idx = txt.downcase.index(/#{kword}/i)
+      pad = (length / 2) - 3
+      tmp = "...#{txt[[idx - pad, 0].max..idx + pad - 1]}..."
+      tmp.sub(/#{kword}/i) { |m| "<mark>#{m}</mark>" }
+    end
+  end
+end

--- a/lib/utils/string_utils.rb
+++ b/lib/utils/string_utils.rb
@@ -2,12 +2,30 @@
 
 class StringUtils
   class << self
+    # @param text The text to be looked at
+    # @param kword The token to be searched
+    # @param length The desired length of the excerpt
     def excerpt(text, kword, length)
+      return '' if text.nil?
+
       txt = text.tr "\n", ''
-      idx = txt.downcase.index(/#{kword}/i)
-      pad = (length / 2) - 3
-      tmp = "...#{txt[[idx - pad, 0].max..idx + pad - 1]}..."
-      tmp.sub(/#{kword}/i) { |m| "<mark>#{m}</mark>" }
+      pos = txt.downcase.index(/#{kword}/i)
+
+      # ie "My text..." if no kword found
+      return "#{txt[0..length - 4]}..." if pos.nil?
+
+      # length of segment before + after kword
+      padding = (length / 2) - 3
+      # ... + txt[pos - 30 .. pos + 30] + ...
+      excerpted = "...#{txt[([pos - padding, 0].max)..(pos + padding - 1)]}..."
+      highlight_kword(excerpted, kword)
+    end
+
+    def highlight_kword(text, kword)
+      return nil if text.nil?
+      return text if kword.nil? || kword.empty?
+
+      text.sub(/#{kword}/i) { |m| "<mark>#{m}</mark>" }
     end
   end
 end

--- a/spec/factories/training_libraries.rb
+++ b/spec/factories/training_libraries.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: training_libraries
+#
+#  id                 :bigint(8)        not null, primary key
+#  name               :string(255)
+#  wiki_page          :string(255)
+#  introduction       :text(65535)
+#  categories         :text(16777215)
+#  translations       :text(16777215)
+#  exclude_from_index :boolean          default: false
+#  slug               :string(255)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+
+FactoryBot.define do
+  factory :training_library do
+  end
+end

--- a/spec/factories/training_modules.rb
+++ b/spec/factories/training_modules.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: training_modules
+#
+#  id            :bigint           not null, primary key
+#  name          :string(255)
+#  estimated_ttc :string(255)
+#  wiki_page     :string(255)
+#  slug          :string(255)
+#  slide_slugs   :text(65535)
+#  description   :text(65535)
+#  translations  :text(16777215)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  kind          :integer          default(0)
+#  settings      :text(65535)
+#
+
+FactoryBot.define do
+  factory :training_module do
+  end
+end

--- a/spec/factories/training_slides.rb
+++ b/spec/factories/training_slides.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: training_slides
+#
+#  id           :bigint(8)        not null, primary key
+#  title        :string(255)
+#  title_prefix :string(255)
+#  summary      :string(255)
+#  button_text  :string(255)
+#  wiki_page    :string(255)
+#  assessment   :text(65535)
+#  content      :text(65535)
+#  translations :text(16777215)
+#  slug         :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+FactoryBot.define do
+  factory :training_slide do
+  end
+end

--- a/spec/features/training_tool_spec.rb
+++ b/spec/features/training_tool_spec.rb
@@ -176,6 +176,23 @@ describe 'Training', type: :feature, js: true do
     end
   end
 
+  describe 'display of a search form' do
+    before do
+      TrainingSlide.load
+      visit '/training'
+    end
+
+    it 'displays a simple search input' do
+      expect(page).to have_field('search_training')
+    end
+
+    it 'displays search results' do
+      fill_in('search_training', with: 'cnn')
+      click_button('glass_training')
+      expect(page).to have_content('Wikipedia policies')
+    end
+  end
+
   describe 'finish module button' do
     context 'logged in user' do
       it 'redirects to their dashboard' do

--- a/spec/features/training_tool_spec.rb
+++ b/spec/features/training_tool_spec.rb
@@ -188,8 +188,8 @@ describe 'Training', type: :feature, js: true do
 
     it 'displays search results' do
       fill_in('search_training', with: 'cnn')
-      click_button('glass_training')
-      expect(page).to have_content('Wikipedia policies')
+      click_button('training_search_button')
+      expect(page).to have_content('Policies and guidelines: basic overview')
     end
   end
 

--- a/spec/lib/training/training_resource_query_object_spec.rb
+++ b/spec/lib/training/training_resource_query_object_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/training/training_resource_query_object"
+
+describe TrainingResourceQueryObject do
+  before(:all) do
+    TrainingModule.load_all
+  end
+
+  let(:current_user) { create(:user) }
+
+  describe '::find_libraries' do
+    before do
+      TrainingSlide.load
+    end
+
+    # The azertyuiop string is supposed not to be present in DB
+    it 'returns empty array if not found' do
+      expect(described_class.find_libraries('azertyuiop', current_user)[1].size).to eq 0
+    end
+
+    # At the time of writing, there are 2 occurences of CNN in DB
+    # In content text field in the TrainingSlide object
+    it 'returns an array of modules' do
+      expect(described_class.find_libraries('cnn', current_user)[1].size).to eq 2
+    end
+  end
+end

--- a/spec/lib/training/training_resource_query_object_spec.rb
+++ b/spec/lib/training/training_resource_query_object_spec.rb
@@ -25,9 +25,51 @@ describe TrainingResourceQueryObject do
     it 'returns an array of modules' do
       expect(query_object('cnn').selected_slides_and_excerpt.size).to eq 2
     end
+
+    context 'add some data to test missing modules/lib' do
+      before do
+        create_some_more_resource_data
+      end
+
+      # Because of unmatched resources
+      # No lone slide is to be returned as a final result
+      # Lone modules are discarded too
+      it 'returns only one result out of 3 matches' do
+        expect(query_object('postpunk').selected_slides_and_excerpt.size).to eq 1
+      end
+
+      it 'returns a complete path for a slide' do
+        expect(query_object('postpunk').selected_slides_and_excerpt.first[:path])
+          .to eq('my-library/my-other-module/my-third')
+      end
+    end
   end
 end
 
 def query_object(search = nil)
   described_class.new(current_user, search)
+end
+
+def create_some_more_resource_data
+  # a lone slide without module
+  # ie it should not appear in results
+  create(:training_slide, id: 100001, title: 'My first',
+         slug: 'my-first', content: 'I like Postpunk')
+  # this slide belongs to a module that does not belong to any library
+  # ie it should not appear in results
+  create(:training_slide, id: 100002, title: 'My second',
+         slug: 'my-second', content: 'I like Postpunk')
+  # a slide that belongs to a module that belongs to a library
+  # THIS ONE, we must fetch it
+  create(:training_slide, id: 100003, title: 'My third',
+         slug: 'my-third', content: 'I like Postpunk')
+
+  # This lone module does not belong to a library
+  create(:training_module, slug: 'my-module', slide_slugs: ['my-second'])
+  # This module belongs to a library
+  create(:training_module, slug: 'my-other-module', slide_slugs: ['my-third'])
+
+  create(:training_library, id: 100001, name: 'My library',
+         slug: 'my-library', introduction: 'Intro',
+         categories: ['modules' => [{ 'slug' => 'my-other-module' }]])
 end

--- a/spec/lib/training/training_resource_query_object_spec.rb
+++ b/spec/lib/training/training_resource_query_object_spec.rb
@@ -10,20 +10,24 @@ describe TrainingResourceQueryObject do
 
   let(:current_user) { create(:user) }
 
-  describe '::find_libraries' do
+  describe '#selected_slides_and_excerpt' do
     before do
       TrainingSlide.load
     end
 
     # The azertyuiop string is supposed not to be present in DB
     it 'returns empty array if not found' do
-      expect(described_class.find_libraries('azertyuiop', current_user)[1].size).to eq 0
+      expect(query_object('azertyuiop').selected_slides_and_excerpt.size).to eq 0
     end
 
     # At the time of writing, there are 2 occurences of CNN in DB
     # In content text field in the TrainingSlide object
     it 'returns an array of modules' do
-      expect(described_class.find_libraries('cnn', current_user)[1].size).to eq 2
+      expect(query_object('cnn').selected_slides_and_excerpt.size).to eq 2
     end
   end
+end
+
+def query_object(search = nil)
+  described_class.new(current_user, search)
 end

--- a/spec/lib/utils/string_utils_spec.rb
+++ b/spec/lib/utils/string_utils_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/utils/string_utils"
+
+describe StringUtils do
+  describe '#excerpt' do
+    it 'pads only at the end when text not found' do
+      expect(described_class.excerpt('One two three', 'four', 20)).to eq 'One two three...'
+    end
+
+    it 'pads left when found text at the beginning' do
+      expect(described_class.excerpt('One two three four', 'One', 20))
+        .to eq '...<mark>One</mark> two...'
+    end
+  end
+end


### PR DESCRIPTION
 - added a lib to handle search
 - extracted previous query from controller
 - localization
 - front: search bar
 - corresponding tests(lib + features)

## What this PR does
At `/training`, a simple search bar is added, it searches in the TrainingSlide objects content for a keyword.
If found, it then displays the matching modules, the same clickable links  as usual(no search).

Issue #5007 
