### PR TITLE
Change course students default sorting to username

### DIFF
--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -4,9 +4,8 @@ import { sortByKey } from '../utils/model_utils';
 const initialState = {
   users: [],
   sort: {
-    sortKey: null,
+    sortKey: 'real_name',
     key: null,
-    initialSortKey: 'real_name'
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -25,17 +24,12 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      const sortKey = state.sort.sortKey || state.sort.initialSortKey;
-      const sortedUsers = sortByKey(action.data.course.users, sortKey, 'username');
+      const sortedUsers = sortByKey(action.data.course.users, state.sort.sortKey, 'username');
       return {
         ...state,
         users: sortedUsers.newModels,
         isLoaded: true,
         lastRequestTimestamp: Date.now(),
-        sort: {
-          ...state.sort,
-          sortKey
-        }
       };
     }
 

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -24,7 +24,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      const sortedUsers = sortByKey(action.data.course.users, state.sort.sortKey, 'username');
+      const sortedUsers = sortByKey(action.data.course.users, state.sort.sortKey, 'username', null, false, false, true);
       return {
         ...state,
         users: sortedUsers.newModels,

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -6,8 +6,8 @@ const initialState = {
   sort: {
     sortKey: null,
     key: null,
-    defaultKey: 'username',
-    defaultDirection: 'desc'
+    initialSortKey: 'real_name',
+    initialSortDirection: 'asc'
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -26,7 +26,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-        const sortedUsers = sortByKey(action.data.course.users, state.sort.defaultKey, null, false, false, false);
+     const sortedUsers = sortByKey(action.data.course.users, state.sort.initialSortKey, 'username' || state.sort.sortKey, null, false, false, false);
       return {
         ...state,
         users: sortedUsers.newModels,

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -6,6 +6,7 @@ const initialState = {
   sort: {
     sortKey: null,
     key: null,
+    initialSortKey: 'real_name'
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -24,8 +25,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      const initialSortKey = 'real_name';
-      const sortKey = state.sort.sortKey || initialSortKey;
+      const sortKey = state.sort.sortKey || state.sort.initialSortKey;
       const sortedUsers = sortByKey(action.data.course.users, sortKey, 'username');
       return {
         ...state,

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -26,7 +26,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-        const sortedUsers = sortByKey(action.data.course.users, state.sort.defaultKey, null, false, false, true);
+        const sortedUsers = sortByKey(action.data.course.users, state.sort.defaultKey, null, false, false, false);
       return {
         ...state,
         users: sortedUsers.newModels,

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -6,8 +6,6 @@ const initialState = {
   sort: {
     sortKey: null,
     key: null,
-    initialSortKey: 'real_name',
-    initialSortDirection: 'asc'
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -26,12 +24,18 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-     const sortedUsers = sortByKey(action.data.course.users, state.sort.initialSortKey, 'username' || state.sort.sortKey, null, false, false, false);
+      const initialSortKey = 'real_name';
+      const sortKey = state.sort.sortKey || initialSortKey;
+      const sortedUsers = sortByKey(action.data.course.users, sortKey, 'username');
       return {
         ...state,
         users: sortedUsers.newModels,
         isLoaded: true,
-        lastRequestTimestamp: Date.now()
+        lastRequestTimestamp: Date.now(),
+        sort: {
+          ...state.sort,
+          sortKey
+        }
       };
     }
 

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -6,6 +6,8 @@ const initialState = {
   sort: {
     sortKey: null,
     key: null,
+    defaultKey: 'username',
+    defaultDirection: 'desc'
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -23,12 +25,16 @@ const SORT_DESCENDING = {
 
 export default function users(state = initialState, action) {
   switch (action.type) {
-    case RECEIVE_USERS: return {
-      ...state,
-      users: action.data.course.users,
-      isLoaded: true,
-      lastRequestTimestamp: Date.now()
-    };
+    case RECEIVE_USERS: {
+        const sortedUsers = sortByKey(action.data.course.users, state.sort.defaultKey, null, false, false, true);
+      return {
+        ...state,
+        users: sortedUsers.newModels,
+        isLoaded: true,
+        lastRequestTimestamp: Date.now()
+      };
+    }
+
     case ADD_USER:
     case REMOVE_USER:
       return {

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -24,7 +24,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      const sortedUsers = sortByKey(action.data.course.users, state.sort.sortKey, 'username', null, false, false, true);
+      const sortedUsers = sortByKey(action.data.course.users, state.sort.sortKey, null, false, false, true);
       return {
         ...state,
         users: sortedUsers.newModels,

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -127,8 +127,8 @@ describe 'Instructor users', type: :feature, js: true do
       click_button 'OK'
       sleep 1
       visit "/courses/#{Course.first.slug}/students"
-      expect(page).to have_content 'Student A'
-      expect(page).not_to have_content 'Student B'
+      expect(page).to have_content 'Student B'
+      expect(page).not_to have_content 'Student A'
     end
 
     it 'is able to assign articles' do

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -27,7 +27,7 @@ describe('users reducer', () => {
       const newInitialState = {
         users: users_array,
         sort: {
-          initialSortKey: 'real_name'
+          sortKey: 'real_name'
         }
       };
       deepFreeze(newInitialState);

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -27,7 +27,7 @@ describe('users reducer', () => {
       const newInitialState = {
         users: users_array,
         sort: {
-          defaultKey: 'username'
+          initialSortKey: 'last_name'
         }
       };
       deepFreeze(newInitialState);
@@ -42,14 +42,14 @@ describe('users reducer', () => {
       });
 
       let users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' }
+        { id: 1, username: 'foo', role: 'student', name: 'foo bar' },
+        { id: 2, username: 'bar', role: 'admin', name: 'foo user' }
       ];
       const mockedReceivedAction = action(RECEIVE_USERS, users_array);
       const receiveUserState = users(newInitialState, mockedReceivedAction);
       expect(receiveUserState.users).toEqual([
-        { id: 2, username: 'bar', role: 'admin' },
-        { id: 1, username: 'foo', role: 'student' }
+        { id: 1, username: 'foo', role: 'student', name: 'foo bar' },
+        { id: 1, username: 'foo', role: 'student', name: 'foo user' }
       ]);
       expect(receiveUserState.isLoaded).toBe(true);
 

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -40,7 +40,7 @@ describe('users reducer', () => {
       ];
       const mockedReceivedAction = action(RECEIVE_USERS, users_array);
       const receiveUserState = users(initialState, mockedReceivedAction);
-      expect(receiveUserState.users).toEqual(users_array);
+      expect(receiveUserState.users).toEq(users_array);
       expect(receiveUserState.isLoaded).toBe(true);
 
       users_array = [

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -24,6 +24,13 @@ describe('users reducer', () => {
     () => {
       const initialState = users(undefined, { type: null });
       deepFreeze(initialState);
+      const newInitialState = {
+        users: users_array,
+        sort: {
+          defaultKey: 'username'
+        }
+      };
+      deepFreeze(newInitialState);
 
       const action = (type, users_array) => ({
         type: type,
@@ -39,8 +46,11 @@ describe('users reducer', () => {
         { id: 2, username: 'bar', role: 'admin' }
       ];
       const mockedReceivedAction = action(RECEIVE_USERS, users_array);
-      const receiveUserState = users(initialState, mockedReceivedAction);
-      expect(receiveUserState.users).toEq(users_array);
+      const receiveUserState = users(newInitialState, mockedReceivedAction);
+      expect(receiveUserState.users).toEqual([
+        { id: 2, username: 'bar', role: 'admin' },
+        { id: 1, username: 'foo', role: 'student' }
+      ]);
       expect(receiveUserState.isLoaded).toBe(true);
 
       users_array = [

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -27,7 +27,7 @@ describe('users reducer', () => {
       const newInitialState = {
         users: users_array,
         sort: {
-          initialSortKey: 'last_name'
+          initialSortKey: 'real_name'
         }
       };
       deepFreeze(newInitialState);

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -49,7 +49,7 @@ describe('users reducer', () => {
       const receiveUserState = users(newInitialState, mockedReceivedAction);
       expect(receiveUserState.users).toEqual([
         { id: 1, username: 'foo', role: 'student', name: 'foo bar' },
-        { id: 1, username: 'foo', role: 'student', name: 'foo user' }
+        { id: 2, username: 'bar', role: 'admin', name: 'foo user' }
       ]);
       expect(receiveUserState.isLoaded).toBe(true);
 


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This PR adds a default sorting on the students tab in the Course Page to username. This helps with a better user experience especially when the facilitator wants to find the students by their names.
This PR is solving this [issue](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5343)

## Screenshots
Before:
![Screenshot from 2023-04-12 08-22-10](https://user-images.githubusercontent.com/88780311/231458042-13bede6b-73eb-40ad-9de4-a429ee908952.png)

After:
![Screenshot from 2023-04-12 08-23-06](https://user-images.githubusercontent.com/88780311/231458120-661cd3a5-7cbf-4687-9441-0b5c16b91fd5.png)
[Screencast from 04-12-2023 08:39:50 AM.webm](https://user-images.githubusercontent.com/88780311/231461218-81feb648-a404-4663-9319-4f5e76140973.webm)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
