### PR TITLE
Converting TicketShowHandler, NewReplyFrom and NotificationsBell into functional components

### DIFF
--- a/app/assets/javascripts/components/nav/notifications_bell.jsx
+++ b/app/assets/javascripts/components/nav/notifications_bell.jsx
@@ -1,36 +1,32 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import request from '../../utils/request';
 
-export default class NotificationsBell extends React.Component {
-  constructor() {
-    super();
-    this.state = { open_tickets: false, requested_accounts: false };
-  }
+const NotificationsBell = () => {
+  const [hasOpenTickets, setHasOpenTickets] = useState(false);
+  const [hasRequestedAccounts, setHasRequestedAccounts] = useState(false);
 
-  componentDidMount() {
+  useEffect(() => {
     const main = document.getElementById('main');
     const userId = main ? main.dataset.userId : null;
-
     if (Features.wikiEd && userId) {
       request(`/td/open_tickets?owner_id=${userId}`)
         .then(res => res.json())
-        .then(({ open_tickets }) => this.setState({ open_tickets }))
+        .then(({ open_tickets }) => setHasOpenTickets(open_tickets))
         .catch(err => err);
     }
 
     request('/requested_accounts.json')
       .then(res => res.json())
-      .then(({ requested_accounts }) => this.setState({ requested_accounts }))
+      .then(({ requested_accounts }) => setHasRequestedAccounts(requested_accounts))
       .catch(err => err); // If this errors, we're going to ignore it
-  }
+  }, []);
 
-  render() {
-    const path = Features.wikiEd ? '/admin' : '/requested_accounts';
-    return (
-      <li aria-describedby="notification-message" className="notifications">
-        <a href={path} className="icon icon-notifications_bell"/>
-        {
-          (this.state.requested_accounts || this.state.open_tickets)
+  const path = Features.wikiEd ? '/admin' : '/requested_accounts';
+  return (
+    <li aria-describedby="notification-message" className="notifications">
+      <a href={path} className="icon icon-notifications_bell" />
+      {
+        (hasRequestedAccounts || hasOpenTickets)
           ? (
             <span className="bubble red">
               <span id="notification-message" className="screen-reader">You have new notifications.</span>
@@ -39,8 +35,9 @@ export default class NotificationsBell extends React.Component {
           : (
             <span id="notification-message" className="screen-reader">You have no new notifications.</span>
           )
-        }
-      </li>
-    );
-  }
-}
+      }
+    </li>
+  );
+};
+
+export default (NotificationsBell);

--- a/app/assets/javascripts/components/tickets/new_reply_form.jsx
+++ b/app/assets/javascripts/components/tickets/new_reply_form.jsx
@@ -124,7 +124,7 @@ const NewReplyForm = ({ ticket, currentUser }) => {
           alt="Show BCC"
           title="Show BCC"
           className="button border plus"
-          onClick={onCCClick.bind(this)}
+          onClick={onCCClick}
         >
           +
         </button>
@@ -136,7 +136,7 @@ const NewReplyForm = ({ ticket, currentUser }) => {
               className="ml1 top2"
               id="bcc"
               name="bcc"
-              onChange={toggleBcc.bind(this)}
+              onChange={toggleBcc}
               type="checkbox"
             />
           </small>
@@ -149,7 +149,7 @@ const NewReplyForm = ({ ticket, currentUser }) => {
             <label>CC:</label>
             <TextInput
               id="cc"
-              onChange={onChange.bind(this)}
+              onChange={onChange}
               value={replyDetails.cc}
               value_key="cc"
               editable
@@ -164,7 +164,7 @@ const NewReplyForm = ({ ticket, currentUser }) => {
           id="content"
           editable
           label="Enter your reply"
-          onChange={onTextAreaChange.bind(this)}
+          onChange={onTextAreaChange}
           value={replyDetails.content}
           value_key="content"
           wysiwyg={true}
@@ -172,27 +172,27 @@ const NewReplyForm = ({ ticket, currentUser }) => {
       </div>
       <button
         className="button dark margin right mt2"
-        disabled={replyDetails.sending}
+        disabled={replyDetails.sending || !replyDetails.content}
         id="reply-resolve"
-        onClick={onResolve.bind(this)}
+        onClick={onResolve}
         type="submit"
       >
         Send Reply and Resolve Ticket
       </button>
       <button
         className="button dark right mt2"
-        disabled={replyDetails.sending}
+        disabled={replyDetails.sending || !replyDetails.content}
         id="reply"
-        onClick={onReply.bind(this)}
+        onClick={onReply}
         type="submit"
       >
         Send Reply
       </button>
       <button
         className="button left mt2"
-        disabled={replyDetails.sending}
+        disabled={replyDetails.sending || !replyDetails.content}
         id="create-note"
-        onClick={onCreateNote.bind(this)}
+        onClick={onCreateNote}
         type="submit"
       >
         Create Note

--- a/app/assets/javascripts/components/tickets/new_reply_form.jsx
+++ b/app/assets/javascripts/components/tickets/new_reply_form.jsx
@@ -4,6 +4,10 @@ import TextAreaInput from '../common/text_area_input.jsx';
 import TextInput from '../common/text_input.jsx';
 import { MESSAGE_KIND_NOTE, MESSAGE_KIND_REPLY, TICKET_STATUS_AWAITING_RESPONSE, TICKET_STATUS_RESOLVED } from '../../constants/tickets';
 import { INSTRUCTOR_ROLE } from '../../constants/user_roles';
+import {
+  createReply,
+  fetchTicket,
+} from '../../actions/tickets_actions';
 
 const isBlank = (string) => {
   if (/\S/.test(string)) {
@@ -87,8 +91,8 @@ export class NewReplyForm extends React.Component {
       body = { ...body, details };
     }
 
-    this.props.createReply(body, status, bccToSalesforce)
-      .then(() => this.props.fetchTicket(ticket.id))
+    this.props.dispatch(createReply(body, status, bccToSalesforce))
+      .then(() => this.props.dispatch(fetchTicket(ticket.id)))
       .then(() => this.setState({ cc: '', content: '', sending: false }));
   }
 

--- a/app/assets/javascripts/components/tickets/sidebar.jsx
+++ b/app/assets/javascripts/components/tickets/sidebar.jsx
@@ -5,21 +5,27 @@ import TicketOwnerHandler from './ticket_owner_handler';
 import { STATUSES } from './util';
 import { toDate } from '../../utils/date_utils';
 import { formatDistanceToNow } from 'date-fns';
+import {
+  deleteTicket,
+  notifyOfMessage,
+} from '../../actions/tickets_actions';
+import { useDispatch } from 'react-redux';
 
-const Sidebar = ({ createdAt, currentUser, deleteTicket, notifyOfMessage, ticket }) => {
+const Sidebar = ({ createdAt, currentUser, ticket }) => {
+  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   const notifyOwner = () => {
-    notifyOfMessage({
+    dispatch(notifyOfMessage({
       message_id: ticket.messages[ticket.messages.length - 1].id,
       sender_id: currentUser.id
-    });
+    }));
   };
 
   const deleteSelectedTicket = () => {
     if (!confirm('Are you sure you want to delete this ticket?')) return;
 
-    deleteTicket(ticket.id)
+    dispatch(deleteTicket(ticket.id))
       .then(() => navigate('/tickets/dashboard'));
   };
   const assignedTo = ticket.owner.id === currentUser.id ? 'You' : ticket.owner.username;

--- a/app/assets/javascripts/components/tickets/ticket_show.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_show.jsx
@@ -3,15 +3,18 @@ import { Link } from 'react-router-dom';
 import Reply from './reply';
 import Sidebar from './sidebar';
 import NewReplyForm from './new_reply_form';
+import { useDispatch, useSelector } from 'react-redux';
 
 export const TicketShow = ({
   createReply,
   deleteTicket,
-  currentUser,
   fetchTicket,
   notifyOfMessage,
   ticket,
 }) => {
+  const dispatch = useDispatch();
+  const currentUser = useSelector(state => state.currentUserFromHtml);
+
   const createdAt = ticket.messages[0].created_at;
   const replies = ticket.messages.map(message => <Reply key={message.id} message={message} />);
 
@@ -19,9 +22,9 @@ export const TicketShow = ({
     <main className="container ticket-dashboard">
       <h4 className="mt1"><Link to="/tickets/dashboard">← Ticketing Dashboard</Link></h4>
       <h2 className="title">
-        Ticket from {ticket.sender.real_name || ticket.sender.username || ticket.sender_email }
+        Ticket from {ticket.sender.real_name || ticket.sender.username || ticket.sender_email}
       </h2>
-      <hr/>
+      <hr />
       <section className="messages">
         {replies}
         <NewReplyForm
@@ -29,6 +32,7 @@ export const TicketShow = ({
           createReply={createReply}
           currentUser={currentUser}
           fetchTicket={fetchTicket}
+          dispatch={dispatch}
         />
       </section>
       <Sidebar

--- a/app/assets/javascripts/components/tickets/ticket_show.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_show.jsx
@@ -3,16 +3,13 @@ import { Link } from 'react-router-dom';
 import Reply from './reply';
 import Sidebar from './sidebar';
 import NewReplyForm from './new_reply_form';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 export const TicketShow = ({
-  createReply,
   deleteTicket,
-  fetchTicket,
   notifyOfMessage,
   ticket,
 }) => {
-  const dispatch = useDispatch();
   const currentUser = useSelector(state => state.currentUserFromHtml);
 
   const createdAt = ticket.messages[0].created_at;
@@ -29,10 +26,7 @@ export const TicketShow = ({
         {replies}
         <NewReplyForm
           ticket={ticket}
-          createReply={createReply}
           currentUser={currentUser}
-          fetchTicket={fetchTicket}
-          dispatch={dispatch}
         />
       </section>
       <Sidebar

--- a/app/assets/javascripts/components/tickets/ticket_show_handler.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_show_handler.jsx
@@ -1,74 +1,58 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import Loading from '../common/loading';
 import Notifications from '../common/notifications';
 import Show from './ticket_show';
 import { getTicketsById } from '../../selectors';
-import withRouter from '../util/withRouter';
 
 import {
-  createReply,
-  deleteTicket,
   fetchTicket,
-  fetchTickets,
-  notifyOfMessage,
   readAllMessages,
   selectTicket
 } from '../../actions/tickets_actions';
+import { useParams } from 'react-router-dom';
 
-export class TicketShowHandler extends React.Component {
-  componentDidMount() {
-    const id = this.props.router.params.id;
-    const ticket = this.props.ticketsById[id];
+const TicketShowHandler = (props) => {
+  const { id } = useParams();
+
+  const dispatch = useDispatch();
+
+  const ticketsById = useSelector(state => getTicketsById(state));
+  const selectedTicket = useSelector(state => state.tickets.selected);
+
+  useEffect(() => {
+    const ticket = ticketsById[id];
 
     if (ticket) {
-      this.props.readAllMessages(ticket);
-      return this.props.selectTicket(ticket);
+      dispatch(readAllMessages(ticket));
+      return dispatch(selectTicket(ticket));
     }
 
-    this.props.fetchTicket(id).then(() => {
-      this.props.readAllMessages(this.props.selectedTicket);
+    dispatch(fetchTicket(id)).then(() => {
+      if (selectedTicket.messages) {
+        dispatch(readAllMessages(selectedTicket));
+      }
     });
-  }
+  }, [selectedTicket.id]);
 
-  render() {
-    const id = this.props.router.params.id;
-    if (!this.props.selectedTicket.id || this.props.selectedTicket.id !== parseInt(id)) return <Loading />;
+  if (!selectedTicket.id || selectedTicket.id !== parseInt(id)) return <Loading />;
 
-    return (
-      <div>
-        <div className="ticket-notifications">
-          <Notifications />
-        </div>
-        <Show
-          deleteTicket={this.props.deleteTicket}
-          createReply={this.props.createReply}
-          currentUser={this.props.currentUserFromHtml}
-          fetchTicket={this.props.fetchTicket}
-          notifyOfMessage={this.props.notifyOfMessage}
-          ticket={this.props.selectedTicket}
-        />
+  return (
+    <div>
+      <div className="ticket-notifications">
+        <Notifications />
       </div>
-    );
-  }
-}
-
-const mapStateToProps = state => ({
-  currentUserFromHtml: state.currentUserFromHtml,
-  ticketsById: getTicketsById(state),
-  selectedTicket: state.tickets.selected
-});
-
-const mapDispatchToProps = {
-  createReply,
-  deleteTicket,
-  fetchTicket,
-  fetchTickets,
-  notifyOfMessage,
-  readAllMessages,
-  selectTicket
+      <Show
+        deleteTicket={props.deleteTicket}
+        createReply={props.createReply}
+        fetchTicket={props.fetchTicket}
+        notifyOfMessage={props.notifyOfMessage}
+        ticket={selectedTicket}
+      />
+    </div>
+  );
 };
 
-const connector = connect(mapStateToProps, mapDispatchToProps);
-export default withRouter(connector(TicketShowHandler));
+
+export default (TicketShowHandler);

--- a/app/assets/javascripts/components/tickets/ticket_show_handler.jsx
+++ b/app/assets/javascripts/components/tickets/ticket_show_handler.jsx
@@ -14,9 +14,10 @@ import {
   fetchTickets,
   notifyOfMessage,
   readAllMessages,
-  selectTicket } from '../../actions/tickets_actions';
+  selectTicket
+} from '../../actions/tickets_actions';
 
-export class TicketShow extends React.Component {
+export class TicketShowHandler extends React.Component {
   componentDidMount() {
     const id = this.props.router.params.id;
     const ticket = this.props.ticketsById[id];
@@ -70,4 +71,4 @@ const mapDispatchToProps = {
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
-export default withRouter(connector(TicketShow));
+export default withRouter(connector(TicketShowHandler));

--- a/test/components/tickets/new_reply_form.spec.jsx
+++ b/test/components/tickets/new_reply_form.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import { INSTRUCTOR_ROLE } from '../../../app/assets/javascripts/constants/user_roles';
 import {
@@ -11,6 +11,12 @@ import {
 } from '../../../app/assets/javascripts/constants/tickets';
 import { NewReplyForm } from '../../../app/assets/javascripts/components/tickets/new_reply_form';
 import '../../testHelper';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('Tickets', () => {
   describe('NewReplyForm', () => {
@@ -27,18 +33,28 @@ describe('Tickets', () => {
     };
     const createReplyFn = jest.fn(() => Promise.resolve());
     const fetchTicketFn = jest.fn(() => Promise.resolve());
+    const mockDispatchFn = jest.fn(() => Promise.resolve());
+
     const props = {
       currentUser: {
         id: 1
       },
       ticket,
-      createReply: createReplyFn,
-      fetchTicket: fetchTicketFn
+      fetchTicket: fetchTicketFn,
+      dispatch: mockDispatchFn
     };
-    const form = shallow(<NewReplyForm {...props} />);
+    const store = mockStore({ validations: { validations: { key: 2 } } });
+    const MockProvider = (mockProps) => {
+      return (
+        <Provider store={store}>
+          <NewReplyForm {...mockProps} />
+        </Provider >
+      );
+    };
+    const form = mount(<MockProvider {...props} />).find('.tickets-reply');
 
     afterEach(() => {
-      form.instance().setState({
+      form.setState({
         cc: '',
         content: '',
         plainText: '',
@@ -81,7 +97,7 @@ describe('Tickets', () => {
       expect(form.find('#cc').length).toBeTruthy;
     });
     it('does not create a new reply if there is no content', async () => {
-      await form.find('#reply-resolve').simulate('click', { preventDefault: () => {} });
+      await form.find('#reply-resolve').simulate('click', { preventDefault: () => { } });
       expect(createReplyFn).not.toHaveBeenCalled();
       expect(fetchTicketFn).not.toHaveBeenCalled();
     });
@@ -113,7 +129,7 @@ describe('Tickets', () => {
         content: content,
         plainText: content
       });
-      await form.find('#reply-resolve').simulate('click', { preventDefault: () => {} });
+      await form.find('#reply-resolve').simulate('click', { preventDefault: () => { } });
 
       const body = {
         content,
@@ -132,7 +148,7 @@ describe('Tickets', () => {
         content: content,
         plainText: content
       });
-      await form.find('#reply').simulate('click', { preventDefault: () => {} });
+      await form.find('#reply').simulate('click', { preventDefault: () => { } });
 
       const body = {
         content,
@@ -151,7 +167,7 @@ describe('Tickets', () => {
         content: content,
         plainText: content
       });
-      await form.find('#create-note').simulate('click', { preventDefault: () => {} });
+      await form.find('#create-note').simulate('click', { preventDefault: () => { } });
 
       const body = {
         content,

--- a/test/components/tickets/new_reply_form.spec.jsx
+++ b/test/components/tickets/new_reply_form.spec.jsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { INSTRUCTOR_ROLE } from '../../../app/assets/javascripts/constants/user_roles';
 import {
-  MESSAGE_KIND_NOTE,
-  MESSAGE_KIND_REPLY,
-  TICKET_STATUS_AWAITING_RESPONSE,
   TICKET_STATUS_OPEN,
-  TICKET_STATUS_RESOLVED
 } from '../../../app/assets/javascripts/constants/tickets';
 import NewReplyForm from '../../../app/assets/javascripts/components/tickets/new_reply_form';
 import '../../testHelper';

--- a/test/components/tickets/ticket_show.spec.jsx
+++ b/test/components/tickets/ticket_show.spec.jsx
@@ -1,19 +1,35 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { MESSAGE_KIND_REPLY, TICKET_STATUS_OPEN } from '../../../app/assets/javascripts/constants/tickets';
 import { TicketShow } from '../../../app/assets/javascripts/components/tickets/ticket_show';
+import configureMockStore from 'redux-mock-store';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import {
+  deleteTicket,
+  notifyOfMessage,
+} from '@actions/tickets_actions';
 import '../../testHelper';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+jest.mock('../../../app/assets/javascripts/actions/tickets_actions', () => ({
+  deleteTicket: jest.fn(),
+  notifyOfMessage: jest.fn(),
+}));
 
 describe('Tickets', () => {
   describe('TicketShow', () => {
-    const currentUser = {};
     const message = {
       id: 1,
       content: '',
-      details: {},
+      details: { delivered: false },
       sender: {},
-      status: MESSAGE_KIND_REPLY
+      status: MESSAGE_KIND_REPLY,
+      created_at: new Date()
     };
     const ticket = {
       id: 1,
@@ -25,34 +41,56 @@ describe('Tickets', () => {
       },
       status: TICKET_STATUS_OPEN
     };
-
+    const store = mockStore({ validations: { validations: { key: 2 } }, currentUserFromHtml: {}, admins: [], messages: [], ticket: ticket });
+    const MockProvider = (mockProps) => {
+      return (
+        <Provider store={store}>
+          <MemoryRouter initialEntries={['/tickets/dashboard/5']}>
+            <Routes>
+              <Route
+                path="/tickets/dashboard/:ticket_id"
+                element={<TicketShow {...mockProps} />}
+              />
+            </Routes>
+          </MemoryRouter>
+        </Provider>
+      );
+    };
     const props = {
-      currentUser,
-      ticket
+      deleteTicket,
+      notifyOfMessage,
+      ticket,
     };
     it('should display the standard information', () => {
-      const show = shallow(<TicketShow {...props} />);
+      const show = mount(<MockProvider {...props} />);
 
-      const link = show.find('Link');
-      expect(link.length).toBeTruthy;
+      const link = show.find('Link').first();
+      expect(link.length).toBeTruthy();
       expect(link.children().text()).toContain('Ticketing Dashboard');
 
       const title = show.find('.title');
-      expect(title.length).toBeTruthy;
+      expect(title.length).toBeTruthy();
       expect(title.text()).toContain('Ticket from Real Name');
 
       const reply = show.find('Reply');
-      expect(reply.length).toBeTruthy;
+      expect(reply.length).toBeTruthy();
 
       const newReplyForm = show.find('NewReplyForm');
-      expect(newReplyForm.length).toBeTruthy;
+      expect(newReplyForm.length).toBeTruthy();
     });
 
     it('can display multiple messages', () => {
       ticket.messages = ticket.messages.concat([
-        { id: 2, content: 'Another message' }
+        {
+          id: 2,
+          content: 'Just another message',
+          details: { delivered: false },
+          sender: {},
+          status: MESSAGE_KIND_REPLY,
+          created_at: new Date()
+        }
       ]);
-      const show = shallow(<TicketShow {...props} />);
+      const show = mount(<MockProvider {...props} />);
 
       const reply = show.find('Reply');
       expect(reply.length).toEqual(2);


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `ticket_show_handler.jsx`, `new_reply_form.jsx` and `notifications_bell.jsx` into functional components. 
**Affected Pages:**

- `/tickets/dashboard/[ticket_id]` (for `ticket_show_handler.jsx` and `new_reply_form.jsx`)
- Any page that uses the main navbar (for `notifications_bell.jsx`)

## Videos/Screenshots
Before `ticket_show_handler.jsx` and `new_reply_form.jsx`

[before refactor ticketshowhandler and newreplyform.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a0fed36c-f2d0-404d-9e8b-5388f75344d4)

After `ticket_show_handler.jsx` and `new_reply_form.jsx`

[after refactor ticketshowhandler and newreplyform.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a2bf70fa-576b-48e8-8666-5e1ff0a6fbea)

Before `notifications_bell.jsx` 
with notifications:
![before refactor with notifs](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/0c1d3be5-b2a4-4514-9901-9782094e69ba)

without notifications:
![before refactor no notifs](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a50bb3e2-1e7d-421d-ae04-78b934cffc40)


After `notifications_bell.jsx`
with notifications:
![after refactor with notifs](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/f1671014-0d47-420d-b324-2774ac6fbf7e)

without notifications:
![after refactor no notifs](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/26848743-cb6b-4caa-92ed-0b5d504ae86f)

## Questions/Concerns
I added a small visual feature to the ticket reply box. You can now see that when the reply box is empty, the reply buttons are disabled until the user starts typing. I thought this was a nice addition so I kept it in.