### PR TITLE
Fix 500 error on survey mailer preview

### DIFF
--- a/spec/mailers/previews/survey_mailer_preview.rb
+++ b/spec/mailers/previews/survey_mailer_preview.rb
@@ -29,13 +29,17 @@ class SurveyMailerPreview < ActionMailer::Preview
   private
 
   def example_notification
-    notification = SurveyNotification.new(
-      survey_assignment: SurveyAssignment.last,
-      course: Course.nonprivate.last
-    )
-    def notification.user
-      User.new(email: 'sage@example.com', username: 'Ragesoss')
-    end
+    survey = OpenStruct.new(id: 10001, name: 'Survey one')
+    survey_assignment = OpenStruct.new(survey:,
+                                       custom_email_subject: 'Survey: the best wikipedia articles')
+    survey_assignment.custom_email_headline = 'Pick your 3 favorite articles'
+    survey_assignment.custom_email_body = 'You will have to chose three articles.'
+    survey_assignment.custom_email_signature = 'The survey creator'
+    notification = OpenStruct.new(survey_assignment:,
+                                  course: Course.nonprivate.last,
+                                  survey:, user:
+                                    User.new(email: 'sage@example.com', username: 'Ragesoss'))
+
     notification
   end
 end


### PR DESCRIPTION
## What this PR does
"Survey Mailer" task of #5078 tasks 

Removes 500 error. Preview depends on DB data that might not be present at any time.
Mailer preview now uses struct objects as mock.

## Screenshots
Before:
See [https://dashboard-testing.wikiedu.org/rails/mailers/survey_mailer/custom_follow_up](url) (500 error)

After:
![mailer_4](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/5203082/52618a76-7ee5-445d-8a38-9e2e78ed4702)

