### PR TITLE
Converting AdminAlerts class component to functional component

### DIFF
--- a/app/assets/javascripts/components/alerts/admin_alerts.jsx
+++ b/app/assets/javascripts/components/alerts/admin_alerts.jsx
@@ -1,31 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import AlertsHandler from './alerts_handler.jsx';
 import { fetchAdminAlerts } from '../../actions/alert_actions';
 
-class AdminAlerts extends React.Component {
-  componentDidMount() {
-    // This adds ALL alerts to the state, to be used in AlertsHandler
-    this.props.fetchAdminAlerts();
-  }
+const AdminAlerts = () => {
+  const dispatch = useDispatch();
 
-  render() {
-    return (
-      <AlertsHandler
-        alertLabel={I18n.t('alerts.alert_label')}
-        noAlertsLabel={I18n.t('alerts.no_alerts')}
-        adminAlert={true}
-      />
-    );
-  }
-}
+  useEffect(() => {
+    // This adds ALL alerts to the state, to be used in AlertsHandler
+    dispatch(fetchAdminAlerts());
+  }, [dispatch]);
+
+
+  return (
+    <AlertsHandler
+      alertLabel={I18n.t('alerts.alert_label')}
+      noAlertsLabel={I18n.t('alerts.no_alerts')}
+      adminAlert={true}
+    />
+  );
+};
 
 AdminAlerts.propTypes = {
   fetchAdminAlerts: PropTypes.func,
 };
 
-const mapDispatchToProps = { fetchAdminAlerts };
-
-export default connect(null, mapDispatchToProps)(AdminAlerts);
+export default (AdminAlerts);


### PR DESCRIPTION
With reference to #5393 
## What this PR does
Converts admin_alerts.jsx into a functional component. Also uses the newer redux hooks
**Affected Pages:** `/alerts_list` (admin-only)
## Videos
Before:

[before refactor.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/d58ada16-8d9c-4a02-8b8f-86cb24ff16b8)

After:

[after refactor.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/f3a8bd16-b34e-4d5b-bd06-ea0d81773e82)
