### PR TITLE
Converted StudentDrawer, QuestionResults, FollowUpQuestionResults, CourseAlertsList components into functional components

### DIFF
--- a/app/assets/javascripts/components/alerts/course_alerts_list.jsx
+++ b/app/assets/javascripts/components/alerts/course_alerts_list.jsx
@@ -1,32 +1,25 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 import AlertsHandler from './alerts_handler.jsx';
 import { fetchCourseAlerts } from '../../actions/alert_actions';
 
-class CourseAlertsList extends React.Component {
-  componentDidMount() {
+const CourseAlertsList = (props) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
     // sets the title of this tab
-    document.title = `${this.props.course.title} - ${I18n.t('courses.alerts')}`;
+    document.title = `${props.course.title} - ${I18n.t('courses.alerts')}`;
     // This adds the specific course alerts to the state, to be used in AlertsHandler
-    this.props.fetchCourseAlerts(this.props.course_id);
-  }
+    dispatch(fetchCourseAlerts(props.course_id));
+  }, []);
 
-  render() {
-    return (
-      <AlertsHandler
-        alertLabel={I18n.t('alerts.alert_label')}
-        noAlertsLabel={I18n.t('alerts.no_alerts')}
-      />
-    );
-  }
-}
-
-CourseAlertsList.propTypes = {
-  fetchCourseAlerts: PropTypes.func,
+  return (
+    <AlertsHandler
+      alertLabel={I18n.t('alerts.alert_label')}
+      noAlertsLabel={I18n.t('alerts.no_alerts')}
+    />
+  );
 };
 
-const mapDispatchToProps = { fetchCourseAlerts };
-
-export default connect(null, mapDispatchToProps)(CourseAlertsList);
+export default (CourseAlertsList);

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/StudentDrawer.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/StudentDrawer.jsx
@@ -1,57 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 // Components
 import Contributions from './Contributions';
 import TrainingStatus from './TrainingStatus/TrainingStatus';
 
-export class StudentDrawer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedIndex: -1,
-    };
-    this.showDiff = this.showDiff.bind(this);
-  }
+export const StudentDrawer = ({
+  course, exerciseView, isOpen, revisions = [],
+  student, trainingModules = [], wikidataLabels
+}) => {
+  const [selectedIndex, setSelectedIndex] = useState(-1);
 
-  shouldComponentUpdate(nextProps) {
-    return !!(nextProps.isOpen || this.props.isOpen);
-  }
-
-  showDiff(index) {
-    this.setState({ selectedIndex: index });
-  }
-
-  render() {
-    const {
-      course, exercises, exerciseView, isOpen, revisions = [],
-      student, trainingModules = [], wikidataLabels
-    } = this.props;
-
-    if (!isOpen) return <tr />;
-
-    return (
-      <tr className="drawer">
-        <td colSpan="7">
-          {
-            exerciseView
+  const showDiff = (index) => {
+    setSelectedIndex(index);
+  };
+  return (
+    <tr className="drawer" style={{ display: isOpen ? 'table-row' : 'none' }}>
+      <td colSpan="7">
+        {
+          exerciseView
             ? (
               <Contributions
                 course={course}
                 revisions={revisions}
-                selectedIndex={this.state.selectedIndex}
-                showDiff={this.showDiff}
+                selectedIndex={selectedIndex}
+                showDiff={showDiff}
                 student={student}
                 wikidataLabels={wikidataLabels}
               />
-            ) : <TrainingStatus exercises={exercises} trainingModules={trainingModules} />
-          }
-        </td>
-      </tr>
-    );
-  }
-}
+            ) : <TrainingStatus trainingModules={trainingModules} />
+        }
+      </td>
+    </tr>
+  );
+};
 
 StudentDrawer.propTypes = {
   course: PropTypes.object,
@@ -63,8 +45,4 @@ StudentDrawer.propTypes = {
   wikidataLabels: PropTypes.object
 };
 
-const mapStateToProps = ({ exercises }) => ({ exercises });
-
-const mapDispatchToProps = null;
-
-export default connect(mapStateToProps, mapDispatchToProps)(StudentDrawer);
+export default (StudentDrawer);

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx
@@ -8,8 +8,10 @@ import ExerciseRows from './ExerciseRows';
 import {
   TRAINING_MODULE_KIND
 } from '~/app/assets/javascripts/constants';
+import { useSelector } from 'react-redux';
 
-const TrainingStatus = ({ exercises, trainingModules }) => {
+const TrainingStatus = ({ trainingModules }) => {
+  const exercises = useSelector(state => state.exercises);
   if (!trainingModules.length) return <div />;
 
   const exerciseTable = !!exercises.count && (
@@ -44,14 +46,13 @@ const TrainingStatus = ({ exercises, trainingModules }) => {
 
   return (
     <>
-      { exerciseTable }
-      { trainingModuleTable }
+      {exerciseTable}
+      {trainingModuleTable}
     </>
   );
 };
 
 TrainingStatus.propTypes = {
-  exercises: PropTypes.object,
   trainingModules: PropTypes.array
 };
 

--- a/app/assets/javascripts/surveys/components/FollowUpQuestionResults.jsx
+++ b/app/assets/javascripts/surveys/components/FollowUpQuestionResults.jsx
@@ -1,23 +1,23 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import TextResults from './TextResults.jsx';
 
-export default class FollowUpQuestionResults extends Component {
-  render() {
-    const answerCount = Object.keys(this.props.follow_up_answers).length;
-    if (answerCount === 0) {
-      return null;
-    }
-    return (
-      <div>
-        <h4>Follow Up Question</h4>
-        <TextResults {...this.props} followUpOnly={true} />
-      </div>
-    );
+const FollowUpQuestionResults = (props) => {
+  const answerCount = Object.keys(props.follow_up_answers).length;
+  if (answerCount === 0) {
+    return null;
   }
-}
+  return (
+    <div>
+      <h4>Follow Up Question</h4>
+      <TextResults {...props} followUpOnly={true} />
+    </div>
+  );
+};
 
 FollowUpQuestionResults.propTypes = {
   follow_up_answers: PropTypes.object,
   type: PropTypes.string
 };
+
+export default (FollowUpQuestionResults);

--- a/app/assets/javascripts/surveys/components/QuestionResults.jsx
+++ b/app/assets/javascripts/surveys/components/QuestionResults.jsx
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import BarGraph from './BarGraph.jsx';
 import TextResults from './TextResults.jsx';
 import RangeGraph from './RangeGraph.jsx';
 import FollowUpQuestionResults from './FollowUpQuestionResults.jsx';
 
-export default class QuestionResults extends Component {
-  _renderQuestionResults(question) {
+const QuestionResults = (props) => {
+  const _renderQuestionResults = (question) => {
     const { type } = question;
     switch (type) {
       case 'radio':
@@ -20,19 +20,14 @@ export default class QuestionResults extends Component {
       default:
         return null;
     }
-  }
+  };
 
-  _data() {
-    return null;
-  }
+  return (
+    <div>
+      {_renderQuestionResults(props)}
+      <FollowUpQuestionResults {...props} />
+    </div>
+  );
+};
 
-  render() {
-    return (
-      <div>
-        {this._renderQuestionResults(this.props)}
-        <FollowUpQuestionResults {...this.props} />
-        {this._data()}
-      </div>
-    );
-  }
-}
+export default (QuestionResults);


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `StudentDrawer.jsx`, `QuestionResults.jsx`, `FollowUpQuestionResults.jsx` and `course_alerts_list.jsx` into functional components. 
**Affected Pages:**

- `/courses/[institution_id]/[course_id]/students/articles/[student_username]` (for `StudentDrawer.jsx`)
- `/survey/results/[survey_id]` (for `QuestionResults.jsx` and `FollowUpQuestionResults.jsx`)
- `/courses/[institution_id]/[course_id]/activity/alerts` (for `course_alerts_list.jsx`)

## Videos/Screenshots
Before `StudentDrawer.jsx`

[before refactor studentDrawer.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/9828f0a9-0e06-4f72-a715-0ac0bf7d9404)

After `StudentDrawer.jsx`

[after refactor studentDrawer.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/e658b1f8-5e6d-418a-b12a-24f773b5d671)

Before `QuestionResults.jsx` and `FollowUpQuestionResults.jsx` 

![before refactor FollowUpQuestionResults](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/2d8daa7f-c9ae-4b18-9f72-0302fa74605b)

After `QuestionResults.jsx` and `FollowUpQuestionResults.jsx` 

![after refactor FollowUpQuestionResults](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/9f82e1b1-6739-4d7f-ab11-f8de6bac1f4e)

Before `course_alerts_list.jsx`

![before refactor CourseAlertsList](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/df04deb0-ce65-42dd-8aac-f2efa817849e)

After `course_alerts_list.jsx`

![after refactor CourseAlertsList](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/ee66c8ab-fdab-4a5b-9c29-b00742fe7508)


