### PR TITLE
Converting StudentRevisionsList and Assignment class components into functional components 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -111,6 +111,10 @@
         {
           "rootPathPrefix": "@constants",
           "rootPathSuffix": "./app/assets/javascripts/constants"
+        },
+        {
+          "rootPathPrefix": "@actions/",
+          "rootPathSuffix": "./app/assets/javascripts/actions"
         }
       ]
     }

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/Actions.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/Actions.jsx
@@ -13,7 +13,7 @@ import Feedback from '~/app/assets/javascripts/components/common/feedback.jsx';
 
 export const Actions = ({
   article, assignment, courseSlug, current_user, isComplete, username,
-  isEnglishWikipedia, isClassroomProgram, handleUpdateAssignment, refreshAssignments, unassign
+  isEnglishWikipedia, isClassroomProgram, unassign
 }) => {
   if (isComplete) {
     // If complete, only return the following
@@ -24,8 +24,6 @@ export const Actions = ({
           key="mark-incomplete-button"
           assignment={assignment}
           courseSlug={courseSlug}
-          handleUpdateAssignment={handleUpdateAssignment}
-          refreshAssignments={refreshAssignments}
         />
       </section>
     );
@@ -76,8 +74,6 @@ Actions.propTypes = {
 
   // actions
   isEnglishWikipedia: PropTypes.func.isRequired,
-  handleUpdateAssignment: PropTypes.func.isRequired,
-  refreshAssignments: PropTypes.func.isRequired,
   unassign: PropTypes.func.isRequired,
 };
 

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { updateAssignmentStatus, fetchAssignments } from '../../../../../../../../../actions/assignment_actions';
+import { updateAssignmentStatus, fetchAssignments } from '@actions/assignment_actions';
 
 const update = ({ assignment, courseSlug, dispatch }) => async () => {
   const statuses = assignment.assignment_all_statuses;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.jsx
@@ -1,36 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { updateAssignmentStatus, fetchAssignments } from '../../../../../../../../../actions/assignment_actions';
 
-const update = ({
-  assignment, courseSlug,
-  handleUpdateAssignment, refreshAssignments
-}) => async () => {
+const update = ({ assignment, courseSlug, dispatch }) => async () => {
   const statuses = assignment.assignment_all_statuses;
   const prev = statuses[statuses.length - 2];
 
-  await handleUpdateAssignment(assignment, prev);
-  await refreshAssignments(courseSlug);
+  await dispatch(updateAssignmentStatus(assignment, prev));
+  await dispatch(fetchAssignments(courseSlug));
 };
 
-export const MarkAsIncompleteButton = props => (
-  <div>
-    <button
-      className="button danger small"
-      onClick={update(props)}
-    >
-      Mark as Incomplete
-    </button>
-  </div>
-);
+export const MarkAsIncompleteButton = (props) => {
+  const dispatch = useDispatch();
+  return (
+    <div>
+      <button
+        className="button danger small"
+        onClick={update({ ...props, dispatch })}
+      >
+        Mark as Incomplete
+      </button>
+    </div>
+  );
+};
 
 MarkAsIncompleteButton.propTypes = {
-  // props
   assignment: PropTypes.object.isRequired,
   courseSlug: PropTypes.string.isRequired,
-
-  // actions
-  handleUpdateAssignment: PropTypes.func.isRequired,
-  refreshAssignments: PropTypes.func.isRequired,
 };
 
 export default MarkAsIncompleteButton;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
@@ -4,6 +4,10 @@ import PropTypes from 'prop-types';
 // components
 import Actions from './Actions/Actions.jsx';
 import MyArticlesAssignmentLinks from './MyArticlesAssignmentLinks.jsx';
+import { initiateConfirm } from '../../../../../../../../actions/confirm_actions';
+import { deleteAssignment } from '../../../../../../../../actions/assignment_actions';
+
+import { useDispatch } from 'react-redux';
 
 const isEnglishWikipedia = ({ assignment, course }) => () => {
   const { language, project } = assignment;
@@ -26,41 +30,41 @@ const isEnglishWikipedia = ({ assignment, course }) => () => {
 
 const isClassroomProgram = course => (course.type === 'ClassroomProgramCourse');
 
-const unassign = ({ assignment, course, initiateConfirm, deleteAssignment }) => {
+const unassign = ({ assignment, course, dispatch }) => {
   const body = { course_slug: course.slug, ...assignment };
   const confirmMessage = I18n.t('assignments.confirm_deletion');
-  const onConfirm = () => deleteAssignment(body);
+  const onConfirm = () => dispatch(deleteAssignment(body));
 
-  return () => initiateConfirm({ confirmMessage, onConfirm });
+  return () => dispatch(initiateConfirm({ confirmMessage, onConfirm }));
 };
 
 export const Header = ({
-  article, articleTitle, assignment, course, current_user, isComplete, username,
-  deleteAssignment, fetchAssignments, initiateConfirm, updateAssignmentStatus
-}) => (
-  <header aria-label={`${articleTitle} assignment`} className="header-wrapper">
-    <MyArticlesAssignmentLinks
-      articleTitle={articleTitle}
-      project={article.project}
-      assignment={assignment}
-      courseType={course.type}
-      current_user={current_user}
-    />
-    <Actions
-      article={article}
-      assignment={assignment}
-      courseSlug={course.slug}
-      current_user={current_user}
-      isEnglishWikipedia={isEnglishWikipedia({ assignment, course })}
-      isClassroomProgram={isClassroomProgram(course)}
-      isComplete={isComplete}
-      refreshAssignments={fetchAssignments}
-      unassign={unassign({ assignment, course, initiateConfirm, deleteAssignment })}
-      handleUpdateAssignment={updateAssignmentStatus}
-      username={username}
-    />
-  </header>
-);
+  article, articleTitle, assignment, course, current_user, isComplete, username
+}) => {
+  const dispatch = useDispatch();
+  return (
+    <header aria-label={`${articleTitle} assignment`} className="header-wrapper">
+      <MyArticlesAssignmentLinks
+        articleTitle={articleTitle}
+        project={article.project}
+        assignment={assignment}
+        courseType={course.type}
+        current_user={current_user}
+      />
+      <Actions
+        article={article}
+        assignment={assignment}
+        courseSlug={course.slug}
+        current_user={current_user}
+        isEnglishWikipedia={isEnglishWikipedia({ assignment, course })}
+        isClassroomProgram={isClassroomProgram(course)}
+        isComplete={isComplete}
+        unassign={unassign({ assignment, course, deleteAssignment, dispatch })}
+        username={username}
+      />
+    </header>
+  );
+};
 
 Header.propTypes = {
   // props
@@ -71,11 +75,6 @@ Header.propTypes = {
   current_user: PropTypes.object.isRequired,
   isComplete: PropTypes.bool.isRequired,
   username: PropTypes.string.isRequired,
-  // actions
-  deleteAssignment: PropTypes.func.isRequired,
-  fetchAssignments: PropTypes.func.isRequired,
-  initiateConfirm: PropTypes.func.isRequired,
-  updateAssignmentStatus: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 // components
 import Actions from './Actions/Actions.jsx';
 import MyArticlesAssignmentLinks from './MyArticlesAssignmentLinks.jsx';
-import { initiateConfirm } from '../../../../../../../../actions/confirm_actions';
-import { deleteAssignment } from '../../../../../../../../actions/assignment_actions';
+import { initiateConfirm } from '@actions/confirm_actions';
+import { deleteAssignment } from '@actions/assignment_actions';
 
 import { useDispatch } from 'react-redux';
 

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/ProgressTracker.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/ProgressTracker.jsx
@@ -21,10 +21,7 @@ export class ProgressTracker extends React.Component {
   }
 
   render() {
-    const {
-      assignment, course,
-      fetchAssignments, updateAssignmentStatus, dispatch
-    } = this.props;
+    const { assignment, course } = this.props;
     const { show } = this.state;
 
     const steps = processes(assignment, course).map((content, index) => (
@@ -34,9 +31,6 @@ export class ProgressTracker extends React.Component {
         course={course}
         index={index}
         key={index}
-        fetchAssignments={fetchAssignments}
-        updateAssignmentStatus={updateAssignmentStatus}
-        dispatch={dispatch}
       />
     ));
 
@@ -67,10 +61,6 @@ ProgressTracker.propTypes = {
   // props
   assignment: PropTypes.object.isRequired,
   course: PropTypes.object.isRequired,
-
-  // actions
-  fetchAssignments: PropTypes.func.isRequired,
-  updateAssignmentStatus: PropTypes.func.isRequired,
 };
 
 export default ProgressTracker;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { updateAssignmentStatus, fetchAssignments } from '../../../../../../../../../actions/assignment_actions';
 
 const update = ({
   assignment, course,
-  updateAssignmentStatus, fetchAssignments, stepAction, dispatch
+  stepAction, dispatch
 }, undo = false) => async () => {
   const {
     assignment_all_statuses: statuses,
@@ -11,15 +13,16 @@ const update = ({
   } = assignment;
   const i = statuses.indexOf(status);
   const updated = (undo ? statuses[i - 1] : statuses[i + 1]) || status;
-
-  await updateAssignmentStatus(assignment, updated);
-  await fetchAssignments(course.slug);
+  await dispatch(updateAssignmentStatus(assignment, updated));
+  await dispatch(fetchAssignments(course.slug));
   if (stepAction) {
     await stepAction({ assignment, course })(dispatch);
   }
 };
 
 export const ButtonNavigation = (props) => {
+  const dispatch = useDispatch();
+
   const {
     active, index, buttonLabel
   } = props;
@@ -31,7 +34,7 @@ export const ButtonNavigation = (props) => {
           <button
             className="button small"
             disabled={!active}
-            onClick={update(props, 'undo')}
+            onClick={update({ ...props, dispatch }, 'undo')}
           >
             &laquo; Go Back a Step
           </button>
@@ -40,7 +43,7 @@ export const ButtonNavigation = (props) => {
       <button
         className="button dark small"
         disabled={!active}
-        onClick={update(props)}
+        onClick={update({ ...props, dispatch })}
       >
         {buttonLabel || 'Mark Complete'} &raquo;
       </button>
@@ -49,14 +52,10 @@ export const ButtonNavigation = (props) => {
 };
 
 ButtonNavigation.propTypes = {
-  // props
   active: PropTypes.bool.isRequired,
   assignment: PropTypes.object.isRequired,
   course: PropTypes.object.isRequired,
   index: PropTypes.number.isRequired,
-  // actions
-  updateAssignmentStatus: PropTypes.func.isRequired,
-  fetchAssignments: PropTypes.func.isRequired,
 };
 
 export default ButtonNavigation;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { updateAssignmentStatus, fetchAssignments } from '../../../../../../../../../actions/assignment_actions';
+import { updateAssignmentStatus, fetchAssignments } from '@actions/assignment_actions';
 
 const update = ({
   assignment, course,

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/Step.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/Step.jsx
@@ -10,9 +10,7 @@ import Reviewers from './Reviewers.jsx';
 import ButtonNavigation from './ButtonNavigation.jsx';
 
 export const Step = ({
-  assignment, content, course, index, status, title, trainings, buttonLabel, stepAction, last = false,
-  updateAssignmentStatus, fetchAssignments, dispatch
-}) => {
+  assignment, content, course, index, status, title, trainings, buttonLabel, stepAction, last = false }) => {
   const active = assignment.assignment_status === status;
   return (
     <article aria-label={active ? 'Current step' : ''} className={`step ${active ? 'active' : ''}`}>
@@ -27,18 +25,14 @@ export const Step = ({
         course={course}
         index={index}
         last={last}
-        updateAssignmentStatus={updateAssignmentStatus}
-        fetchAssignments={fetchAssignments}
         buttonLabel={buttonLabel}
         stepAction={stepAction}
-        dispatch={dispatch}
       />
     </article>
   );
 };
 
 Step.propTypes = {
-  // props
   assignment: PropTypes.object.isRequired,
   content: PropTypes.string.isRequired,
   course: PropTypes.object.isRequired,
@@ -46,10 +40,6 @@ Step.propTypes = {
   status: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   trainings: PropTypes.array.isRequired,
-
-  // actions
-  updateAssignmentStatus: PropTypes.func.isRequired,
-  fetchAssignments: PropTypes.func.isRequired,
 };
 
 export default Step;

--- a/app/assets/javascripts/components/overview/my_articles/containers/Assignment.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/containers/Assignment.jsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import CourseUtils from '~/app/assets/javascripts/utils/course_utils.js';
 import MyArticlesHeader from '@components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx';
 import MyArticlesCompletedAssignment from '@components/overview/my_articles/components/Categories/List/Assignment/CompletedAssignment.jsx';
 import MyArticlesProgressTracker from '@components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/ProgressTracker.jsx';
-
-import { initiateConfirm } from '~/app/assets/javascripts/actions/confirm_actions';
-import { deleteAssignment, fetchAssignments, updateAssignmentStatus } from '~/app/assets/javascripts/actions/assignment_actions';
 
 // Main Component
 export const Assignment = (props) => {
@@ -39,26 +35,11 @@ export const Assignment = (props) => {
 };
 
 Assignment.propTypes = {
-  // props
   assignment: PropTypes.object.isRequired,
   course: PropTypes.object.isRequired,
   current_user: PropTypes.object,
   username: PropTypes.string,
   wikidataLabels: PropTypes.object.isRequired,
-
-  // actions
-  deleteAssignment: PropTypes.func.isRequired,
-  fetchAssignments: PropTypes.func.isRequired,
-  initiateConfirm: PropTypes.func.isRequired,
-  updateAssignmentStatus: PropTypes.func.isRequired
 };
 
-const mapDispatchToProps = {
-  initiateConfirm,
-  deleteAssignment,
-  fetchAssignments,
-  updateAssignmentStatus,
-  dispatch: dis => dis
-};
-
-export default connect(null, mapDispatchToProps)(Assignment);
+export default (Assignment);

--- a/app/assets/javascripts/components/overview/my_articles/containers/Assignment.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/containers/Assignment.jsx
@@ -10,38 +10,33 @@ import { initiateConfirm } from '~/app/assets/javascripts/actions/confirm_action
 import { deleteAssignment, fetchAssignments, updateAssignmentStatus } from '~/app/assets/javascripts/actions/assignment_actions';
 
 // Main Component
-export class Assignment extends React.Component {
-  isComplete() {
-    const { assignment } = this.props;
+export const Assignment = (props) => {
+  const { assignment, course, wikidataLabels } = props;
+  const isAssignmentComplete = () => {
     const allStatuses = assignment.assignment_all_statuses;
     const lastStatus = allStatuses[allStatuses.length - 1];
     return assignment.assignment_status === lastStatus;
-  }
+  };
 
-  render() {
-    const { assignment, course, wikidataLabels } = this.props;
+  const {
+    article, title
+  } = CourseUtils.articleAndArticleTitle(assignment, course, wikidataLabels);
 
-    const {
-      article, title
-    } = CourseUtils.articleAndArticleTitle(assignment, course, wikidataLabels);
+  const isClassroomProgram = course.type === 'ClassroomProgramCourse';
+  const enable = isClassroomProgram && Features.wikiEd;
+  const isComplete = isAssignmentComplete();
+  const articlesProps = { ...props, article, articleTitle: title, isComplete };
+  const progressTracker = isComplete
+    ? <MyArticlesCompletedAssignment />
+    : <MyArticlesProgressTracker {...articlesProps} />;
 
-    const isComplete = this.isComplete();
-    const isClassroomProgram = course.type === 'ClassroomProgramCourse';
-    const enable = isClassroomProgram && Features.wikiEd;
-
-    const props = { ...this.props, article, articleTitle: title, isComplete };
-    const progressTracker = isComplete
-      ? <MyArticlesCompletedAssignment />
-      : <MyArticlesProgressTracker {...props} />;
-
-    return (
-      <div className={`my-assignment mb1${(isComplete && enable) ? ' complete' : ''}`}>
-        <MyArticlesHeader {...props} />
-        { enable ? progressTracker : null }
-      </div>
-    );
-  }
-}
+  return (
+    <div className={`my-assignment mb1${(isComplete && enable) ? ' complete' : ''}`}>
+      <MyArticlesHeader {...articlesProps} />
+      {enable ? progressTracker : null}
+    </div>
+  );
+};
 
 Assignment.propTypes = {
   // props

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/RevisionsList/StudentRevisionsList.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/RevisionsList/StudentRevisionsList.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 // Components
@@ -11,134 +11,105 @@ import CourseUtils from '~/app/assets/javascripts/utils/course_utils.js';
 import ArticleUtils from '~/app/assets/javascripts/utils/article_utils.js';
 import studentListKeys from '@components/students/shared/StudentList/student_list_keys.js';
 
-export class StudentRevisionsList extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: false,
-      namespace: 'all' // show all namespace revisions by default
-    };
+export const StudentRevisionsList = ({ course, fetchUserRevisions, student, wikidataLabels, userRevisions }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [namespace, setNamespace] = useState('all');
 
-    this.toggleDrawer = this.toggleDrawer.bind(this);
-  }
-
-  onNamespaceChange = (e) => {
+  const onNamespaceChange = (e) => {
     // Open the drawer when filter is used
-    if (!this.state.isOpen) this.setState({ isOpen: true });
-    return this.setState({ namespace: e.target.value });
+    if (!isOpen) setIsOpen(true);
+    setNamespace(e.target.value);
   };
 
   // filter the revisions according to namespace
-  getfilteredRevisions() {
-    const { student, userRevisions } = this.props;
-
+  const getfilteredRevisions = () => {
     let revisions = [];
     if (userRevisions[student.id] !== undefined && userRevisions[student.id] !== null) {
-      revisions = (this.state.namespace === 'all')
+      revisions = (namespace === 'all')
         ? userRevisions[student.id]
         : userRevisions[student.id].filter((rev) => {
-          const current_ns_id = ArticleUtils.getNamespaceId(this.state.namespace);
+          const current_ns_id = ArticleUtils.getNamespaceId(namespace);
           return rev.article.namespace === current_ns_id;
         });
     }
     return revisions;
-  }
+  };
 
-  _shouldShowRealName() {
-    const STUDENT_ROLE = 0;
-    const { current_user, student } = this.props;
-    const isAdmin = current_user.admin;
-    const isNonStudent = current_user.role > STUDENT_ROLE;
+  const toggleDrawer = () => {
+    setIsOpen(!isOpen);
+  };
 
-    if (!student.real_name) { return false; }
-    return current_user && (isAdmin || isNonStudent);
-  }
 
-  toggleDrawer() {
-    this.setState({ isOpen: !this.state.isOpen });
-  }
+  if (!userRevisions[student.id]) fetchUserRevisions(course.id, student.id);
+  const filteredRevisions = getfilteredRevisions();
+  const uploadsLink = `/courses/${course.slug}/uploads`;
+  const elements = [
+    <StudentRevisionRow
+      key={`${student.id}-row`}
+      course={course}
+      isOpen={isOpen}
+      toggleDrawer={toggleDrawer}
+      student={student}
+      uploadsLink={uploadsLink}
+    />,
+    <StudentDrawer
+      key={`${student.id}-drawer`}
+      student={student}
+      course={course}
+      exerciseView={true}
+      isOpen={isOpen}
+      revisions={filteredRevisions}
+      wikidataLabels={wikidataLabels}
+    />
+  ];
 
-  render() {
-    const {
-      course, student, fetchUserRevisions, wikidataLabels, userRevisions
-    } = this.props;
-    const { isOpen } = this.state;
+  const {
+    recent_revisions, character_sum_ms, references_count, total_uploads
+  } = studentListKeys(course);
+  const keys = { recent_revisions, character_sum_ms, references_count, total_uploads };
 
-    if (!userRevisions[student.id]) fetchUserRevisions(course.id, student.id);
-    const filteredRevisions = this.getfilteredRevisions();
-    const uploadsLink = `/courses/${course.slug}/uploads`;
-    const elements = [
-      <StudentRevisionRow
-        key={`${student.id}-row`}
-        course={course}
-        isOpen={isOpen}
-        toggleDrawer={this.toggleDrawer}
-        student={student}
-        uploadsLink={uploadsLink}
-      />,
-      <StudentDrawer
-        key={`${student.id}-drawer`}
-        student={student}
-        course={course}
-        exerciseView={true}
-        isOpen={isOpen}
-        revisions={filteredRevisions}
-        wikidataLabels={wikidataLabels}
+  const filterLabel = <b>Namespace Filter:</b>;
+  const filterRevisions = (
+    <select
+      className="filter-revisions"
+      value={namespace}
+      onChange={onNamespaceChange}
+    >
+      <option value={'all'}>{I18n.t('namespace.all')}</option>
+      <option value={'main'}>{I18n.t('namespace.main')}</option>
+      <option value={'user'}>{I18n.t('namespace.user')}</option>
+      <option value={'talk'}>{I18n.t('namespace.talk')}</option>
+    </select>
+  );
+  return (
+    <div className="list__wrapper">
+      <h4 className="assignments-list-title">
+        {I18n.t('users.revisions')}
+        <div className="wrap-filters">
+          {filterLabel}
+          {filterRevisions}
+        </div>
+      </h4>
+
+      <List
+        elements={elements}
+        className="table--expandable table--hoverable"
+        keys={keys}
+        none_message={CourseUtils.i18n('students_none', course.string_prefix)}
       />
-    ];
-
-    const {
-      recent_revisions, character_sum_ms, references_count, total_uploads
-    } = studentListKeys(course);
-    const keys = { recent_revisions, character_sum_ms, references_count, total_uploads };
-
-    const filterLabel = <b>Namespace Filter:</b>;
-    const filterRevisions = (
-      <select
-        className="filter-revisions"
-        value={this.state.namespace}
-        onChange={this.onNamespaceChange}
-      >
-        <option value={'all'}>{I18n.t('namespace.all')}</option>
-        <option value={'main'}>{I18n.t('namespace.main')}</option>
-        <option value={'user'}>{I18n.t('namespace.user')}</option>
-        <option value={'talk'}>{I18n.t('namespace.talk')}</option>
-      </select>
-    );
-    return (
-      <div className="list__wrapper">
-        <h4 className="assignments-list-title">
-          {I18n.t('users.revisions')}
-          <div className="wrap-filters">
-            {filterLabel}
-            {filterRevisions}
-          </div>
-        </h4>
-        <List
-          elements={elements}
-          className="table--expandable table--hoverable"
-          keys={keys}
-          none_message={CourseUtils.i18n('students_none', course.string_prefix)}
-        />
-      </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 StudentRevisionsList.propTypes = {
   course: PropTypes.shape({
     id: PropTypes.number.isRequired
-  }).isRequired,
-  current_user: PropTypes.shape({
-    admin: PropTypes.bool,
-    role: PropTypes.number
   }).isRequired,
   student: PropTypes.shape({
     id: PropTypes.number.isRequired,
     real_name: PropTypes.string
   }).isRequired,
   fetchUserRevisions: PropTypes.func.isRequired,
-  setUploadFilters: PropTypes.func.isRequired,
 };
 
 export default StudentRevisionsList;

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
@@ -18,7 +18,7 @@ import { useLocation, useParams, Navigate } from 'react-router-dom';
 
 export const SelectedStudent = ({
   groupedArticles, assignments, course, current_user, fetchArticleDetails,
-  fetchUserRevisions, hasExercisesOrTrainings, openKey, setUploadFilters,
+  fetchUserRevisions, hasExercisesOrTrainings, openKey,
   sort, sortUsers, toggleUI, trainingStatus, wikidataLabels, userRevisions,
   students, articlesUrl
 }) => {
@@ -27,7 +27,7 @@ export const SelectedStudent = ({
   const selected = selectUserByUsernameParam(students, username);
   if (!selected) {
     // if user does not exist, then redirect to the articles home page
-    return <Navigate to={articlesUrl}/>;
+    return <Navigate to={articlesUrl} />;
   }
   const {
     assigned, reviewing
@@ -104,14 +104,8 @@ export const SelectedStudent = ({
       <StudentRevisionsList
         key={`student-revisions-${selected.id}`}
         course={course}
-        current_user={current_user}
         fetchUserRevisions={fetchUserRevisions}
-        openKey={openKey}
-        setUploadFilters={setUploadFilters}
-        sort={sort}
-        sortUsers={sortUsers}
         student={selected}
-        trainingStatus={trainingStatus}
         wikidataLabels={wikidataLabels}
         userRevisions={userRevisions}
       />

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,6 +22,10 @@ module.exports = {
           {
             rootPathSuffix: './app/assets/javascripts/constants',
             rootPathPrefix: '@constants/'
+          },
+          {
+            rootPathSuffix: './app/assets/javascripts/actions',
+            rootPathPrefix: '@actions/'
           }
         ]
       }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "jsx": "preserve",
     "paths": {
-      "@components/*": [ "./app/assets/javascripts/components/*" ]
+      "@components/*": [ "./app/assets/javascripts/components/*" ],
+      "@actions/*": [ "./app/assets/javascripts/actions/*" ]
     }
   },
   "include": [ "app" ]

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.spec.jsx
@@ -1,24 +1,37 @@
+// @ts-nocheck
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import '../../../../../../../../../testHelper';
-
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import MarkAsIncompleteButton from '../../../../../../../../../../app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton';
+import { Provider } from 'react-redux';
 
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 describe('MarkAsIncompleteButton', () => {
+  const store = mockStore({
+  });
+
+  const MockProvider = (mockProps) => {
+    return (
+      <Provider store={store}>
+        <MarkAsIncompleteButton {...mockProps} />
+      </Provider >
+    );
+  };
   const update = jest.fn();
   const props = {
     assignment: { assignment_all_statuses: [] },
     courseSlug: 'course/slug',
-    handleUpdateAssignment: update,
-    refreshAssignments: jest.fn()
   };
   it('should show the button', () => {
-    const component = shallow(<MarkAsIncompleteButton {...props} />);
+    const component = mount(<MockProvider {...props} />);
     expect(component).toMatchSnapshot();
   });
 
   it('should update the assignment on button click', async () => {
-    const component = shallow(<MarkAsIncompleteButton {...props} />);
+    const component = mount(<MockProvider {...props} />);
     const button = component.find('button');
 
     await button.props().onClick();

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.spec.jsx
@@ -4,11 +4,15 @@ import { mount } from 'enzyme';
 import '../../../../../../../../../testHelper';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { updateAssignmentStatus, fetchAssignments } from '../../../../../../../../../../app/assets/javascripts/actions/assignment_actions';
 import MarkAsIncompleteButton from '../../../../../../../../../../app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton';
 import { Provider } from 'react-redux';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
+jest.mock('../../../../../../../../../../app/assets/javascripts/actions/assignment_actions', () => ({
+  updateAssignmentStatus: jest.fn(),
+}));
 describe('MarkAsIncompleteButton', () => {
   const store = mockStore({
   });
@@ -20,7 +24,6 @@ describe('MarkAsIncompleteButton', () => {
       </Provider >
     );
   };
-  const update = jest.fn();
   const props = {
     assignment: { assignment_all_statuses: [] },
     courseSlug: 'course/slug',
@@ -31,10 +34,14 @@ describe('MarkAsIncompleteButton', () => {
   });
 
   it('should update the assignment on button click', async () => {
-    const component = mount(<MockProvider {...props} />);
-    const button = component.find('button');
+    const newProps = {
+      assignment: { assignment_all_statuses: ['status1', 'status2'] },
+      courseSlug: 'course1',
+    };
 
-    await button.props().onClick();
-    expect(update.mock.calls.length).toEqual(1);
+    const component = mount(<MockProvider {...newProps} />);
+    component.find('button').simulate('click');
+
+    expect(updateAssignmentStatus).toHaveBeenCalledWith(newProps.assignment, 'status1');
   });
 });

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton.spec.jsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 import React from 'react';
 import { mount } from 'enzyme';
 import '../../../../../../../../../testHelper';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { updateAssignmentStatus, fetchAssignments } from '../../../../../../../../../../app/assets/javascripts/actions/assignment_actions';
+import { updateAssignmentStatus } from '../../../../../../../../../../app/assets/javascripts/actions/assignment_actions';
 import MarkAsIncompleteButton from '../../../../../../../../../../app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/MarkAsIncompleteButton';
 import { Provider } from 'react-redux';
 

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/__snapshots__/MarkAsIncompleteButton.spec.jsx.snap
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/Actions/__snapshots__/MarkAsIncompleteButton.spec.jsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MarkAsIncompleteButton should show the button 1`] = `ShallowWrapper {}`;
+exports[`MarkAsIncompleteButton should show the button 1`] = `ReactWrapper {}`;

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/__snapshots__/index.spec.jsx.snap
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/__snapshots__/index.spec.jsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header displays the links and actions 1`] = `ShallowWrapper {}`;
+exports[`Header displays the links and actions 1`] = `ReactWrapper {}`;

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/Header/index.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/Header/index.spec.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import '../../../../../../../../testHelper';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
 
 import Header from '@components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx';
 
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 describe('Header', () => {
+  const store = mockStore({
+  });
+
+  const MockProvider = (mockProps) => {
+    return (
+      <Provider store={store}>
+        <Header {...mockProps} />
+      </Provider >
+    );
+  };
   const props = {
     article: {
       project: 'project'
@@ -22,7 +37,7 @@ describe('Header', () => {
   };
 
   it('displays the links and actions', () => {
-    const component = shallow(<Header {...props} />);
+    const component = mount(<MockProvider {...props} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation.spec.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import '../../../../../../../../../testHelper';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
 
 import ButtonNavigation from '../../../../../../../../../../app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/Step/ButtonNavigation';
 
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 describe('ButtonNavigation', () => {
+  const store = mockStore({
+  });
+
   const props = {
     active: true,
     assignment: {},
@@ -15,8 +24,16 @@ describe('ButtonNavigation', () => {
     fetchAssignments: jest.fn()
   };
 
+  const MockProvider = (mockProps) => {
+    return (
+      <Provider store={store}>
+        <ButtonNavigation {...mockProps} />
+      </Provider >
+    );
+  };
+
   it('should show the Mark Complete button and Go Back a Step button', () => {
-    const component = shallow(<ButtonNavigation {...props} />);
+    const component = mount(<MockProvider {...props} />);
     const buttons = component.find('button');
 
     expect(buttons.length).toEqual(2);
@@ -25,7 +42,7 @@ describe('ButtonNavigation', () => {
   });
 
   it('should not show the Go Back a Step button if it is the first step', () => {
-    const component = shallow(<ButtonNavigation {...props} index={0} />);
+    const component = mount(<MockProvider {...props} index={0} />);
     const buttons = component.find('button');
 
     expect(buttons.length).toEqual(1);
@@ -33,7 +50,7 @@ describe('ButtonNavigation', () => {
   });
 
   it('should disable all buttons if the step is not active', () => {
-    const component = shallow(<ButtonNavigation {...props} active={false} />);
+    const component = mount(<MockProvider {...props} active={false} />);
     const buttons = component.find('button');
 
     expect(buttons.length).toEqual(2);


### PR DESCRIPTION
With reference to #5393 

## What this PR does
Converts `StudentRevisionsList.jsx` and `Assignment.jsx` into functional components. 
**Affected Pages:**

- `/courses/[institution_id]/[course_id]/students/articles/[student_username]` (for `StudentRevisionsList.jsx`)
- `/courses/[institution_id]/[course_id]` (for `Assignment.jsx`, only if it's an edu course)

## Videos
Before `StudentRevisionsList.jsx`

[before refactor studentRevisionList.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/63c2a365-47ba-46b5-a9b5-5482fe4c39ed)

After `StudentRevisionsList.jsx`

[after refactor studentRevisionList.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/8880a635-01c3-442c-915b-5dc9be69d7ca)

Before `Assignment.jsx`

[before refactor assignment.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/2fb4b0cf-99ff-43d3-8717-626fe5f6a8cd)

After `Assignment.jsx`

[after refactor assignment.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/77252d0f-8e1c-4b35-a3ca-2fb7618d7628)

## Redux Hooks Refactor
When refactoring `Assignment.jsx` to use redux hooks. I noticed that the the dispatched actions weren't actually being used in Assignment. They were used in Assignment's child components. So I removed the use of redux in Assignment and instead only imported the actions in the child components that were using them directly. Then I called useDispatch in those child components to actually dispatch the actions.

## Test Changes
I made some changes to the tests to account for the use of redux hooks. I also had to update two test snapshots because they were no longer valid due to me using `mount()` instead of `shallow()`