### PR TITLE
Fix issue 1038

### DIFF
--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import TextInput from '../common/text_input.jsx';
 import DatePicker from '../common/date_picker.jsx';
 import TextAreaInput from '../common/text_area_input.jsx';
@@ -8,6 +10,7 @@ import TrainingModules from './TrainingModules/TrainingModules';
 import BlockTypeSelect from './block_type_select.jsx';
 import TrainingModulesViewMode from './TrainingModules/TrainingModulesViewMode.jsx';
 import { BLOCK_KIND_RESOURCES } from '../../constants';
+import { initiateConfirm } from '../../actions/confirm_actions.js';
 
 const DEFAULT_POINTS = 10;
 
@@ -26,7 +29,8 @@ const Block = createReactClass({
     all_training_modules: PropTypes.array,
     weekStart: PropTypes.object,
     trainingLibrarySlug: PropTypes.string.isRequired,
-    current_user: PropTypes.object
+    current_user: PropTypes.object,
+    initiateConfirm: PropTypes.func.isRequired
   },
 
   updateBlock(valueKey, value) {
@@ -43,9 +47,10 @@ const Block = createReactClass({
   },
 
   deleteBlock() {
-    if (confirm('Are you sure you want to delete this block? This will delete the block and all of its content.\n\nThis cannot be undone.')) {
-      return this.props.deleteBlock(this.props.block.id);
-    }
+    const confirmMessage = 'Are you sure you want to delete this block? This will delete the block and all of its content.\n\nThis cannot be undone.';
+    const deleteBlock = this.props.deleteBlock;
+    const onConfirm = () => deleteBlock(this.props.block.id);
+    return this.props.initiateConfirm({ confirmMessage, onConfirm });
   },
 
   _setEditable() {
@@ -269,5 +274,10 @@ const Block = createReactClass({
 }
 );
 
+const mapDispatchToProps = { initiateConfirm };
 
-export default Block;
+export default connect(null, mapDispatchToProps)(
+  // Expandable(Block)
+  Block
+);
+// export default Block;

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -277,7 +277,5 @@ const Block = createReactClass({
 const mapDispatchToProps = { initiateConfirm };
 
 export default connect(null, mapDispatchToProps)(
-  // Expandable(Block)
   Block
 );
-// export default Block;

--- a/spec/features/timeline_editing_spec.rb
+++ b/spec/features/timeline_editing_spec.rb
@@ -112,10 +112,9 @@ describe 'timeline editing', type: :feature, js: true do
     sleep 0.5
     within('.week-1') do
       find('.block__edit-block', match: :first).click
-      accept_confirm do
-        click_button 'Delete Block'
-      end
+      click_button 'Delete Block'
     end
+    click_button 'OK'
 
     expect(page).not_to have_content 'Block Title'
     sleep 1
@@ -145,10 +144,9 @@ describe 'timeline editing', type: :feature, js: true do
     sleep 0.5
     within ".week-1 .block-kind-#{Block::KINDS['in_class']}" do
       find('.block__edit-block', match: :first).click
-      accept_confirm do
-        click_button 'Delete Block'
-      end
+      click_button 'Delete Block'
     end
+    click_button 'OK'
     sleep 1
 
     # click Save All


### PR DESCRIPTION
With Reference to https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1038

## What this PR does
This PR replaces the javascript confirm() instance with Confirm component, that is, initiateConfirm() function in the block.jsx file.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/57138717/224565075-d1a8b4eb-1f49-405e-ad9d-e47f8b427bee.png)

After:
![image](https://user-images.githubusercontent.com/57138717/224565084-7f560816-546b-42f3-85ea-f2b1d6b5f7d4.png)
