### PR TITLE
Optimize survey results

### DIFF
--- a/app/helpers/question_results_helper.rb
+++ b/app/helpers/question_results_helper.rb
@@ -30,7 +30,7 @@ module QuestionResultsHelper
 
   def question_answers(question)
     question.answers.map do |answer|
-      course = answer.course(@survey.id)
+      course = answer.course(@survey.id, answer.user)
       { data: answer, user: answer.user, course:, campaigns: course&.campaigns,
         tags: course&.tags, sentiment: calculate_sentiment(question, answer) }
     end

--- a/app/helpers/question_results_helper.rb
+++ b/app/helpers/question_results_helper.rb
@@ -8,8 +8,8 @@
 require 'sentimental'
 
 module QuestionResultsHelper
-  def question_results_data(question)
-    answers = question_answers(question)
+  def question_results_data(question, survey_user_cache)
+    answers = question_answers(question, survey_user_cache)
     {
       type: question_type_to_string(question),
       question:,
@@ -28,9 +28,14 @@ module QuestionResultsHelper
     answers.map { |a| a.split(Rapidfire.answers_delimiter) }.flatten
   end
 
-  def question_answers(question)
+  def question_answers(question, survey_user_cache)
     question.answers.map do |answer|
-      course = answer.course(@survey.id, answer.user)
+      if survey_user_cache.key?(answer.user.id)
+        course = survey_user_cache[answer.user.id]
+      else
+        course = answer.course(@survey.id, answer.user)
+        survey_user_cache[answer.user.id] = course
+      end
       { data: answer, user: answer.user, course:, campaigns: course&.campaigns,
         tags: course&.tags, sentiment: calculate_sentiment(question, answer) }
     end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -88,6 +88,7 @@ module SurveysHelper
     @answer_group_builder = Rapidfire::AnswerGroupBuilder.new(params: {},
                                                               user: current_user,
                                                               question_group: @question_group)
+    @questions = surveys_question_group.rapidfire_question_group.questions
     return { question_group: @question_group,
       answer_group_builder: @answer_group_builder,
       question_group_index: index,

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -95,7 +95,7 @@ module SurveysHelper
                  .includes(answers: { user: :survey_notifications })
 
     @id_to_question = {}
-
+    @survey_user_cache = {}
     @questions.each do |question|
       @id_to_question[question.id] = question
     end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -83,6 +83,7 @@ module SurveysHelper
     answer.question.validation_rules[:grouped_question]
   end
 
+  # rubocop:disable Metrics/MethodLength
   def question_group_locals(surveys_question_group, index, total, is_results_view:)
     @question_group = surveys_question_group.rapidfire_question_group
     @answer_group_builder = Rapidfire::AnswerGroupBuilder.new(params: {},
@@ -93,6 +94,12 @@ module SurveysHelper
                  .questions
                  .includes(answers: { user: :survey_notifications })
 
+    @id_to_question = {}
+
+    @questions.each do |question|
+      @id_to_question[question.id] = question
+    end
+
     return { question_group: @question_group,
       answer_group_builder: @answer_group_builder,
       question_group_index: index,
@@ -100,6 +107,7 @@ module SurveysHelper
       total:,
       results: is_results_view }
   end
+  # rubocop:enable Metrics/MethodLength
 
   def question_conditional_string(question)
     return '' if question.nil?

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -88,7 +88,11 @@ module SurveysHelper
     @answer_group_builder = Rapidfire::AnswerGroupBuilder.new(params: {},
                                                               user: current_user,
                                                               question_group: @question_group)
-    @questions = surveys_question_group.rapidfire_question_group.questions
+    @questions = surveys_question_group
+                 .rapidfire_question_group
+                 .questions
+                 .includes(answers: { user: :survey_notifications })
+
     return { question_group: @question_group,
       answer_group_builder: @answer_group_builder,
       question_group_index: index,

--- a/app/views/surveys/_question_group.html.haml
+++ b/app/views/surveys/_question_group.html.haml
@@ -35,7 +35,7 @@
 
           - if results
             = render partial: "rapidfire/answers/question_text", locals: {f: answer_form, answer: answer}
-            = render partial: "question_results", locals: { question: @questions.find(answer.question.id) }
+            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id] }
           - else
             = render_answer_form_helper(answer, answer_form)
 

--- a/app/views/surveys/_question_group.html.haml
+++ b/app/views/surveys/_question_group.html.haml
@@ -35,7 +35,7 @@
 
           - if results
             = render partial: "rapidfire/answers/question_text", locals: {f: answer_form, answer: answer}
-            = render partial: "question_results", locals: { question: @questions.includes(answers: {user: :survey_notifications}).find(answer.question.id) }
+            = render partial: "question_results", locals: { question: @questions.find(answer.question.id) }
           - else
             = render_answer_form_helper(answer, answer_form)
 

--- a/app/views/surveys/_question_group.html.haml
+++ b/app/views/surveys/_question_group.html.haml
@@ -35,7 +35,7 @@
 
           - if results
             = render partial: "rapidfire/answers/question_text", locals: {f: answer_form, answer: answer}
-            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id] }
+            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id], survey_user_cache: @survey_user_cache }
           - else
             = render_answer_form_helper(answer, answer_form)
 

--- a/app/views/surveys/_question_group.html.haml
+++ b/app/views/surveys/_question_group.html.haml
@@ -35,7 +35,7 @@
 
           - if results
             = render partial: "rapidfire/answers/question_text", locals: {f: answer_form, answer: answer}
-            = render partial: "question_results", locals: { question: answer.question }
+            = render partial: "question_results", locals: { question: @questions.includes(answers: {user: :survey_notifications}).find(answer.question.id) }
           - else
             = render_answer_form_helper(answer, answer_form)
 

--- a/app/views/surveys/_question_results.html.haml
+++ b/app/views/surveys/_question_results.html.haml
@@ -1,4 +1,4 @@
-%div{data: { question_results: question_results_data(question) }}
+%div{data: { question_results: question_results_data(question, survey_user_cache) }}
 .results__question-footer
   %strong= respondents(question)
   = link_to "Download Results CSV", question_results_path(question, format: 'csv')

--- a/config/initializers/surveys.rb
+++ b/config/initializers/surveys.rb
@@ -18,14 +18,21 @@ Rails.application.config.to_prepare do
   Rapidfire::Answer.class_eval do
     has_one :user, through: :answer_group
 
-    def notification(survey_id)
-      notifications = user.survey_notifications.completed
+    def notification(survey_id, curr_user=nil)
+      if curr_user.nil?
+        # if curr_user is nil, then we haven't preloaded the user's notifications
+        notifications = user.survey_notifications
+      else
+        # if it isn't nil, then we have preloaded the user's notifications via includes in app/views/surveys/_question_group.html.haml
+        notifications = curr_user.survey_notifications
+      end
+      
       return nil if notifications.empty?
-      notifications.map {|n| n if n.survey.id == survey_id }.compact.first
+      notifications.includes(:survey).map {|n| n if n.survey.id == survey_id }.compact.first
     end
 
-    def course(survey_id)
-      n = notification(survey_id)
+    def course(survey_id, curr_user=nil)
+      n = notification(survey_id, curr_user)
       return nil if n.nil?
       n.course
     end

--- a/config/initializers/surveys.rb
+++ b/config/initializers/surveys.rb
@@ -21,14 +21,14 @@ Rails.application.config.to_prepare do
     def notification(survey_id, curr_user=nil)
       if curr_user.nil?
         # if curr_user is nil, then we haven't preloaded the user's notifications
-        notifications = user.survey_notifications
+        notifications = user.survey_notifications.completed
       else
         # if it isn't nil, then we have preloaded the user's notifications via includes in app/views/surveys/_question_group.html.haml
-        notifications = curr_user.survey_notifications
+        notifications = curr_user.survey_notifications.completed
       end
       
       return nil if notifications.empty?
-      notifications.includes(:survey).map {|n| n if n.survey.id == survey_id }.compact.first
+      notifications.map {|n| n if n.survey.id == survey_id }.compact.first
     end
 
     def course(survey_id, curr_user=nil)

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "#{Rails.root}/setup/populate_dashboard"
+require "#{Rails.root}/setup/populate_surveys"
 
 namespace :dev do
   desc 'Set up some example data'
@@ -14,5 +15,10 @@ namespace :dev do
 
     course_url = ARGV[1]
     make_copy_of course_url
+  end
+  desc 'Populate Survey Questions'
+  task populate_surveys: :environment do
+    populate_survey_questions
+    populate_survey_answers
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -18,7 +18,14 @@ namespace :dev do
   end
   desc 'Populate Survey Questions'
   task populate_surveys: :environment do
-    populate_survey_questions
-    populate_survey_answers
+    mode = ENV['mode']
+    case mode
+    when 'clear'
+      clear_survey_questions
+      clear_survey_answers
+    else
+      populate_survey_questions
+      populate_survey_answers
+    end
   end
 end

--- a/setup/populate_surveys.rb
+++ b/setup/populate_surveys.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+ActiveRecord::Base.logger = Logger.new(STDOUT)
+def populate_survey_questions
+  group = Rapidfire::QuestionGroup.find_or_create_by(
+    name: "Populated Survey",
+    tags: ""
+  )
+  Rapidfire::Question.where(question_group_id: group.id).destroy_all
+  to_create = []
+
+  1..100.times do |i|
+    to_create << {
+      question_group_id: group.id, 
+      question_text: "Question #{i}", 
+      type: "Rapidfire::Questions::Checkbox", 
+      position: i,
+      answer_options: "A\r\nB\r\nC\r\nD",
+      validation_rules: {
+        presence: '1',
+        grouped: '0',
+        grouped_question: '',
+        minimum: '',
+        maximum: '',
+        range_minimum: '',
+        range_maximum: '',
+        range_increment: '',
+        range_divisions: '',
+        range_format: '',
+        greater_than_or_equal_to: '',
+        less_than_or_equal_to: ''
+      }
+    }
+  end
+  Rapidfire::Question.insert_all(to_create)
+end
+
+def populate_survey_answers
+  question_group = Rapidfire::QuestionGroup.find_by(name: "Populated Survey")
+  to_delete = []
+  Rapidfire::AnswerGroup.where(
+    question_group_id: question_group.id,
+  ).each do |answer_group|
+    Rapidfire::Answer.where(
+      answer_group_id: answer_group.id
+    ).each do |answer|
+      to_delete << answer
+    end
+  end
+  Rapidfire::Answer.delete(to_delete)
+  to_create = []
+  1..100.times do |round|
+    answer_group = Rapidfire::AnswerGroup.create(
+      question_group_id: question_group.id,
+      user_id: User.first.id,
+    )
+    Rapidfire::Question.where(
+      question_group_id: question_group.id,
+    ).each do |question|
+      to_create << {
+        answer_group_id: answer_group.id,
+        question_id: question.id,
+        answer_text: ["A","B","C","D"].sample
+      }
+    end
+  end
+  Rapidfire::Answer.insert_all(to_create)
+end

--- a/setup/populate_surveys.rb
+++ b/setup/populate_surveys.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 ActiveRecord::Base.logger = Logger.new(STDOUT)
+
 def populate_survey_questions
+  clear_survey_questions
   group = Rapidfire::QuestionGroup.find_or_create_by(
     name: "Populated Survey",
     tags: ""
   )
-  Rapidfire::Question.where(question_group_id: group.id).destroy_all
   to_create = []
+  
+  n_questions = ENV['questions'] || 100
 
-  1..100.times do |i|
+  1..n_questions.to_i.times do |i|
     to_create << {
       question_group_id: group.id, 
       question_text: "Question #{i}", 
@@ -35,23 +38,16 @@ def populate_survey_questions
 end
 
 def populate_survey_answers
+  clear_survey_answers
   question_group = Rapidfire::QuestionGroup.find_by(name: "Populated Survey")
-  to_delete = []
-  Rapidfire::AnswerGroup.where(
-    question_group_id: question_group.id,
-  ).each do |answer_group|
-    Rapidfire::Answer.where(
-      answer_group_id: answer_group.id
-    ).each do |answer|
-      to_delete << answer
-    end
-  end
-  Rapidfire::Answer.delete(to_delete)
   to_create = []
-  1..100.times do |round|
+
+  n_responses = ENV['responses'] || 100
+
+  1..n_responses.to_i.times do |round|
     answer_group = Rapidfire::AnswerGroup.create(
       question_group_id: question_group.id,
-      user_id: User.first.id,
+      user_id: User.order('RAND()').first.id,
     )
     Rapidfire::Question.where(
       question_group_id: question_group.id,
@@ -64,4 +60,26 @@ def populate_survey_answers
     end
   end
   Rapidfire::Answer.insert_all(to_create)
+end
+
+def clear_survey_answers
+  question_group = Rapidfire::QuestionGroup.find_by(name: "Populated Survey")
+  to_delete = []
+  Rapidfire::AnswerGroup.where(
+    question_group_id: question_group.id,
+  ).each do |answer_group|
+    Rapidfire::Answer.where(
+      answer_group_id: answer_group.id
+    ).each do |answer|
+      to_delete << answer
+    end
+  end
+  Rapidfire::Answer.delete(to_delete)
+end
+
+def clear_survey_questions
+  question_group = Rapidfire::QuestionGroup.find_by(name: "Populated Survey")
+  Rapidfire::Question.where(
+    question_group_id: question_group.id,
+  ).destroy_all
 end


### PR DESCRIPTION
Attempts to address #984 

Here's the setup I've used

1. 2 Users
2. 1 User has an entry in Survey Notification
3. 1 question group
4. 100 questions
5. 100 responses for each question

# Before - 125 seconds

![Screenshot_20230225_212326](https://user-images.githubusercontent.com/10794178/221367024-41cf3007-d9c4-4cd4-b17c-e64e9d335b62.png)

# After - 7 seconds

![image](https://user-images.githubusercontent.com/10794178/221366996-5f7e35d1-0591-47b5-9810-0b4882696e73.png)

# Working

The improvements stem from two queries which were being made for each answer - one is the query for user information and another for the `survey_notification`. 

For the first one, I was able to improve things by eagerly joining the table - rather than doing a join on every attribute access. For the second one, I wasn't able to prefetch in a reliable and consistent way.

So instead I used a hash as a cache which is present for each question group and maps a user id to a course. If we've already computed the course for a user id, we don't need to make any query.