### PR TITLE
Fix error on Ticket Notification Mailer

### DIFF
--- a/spec/mailers/previews/ticket_notification_mailer_preview.rb
+++ b/spec/mailers/previews/ticket_notification_mailer_preview.rb
@@ -4,8 +4,9 @@ class TicketNotificationMailerPreview < ActionMailer::Preview
   def message_to_student
     sender = User.new(username: 'admin',
                       real_name: 'Delano (Wiki Edu)',
-                      permissions: User::Permissions::ADMIN)
-    recipient = User.new(username: 'flanagan.hyder')
+                      permissions: User::Permissions::ADMIN,
+                      email: 'admin@mail.com')
+    recipient = User.new(username: 'flanagan.hyder', email: 'recipient@mail.com')
     TicketNotificationMailer.notify(
       course:, message:, recipient:,
       sender:, bcc_to_salesforce: false
@@ -13,10 +14,11 @@ class TicketNotificationMailerPreview < ActionMailer::Preview
   end
 
   def message_to_instructor
-    sender = User.new(username: 'flanagan.hyder')
+    sender = User.new(username: 'flanagan.hyder', email: 'student@mail.com')
     recipient = User.new(username: 'admin',
                          real_name: 'Delano (Wiki Edu)',
-                         permissions: User::Permissions::ADMIN)
+                         permissions: User::Permissions::ADMIN,
+                         email: 'admin@mail.com')
     TicketNotificationMailer.notify(
       course:, message:, recipient:,
       sender:, bcc_to_salesforce: false
@@ -39,7 +41,21 @@ class TicketNotificationMailerPreview < ActionMailer::Preview
   end
 
   def message
-    ticket = TicketDispenser::Ticket.first
-    ticket.messages.last
+    message1 = OpenStruct.new(
+      reply?: 0,
+      content: 'I cannot log to this course ...',
+      details: { cc: [{ email: 'other@email.com' }], delivered: Time.zone.now },
+      created_at: Time.zone.now
+    )
+    message2 = OpenStruct.new(
+      reply?: 0,
+      content: 'Did you properly register ?',
+      details: { cc: [{ email: 'other@email.com' }], delivered: Time.zone.now },
+      created_at: Time.zone.now
+    )
+    ticket = OpenStruct.new(messages: [message1, message2])
+    message1.ticket = ticket
+    message2.ticket = ticket
+    message2
   end
 end


### PR DESCRIPTION
## What this PR does
Fixes error on Ticket Notification Mailer Preview

One task of  #5078

It appears that preview is done with actual DB data. There are cases where there are no such data.
Here, there might be no tickets in DB, even example data, as example Ticket data has to be imported with a rake task.
It seems the case also in staging.

To bypass this and ensure a preview even if there are no Ticket data in DB, we can "mock" the missing objects with structs (here OpenStruct):

## Screenshots
Before:
See [https://dashboard-testing.wikiedu.org/rails/mailers/ticket_notification_mailer/message_to_instructor](url)

After:
![mailer_3](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/5203082/432afe17-bc6c-4a29-bf4f-663203638a5c)

