### PR TITLE
Converting BadWorkAlert and Overview into functional components

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/BadWorkAlert.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/BadWorkAlert.jsx
@@ -1,50 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import ArticleUtils from '../../../../../utils/article_utils';
 // Components
 import SubmitIssuePanel from '@components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx';
 
-export class BadWorkAlert extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { message: '', isSubmitting: false };
+const BadWorkAlert = ({ project, submitBadWorkAlert }) => {
+  const [message, setMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
+  const handleChange = (_key, messageText) => {
+    setMessage(messageText);
+  };
 
-  handleChange(_key, message) {
-    this.setState({ message });
-  }
-
-  handleSubmit(e) {
+  const handleSubmit = (e) => {
     e.preventDefault();
-    this.props.submitBadWorkAlert(this.state.message);
-    this.setState({ isSubmitting: true });
-  }
+    submitBadWorkAlert(message);
+    setIsSubmitting(true);
+  };
 
-  render() {
-    const { isSubmitting, message } = this.state;
+  return (
+    <section className="article-alert">
+      <article className="learn-more">
+        <p>{I18n.t(`instructor_view.bad_work.${ArticleUtils.projectSuffix(project, 'learn_more')}`)}</p>
+        <a target="_blank" className="button dark" href="/training/instructors/fixing-bad-articles/instructors-role-in-cleanup">
+          {I18n.t('instructor_view.bad_work.learn_more_button')}
+        </a>
+      </article>
+      <SubmitIssuePanel
+        handleChange={handleChange}
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        message={message}
+        project={project}
+      />
+    </section>
+  );
+};
 
-    return (
-      <section className="article-alert">
-        <article className="learn-more">
-          <p>{I18n.t(`instructor_view.bad_work.${ArticleUtils.projectSuffix(this.props.project, 'learn_more')}`)}</p>
-          <a target="_blank" className="button dark" href="/training/instructors/fixing-bad-articles/instructors-role-in-cleanup">
-            {I18n.t('instructor_view.bad_work.learn_more_button')}
-          </a>
-        </article>
-        <SubmitIssuePanel
-          handleChange={this.handleChange}
-          handleSubmit={this.handleSubmit}
-          isSubmitting={isSubmitting}
-          message={message}
-          project={this.props.project}
-        />
-      </section>
-    );
-  }
-}
 BadWorkAlert.propTypes = {
   project: PropTypes.string.isRequired,
   submitBadWorkAlert: PropTypes.func.isRequired

--- a/app/assets/javascripts/components/students/containers/Overview.jsx
+++ b/app/assets/javascripts/components/students/containers/Overview.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import { getStudentUsers, editPermissions } from '~/app/assets/javascripts/selectors';
+import { getStudentUsers } from '~/app/assets/javascripts/selectors';
 
 import StudentsSubNavigation from '@components/students/components/StudentsSubNavigation.jsx';
 import Controls from '@components/students/components/Overview/Controls/Controls.jsx';
@@ -10,30 +10,26 @@ import StudentList from '../shared/StudentList/StudentList.jsx';
 import RandomPeerAssignButton from '@components/students/components/RandomPeerAssignButton.jsx';
 import Loading from '@components/common/loading.jsx';
 
-export class Overview extends React.Component {
-  componentDidMount() {
+const Overview = ({ course, current_user, prefix, sortUsers, notify, sortSelect }) => {
+  const assignments = useSelector(state => state.assignments.assignments);
+  const loadingAssignments = useSelector(state => state.assignments.loading);
+  const students = useSelector(state => getStudentUsers(state));
+
+  useEffect(() => {
     // sets the title of this tab
-    const { prefix } = this.props;
     const header = I18n.t('users.sub_navigation.student_overview', { prefix });
-    document.title = `${this.props.course.title} - ${header}`;
-  }
+    document.title = `${course.title} - ${header}`;
+  }, []);
 
-  render() {
-    const {
-      assignments, course, current_user, prefix, sort, students,
-      trainingStatus, wikidataLabels, sortUsers, userRevisions,
-      notify, sortSelect
-    } = this.props;
-
-    return (
-      <div className="list__wrapper">
-        <StudentsSubNavigation
-          course={course}
-          heading={I18n.t('instructor_view.overview', { prefix })}
-          prefix={prefix}
-        />
-        {
-          current_user.isAdvancedRole
+  return (
+    <div className="list__wrapper">
+      <StudentsSubNavigation
+        course={course}
+        heading={I18n.t('instructor_view.overview', { prefix })}
+        prefix={prefix}
+      />
+      {
+        current_user.isAdvancedRole
           ? (
             <Controls
               course={course}
@@ -43,55 +39,29 @@ export class Overview extends React.Component {
               sortSelect={sortSelect}
             />
           ) : null
-        }
+      }
 
-        <RandomPeerAssignButton {...this.props} />
-        { this.props.loadingAssignments && <Loading /> }
+      <RandomPeerAssignButton current_user={current_user} course={course} assignments={assignments} students={students} />
+      {loadingAssignments && <Loading />}
 
-        { !this.props.loadingAssignments && (
-          <StudentList
-            assignments={assignments}
-            course={course}
-            current_user={current_user}
-            sort={sort}
-            sortUsers={sortUsers}
-            students={students}
-            trainingStatus={trainingStatus}
-            userRevisions={userRevisions}
-            wikidataLabels={wikidataLabels}
-          />)}
-      </div>
-    );
-  }
-}
+      {!loadingAssignments && (
+        <StudentList
+          assignments={assignments}
+          course={course}
+          current_user={current_user}
+          sortUsers={sortUsers}
+          students={students}
+        />)}
+    </div>
+  );
+};
 
 Overview.propTypes = {
   course: PropTypes.object.isRequired,
   current_user: PropTypes.object.isRequired,
-  editPermissions: PropTypes.bool.isRequired,
   prefix: PropTypes.string.isRequired,
-  students: PropTypes.array,
-  openKey: PropTypes.string,
-  userRevisions: PropTypes.object.isRequired,
-  trainingStatus: PropTypes.object.isRequired,
-
-  notifyOverdue: PropTypes.func.isRequired,
-  sort: PropTypes.object.isRequired,
   sortSelect: PropTypes.func.isRequired,
   sortUsers: PropTypes.func.isRequired
 };
 
-const mapStateToProps = state => ({
-  assignments: state.assignments.assignments,
-  loadingAssignments: state.assignments.loading,
-
-  openKey: state.ui.openKey,
-  students: getStudentUsers(state),
-  sort: state.users.sort,
-  userRevisions: state.userRevisions,
-  trainingStatus: state.trainingStatus,
-  editPermissions: editPermissions(state),
-  wikidataLabels: state.wikidataLabels.labels
-});
-
-export default connect(mapStateToProps)(Overview);
+export default (Overview);

--- a/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
@@ -34,7 +34,6 @@ const Student = createReactClass({
     fetchTrainingStatus: PropTypes.func.isRequired,
     minimalView: PropTypes.bool,
     student: PropTypes.object.isRequired,
-    wikidataLabels: PropTypes.object
   },
 
   setUploadFilters(selectedFilters) {
@@ -59,7 +58,7 @@ const Student = createReactClass({
   render() {
     const {
       assignments, course, current_user, editable,
-      showRecent, student, wikidataLabels
+      showRecent, student
     } = this.props;
 
     let recentRevisions;
@@ -89,7 +88,6 @@ const Student = createReactClass({
           isStudentsPage
           student={student}
           role={ASSIGNED_ROLE}
-          wikidataLabels={wikidataLabels}
           unassigned={unassigned}
         />
       );
@@ -104,7 +102,6 @@ const Student = createReactClass({
           isStudentsPage
           student={student}
           role={REVIEWING_ROLE}
-          wikidataLabels={wikidataLabels}
           unassigned={reviewable}
         />
       );

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentList.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentList.jsx
@@ -11,6 +11,7 @@ import studentListKeys from './student_list_keys';
 
 import { addDays, isAfter } from 'date-fns';
 import { toDate } from '../../../../utils/date_utils';
+import { useSelector } from 'react-redux';
 
 // Helper Functions
 const showRecent = (course) => {
@@ -22,11 +23,8 @@ const showRecent = (course) => {
   return isAfter(addDays(toDate(lastUpdate.end_time), 7), new Date());
 };
 
-export const StudentList = (props) => {
-  const {
-    assignments, course, current_user, editAssignments, sort, students,
-    wikidataLabels, sortUsers = {}
-  } = props;
+export const StudentList = ({ assignments, course, current_user, editAssignments, students, sortUsers = {} }) => {
+  const sort = useSelector(state => state.users.sort);
 
   const rows = students.map(student => (
     <StudentRow
@@ -37,7 +35,6 @@ export const StudentList = (props) => {
       key={student.id}
       showRecent={showRecent(course)}
       student={student}
-      wikidataLabels={wikidataLabels}
     />
   ));
 
@@ -61,8 +58,6 @@ export const StudentList = (props) => {
 
 StudentList.propTypes = {
   assignments: PropTypes.array,
-  trainingStatus: PropTypes.object.isRequired,
-  userRevisions: PropTypes.object,
   course: PropTypes.shape({
     string_prefix: PropTypes.string.isRequired,
     updates: PropTypes.shape({
@@ -73,12 +68,7 @@ StudentList.propTypes = {
   }).isRequired,
   current_user: PropTypes.object.isRequired,
   editAssignments: PropTypes.bool,
-  sort: PropTypes.shape({
-    key: PropTypes.string,
-    sortKey: PropTypes.string
-  }).isRequired,
   sortUsers: PropTypes.func,
-  wikidataLabels: PropTypes.object,
 };
 
 export default StudentList;


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `BadWorkAlert.jsx` and `Overview.jsx` into functional components. 
**Affected Pages:**
- `/courses/[institution_id]/[course_id]/students/articles/[student_username]?showArticles` (for `BadWorkAlert.jsx`)
- `/courses/[institution_id]/[course_id]/students/overview` (for `Overview.jsx`)
## Videos
Before `BadWorkAlert.jsx` 

[before refactor BadWorkAlert.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/5f949619-714f-42a9-b1f4-afbfcda77f04)

After `BadWorkAlert.jsx` 

[after refactor BadWorkAlert.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/e5b2f9de-65b9-497b-a2fd-af46f9104787)

Before `Overview.jsx` 

[before refactor Overview.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/c32c4764-e9ef-4885-83a9-eaebc5b6c94a)

After `Overview.jsx`

[after refactor Overview.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/341e0ed8-01eb-4f36-ac2c-05cd132b1fcb)
