### PR TITLE
Fixed popover height issue for student details page

### DIFF
--- a/app/assets/stylesheets/modules/_popover.styl
+++ b/app/assets/stylesheets/modules/_popover.styl
@@ -11,7 +11,7 @@
     box-shadow 0 0 15px 0 rgba(0, 0, 0, .2)
     left 50%
     opacity 0
-    visibility hidden
+    display none
     pointer-events none
     position absolute
     top calc(100% + 14px)
@@ -26,7 +26,7 @@
       left 0
     &.open
       opacity 1
-      visibility visible
+      display block
       pointer-events all
       /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ transform translateX(0px) translateY(0) scale(1, 1)
       /*@replace: translateX(0px) translateY(0) scale(1, 1)*/ -webkit-transform translateX(0px) translateY(0) scale(1, 1)


### PR DESCRIPTION
With reference to #5389 
## What this PR does
The pop-up window for "Assign/Remove an article" uses a css property called `visibility`. It's set to `visibility: hidden` when the button hasn't been clicked yet and set to `visibility: visible` when the button is clicked. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility):

> The visibility CSS property shows or hides an element without changing the layout of a document

For students that have a lot of articles that can be assigned to them, the hidden pop-up gains a lot of vertical height and pushes the page down, causing the empty space issue. This PR fixes this issue by using `display` instead of `visibility`. With display, when an element is hidden it does not take up space in the page, fixing the height issue.

## Videos
Before:

[Screencast from 05-12-2023 05:16:01 PM.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/1ed1888a-5068-4005-84c2-7a39a5e8ed0e)



After:

[Screencast from 05-12-2023 05:17:32 PM.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a73f44a0-eb2f-4e36-8626-6d55b3996280)


