### PR TITLE
upgrade i18n to version 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     choice (0.2.0)
     climate_control (0.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml
@@ -247,6 +247,7 @@ GEM
       raabro (~> 1.4)
     fuzzily_reloaded (1.0.1)
       activerecord (>= 5.1)
+    glob (0.4.0)
     globalid (1.0.1)
       activesupport (>= 5.0)
     griddler (1.5.2)
@@ -299,8 +300,9 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    i18n-js (3.9.2)
-      i18n (>= 0.6.6)
+    i18n-js (4.2.2)
+      glob (>= 0.4.0)
+      i18n
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)

--- a/app/assets/javascripts/components/campaign/campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_list.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';

--- a/app/assets/javascripts/components/campaign/detailed_campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/detailed_campaign_list.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React from 'react';
 import CampaignList from './campaign_list';
 import DetailedCampaignRow from './detailed_campaign_row';

--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import OverviewStat from './OverviewStats/overview_stat';
-import I18n from 'i18n-js';
 
 const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
   let containerClass = 'wikidata-stats-container';

--- a/app/assets/javascripts/components/course/searchable_course_list.jsx
+++ b/app/assets/javascripts/components/course/searchable_course_list.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React, { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import SearchBar from '../common/search_bar';

--- a/app/assets/javascripts/components/explore/explore.jsx
+++ b/app/assets/javascripts/components/explore/explore.jsx
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { getCurrentUser } from '../../selectors';

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -2,6 +2,7 @@ import { I18n } from 'i18n-js';
 
 // eslint-disable-next-line no-var
 const i18n = new I18n();
+i18n.enableFallback = true;
 
 window.i18n = i18n;
 window.I18n = i18n;

--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -1,0 +1,8 @@
+import { I18n } from 'i18n-js';
+
+// eslint-disable-next-line no-var
+const i18n = new I18n();
+
+window.i18n = i18n;
+window.I18n = i18n;
+export default i18n;

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -14,9 +14,6 @@ window.List = require('list.js'); // List is used for sorting tables outside of 
 
 document.addEventListener('DOMContentLoaded', () => {
   /* eslint-disable */
-  import('i18n-js').then(({ default: I18n }) => {
-    window.I18n = I18n;
-  });
   import('./utils/course.js'); // This adds jquery features for some views outside of React
   
   // This is the main React entry point. It renders the navbar throughout the app, and

--- a/app/assets/javascripts/reducers/wizard.js
+++ b/app/assets/javascripts/reducers/wizard.js
@@ -1,4 +1,3 @@
-import I18n from 'i18n-js';
 import {
   RECEIVE_WIZARD_ASSIGNMENT_OPTIONS,
   RECEIVE_WIZARD_PANELS,

--- a/app/assets/javascripts/training/components/training_slide_handler.jsx
+++ b/app/assets/javascripts/training/components/training_slide_handler.jsx
@@ -7,7 +7,6 @@ import SlideLink from './slide_link.jsx';
 import SlideMenu from './slide_menu.jsx';
 import Quiz from './quiz.jsx';
 import Notifications from '../../components/common/notifications.jsx';
-import I18n from 'i18n-js';
 
 
 const md = require('../../utils/markdown_it.js').default({ openLinksExternally: true });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,17 +44,14 @@ module ApplicationHelper
     manifest[filename].split('/').last
   end
 
-  def get_valid_locale(locale)
-    # this is for when a variant of a locale is used, e.g. 'en-US' which doesn't have a
-    # corresponding i18n file. In that case, we use the base locale, e.g. 'en'
-    unless File.exist?("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js")
-      locale = locale.split('-').first
-    end
+  def en_if_invalid(locale)
+    # if the locale is not valid, use the default locale
+    return 'en' unless File.exist?("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js")
     locale
   end
 
   def i18n_javascript_tag(locale)
-    locale = get_valid_locale(locale)
+    locale = en_if_invalid(locale)
     md5 = Digest::MD5.file("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js").hexdigest
     javascript_include_tag "/assets/javascripts/i18n/#{locale}.js?v=#{md5}"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,6 +45,11 @@ module ApplicationHelper
   end
 
   def i18n_javascript_tag(locale)
+    # this is for when a variant of a locale is used, e.g. 'en-US' which doesn't have a
+    # corresponding i18n file. In that case, we use the base locale, e.g. 'en'
+    unless File.exist?("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js")
+      locale = locale.split('-').first
+    end
     md5 = Digest::MD5.file("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js").hexdigest
     javascript_include_tag "/assets/javascripts/i18n/#{locale}.js?v=#{md5}"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,12 +44,17 @@ module ApplicationHelper
     manifest[filename].split('/').last
   end
 
-  def i18n_javascript_tag(locale)
+  def get_valid_locale(locale)
     # this is for when a variant of a locale is used, e.g. 'en-US' which doesn't have a
     # corresponding i18n file. In that case, we use the base locale, e.g. 'en'
     unless File.exist?("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js")
       locale = locale.split('-').first
     end
+    locale
+  end
+
+  def i18n_javascript_tag(locale)
+    locale = get_valid_locale(locale)
     md5 = Digest::MD5.file("#{Rails.root}/public/assets/javascripts/i18n/#{locale}.js").hexdigest
     javascript_include_tag "/assets/javascripts/i18n/#{locale}.js?v=#{md5}"
   end

--- a/app/views/layouts/stats.html.haml
+++ b/app/views/layouts/stats.html.haml
@@ -10,9 +10,16 @@
   = dashboard_stylesheet_tag("main")
   %script(src="https://unpkg.com/react@16.0.0/umd/react.production.min.js")
   %script(src="https://unpkg.com/react-dom@16.0.0/umd/react-dom.production.min.js")
+  %script(src="https://cdn.jsdelivr.net/npm/i18n-js@4.2.2/dist/browser/index.js")
+ 
+  :javascript
+    const i18n = new I18n.I18n();
+    i18n.enableFallback = true;
 
-  = javascript_include_tag '/assets/javascripts/i18n'
-  = i18n_javascript_tag I18n.locale.to_s
+    window.i18n = i18n;
+    window.I18n = i18n;
+  
+  = i18n_javascript_tag get_valid_locale I18n.locale.to_s
   :javascript
     I18n.defaultLocale = "#{I18n.default_locale}";
     I18n.locale = "#{I18n.locale}";

--- a/app/views/layouts/stats.html.haml
+++ b/app/views/layouts/stats.html.haml
@@ -19,7 +19,7 @@
     window.i18n = i18n;
     window.I18n = i18n;
   
-  = i18n_javascript_tag get_valid_locale I18n.locale.to_s
+  = i18n_javascript_tag en_if_invalid I18n.locale.to_s
   :javascript
     I18n.defaultLocale = "#{I18n.default_locale}";
     I18n.locale = "#{I18n.locale}";

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -19,9 +19,9 @@
   %meta{name: "data-languages", content: Wiki::LANGUAGES.to_json}
   %meta{name: "data-namespaces", content: Wiki::PROJECTS_NAMESPACES.to_json}
   :javascript
-    I18n.defaultLocale = "#{I18n.default_locale}";
-    I18n.locale = "#{I18n.locale}";
-    I18n.availableLocales = #{I18n.available_locales.to_json.html_safe}
+    I18n.defaultLocale = "#{get_valid_locale I18n.default_locale.to_s}";
+    I18n.locale = "#{get_valid_locale I18n.locale.to_s}";
+    I18n.availableLocales = #{I18n.available_locales.to_json.html_safe};
 
     currentUser = {
       id: "#{current_user&.id || ''}",

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -12,7 +12,8 @@
 
   = content_for :head
 
-  = javascript_include_tag '/assets/javascripts/i18n'
+  = hot_javascript_tag "vendors"
+  = hot_javascript_tag "i18n"
   = i18n_javascript_tag I18n.locale.to_s
   %meta{name: "data-projects", content: Wiki::PROJECTS.to_json}
   %meta{name: "data-languages", content: Wiki::LANGUAGES.to_json}
@@ -47,7 +48,6 @@
     SalesforceServer = "#{ENV['SF_SERVER']}"
     dashboardTitle = "#{title}"
 
-  = hot_javascript_tag "vendors"
   - if Features.sentry?
     = hot_javascript_tag("sentry")
     // Sentry logging

--- a/app/views/shared/_head.html.haml
+++ b/app/views/shared/_head.html.haml
@@ -19,8 +19,8 @@
   %meta{name: "data-languages", content: Wiki::LANGUAGES.to_json}
   %meta{name: "data-namespaces", content: Wiki::PROJECTS_NAMESPACES.to_json}
   :javascript
-    I18n.defaultLocale = "#{get_valid_locale I18n.default_locale.to_s}";
-    I18n.locale = "#{get_valid_locale I18n.locale.to_s}";
+    I18n.defaultLocale = "#{en_if_invalid I18n.default_locale.to_s}";
+    I18n.locale = "#{en_if_invalid I18n.locale.to_s}";
     I18n.availableLocales = #{I18n.available_locales.to_json.html_safe};
 
     currentUser = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,4 @@
 Rails.application.configure do
-  config.middleware.use I18n::JS::Middleware
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -37,10 +36,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.i18n.raise_on_missing_translations = true
-
-  # i18n-js
-  # Provides support for localization/translations on the front end utilizing Rails localization.
-  # Uses same translation files, config/
-  # In combination with configuration
-  config.middleware.use I18n::JS::Middleware
 end

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -1,29 +1,10 @@
-# Split context in several files.
-#
-# By default only one file with all translations is exported and
-# no configuration is required. Your settings for asset pipeline
-# are automatically recognized.
-#
-# If you want to split translations into several files or specify
-# locale contexts that will be exported, just use this file to do
-# so.
-#
-# For more informations about the export options with this file, please
-# refer to the README
-#
-#
-# If you're going to use the Rails 3.1 asset pipeline, change
-# the following configuration to something like this:
-#
-# translations:
-#   - file: "app/assets/javascripts/i18n/translations.js"
-#
-# If you're running an old version, you can use something
-# like this:
-#
-fallbacks: :en
-export_i18n_js: "public/assets/javascripts"
 translations:
-  - file: "public/assets/javascripts/i18n/%{locale}.js"
-    only: "*"
-#
+  - file: "public/assets/javascripts/i18n/:locale.json"
+    patterns: 
+      - "*"
+
+export_files:
+  enabled: true
+  files:
+    - template: template.erb
+      output: "%{dir}/%{base_name}.js"

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -8,3 +8,6 @@ export_files:
   files:
     - template: template.erb
       output: "%{dir}/%{base_name}.js"
+
+embed_fallback_translations:
+  enabled: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
 
   // all these are ESM modules which must be converted to CJS
   transformIgnorePatterns: [
-    '/node_modules/(?!@react-dnd|react-dnd|dnd-core|react-dnd-html5-backend|lodash-es)',
+    '/node_modules/(?!@react-dnd|react-dnd|dnd-core|react-dnd-html5-backend|lodash-es|i18n-js)',
   ],
+  setupFiles: ['./test/setup.js'],
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.5",
     "fetch-jsonp": "^1.2.1",
-    "i18n-js": "^3.5.1",
+    "i18n-js": "^4.2.2",
     "isomorphic-fetch": "^3.0.0",
     "jeet": "^7.2.0",
     "jest": "^26.0.1",

--- a/prepare.js
+++ b/prepare.js
@@ -17,7 +17,7 @@ console.log('\x1b[33m%s\x1b[0m', `Finished cleaning stale assets after ${elapsed
 
 // export i18n files
 console.log('Started emitting i18n translations');
-execSync('bundle exec rails i18n:js:export');
+execSync('bundle exec i18n export -c ./config/i18n-js.yml');
 console.log('\x1b[33m%s\x1b[0m', `Finished emitting i18n translations after ${elapsed(process.hrtime(start))} seconds`);
 
 // copies static assets from the source to assets folder

--- a/spec/features/language_switcher_spec.rb
+++ b/spec/features/language_switcher_spec.rb
@@ -25,6 +25,17 @@ describe 'language_switcher', type: :feature, js: true do
       expect(page).to have_current_path(root_path(locale: 'fr'))
       expect(page).to have_text('Se connecter à Wikipédia')
     end
+
+    it 'fallbacks to en for locales with incomplete translations' do
+      visit root_path(locale: 'az')
+      expect(page).to have_current_path(root_path(locale: 'az'))
+      expect(page).to have_text('Daxil ol')
+      expect(page).to have_text('Kömək')
+
+      # az.application.training is missing so it should fallback to en
+      expect(page).to have_no_content('[missing "az.')
+      expect(page).to have_content('Training')
+    end
   end
 
   context 'user logged in' do

--- a/template.erb
+++ b/template.erb
@@ -1,0 +1,1 @@
+i18n.store(<%= JSON.pretty_generate(translations) %>);

--- a/template.erb
+++ b/template.erb
@@ -1,1 +1,1 @@
-i18n.store(<%= JSON.pretty_generate(translations) %>);
+i18n.store(<%= JSON.generate(translations) %>);

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+require('../app/assets/javascripts/i18n');
+require('../public/assets/javascripts/i18n/en.js');
+

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -22,7 +22,7 @@ configure({ adapter: new Adapter() });
 
 const sinon = require('sinon');
 const $ = require('jquery');
-const I18n = require('../public/assets/javascripts/i18n.js'); // eslint-disable-line import/no-unresolved
+
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 
@@ -31,7 +31,6 @@ const reduxStore = createStore(reducer, applyMiddleware(thunk));
 global.reduxStore = reduxStore;
 global.$ = $;
 global.sinon = sinon;
-global.I18n = I18n;
 global.Features = {};
 global.currentUser = {};
 global.WikiProjects = JSON.stringify([

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = (env) => {
     embed_course_stats: [`${jsSource}/embed_course_stats.js`],
     accordian: [`${jsSource}/accordian.js`],
     editable: [`${jsSource}/utils/editable.js`],
+    i18n: [`${jsSource}/i18n.js`],
 
     surveys: [`${cssSource}/surveys.styl`],
     training: [`${cssSource}/training.styl`],
@@ -147,7 +148,6 @@ module.exports = (env) => {
     },
     externals: {
       jquery: 'jQuery',
-      'i18n-js': 'I18n'
     },
     devtool,
     stats: env.stats ? 'normal' : 'minimal',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,7 +2739,7 @@ __metadata:
     eslint-plugin-react: ^7.20.5
     eslint-webpack-plugin: ^3.1.1
     fetch-jsonp: ^1.2.1
-    i18n-js: ^3.5.1
+    i18n-js: ^4.2.2
     isomorphic-fetch: ^3.0.0
     jeet: ^7.2.0
     jest: ^26.0.1
@@ -3657,6 +3657,13 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: b89b6e8419b097a8fb4ed2399a1931a68c612bce3cfd5ca8c214b2d017531191070f990598de2fc6f3f993d91c0f08aa82697717f6b3b8732c9731866d233c9e
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:*":
+  version: 9.1.1
+  resolution: "bignumber.js@npm:9.1.1"
+  checksum: ad243b7e2f9120b112d670bb3d674128f0bd2ca1745b0a6c9df0433bd2c0252c43e6315d944c2ac07b4c639e7496b425e46842773cf89c6a2dcd4f31e5c4b11e
   languageName: node
   linkType: hard
 
@@ -7181,10 +7188,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18n-js@npm:^3.5.1":
-  version: 3.9.2
-  resolution: "i18n-js@npm:3.9.2"
-  checksum: b405ad0861dbd57a8757811dcee791e8526a705d67c4a4353e27c924fa2c3422130fba16a21875bd89be871c86ef82f26212b002ba527c09956ff230c47e5026
+"i18n-js@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "i18n-js@npm:4.2.2"
+  dependencies:
+    bignumber.js: "*"
+    lodash: "*"
+  checksum: 288968783c4455caa4f1041e41be521731a04fb0b7e02c4b5fddd7538baa5621ae96ec4ee0f6151d417593a95f502ea5809165880c9ea5d246f228b79c2872ca
   languageName: node
   linkType: hard
 
@@ -8670,7 +8680,7 @@ __metadata:
   resolution: "list.js@https://github.com/WikiEducationFoundation/list.js.git#commit=3be71e3414d60e8a40b41a0ca8d582f2f40f9308"
   dependencies:
     string-natural-compare: ^2.0.2
-  checksum: b853ac7141ebd1bf530ca6104950c0ec0f43b1b4d791db8488ba4523011c72301f62e344e1b8aaf060f69fbd93207826ab4ece0a40c99f6c1c929af417e2f9ec
+  checksum: ea0e976ceae4ddc2b7c78ec41214ceabc4e65368261cc635324b1ef0b7fb67cfca0de6f9af0eb6399da08f31480a5804a2927496ea3b238544b6317f2ad0f687
   languageName: node
   linkType: hard
 
@@ -8814,7 +8824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
+"lodash@npm:*, lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -12072,7 +12082,7 @@ __metadata:
   resolution: "slick-carousel@https://github.com/cfoehrdes/slick.git#commit=a4d85536c42951933e1d887bcc013615e25b03e7"
   dependencies:
     jquery: ">=1.7.2"
-  checksum: 30b5f877b84b8edd48ea7bfb39813c95622cb8f0351956b2398b42b092eca5eeaf593482b904010d77360e04c7a2f5d76e06ba642847450e334368a01f100022
+  checksum: cfa2527b8425260101f0232d5f0aa4c20b8e9b3954ec82a5c006ddd0b3e682b82e696fa6180eff8c7076a07dc6be15f57168247a1383bd7a706d569385e0599e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a follow up of #5119 which unfortunately couldn't go anywhere since v4 of the `i18n-js` gem didn't support exporting JS files. However, with [Add export files plugin to generate files out of translations(#682)](https://github.com/fnando/i18n-js/pull/682) this is possible and so the migration is a lot more straightforward.

This also addresses some of the performance issues we were having with generating the translations. 

Before:

![Screenshot_20230202_163634](https://user-images.githubusercontent.com/10794178/216310520-a4ec6803-a2eb-46e5-85eb-0f728b9e8a7a.png)

After:

![Screenshot_20230202_162821](https://user-images.githubusercontent.com/10794178/216310736-c5219ff3-b043-4859-9da3-2d91966abf3c.png)
