### PR TITLE
Tickets should be searchable by course #5224

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -15,7 +15,6 @@ import { enableAccountRequests } from '../../actions/new_account_actions.js';
 import { needsUpdate, linkToSalesforce, updateSalesforceRecord, deleteCourse } from '../../actions/course_actions';
 import { STUDENT_ROLE, ONLINE_VOLUNTEER_ROLE } from '../../constants/user_roles';
 import { removeUser } from '../../actions/user_actions';
-import I18n from 'i18n-js';
 
 const AvailableActions = createReactClass({
   displayName: 'AvailableActions',

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -15,6 +15,7 @@ import { enableAccountRequests } from '../../actions/new_account_actions.js';
 import { needsUpdate, linkToSalesforce, updateSalesforceRecord, deleteCourse } from '../../actions/course_actions';
 import { STUDENT_ROLE, ONLINE_VOLUNTEER_ROLE } from '../../constants/user_roles';
 import { removeUser } from '../../actions/user_actions';
+import I18n from 'i18n-js';
 
 const AvailableActions = createReactClass({
   displayName: 'AvailableActions',
@@ -118,6 +119,10 @@ const AvailableActions = createReactClass({
             <div key="leave" className="available-action"><button onClick={this.leave} className="button">{CourseUtils.i18n('leave_course', course.string_prefix)}</button></div>
           ));
         }
+      }
+      // If user is admin, go to list of tickets related to this course
+      if (user.admin) {
+        controls.push((<div key="search" className="available-action"><a href={`/tickets/dashboard?search_by_course=${this.props.course.slug}`} className="button">{I18n.t('courses.search_all_tickets_for_this_course')}</a></div>));
       }
       // If course is not published, show the 'delete' button to instructors and admins.
       // Show a disabled version of it on P&E Dashboard even if a course is published,

--- a/app/assets/javascripts/components/tickets/search_type_selector.jsx
+++ b/app/assets/javascripts/components/tickets/search_type_selector.jsx
@@ -7,7 +7,8 @@ const SearchTypeSelector = ({ handleChange, value }, ref) => {
     { value: 'no_search', label: 'No search' },
     { value: 'by_email_or_username', label: 'Search by email or user name' },
     { value: 'in_content', label: 'Search in content' },
-    { value: 'in_subject', label: 'Search in subject' }
+    { value: 'in_subject', label: 'Search in subject' },
+    { value: 'by_course', label: 'Search by course slug' }
   ];
 
   return (

--- a/app/assets/javascripts/components/tickets/sidebar.jsx
+++ b/app/assets/javascripts/components/tickets/sidebar.jsx
@@ -48,6 +48,11 @@ export class Sidebar extends React.Component {
               : 'Course Unknown'
           }
         </section>
+        <section className="course-name">
+          <Link target="_blank" to={`/tickets/dashboard?search_by_course=${ticket.project.slug}`}>
+            Search all tickets for course: {ticket.project.title}
+          </Link>
+        </section>
         <section className="course-user-details">
           {
             ticket.project.id && ticket.sender.username

--- a/app/assets/javascripts/components/tickets/sidebar.jsx
+++ b/app/assets/javascripts/components/tickets/sidebar.jsx
@@ -48,7 +48,7 @@ export class Sidebar extends React.Component {
               : 'Course Unknown'
           }
         </section>
-        <section className="course-name">
+        <section className="related-tickets">
           <Link target="_blank" to={`/tickets/dashboard?search_by_course=${ticket.project.slug}`}>
             Search all tickets for course: {ticket.project.title}
           </Link>

--- a/app/assets/javascripts/components/tickets/sidebar.jsx
+++ b/app/assets/javascripts/components/tickets/sidebar.jsx
@@ -50,7 +50,7 @@ export class Sidebar extends React.Component {
         </section>
         <section className="related-tickets">
           <Link target="_blank" to={`/tickets/dashboard?search_by_course=${ticket.project.slug}`}>
-            Search all tickets for course: {ticket.project.title}
+            Search all tickets for: {ticket.project.title}
           </Link>
         </section>
         <section className="course-user-details">

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -15,28 +15,38 @@ import { getFilteredTickets } from '../../selectors';
 export class TicketsHandler extends React.Component {
   constructor(props) {
     super(props);
+    this.SearchByCourseParamInURL = this.getCourseSearchParamInURL();
     this.state = {
       page: 0,
       mode: 'filter',
-      searchType: 'no_search'
+      searchType: this.SearchByCourseParamInURL ? 'by_course' : 'no_search',
+      searchText: this.SearchByCourseParamInURL || ''
     };
     this.searchBarRef = React.createRef();
     this.searchTypeRef = React.createRef();
   }
 
   componentDidMount() {
-    if (!this.props.tickets.all.length) {
-      this.props.fetchTickets();
-      this.props.setInitialTicketFilters();
-    }
+    if (this.SearchByCourseParamInURL) {
+      this.props.fetchTickets({ search: this.SearchByCourseParamInURL, what: 'by_course' });
+    } else if (!this.props.tickets.all.length) {
+        this.props.fetchTickets();
+        this.props.setInitialTicketFilters();
+      }
+  }
+
+  getCourseSearchParamInURL() {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('search_by_course');
   }
 
   doSearch = () => {
     this.props.fetchTickets({ search: this.searchBarRef?.current.value, what: this.state.searchType });
+    this.setState({ searchText: this.searchBarRef?.current.value });
   };
 
   changeMode = (e) => {
-    this.setState({ searchType: e.value });
+    this.setState({ searchType: e.value, searchText: '' });
     if (e.value === 'no_search') {
       this.setState({ mode: 'filter' });
       this.props.fetchTickets();
@@ -126,6 +136,7 @@ export class TicketsHandler extends React.Component {
             />
             <SearchBar
               name="tickets_search"
+              value={this.state.searchText}
               onClickHandler={this.doSearch} ref={this.searchBarRef}
               placeholder={I18n.t('tickets.search_bar_placeholder')}
             />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -732,6 +732,7 @@ en:
     revisions_none: This course has no recent Wikipedia editing activity.
     school: School
     school_and_term: Institution/Term
+    search_all_tickets_for_this_course: Search all tickets for this course
     search_courses: Search courses
     start: Start
     start_typing: Start typing

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -831,6 +831,7 @@ fr:
     revisions_none: Ce cours n’a aucune activité récente de modification de Wikipédia.
     school: École
     school_and_term: Institution / Période
+    search_all_tickets_for_this_course: Chercher tous les tickets pour ce cours
     search_courses: Chercher des cours
     start: Démarrer
     start_typing: Commencer à taper

--- a/lib/tickets/ticket_query_object.rb
+++ b/lib/tickets/ticket_query_object.rb
@@ -16,6 +16,8 @@ class TicketQueryObject
       search_by_subject
     when 'in_content'
       search_by_content
+    when 'by_course'
+      search_by_course
     end
   end
 
@@ -48,6 +50,13 @@ class TicketQueryObject
         .pluck(:id) })
            .offset(@offset)
            .limit(@limit)
+  end
+
+  def search_by_course
+    tickets
+      .where(project: Course.find_by(slug: @search))
+      .offset(@offset)
+      .limit(@limit)
   end
 
   private

--- a/spec/features/tickets_dashboard_spec.rb
+++ b/spec/features/tickets_dashboard_spec.rb
@@ -178,7 +178,7 @@ describe 'ticket dashboard', type: :feature, js: true do
 
       # bc opens in a new tab
       ticket_window = window_opened_by do
-        find_link("Search all tickets for course: #{ticket.project.title}").click
+        find_link("Search all tickets for: #{ticket.project.title}").click
       end
       within_window ticket_window do
         url = URI(current_url)

--- a/test/components/overview/available_actions.spec.jsx
+++ b/test/components/overview/available_actions.spec.jsx
@@ -49,21 +49,24 @@ describe('AvailableActions', () => {
     );
 
     const actions = TestAvailableActions.find('.available-action');
-    expect(actions.length).toEqual(5);
+    expect(actions.length).toEqual(6);
 
-    const deleteButton = actions.at(0);
+    const searchButton = actions.at(0);
+    expect(searchButton.text()).toEqual(I18n.t('courses.search_all_tickets_for_this_course'));
+
+    const deleteButton = actions.at(1);
     expect(deleteButton.text()).toEqual('Delete course');
 
-    const enableAccountRequestsButton = actions.at(1);
+    const enableAccountRequestsButton = actions.at(2);
     expect(enableAccountRequestsButton.text()).toEqual('Enable account requests');
 
-    const downloadStatsButton = actions.at(2);
+    const downloadStatsButton = actions.at(3);
     expect(downloadStatsButton.text()).toEqual('Download stats');
 
-    const embedStatsButton = actions.at(3);
+    const embedStatsButton = actions.at(4);
     expect(embedStatsButton.text()).toEqual('Embed Course Stats');
 
-    const cloneCourseButton = actions.at(4);
+    const cloneCourseButton = actions.at(5);
     expect(cloneCourseButton.text()).toEqual('Clone This Course');
   });
 
@@ -90,18 +93,21 @@ describe('AvailableActions', () => {
     );
 
     const actions = TestAvailableActions.find('.available-action');
-    expect(actions.length).toEqual(4);
+    expect(actions.length).toEqual(5);
 
-    const enableAccountRequestsButton = actions.at(0);
+    const searchButton = actions.at(0);
+    expect(searchButton.text()).toEqual(I18n.t('courses.search_all_tickets_for_this_course'));
+
+    const enableAccountRequestsButton = actions.at(1);
     expect(enableAccountRequestsButton.text()).toEqual('Enable account requests');
 
-    const downloadStatsButton = actions.at(1);
+    const downloadStatsButton = actions.at(2);
     expect(downloadStatsButton.text()).toEqual('Download stats');
 
-    const embedStatsButton = actions.at(2);
+    const embedStatsButton = actions.at(3);
     expect(embedStatsButton.text()).toEqual('Embed Course Stats');
 
-    const cloneCourseButton = actions.at(3);
+    const cloneCourseButton = actions.at(4);
     expect(cloneCourseButton.text()).toEqual('Clone This Course');
   });
 });

--- a/test/components/tickets/sidebar.spec.jsx
+++ b/test/components/tickets/sidebar.spec.jsx
@@ -29,7 +29,7 @@ describe('Tickets', () => {
       expect(component.find('.sidebar .course-name').text()).toEqual('Course Unknown');
 
       expect(component.find('.sidebar .related-tickets').length).toBeTruthy;
-      expect(component.find('.sidebar .related-tickets').text()).toEqual('Search all tickets for course: ');
+      expect(component.find('.sidebar .related-tickets').text()).toEqual('Search all tickets for: ');
 
       expect(component.find('.sidebar .user-record').length).toBeTruthy;
       expect(component.find('.sidebar .user-record').text()).toEqual('Unknown User Record');

--- a/test/components/tickets/sidebar.spec.jsx
+++ b/test/components/tickets/sidebar.spec.jsx
@@ -28,6 +28,9 @@ describe('Tickets', () => {
       expect(component.find('.sidebar .course-name').length).toBeTruthy;
       expect(component.find('.sidebar .course-name').text()).toEqual('Course Unknown');
 
+      expect(component.find('.sidebar .related-tickets').length).toBeTruthy;
+      expect(component.find('.sidebar .related-tickets').text()).toEqual('Search all tickets for course: ');
+
       expect(component.find('.sidebar .user-record').length).toBeTruthy;
       expect(component.find('.sidebar .user-record').text()).toEqual('Unknown User Record');
 


### PR DESCRIPTION
## What this PR does
This PR aims to resolve #5224 .

That is : 
 - add a new option for searching tickets: by course (by course slug)
 - also add a link from a course to search for all tickets related to that very course (for admins)
 - also add a link from a ticket detail to search for all other tickets related to the same course that this very ticket. 

Click one of this 2 new links display the dashboard with a search done and the matching tickets listed.