### PR TITLE
Fix "No results found for" bug on the campaigns page when there's zero campaigns in the database

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_list.jsx
@@ -68,7 +68,7 @@ const CampaignList = ({ keys, showSearch, RowElement, headerText, userOnly, newe
       <List
         elements={campaignElements}
         keys={keys}
-        none_message={I18n.t('application.no_results', { query: inputRef?.current?.value })}
+        none_message={I18n.t('application.no_results', { query: inputRef?.current?.value || ' ' })}
         sortable={true}
         sortBy={sortBy}
         className="table--expandable table--hoverable"


### PR DESCRIPTION
When there are zero campaigns in the database, No results found for '[missing "%{query}" value]' was being displayed, changed it to instead render No results found for ' '

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

**Fix No results found for '[missing "%{query}" value]' bug when there are zero campaigns in the database**

The none_message in the campaign_list,jsx did not handle the case when there is no current search query value and the fetched all_campaigns array from the database is empty. So if the value is empty or null, the query parameter in the I18n.t function call will be undefined and will not match the %{query} placeholder in the translation string resulting in it rendering "No results found for '[missing "%{query}" value]' ".

This pull request fixes that bug by giving an option of rendering an empty string for the mentioned scenario.

 


## Screenshots
Before:
< add a screenshot of the UI before your change >
![wikimedia-campaigns](https://user-images.githubusercontent.com/64524758/229179122-11fc4fca-9dae-466e-b4ad-6a708649a932.png)


After:
< add a screenshot of the UI after your change >
![wikimedi_after](https://user-images.githubusercontent.com/64524758/229181114-971e3001-0802-476d-a6d8-20d300c40e4c.png)



## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
