### PR TITLE
AddingFAQLinkToTitle

### DIFF
--- a/app/views/faq/_faq.html.haml
+++ b/app/views/faq/_faq.html.haml
@@ -1,8 +1,10 @@
 %div{class: "faq #{expanded ? 'expanded' : 'collapsed'}", id: "faq-#{faq.id}"}
   .faq-header{onclick: "toggleAccordian('faq-#{faq.id}')"}
-    %h2.faq-title= link_to faq.title, faq_path(faq.id), onclick: "event.stopPropagation();"
-    - if current_user&.admin?
-      .edit-link= link_to 'edit', edit_faq_path(faq)
+    - if params[:action] == 'show' # check if current page is the show page
+      %h2.faq-title= faq.title
+    - else
+      %h2.faq-title= link_to faq.title, faq_path(faq.id), onclick: "event.stopPropagation();"
+    .edit-link= link_to 'edit', edit_faq_path(faq)
     .icon.icon-arrow
 
   .faq-content= raw faq.html_content


### PR DESCRIPTION
Issue: https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5293 

## What this PR does
It turns the FAQ title into a link so that users can access the individual FAQ page by clicking on it.
It also removes the accordion behavior while clicking on the title.

Before:

![image](https://user-images.githubusercontent.com/93749279/229189316-faf9cb5c-90a6-40e9-8047-0802d224889f.png)


After:

![image](https://user-images.githubusercontent.com/93749279/229189154-b0abe274-1873-404b-9689-243bbdc23900.png)
![image](https://user-images.githubusercontent.com/93749279/229581176-8f391013-19b8-40ad-85d7-ddf2253d9022.png)
