### PR TITLE
removed package merge stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "lodash-es": "^4.17.15",
     "markdown-it": "^12.3.2",
     "markdown-it-footnote": "^3.0.2",
-    "merge-stream": "^2.0.0",
     "mini-css-extract-plugin": "^2.6.0",
     "nouislider": "^14.2.0",
     "nyc": "^15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,7 +2838,6 @@ __metadata:
     lodash-es: ^4.17.15
     markdown-it: ^12.3.2
     markdown-it-footnote: ^3.0.2
-    merge-stream: ^2.0.0
     mini-css-extract-plugin: ^2.6.0
     nouislider: ^14.2.0
     nyc: ^15.1.0


### PR DESCRIPTION
## What this PR does
This PR removes package [merge-stream](https://www.npmjs.com/package/merge-stream) since it was [added](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/d3bfec332de3948bbc155b17e39b7a1c776b1a7c#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) 8 years ago for merging gulp files. So, is of no use now.
