### PR TITLE
detect deb platform correctly on script setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def osx_setup():
                    shell=True, check=True)
 
 if platform.platform().lower().find('ubuntu') != -1 \
-        or platform.platform().lower().find('wsl2') !=1 \
+        or platform.platform().lower().find('wsl2') != -1 \
         or platform.platform().lower().find('debian') != -1 \
         or platform.platform().lower().find('elementary') != -1 \
         or platform.uname().version.lower().find('ubuntu') != -1:


### PR DESCRIPTION
## What this PR does
I recently tried to set up the project on a macbook and the python setup script detected my OS as a Debian-based platform. I think there is a typo on the condition that evaluates the platform