### PR TITLE
Added functional show more button for course editors tab

### DIFF
--- a/app/assets/javascripts/actions/articles_actions.js
+++ b/app/assets/javascripts/actions/articles_actions.js
@@ -18,20 +18,19 @@ const fetchArticlesPromise = (courseId, limit) => {
     });
 };
 
-
-export const fetchArticles = (courseId, limit, refresh = false) => (dispatch) => {
-  return (
-    fetchArticlesPromise(courseId, limit)
+export const fetchArticles = (courseId, limit, refresh = false) => {
+  return (dispatch) => {
+    return fetchArticlesPromise(courseId, limit)
       .then((resp) => {
         dispatch({
           type: types.RECEIVE_ARTICLES,
           data: resp,
-          limit: limit
+          limit: limit,
         });
         dispatch({
           type: types.SORT_ARTICLES,
           key: 'character_sum',
-          refresh
+          refresh,
         });
         if (refresh) {
           dispatch({ type: DONE_REFRESHING_DATA });
@@ -39,15 +38,30 @@ export const fetchArticles = (courseId, limit, refresh = false) => (dispatch) =>
         // Now that we received the articles data, query wikidata.org for the labels
         // of any Wikidata entries that are among the articles.
         fetchWikidataLabelsForArticles(resp.course.articles, dispatch);
-       })
-      .catch(response => dispatch({ type: types.API_FAIL, data: response }))
-  );
+      })
+      .catch((response) => {
+        dispatch({ type: types.API_FAIL, data: response });
+      });
+  };
 };
 
-export const sortArticles = (key, refresh) => ({ type: types.SORT_ARTICLES, key: key, refresh });
+export const sortArticles = (key, refresh) => ({
+  type: types.SORT_ARTICLES,
+  key: key,
+  refresh,
+});
 
-export const filterArticles = wiki => ({ type: types.SET_PROJECT_FILTER, wiki: wiki });
+export const filterArticles = wiki => ({
+  type: types.SET_PROJECT_FILTER,
+  wiki: wiki,
+});
 
-export const filterNewness = newness => ({ type: types.SET_NEWNESS_FILTER, newness });
+export const filterNewness = newness => ({
+  type: types.SET_NEWNESS_FILTER,
+  newness,
+});
 
-export const filterTrackedStatus = trackedStatus => ({ type: types.SET_TRACKED_STATUS_FILTER, trackedStatus });
+export const filterTrackedStatus = trackedStatus => ({
+  type: types.SET_TRACKED_STATUS_FILTER,
+  trackedStatus,
+});

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -282,7 +282,7 @@ const ArticleList = createReactClass({
     const limitReached = this.props.limitReached;
     const showMoreSection = (
       <div className="see-more">
-        <PaginatedArticleControls showMore={this.showMore} limitReached={limitReached}/>
+        <PaginatedArticleControls showMore={this.showMore} limitReached={limitReached} />
       </div>
     );
 
@@ -304,10 +304,12 @@ const ArticleList = createReactClass({
   }
 });
 
-const mapStateToProps = state => ({
-  articleDetails: state.articleDetails,
-  sort: state.articles.sort,
-});
+const mapStateToProps = (state) => {
+  return ({
+    articleDetails: state.articleDetails,
+    sort: state.articles.sort,
+  });
+};
 
 const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators({ ...ArticleActions }, dispatch)

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
@@ -80,8 +80,6 @@ EditedUnassignedArticles.propTypes = {
 
 const mapStateToProps = (state) => {
   return ({
-    articleDetails: state.articleDetails,
-    sort: state.articles.sort,
     limit: state.articles.limit,
     limitReached: state.articles.limitReached,
   });

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
@@ -1,26 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import * as ArticleActions from '../../../../../../actions/articles_actions';
+import { bindActionCreators } from 'redux';
 
 // Components
 import EditedUnassignedArticleRow from './EditedUnassignedArticleRow';
 import List from '@components/common/list.jsx';
+import { connect } from 'react-redux';
+import withRouter from '../../../../../util/withRouter.jsx';
 
-export const EditedUnassignedArticles = ({
+const EditedUnassignedArticles = ({
   articles, course, current_user, showArticleId, title, user,
-  fetchArticleDetails
+  fetchArticleDetails, ...props
 }) => {
   const rows = articles.map(article => (
     <EditedUnassignedArticleRow
       key={`article-${article.id}`}
       article={article}
-      course={course}
+      course={course} s
       current_user={current_user}
       fetchArticleDetails={fetchArticleDetails}
       showArticleId={showArticleId}
       user={user}
     />
   ));
-
   const options = { desktop_only: false, sortable: false };
   const keys = {
     article_name: {
@@ -32,10 +35,18 @@ export const EditedUnassignedArticles = ({
       ...options
     }
   };
+  const getCourseSlug = () => {
+    const { course_school, course_title } = props.router.params;
+    return `${course_school}/${course_title}`;
+  };
 
+  const showMore = () => {
+    return props.actions.fetchArticles(getCourseSlug(), props.limit + 500);
+  };
   return (
     <div className="list__wrapper">
       <h4 className="assignments-list-title">{title}</h4>
+
       <List
         elements={rows}
         className="table--expandable table--hoverable"
@@ -44,6 +55,18 @@ export const EditedUnassignedArticles = ({
         stickyHeader={false}
         sortable={false}
       />
+      <div className="see-more">
+        {!props.limitReached
+          && (
+            <button
+              style={{ width: 'max-content', height: 'max-content', marginTop: '20px' }}
+              className="button ghost articles-see-more-btn " onClick={showMore}
+            >
+              {I18n.t('articles.see_more')}
+            </button>
+          )
+        }
+      </div>
     </div>
   );
 };
@@ -58,4 +81,20 @@ EditedUnassignedArticles.propTypes = {
   fetchArticleDetails: PropTypes.func.isRequired
 };
 
-export default EditedUnassignedArticles;
+const mapStateToProps = (state) => {
+  return ({
+    articleDetails: state.articleDetails,
+    sort: state.articles.sort,
+    limit: state.articles.limit,
+    limitReached: state.articles.limitReached,
+  });
+};
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators({ ...ArticleActions }, dispatch)
+});
+
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EditedUnassignedArticles));
+
+

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
@@ -35,13 +35,10 @@ const EditedUnassignedArticles = ({
       ...options
     }
   };
-  const getCourseSlug = () => {
-    const { course_school, course_title } = props.router.params;
-    return `${course_school}/${course_title}`;
-  };
+
 
   const showMore = () => {
-    return props.actions.fetchArticles(getCourseSlug(), props.limit + 500);
+    return props.actions.fetchArticles(course.slug, props.limit + 500);
   };
   return (
     <div className="list__wrapper">

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
@@ -17,7 +17,7 @@ const EditedUnassignedArticles = ({
     <EditedUnassignedArticleRow
       key={`article-${article.id}`}
       article={article}
-      course={course} s
+      course={course}
       current_user={current_user}
       fetchArticleDetails={fetchArticleDetails}
       showArticleId={showArticleId}


### PR DESCRIPTION
With reference to issue #5106 

## What this PR does
This PR adds a show more button at the bottom of the course editors list in the dashboard. When clicked, the button displays more edited articles related to the specified course editor. The show more button disappears after the article limit is reached.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/39999898/220441949-5b04a737-d75d-4e2e-89b5-d626a490516b.png)


After:
![image](https://user-images.githubusercontent.com/39999898/220441214-9c8e76ec-2ed4-41ee-bce9-a31bf3e9c31d.png)

## Open questions and concerns
I'm unsure about tests that should be written for this. If tests should be written at all.