### PR TITLE
Converting MyArticlesContainer and MyExercicesContainer into functional components

### DIFF
--- a/app/assets/javascripts/components/overview/my_articles/containers/index.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/containers/index.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 // components
 import MyArticlesInstructorMessage from '@components/overview/my_articles/components/InstructorMessage.jsx';
@@ -15,88 +15,70 @@ import { fetchAssignments } from '~/app/assets/javascripts/actions/assignment_ac
 import { processAssignments } from '@components/overview/my_articles/utils/processAssignments';
 import ArticleUtils from '../../../../utils/article_utils';
 
-export class MyArticlesContainer extends React.Component {
-  componentDidMount() {
-    if (this.props.loading) {
-      this.props.fetchAssignments(this.props.course.slug);
+const MyArticlesContainer = ({ current_user }) => {
+  const dispatch = useDispatch();
+
+  const assignments = useSelector(state => state.assignments.assignments);
+  const course = useSelector(state => state.course);
+  const loading = useSelector(state => state.assignments.loading);
+  const wikidataLabels = useSelector(state => state.wikidataLabels);
+
+  useEffect(() => {
+    if (loading) {
+      dispatch(fetchAssignments(course.slug));
+    }
+  }, []);
+
+  const {
+    assigned,
+    reviewing,
+    reviewable,
+    assignable,
+    all
+  } = processAssignments({ assignments, course, current_user });
+
+  const rightUserType = current_user.isStudent || current_user.isInstructor;
+  if (loading || !rightUserType) return null;
+  let noArticlesMessage;
+  if (!assigned.length && current_user.isStudent) {
+    if (Features.wikiEd) {
+      noArticlesMessage = <MyArticlesNoAssignmentMessage course={course} />;
+    } else {
+      noArticlesMessage = <p id="no-assignment-message">{I18n.t(`assignments.${ArticleUtils.projectSuffix(course.home_wiki.project, 'none_short')}`)}</p>;
     }
   }
 
-  render() {
-    const {
-      course, current_user, loading, wikidataLabels
-    } = this.props;
+  let instructorMessage;
+  if (Features.wikiEd && current_user.isInstructor) {
+    instructorMessage = <MyArticlesInstructorMessage msg={I18n.t(`courses.${ArticleUtils.projectSuffix(course.home_wiki.project, 'instructor_message')}`)} />;
+  }
 
-    const {
-      assigned,
-      reviewing,
-      reviewable,
-      assignable,
-      all
-    } = processAssignments(this.props);
-
-    const rightUserType = current_user.isStudent || current_user.isInstructor;
-    if (loading || !rightUserType) return null;
-    let noArticlesMessage;
-    if (!assigned.length && current_user.isStudent) {
-      if (Features.wikiEd) {
-        noArticlesMessage = <MyArticlesNoAssignmentMessage course={course} />;
-      } else {
-        noArticlesMessage = <p id="no-assignment-message">{I18n.t(`assignments.${ArticleUtils.projectSuffix(course.home_wiki.project, 'none_short')}`)}</p>;
-      }
-    }
-
-    let instructorMessage;
-    if (Features.wikiEd && current_user.isInstructor) {
-      instructorMessage = <MyArticlesInstructorMessage msg={I18n.t(`courses.${ArticleUtils.projectSuffix(course.home_wiki.project, 'instructor_message')}`)} />;
-    }
-
-    return (
-      <div>
-        <div className="module my-articles">
-          {instructorMessage}
-          <MyArticlesHeader
-            assigned={assigned}
-            course={course}
-            current_user={current_user}
-            reviewable={reviewable}
-            reviewing={reviewing}
-            unassigned={assignable}
-            wikidataLabels={wikidataLabels}
-          />
-          <MyArticlesCategories
-            assignments={all}
-            course={course}
-            current_user={current_user}
-            loading={loading}
-            wikidataLabels={wikidataLabels}
-          />
-          {noArticlesMessage}
-        </div>
+  return (
+    <div>
+      <div className="module my-articles">
+        {instructorMessage}
+        <MyArticlesHeader
+          assigned={assigned}
+          course={course}
+          current_user={current_user}
+          reviewable={reviewable}
+          reviewing={reviewing}
+          unassigned={assignable}
+          wikidataLabels={wikidataLabels}
+        />
+        <MyArticlesCategories
+          assignments={all}
+          course={course}
+          current_user={current_user}
+          loading={loading}
+          wikidataLabels={wikidataLabels}
+        />
+        {noArticlesMessage}
       </div>
-    );
-  }
-}
-
-MyArticlesContainer.propTypes = {
-  // props
-  assignments: PropTypes.array.isRequired,
-  course: PropTypes.object.isRequired,
-  current_user: PropTypes.object,
-  loading: PropTypes.bool.isRequired,
-  wikidataLabels: PropTypes.object.isRequired,
-
-  // actions
-  fetchAssignments: PropTypes.func.isRequired,
+    </div>
+  );
 };
 
-const mapStateToProps = state => ({
-  assignments: state.assignments.assignments,
-  course: state.course,
-  loading: state.assignments.loading,
-  wikidataLabels: state.wikidataLabels
-});
+MyArticlesContainer.propTypes = { current_user: PropTypes.object };
 
-const mapDispatchToProps = { fetchAssignments };
-
-export default connect(mapStateToProps, mapDispatchToProps)(MyArticlesContainer);
+export default (MyArticlesContainer);

--- a/app/assets/javascripts/components/overview/my_exercises/containers/Container.jsx
+++ b/app/assets/javascripts/components/overview/my_exercises/containers/Container.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 // Components
 import UpcomingExercise from '../components/UpcomingExercise.jsx';
@@ -11,54 +11,47 @@ import {
   fetchTrainingModuleExercisesByUser
 } from '~/app/assets/javascripts/actions/exercises_actions';
 
-export class MyExercisesContainer extends React.Component {
-  componentDidMount() {
-    return this.props.fetchTrainingModuleExercisesByUser(this.props.course.id);
-  }
+const MyExercisesContainer = ({ trainingLibrarySlug }) => {
+  const dispatch = useDispatch();
 
-  render() {
-    const { course, exercises, trainingLibrarySlug } = this.props;
-    const incomplete = exercises.incomplete.concat(exercises.unread);
-    if (!incomplete.length) return null;
-    if (exercises.loading) {
-      return (
-        <div className="module my-exercises">
-          <h3>Loading...</h3>
-        </div>
-      );
-    }
+  const exercises = useSelector(state => state.exercises);
+  const course = useSelector(state => state.course);
 
-    const [latest, ...remaining] = [...incomplete].sort((a, b) => {
-      if (a.block_id === b.block_id) { return 0; }
-      return a.block_id > b.block_id ? 1 : -1;
-    });
-    if (!latest) {
-      return (
-        <div className="module my-exercises">
-          <Header completed={true} course={course} text="Completed all exercises" />
-        </div>
-      );
-    }
+  useEffect(() => dispatch(fetchTrainingModuleExercisesByUser(course.id)), []);
 
+  const incomplete = exercises.incomplete.concat(exercises.unread);
+  if (!incomplete.length) return null;
+  if (exercises.loading) {
     return (
       <div className="module my-exercises">
-        <Header course={course} remaining={remaining} text="Upcoming Exercises" />
-        <UpcomingExercise exercise={latest} trainingLibrarySlug={trainingLibrarySlug} />
+        <h3>Loading...</h3>
       </div>
     );
   }
-}
+
+  const [latest, ...remaining] = [...incomplete].sort((a, b) => {
+    if (a.block_id === b.block_id) { return 0; }
+    return a.block_id > b.block_id ? 1 : -1;
+  });
+  if (!latest) {
+    return (
+      <div className="module my-exercises">
+        <Header completed={true} course={course} text="Completed all exercises" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="module my-exercises">
+      <Header course={course} remaining={remaining} text="Upcoming Exercises" />
+      <UpcomingExercise exercise={latest} trainingLibrarySlug={trainingLibrarySlug} />
+    </div>
+  );
+};
 
 MyExercisesContainer.propTypes = {
-  exercises: PropTypes.object.isRequired,
-  course: PropTypes.object.isRequired,
   trainingLibrarySlug: PropTypes.string.isRequired
 };
 
-const mapStateToProps = ({ course, exercises }) => ({ course, exercises });
 
-const mapDispatchToProps = {
-  fetchTrainingModuleExercisesByUser
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(MyExercisesContainer);
+export default (MyExercisesContainer);

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -430,7 +430,7 @@ describe 'the course page', type: :feature, js: true do
         user_id: 1,
         file_name: 'File:Example.jpg',
         uploaded_at: '2015-06-01',
-        thumburl: 'https://upload.wikimedia.org/wikipedia/commons/c/c3/Real_Grottolella.png'
+        thumburl: 'https://upload.wikimedia.org/wikipedia/commons/a/af/Grottolella.jpg'
       )
     end
 


### PR DESCRIPTION
## What this PR does
Converts `index.jsx` (in my_articles/containers) and `container.jsx` (in my_exercices/containers) into functional components. 
**Affected Pages:**
- `/courses/[institution_slug]/[course_slug]` (for `index.jsx` [in my_articles/containers] and `container.jsx` [in my_exercices/containers])
## Screenshots
Before `index.jsx` (in my_articles/containers):
![before refactor MyArticlesHandler](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/2b5ea570-d7a4-45ae-92a2-3eafb4dc0c4b)

After `index.jsx` (in my_articles/containers):
![after refactor MyArticlesContainer](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/211ffa42-cc17-4f87-9ed5-0003b45b44d0)

Before `container.jsx` (in my_exercices/containers):
![before refactor MyExercicesContainer](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/cf225737-bd7f-47c9-bdff-1e4d8606c985)


After `container.jsx` (in my_exercices/containers):
![after refactor MyExercicesContainer](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/d12d796b-22c9-4541-b4cb-08567c8702ce)
