### PR TITLE
Update New instructor enrollment mailer preview

### DIFF
--- a/app/mailers/new_instructor_enrollment_mailer.rb
+++ b/app/mailers/new_instructor_enrollment_mailer.rb
@@ -5,14 +5,15 @@ class NewInstructorEnrollmentMailer < ApplicationMailer
     return unless Features.email?
     staffer = SpecialUsers.classroom_program_manager
     return unless staffer
-    email(course, staffer, adder, new_instructor).deliver_now
+    courses_user = CoursesUsers.find_by(course: @course, user: @new_instructor,
+                                        role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    email(course, staffer, adder, new_instructor, courses_user).deliver_now
   end
 
-  def email(course, staffer, adder, new_instructor)
+  def email(course, staffer, adder, new_instructor, courses_user)
     @course = course
     @new_instructor = new_instructor
-    @courses_user = CoursesUsers.find_by(course: @course, user: @new_instructor,
-                                         role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    @courses_user = courses_user
     @adder = adder
     @course_link = "https://#{ENV['dashboard_url']}/courses/#{@course.slug}"
     mail(to: staffer.email,

--- a/app/views/new_instructor_enrollment_mailer/email.html.haml
+++ b/app/views/new_instructor_enrollment_mailer/email.html.haml
@@ -11,6 +11,6 @@
               %p.paragraph
                 = "Name: #{@courses_user&.real_name}"
               %p.paragraph
-                = "Role: #{@courses_use&.role_description}"
+                = "Role: #{@courses_user&.role_description}"
               %p.paragraph
                 %a.link{href: @course_link}= @course.slug

--- a/spec/mailers/previews/new_instructor_enrollment_mailer_preview.rb
+++ b/spec/mailers/previews/new_instructor_enrollment_mailer_preview.rb
@@ -2,7 +2,7 @@
 
 class NewInstructorEnrollmentMailerPreview < ActionMailer::Preview
   def alert_staff
-    NewInstructorEnrollmentMailer.email(course, staffer, adder, new_instructor)
+    NewInstructorEnrollmentMailer.email(course, staffer, adder, new_instructor, courses_user)
   end
 
   private
@@ -23,5 +23,9 @@ class NewInstructorEnrollmentMailerPreview < ActionMailer::Preview
 
   def new_instructor
     User.new(username: 'New Instructor')
+  end
+
+  def courses_user
+    OpenStruct.new(real_name: 'Alice Bob', role_description: 'Teaches Wikipedia basics')
   end
 end


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
Update mailer preview as it was incomplete and could not work entirely.
Typo on an object name in the view.
Injection of a dependency in order to mock an ActiveRecord object who could be nil or empty.

One task of the #5078 issue

## Screenshots
Before:
See [https://dashboard-testing.wikiedu.org/rails/mailers/new_instructor_enrollment_mailer/alert_staff](url)
Name & Role are empty

After:
Name & Role are there
![mailer_7](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/5203082/bc916e58-8e02-424b-b7d8-e46e037f6a12)

