### PR TITLE
Prevent double fetching when one clicks on course edit details

### DIFF
--- a/app/assets/javascripts/components/overview/campaign_editable.jsx
+++ b/app/assets/javascripts/components/overview/campaign_editable.jsx
@@ -13,9 +13,8 @@ import Conditional from '../high_order/conditional.jsx';
 import { removeCampaign, fetchAllCampaigns, addCampaign } from '../../actions/campaign_actions';
 import { fetchUsers } from '../../actions/user_actions';
 
-const CampaignEditable = ({ course_id, campaigns, open, is_open, stop }) => {
+const CampaignEditable = ({ course_id, campaigns, is_open, stop }) => {
   const [selectedCampaigns, setSelectedCampaigns] = useState([]);
-  console.log(open, is_open, stop);
   const campaignSelectRef = useRef(null);
   const dispatch = useDispatch();
 

--- a/app/assets/javascripts/components/overview/campaign_editable.jsx
+++ b/app/assets/javascripts/components/overview/campaign_editable.jsx
@@ -1,70 +1,56 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState, useEffect, useRef } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import Select from 'react-select';
 
 import { getAvailableCampaigns } from '../../selectors';
 import selectStyles from '../../styles/select';
 
-import PopoverExpandable from '../high_order/popover_expandable.jsx';
+// import PopoverExpandable from '../high_order/popover_expandable.jsx';
 import Popover from '../common/popover.jsx';
 import Conditional from '../high_order/conditional.jsx';
 
 import { removeCampaign, fetchAllCampaigns, addCampaign } from '../../actions/campaign_actions';
 import { fetchUsers } from '../../actions/user_actions';
 
+const CampaignEditable = ({ course_id, campaigns, open, is_open, stop }) => {
+  const [selectedCampaigns, setSelectedCampaigns] = useState([]);
+  console.log(open, is_open, stop);
+  const campaignSelectRef = useRef(null);
+  const dispatch = useDispatch();
 
-const CampaignEditable = createReactClass({
-  displayName: 'CampaignEditable',
+  useEffect(() => {
+    dispatch(fetchAllCampaigns());
+  }, [fetchAllCampaigns]);
 
-  propTypes: {
-    campaigns: PropTypes.array,
-    availableCampaigns: PropTypes.array,
-    fetchAllCampaigns: PropTypes.func
-  },
-
-  getInitialState() {
-    return {
-      selectedCampaigns: []
-    };
-  },
-
-  componentDidMount() {
-    return this.props.fetchAllCampaigns();
-  },
-
-  getKey() {
-    return 'add_campaign';
-  },
-
-  handleChangeCampaign(values) {
+  const handleChangeCampaign = (values) => {
     if (values.length > 0) {
-      this.setState({ selectedCampaigns: values });
+      setSelectedCampaigns(values);
     }
-  },
+  };
 
-  openPopover(e) {
-    if (!this.props.is_open && this.refs.campaignSelect) {
-      this.refs.campaignSelect.focus();
+  const openPopover = (e, props) => {
+    if (!is_open && campaignSelectRef.current) {
+      campaignSelectRef.current.focus();
     }
-    return this.props.open(e);
-  },
+    return props.open(e);
+  };
 
-  removeCampaign(campaignId) {
-    this.props.removeCampaign(this.props.course_id, campaignId);
-  },
+  openPopover.propTypes = {
+    open: PropTypes.func
+  };
 
-  addCampaign() {
+  const removeCampaignHandler = (campaignId) => {
+    removeCampaign(course_id, campaignId);
+  };
+
+  const addCampaignHandler = () => {
     // After adding the campaign, request users so that any defaults are
     // immediately propagated.
-    const { selectedCampaigns } = this.state;
-    const { course_id } = this.props;
-
     const addCampaignPromises = [];
 
     selectedCampaigns.forEach((selectedCampaign) => {
-      const promise = this.props.addCampaign(course_id, selectedCampaign.value);
+      const promise = addCampaign(course_id, selectedCampaign.value);
       addCampaignPromises.push(promise);
     });
 
@@ -73,80 +59,75 @@ const CampaignEditable = createReactClass({
       const updatedSelectedCampaigns = selectedCampaigns.filter((selectedCampaign) => {
         let shouldRemove = false;
 
-        this.props.campaigns.forEach((campaign) => {
+        campaigns.forEach((campaign) => {
           if (campaign.title === selectedCampaign.value) shouldRemove = true;
         });
 
         return !shouldRemove;
       });
 
-      this.setState({ selectedCampaigns: updatedSelectedCampaigns });
-      this.props.fetchUsers(this.props.course_id);
+      setSelectedCampaigns(updatedSelectedCampaigns);
+      fetchUsers(course_id);
     });
-  },
+  };
 
-  render() {
-    // In editable mode we'll show a list of campaigns and a remove button plus a selector to add new campaigns
-
-    const campaignList = this.props.campaigns.map((campaign) => {
-      const removeButton = (
-        <button className="button border plus" aria-label="Remove campaign" onClick={this.removeCampaign.bind(this, campaign.title)}>-</button>
-      );
-      return (
-        <tr key={`${campaign.id}_campaign`}>
-          <td>{campaign.title}{removeButton}</td>
-        </tr>
-      );
-    });
-
-    let campaignSelect;
-    if (this.props.availableCampaigns.length > 0) {
-      const campaignOptions = this.props.availableCampaigns.map((campaign) => {
-        return { label: campaign, value: campaign };
-      });
-      let addCampaignButtonDisabled = true;
-      if (this.state.selectedCampaigns.length > 0) {
-        addCampaignButtonDisabled = false;
-      }
-      campaignSelect = (
-        <tr>
-          <th>
-            <div className="select-with-button">
-              <Select
-                className="fixed-width"
-                ref="campaignSelect"
-                name="campaign"
-                value={this.state.selectedCampaigns}
-                placeholder={I18n.t('courses.campaign_select')}
-                onChange={this.handleChangeCampaign}
-                options={campaignOptions}
-                styles={selectStyles}
-                isClearable
-                isSearchable
-                isMulti={true}
-              />
-              <button type="submit" className="button dark" disabled={addCampaignButtonDisabled} onClick={this.addCampaign}>
-                Add
-              </button>
-            </div>
-          </th>
-        </tr>
-      );
-    }
-
-    return (
-      <div key="campaigns" className="pop__container campaigns open" onClick={this.stop}>
-        <button className="button border plus open" onClick={this.openPopover}>+</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={campaignSelect}
-          rows={campaignList}
-        />
-      </div>
+  const campaignList = campaigns.map((campaign) => {
+    const removeButton = (
+      <button className="button border plus" aria-label="Remove campaign" onClick={() => removeCampaignHandler(campaign.title)}>-</button>
     );
-  }
+    return (
+      <tr key={`${campaign.id}_campaign`}>
+        <td>{campaign.title}{removeButton}</td>
+      </tr>
+    );
+  });
 
-});
+  let campaignSelect;
+  if (getAvailableCampaigns.length > 0) {
+    const campaignOptions = getAvailableCampaigns.map((campaign) => {
+      return { label: campaign, value: campaign };
+    });
+    let addCampaignButtonDisabled = true;
+    if (selectedCampaigns.length > 0) {
+      addCampaignButtonDisabled = false;
+    }
+    campaignSelect = (
+      <tr>
+        <th>
+          <div className="select-with-button">
+            <Select
+              className="fixed-width"
+              ref={campaignSelectRef}
+              name="campaign"
+              value={selectedCampaigns}
+              placeholder={I18n.t('courses.campaign_select')}
+              onChange={handleChangeCampaign}
+              options={campaignOptions}
+              styles={selectStyles}
+              isClearable
+              isSearchable
+              isMulti={true}
+            />
+            <button type="submit" className="button dark" disabled={addCampaignButtonDisabled} onClick={addCampaignHandler}>
+              Add
+            </button>
+          </div>
+        </th>
+      </tr>
+            );
+          }
+
+          return (
+            <div key="campaigns" className="pop__container campaigns open" onClick={stop}>
+              <button className="button border plus open" onClick={openPopover}>+</button>
+              <Popover
+                is_open={is_open}
+                edit_row={campaignSelect}
+                rows={campaignList}
+              />
+            </div>
+          );
+          };
 
 const mapStateToProps = state => ({
   availableCampaigns: getAvailableCampaigns(state),
@@ -161,5 +142,5 @@ const mapDispatchToProps = {
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(
-  Conditional(PopoverExpandable(CampaignEditable))
+  Conditional(CampaignEditable)
 );


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
Currently when a user clicks on edit details on a course page, the fetchAllCampaigns action is fetched twice.

## Screenshots
Before:
[Screencast from 04-28-2023 10:08:07 PM.webm](https://user-images.githubusercontent.com/88780311/235234814-1714fb4b-0ef0-49e5-ad2e-a6f9d31bded4.webm)

After:
[Screencast from 04-28-2023 10:24:35 PM.webm](https://user-images.githubusercontent.com/88780311/235235538-8959a091-3b5d-41c5-89e9-cb599190316c.webm)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
