### PR TITLE
removed package url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "stylelint-config-standard": "^32.0.0",
     "stylus": "^0.54.8",
     "tinymce": "^5.2.2",
-    "url-loader": "^4.1.0",
     "uuid": "^3.4.0",
     "velocity-animate": "^1.5.1",
     "vinyl-buffer": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,7 +2881,6 @@ __metadata:
     stylus: ^0.54.8
     stylus-native-loader: ^1.1.2
     tinymce: ^5.2.2
-    url-loader: ^4.1.0
     uuid: ^3.4.0
     velocity-animate: ^1.5.1
     vinyl-buffer: ^1.0.1
@@ -12763,23 +12762,6 @@ __metadata:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 4c076ecfbf3411e888547fe844e52378ab5ada2d2f27625139011eada79925e77f7fbf0e4016d45e6a9e9adb6b7e64981bd49b22700c7c401c5fc15f423303b3
-  languageName: node
-  linkType: hard
-
-"url-loader@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "url-loader@npm:4.1.1"
-  dependencies:
-    loader-utils: ^2.0.0
-    mime-types: ^2.1.27
-    schema-utils: ^3.0.0
-  peerDependencies:
-    file-loader: "*"
-    webpack: ^4.0.0 || ^5.0.0
-  peerDependenciesMeta:
-    file-loader:
-      optional: true
-  checksum: c1122a992c6cff70a7e56dfc2b7474534d48eb40b2cc75467cde0c6972e7597faf8e43acb4f45f93c2473645dfd803bcbc20960b57544dd1e4c96e77f72ba6fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does
Removed package [url-loader](https://www.npmjs.com/package/url-loader) as it is no longer used in the project. According to the documentation it is a loader for webpack and [here](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/ba478e38a10e7107597a12d88be87150594e7ae1#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166f) is the commit using this loader. But our current version of webpack is not using this loader.
