### PR TITLE
allow user to clear selection when adding a campaign to a course

### DIFF
--- a/app/assets/javascripts/components/overview/campaign_editable.jsx
+++ b/app/assets/javascripts/components/overview/campaign_editable.jsx
@@ -41,6 +41,8 @@ const CampaignEditable = createReactClass({
   handleChangeCampaign(values) {
     if (values.length > 0) {
       this.setState({ selectedCampaigns: values });
+    } else {
+      this.setState({ selectedCampaigns: [] });
     }
   },
 
@@ -119,6 +121,7 @@ const CampaignEditable = createReactClass({
                 value={this.state.selectedCampaigns}
                 placeholder={I18n.t('courses.campaign_select')}
                 onChange={this.handleChangeCampaign}
+                onInputChange={this.handleClearSelect}
                 options={campaignOptions}
                 styles={selectStyles}
                 isClearable


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
When editing course details, the user can add or remove a campaign to their course. This PR allows the user to clear an added selection in case the user wants to select a different one or do away with the current selection using the clearable buttons.
This PR solves issue [5381](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5381)

## Screenshots
Before:
[Screencast from 04-28-2023 11:53:33 PM.webm](https://user-images.githubusercontent.com/88780311/235252383-73df5c68-d93f-47f4-853c-adb77593a6fd.webm)


After:
[Screencast from 04-28-2023 11:52:53 PM.webm](https://user-images.githubusercontent.com/88780311/235252429-22891cb7-aa65-4ba1-b28c-58cf688da9b3.webm)
