### PR TITLE
improved view of course timeline page in diffrent display sizes 

### DIFF
--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -74,7 +74,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
   return (
     <div className="container">
       {courseLinkElement}
-      <nav>
+      <nav id="navbar-main" >
         <div className="nav__item" id="overview-link">
           <p><NavLink to={homeLink} className={({ isActive }) => (isActive ? 'active' : homeLinkClassName)}>{I18n.t('courses.overview')}</NavLink></p>
         </div>

--- a/app/assets/javascripts/components/course/course.jsx
+++ b/app/assets/javascripts/components/course/course.jsx
@@ -42,9 +42,20 @@ export const Course = withRouter(createReactClass({
     persistCourse: PropTypes.func.isRequired,
     fetchTimeline: PropTypes.func.isRequired
   },
+  getInitialState() {
+    return { navBarHeight: 0, courseAlertsHeight: 0 };
+  },
 
   // Fetch all the data needed to render a course page
   componentDidMount() {
+    this.timer = setTimeout(
+      () => {
+        const availableWidthPx = document.getElementById('navbar-main');
+        const courseAlertsHeight = document.getElementById('course-alerts');
+        this.setState(() => ({ navBarHeight: availableWidthPx?.clientHeight, courseAlertsHeight: courseAlertsHeight?.clientHeight }));
+      },
+      1000,
+    );
     const courseSlug = this.getCourseSlug();
     this.props.fetchCourse(courseSlug);
     this.props.fetchUsers(courseSlug);
@@ -131,19 +142,21 @@ export const Course = withRouter(createReactClass({
             <Notifications />
           </Affix>
         </div>
-        <CourseAlerts
-          courseAlerts={this.props.courseAlerts}
-          course={course}
-          userRoles={userRoles}
-          weeks={this.props.weeks}
-          courseLinkParams={this._courseLinkParams()}
-          usersLoaded={this.props.usersLoaded}
-          studentCount={this.props.studentCount}
-          updateCourse={this.props.updateCourse}
-          persistCourse={this.props.persistCourse}
-          dismissNotification={this.props.dismissNotification}
-        />
-        <div className="course_main container">
+        <div style={{ marginTop: `${this.state.navBarHeight}px` }} className="course-alerts-wrapper">
+          <CourseAlerts
+            courseAlerts={this.props.courseAlerts}
+            course={course}
+            userRoles={userRoles}
+            weeks={this.props.weeks}
+            courseLinkParams={this._courseLinkParams()}
+            usersLoaded={this.props.usersLoaded}
+            studentCount={this.props.studentCount}
+            updateCourse={this.props.updateCourse}
+            persistCourse={this.props.persistCourse}
+            dismissNotification={this.props.dismissNotification}
+          />
+        </div>
+        <div className="course_main container" style={{ marginTop: `${this.state.courseAlertsHeight}px` }}>
           <Confirm />
           {courseApprovalForm}
           {enrollCard}

--- a/app/assets/javascripts/components/course/course_alert.jsx
+++ b/app/assets/javascripts/components/course/course_alert.jsx
@@ -40,7 +40,7 @@ const CourseAlert = createReactClass({
     }
     const messages = [].concat(this.props.message);
     return (
-      <div className={this.props.className ? `${this.props.className} notification` : 'notification'}>
+      <div className={this.props.className ? `${this.props.className} notification` : 'notification'} id="course-alerts">
         <div className="container">
           { messages.map((message, i) => <p key={i}>{ message }</p>) }
           {action}

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -6,6 +6,9 @@
     margin-bottom 0px
     margin-top 0px
 
+.course_main
+  +above(desktop)
+    margin-top 30px !important
 .course
   background #fff
   border 1px solid $border_lt

--- a/app/assets/stylesheets/modules/_modules.styl
+++ b/app/assets/stylesheets/modules/_modules.styl
@@ -122,3 +122,7 @@
     +below(desktop)
       margin-top: 0px
 
+.course-alerts-wrapper
+  +above(desktop)
+    margin-top: 0px !important
+


### PR DESCRIPTION

## What this PR does
Focusses on enhancing preview of course timeline page issue #3648

## Screenshots

After:
![image](https://user-images.githubusercontent.com/72390769/222258703-1dc51c81-4530-42dd-8a15-eaa196bbe531.png)
