### PR TITLE
Issue #5195 Added global_id column next to username column to CSV export of editor data

### DIFF
--- a/lib/analytics/course_students_csv_builder.rb
+++ b/lib/analytics/course_students_csv_builder.rb
@@ -51,6 +51,7 @@ class CourseStudentsCsvBuilder
 
   CSV_HEADERS = %w[
     username
+    global_id
     enrollment_timestamp
     registered_at
     revisions_during_project
@@ -65,6 +66,7 @@ class CourseStudentsCsvBuilder
   # rubocop:disable Metrics/AbcSize
   def row(courses_user)
     row = [courses_user.user.username]
+    row << courses_user.user.global_id
     row << courses_user.created_at
     row << courses_user.user.registered_at
     row << courses_user.revision_count

--- a/spec/lib/analytics/course_students_csv_builder_spec.rb
+++ b/spec/lib/analytics/course_students_csv_builder_spec.rb
@@ -42,12 +42,12 @@ describe CourseStudentsCsvBuilder do
       columns = line.split(',')
       username = columns[0]
       user_result = expected_result[username]
-      # column 9 is 'registered_during_project', which should be true
-      expect(columns[8]).to eq('true')
-      # column 10 is 'total_articles_created'
-      expect(columns[9]).to eq(user_result[:articles_created])
-      # column 11 is 'total_articles_edited'
-      expect(columns[10]).to eq(user_result[:articles_updated])
+      # column 10 is 'registered_during_project', which should be true
+      expect(columns[9]).to eq('true')
+      # column 11 is 'total_articles_created'
+      expect(columns[10]).to eq(user_result[:articles_created])
+      # column 12 is 'total_articles_edited'
+      expect(columns[11]).to eq(user_result[:articles_updated])
     end
   end
 end


### PR DESCRIPTION
Issue #5195
Updated CSV Export of data , added a global_id column next to username column in CSV export
Old CSV:-
![image](https://user-images.githubusercontent.com/72390769/210873678-078a2dbf-ac64-4de0-8875-66d911c48ad2.png)


New CSV:-
![image](https://user-images.githubusercontent.com/72390769/210873795-672ff405-dd28-498b-a693-4859c1b9d296.png)

