### PR TITLE
Converting ArticleViewer into a functional component

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/BadWorkAlert.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/BadWorkAlert.jsx
@@ -25,18 +25,16 @@ export class BadWorkAlert extends React.Component {
 
   render() {
     const { isSubmitting, message } = this.state;
-    const { alertStatus } = this.props;
 
     return (
       <section className="article-alert">
         <article className="learn-more">
-          <p>{ I18n.t(`instructor_view.bad_work.${ArticleUtils.projectSuffix(this.props.project, 'learn_more')}`) }</p>
+          <p>{I18n.t(`instructor_view.bad_work.${ArticleUtils.projectSuffix(this.props.project, 'learn_more')}`)}</p>
           <a target="_blank" className="button dark" href="/training/instructors/fixing-bad-articles/instructors-role-in-cleanup">
             {I18n.t('instructor_view.bad_work.learn_more_button')}
           </a>
         </article>
         <SubmitIssuePanel
-          alertStatus={alertStatus}
           handleChange={this.handleChange}
           handleSubmit={this.handleSubmit}
           isSubmitting={isSubmitting}
@@ -48,9 +46,6 @@ export class BadWorkAlert extends React.Component {
   }
 }
 BadWorkAlert.propTypes = {
-  alertStatus: PropTypes.shape({
-    created: PropTypes.bool.isRequired
-  }).isRequired,
   project: PropTypes.string.isRequired,
   submitBadWorkAlert: PropTypes.func.isRequired
 };

--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx
@@ -4,8 +4,10 @@ import ArticleUtils from '../../../../../utils/article_utils';
 
 // Components
 import TextAreaInput from '@components/common/text_area_input.jsx';
+import { useSelector } from 'react-redux';
 
-export const SubmitIssuePanel = ({ alertStatus, handleChange, handleSubmit, isSubmitting, message, project }) => {
+export const SubmitIssuePanel = ({ handleChange, handleSubmit, isSubmitting, message, project }) => {
+  const alertStatus = useSelector(state => state.badWorkAlert);
   if (alertStatus.created) {
     return (
       <article className="submit-alert">
@@ -37,9 +39,6 @@ export const SubmitIssuePanel = ({ alertStatus, handleChange, handleSubmit, isSu
 };
 
 SubmitIssuePanel.propTypes = {
-  alertStatus: PropTypes.shape({
-    created: PropTypes.bool.isRequired
-  }).isRequired,
   handleChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   message: PropTypes.string.isRequired,

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -62,6 +62,13 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     }
   }, [showArticle]);
 
+  // Wait for whocolor API to return the raw HTML before highlighting it
+  useEffect(() => {
+    if (whoColorHtml) {
+      highlightAuthors();
+    }
+  }, [whoColorHtml]);
+
   // This runs when the user accesses the articleViewer directly from a permalink
   useEffect(() => {
     if (showOnMount) {
@@ -147,8 +154,8 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const highlightAuthors = () => {
     let html = whoColorHtml;
     if (!html) { return; }
-    let i = 0;
-    forEach(usersState, (user) => {
+
+    forEach(usersState, (user, i) => {
       // Move spaces inside spans, so that background color is continuous
       html = html.replace(/ (<span class="editor-token.*?>)/g, '$1 ');
 
@@ -160,7 +167,6 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
       const authorSpanMatcher = new RegExp(`<span class="editor-token token-editor-${user.userid}`, 'g');
       html = html.replace(authorSpanMatcher, styledAuthorSpan);
       if (prevHtml !== html) user.activeRevision = true;
-      i += 1;
     });
     setHighlightedHtml(html);
   };
@@ -185,7 +191,6 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     api.fetchWhocolorHtml()
       .then((response) => {
         setWhoColorHtml(response.html);
-        highlightAuthors();
       }).catch((error) => {
         setWhoColorFailed(true);
         setFailureMessage(error.message);

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -28,14 +28,6 @@ import colors from '@components/common/ArticleViewer/constants/colors';
 // Actions
 import { resetBadWorkAlert, submitBadWorkAlert } from '~/app/assets/javascripts/actions/alert_actions.js';
 
-// const usePreviousValue = (value) => {
-//   const ref = useRef();
-//   useEffect(() => {
-//     ref.current = value;
-//   });
-//   return ref.current;
-// };
-
 const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel, fetchArticleDetails, assignedUsers, article, course,
   alertStatus, current_user = {}, showButtonClass, showPermalink = true, title, ...props }) => {
   const [failureMessage, setFailureMessage] = useState(null);
@@ -51,20 +43,15 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
 
   const ref = useRef();
 
-  // const prevUsers = usePreviousValue(users);
-  // const prevUserIdsFetched = usePreviousValue(userIdsFetched);
-
-  // useEffect(() => {
-  //     console.log('prevUsers:', prevUsers, 'users:', users, 'prevUserIdsFetched:', prevUserIdsFetched);
-  //     if (!prevUsers && users) {
-  //       if (!prevUserIdsFetched) {
-  //         fetchUserIds();
-  //       }
-  //     }
-  //   }, []);
+  useEffect(() => {
+    if (showArticle && users) {
+      fetchUserIds();
+    }
+  }, [showArticle]);
 
   useEffect(() => {
     if (showOnMount) {
+      fetchUserIds();
       openArticle();
     }
   }, [showOnMount]);
@@ -80,12 +67,6 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   // addition to the users prop, which in this case contains all the users that have edited
   // the article but not been assigned to it. The assignedUsers prop, if available, is then
   // used in the fetchUserIds function.
-
-  useEffect(() => {
-    if (users && !userIdsFetched) {
-      fetchUserIds();
-    }
-  }, [users, userIdsFetched]);
 
   useEffect(() => {
     if (showArticle) {

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 // Utilities
 import { forEach, union } from 'lodash-es';
@@ -40,8 +40,8 @@ import { resetBadWorkAlert, submitBadWorkAlert } from '~/app/assets/javascripts/
     'useEffect' fetches MediaWiki user IDs for coloration as soon as the usernames are available
 */
 const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
-  fetchArticleDetails, assignedUsers, article, course, alertStatus, current_user = {},
-  showButtonClass, showPermalink = true, title, ...props }) => {
+  fetchArticleDetails, assignedUsers, article, course, current_user = {},
+  showButtonClass, showPermalink = true, title }) => {
   const [failureMessage, setFailureMessage] = useState(null);
   const [fetched, setFetched] = useState(false);
   const [highlightedHtml, setHighlightedHtml] = useState(null);
@@ -53,6 +53,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const [whoColorHtml, setWhoColorHtml] = useState(null);
   const [parsedArticle, setParsedArticle] = useState(null);
 
+  const dispatch = useDispatch();
   const ref = useRef();
 
   useEffect(() => {
@@ -127,7 +128,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     if (!showArticle) { return; }
     setShowBadArticleAlert(false);
     setShowArticle(false);
-    props.resetBadWorkAlert();
+    dispatch(resetBadWorkAlert());
     // removes the article parameter from the URL
     removeParamFromURL(e);
   };
@@ -219,14 +220,6 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
       });
   };
 
-  const _submitBadWorkAlert = (message) => {
-    props.submitBadWorkAlert({
-      article_id: article.id,
-      course_id: course.id,
-      message
-    });
-  };
-
   const handleClickOutside = (event) => {
     const element = ref.current;
     if (element && !element.contains(event.target)) {
@@ -277,9 +270,12 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
         {
           showBadArticleAlert && (
             <BadWorkAlert
-              alertStatus={alertStatus}
               project={article.project}
-              submitBadWorkAlert={_submitBadWorkAlert}
+              submitBadWorkAlert={message => dispatch(submitBadWorkAlert({
+                article_id: article.id,
+                course_id: course.id,
+                message
+              }))} // Passed as a function that calls dispatch
             />
           )
         }
@@ -308,7 +304,6 @@ ArticleViewer.defaultProps = {
 };
 
 ArticleViewer.propTypes = {
-  alertStatus: PropTypes.object.isRequired,
   article: PropTypes.shape({
     id: PropTypes.number,
     language: PropTypes.string,
@@ -326,9 +321,4 @@ ArticleViewer.propTypes = {
   users: PropTypes.array,
 };
 
-const mapStateToProps = ({ badWorkAlert }) => ({ alertStatus: badWorkAlert });
-const mapDispatchToProps = {
-  resetBadWorkAlert,
-  submitBadWorkAlert
-};
-export default connect(mapStateToProps, mapDispatchToProps)(ArticleViewer);
+export default (ArticleViewer);

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -28,8 +28,20 @@ import colors from '@components/common/ArticleViewer/constants/colors';
 // Actions
 import { resetBadWorkAlert, submitBadWorkAlert } from '~/app/assets/javascripts/actions/alert_actions.js';
 
-const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel, fetchArticleDetails, assignedUsers, article, course,
-  alertStatus, current_user = {}, showButtonClass, showPermalink = true, title, ...props }) => {
+/*
+  Quick summary of the ArticleViewer component's main logic
+
+  The 'openArticle()' function opens the 'articleViewer' component.
+
+  If usernames are already available in the props:
+    'openArticle()' fetches MediaWiki user IDs for coloration
+  If the usernames aren't already available in the props:
+    'openArticle()' fetches the usernames
+    'useEffect' fetches MediaWiki user IDs for coloration as soon as the usernames are available
+*/
+const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
+  fetchArticleDetails, assignedUsers, article, course, alertStatus, current_user = {},
+  showButtonClass, showPermalink = true, title, ...props }) => {
   const [failureMessage, setFailureMessage] = useState(null);
   const [fetched, setFetched] = useState(false);
   const [highlightedHtml, setHighlightedHtml] = useState(null);
@@ -49,6 +61,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     }
   }, [showArticle]);
 
+  // This runs when the user accesses the articleViewer directly from a permalink
   useEffect(() => {
     if (showOnMount) {
       fetchUserIds();
@@ -56,21 +69,8 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     }
   }, [showOnMount]);
 
-  // When 'show' is clicked, this component may or may not already have
-  // users data (a list of usernames) in its props. If it does, then 'show' will
-  // fetch the MediaWiki user ids, which are used for coloration. Those can't be
-  // fetched until the usernames are available, so 'show' will fetch the usernames
-  // first in that case. In that case, componentDidUpdate fetches the
-  // user ids as soon as usernames are avaialable. In case the articleViewer is
-  // accessed through the Students/Editors tab, an extra prop called assignedUsers,that
-  // holds all users extracted from assigned articles, will be passed to the articleViewer in
-  // addition to the users prop, which in this case contains all the users that have edited
-  // the article but not been assigned to it. The assignedUsers prop, if available, is then
-  // used in the fetchUserIds function.
-
   useEffect(() => {
     if (showArticle) {
-      // Add event listener when the component is visible
       document.addEventListener('mousedown', handleClickOutside);
     }
     return () => document.removeEventListener('mousedown', handleClickOutside);
@@ -194,12 +194,13 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   // These are mediawiki user ids, and don't necessarily match the dashboard
   // database user ids, so we must fetch them by username from the wiki.
   const fetchUserIds = () => {
-    // if articleViewer is accessed through Students/Editors tab, a combination
-    // of both assignedUsers and users will be passed to the URLBuilder, whenever the
-    // fetchUserIds function is called. However, if the articleViewer is accessed
-    // through any other tab, e.g Articles tab, only the users prop will be passed
-    // to the URLBuilder as the assignedUsers prop would be undefined. In this case
-    // the users prop will be combined with an empty array.
+    /*
+      if articleViewer is accessed through Students/Editors tab, a combination
+      of both assignedUsers and users will be passed to the URLBuilder.
+      However, if the articleViewer is accessed through any other tab. Only the users prop will be passed
+      to the URLBuilder as the assignedUsers prop would be undefined.
+      In this case, the users prop will be combined with an empty array.
+     */
     const allUsers = union(assignedUsers || [], users);
     const builder = new URLBuilder({ article: article, users: allUsers });
     const api = new ArticleViewerAPI({ builder });

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -287,7 +287,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
             <CloseButton hideArticle={hideArticle} />
             {
               current_user.isAdvancedRole && (
-                <BadWorkAlertButton showBadArticleAlert={showBadArticleAlert} />
+                <BadWorkAlertButton showBadArticleAlert={() => setShowBadArticleAlert(true)} /> // Passed as a function for onclick
               )
             }
           </p>

--- a/test/components/common/article_viewer.spec.jsx
+++ b/test/components/common/article_viewer.spec.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { ArticleViewer } from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
+import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
 import '../../testHelper';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 describe('ArticleViewer', () => {
+  const store = mockStore({
+  });
   it('renders', () => {
     const article = {
       id: 99,
@@ -17,12 +24,15 @@ describe('ArticleViewer', () => {
       id: 1
     };
     const TestArticleViewer = ReactTestUtils.renderIntoDocument(
-      <ArticleViewer
-        alertStatus={{}}
-        article={article}
-        course={course}
-        fetchArticleDetails={() => null}
-      />
+      <Provider store={store} >
+        <ArticleViewer
+          alertStatus={{}}
+          article={article}
+          course={course}
+          fetchArticleDetails={() => null}
+        />
+      </Provider>
+
     );
     expect(TestArticleViewer).toExist;
   });


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `ArticleViewer.jsx` into a functional component. 
**Affected Pages:**
`ArticleViewer.jsx` is used in the following 3 pages:
- `/courses/[institution_slug]/[course_slug]/students/articles/[student_username]` 
- `/courses/[institution_slug]/[course_slug]/students/articles/edited` 
- `/courses/[institution_slug]/[course_slug]/article_finder` 

## Videos
(Videos were too big to directly embed on github, I linked to unlisted youtube videos instead)

Before `ArticleViewer.jsx` (shows all 3 pages)

[Before](https://youtu.be/r4Iq6K4f9uU)

After `ArticleViewer.jsx` (shows all 3 pages)

[After](https://youtu.be/1RbjtnxCPMU)

## Questions/Concerns
I noticed that there's an unrelated bug with articleViewer in the article finder page (happened before the refactor too), when attempting to send a bad quality alert it causes an internal server issue. Should I open up a separate issue for this?
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/b90beb2a-d00c-4851-9e72-f50707e2e655)
