### PR TITLE
When we were under /admin page then when one clicked on users then 

### DIFF
--- a/app/views/admin/_navigation.html.haml
+++ b/app/views/admin/_navigation.html.haml
@@ -7,5 +7,5 @@
     %div.nav__item= link_to 'Feedback', '/feedback_form_responses', class: class_for_path(request, '/feedback_form_responses')
     %div.nav__item= link_to 'Alerts', '/alerts_list', class: class_for_path(request, '/alerts_list')
     %div.nav__item= link_to 'Users', users_path, class: class_for_path(request, users_path)
-    %div.nav__item= link_to 'Account Requests', '/requested_accounts', class: class_for_path(request, users_path)
-    %div.nav__item= link_to 'Tickets', '/tickets/dashboard', class: class_for_path(request, users_path)
+    %div.nav__item= link_to 'Account Requests', '/requested_accounts'
+    %div.nav__item= link_to 'Tickets', '/tickets/dashboard'


### PR DESCRIPTION
Account request and Tickets were also highlighted with the blue hover effect. This was a bug due to extra class which was applied on Account request and Tickets in the NavBar. I removed those as that was creating a unhealthy effect on the page

## What this PR does
This Pull Request have fixed the extra highlighting of Account Request and Tickets under the '/admin' page .. When one was clicking on Users then these two were also highlighted with a blue color line below them

## Screenshots
Before:
![buggg](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/108119109/49c1e4f8-9230-4c86-a37c-b506f506b0e2)


After:
![Screenshot from 2023-05-11 23-32-22](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/108119109/07ce4375-d9fb-4e3c-9beb-1c78a605c333)

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/108119109/a4948116-0b45-4909-a159-70659b4902c6


## Open questions and concerns
I learnt about how we can find any code file/path from inspect section from any browser
