### PR TITLE
Fixed campaign article table overflow issue

### DIFF
--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -13,4 +13,4 @@
       = "#{article.wiki.language}.#{article.wiki.project}"
   %td.course_title
     %small
-      = link_to article_course.course.slug, "/courses/#{article_course.course.slug}"
+      = link_to article_course.course.slug.gsub('_',' '), "/courses/#{article_course.course.slug}"


### PR DESCRIPTION
With reference to #1883 
## What this PR does
This PR makes a change to the article table under Campaign > Articles. By replacing the underscores in the "Programs" column with spaces. The text now wraps downwards, fixing the container overflow issue.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/39999898/224082041-e26dc267-4120-4ed0-ac31-34ab5ae587ab.png)

After:
![image](https://user-images.githubusercontent.com/39999898/224082233-1517d2f8-022e-4ad5-a6e7-757b4ccd1000.png)
