### PR TITLE
speed up rendering of Articles Tab

### DIFF
--- a/app/assets/javascripts/components/articles/article_graphs.jsx
+++ b/app/assets/javascripts/components/articles/article_graphs.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import OnClickOutside from 'react-onclickoutside';
 import Wp10Graph from './wp10_graph.jsx';
 import EditSizeGraph from './edit_size_graph.jsx';
 import Loading from '../common/loading.jsx';
@@ -23,6 +22,21 @@ const ArticleGraphs = createReactClass({
     };
   },
 
+  componentDidMount() {
+    this.ref = React.createRef();
+  },
+
+  componentDidUpdate(_, prevState) {
+    if (this.state.showGraph && !prevState.showGraph) {
+      // Add event listener when the component is visible
+      document.addEventListener('mousedown', this.handleClickOutside);
+    }
+    if (!this.state.showGraph && prevState.showGraph) {
+      // remove event listener when the component is hidden
+      document.removeEventListener('mousedown', this.handleClickOutside);
+    }
+  },
+
   getData() {
     if (this.state.articleData) { return; }
 
@@ -33,6 +47,13 @@ const ArticleGraphs = createReactClass({
       .then((data) => {
         this.setState({ articleData: data });
       });
+  },
+
+  handleClickOutside(event) {
+    const element = this.ref.current;
+    if (element && !element.contains(event.target)) {
+      this.hideGraph();
+    }
   },
 
   showGraph() {
@@ -49,10 +70,6 @@ const ArticleGraphs = createReactClass({
   hideGraph() {
     this.state.articleData = null;
     this.setState({ showGraph: false });
-  },
-
-  handleClickOutside() {
-    this.hideGraph();
   },
 
   graphId() {
@@ -138,7 +155,7 @@ const ArticleGraphs = createReactClass({
     return (
       <a onClick={this.showGraph} className="inline">
         {I18n.t('articles.article_development')}
-        <div className={className}>
+        <div className={className} ref={this.ref}>
           <div className="radio-row">
             {radioInput}
             {editSize}
@@ -150,4 +167,4 @@ const ArticleGraphs = createReactClass({
   }
 });
 
-export default OnClickOutside(ArticleGraphs);
+export default ArticleGraphs;

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import OnClickOutside from 'react-onclickoutside';
 
 // Utilities
 import { forEach, union } from 'lodash-es';
@@ -49,6 +48,8 @@ export class ArticleViewer extends React.Component {
     this.showBadArticleAlert = this.showBadArticleAlert.bind(this);
     this.submitBadWorkAlert = this.submitBadWorkAlert.bind(this);
     this.isWhocolorLang = this.isWhocolorLang.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.ref = React.createRef();
   }
 
   componentDidMount() {
@@ -73,6 +74,14 @@ export class ArticleViewer extends React.Component {
         if (!prevState.userIdsFetched) {
           this.fetchUserIds();
       }
+    }
+    if (!prevState.showArticle && this.state.showArticle) {
+      // Add event listener when the component is visible
+      document.addEventListener('mousedown', this.handleClickOutside);
+    }
+    if (prevState.showArticle && !this.state.showArticle) {
+      // Remove event listener when the component is hidden
+      document.removeEventListener('mousedown', this.handleClickOutside);
     }
   }
 
@@ -139,10 +148,6 @@ export class ArticleViewer extends React.Component {
     this.props.resetBadWorkAlert();
     // removes the article parameter from the URL
     this.removeParamFromURL(e);
-  }
-
-  handleClickOutside() {
-    this.hideArticle();
   }
 
   isWhocolorLang() {
@@ -249,6 +254,13 @@ export class ArticleViewer extends React.Component {
     });
   }
 
+  handleClickOutside(event) {
+    const element = this.ref.current;
+    if (element && !element.contains(event.target)) {
+      this.hideArticle(event);
+    }
+  }
+
   render() {
     const {
       alertStatus, article, current_user = {}, showButtonClass, showPermalink = true,
@@ -283,7 +295,7 @@ export class ArticleViewer extends React.Component {
     }
 
     return (
-      <div className="ignore-react-onclickoutside">
+      <div ref={this.ref}>
         <div className={`article-viewer ${showArticle ? '' : 'hidden'}`}>
           <div className="article-header">
             <p>
@@ -349,13 +361,12 @@ ArticleViewer.propTypes = {
   showButtonClass: PropTypes.string,
   showOnMount: PropTypes.bool,
   title: PropTypes.string,
-  users: PropTypes.array
+  users: PropTypes.array,
 };
 
-const clickOutsideComponent = OnClickOutside(ArticleViewer);
 const mapStateToProps = ({ badWorkAlert }) => ({ alertStatus: badWorkAlert });
 const mapDispatchToProps = {
   resetBadWorkAlert,
   submitBadWorkAlert
 };
-export default connect(mapStateToProps, mapDispatchToProps)(clickOutsideComponent);
+export default connect(mapStateToProps, mapDispatchToProps)(ArticleViewer);


### PR DESCRIPTION
Previously, there was an event listener for each Article Viewer, along with each graph. For a total of 500 articles, it meant that the a simple mouse click would have to go through 1000 event handlers, most of whom were redundant since their article wasn't currently selected.

This PR attempts to improve the performance of the page by keeping just a single event listener around for the currently open modal. When that modal is closed, the event listener is removed entirely. 

To test this out, simply scroll and try right clicking on any empty space. Before this PR, these mouse events took a noticeable amount time to register on the UI.