### PR TITLE
Converting RangeGraph and TextResults into functional components

### DIFF
--- a/app/assets/javascripts/surveys/components/RangeGraph.jsx
+++ b/app/assets/javascripts/surveys/components/RangeGraph.jsx
@@ -1,86 +1,78 @@
 import { keys, values } from 'lodash-es';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { answerFrequency } from './utils';
 
-export default class RangeGraph extends Component {
-  constructor() {
-    super();
-    this.state = {
-      showValue: null
-    };
-    this.showValue = this._showValue.bind(this);
-  }
-  _showValue(val) {
-    this.setState({ showValue: val });
-  }
-  render() {
-    const validationRules = this.props.question.validation_rules;
-    const min = validationRules.range_minimum;
-    const max = validationRules.range_maximum;
-    const answers = answerFrequency(this.props);
-    const answerKeys = keys(answers).sort((a, b) => { return a - b; });
-    const mostFrequent = values(answers).sort((a, b) => { return a - b; }).pop();
-    const graphHeight = mostFrequent * 40;
-    const showValue = this.state.showValue;
+const RangeGraph = ({ question, answers }) => {
+  const [showValue, setShowValue] = useState(null);
 
-    const xAxis = () => {
-      return (
-        <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, width: '100%' }}>
-          <span className="results__range-graph__min">{min}</span>
-          <span className="results__range-graph__mid">{(max - min) / 2}</span>
-          {answerKeys.map((key) => {
-            const increment = (graphHeight / mostFrequent);
-            const xPos = (key / max) * 100;
-            const show = showValue === key;
-            const value = <div className={`results__range-graph__value ${show ? 'show' : ''}`} style={{ position: 'absolute', left: 0 }}>{key}</div>;
-            return (
-              <div key={key} style={{ display: 'inline-block', textAlign: 'center', position: 'absolute', left: `${xPos}%`, bottom: 0 }}>
-                {value}
-                <div
-                  className="results__range-graph__bar"
-                  onMouseEnter={() => { this.showValue(key); }}
-                  onMouseLeave={() => { this.showValue(null); }}
-                  style={{ position: 'absolute', display: 'block', width: 10, left: -10, bottom: 0, height: (increment * answers[key]) }}
-                />
-              </div>
-            );
-          })}
-          <span className="results__range-graph__max">{max}</span>
-        </div>
-      );
-    };
+  const validationRules = question.validation_rules;
+  const min = validationRules.range_minimum;
+  const max = validationRules.range_maximum;
+  const answerFrequencies = answerFrequency(answers);
+  const answerKeys = keys(answerFrequencies).sort((a, b) => { return a - b; });
+  const mostFrequent = values(answerFrequencies).sort((a, b) => { return a - b; }).pop();
+  const graphHeight = mostFrequent * 40;
 
-    const yAxis = () => {
-      let i = 0;
-      const increment = (graphHeight / mostFrequent) - 1;
-      const yRows = [];
-      while (i < mostFrequent) {
-        i += 1;
-        yRows.push(
-          <div key={`row${i}`} style={{ position: 'relative', height: increment }} className="results__range-graph__row">
-            <div style={{ position: 'absolute', height: 15, top: -8, left: -20 }}>{mostFrequent - (i - 1)}</div>
-          </div>
-        );
-      }
-      return yRows;
-    };
-
+  const xAxis = () => {
     return (
-      <div>
-        <span className="contextual">Frequency</span>
-        <div style={{ padding: '20px 0 20px 20px' }}>
-          <div className="results__range-graph" style={{ position: 'relative', width: '100%', height: graphHeight }}>
-            {yAxis()}
-            {xAxis()}
-          </div>
-        </div>
-        <div className="text-center p1"><span className="contextual">Values</span></div>
+      <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, width: '100%' }}>
+        <span className="results__range-graph__min">{min}</span>
+        <span className="results__range-graph__mid">{(max - min) / 2}</span>
+        {answerKeys.map((key) => {
+          const increment = (graphHeight / mostFrequent);
+          const xPos = (key / max) * 100;
+          const show = showValue === key;
+          const value = <div className={`results__range-graph__value ${show ? 'show' : ''}`} style={{ position: 'absolute', left: 0 }}>{key}</div>;
+          return (
+            <div key={key} style={{ display: 'inline-block', textAlign: 'center', position: 'absolute', left: `${xPos}%`, bottom: 0 }}>
+              {value}
+              <div
+                className="results__range-graph__bar"
+                onMouseEnter={() => { setShowValue(key); }}
+                onMouseLeave={() => { setShowValue(null); }}
+                style={{ position: 'absolute', display: 'block', width: 10, left: -10, bottom: 0, height: (increment * answerFrequencies[key]) }}
+              />
+            </div>
+          );
+        })}
+        <span className="results__range-graph__max">{max}</span>
       </div>
     );
-  }
-}
+  };
+
+  const yAxis = () => {
+    let i = 0;
+    const increment = (graphHeight / mostFrequent) - 1;
+    const yRows = [];
+    while (i < mostFrequent) {
+      i += 1;
+      yRows.push(
+        <div key={`row${i}`} style={{ position: 'relative', height: increment }} className="results__range-graph__row">
+          <div style={{ position: 'absolute', height: 15, top: -8, left: -20 }}>{mostFrequent - (i - 1)}</div>
+        </div>
+      );
+    }
+    return yRows;
+  };
+
+  return (
+    <div>
+      <span className="contextual">Frequency</span>
+      <div style={{ padding: '20px 0 20px 20px' }}>
+        <div className="results__range-graph" style={{ position: 'relative', width: '100%', height: graphHeight }}>
+          {yAxis()}
+          {xAxis()}
+        </div>
+      </div>
+      <div className="text-center p1"><span className="contextual">Values</span></div>
+    </div>
+  );
+};
 
 RangeGraph.propTypes = {
-  question: PropTypes.object
+  question: PropTypes.object,
+  answers: PropTypes.array
 };
+
+export default (RangeGraph);

--- a/app/assets/javascripts/surveys/components/utils.js
+++ b/app/assets/javascripts/surveys/components/utils.js
@@ -12,9 +12,9 @@ export function answerTotals(question) {
   return optionTotals;
 }
 
-export function answerFrequency(question) {
+export function answerFrequency(answers) {
   const counts = {};
-  question.answers.forEach((answer) => {
+  answers.forEach((answer) => {
     if (counts[answer] === undefined) {
       counts[answer] = 1;
     } else {


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `RangeGraph.jsx` and `TextResults.jsx` into functional components. 
**Affected Pages:**
- `/survey/results/[survey_id]` (for `RangeGraph.jsx` and `TextResults.jsx`)

## Screenshots
Before `RangeGraph.jsx` 
![before refactor RangeGraph](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/7917795c-0005-4207-8fdd-f365a9dca46f)

After `RangeGraph.jsx` 
![after refactor RangeGraph](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/b675f29e-b74d-467e-9afd-417e3bcfdf18)

Before `TextResults.jsx` 
![before refactor TextResults](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/935e385d-980f-40a2-a6a9-739fd92c51e9)

After `TextResults.jsx` 
![after refactor textResults](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/59393b12-b60b-41b7-af5d-5dcda23c9835)
