### PR TITLE
Fix violations of the Rails/SkipsModelValidations cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -112,8 +112,6 @@ Rails/I18nLocaleTexts:
 
 Rails/FilePath:
   Enabled: false
-Rails/SkipsModelValidations:
-  Enabled: false
 Performance/UnfreezeString:
   Enabled: false
 Style/GuardClause:

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -187,7 +187,7 @@ class CoursesController < ApplicationController
 
   def needs_update
     @course = find_course_by_slug(params[:id])
-    @course.update_attribute(:needs_update, true)
+    @course.update(needs_update: true)
     render json: { result: I18n.t('courses.creator.update_scheduled') },
            status: :ok
   end
@@ -255,7 +255,7 @@ class CoursesController < ApplicationController
 
   def ensure_passcode_set
     return unless course_params[:passcode].nil?
-    @course.update_attribute(:passcode, GeneratePasscode.call)
+    @course.update(passcode: GeneratePasscode.call)
   end
 
   def initial_campaign_params

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -131,7 +131,7 @@ class RequestedAccountsController < ApplicationController
   def handle_existing_request
     existing_request = RequestedAccount.find_by(course: @course, username: params[:username])
     if existing_request
-      existing_request.update_attribute(:email, params[:email])
+      existing_request.update(email: params[:email])
       render json: { message: existing_request.updated_email_message }
       yield
     end

--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -57,7 +57,7 @@ class TrainingModulesUsersController < ApplicationController
   end
 
   def complete_module
-    @training_module_user.update_attribute(:completed_at, Time.now.utc)
+    @training_module_user.update(completed_at: Time.now.utc)
   end
 
   def last_slide?

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -56,7 +56,7 @@ class UserProfilesController < ApplicationController
 
   def delete_profile_image
     @user.user_profile.image.destroy
-    @user.user_profile.update_attribute(:image_file_link, nil)
+    @user.user_profile.update(image_file_link: nil)
     @user.user_profile.save
     redirect_to controller: 'user_profiles', action: 'show', username: @user.username
   end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -123,7 +123,7 @@ class Alert < ApplicationRecord
     experts = content_experts
     return if experts.empty?
     experts.each { |expert| AlertMailer.send_alert_email(self, expert) }
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 
   def email_course_admins
@@ -132,14 +132,14 @@ class Alert < ApplicationRecord
     admins.each do |admin|
       AlertMailer.send_alert_email(self, admin)
     end
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 
   def email_target_user
     return if emails_disabled?
     return if target_user.nil?
     AlertMailer.send_alert_email(self, target_user)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 
   # Disable emails for specific alert types in application.yml, like so:

--- a/app/models/alert_types/d_y_k_nomination_alert.rb
+++ b/app/models/alert_types/d_y_k_nomination_alert.rb
@@ -44,6 +44,6 @@ class DYKNominationAlert < Alert
   def email_instructors_and_wikipedia_experts
     return if emails_disabled?
     DidYouKnowAlertMailer.send_dyk_email(self)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 end

--- a/app/models/alert_types/first_enrolled_student_alert.rb
+++ b/app/models/alert_types/first_enrolled_student_alert.rb
@@ -33,7 +33,7 @@ class FirstEnrolledStudentAlert < Alert
   def send_email
     return if emails_disabled?
     FirstEnrolledStudentAlertMailer.send_email(self)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 
   def from_user

--- a/app/models/alert_types/high_quality_article_assignment_alert.rb
+++ b/app/models/alert_types/high_quality_article_assignment_alert.rb
@@ -47,6 +47,6 @@ class HighQualityArticleAssignmentAlert < Alert
   def email_involved_users
     return if emails_disabled?
     HighQualityArticleAssignmentMailer.send_email(self)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 end

--- a/app/models/alert_types/no_enrolled_students_alert.rb
+++ b/app/models/alert_types/no_enrolled_students_alert.rb
@@ -33,7 +33,7 @@ class NoEnrolledStudentsAlert < Alert
   def send_email
     return if emails_disabled?
     NoEnrolledStudentsAlertMailer.send_email(self)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 
   def from_user

--- a/app/models/alert_types/untrained_students_alert.rb
+++ b/app/models/alert_types/untrained_students_alert.rb
@@ -33,7 +33,7 @@ class UntrainedStudentsAlert < Alert
   def send_email
     return if emails_disabled?
     UntrainedStudentsAlertMailer.send_email(self)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   end
 
   def from_user

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -496,7 +496,7 @@ class Course < ApplicationRecord
   # Weeks are expected to have the same order as their ids.
   def reorder_weeks
     weeks.each_with_index do |week, i|
-      week.update_attribute(:order, i + 1)
+      week.update(order: i + 1)
     end
   end
 

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -124,7 +124,9 @@ class ArticlesCourses < ApplicationRecord
     return if new_records.empty?
     # Do this is batches to avoid running the MySQL server out of memory
     new_records.each_slice(5000) do |new_record_slice|
+      # rubocop:disable Rails/SkipsModelValidations
       insert_all new_record_slice
+      # rubocop:enable Rails/SkipsModelValidations
     end
   end
 

--- a/app/models/surveys/survey_notification.rb
+++ b/app/models/surveys/survey_notification.rb
@@ -51,7 +51,7 @@ class SurveyNotification < ApplicationRecord
     return if email_sent_at.present?
     return if user.email.nil?
     SurveyMailer.send_notification(self)
-    update_attribute(:email_sent_at, Time.zone.now)
+    update(email_sent_at: Time.zone.now)
   rescue Mailgun::CommunicationError => e
     Sentry.capture_exception e, extra: { username: user.username,
                                          email: user.email,

--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -44,9 +44,11 @@ class Category < ApplicationRecord
       sanitize_4_byte_string ArticleUtils.format_article_title(title)
     end
     save
+    # rubocop:disable Rails/SkipsModelValidations
     # Using touch to update the timestamps even when there is actually no
     # updation (SQL update query) in the category
     touch(:updated_at)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def article_ids

--- a/lib/article_status_manager.rb
+++ b/lib/article_status_manager.rb
@@ -24,7 +24,9 @@ class ArticleStatusManager
         # excuted in a single query, otherwise if we use find_in_batches, query for
         # each article for updating the same would be required
         new(wiki).update_status(article_batch)
+        # rubocop:disable Rails/SkipsModelValidations
         article_batch.touch_all(:updated_at)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
   end
@@ -126,7 +128,7 @@ class ArticleStatusManager
       # Reload to account for articles that have had their mw_page_id changed
       # because the page was moved rather than deleted.
       next unless @deleted_page_ids.include? article.reload.mw_page_id
-      article.update_attribute(:deleted, true)
+      article.update(deleted: true)
     end
   end
 
@@ -144,7 +146,9 @@ class ArticleStatusManager
     # If there is only one copy of the article, it was already found and updated
     # via `update_title_and_namespace`
     return unless nondeleted_article
+    # rubocop:disable Rails/SkipsModelValidations
     article.revisions.update_all(article_id: nondeleted_article.id)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def data_matches_article?(article_data, article)

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -94,7 +94,12 @@ class CourseCloneManager
 
   def clear_meeting_days_and_due_dates
     @clone.update(day_exceptions: '', weekdays: '0000000', no_day_exceptions: false)
+
+    # we can use `update_all` since there are no callbacks on Block
+    # rubocop:disable Rails/SkipsModelValidations
     @clone.blocks.update_all(due_date: nil)
+    # rubocop:enable Rails/SkipsModelValidations
+
     @clone.reload
   end
 

--- a/lib/importers/upload_importer.rb
+++ b/lib/importers/upload_importer.rb
@@ -40,7 +40,7 @@ class UploadImporter
                  .find_in_batches(batch_size: 50) do |file_batch|
       deleted_files = Commons.find_missing_files file_batch
       CommonsUpload.transaction do
-        deleted_files.each { |file| file.update_attribute(:deleted, true) }
+        deleted_files.each { |file| file.update(deleted: true) }
       end
     end
   end

--- a/lib/modified_revisions_manager.rb
+++ b/lib/modified_revisions_manager.rb
@@ -45,11 +45,15 @@ class ModifiedRevisionsManager
   end
 
   def update_deleted_revisions(rev_ids)
+    # rubocop:disable Rails/SkipsModelValidations
     Revision.where(wiki_id: @wiki.id, mw_rev_id: rev_ids).update_all(deleted: true)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def update_nondeleted_revisions(rev_ids)
+    # rubocop:disable Rails/SkipsModelValidations
     Revision.where(wiki_id: @wiki.id, mw_rev_id: rev_ids).update_all(deleted: false)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 
   def handle_moved_revision(moved)

--- a/lib/tasks/assignment.rake
+++ b/lib/tasks/assignment.rake
@@ -24,7 +24,9 @@ namespace :assignment do
     Assignment.where('created_at < ?', '2019-08-01'.to_date).find_each do |assignment|
       url = generate_generic_sandbox_url(assignment)
       # update_columns will skip the callbacks on assignment
+      # rubocop:disable Rails/SkipsModelValidations
       assignment.update_columns(sandbox_url: url) if url
+      # rubocop:enable Rails/SkipsModelValidations
     end
   end
 end

--- a/lib/wiki_edits.rb
+++ b/lib/wiki_edits.rb
@@ -14,7 +14,10 @@ class WikiEdits
   #######################
   def oauth_credentials_valid?(current_user)
     get_tokens(current_user)
+    # this will only update the `updated_at` field, and will skip callbacks
+    # rubocop:disable Rails/SkipsModelValidations
     current_user.touch
+    # rubocop:enable Rails/SkipsModelValidations
     current_user.wiki_token != 'invalid'
   end
 

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -209,7 +209,11 @@ describe CoursesController, type: :request do
     context 'setting passcode' do
       let(:course) { create(:course, slug: slug_params) }
 
-      before { course.update(passcode: nil) }
+      before do
+        # skip validations here - some course types allow nil passcodes, some dont
+        course.passcode = nil
+        course.save(validate: false)
+      end
 
       it 'sets randomly if it is nil and not in params' do
         params = { id: course.slug, course: { title: 'foo' } }

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -209,7 +209,7 @@ describe CoursesController, type: :request do
     context 'setting passcode' do
       let(:course) { create(:course, slug: slug_params) }
 
-      before { course.update_attribute(:passcode, nil) }
+      before { course.update(passcode: nil) }
 
       it 'sets randomly if it is nil and not in params' do
         params = { id: course.slug, course: { title: 'foo' } }

--- a/spec/features/course_overview_spec.rb
+++ b/spec/features/course_overview_spec.rb
@@ -51,7 +51,7 @@ describe 'course overview page', type: :feature, js: true do
     let(:timeline_start) { '2025-02-11'.to_date + 2.weeks } # a Tuesday
 
     before do
-      course.update_attribute(:timeline_start, timeline_start)
+      course.update(timeline_start:)
       visit "/courses/#{course.slug}"
       sleep 1
     end

--- a/spec/lib/alerts/continued_course_activity_alert_manager_spec.rb
+++ b/spec/lib/alerts/continued_course_activity_alert_manager_spec.rb
@@ -76,7 +76,7 @@ describe ContinuedCourseActivityAlertManager do
       revision
       subject.create_alerts
 
-      Alert.first.update_attribute(:resolved, true)
+      Alert.first.update(resolved: true)
 
       subject.create_alerts
 

--- a/spec/lib/course_training_progress_manager_spec.rb
+++ b/spec/lib/course_training_progress_manager_spec.rb
@@ -70,7 +70,7 @@ describe CourseTrainingProgressManager do
                    training_module_id: tm_id,
                    user_id: user.id)
           end
-          TrainingModulesUsers.last.update_attribute(:completed_at, 1.hour.ago)
+          TrainingModulesUsers.last.update(completed_at: 1.hour.ago)
         end
 
         it 'returns "1/1 training modules completed"' do
@@ -89,7 +89,7 @@ describe CourseTrainingProgressManager do
                    training_module_id: tm_id,
                    user_id: user.id)
           end
-          TrainingModulesUsers.last.update_attribute(:completed_at, 1.hour.ago)
+          TrainingModulesUsers.last.update(completed_at: 1.hour.ago)
         end
 
         it 'returns "1/2 training modules completed"' do
@@ -109,8 +109,8 @@ describe CourseTrainingProgressManager do
                    user_id: user.id)
           end
           # Complete module 1 and 35
-          TrainingModulesUsers.first.update_attribute(:completed_at, 1.hour.ago)
-          TrainingModulesUsers.last.update_attribute(:completed_at, 1.hour.ago)
+          TrainingModulesUsers.first.update(completed_at: 1.hour.ago)
+          TrainingModulesUsers.last.update(completed_at: 1.hour.ago)
         end
 
         it 'returns "1/2 training modules completed"' do
@@ -166,8 +166,8 @@ describe CourseTrainingProgressManager do
                    user_id: user.id)
           end
           exercise = TrainingModulesUsers.last
-          exercise.update_attribute(:completed_at, 1.hour.ago)
-          exercise.update_attribute(:flags, marked_complete: true)
+          exercise.update(completed_at: 1.hour.ago)
+          exercise.update(flags: { marked_complete: true })
         end
 
         it 'returns "1/1 exercise completed"' do
@@ -187,8 +187,8 @@ describe CourseTrainingProgressManager do
                    user_id: user.id)
           end
           exercise = TrainingModulesUsers.last
-          exercise.update_attribute(:completed_at, 1.hour.ago)
-          exercise.update_attribute(:flags, marked_complete: true)
+          exercise.update(completed_at: 1.hour.ago)
+          exercise.update(flags: { marked_complete: true })
         end
 
         it 'returns "1/2 exercises completed"' do
@@ -208,10 +208,10 @@ describe CourseTrainingProgressManager do
                    user_id: user.id)
           end
           # Complete module 1 and 35
-          TrainingModulesUsers.first.update_attribute(:completed_at, 1.hour.ago)
+          TrainingModulesUsers.first.update(completed_at: 1.hour.ago)
           exercise = TrainingModulesUsers.last
-          exercise.update_attribute(:completed_at, 1.hour.ago)
-          exercise.update_attribute(:flags, marked_complete: true)
+          exercise.update(completed_at: 1.hour.ago)
+          exercise.update(flags: { marked_complete: true })
         end
 
         it 'returns "1/2 exercises completed"' do

--- a/spec/lib/revision_stat_spec.rb
+++ b/spec/lib/revision_stat_spec.rb
@@ -49,7 +49,7 @@ describe RevisionStat do
 
     context 'course id' do
       context 'not for this course' do
-        before { course.update_column(:id, 1000) }
+        before { course.update(id: 1000) }
 
         it 'does not include in scope' do
           expect(subject).to eq(0)
@@ -88,7 +88,7 @@ describe RevisionStat do
     end
 
     context 'for user' do
-      before { user.update_attribute(:id, user_id) }
+      before { user.update(id: user_id) }
 
       context 'user has courses users' do
         let(:user_id) { user.id }
@@ -115,7 +115,7 @@ describe RevisionStat do
       end
 
       context 'user has no revisions' do
-        before { revision.update_attribute(:user_id, (user.id - 1)) }
+        before { revision.update(user_id: (user.id - 1)) }
 
         it 'is empty' do
           expect(subject.count).to eq(0)


### PR DESCRIPTION
## What this PR does
This PR is a part of https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5297. It should fix all violations of the `Rails/SkipsModelValidations` cop, and remove the rule from the temporary exceptions list in `rubocop.yml`. We allow exceptions to this rule in-line when we are bulk updating potentially many rows on a table and don't care about skipping callbacks. 

## Open questions and concerns
My thought is that we should enforce the rule, but allow exceptions in-line for when we know what we are doing. It pollutes the code with `rubocop:enable`/`rubocop:disable` comments, but it helps contributors and reviewers not skip callbacks they were intending to run. How do we feel about that? 
