### PR TITLE
further optimize survey results

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -150,6 +150,7 @@ class SurveysController < ApplicationController
   def set_question_groups
     @question_groups = Rapidfire::QuestionGroup.all
     @surveys_question_groups = SurveysQuestionGroup.by_position(params[:id])
+    @survey_user_cache = {}
   end
 
   # This removes the question groups that do not apply to the course, because

--- a/app/helpers/question_results_helper.rb
+++ b/app/helpers/question_results_helper.rb
@@ -64,8 +64,8 @@ module QuestionResultsHelper
     }
   end
 
-  def respondents(question)
-    total = question.answers.count
+  def respondents(question, question_answers_count)
+    total = question_answers_count[question.id]
     label = 'Respondents'
     label.pluralize if total > 1
     "#{total} #{label}"

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -95,9 +95,17 @@ module SurveysHelper
                  .includes(answers: { user: :survey_notifications })
 
     @id_to_question = {}
-    @survey_user_cache = {}
     @questions.each do |question|
       @id_to_question[question.id] = question
+    end
+
+    @question_answers_count = Rapidfire::Answer
+                              .where(question_id: @questions.pluck(:id))
+                              .group(:question_id).count
+
+    @answer_group_builder.answers.each do |answer|
+      question = @id_to_question[answer.question_id]
+      answer.question = question
     end
 
     return { question_group: @question_group,

--- a/app/models/surveys/survey_assignment.rb
+++ b/app/models/surveys/survey_assignment.rb
@@ -87,10 +87,6 @@ class SurveyAssignment < ApplicationRecord
     CoursesUsers.where(course: courses_ready_for_notifications, role: courses_user_role)
   end
 
-  def survey
-    Survey.find_by(id: survey_id)
-  end
-
   def active?
     published && !courses_with_pending_notifications.empty?
   end

--- a/app/models/surveys/survey_notification.rb
+++ b/app/models/surveys/survey_notification.rb
@@ -69,10 +69,6 @@ class SurveyNotification < ApplicationRecord
            follow_up_count: follow_up_count + 1)
   end
 
-  def survey_assignment
-    SurveyAssignment.find(survey_assignment_id)
-  end
-
   def survey
     survey_assignment.survey
   end

--- a/app/views/surveys/_question_results.html.haml
+++ b/app/views/surveys/_question_results.html.haml
@@ -1,4 +1,4 @@
 %div{data: { question_results: question_results_data(question, survey_user_cache) }}
 .results__question-footer
-  %strong= respondents(question)
+  %strong= respondents(question, @question_answers_count)
   = link_to "Download Results CSV", question_results_path(question, format: 'csv')

--- a/config/initializers/surveys.rb
+++ b/config/initializers/surveys.rb
@@ -21,10 +21,10 @@ Rails.application.config.to_prepare do
     def notification(survey_id, curr_user=nil)
       if curr_user.nil?
         # if curr_user is nil, then we haven't preloaded the user's notifications
-        notifications = user.survey_notifications.completed
+        notifications = user.survey_notifications.completed.includes(survey_assignment: :survey)
       else
         # if it isn't nil, then we have preloaded the user's notifications via includes in app/views/surveys/_question_group.html.haml
-        notifications = curr_user.survey_notifications.completed
+        notifications = curr_user.survey_notifications.completed.includes(survey_assignment: :survey)
       end
       
       return nil if notifications.empty?


### PR DESCRIPTION
This does the following optimizations:

1. caches the users for the entire survey rather than per question group
2. computes number of answers per question eagerly so that no queries are needed while rendering the template
3. attach question to answer object to avoid extra queries while rendering the template

## Setup

Simply run `rake dev:populate_surveys` and visit `/surveys` and find the survey named "generated survey". 

## Before ~ 13 seconds

![image](https://user-images.githubusercontent.com/10794178/222893257-26d35de7-d6ba-4579-ba27-797c1380e485.png)

## After ~ 7 seconds

![image](https://user-images.githubusercontent.com/10794178/222892814-82964e31-83ee-41ad-b68c-39c731ec9887.png)



