### PR TITLE
Removed unnecessary display of alert button in article finder's preview article UI

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -266,9 +266,9 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
             }
             <CloseButton hideArticle={hideArticle} />
             {
-              current_user.isAdvancedRole && (
+              current_user.isAdvancedRole && !showArticleFinder ? (
                 <BadWorkAlertButton showBadArticleAlert={() => setShowBadArticleAlert(true)} /> // Passed as a function for onclick
-              )
+              ) : ''
             }
           </p>
         </div>


### PR DESCRIPTION
Fixes #5422 
## What this PR does
Fixed an issue where the send alert button would be displayed on the article finder page.

## Screenshots
Before (the button is displayed):
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/093d7ea0-4eb2-4922-9535-05d7340e209a)

After (the button is no longer displayed):
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a43e98a3-2953-4052-ba1c-34be864d1771)

Note that this only affects the article finder page. The other pages that use the article viewer remain unaffected and are working fine.
