### PR TITLE
Converting LanguagePicker and Sidebar class components into functional components

### DIFF
--- a/app/assets/javascripts/components/nav/language_picker.jsx
+++ b/app/assets/javascripts/components/nav/language_picker.jsx
@@ -11,64 +11,63 @@ const getNativeName = (code) => {
   return language.nativeName;
 };
 
-class LanguagePicker extends React.Component {
-  selectLanguage(locale) {
-    const name = locale.value;
-    if (name === 'help_translate') {
-      window.open('https://translatewiki.net/wiki/Translating:Wiki_Ed_Dashboard');
-      return;
-    }
-    if (window.currentUser.id !== '') {
-      request(`/update_locale/${name}`, {
-        method: 'POST',
-      }).then(req => req.text()).then(() => {
-        location.reload();
-      });
-    } else {
-      window.location = `?locale=${name}`;
-    }
+const selectLanguage = (locale) => {
+  const name = locale.value;
+  if (name === 'help_translate') {
+    window.open('https://translatewiki.net/wiki/Translating:Wiki_Ed_Dashboard');
+    return;
   }
-  render() {
-    const enN = getNativeName('en');
-    const esN = getNativeName('es');
-    const frN = getNativeName('fr');
-
-    const popularLocales = [
-      { label: enN, value: 'en' },
-      { label: esN, value: 'es' },
-      { label: frN, value: 'fr' },
-    ];
-
-    const translateLink = [
-      { label: 'Help translate', value: 'help_translate' },
-    ];
-
-    const allLocales = compact(I18n.availableLocales).map((code) => {
-      const nativeName = getNativeName(code);
-      if (nativeName !== enN && nativeName !== esN && nativeName !== frN) {
-        return { label: nativeName || code, value: code };
-      }
-      return undefined;
+  if (window.currentUser.id !== '') {
+    request(`/update_locale/${name}`, {
+      method: 'POST',
+    }).then(req => req.text()).then(() => {
+      location.reload();
     });
-
-    const defLocales = without(allLocales, undefined);
-    const newLocales = translateLink.concat(popularLocales).concat(defLocales);
-    const curLocale = <span><img src="/assets/images/icon-language.png" alt="Translate this page" /> {I18n.locale} </span>;
-
-    return (
-      <span className="language-picker">
-        <Select
-          name="language-picker"
-          classNamePrefix="language-picker"
-          placeholder={curLocale}
-          options={newLocales}
-          onChange={this.selectLanguage}
-          clearable={false}
-          styles={selectStyles}
-        />
-      </span>
-    );
+  } else {
+    window.location = `?locale=${name}`;
   }
-}
+};
+
+const LanguagePicker = () => {
+  const enN = getNativeName('en');
+  const esN = getNativeName('es');
+  const frN = getNativeName('fr');
+
+  const popularLocales = [
+    { label: enN, value: 'en' },
+    { label: esN, value: 'es' },
+    { label: frN, value: 'fr' },
+  ];
+
+  const translateLink = [
+    { label: 'Help translate', value: 'help_translate' },
+  ];
+
+  const allLocales = compact(I18n.availableLocales).map((code) => {
+    const nativeName = getNativeName(code);
+    if (nativeName !== enN && nativeName !== esN && nativeName !== frN) {
+      return { label: nativeName || code, value: code };
+    }
+    return undefined;
+  });
+
+  const defLocales = without(allLocales, undefined);
+  const newLocales = translateLink.concat(popularLocales).concat(defLocales);
+  const curLocale = <span><img src="/assets/images/icon-language.png" alt="Translate this page" /> {I18n.locale} </span>;
+
+  return (
+    <span className="language-picker">
+      <Select
+        name="language-picker"
+        classNamePrefix="language-picker"
+        placeholder={curLocale}
+        options={newLocales}
+        onChange={selectLanguage}
+        clearable={false}
+        styles={selectStyles}
+      />
+    </span>
+  );
+};
 
 export default LanguagePicker;

--- a/app/assets/javascripts/components/tickets/sidebar.jsx
+++ b/app/assets/javascripts/components/tickets/sidebar.jsx
@@ -1,81 +1,76 @@
 import React from 'react';
-import withRouter from '../util/withRouter';
-import { Link } from 'react-router-dom';
-
+import { useNavigate, Link } from 'react-router-dom';
 import TicketStatusHandler from './ticket_status_handler';
 import TicketOwnerHandler from './ticket_owner_handler';
 import { STATUSES } from './util';
 import { toDate } from '../../utils/date_utils';
 import { formatDistanceToNow } from 'date-fns';
 
-export class Sidebar extends React.Component {
-  notifyOwner() {
-    const { currentUser, ticket } = this.props;
-    this.props.notifyOfMessage({
+const Sidebar = ({ createdAt, currentUser, deleteTicket, notifyOfMessage, ticket }) => {
+  const navigate = useNavigate();
+
+  const notifyOwner = () => {
+    notifyOfMessage({
       message_id: ticket.messages[ticket.messages.length - 1].id,
       sender_id: currentUser.id
     });
-  }
+  };
 
-  deleteTicket() {
+  const deleteSelectedTicket = () => {
     if (!confirm('Are you sure you want to delete this ticket?')) return;
 
-    this.props.deleteTicket(this.props.ticket.id)
-      .then(() => this.props.router.navigate('/tickets/dashboard'));
-  }
+    deleteTicket(ticket.id)
+      .then(() => navigate('/tickets/dashboard'));
+  };
+  const assignedTo = ticket.owner.id === currentUser.id ? 'You' : ticket.owner.username;
+  const status = STATUSES[ticket.status];
+  const realName = ticket.sender.real_name ? `(${ticket.sender.real_name})` : '';
 
-  render() {
-    const { createdAt, currentUser, ticket } = this.props;
-    const assignedTo = ticket.owner.id === currentUser.id ? 'You' : ticket.owner.username;
-    const status = STATUSES[ticket.status];
-    const realName = ticket.sender.real_name ? `(${ticket.sender.real_name})` : '';
-
-    return (
-      <section className="sidebar">
-        <section className="created-at">Created <time className="bold">{formatDistanceToNow(toDate(createdAt), { addSuffix: true })}</time></section>
-        <section className="status">
-          Ticket is currently <span className={`${status.toLowerCase()} bold`}>{status}</span>
-          <TicketStatusHandler ticket={ticket} />
-        </section>
-        <section className="owner">
-          Assigned to <span className="bold">{assignedTo}</span>
-          <TicketOwnerHandler ticket={ticket} />
-        </section>
-        <section className="course-name">
-          {
-            ticket.project.id
-              ? <Link target="_blank" to={`/courses/${ticket.project.slug}`}>Course page: {ticket.project.title}</Link>
-              : 'Course Unknown'
-          }
-        </section>
-        <section className="related-tickets">
-          <Link target="_blank" to={`/tickets/dashboard?search_by_course=${ticket.project.slug}`}>
-            Search all tickets for: {ticket.project.title}
-          </Link>
-        </section>
-        <section className="course-user-details">
-          {
-            ticket.project.id && ticket.sender.username
-              ? <Link target="_blank" to={`/courses/${ticket.project.slug}/students/articles/${ticket.sender.username}`}>User assignments: {ticket.sender.username}</Link>
-              : ''
-          }
-        </section>
-        <section className="user-record">
-          {
-            ticket.sender.username
-              ? <a target="_blank" href={`/users/${this.props.ticket.sender.username}`}>Profile: {`${ticket.sender.username} ${realName}`}</a>
-              : 'Unknown User Record'
-          }
-        </section>
-        <section>
-          <button className="button info" onClick={() => this.notifyOwner()}>Email Ticket Owner</button>
-        </section>
-        <section>
-          <button className="button danger" onClick={() => this.deleteTicket()}>Delete Ticket</button>
-        </section>
+  return (
+    <section className="sidebar">
+      <section className="created-at">Created <time className="bold">{formatDistanceToNow(toDate(createdAt), { addSuffix: true })}</time></section>
+      <section className="status">
+        Ticket is currently <span className={`${status.toLowerCase()} bold`}>{status}</span>
+        <TicketStatusHandler ticket={ticket} />
       </section>
-    );
-  }
-}
+      <section className="owner">
+        Assigned to <span className="bold">{assignedTo}</span>
+        <TicketOwnerHandler ticket={ticket} />
+      </section>
+      <section className="course-name">
+        {
+          ticket.project.id
+            ? <Link target="_blank" to={`/courses/${ticket.project.slug}`}>Course page: {ticket.project.title}</Link>
+            : 'Course Unknown'
+        }
+      </section>
+      <section className="related-tickets">
+        <Link target="_blank" to={`/tickets/dashboard?search_by_course=${ticket.project.slug}`}>
+          Search all tickets for: {ticket.project.title}
+        </Link>
+      </section>
+      <section className="course-user-details">
+        {
+          ticket.project.id && ticket.sender.username
+            ? <Link target="_blank" to={`/courses/${ticket.project.slug}/students/articles/${ticket.sender.username}`}>User assignments: {ticket.sender.username}</Link>
+            : ''
+        }
+      </section>
+      <section className="user-record">
+        {
+          ticket.sender.username
+            ? <a target="_blank" href={`/users/${ticket.sender.username}`}>Profile: {`${ticket.sender.username} ${realName}`}</a>
+            : 'Unknown User Record'
+        }
+      </section>
+      <section>
+        <button className="button info" onClick={() => notifyOwner()}>Email Ticket Owner</button>
+      </section>
+      <section>
+        <button className="button danger" onClick={() => deleteSelectedTicket()}>Delete Ticket</button>
+      </section>
+    </section>
+  );
+};
 
-export default withRouter(Sidebar);
+export default (Sidebar);

--- a/test/components/tickets/sidebar.spec.jsx
+++ b/test/components/tickets/sidebar.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
 
-import { Sidebar } from '../../../app/assets/javascripts/components/tickets/sidebar.jsx';
+import Sidebar from '../../../app/assets/javascripts/components/tickets/sidebar.jsx';
 import '../../testHelper';
 
 describe('Tickets', () => {

--- a/test/components/tickets/sidebar.spec.jsx
+++ b/test/components/tickets/sidebar.spec.jsx
@@ -1,25 +1,47 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Link } from 'react-router-dom';
+import { mount } from 'enzyme';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 
 import Sidebar from '../../../app/assets/javascripts/components/tickets/sidebar.jsx';
 import '../../testHelper';
+import { Provider } from 'react-redux';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('Tickets', () => {
+  const store = mockStore({
+    admins: []
+  });
+  const ticket = {
+    project: {},
+    owner: {},
+    sender: {},
+    status: 0
+  };
+  const props = {
+    currentUser: {},
+    ticket,
+    createdAt: new Date(),
+  };
+  const MockProvider = (mockProps) => {
+    return (
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/tickets/dashboard/5']}>
+          <Routes>
+            <Route
+              path="/tickets/dashboard/:ticket_id"
+              element={<Sidebar {...mockProps} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+  };
+  const component = mount(<MockProvider {...props} />);
   describe('Sidebar', () => {
-    const ticket = {
-      project: {},
-      owner: {},
-      sender: {},
-      status: 0
-    };
-    const props = {
-      currentUser: {},
-      ticket,
-      createdAt: new Date(),
-    };
-    const component = shallow(<Sidebar {...props} />);
-
     it('should display the standard information', () => {
       expect(component.find('.sidebar .created-at').length).toBeTruthy;
       expect(component.find('.sidebar .status').length).toBeTruthy;
@@ -44,7 +66,7 @@ describe('Tickets', () => {
       ticket.owner = { id: 1 };
       props.currentUser = { id: 1 };
 
-      const sidebar = shallow(<Sidebar {...props} />);
+      const sidebar = mount(<MockProvider {...props} />);
       const text = sidebar.find('.sidebar .owner').text();
 
       expect(text).toContain('You');
@@ -55,7 +77,7 @@ describe('Tickets', () => {
     it('should display the course name if a course is given', () => {
       ticket.project = { id: 1, title: 'Title', slug: 'title-slug' };
 
-      const courseName = shallow(<Sidebar {...props} />).find('.sidebar .course-name');
+      const courseName = mount(<MockProvider {...props} />).find('.sidebar .course-name');
       const link = courseName.children().first();
       expect(link.type()).toEqual(Link);
 
@@ -67,7 +89,7 @@ describe('Tickets', () => {
     it('should display the user name if a user is given', () => {
       ticket.sender = { id: 1, username: 'username' };
 
-      const sidebar = shallow(<Sidebar {...props} />);
+      const sidebar = mount(<MockProvider {...props} />);
       const text = sidebar.find('.sidebar .user-record').text();
 
       expect(text).toContain('username');


### PR DESCRIPTION
With reference to #5393 
## What this PR does
Converts `language_picker.jsx` and `sidebar.jsx` into functional components. 
**Affected Pages:**

- Any page that has the main top navbar in it (related to `language_picker.jsx`)
- `/tickets/dashboard/[ticket_id]` (related to `sidebar.jsx`)

## Videos
Before `language_picker.jsx`:

[before refactor language_picker.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/71334f72-32ba-4d96-ae5b-a71c142b13bc)

After `language_picker.jsx`:

[after refactor language_picker.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/0d779fd8-8d54-495a-ae7e-87f8c0077a88)

Before `sidebar.jsx`:

[before refactor sidebar.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/f46c4ddc-6ac5-4076-9330-edeb4d680c72)

After `sidebar.jsx`:

[after refactor sidebar.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/fc64334a-73c8-4a87-8f8d-7a38686144f8)
