### PR TITLE
Fixing form validation

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -118,7 +118,7 @@ SimpleForm.setup do |config|
   # in this configuration, which is recommended due to some quirks from different browsers.
   # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
   # change this configuration to true.
-  config.browser_validations = false
+  config.browser_validations = true
 
   # Collection of methods to detect if a file type was given.
   # config.file_methods = [ :mounted_as, :file?, :public_filename ]


### PR DESCRIPTION
With Reference to #5281 and many other form issues
## What this PR does
This PR turns on HTML5 form validation for forms that are using the simple_form library. This affects and fixes many forms that allow you to submit empty required field which then cause server errors. Some of the forms affected are:

**-The create question group form:** Used to crash when submitting an empty name, now asks the user to fill in the name field if empty)
**-The edit question group form:** Used to crash when editing the name field to be empty, now asks the user to fill in the name field if empty)

Technically, this affects more than these two forms, but there aren't really any visible changes to them since they don't use the "required" attribute. So I won't list them here.
## Videos
**Before:** 
Create question group

[224089284-1f313b0c-fd04-47ec-8ced-83bf0b66d299.webm](https://user-images.githubusercontent.com/39999898/224145264-756b641e-27eb-489d-a5c3-23e3bc9d06e7.webm)

Edit question group

[Screencast from 03-09-2023 09:23:34 PM.webm](https://user-images.githubusercontent.com/39999898/224147012-e053675e-5c8a-426c-902a-8a59c291f777.webm)

**After:** 
Create question group

[Screencast from 03-09-2023 09:20:29 PM.webm](https://user-images.githubusercontent.com/39999898/224146525-9265ec00-3eec-49e0-84eb-5d6abfe5b4fe.webm)

Edit question group

[Screencast from 03-09-2023 09:26:10 PM.webm](https://user-images.githubusercontent.com/39999898/224147714-37aafaad-568d-4a9e-9b62-8c853877df9b.webm)
