### PR TITLE
Strip unwanted span tags that might be returned

### DIFF
--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -10,6 +10,7 @@ class WikiSlideParser
     remove_noinclude
     remove_translation_markers
     remove_translate_tags
+    remove_span_tags
     extract_quiz_template
     extract_category_templates # only relevant for TrainingLibrary
     convert_image_templates
@@ -75,6 +76,14 @@ class WikiSlideParser
     @wikitext.gsub!(%r{\s*</translate>}, '')
     @wikitext.gsub!(/<tvar.*?>/, '')
     @wikitext.gsub!(%r{</>}, '')
+  end
+
+  def remove_span_tags
+    # Remove both the tags and any excess whitespace within them,
+    # Aim is to get rid of <span lang="en" dir="ltr" class="mw-content-ltr">
+    # that may appear in cas of incomplete translations.
+    @wikitext.gsub!(/<span .*?>\s*/, '')
+    @wikitext.gsub!(%r{\s*</span>}, '')
   end
 
   def extract_quiz_template

--- a/spec/lib/training/wiki_slide_parser_spec.rb
+++ b/spec/lib/training/wiki_slide_parser_spec.rb
@@ -206,6 +206,30 @@ describe WikiSlideParser do
     WIKITEXT
   end
 
+  # https://meta.wikimedia.org/w/index.php?title=Special:ExportTranslations&language=es&group=page-Training+modules%2Fdashboard%2Flibraries%2Fediting-wikipedia
+  let(:uncomplete_spanish_translation) do
+    <<~WIKITEXT
+      <noinclude><languages /></noinclude>
+      <span lang="en" dir="ltr" class="mw-content-ltr">== Wikipedia Training Modules ==</span>#{' '}
+
+      <span lang="en" dir="ltr" class="mw-content-ltr">This set of modules helps new editors get started with Wikipedia. This page lists every module, including specialized modules for particular topics.</span>
+
+      {{Training module category
+      | title =  <span lang="en" dir="ltr" class="mw-content-ltr">Basics</span>
+      | description =  <span lang="en" dir="ltr" class="mw-content-ltr">These modules cover the basic rules of Wikipedia.</span>
+      | module_name_1 =  <span lang="en" dir="ltr" class="mw-content-ltr">Wikipedia Essentials</span>
+      | module_slug_1 = wikipedia-essentials
+      | module_description_1 =  <span lang="en" dir="ltr" class="mw-content-ltr">An overview of Wikipedia's main rules</span>
+      | module_name_2 = <span lang="en" dir="ltr" class="mw-content-ltr">Editing Basics</span>
+      | module_slug_2 = editing-basics
+      | module_description_2 =  <span lang="en" dir="ltr" class="mw-content-ltr">An introduction to editing Wikipedia pages</span>
+      | module_name_3 =  <span lang="en" dir="ltr" class="mw-content-ltr">Evaluating Articles and Sources</span>
+      | module_slug_3 = evaluating-articles
+      | module_description_3 =  <span lang="en" dir="ltr" class="mw-content-ltr">Advice for thinking critically about Wikipedia article quality</span>
+      }}
+    WIKITEXT
+  end
+
   describe '#title' do
     it 'extracts title from translation-enabled source wikitext' do
       output = described_class.new(source_wikitext.dup).title
@@ -235,6 +259,11 @@ describe WikiSlideParser do
     it 'works for training libraries' do
       output = described_class.new(editathons_library_wikitext.dup).title
       expect(output).to eq('Running Editathons and other Editing Events')
+    end
+
+    it 'extracts title propery if span tags' do
+      output = described_class.new(uncomplete_spanish_translation.dup).title
+      expect(output).to eq('Wikipedia Training Modules')
     end
   end
 
@@ -278,6 +307,11 @@ describe WikiSlideParser do
     it 'handles nil input' do
       output = described_class.new(''.dup).content
       expect(output).to eq('')
+    end
+
+    it 'strips span tags from content' do
+      output = described_class.new(uncomplete_spanish_translation.dup).content
+      expect(output).not_to match('<span')
     end
   end
 


### PR DESCRIPTION

Tries to fix issue #5383 

Span tags and more precisely <span lang="en" dir="ltr" class="mw-content-ltr"> might wrap untranslated text in an unfinished translation.
I added a method to the parser to strip those span tags.

## Screenshots
Before:
See #5383 

After:
English and spanish are mixing well

![spanish_1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/5203082/3462fcae-a1cc-42e1-9f00-41da4df3bf54)

![spanish_2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/5203082/6ed5e6ee-6f41-4ea3-8ec4-6a0ef8ab9ca8)

