### PR TITLE
Converting Upload into functional component

### DIFF
--- a/app/assets/stylesheets/modules/_uploads.styl
+++ b/app/assets/stylesheets/modules/_uploads.styl
@@ -65,6 +65,8 @@
   img
     min-width 250px
     max-width 250px
+  .credit-loading
+    min-width 25px
 
 .tile-view
   .tile-container


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `upload.jsx` into a functional component. 
**Affected Pages:**
- `/courses/[institution_id]/[course_id]/uploads` (for `upload.jsx`)
## Videos
Before `upload.jsx` 

[before refactor Upload.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/718ca379-bcba-4cfb-bd33-248b6bae9c48)

After `upload.jsx` 

[after refactor Upload.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/fe1ffd49-4c7b-4590-976c-b01f8636991b)
