### PR TITLE
Fixed Add Week button logic to account for available space on the timeline

### DIFF
--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -364,7 +364,7 @@ const Timeline = createReactClass({
 
       const start = toDate(this.props.course.timeline_start);
       const end = toDate(this.props.course.timeline_end);
-      const weeksDiff = differenceInWeeks(end, start);
+      const weeksDiff = differenceInWeeks(end, start, { roundingMethod: 'ceil' });
       const timelineFull = weeksDiff - weekComponents.length <= 0;
       addWeekLink = timelineFull ? (
         <li>


### PR DESCRIPTION
…timeline #5438


## What this PR does

Bug Fix:

 * Updated 'Add Week' button logic to account for available space on the timeline

Solution:
* Made a modification to the code by specifying the roundingMethod option as `ceil` in the `differenceInWeeks` function. This change will ensure that fractional values are rounded up instead of being truncated to zero. By using 'ceil' as the rounding method, the calculation will accurately determine the number of weeks between the end and start dates. This should address the issue where the 'Add Week' button was incorrectly disabled when there was some available space on the timeline.
* Refrence - https://date-fns.org/v2.30.0/docs/differenceInWeeks

## Screenshots

Before:

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/bf20969c-aac9-44cc-98b9-5cfc5f15b159)



After:

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/425fb461-b980-4d1a-92e6-86ec22dcc5f3)



