### PR TITLE
Update Reply cmpnent: html link opens in new tab

### DIFF
--- a/app/assets/javascripts/components/tickets/reply.jsx
+++ b/app/assets/javascripts/components/tickets/reply.jsx
@@ -53,7 +53,7 @@ export const Reply = ({ message }) => {
         {subject}
         { cc }
         { (subject || cc) && <hr /> }
-        <div className="plaintext message-body" dangerouslySetInnerHTML={{ __html: linkifyHtml(message.content) }} />
+        <div className="plaintext message-body" dangerouslySetInnerHTML={{ __html: linkifyHtml(message.content, { target: { url: '_blank' } }) }} />
       </section>
       <aside className="reply-details">
         <span className="from">


### PR DESCRIPTION
## What this PR does
This PR tries to solve issue #5379 

The `linkifyHtml` library transform text into Html. The added option allows to add the target = '_blank' in the generated link.
Link then opens in a new tab.