### PR TITLE
removed package babel-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "autosize": "^4.0.2",
     "babel-core": "^7.0.0-bridge.0",
-    "babel-jest": "^26.0.1",
     "babel-loader": "^8.2.2",
     "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-istanbul": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,7 +2797,6 @@ __metadata:
     "@wojtekmaj/enzyme-adapter-react-17": ^0.6.6
     autosize: ^4.0.2
     babel-core: ^7.0.0-bridge.0
-    babel-jest: ^26.0.1
     babel-loader: ^8.2.2
     babel-plugin-add-module-exports: ^1.0.2
     babel-plugin-istanbul: ^6.1.1
@@ -3411,7 +3410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^26.0.1, babel-jest@npm:^26.6.3":
+"babel-jest@npm:^26.6.3":
   version: 26.6.3
   resolution: "babel-jest@npm:26.6.3"
   dependencies:


### PR DESCRIPTION
 What this PR does
This PR removes package [babel-jest](https://www.npmjs.com/package/babel-jest) since, according to the docs it is to be used with `jest-cli` and was added with it [commit](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/ada207e83f5c7c1a04286e63676398323b27850a). But someone removed `jest-cli` but forgot to remove this and is not being used in project.


## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
