### PR TITLE
Enable rspec multiple describe linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,8 +162,6 @@ RSpec/DescribeClass:
   Enabled: false
 RSpec/ExpectInHook:
   Enabled: false
-RSpec/MultipleDescribes:
-  Enabled: false
 RSpec/ExampleWording:
   Enabled: false
 Style/DateTime:

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -6,9 +6,9 @@ require_dependency "#{Rails.root}/lib/importers/course_upload_importer"
 require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
-require_dependency "#{Rails.root}/lib/importers/average_views_importer"
-require_dependency "#{Rails.root}/lib/errors/update_service_error_helper"
-require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
+require_dependency Rails.root.join('lib', 'importers', 'average_views_importer')
+require_dependency Rails.root.join('lib', 'errors', 'update_service_error_helper')
+require_dependency Rails.root.join('lib', 'data_cycle', 'course_queue_sorting')
 
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -6,9 +6,9 @@ require_dependency "#{Rails.root}/lib/importers/course_upload_importer"
 require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
-require_dependency Rails.root.join('lib', 'importers', 'average_views_importer')
-require_dependency Rails.root.join('lib', 'errors', 'update_service_error_helper')
-require_dependency Rails.root.join('lib', 'data_cycle', 'course_queue_sorting')
+require_dependency "#{Rails.root}/lib/importers/average_views_importer"
+require_dependency "#{Rails.root}/lib/errors/update_service_error_helper"
+require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
 
 #= Pulls in new revisions for a single course and updates the corresponding records
 class UpdateCourseStats

--- a/spec/features/invalid_oauth_spec.rb
+++ b/spec/features/invalid_oauth_spec.rb
@@ -3,31 +3,31 @@
 require 'rails_helper'
 
 describe 'user authentication with oauth credentials', type: :feature do
-describe 'a user with invalid oauth credentials' do
-  before do
-    user = create(:user, wiki_token: 'invalid')
-    login_as user
+  describe 'a user with invalid oauth credentials' do
+    before do
+      user = create(:user, wiki_token: 'invalid')
+      login_as user
+    end
+
+    it 'gets logged out and see a message about the problem' do
+      error_message = I18n.t('error.oauth_invalid')
+      visit root_path
+      expect(page).to have_content error_message
+      expect(page).to have_content 'Log in'
+    end
   end
 
-  it 'gets logged out and see a message about the problem' do
-    error_message = I18n.t('error.oauth_invalid')
-    visit root_path
-    expect(page).to have_content error_message
-    expect(page).to have_content 'Log in'
+  describe 'a user whose oauth credentials expire', type: :feature do
+    let(:admin)  { create(:admin) }
+    let(:course) { create(:course, end: 1.year.from_now, submitted: true) }
+
+    it 'is logged out upon visiting a course' do
+      stub_token_request_failure
+
+      login_as admin
+      visit "/courses/#{escaped_slug course.slug}"
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content 'Your Wikipedia authorization has expired'
+    end
   end
-end
-
-describe 'a user whose oauth credentials expire', type: :feature do
-  let(:admin)  { create(:admin) }
-  let(:course) { create(:course, end: 1.year.from_now, submitted: true) }
-
-  it 'is logged out upon visiting a course' do
-    stub_token_request_failure
-
-    login_as admin
-    visit "/courses/#{escaped_slug course.slug}"
-    expect(page).to have_current_path(root_path)
-    expect(page).to have_content 'Your Wikipedia authorization has expired'
-  end
-end
 end

--- a/spec/features/invalid_oauth_spec.rb
+++ b/spec/features/invalid_oauth_spec.rb
@@ -2,7 +2,8 @@
 
 require 'rails_helper'
 
-describe 'a user with invalid oauth credentials', type: :feature do
+describe 'user authentication with oauth credentials', type: :feature do
+describe 'a user with invalid oauth credentials' do
   before do
     user = create(:user, wiki_token: 'invalid')
     login_as user
@@ -28,4 +29,5 @@ describe 'a user whose oauth credentials expire', type: :feature do
     expect(page).to have_current_path(root_path)
     expect(page).to have_content 'Your Wikipedia authorization has expired'
   end
+end
 end


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

**Enable Rspec/MultipleDescribe linter rule**
Fixed  Rspec/MultipleDescribe linter error by changing the feature specs for invalid and expired OAuth credentials to use a single describe block. The code has been organized into separate describe blocks, each containing one or more it blocks with a specific test case. This improves the readability and maintainability of the code. No functionality has been changed, only the structure of the code.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
