### PR TITLE
Fixed alert table course highlight bug

### DIFF
--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -17,11 +17,17 @@
       th
         width 20%
 
-.campaign_main.alerts td
-  max-width 400px
-  overflow hidden
-  padding 12px
-  text-overflow ellipsis
+.campaign_main.alerts 
+  thead
+    th
+      background: transparent
+      &:before
+        display: none
+  td
+    max-width 400px
+    overflow hidden
+    padding 12px
+    text-overflow ellipsis
 
 .table, .training table
   width 100%


### PR DESCRIPTION
With reference to issue #5398 
## What this PR does
This PR fixes the white highlight issue on the alerts table course column header. 
## Origin of issue
This issue was actually caused by two files that are supposed to be unrelated. The `alerts_list.jsx` component passes in an `I18n.t('campaign.course')` value to the `list.jsx` file. The list component then passes in that value as a class name for the course header. It just so happens that `I18n.t('campaign.course')` evaluates to 'course'. Which already has some styling written for it in `_course.styl`. That styling was targeted towards a different page in the dashboard, unrelated to the alerts page.
## The fix
I fixed this by adding in some extra specificity to the `_tables.styl` file.
## Screenshots
Before:
![highlightBugBeforeFix](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/f7228eb8-a890-4df3-a9df-8804854754a5)


After:
![highlightBugAfterFix](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a7e4d5c9-9c73-4b05-8c5a-f37eae20ba8e)

