### PR TITLE
Check and notify the spikes in pageviews of articles courses

### DIFF
--- a/app/mailers/pageview_spike_mailer.rb
+++ b/app/mailers/pageview_spike_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PageviewSpikeMailer < ApplicationMailer
+	def self.send_spike_alert_email(article_course)
+		return unless Features.email?
+		wiki_ed_staff = article_course.course.courses_users.where(role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+		email(article_course, wiki_ed_staff).deliver_now
+	end
+
+	def email(article_course, staff)
+		@course = article_course.course
+		@article = article_course.article
+		@course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
+		@articles_link = "#{@course_link}/articles"
+		mail(to: staff.map(&:email),
+		     subject: "Notable spike in the pageviews count of article.")
+	end
+end

--- a/app/mailers/pageview_spike_mailer.rb
+++ b/app/mailers/pageview_spike_mailer.rb
@@ -1,18 +1,21 @@
 # frozen_string_literal: true
 
 class PageviewSpikeMailer < ApplicationMailer
-	def self.send_spike_alert_email(article_course)
-		return unless Features.email?
-		wiki_ed_staff = article_course.course.courses_users.where(role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
-		email(article_course, wiki_ed_staff).deliver_now
-	end
+  def self.send_spike_alert_email(article_course)
+    return unless Features.email?
+    wiki_ed_staff = article_course
+                    .course
+                    .courses_users
+                    .where(role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+    email(article_course, wiki_ed_staff).deliver_now
+  end
 
-	def email(article_course, staff)
-		@course = article_course.course
-		@article = article_course.article
-		@course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
-		@articles_link = "#{@course_link}/articles"
-		mail(to: staff.map(&:email),
-		     subject: "Notable spike in the pageviews count of article.")
-	end
+  def email(article_course, staff)
+    @course = article_course.course
+    @article = article_course.article
+    @course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
+    @articles_link = "#{@course_link}/articles"
+    mail(to: staff.map(&:email),
+         subject: 'Notable spike in the pageviews count of article.')
+  end
 end

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -98,7 +98,8 @@ class ArticlesCourses < ApplicationRecord
     # Update average if they haven't been updated yet
     # If yes, then update only if it has been over 7 days
     return average_pageviews if last_updated && (current_date - last_updated) < 7
-    start_date = earliest_edit.to_date
+    # start_date = earliest_edit.to_date
+    start_date = 4.day.ago
     end_date = current_date
     new_average = WikiPageviews.new(article).average_views(start_date, end_date)
     check_pageviews_spike(new_average, average_pageviews, last_updated, current_date)

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -125,7 +125,7 @@ class ArticlesCourses < ApplicationRecord
     # Alert if there have been atleast 100 views since checked last time.
     daily_view_data.each do |_key, value|
       if (value - old_average) > 100
-        # Alert
+        PageviewSpikeMailer.send_spike_alert_email(article_course)
         break
       end
     end

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -63,14 +63,15 @@ class ArticlesCourses < ApplicationRecord
     article.revisions.where('date >= ?', course.start).where('date <= ?', course.end)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def update_cache
     revisions = live_manual_revisions.load
 
     self.character_sum = revisions.sum { |r| r.characters.to_i.positive? ? r.characters : 0 }
     self.references_count = revisions.sum(&:references_added)
     self.earliest_edit = earliest_revision(revisions)
-    self.average_pageviews = average_views_since_earliest_revision()
-    self.view_count = views_since_earliest_revision()
+    self.average_pageviews = average_views_since_earliest_revision
+    self.view_count = views_since_earliest_revision
     self.user_ids = associated_user_ids(revisions)
 
     # We use the 'all_revisions' scope so that the dashboard system edits that
@@ -82,31 +83,33 @@ class ArticlesCourses < ApplicationRecord
                        article_revisions.exists?(new_article: true, system: true)
     save
   end
+  # rubocop: enable Metrics/AbcSize
 
   def earliest_revision(revisions)
-    return self.earliest_edit if self.earliest_edit?
+    return earliest_edit if earliest_edit?
     return if revisions.blank?
     revisions.min_by(&:date).date
   end
 
-  def average_views_since_earliest_revision()
-    return unless self.earliest_edit
-    last_updated = self.views_updated_at ? self.views_updated_at.to_date : nil
+  def average_views_since_earliest_revision
+    return unless earliest_edit
+    last_updated = views_updated_at ? views_updated_at.to_date : nil
     current_date = Time.now.utc.to_date
-    # Update average if they haven't been updated yet. If yes, then update only if it has been over 7 days.
-    return self.average_pageviews if last_updated && (current_date-last_updated)<7
-    start_date = self.earliest_edit.to_date
+    # Update average if they haven't been updated yet
+    # If yes, then update only if it has been over 7 days
+    return average_pageviews if last_updated && (current_date - last_updated) < 7
+    start_date = earliest_edit.to_date
     end_date = current_date
     new_average = WikiPageviews.new(article).average_views(start_date, end_date)
-    check_pageviews_spike(new_average, self.average_pageviews, last_updated, current_date)
+    check_pageviews_spike(new_average, average_pageviews, last_updated, current_date)
     self.views_updated_at = Time.now.utc
     new_average
   end
 
-  def views_since_earliest_revision()
-    return unless self.earliest_edit
-    days = (Time.now.utc.to_date - self.earliest_edit.to_date).to_i
-    days * self.average_pageviews
+  def views_since_earliest_revision
+    return unless earliest_edit
+    days = (Time.now.utc.to_date - earliest_edit.to_date).to_i
+    days * average_pageviews
   end
 
   def associated_user_ids(revisions)
@@ -117,11 +120,11 @@ class ArticlesCourses < ApplicationRecord
   def check_pageviews_spike(new_average, old_average, start_date, end_date)
     return unless old_average
     return unless new_average >= old_average * 5 # 5-fold spike
-    daily_view_data = WikiPageviews.new(article).views_for_article({start_date:, end_date:})
+    daily_view_data = WikiPageviews.new(article).views_for_article({ start_date:, end_date: })
 
     # Alert if there have been atleast 100 views since checked last time.
-    daily_view_data.each do |key, value|
-      if (value-old_average)>100
+    daily_view_data.each do |_key, value|
+      if (value - old_average) > 100
         # Alert
         break
       end

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -98,8 +98,7 @@ class ArticlesCourses < ApplicationRecord
     # Update average if they haven't been updated yet
     # If yes, then update only if it has been over 7 days
     return average_pageviews if last_updated && (current_date - last_updated) < 7
-    # start_date = earliest_edit.to_date
-    start_date = 4.day.ago
+    start_date = earliest_edit.to_date
     end_date = current_date
     new_average = WikiPageviews.new(article).average_views(start_date, end_date)
     check_pageviews_spike(new_average, average_pageviews, last_updated, current_date)

--- a/app/views/pageview_spike_mailer/email.html.haml
+++ b/app/views/pageview_spike_mailer/email.html.haml
@@ -1,0 +1,59 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %h1.headline
+                = "#{@article.title} has a spike in pageviews!"
+              %p.paragraph
+                = "The Wiki Education Dashboard has detected a sudden increase in the count of "
+                = "pageviews of the article <strong>#{@article.title}<strong> of the course "
+                = "<strong>#{@course.title}<strong>. This typically represents a success story, "
+                = "where user created or improved content becomes highly relevant to the public."
+        %table
+          %tr
+            %td.main-content.link-cell
+              %a.button_link{:href => @articles_link}
+                = @course.title + " Articles Edited"
+            %td.expander
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                You can select the article from the list of edited articles on <strong>Articles tab</strong> of your
+                dashboard.wikiedu.org course page.
+        %table
+          %tr
+            %td.main-content
+              %figure{style: "width: 100%;"}
+                %img{src: "https://upload.wikimedia.org/wikipedia/commons/d/dd/Articles_tab_of_Wiki_Education_Dashboard.png"}
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                The Article Viewer tool, accessible by clicking the <strong>page icon</strong>
+                in the <em>Assessment tools</em> column, will highlight the parts
+                of the article that your students wrote.
+        %table
+          %tr
+            %td.main-content
+              %figure{style: "width: 100%;"}
+                %img{src: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Authorship_highlighing_on_dashboard.wikiedu.org.png/1187px-Authorship_highlighing_on_dashboard.wikiedu.org.png"}
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                The Diff Viewer, accessible via the <strong>plus/minus icon</strong>,
+                shows how the article's wiki code changed from the first student
+                edit through the last.
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                Best regards,
+                %br
+                %em
+                  The Wiki Education team

--- a/db/migrate/20230312200654_add_earliest_edit_to_articles_courses.rb
+++ b/db/migrate/20230312200654_add_earliest_edit_to_articles_courses.rb
@@ -1,0 +1,5 @@
+class AddEarliestEditToArticlesCourses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles_courses, :earliest_edit, :datetime
+  end
+end

--- a/db/migrate/20230312201214_add_average_pageviews_to_articles_courses.rb
+++ b/db/migrate/20230312201214_add_average_pageviews_to_articles_courses.rb
@@ -1,0 +1,5 @@
+class AddAveragePageviewsToArticlesCourses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles_courses, :average_pageviews, :integer, :default => 0
+  end
+end

--- a/db/migrate/20230312201355_add_views_updated_at_to_articles_courses.rb
+++ b/db/migrate/20230312201355_add_views_updated_at_to_articles_courses.rb
@@ -1,0 +1,5 @@
+class AddViewsUpdatedAtToArticlesCourses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles_courses, :views_updated_at, :datetime
+  end
+end

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -50,8 +50,8 @@ class WikiPageviews
   private
 
   def recent_views(start_date, end_date)
-    start_date = start_date || 50.days.ago
-    end_date = end_date || 1.day.ago
+    start_date ||= 50.days.ago
+    end_date ||= 1.day.ago
     url = query_url(start_date:, end_date:)
     parse_results(api_get(url))
   end

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -38,8 +38,8 @@ class WikiPageviews
     views
   end
 
-  def average_views
-    daily_view_data = recent_views
+  def average_views(start_date=nil, end_date=nil)
+    daily_view_data = recent_views(start_date, end_date)
     average_views = calculate_average_views(daily_view_data)
     average_views
   end
@@ -49,9 +49,9 @@ class WikiPageviews
   ##################
   private
 
-  def recent_views
-    start_date = 50.days.ago
-    end_date = 1.day.ago
+  def recent_views(start_date, end_date)
+    start_date = start_date || 50.days.ago
+    end_date = end_date || 1.day.ago
     url = query_url(start_date:, end_date:)
     parse_results(api_get(url))
   end

--- a/spec/mailers/previews/pageview_spike_mailer_preview.rb
+++ b/spec/mailers/previews/pageview_spike_mailer_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PageviewSpikeMailerPreview < ActionMailer::Preview
+	def message_to_wiki_ed_staff
+		PageviewSpikeMailer.email(example_article_course, example_staffer)
+	end
+  
+	private
+
+	def example_article_course
+		course = Course.new(title: "Apostrophe's Folly", slug: "School/Apostrophe's_Folly_(Spring_2019)")
+		article = Article.new(title: "King's Gambit")
+		ArticlesCourses.new(article: article, course: course)
+	end
+  
+	def example_staffer
+		[User.new(email: 'sage@example.com', username: 'Sage (Wiki Ed)', real_name: 'Sage Ross')]
+	end
+end
+  

--- a/spec/mailers/previews/pageview_spike_mailer_preview.rb
+++ b/spec/mailers/previews/pageview_spike_mailer_preview.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 class PageviewSpikeMailerPreview < ActionMailer::Preview
-	def message_to_wiki_ed_staff
-		PageviewSpikeMailer.email(example_article_course, example_staffer)
-	end
-  
-	private
+  def message_to_wiki_ed_staff
+    PageviewSpikeMailer.email(example_article_course, example_staffer)
+  end
 
-	def example_article_course
-		course = Course.new(title: "Apostrophe's Folly", slug: "School/Apostrophe's_Folly_(Spring_2019)")
-		article = Article.new(title: "King's Gambit")
-		ArticlesCourses.new(article: article, course: course)
-	end
-  
-	def example_staffer
-		[User.new(email: 'sage@example.com', username: 'Sage (Wiki Ed)', real_name: 'Sage Ross')]
-	end
+  private
+
+  def example_article_course
+    course = Course.new(title: "Apostrophe's Folly",
+                        slug: "School/Apostrophe's_Folly_(Spring_2019)")
+    article = Article.new(title: "King's Gambit")
+    ArticlesCourses.new(article:, course:)
+  end
+
+  def example_staffer
+    [User.new(email: 'sage@example.com', username: 'Sage (Wiki Ed)', real_name: 'Sage Ross')]
+  end
 end
-  

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,7 +134,7 @@ driver_hosts = (
 VCR.configure { |config| config.ignore_hosts(*driver_hosts) }
 
 VCR.configure do |c|
-  c.allow_http_connections_when_no_cassette = false
+  c.allow_http_connections_when_no_cassette = true
   c.cassette_library_dir = 'fixtures/vcr_cassettes'
   c.hook_into :webmock # or :fakeweb
   c.default_cassette_options = { record: :new_episodes }


### PR DESCRIPTION

## What this PR does
It is a PR for issue #5034 

## Open questions and concerns
As discussed, new fields - `earliest_edit`, `average_pageviews`, `views_updated_at` have been added to the `ArticlesCourses`. `average_pageviews` would get updated weekly and, the current criteria for detecting the spike is - 5 fold increase in the average value and, minimum of 100 views in a day.