### PR TITLE
Converting CampaignAlerts class component to functional component

### DIFF
--- a/app/assets/javascripts/components/alerts/admin_alerts.jsx
+++ b/app/assets/javascripts/components/alerts/admin_alerts.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
 import AlertsHandler from './alerts_handler.jsx';
@@ -21,10 +20,6 @@ const AdminAlerts = () => {
       adminAlert={true}
     />
   );
-};
-
-AdminAlerts.propTypes = {
-  fetchAdminAlerts: PropTypes.func,
 };
 
 export default (AdminAlerts);

--- a/app/assets/javascripts/components/alerts/campaign_alerts.jsx
+++ b/app/assets/javascripts/components/alerts/campaign_alerts.jsx
@@ -1,63 +1,47 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import withRouter from '../util/withRouter';
-import { connect } from 'react-redux';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import AlertsHandler from './alerts_handler.jsx';
 import { fetchCampaignAlerts, filterAlerts } from '../../actions/alert_actions';
 
-class CampaignAlerts extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      defaultFilters: [
-        { value: 'ArticlesForDeletionAlert', label: 'Articles For Deletion' },
-        { value: 'DiscretionarySanctionsEditAlert', label: 'Discretionary Sanctions' }
-      ],
-    };
+const CampaignAlerts = () => {
+  const [defaultFilters] = useState([
+    { value: 'ArticlesForDeletionAlert', label: 'Articles For Deletion' },
+    { value: 'DiscretionarySanctionsEditAlert', label: 'Discretionary Sanctions' }
+  ]);
+  const dispatch = useDispatch();
 
-    this.getCampaignSlug = this.getCampaignSlug.bind(this);
-  }
+  const { campaign_slug } = useParams(); // Gets campaign slug from router params using a hook
 
-  componentDidMount() {
-    // This clears Rails parts of the previous pages, when changing Campagn tabs
-      if (document.getElementById('users')) {
-        document.getElementById('users').innerHTML = '';
-      }
-      if (document.getElementById('campaign-articles')) {
-        document.getElementById('campaign-articles').innerHTML = '';
-      }
-      if (document.getElementById('courses')) {
-        document.getElementById('courses').innerHTML = '';
-      }
-      if (document.getElementById('overview-campaign-details')) {
-        document.getElementById('overview-campaign-details').innerHTML = '';
-      }
 
-    // This adds the specific campaign alerts to the state, to be used in AlertsHandler
-    this.props.fetchCampaignAlerts(this.getCampaignSlug());
-    this.props.filterAlerts(this.state.defaultFilters);
-  }
+  useEffect(() => {
+    // This clears Rails parts of the previous pages, when changing Campaign tabs
+    if (document.getElementById('users')) {
+      document.getElementById('users').innerHTML = '';
+    }
+    if (document.getElementById('campaign-articles')) {
+      document.getElementById('campaign-articles').innerHTML = '';
+    }
+    if (document.getElementById('courses')) {
+      document.getElementById('courses').innerHTML = '';
+    }
+    if (document.getElementById('overview-campaign-details')) {
+      document.getElementById('overview-campaign-details').innerHTML = '';
+    }
 
-  getCampaignSlug() {
-    return `${this.props.router.params.campaign_slug}`;
-  }
+    // This adds the specific campaign alerts to the redux state, to be used in AlertsHandler
+    dispatch(fetchCampaignAlerts(campaign_slug));
+    dispatch(filterAlerts(defaultFilters));
+  }, []);
 
-  render() {
-    return (
-      <AlertsHandler
-        alertLabel={I18n.t('campaign.alert_label')}
-        noAlertsLabel={I18n.t('campaign.no_alerts')}
-      />
-    );
-  }
-}
 
-CampaignAlerts.propTypes = {
-  fetchCampaignAlerts: PropTypes.func,
-  filterAlerts: PropTypes.func,
+  return (
+    <AlertsHandler
+      alertLabel={I18n.t('campaign.alert_label')}
+      noAlertsLabel={I18n.t('campaign.no_alerts')}
+    />
+  );
 };
 
-const mapDispatchToProps = { fetchCampaignAlerts, filterAlerts };
-
-export default withRouter(connect(null, mapDispatchToProps)(CampaignAlerts));
+export default (CampaignAlerts);


### PR DESCRIPTION
With reference to #5393 
## What this PR does
Converts campaign_alerts.jsx into a functional component. Also uses the newer redux hooks
**Affected Pages:** `/campaigns/[campaign_title]/alerts`
## Videos
Before:

[before refactor assignment alerts.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/aaab269b-0ab8-4a7c-be52-99b2ee1a577a)

After:

[after refactor assignment alerts.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/2fe75429-4b0e-4a4c-9c8d-8d76f6698fce)

## Questions and Concerns
Unrelated question: I noticed that the "course" column in the alerts table is always highlighted white even when sorting by date or other columns. Is this intended design behaviour or is the white highlight supposed to change based on the column that we're sorting by?