### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,3 +44,4 @@ Your system has cmdtest installed, which provides a different program as yarn. U
 - **To check if redis is running as a daemon in Linux** `ps aux | grep redis-server`
 
 - Use node v10 or lower to avoid any errors.
+- **For WSL users , if rspec tests are taking too long to run** make sure to fork the repo in the linux file system and not in the windows partition. Use command `pwd` to know the exact location of your repo.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,4 +44,4 @@ Your system has cmdtest installed, which provides a different program as yarn. U
 - **To check if redis is running as a daemon in Linux** `ps aux | grep redis-server`
 
 - Use node v10 or lower to avoid any errors.
-- **For WSL users , if rspec tests are taking too long to run** make sure to fork the repo in the linux file system and not in the windows partition. Use command `pwd` to know the exact location of your repo.
+- **For WSL users , if rspec tests are taking too long to run** make sure to fork the repo in the linux file system and not in the windows partition. Use command `pwd` to know the exact path of your repo. If the path starts with `/mnt/`, the repo is in windows partition. Follow the documentation availible at link: https://learn.microsoft.com/en-us/windows/wsl/filesystems to know more about storing and moving files in the linux file system. 


### PR DESCRIPTION
## What this PR does
Updating troubleshooting.md to address the rspec test performance issues for WSL users.

The following lines were added to troubleshooting.md:

**For WSL users , if rspec tests are taking too long to run** make sure to fork the repo in the linux file system and not in the windows partition. Use command `pwd` to know the exact path of your repo. If the path starts with `/mnt/`, the repo is in windows partition. Follow the documentation availible at link: https://learn.microsoft.com/en-us/windows/wsl/filesystems to know more about storing and moving files in the linux file system. 

