### PR TITLE
Converting TaggedCourseAlerts, SyllabusUpload and ProgressTracker into functional components

### DIFF
--- a/app/assets/javascripts/components/alerts/tagged_course_alerts.jsx
+++ b/app/assets/javascripts/components/alerts/tagged_course_alerts.jsx
@@ -1,40 +1,21 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import withRouter from '../util/withRouter';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import AlertsHandler from './alerts_handler.jsx';
-import { fetchTaggedCourseAlerts, filterAlerts } from '../../actions/alert_actions';
+import { fetchTaggedCourseAlerts } from '../../actions/alert_actions';
+import { useParams } from 'react-router-dom';
 
-class TaggedCourseAlerts extends React.Component {
-  constructor(props) {
-    super(props);
+const TaggedCourseAlerts = () => {
+  const { tag } = useParams();
+  const dispatch = useDispatch();
 
-    this.getTag = this.getTag.bind(this);
-  }
+  useEffect(() => dispatch(fetchTaggedCourseAlerts(tag)), []);
 
-  componentDidMount() {
-    // This adds the specific campaign alerts to the state, to be used in AlertsHandler
-    this.props.fetchTaggedCourseAlerts(this.getTag());
-  }
-
-  getTag() {
-    return `${this.props.router.params.tag}`;
-  }
-
-  render() {
-    return (
-      <AlertsHandler
-        alertLabel={I18n.t('campaign.alert_label')}
-        noAlertsLabel={I18n.t('campaign.no_alerts')}
-      />
-    );
-  }
-}
-
-TaggedCourseAlerts.propTypes = {
-  fetchTaggedCourseAlerts: PropTypes.func
+  return (
+    <AlertsHandler
+      alertLabel={I18n.t('campaign.alert_label')}
+      noAlertsLabel={I18n.t('campaign.no_alerts')}
+    />
+  );
 };
 
-const mapDispatchToProps = { fetchTaggedCourseAlerts, filterAlerts };
-
-export default withRouter(connect(null, mapDispatchToProps)(TaggedCourseAlerts));
+export default (TaggedCourseAlerts);

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/NavigationElements.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/NavigationElements.jsx
@@ -7,7 +7,7 @@ import ListItem from './ListItem';
 // helpers
 import processes from '@components/overview/my_articles/step_processes';
 
-export const Navigation = ({ assignment, show, course }) => {
+export const Navigation = ({ assignment, showTracker, course }) => {
   const lis = processes(assignment, course).map((props, i) => (
     <ListItem
       {...props}
@@ -19,9 +19,9 @@ export const Navigation = ({ assignment, show, course }) => {
 
   return (
     <ul>
-      { lis }
+      {lis}
       {
-        show
+        showTracker
           ? <li className="icon icon-arrow-reverse table-expandable-indicator limit-size" />
           : <li className="icon icon-arrow table-expandable-indicator limit-size" />
       }
@@ -32,7 +32,7 @@ export const Navigation = ({ assignment, show, course }) => {
 Navigation.propTypes = {
   // props
   assignment: PropTypes.object.isRequired,
-  show: PropTypes.bool.isRequired,
+  showTracker: PropTypes.bool.isRequired,
 };
 
 export default Navigation;

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/ProgressTracker.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/ProgressTracker.jsx
@@ -1,64 +1,50 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import processes from '@components/overview/my_articles/step_processes';
 
-// components
 import Step from './Step/Step.jsx';
 import NavigationElements from './NavigationElements/NavigationElements';
 
-export class ProgressTracker extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      show: false
-    };
+const ProgressTracker = ({ assignment, course }) => {
+  const [showTracker, setShowTracker] = useState(false);
 
-    this.toggle = this.toggle.bind(this);
-  }
+  const toggle = () => {
+    setShowTracker(prevState => !prevState);
+  };
 
-  toggle() {
-    this.setState({ show: !this.state.show });
-  }
+  const steps = processes(assignment, course).map((content, index) => (
+    <Step
+      {...content}
+      assignment={assignment}
+      course={course}
+      index={index}
+      key={index}
+    />
+  ));
 
-  render() {
-    const { assignment, course } = this.props;
-    const { show } = this.state;
-
-    const steps = processes(assignment, course).map((content, index) => (
-      <Step
-        {...content}
-        assignment={assignment}
-        course={course}
-        index={index}
-        key={index}
-      />
-    ));
-
-    return (
-      <div className="progress-tracker">
-        <button
-          className="screen-reader"
-          onClick={this.toggle}
-        >
-          Click to hide or show progress tracker
-        </button>
-        <nav
-          aria-label="Click to hide or show progress tracker"
-          className="toggle-progress-tracker"
-          onClick={this.toggle}
-        >
-          <NavigationElements assignment={assignment} show={show} course={course} />
-        </nav>
-        <section className="flow">
-          {show ? steps : null}
-        </section>
-      </div>
-    );
-  }
-}
+  return (
+    <div className="progress-tracker">
+      <button
+        className="screen-reader"
+        onClick={toggle}
+      >
+        Click to hide or show progress tracker
+      </button>
+      <nav
+        aria-label="Click to hide or show progress tracker"
+        className="toggle-progress-tracker"
+        onClick={toggle}
+      >
+        <NavigationElements assignment={assignment} showTracker={showTracker} course={course} />
+      </nav>
+      <section className="flow">
+        {showTracker ? steps : null}
+      </section>
+    </div>
+  );
+};
 
 ProgressTracker.propTypes = {
-  // props
   assignment: PropTypes.object.isRequired,
   course: PropTypes.object.isRequired,
 };

--- a/app/assets/javascripts/components/overview/overview_handler.jsx
+++ b/app/assets/javascripts/components/overview/overview_handler.jsx
@@ -88,7 +88,7 @@ const Overview = createReactClass({
     if (query.syllabus_upload === 'true' && this.props.current_user.admin) {
       syllabusUpload = (
         <Modal modalClass="course__syllabus-upload">
-          <SyllabusUpload {...this.props} />
+          <SyllabusUpload course={this.props.course} />
         </Modal>
       );
     }
@@ -167,12 +167,12 @@ const Overview = createReactClass({
 
     let overviewStatsTabs;
     if (course.course_stats && course.course_stats.stats_hash) {
-      overviewStatsTabs = <OverviewStatsTabs statistics={course.course_stats.stats_hash}/>;
+      overviewStatsTabs = <OverviewStatsTabs statistics={course.course_stats.stats_hash} />;
     }
 
     return (
       <section className="overview container">
-        { syllabusUpload }
+        {syllabusUpload}
         <OverviewStats course={course} />
         {overviewStatsTabs}
         <StatisticsUpdateInfo course={course} />
@@ -196,7 +196,7 @@ const mapStateToProps = state => ({
   firstErrorMessage: firstValidationErrorMessage(state),
   isValid: isValid(state),
   courseCreationNotice: state.courseCreator.courseCreationNotice
- });
+});
 
 const mapDispatchToProps = {
   initiateConfirm,

--- a/app/assets/javascripts/components/overview/syllabus-upload.jsx
+++ b/app/assets/javascripts/components/overview/syllabus-upload.jsx
@@ -1,28 +1,27 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import Dropzone from 'react-dropzone';
 import Loading from '../common/loading.jsx';
 import { toggleEditingSyllabus, uploadSyllabus } from '../../actions/course_actions';
 
-class SyllabusUpload extends React.Component {
-  constructor() {
-    super();
-    this.onDrop = this._onDrop.bind(this);
-    this.removeSyllabus = this._removeSyllabus.bind(this);
-  }
-  _onDrop(files) {
-    this.props.uploadSyllabus({
-      courseId: this.props.course.id,
+const SyllabusUpload = ({ course }) => {
+  const [isUploadingSyllabus, setIsUploadingSyllabus] = useState(false);
+  const dispatch = useDispatch();
+
+  const onDrop = (files) => {
+    setIsUploadingSyllabus(true);
+    dispatch(uploadSyllabus({
+      courseId: course.id,
       file: files[0]
-    });
-  }
-  _uploader() {
-    const { uploadingSyllabus } = this.props;
-    const cancelButton = <button className="link-button" onClick={this.props.toggleEditingSyllabus}>cancel</button>;
+    })).then(() => setIsUploadingSyllabus(false));
+  };
+
+  const Uploader = () => {
+    const cancelButton = <button className="link-button" onClick={() => dispatch(toggleEditingSyllabus())}>cancel</button>;
     const loadingAnimation = <Loading message={false} />;
     const dropzone = (
-      <Dropzone onDrop={this.onDrop} multiple={false}>
+      <Dropzone onDrop={onDrop} multiple={false}>
         {({ getRootProps, getInputProps }) => (
           <div {...getRootProps()} className="course-syllabus__uploader">
             <input {...getInputProps()} />
@@ -35,61 +34,47 @@ class SyllabusUpload extends React.Component {
     );
     return (
       <div>
-        {(uploadingSyllabus ? loadingAnimation : dropzone)}
+        {(isUploadingSyllabus ? loadingAnimation : dropzone)}
         {cancelButton}
       </div>
     );
-  }
+  };
 
-  _syllabusLink() {
-    const { syllabus } = this.props.course;
+  const SyllabusLink = () => {
+    const { syllabus } = course;
     let link = <span>No syllabus has been added.</span>;
     if (syllabus !== undefined) {
       const filename = syllabus.split('/').pop().split('?')[0];
       link = <a href={syllabus}>{filename}</a>;
     }
     return link;
-  }
-  _removeSyllabus() {
-    this.props.uploadSyllabus({
-      courseId: this.props.course.id,
+  };
+  const removeSyllabus = () => {
+    dispatch(uploadSyllabus({
+      courseId: course.id,
       file: null
-    });
-  }
-  render() {
-    const { syllabus, canUploadSyllabus, editingSyllabus } = this.props.course;
-    const editButton = canUploadSyllabus ? <button className="link-button" onClick={this.props.toggleEditingSyllabus}>edit</button> : null;
-    return (
-      <div className="module course-description course__syllabus-upload__inner">
-        <div className="module__data">
-          <h3>Syllabus</h3>
-          {this._syllabusLink()}
-          &nbsp;
-          &nbsp;
-          {(canUploadSyllabus && editingSyllabus ? this._uploader() : editButton)}
-          &nbsp;
-          &nbsp;
-          {(syllabus !== undefined ? <button className="link-button" onClick={this.removeSyllabus}>remove</button> : null)}
-          &nbsp;
-          &nbsp;
-          <a className="link-button" href={`/courses/${this.props.course.slug}`}>save</a>
-        </div>
+    }));
+  };
+  const { syllabus, canUploadSyllabus, editingSyllabus } = course;
+  const editButton = canUploadSyllabus ? <button className="link-button" onClick={() => dispatch(toggleEditingSyllabus())}>edit</button> : null;
+  return (
+    <div className="module course-description course__syllabus-upload__inner">
+      <div className="module__data">
+        <h3>Syllabus</h3>
+        <SyllabusLink />
+        {' '}
+        {(canUploadSyllabus && editingSyllabus ? <Uploader /> : editButton)}
+        {' '}
+        {(syllabus !== undefined ? <button className="link-button" onClick={removeSyllabus}>remove</button> : null)}
+        {' '}
+        <a className="link-button" href={`/courses/${course.slug}`}>save</a>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 SyllabusUpload.propTypes = {
   course: PropTypes.object.isRequired,
-  syllabus: PropTypes.string,
-  editingSyllabus: PropTypes.bool,
-  uploadingSyllabus: PropTypes.bool,
-  toggleEditingSyllabus: PropTypes.func.isRequired
 };
 
-const mapDispathToProps = {
-  toggleEditingSyllabus,
-  uploadSyllabus
-};
-
-export default connect(null, mapDispathToProps)(SyllabusUpload);
+export default (SyllabusUpload);

--- a/test/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/index.spec.jsx
+++ b/test/components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/index.spec.jsx
@@ -5,8 +5,8 @@ import '../../../../../../../../../testHelper';
 import NavigationElements from '@components/overview/my_articles/components/Categories/List/Assignment/ProgressTracker/NavigationElements/NavigationElements.jsx';
 
 describe('NavigationElements', () => {
-  const props = { assignment: {}, show: false };
-  it('should show the down arrow when `show` is false', () => {
+  const props = { assignment: {}, showTracker: false };
+  it('should show the down arrow when `showTracker` is false', () => {
     const component = shallow(<NavigationElements {...props} />);
     const li = component.find('li');
 
@@ -14,8 +14,8 @@ describe('NavigationElements', () => {
     expect(li.props().className).toContain('icon-arrow');
   });
 
-  it('should show the up arrow when `show` is true', () => {
-    const component = shallow(<NavigationElements {...props} show={true} />);
+  it('should show the up arrow when `showTracker` is true', () => {
+    const component = shallow(<NavigationElements {...props} showTracker={true} />);
     const li = component.find('li');
 
     expect(li.length).toEqual(1);
@@ -24,7 +24,7 @@ describe('NavigationElements', () => {
 
   it('displays list items when given an assignment', () => {
     const component = shallow(
-      <NavigationElements assignment={{ sandboxUrl: 'url' }} show={true} />
+      <NavigationElements assignment={{ sandboxUrl: 'url' }} showTracker={true} />
     );
     const listItem = component.find('ListItem');
     expect(listItem.length).toBeTruthy;


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `tagged_course_alerts.jsx`, `syllabus-upload.jsx` and `ProgressTracker.jsx` into functional components. 
**Affected Pages:**
- `/tagged_courses/[tag]/alerts` (for `tagged_course_alerts.jsx`)
- `/courses/[institution_slug]/[course_slug]/?syllabus_upload=true` (for `syllabus-upload.jsx`)
- `/courses/[institution_slug]/[course_slug]` (for `ProgressTracker.jsx`)

## Videos/Screenshots
Before `tagged_course_alerts.jsx` 
![before refactor TaggedCourseAlerts](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/59f2471f-f9ca-48e8-ae8a-4622346cfdcf)

After `tagged_course_alerts.jsx` 
![after refactor TaggedCourseAlerts](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/9d5e8739-8e9c-4572-978b-da4c06e9e4fb)

Before `syllabus-upload.jsx` 

[before refactor SyllabusUpload.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/35e4e22d-b4b8-4c49-b121-037ea5c2ea86)

After `syllabus-upload.jsx` 

[after refactor SyllabusUpload.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/e97afb5d-9e54-4f64-8f5d-1ee1950b213a)

Before `ProgressTracker.jsx` 

[before refactor ProgressTracker.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/8b4a85a6-efcd-4296-9ecf-09635f5de212)

After `ProgressTracker.jsx` 

[after refactor ProgressTracker.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a12124b2-3d52-4a0e-b835-166134fd10d6)

## Questions/Concerns
For `syllabus-upload.jsx`, I added a working loading animation during the upload. The boolean conditional for it was broken because uploadingSyllabus wasn't being passed in as a prop.