### PR TITLE
make required fields more clear on CourseClonedModal

### DIFF
--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -146,14 +146,6 @@ const CourseClonedModal = createReactClass({
     return course.cloned_status === 2;
   },
 
-  saveEnabled() {
-    // You must be logged in and have permission to edit the course.
-    // This will be the case if you created it (and are therefore the instructor) or if you are an admin.
-    if (!this.props.currentUser.isAdvancedRole) { return false; }
-    if (this.state.valuesUpdated && this.state.dateValuesUpdated) { return true; }
-    return false;
-  },
-
   render() {
     const i18nPrefix = this.props.course.string_prefix;
     let buttonClass = 'button dark';
@@ -176,7 +168,6 @@ const CourseClonedModal = createReactClass({
     }
 
     const dateProps = CourseDateUtils.dateProps(this.state.course);
-    const saveDisabled = this.saveEnabled() ? '' : 'disabled';
 
     // Form components that are conditional on course type
     let expectedStudents;
@@ -397,7 +388,7 @@ const CourseClonedModal = createReactClass({
               </div>
               {rightColumn}
               <button onClick={this.cancelCloneCourse} className="button light">{CourseUtils.i18n('creator.cancel_course_clone', i18nPrefix)}</button>
-              <button onClick={this.saveCourse} disabled={saveDisabled} className={buttonClass}>{CourseUtils.i18n('creator.save_cloned_course', i18nPrefix)}</button>
+              <button onClick={this.saveCourse} className={buttonClass}>{CourseUtils.i18n('creator.save_cloned_course', i18nPrefix)}</button>
             </div>
           </div>
         </div>

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -146,6 +146,13 @@ const CourseClonedModal = createReactClass({
     return course.cloned_status === 2;
   },
 
+  saveEnabled() {
+    // You must be logged in and have permission to edit the course.
+    // This will be the case if you created it (and are therefore the instructor) or if you are an admin.
+    if (!this.props.currentUser.isAdvancedRole) { return false; }
+    return true;
+  },
+
   render() {
     const i18nPrefix = this.props.course.string_prefix;
     let buttonClass = 'button dark';
@@ -168,6 +175,7 @@ const CourseClonedModal = createReactClass({
     }
 
     const dateProps = CourseDateUtils.dateProps(this.state.course);
+    const saveDisabled = this.saveEnabled() ? '' : 'disabled';
 
     // Form components that are conditional on course type
     let expectedStudents;
@@ -388,7 +396,7 @@ const CourseClonedModal = createReactClass({
               </div>
               {rightColumn}
               <button onClick={this.cancelCloneCourse} className="button light">{CourseUtils.i18n('creator.cancel_course_clone', i18nPrefix)}</button>
-              <button onClick={this.saveCourse} className={buttonClass}>{CourseUtils.i18n('creator.save_cloned_course', i18nPrefix)}</button>
+              <button onClick={this.saveCourse} disabled={saveDisabled} className={buttonClass}>{CourseUtils.i18n('creator.save_cloned_course', i18nPrefix)}</button>
             </div>
           </div>
         </div>

--- a/app/assets/stylesheets/modules/_inputs.styl
+++ b/app/assets/stylesheets/modules/_inputs.styl
@@ -9,7 +9,7 @@ select,
   border 1px solid $border_lt
   border-radius 0px
   font-family body-font
-  color body-color
+  color text-dark
   font-size 15px
   padding 10px
   outline none
@@ -26,6 +26,9 @@ select,
 
   &::-ms-expand
     display none
+
+  &::placeholder
+    color: text_lt
 
 // Custom dropdown arrow for selects
 select:not([multiple])

--- a/test/components/overview/course_cloned_modal.spec.jsx
+++ b/test/components/overview/course_cloned_modal.spec.jsx
@@ -54,6 +54,5 @@ describe('CourseClonedModal', () => {
 
     const create = renderedModal.find('.button.dark');
     expect(create).toHaveLength(1);
-    expect(create.prop('disabled')).toEqual('disabled');
   });
 });


### PR DESCRIPTION
Closes #5403 

## What this PR does
This PR adds a couple behavior and UI tweaks to the CourseClonedModal to add more clearance on the fields that must be filled in the form before saving the course. The following changes were made:

- Added a different font color to the input value and the placeholder to have a bigger contrast between them
- Removed the disabled behavior on the Save button so that validations run on the required fields and the user could click it and see the empty fields highlighted. This would make this form consistent with the course creation modal, so both forms would behave equally.

## Screenshots
Before:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/27536621/5b51bb4c-e79b-4b77-8852-57c8be3c9875)

After:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/27536621/1517f714-2fb0-4243-8bcc-db6a569b84d9)

https://www.loom.com/share/933a180ee91a486084f0c97a06b4ba9d
