### PR TITLE
Add language codes guc and gur

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -44,7 +44,7 @@ class Wiki < ApplicationRecord
     bug bxr ca cbk-zam cdo ce ceb ch cho chr chy ckb cmn co commons cr crh cs csb cu
     cv cy da dag de din diq dk dsb dty dv dz ee egl el eml en eo epo es et eu ext fa
     ff fi fiu-vro fj fo fr frp frr fur fy ga gag gan gcr gd gl glk gn gom gor got gsw
-    gu guw gv ha hak haw he hi hif ho hr hsb ht hu hy hyw hz ia id ie ig ii ik ilo
+    gu guc gur guw gv ha hak haw he hi hif ho hr hsb ht hu hy hyw hz ia id ie ig ii ik ilo
     incubator inh io is it iu ja jam jbo jp jv ka kaa kab kcg kbd kbp kg ki kj kk kl km kn ko
     koi kr krc ks ksh ku kv kw ky la lad lb lbe lez lfn lg li lij lld lmo ln lo lrc lt
     ltg lv lzh mad mai map-bms mdf mg mh mhr mi min minnan mk ml mn mni mnw mo mr mrj ms mt


### PR DESCRIPTION
These Wikipedias were added recently, see
https://incubator.wikimedia.org/wiki/Incubator:Site_creation_log

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
It's impossible at the moment to select projects in languages Wayuu (guc) and Farefare (gur). This patch tries to add support for them.

I never added languages here, so I'm just guessing that this is the way to do it, and it requires careful review. If this one goes well, I'll also document the process in https://wikitech.wikimedia.org/wiki/Add_a_wiki and https://www.mediawiki.org/wiki/Manual:Adding_and_removing_languages .

Thanks! :)