### PR TITLE
Fix error on Unsubmitted course alert mailer preview

### DIFF
--- a/app/mailers/unsubmitted_course_alert_mailer.rb
+++ b/app/mailers/unsubmitted_course_alert_mailer.rb
@@ -13,7 +13,7 @@ class UnsubmittedCourseAlertMailer < ApplicationMailer
     @classroom_program_manager = SpecialUsers.classroom_program_manager
     subject = 'Reminder: Submit your Wiki Education course page'
     mail(to: @instructor.email,
-         reply_to: @classroom_program_manager.email,
+         reply_to: @classroom_program_manager&.email,
          subject:)
   end
 end

--- a/app/views/unsubmitted_course_alert_mailer/email.html.haml
+++ b/app/views/unsubmitted_course_alert_mailer/email.html.haml
@@ -22,4 +22,4 @@
                 Best,
                 %br
                 %em
-                  =@classroom_program_manager&.username || 'The system'
+                  =@classroom_program_manager&.username || 'Classroom Program Manager'

--- a/app/views/unsubmitted_course_alert_mailer/email.html.haml
+++ b/app/views/unsubmitted_course_alert_mailer/email.html.haml
@@ -22,4 +22,4 @@
                 Best,
                 %br
                 %em
-                  =@classroom_program_manager.username
+                  =@classroom_program_manager&.username || 'The system'


### PR DESCRIPTION
## What this PR does
Fix error when previewing Unsubmitted Course Alert Mailer Preview
Task of #5078 

Allow a fallback in case of nil value

Due to some git manipulation, PR #5415 has been involuntary closed.
