### PR TITLE
Fixed FAQ page styling for smaller screens

### DIFF
--- a/app/assets/stylesheets/modules/_faq.styl
+++ b/app/assets/stylesheets/modules/_faq.styl
@@ -1,25 +1,40 @@
 .faq-header
-  input
-    width 100%
-    max-width 400px
-  button.search
-    right 30px
-    position relative
-    color #888
-  button.search:hover
-    color inherit
+  form
+    display flex
+    justify-content center
+    input
+      width 100%
+      max-width 400px
+    button.search
+      right 30px
+      position relative
+      color #888
+    button.search:hover
+      color inherit
+.faq-body
+  display flex
+  justify-content space-between
+  gap 20px
 
-.faq-list
-  width 70%
-  float left
+  .faq-list
+    width 70%
+
+  .faq-topic-list
+    width 20%
+
+  @media only screen and (max-width: 500px)
+    flex-direction column-reverse
+    .faq-list
+      width 100%
+
+    .faq-topic-list
+      width 100%
+
 
 .faq-feedback
   margin-top 20px
   float left
 
-.faq-topic-list
-  width 20%
-  float right
 
 .faq
   border-bottom 1px solid #ccc

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -7,7 +7,7 @@
       = text_field_tag(:search, @query, placeholder: 'search', id: 'faq_search')
       %button.search#submit_search{type: 'submit'}
         %i.icon.icon-search
-.container
+.container.faq-body
   .faq-list
     - @faqs.each do |faq|
       = render 'faq', faq: faq, expanded: @faqs.one?


### PR DESCRIPTION
With reference to #4339
## What this PR does
Cleans up the styling for the faq page by using flex and adding a media query for smaller screens
## Screenshots
Before:
![image](https://user-images.githubusercontent.com/39999898/224496870-2b87a233-4f62-437a-b75d-870aa415b6d6.png)


After:
![image](https://user-images.githubusercontent.com/39999898/224496924-14677e2f-9bca-40e4-aa65-57de0441fb91.png)
