### PR TITLE
Fixed some warnings in the jest test suite

### DIFF
--- a/app/assets/javascripts/utils/request.js
+++ b/app/assets/javascripts/utils/request.js
@@ -15,5 +15,5 @@ export default (path, { method = 'GET', body = null, ...extraOptions } = {}) => 
   // If the path is an internal request, include the CSRF Token
   if (isRelativePath(path)) options.headers['X-CSRF-Token'] = Rails.csrfToken();
 
-  return fetch(path, body ? { body, ...options } : options);
+  return fetch(new URL(path, window.location.origin).href, body ? { body, ...options } : options);
 };

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/index.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/index.spec.jsx
@@ -6,7 +6,9 @@ import Header from '@components/overview/my_articles/components/Categories/List/
 
 describe('Header', () => {
   const props = {
-    article: {},
+    article: {
+      project: 'project'
+    },
     articleTitle: 'title',
     assignment: {},
     course: { slug: 'course/slug', type: 'ClassroomProgramCourse' },

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.spec.jsx
@@ -8,6 +8,7 @@ describe('ButtonNavigation', () => {
   const props = {
     active: true,
     assignment: {},
+    course: {},
     courseSlug: 'course/slug',
     index: 1,
     updateAssignmentStatus: jest.fn(),


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
In the issue #5300 is mentioned to fix some warnings or errors from the jest test suite, and many of them were fixed with a few changes. However there is a new log from jest. The log is 'Cannot log after tests are done. Did you forget to wait for something async in your test? when running the `test/components/overview/campaign_expandable.spec.jsx` test. I really don't know how to solve that, but is one step further to fix warnings from jest. 

## Screenshots
Before:
doesn't apply

After:
doesn't apply
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >

Edit: The mentioned log error looks to occur on local. The git build passed very well.
