### PR TITLE
removed package isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint-plugin-react": "^7.20.5",
     "fetch-jsonp": "^1.2.1",
     "i18n-js": "^4.2.2",
-    "isomorphic-fetch": "^3.0.0",
     "jeet": "^7.2.0",
     "jest": "^26.0.1",
     "jquery": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,7 +2823,6 @@ __metadata:
     eslint-webpack-plugin: ^3.1.1
     fetch-jsonp: ^1.2.1
     i18n-js: ^4.2.2
-    isomorphic-fetch: ^3.0.0
     jeet: ^7.2.0
     jest: ^26.0.1
     jquery: ^3.5.1
@@ -7503,16 +7502,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-fetch@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "isomorphic-fetch@npm:3.0.0"
-  dependencies:
-    node-fetch: ^2.6.1
-    whatwg-fetch: ^3.4.1
-  checksum: e5ab79a56ce5af6ddd21265f59312ad9a4bc5a72cebc98b54797b42cb30441d5c5f8d17c5cd84a99e18101c8af6f90c081ecb8d12fd79e332be1778d58486d75
-  languageName: node
-  linkType: hard
-
 "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
   version: 3.2.0
   resolution: "istanbul-lib-coverage@npm:3.2.0"
@@ -9075,7 +9064,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.1":
+"node-fetch@npm:2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -13113,13 +13102,6 @@ __metadata:
   dependencies:
     iconv-lite: 0.4.24
   checksum: 5be4efe111dce29ddee3448d3915477fcc3b28f991d9cf1300b4e50d6d189010d47bca2f51140a844cf9b726e8f066f4aee72a04d687bfe4f2ee2767b2f5b1e6
-  languageName: node
-  linkType: hard
-
-"whatwg-fetch@npm:^3.4.1":
-  version: 3.6.2
-  resolution: "whatwg-fetch@npm:3.6.2"
-  checksum: ee976b7249e7791edb0d0a62cd806b29006ad7ec3a3d89145921ad8c00a3a67e4be8f3fb3ec6bc7b58498724fd568d11aeeeea1f7827e7e1e5eae6c8a275afed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does
Removed package [isomorphic-fetch](https://www.npmjs.com/package/isomorphic-fetch). As the documentation says, 

> The Fetch API is currently not implemented consistently across browsers. This module will enable you to use fetch in your Node code in a cross-browser-compliant fashion.

But, now our project is using fetch API and not using this. [Here](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/156678cde9278c4bfc9a9fdeddb22e0fb776def1) is the commit adding and using this package.