### PR TITLE
Add stats for edits in the lexeme namespace on wikidata

### DIFF
--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -213,8 +213,18 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
             />
           </div>
         </div>
-
-
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('items.lexeme')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="lexeme-created"
+              className="stat-display__value-small"
+              stat={statistics['lexeme items created']}
+              statMsg={I18n.t('metrics.created')}
+              renderZero={true}
+            />
+          </div>
+        </div>
       </div>
     </div>
     );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,7 @@ en:
 
   items:
     items: Items
+    lexeme: Lexeme
     article_not_found: "This item has not been created yet."
     assigned: Assigned Items
     assignments_none: There are no assigned items yet.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -254,6 +254,7 @@ fr:
     page_logs: (journaux des pages)
   items:
     items: Éléments
+    lexeme: Lexème
     article_not_found: Cet élément n’a pas encore été créé.
     assigned: Éléments affectés
     assignments_none: Il n’y a encore aucun élément affecté.

--- a/lib/analytics/course_wikidata_csv_builder.rb
+++ b/lib/analytics/course_wikidata_csv_builder.rb
@@ -27,6 +27,7 @@ class CourseWikidataCsvBuilder
     'claims changed',
     'claims removed',
     'items created',
+    'lexeme items created',
     'labels added',
     'labels changed',
     'labels removed',

--- a/lib/wikidata_summary_parser.rb
+++ b/lib/wikidata_summary_parser.rb
@@ -139,7 +139,8 @@ class WikidataSummaryParser
   end
 
   def created_item?
-    @summary.include? 'wbeditentity-create'
+    @summary.include?('wbeditentity-create') &&
+      @summary.exclude?('wbeditentity-create-lexeme')
   end
 
   def created_lexeme_item?

--- a/lib/wikidata_summary_parser.rb
+++ b/lib/wikidata_summary_parser.rb
@@ -10,6 +10,7 @@ class WikidataSummaryParser
     'claims changed' => :changed_claim?,
     'claims removed' => :removed_claim?,
     'items created' => :created_item?,
+    'lexeme items created' => :created_lexeme_item?,
     'labels added' => :added_label?,
     'labels changed' => :changed_label?,
     'labels removed' => :removed_label?,
@@ -68,6 +69,7 @@ class WikidataSummaryParser
       !changed_label? &&
       !removed_label? &&
       !created_item? &&
+      !created_lexeme_item? &&
       !merged_from? &&
       !merged_to? &&
       !added_interwiki_link? &&
@@ -138,6 +140,10 @@ class WikidataSummaryParser
 
   def created_item?
     @summary.include? 'wbeditentity-create'
+  end
+
+  def created_lexeme_item?
+    @summary.include? 'wbeditentity-create-lexeme'
   end
 
   # This edit summary can mean adding a claim, but it seems to be generic for edits


### PR DESCRIPTION
## What this PR does
Issue   #4283 (Add stats for edits in the Lexeme namespace on Wikidata) 

- new locales
- add a header for the csv generation + processing of a new string in revisions summary
- add data at the Front End: top of Course/Campaign page