### PR TITLE
Fix 500 error on overdue training mailer alert

### DIFF
--- a/spec/mailers/previews/overdue_training_alert_mailer_preview.rb
+++ b/spec/mailers/previews/overdue_training_alert_mailer_preview.rb
@@ -20,7 +20,7 @@ class OverdueTrainingAlertMailerPreview < ActionMailer::Preview
 
   def example_alert
     OverdueTrainingAlert.new(user: example_profile.user,
-                             course: Course.first,
+                             course: Course.nonprivate.last,
                              details: example_alert_details)
   end
 

--- a/spec/mailers/previews/overdue_training_alert_mailer_preview.rb
+++ b/spec/mailers/previews/overdue_training_alert_mailer_preview.rb
@@ -20,7 +20,7 @@ class OverdueTrainingAlertMailerPreview < ActionMailer::Preview
 
   def example_alert
     OverdueTrainingAlert.new(user: example_profile.user,
-                             course: ClassroomProgramCourse.current.nonprivate.last,
+                             course: Course.first,
                              details: example_alert_details)
   end
 


### PR DESCRIPTION
## What this PR does
Fix 500 error on overdue training mailer alert

Task of #5078 
## Screenshots
Before:
See [https://dashboard-testing.wikiedu.org/rails/mailers/overdue_training_alert_mailer/message_to_student](url)

After:
![mailer_6](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/5203082/5990393a-72b1-42a9-b173-450c79b9f7bc)
