### PR TITLE
refresh stale data on tab switch

### DIFF
--- a/app/assets/javascripts/actions/articles_actions.js
+++ b/app/assets/javascripts/actions/articles_actions.js
@@ -18,7 +18,7 @@ const fetchArticlesPromise = (courseId, limit) => {
 };
 
 
-export const fetchArticles = (courseId, limit) => (dispatch) => {
+export const fetchArticles = (courseId, limit, refresh = false) => (dispatch) => {
   return (
     fetchArticlesPromise(courseId, limit)
       .then((resp) => {
@@ -29,7 +29,8 @@ export const fetchArticles = (courseId, limit) => (dispatch) => {
         });
         dispatch({
           type: types.SORT_ARTICLES,
-          key: 'character_sum'
+          key: 'character_sum',
+          refresh
         });
         // Now that we received the articles data, query wikidata.org for the labels
         // of any Wikidata entries that are among the articles.
@@ -39,7 +40,7 @@ export const fetchArticles = (courseId, limit) => (dispatch) => {
   );
 };
 
-export const sortArticles = key => ({ type: types.SORT_ARTICLES, key: key });
+export const sortArticles = (key, refresh) => ({ type: types.SORT_ARTICLES, key: key, refresh });
 
 export const filterArticles = wiki => ({ type: types.SET_PROJECT_FILTER, wiki: wiki });
 

--- a/app/assets/javascripts/components/Main.jsx
+++ b/app/assets/javascripts/components/Main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import routes from './util/routes.jsx';
+import Routes from './util/routes.jsx';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from './util/create_store';
@@ -9,7 +9,7 @@ const Main = () => {
   return (
     <Provider store={store} >
       <BrowserRouter>
-        {routes}
+        <Routes />
       </BrowserRouter>
     </Provider>
   );

--- a/app/assets/javascripts/components/util/refresh.js
+++ b/app/assets/javascripts/components/util/refresh.js
@@ -1,0 +1,49 @@
+import { fetchArticles } from '../../actions/articles_actions';
+import { fetchAssignments } from '../../actions/assignment_actions';
+import { fetchUsers } from '../../actions/user_actions';
+
+// this tells us if the data is stale and needs to be refreshed
+/**
+ * @param  {number} lastRequestTimestamp - UNIX timestamp in milliseconds
+ * @param  {number} staleTime - in milliseconds (default: 60 seconds)
+ * @returns {boolean}
+*/
+
+export const isStale = (lastRequestTimestamp, staleTime = 60 * 1000) => {
+  const now = Date.now();
+  return Math.abs(now - lastRequestTimestamp) > staleTime;
+};
+
+// used to refresh stale data on the following routes:
+// 1. /courses/:course_school/:course_title/students/*
+// 2. /courses/:course_school/:course_title/articles/*
+export const refreshData = (location, args, dispatch) => {
+  const {
+    lastUserRequestTimestamp,
+    courseSlug,
+    limit,
+    lastRequestArticleTimestamp,
+    lastRequestAssignmentTimestamp
+  } = args;
+
+  // if we're on either of the student's routes, refresh the student data
+  if (location.pathname.match(/\/.+students\/(overview|articles).*/)) {
+    if (courseSlug !== null && courseSlug !== undefined && isStale(lastUserRequestTimestamp)) {
+      dispatch(fetchUsers(courseSlug));
+    }
+  }
+
+  // if we're on the articles route, refresh the article data
+  if (location.pathname.includes('/articles/edited')) {
+    if (courseSlug !== null && courseSlug !== undefined && isStale(lastRequestArticleTimestamp)) {
+      dispatch(fetchArticles(courseSlug, limit, true));
+    }
+  }
+
+  // as for the assignments, we refresh the data if we're on the assignments route or the student's overview route(which also shows the assignments)
+  if (location.pathname.includes('/articles/assigned') || location.pathname.match(/\/.+students\/(overview|articles).*/)) {
+    if (courseSlug !== null && courseSlug !== undefined && isStale(lastRequestAssignmentTimestamp)) {
+      dispatch(fetchAssignments(courseSlug));
+    }
+  }
+};

--- a/app/assets/javascripts/components/util/refresh.js
+++ b/app/assets/javascripts/components/util/refresh.js
@@ -17,6 +17,7 @@ export const isStale = (lastRequestTimestamp, staleTime = 60 * 1000) => {
 // used to refresh stale data on the following routes:
 // 1. /courses/:course_school/:course_title/students/*
 // 2. /courses/:course_school/:course_title/articles/*
+// The data is refreshed only if it is stale (older than 60 seconds)
 export const refreshData = (location, args, dispatch) => {
   const {
     lastUserRequestTimestamp,

--- a/app/assets/javascripts/components/util/refresh.js
+++ b/app/assets/javascripts/components/util/refresh.js
@@ -21,7 +21,7 @@ export const refreshData = (location, args, dispatch) => {
   const {
     lastUserRequestTimestamp,
     courseSlug,
-    limit,
+    articlesLimit,
     lastRequestArticleTimestamp,
     lastRequestAssignmentTimestamp
   } = args;
@@ -36,7 +36,7 @@ export const refreshData = (location, args, dispatch) => {
   // if we're on the articles route, refresh the article data
   if (location.pathname.includes('/articles/edited')) {
     if (courseSlug !== null && courseSlug !== undefined && isStale(lastRequestArticleTimestamp)) {
-      dispatch(fetchArticles(courseSlug, limit, true));
+      dispatch(fetchArticles(courseSlug, articlesLimit, true));
     }
   }
 

--- a/app/assets/javascripts/components/util/routes.jsx
+++ b/app/assets/javascripts/components/util/routes.jsx
@@ -33,6 +33,7 @@ const routes = () => {
     lastRequestAssignmentTimestamp: useSelector(state => state.assignments.lastRequestTimestamp)
   };
 
+  // this is called whenever the route changes
   useEffect(() => {
     refreshData(location, refreshArgs, dispatch);
   }, [location.pathname]);

--- a/app/assets/javascripts/components/util/routes.jsx
+++ b/app/assets/javascripts/components/util/routes.jsx
@@ -33,7 +33,17 @@ const routes = () => {
     lastRequestAssignmentTimestamp: useSelector(state => state.assignments.lastRequestTimestamp)
   };
 
+
   // this is called whenever the route changes
+  // it ensures that the user isn't displayed stale/outdated data for a route
+  // they previously visited(and thus had already loaded the data for in the Redux store)
+  // this fires the refreshData function, which does a series of URL checks and checks to see if
+  // the data is stale, and if so, refresh it by triggering the appropriate Redux action
+  // see refresh.js for more details on how this works
+
+  // the reason this exists here rather than in the individual components is to make the
+  // entire thing more centralized and easier to maintain. Besides, the fact that the
+  // this component deals with just the routes means that unnecessary re-renders are avoided
   useEffect(() => {
     refreshData(location, refreshArgs, dispatch);
   }, [location.pathname]);

--- a/app/assets/javascripts/components/util/routes.jsx
+++ b/app/assets/javascripts/components/util/routes.jsx
@@ -28,7 +28,7 @@ const routes = () => {
   const refreshArgs = {
     lastUserRequestTimestamp: useSelector(state => state.users.lastRequestTimestamp),
     courseSlug: useSelector(state => state.course.slug),
-    limit: useSelector(state => state.articles.limit),
+    articlesLimit: useSelector(state => state.articles.limit),
     lastRequestArticleTimestamp: useSelector(state => state.articles.lastRequestTimestamp),
     lastRequestAssignmentTimestamp: useSelector(state => state.assignments.lastRequestTimestamp)
   };

--- a/app/assets/javascripts/components/util/routes.jsx
+++ b/app/assets/javascripts/components/util/routes.jsx
@@ -1,10 +1,8 @@
 import React, { Suspense, lazy, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { fetchArticles } from '../../actions/articles_actions.js';
-import { fetchAssignments } from '../../actions/assignment_actions.js';
-import { fetchUsers } from '../../actions/user_actions.js';
 import Loading from '../common/loading.jsx';
+import { refreshData } from './refresh.js';
 
 const Course = lazy(() => import('../course/course.jsx'));
 const Onboarding = lazy(() => import('../onboarding/index.jsx'));
@@ -27,11 +25,16 @@ const CoursesByWikiHandler = lazy(() => import('../courses_by_wiki/courses_by_wi
 const routes = () => {
   const location = useLocation();
   const dispatch = useDispatch();
-  const courseSlug = useSelector(state => state.course.slug);
-  const limit = useSelector(state => state.articles.limit);
+  const refreshArgs = {
+    lastUserRequestTimestamp: useSelector(state => state.users.lastRequestTimestamp),
+    courseSlug: useSelector(state => state.course.slug),
+    limit: useSelector(state => state.articles.limit),
+    lastRequestArticleTimestamp: useSelector(state => state.articles.lastRequestTimestamp),
+    lastRequestAssignmentTimestamp: useSelector(state => state.assignments.lastRequestTimestamp)
+  };
 
   useEffect(() => {
-    refreshData(location, courseSlug, dispatch, limit);
+    refreshData(location, refreshArgs, dispatch);
   }, [location.pathname]);
 
   return (
@@ -60,24 +63,7 @@ const routes = () => {
         <Route path="*" element={<div style={{ display: 'none' }}/>} />
       </Routes>
     </Suspense>
-);
+  );
 };
 
 export default routes;
-
-function refreshData(location, courseSlug, dispatch, limit) {
-  if (location.pathname.match(/\/.+students\/(overview|assignments).*/)) {
-    if (courseSlug !== null && courseSlug !== undefined) {
-      dispatch(fetchUsers(courseSlug));
-    }
-  } else if (location.pathname.includes('/articles/edited')) {
-    if (courseSlug !== null && courseSlug !== undefined) {
-      dispatch(fetchArticles(courseSlug, limit, true));
-    }
-  } else if (location.pathname.includes('/articles/assigned')) {
-    if (courseSlug !== null && courseSlug !== undefined) {
-      dispatch(fetchAssignments(courseSlug));
-    }
-  }
-}
-

--- a/app/assets/javascripts/reducers/articles.js
+++ b/app/assets/javascripts/reducers/articles.js
@@ -83,7 +83,9 @@ export default function articles(state = initialState, action) {
         state.articles,
         action.key,
         state.sort.sortKey,
-        SORT_DESCENDING[action.key]
+        SORT_DESCENDING[action.key],
+        undefined,
+        action.refresh
       );
       return {
         ...state,

--- a/app/assets/javascripts/reducers/articles.js
+++ b/app/assets/javascripts/reducers/articles.js
@@ -23,7 +23,8 @@ const initialState = {
   trackedStatusFilter: 'tracked',
   loading: true,
   newnessFilterEnabled: false,
-  trackedStatusFilterEnabled: false
+  trackedStatusFilterEnabled: false,
+  lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
 };
 
 const SORT_DESCENDING = {
@@ -74,7 +75,8 @@ export default function articles(state = initialState, action) {
         trackedStatusFilter,
         newnessFilterEnabled,
         trackedStatusFilterEnabled,
-        loading: false
+        loading: false,
+        lastRequestTimestamp: Date.now()
       };
     }
 

--- a/app/assets/javascripts/reducers/assignments.js
+++ b/app/assets/javascripts/reducers/assignments.js
@@ -5,7 +5,8 @@ import { RECEIVE_ASSIGNMENTS, ADD_ASSIGNMENT, DELETE_ASSIGNMENT, UPDATE_ASSIGNME
 const initialState = {
   assignments: [],
   sortKey: null,
-  loading: true
+  loading: true,
+  lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
 };
 
 const SORT_DESCENDING = {};
@@ -19,7 +20,8 @@ export default function assignments(state = initialState, action) {
       return {
         assignments: sortedModel.newModels,
         sortKey: sortedModel.newKey,
-        loading: false
+        loading: false,
+        lastRequestTimestamp: Date.now()
       };
     }
     case ADD_ASSIGNMENT: {

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -7,7 +7,8 @@ const initialState = {
     sortKey: null,
     key: null,
   },
-  isLoaded: false
+  isLoaded: false,
+  lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
 };
 
 const SORT_DESCENDING = {
@@ -22,7 +23,12 @@ const SORT_DESCENDING = {
 
 export default function users(state = initialState, action) {
   switch (action.type) {
-    case RECEIVE_USERS:
+    case RECEIVE_USERS: return {
+      ...state,
+      users: action.data.course.users,
+      isLoaded: true,
+      lastRequestTimestamp: Date.now()
+    };
     case ADD_USER:
     case REMOVE_USER:
       return {

--- a/app/assets/javascripts/utils/model_utils.js
+++ b/app/assets/javascripts/utils/model_utils.js
@@ -19,7 +19,7 @@ export const getFiltered = (models, options) => {
 // already sorted by, and the default sorting direction.
 // If you sort a second time by the same key, then it will reverse the sorting.
 // Otherwise, it will just sort by that key.
-export const sortByKey = (models, sortKey, previousKey = null, desc = false, absolute = false) => {
+export const sortByKey = (models, sortKey, previousKey = null, desc = false, absolute = false, refresh = false) => {
   const sameKey = sortKey === previousKey;
   let newKey;
   if (sameKey) {
@@ -43,7 +43,9 @@ export const sortByKey = (models, sortKey, previousKey = null, desc = false, abs
     return model[sortKey] ?? 0;
   };
 
-  const reverse = !sameKey !== !desc; // sameKey OR desc is truthy, but not both
+  // if we're simply refreshing, we don't want to consider the previous key
+  const reverse = refresh ? desc : !sameKey !== !desc; // sameKey OR desc is truthy, but not both
+
   let newModels;
   if (absolute) {
     const sorted = sortBy(models, [o => Math.abs(o[sortKey])]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8670,7 +8670,7 @@ __metadata:
   resolution: "list.js@https://github.com/WikiEducationFoundation/list.js.git#commit=3be71e3414d60e8a40b41a0ca8d582f2f40f9308"
   dependencies:
     string-natural-compare: ^2.0.2
-  checksum: ea0e976ceae4ddc2b7c78ec41214ceabc4e65368261cc635324b1ef0b7fb67cfca0de6f9af0eb6399da08f31480a5804a2927496ea3b238544b6317f2ad0f687
+  checksum: b853ac7141ebd1bf530ca6104950c0ec0f43b1b4d791db8488ba4523011c72301f62e344e1b8aaf060f69fbd93207826ab4ece0a40c99f6c1c929af417e2f9ec
   languageName: node
   linkType: hard
 
@@ -12072,7 +12072,7 @@ __metadata:
   resolution: "slick-carousel@https://github.com/cfoehrdes/slick.git#commit=a4d85536c42951933e1d887bcc013615e25b03e7"
   dependencies:
     jquery: ">=1.7.2"
-  checksum: cfa2527b8425260101f0232d5f0aa4c20b8e9b3954ec82a5c006ddd0b3e682b82e696fa6180eff8c7076a07dc6be15f57168247a1383bd7a706d569385e0599e
+  checksum: 30b5f877b84b8edd48ea7bfb39813c95622cb8f0351956b2398b42b092eca5eeaf593482b904010d77360e04c7a2f5d76e06ba642847450e334368a01f100022
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8670,7 +8670,7 @@ __metadata:
   resolution: "list.js@https://github.com/WikiEducationFoundation/list.js.git#commit=3be71e3414d60e8a40b41a0ca8d582f2f40f9308"
   dependencies:
     string-natural-compare: ^2.0.2
-  checksum: b853ac7141ebd1bf530ca6104950c0ec0f43b1b4d791db8488ba4523011c72301f62e344e1b8aaf060f69fbd93207826ab4ece0a40c99f6c1c929af417e2f9ec
+  checksum: ea0e976ceae4ddc2b7c78ec41214ceabc4e65368261cc635324b1ef0b7fb67cfca0de6f9af0eb6399da08f31480a5804a2927496ea3b238544b6317f2ad0f687
   languageName: node
   linkType: hard
 
@@ -12072,7 +12072,7 @@ __metadata:
   resolution: "slick-carousel@https://github.com/cfoehrdes/slick.git#commit=a4d85536c42951933e1d887bcc013615e25b03e7"
   dependencies:
     jquery: ">=1.7.2"
-  checksum: 30b5f877b84b8edd48ea7bfb39813c95622cb8f0351956b2398b42b092eca5eeaf593482b904010d77360e04c7a2f5d76e06ba642847450e334368a01f100022
+  checksum: cfa2527b8425260101f0232d5f0aa4c20b8e9b3954ec82a5c006ddd0b3e682b82e696fa6180eff8c7076a07dc6be15f57168247a1383bd7a706d569385e0599e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses #5165 

This works by re-fetching data when the user navigates from tab to tab. However, to prevent too many requests, the previously fetched data must be at least a minute old.

To test this out, go to the course page. In another window, make some changes to the course - like adding a new user. In the old window, navigate between the tabs and after a minute, when you go back to the student tab, the data will be re-fetched. 

There are some improvements but I'm not sure if they are worth pursuing - 

1. Data could be re-fetched automatically after some point of time when on the same tab. With the current implementation, if you're on the Student's tab and a new student is added, you won't notice it until you move away or come back(or directly click on the student tab - which refreshes it the same way) Like I wrote in the issue, it would be easy enough to have a `setTimeout` run every now and then and refresh the data. 
2. Have some sort of "notification" so that the user knows that the data has updated. 

Do let me know what you think of these ideas.