### PR TITLE
Upgraded package react-router-hash-link to ^2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-paginate": "^8.1.5",
     "react-redux": "^7.2.3",
     "react-router-dom": "^6.2.2",
-    "react-router-hash-link": "^1.2.2",
+    "react-router-hash-link": "^2.4.3",
     "react-scroll": "^1.8.1",
     "react-select": "^5.7.2",
     "react-switch": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,7 +2860,7 @@ __metadata:
     react-redux: ^7.2.3
     react-refresh: ^0.14.0
     react-router-dom: ^6.2.2
-    react-router-hash-link: ^1.2.2
+    react-router-hash-link: ^2.4.3
     react-scroll: ^1.8.1
     react-select: ^5.7.2
     react-switch: ^6.0.0
@@ -10727,15 +10727,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-hash-link@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "react-router-hash-link@npm:1.2.2"
+"react-router-hash-link@npm:^2.4.3":
+  version: 2.4.3
+  resolution: "react-router-hash-link@npm:2.4.3"
   dependencies:
-    prop-types: ^15.6.0
+    prop-types: ^15.7.2
   peerDependencies:
     react: ">=15"
     react-router-dom: ">=4"
-  checksum: 0636f08edbe252178f54733d65468fb1bf2a21a79a0a3b83b6c7c19c4087a7b1475c6026e348bfc3d8c79af2cce68a1d459d40b1128e15f64a04c80bca473a0a
+  checksum: 7dad53ebbd726e8a1ab379f4e68bce3a6b406e55af3de8a9c128510a81ad4a681ce9a5e25c0efc3d3c283b276145729b6228d0173d1d0c6e04b9cc6fb10738d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does
upgraded [react-router-hash-link](https://www.npmjs.com/package/react-router-hash-link) which is used for hash link scrolling to latest version 2.4.3.

## Screenshots
[Screencast from 09-04-23 09:14:45 PM IST.webm](https://user-images.githubusercontent.com/72390769/230782728-83a6aa5d-99dc-4fc1-883e-f6942dc47e46.webm)
