### PR TITLE
error message when home wiki is changed to invalid

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -49,6 +49,8 @@ class CoursesController < ApplicationController
     ensure_passcode_set
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
+  rescue Wiki::InvalidWikiError => e
+    render json: { errors: e, message: I18n.t('courses.error.invalid_language_or_project') }, status: :not_found
   end
 
   def destroy

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -50,7 +50,10 @@ class CoursesController < ApplicationController
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
   rescue Wiki::InvalidWikiError => e
-    render json: { errors: e, message: I18n.t('courses.error.invalid_language_or_project') },
+    language = params.dig(:course, :home_wiki, :language)
+    project = params.dig(:course, :home_wiki, :project)
+    message = I18n.t('courses.error.invalid_wiki', language:, project:)
+    render json: { errors: e, message: },
            status: :not_found
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -50,9 +50,8 @@ class CoursesController < ApplicationController
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
   rescue Wiki::InvalidWikiError => e
-    language = params.dig(:course, :home_wiki, :language)
-    project = params.dig(:course, :home_wiki, :project)
-    message = I18n.t('courses.error.invalid_wiki', language:, project:)
+    domain_name = e.domain_name
+    message = I18n.t('courses.error.invalid_wiki', domain_name:)
     render json: { errors: e, message: },
            status: :not_found
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -50,7 +50,8 @@ class CoursesController < ApplicationController
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
   rescue Wiki::InvalidWikiError => e
-    render json: { errors: e, message: I18n.t('courses.error.invalid_language_or_project') }, status: :not_found
+    render json: { errors: e, message: I18n.t('courses.error.invalid_language_or_project') },
+           status: :not_found
   end
 
   def destroy

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -50,8 +50,7 @@ class CoursesController < ApplicationController
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
   rescue Wiki::InvalidWikiError => e
-    domain_name = e.domain_name
-    message = I18n.t('courses.error.invalid_wiki', domain_name:)
+    message = I18n.t('courses.error.invalid_wiki', domain: e.domain)
     render json: { errors: e, message: },
            status: :not_found
   end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -190,10 +190,10 @@ class Wiki < ApplicationRecord
   end
 
   class InvalidWikiError < StandardError
-    def initialize(project, language)
-      super
+    def initialize(project, language, msg = 'Invalid Language/Project')
       @project = project
       @language = language
+      super(msg)
     end
 
     def domain_name

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -177,16 +177,16 @@ class Wiki < ApplicationRecord
       return
     end
 
-    raise InvalidWikiError.new(domain) unless PROJECTS.include?(project)
-    raise InvalidWikiError.new(domain) unless LANGUAGES.include?(language)
+    raise InvalidWikiError, domain unless PROJECTS.include?(project)
+    raise InvalidWikiError, domain unless LANGUAGES.include?(language)
   end
 
   def ensure_wiki_exists
     return if errors.any? # Skip this check if the wiki had a validation error.
     site_info = WikiApi.new(self).query(meta: :siteinfo)
-    raise InvalidWikiError.new(domain) if site_info.nil?
+    raise InvalidWikiError, domain if site_info.nil?
     servername = site_info.data.dig('general', 'servername')
-    raise InvalidWikiError.new(domain) unless base_url == "https://#{servername}"
+    raise InvalidWikiError, domain unless base_url == "https://#{servername}"
   end
 
   class InvalidWikiError < StandardError
@@ -196,8 +196,6 @@ class Wiki < ApplicationRecord
       super(msg)
     end
 
-    def domain
-      @domain
-    end
+    attr_reader :domain
   end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -177,27 +177,27 @@ class Wiki < ApplicationRecord
       return
     end
 
-    raise InvalidWikiError.new(project, language) unless PROJECTS.include?(project)
-    raise InvalidWikiError.new(project, language) unless LANGUAGES.include?(language)
+    raise InvalidWikiError.new(domain) unless PROJECTS.include?(project)
+    raise InvalidWikiError.new(domain) unless LANGUAGES.include?(language)
   end
 
   def ensure_wiki_exists
     return if errors.any? # Skip this check if the wiki had a validation error.
     site_info = WikiApi.new(self).query(meta: :siteinfo)
-    raise InvalidWikiError.new(project, language) if site_info.nil?
+    raise InvalidWikiError.new(domain) if site_info.nil?
     servername = site_info.data.dig('general', 'servername')
-    raise InvalidWikiError.new(project, language) unless base_url == "https://#{servername}"
+    raise InvalidWikiError.new(domain) unless base_url == "https://#{servername}"
   end
 
   class InvalidWikiError < StandardError
-    def initialize(project, language, msg = 'Invalid Language/Project')
-      @project = project
-      @language = language
+    def initialize(domain, msg = 'Invalid Language/Project')
+      @msg = msg
+      @domain = domain
       super(msg)
     end
 
-    def domain_name
-      "#{@language}.#{@project}.org"
+    def domain
+      @domain
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -621,6 +621,7 @@ en:
       user_exists: "Sorry, %{username} is not an existing user."
       user_exists_on_wiki: "Sorry, %{username} is not an existing user on %{domain}."
       invalid_language_or_project: Invalid language/project
+      invalid_wiki: "Cannot connect to %{language}.%{project}.org. It may not be a valid wiki."
       invalid_slug: Blank school/title for course.
       duplicate_slug: "Another program called %{slug} already exists."
     expected_students: Expected Students

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -621,7 +621,7 @@ en:
       user_exists: "Sorry, %{username} is not an existing user."
       user_exists_on_wiki: "Sorry, %{username} is not an existing user on %{domain}."
       invalid_language_or_project: Invalid language/project
-      invalid_wiki: "Cannot connect to %{domain_name}. It may not be a valid wiki."
+      invalid_wiki: "Cannot connect to %{domain}. It may not be a valid wiki."
       invalid_slug: Blank school/title for course.
       duplicate_slug: "Another program called %{slug} already exists."
     expected_students: Expected Students

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -621,7 +621,7 @@ en:
       user_exists: "Sorry, %{username} is not an existing user."
       user_exists_on_wiki: "Sorry, %{username} is not an existing user on %{domain}."
       invalid_language_or_project: Invalid language/project
-      invalid_wiki: "Cannot connect to %{language}.%{project}.org. It may not be a valid wiki."
+      invalid_wiki: "Cannot connect to %{domain_name}. It may not be a valid wiki."
       invalid_slug: Blank school/title for course.
       duplicate_slug: "Another program called %{slug} already exists."
     expected_students: Expected Students


### PR DESCRIPTION
### This PR Solves
### **Issue #1760**
Current workflow goes like
initially it goes through `get_or_create` if provided wiki doesn't exist then it tries to create a new one in db, to create new wiki for db, we have 2 checks. 

1. ensuring valid project(which just checks if the project name is mentioned in the provided array or not)

2. ensuring wiki exists(which pings the given server using language and project name provided ex lang = "egl' and project name = "wikidata")

in the above example, since, it doesn't exist so, it will create , for that it will first go through first check which will pass since the language and project provided is valid but for the 2nd check it will fail since wiki doesn't exist. 

Old error:- 
![image](https://user-images.githubusercontent.com/72390769/216459164-db5aea67-3486-4d5b-bb00-228873f6dc21.png)

Updated error
![Screenshot from 2023-02-04 00-59-09](https://user-images.githubusercontent.com/72390769/217022249-d92e7a07-2baa-4787-b2d0-d2b1984948bd.png)


