### PR TITLE
Fixing error for for FAQ edit link

### DIFF
--- a/app/views/faq/_faq.html.haml
+++ b/app/views/faq/_faq.html.haml
@@ -4,7 +4,8 @@
       %h2.faq-title= faq.title
     - else
       %h2.faq-title= link_to faq.title, faq_path(faq.id), onclick: "event.stopPropagation();"
-    .edit-link= link_to 'edit', edit_faq_path(faq)
+    - if current_user&.admin?
+      .edit-link= link_to 'edit', edit_faq_path(faq)
     .icon.icon-arrow
 
   .faq-content= raw faq.html_content


### PR DESCRIPTION
This PR fixes the error of having the edit link for only admin accounts.

When any admin users log in, they can see the edit link:
![image](https://user-images.githubusercontent.com/93749279/229589034-f4f9cccb-4a2b-4286-b87f-3eb3897900e2.png)


When logged out the FAQ page looks like this:
![image](https://user-images.githubusercontent.com/93749279/229588766-410e7457-5779-465c-94d8-cb537fe70246.png)
