### PR TITLE
Converting ActivityHandler, ActivityTableRow and ActivityTable into functional components

### DIFF
--- a/app/assets/javascripts/components/activity/activity_handler.jsx
+++ b/app/assets/javascripts/components/activity/activity_handler.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
-import withRouter from '../util/withRouter';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import SubNavigation from '../common/sub_navigation.jsx';
@@ -9,46 +7,43 @@ import CourseAlertsList from '../alerts/course_alerts_list';
 import RevisionHandler from '../revisions/revisions_handler';
 import PossiblePlagiarismHandler from '../suspected_plagiarism/suspected_plagiarism_handler';
 
-export const ActivityHandler = createReactClass({
-  displayName: 'ActivityHandler',
+const ActivityHandler = (props) => {
+  const { course, current_user } = props;
+  const links = [
+    {
+      href: `/courses/${course.slug}/activity/recent`,
+      text: I18n.t('application.recent_activity')
+    },
+    {
+      href: `/courses/${course.slug}/activity/plagiarism`,
+      text: I18n.t('recent_activity.possible_plagiarism')
+    },
+  ];
 
-  propTypes: {
-    course_id: PropTypes.string,
-    current_user: PropTypes.object,
-    course: PropTypes.object,
-  },
-
-  render() {
-    const links = [
-      {
-        href: `/courses/${this.props.course.slug}/activity/recent`,
-        text: I18n.t('application.recent_activity')
-      },
-      {
-        href: `/courses/${this.props.course.slug}/activity/plagiarism`,
-        text: I18n.t('recent_activity.possible_plagiarism')
-      },
-    ];
-
-    if (this.props.current_user.admin) {
-      links.push({
-        href: `/courses/${this.props.course.slug}/activity/alerts`,
-        text: I18n.t('courses.alerts')
-      });
-    }
-
-    return (
-      <div className="activity-handler">
-        <SubNavigation links={links}/>
-        <Routes>
-          {this.props.usersLoaded && <Route path="recent" element={<RevisionHandler {...this.props}/>} />}
-          <Route path="alerts" element={<CourseAlertsList {...this.props} />} />
-          <Route path="plagiarism" element={<PossiblePlagiarismHandler {...this.props} />}/>
-          <Route path="*" element={<Navigate replace to="recent"/>}/>
-        </Routes>
-      </div>
-    );
+  if (current_user.admin) {
+    links.push({
+      href: `/courses/${course.slug}/activity/alerts`,
+      text: I18n.t('courses.alerts')
+    });
   }
-});
 
-export default withRouter(ActivityHandler);
+  return (
+    <div className="activity-handler">
+      <SubNavigation links={links} />
+      <Routes>
+        {props.usersLoaded && <Route path="recent" element={<RevisionHandler {...props} />} />}
+        <Route path="alerts" element={<CourseAlertsList {...props} />} />
+        <Route path="plagiarism" element={<PossiblePlagiarismHandler {...props} />} />
+        <Route path="*" element={<Navigate replace to="recent" />} />
+      </Routes>
+    </div>
+  );
+};
+
+ActivityHandler.propTypes = {
+  course_id: PropTypes.string,
+  current_user: PropTypes.object,
+  course: PropTypes.object,
+};
+
+export default ActivityHandler;

--- a/app/assets/javascripts/components/activity/activity_table_row.jsx
+++ b/app/assets/javascripts/components/activity/activity_table_row.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DiffViewer from '../revisions/diff_viewer.jsx';
+import { toggleUI } from '../../actions';
+import { useDispatch } from 'react-redux';
 
-const ActivityTableRow = ({ toggleDrawer, isOpen, diffUrl, revisionDateTime,
+const ActivityTableRow = ({ isOpen, diffUrl, revisionDateTime,
   revisionScore, reportUrl, revision, rowId, articleUrl, title, talkPageLink,
   author }) => {
+  const dispatch = useDispatch();
+
   const openDrawer = () => {
-    return toggleDrawer(`drawer_${rowId}`);
+    return dispatch(toggleUI(`drawer_${rowId}`));
   };
 
   let revDateElement;
@@ -74,7 +78,6 @@ ActivityTableRow.propTypes = {
   title: PropTypes.string,
   revision: PropTypes.object,
   isOpen: PropTypes.bool,
-  toggleDrawer: PropTypes.func
 };
 
 export default ActivityTableRow;

--- a/app/assets/javascripts/components/activity/activity_table_row.jsx
+++ b/app/assets/javascripts/components/activity/activity_table_row.jsx
@@ -1,83 +1,80 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import DiffViewer from '../revisions/diff_viewer.jsx';
 
-const ActivityTableRow = createReactClass({
-  displayName: 'ActivityTableRow',
+const ActivityTableRow = ({ toggleDrawer, isOpen, diffUrl, revisionDateTime,
+  revisionScore, reportUrl, revision, rowId, articleUrl, title, talkPageLink,
+  author }) => {
+  const openDrawer = () => {
+    return toggleDrawer(`drawer_${rowId}`);
+  };
 
-  propTypes: {
-    rowId: PropTypes.number,
-    diffUrl: PropTypes.string,
-    revisionDateTime: PropTypes.string,
-    reportUrl: PropTypes.string,
-    revisionScore: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    articleUrl: PropTypes.string,
-    talkPageLink: PropTypes.string,
-    author: PropTypes.string,
-    title: PropTypes.string,
-    revision: PropTypes.object,
-    isOpen: PropTypes.bool,
-    toggleDrawer: PropTypes.func
-  },
+  let revDateElement;
+  let col2;
+  const className = isOpen ? 'open' : 'closed';
 
-  openDrawer() {
-    return this.props.toggleDrawer(`drawer_${this.props.rowId}`);
-  },
-
-  render() {
-    let revisionDateTime;
-    let col2;
-    const className = this.props.isOpen ? 'open' : 'closed';
-
-    if (this.props.diffUrl) {
-      revisionDateTime = (
-        <a href={this.props.diffUrl} target="_blank">{this.props.revisionDateTime}</a>
-      );
-    }
-
-    if (this.props.revisionScore) {
-      col2 = (
-        <td>
-          {this.props.revisionScore}
-        </td>
-      );
-    }
-
-    if (this.props.reportUrl) {
-      col2 = (
-        <td>
-          <a href={this.props.reportUrl} target="_blank">Report</a>
-        </td>
-      );
-    }
-
-    let diffViewer;
-    if (this.props.revision && this.props.revision.api_url) {
-      diffViewer = <DiffViewer revision={this.props.revision} />;
-    }
-
-    return (
-      <tr className={className} key={this.props.rowId}>
-        <td onClick={this.openDrawer}>
-          <a href={this.props.articleUrl} target="_blank">{this.props.title}</a>
-        </td>
-        {col2}
-        <td onClick={this.openDrawer}>
-          <a href={this.props.talkPageLink} target="_blank">{this.props.author}</a>
-        </td>
-        <td onClick={this.openDrawer}>
-          {revisionDateTime}
-        </td>
-        <td>
-          {diffViewer}
-        </td>
-      </tr>
+  if (diffUrl) {
+    revDateElement = (
+      <a href={diffUrl} target="_blank">{revisionDateTime}</a>
     );
   }
-});
+
+  if (revisionScore) {
+    col2 = (
+      <td>
+        {revisionScore}
+      </td>
+    );
+  }
+
+  if (reportUrl) {
+    col2 = (
+      <td>
+        <a href={reportUrl} target="_blank">Report</a>
+      </td>
+    );
+  }
+
+  let diffViewer;
+  if (revision && revision.api_url) {
+    diffViewer = <DiffViewer revision={revision} />;
+  }
+
+  return (
+    <tr className={className} key={rowId}>
+      <td onClick={openDrawer}>
+        <a href={articleUrl} target="_blank">{title}</a>
+      </td>
+      {col2}
+      <td onClick={openDrawer}>
+        <a href={talkPageLink} target="_blank">{author}</a>
+      </td>
+      <td onClick={openDrawer}>
+        {revDateElement}
+      </td>
+      <td>
+        {diffViewer}
+      </td>
+    </tr>
+  );
+};
+
+ActivityTableRow.propTypes = {
+  rowId: PropTypes.number,
+  diffUrl: PropTypes.string,
+  revisionDateTime: PropTypes.string,
+  reportUrl: PropTypes.string,
+  revisionScore: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  articleUrl: PropTypes.string,
+  talkPageLink: PropTypes.string,
+  author: PropTypes.string,
+  title: PropTypes.string,
+  revision: PropTypes.object,
+  isOpen: PropTypes.bool,
+  toggleDrawer: PropTypes.func
+};
 
 export default ActivityTableRow;

--- a/test/components/activity/activity_table_row.spec.jsx
+++ b/test/components/activity/activity_table_row.spec.jsx
@@ -1,26 +1,33 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import '../../testHelper';
 
 import ActivityTableRow from '../../../app/assets/javascripts/components/activity/activity_table_row.jsx';
+import { Provider } from 'react-redux';
 
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+const store = mockStore({});
 describe('ActivityTableRow', () => {
   const TestRow = ReactTestUtils.renderIntoDocument(
     <table>
       <tbody>
-        <ActivityTableRow
-          key={'23948'}
-          rowId={675818536}
-          title="Selfie"
-          articleUrl="https://en.wikipedia.org/wiki/Selfie"
-          author="Wavelength"
-          talkPageLink="https://en.wikipedia.org/wiki/User_talk:Wavelength"
-          diffUrl="https://en.wikipedia.org/w/index.php?title=Selfie&diff=675818536&oldid=675437996"
-          revisionDateTime="2015/08/012 9:43 pm"
-          revisionScore={61}
-          isOpen={false}
-        />
+        <Provider store={store}>
+          <ActivityTableRow
+            key={'23948'}
+            rowId={675818536}
+            title="Selfie"
+            articleUrl="https://en.wikipedia.org/wiki/Selfie"
+            author="Wavelength"
+            talkPageLink="https://en.wikipedia.org/wiki/User_talk:Wavelength"
+            diffUrl="https://en.wikipedia.org/w/index.php?title=Selfie&diff=675818536&oldid=675437996"
+            revisionDateTime="2015/08/012 9:43 pm"
+            revisionScore={61}
+            isOpen={false}
+          />
+        </Provider>
       </tbody>
     </table>
   );


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `activity_handler.jsx`, `activity_table_row.jsx` and `activity_table.jsx` into functional components
**Affected Pages:**
- `/courses/[institution_id]/[course_id]/activity/[chosen_page_name]` (for `activity_handler.jsx`)
- `/recent-activity/[chosen_page_name]` (for `activity_table_row.jsx` and `activity_table.jsx`)

## Videos
Before `activity_handler.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a5ddd78c-4700-453f-a989-509bdeeacae7

After `activity_handler.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/fa6e15ef-522f-40b3-977e-4e8c5dbbb6fb

Before `activity_table_row.jsx` and `activity_table.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/b01aa9c3-9eaf-45bb-8428-8e47527a05ab

After `activity_table_row.jsx` and `activity_table.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/71633486-e001-4ed9-8c02-ceed5678834d


