### PR TITLE
Replace ajax with fetch

### DIFF
--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -276,23 +276,20 @@ const Survey = {
 
   updateSurveyNotification() {
     if (this.surveyNotificationId === undefined) { return; }
-    $.ajax({
-      type: 'PUT',
-      url: '/survey_notification',
+    fetch('/survey_notification', {
+      credentials: 'include',
+      method: 'PUT',
       headers: {
+        'Content-Type': 'application/json',
         'X-CSRF-Token': Rails.csrfToken()
       },
-      dataType: 'json',
-      data: {
+      body: JSON.stringify({
         survey_notification: {
           id: this.surveyNotificationId,
           dismissed: true,
           completed: true
         }
-      },
-      success() {
-        // console.log(data);
-      }
+      })
     });
   },
 

--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -8,6 +8,7 @@ import Rails from '@rails/ujs';
 //--------------------------------------------------------
 
 import Utils from './SurveyUtils.js';
+import request from '../../utils/request';
 
 //--------------------------------------------------------
 // Vendor Requirements [requires]
@@ -20,6 +21,7 @@ const rangeslider = require('nouislider');
 const wNumb = require('wnumb');
 require('slick-carousel');
 require('velocity-animate');
+
 
 // const markdown = require('../../utils/markdown_it.js').default();
 
@@ -261,6 +263,7 @@ const Survey = {
           'Content-Type': 'application/json',
           'X-CSRF-Token': Rails.csrfToken()
         },
+        redirect: 'manual'
         // success(d) { return console.log('success', d); },
         // error(er) { return console.log('error', er); }
       });
@@ -278,13 +281,8 @@ const Survey = {
 
   updateSurveyNotification() {
     if (this.surveyNotificationId === undefined) { return; }
-    fetch('/survey_notification', {
-      credentials: 'include',
+    request('/survey_notification', {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': Rails.csrfToken()
-      },
       body: JSON.stringify({
         survey_notification: {
           id: this.surveyNotificationId,

--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -253,12 +253,14 @@ const Survey = {
     $form.on('submit', function (e) {
       e.preventDefault();
       const data = _context.processQuestionGroupData($(this).serializeArray());
-      return $.ajax({
-        url,
-        method,
-        data: JSON.stringify(data),
-        dataType: 'json',
-        contentType: 'application/json',
+      return fetch(url, {
+        method: method,
+        body: JSON.stringify(data),
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': Rails.csrfToken()
+        },
         // success(d) { return console.log('success', d); },
         // error(er) { return console.log('error', er); }
       });

--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -260,10 +260,10 @@ const Survey = {
         body: JSON.stringify(data),
         credentials: 'include',
         headers: {
+          Accept: 'application/json',
           'Content-Type': 'application/json',
           'X-CSRF-Token': Rails.csrfToken()
         },
-        redirect: 'manual'
         // success(d) { return console.log('success', d); },
         // error(er) { return console.log('error', er); }
       });

--- a/app/assets/javascripts/surveys/modules/SurveyAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAdmin.js
@@ -176,12 +176,18 @@ const SurveyAdmin = {
   },
 
   getQuestion(id) {
-    return $.ajax({
-      url: `/surveys/question_group_question/${id}`,
-      method: 'get',
-      dataType: 'json',
-      contentType: 'application/json',
+    return fetch(`/surveys/question_group_question/${id}`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': SurveyAdmin.$csrf_token.content
+      },
       success: $.proxy(this, 'handleConditionalQuestionSelect')
+    }).then((response) => {
+      if (response.ok) {
+        $.proxy(this, 'handleConditionalQuestionSelect');
+      }
     });
   },
 

--- a/app/assets/javascripts/surveys/modules/SurveyAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAdmin.js
@@ -176,6 +176,7 @@ const SurveyAdmin = {
   },
 
   getQuestion(id) {
+    const that = this; // This is done to store the correct "this" pointer to the object while inside the promise
     return fetch(`/surveys/question_group_question/${id}`, {
       method: 'GET',
       credentials: 'include',
@@ -183,11 +184,9 @@ const SurveyAdmin = {
         'Content-Type': 'application/json',
         'X-CSRF-Token': SurveyAdmin.$csrf_token.content
       },
-      success: $.proxy(this, 'handleConditionalQuestionSelect')
-    }).then((response) => {
-      if (response.ok) {
-        $.proxy(this, 'handleConditionalQuestionSelect');
-      }
+    }).then(response => response.json())
+      .then((data) => {
+        SurveyAdmin.handleConditionalQuestionSelect.call(that, data);
     });
   },
 

--- a/app/assets/javascripts/surveys/modules/SurveyAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAdmin.js
@@ -64,6 +64,8 @@ const SurveyAdmin = {
     this.$matrix_options_checkbox = $('[data-matrix-checkbox]');
     this.$course_data_type_select = $('#question_course_data_type');
     this.$answer_options = $('[data-answer-options]');
+    this.$csrf_token = document.querySelector('meta[name="csrf-token"]');
+
     return this.$range_input_options = $('[data-question-type-options="RangeInput"');
   },
 
@@ -85,11 +87,10 @@ const SurveyAdmin = {
       update(e, ui) {
         const itemId = ui.item.data('item-id');
         const position = ui.item.index() + 1; // acts_as_list defaults to start at 1
-        return $.ajax({
-          type: 'PUT',
-          url: '/surveys/question_position',
-          dataType: 'json',
-          data: { question_group_id: questionGroupId, id: itemId, position }
+        return fetch('/surveys/question_position', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': SurveyAdmin.$csrf_token.content },
+          body: JSON.stringify({ question_group_id: questionGroupId, id: itemId, position })
         });
       }
     });
@@ -117,7 +118,7 @@ const SurveyAdmin = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+            'X-CSRF-Token': SurveyAdmin.$csrf_token.content
           },
           body: JSON.stringify({ survey_id: surveyId, question_group_id: itemId, position })
         });

--- a/app/assets/javascripts/surveys/modules/SurveyAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAdmin.js
@@ -112,11 +112,14 @@ const SurveyAdmin = {
       update(e, ui) {
         const itemId = ui.item.data('item-id');
         const position = ui.item.index() + 1; // acts_as_list defaults to start at 1
-        return $.ajax({
-          type: 'POST',
-          url: '/surveys/update_question_group_position',
-          dataType: 'json',
-          data: { survey_id: surveyId, question_group_id: itemId, position }
+        return fetch('/surveys/update_question_group_position', {
+          credentials: 'include',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+          },
+          body: JSON.stringify({ survey_id: surveyId, question_group_id: itemId, position })
         });
       }
     });

--- a/app/assets/javascripts/utils/request.js
+++ b/app/assets/javascripts/utils/request.js
@@ -4,14 +4,16 @@ import Rails from '@rails/ujs';
 // it is a relative path if it doesn't start with http or https
 const isRelativePath = path => !path.match(/^http(s?)/);
 
-export default (path, { method = 'GET', body = null } = {}) => {
+export default (path, { method = 'GET', body = null, ...extraOptions } = {}) => {
   const options = {
     headers: {
       'Content-Type': 'application/json'
     },
-    method
+    method,
+    ...extraOptions
   };
   // If the path is an internal request, include the CSRF Token
   if (isRelativePath(path)) options.headers['X-CSRF-Token'] = Rails.csrfToken();
+
   return fetch(path, body ? { body, ...options } : options);
 };


### PR DESCRIPTION
With reference to #2015 
## What this PR does
Replaces the remaining ajax calls in the codebase with fetch API. Most of the replaced ajax calls here are related to the survey system. Specifically `Survey.js` and `SurveyAdmin.js`

## Open questions and concerns
There's one fetch call that is causing odd behaviour but doesn't seem to affect user experience. 

When submitting a survey as a student, a POST call is made to `/surveys/rapidfire/question_groups/[id]/answer_groups`. This call returns status code `302 found.` This causes the POST call to be redirected to `surveys/rapidfire/question_groups` which returns status code `401 unauthorized`. However, the actual survey is still submitted and recorded, with the UI still behaving normally.

See the screenshots below for more details.

**Initial fetch call:**
![image](https://user-images.githubusercontent.com/39999898/223184426-f6636889-2337-49dc-b598-27913c5829aa.png)

**Redirected to:**
![image](https://user-images.githubusercontent.com/39999898/223184537-0c748bc1-0fc6-4a19-9c7d-13f61be2dc63.png)
