### PR TITLE
Converting DidYouKnowHandler, PlagiarismHandler, RecentEditsHandler and RecentUploadsHandlerBase into functional components

### DIFF
--- a/app/assets/javascripts/components/activity/did_you_know_handler.jsx
+++ b/app/assets/javascripts/components/activity/did_you_know_handler.jsx
@@ -44,7 +44,7 @@ const DidYouKnowHandler = () => {
         activity={articles}
         headers={HEADERS}
         noActivityMessage={NO_ACTIVITY_MESSAGE}
-        onSort={dataSortKey => sortDYKArticles(dataSortKey)}
+        onSort={dataSortKey => dispatch(sortDYKArticles(dataSortKey))}
       />
     </div>
   );

--- a/app/assets/javascripts/components/activity/did_you_know_handler.jsx
+++ b/app/assets/javascripts/components/activity/did_you_know_handler.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import ActivityTable from './activity_table.jsx';
 import { fetchDYKArticles, sortDYKArticles } from '../../actions/did_you_know_actions.js';
 
@@ -14,55 +13,47 @@ const HEADERS = [
   { title: I18n.t('recent_activity.revision_datetime'), key: 'datetime', style: { width: 200 } }
 ];
 
-const DidYouKnowHandler = createReactClass({
-  displayName: 'DidYouKnowHandler',
+const DidYouKnowHandler = () => {
+  const myCoursesRef = useRef(null);
 
-  propTypes: {
-    fetchDYKArticles: PropTypes.func,
-    articles: PropTypes.array,
-    loading: PropTypes.bool
-  },
+  const dispatch = useDispatch();
+  const articles = useSelector(state => state.didYouKnow.articles);
+  const loading = useSelector(state => state.didYouKnow.loading);
 
-  componentDidMount() {
-    this.props.fetchDYKArticles();
-  },
+  useEffect(() => {
+    dispatch(fetchDYKArticles());
+  }, []);
 
-  setCourseScope(e) {
+  const setCourseScope = (e) => {
     const scoped = e.target.checked;
-    this.props.fetchDYKArticles({ scoped });
-  },
+    dispatch(fetchDYKArticles({ scoped }));
+  };
 
-  render() {
-    return (
-      <div>
-        <label>
-          <input
-            ref="myCourses"
-            type="checkbox"
-            onChange={this.setCourseScope}
-          />
-          {I18n.t('recent_activity.show_courses')}
-        </label>
-        <ActivityTable
-          loading={this.props.loading}
-          activity={this.props.articles}
-          headers={HEADERS}
-          noActivityMessage={NO_ACTIVITY_MESSAGE}
-          onSort={this.props.sortDYKArticles}
+  return (
+    <div>
+      <label>
+        <input
+          ref={myCoursesRef}
+          type="checkbox"
+          onChange={setCourseScope}
         />
-      </div>
-    );
-  }
-});
-
-const mapStateToProps = state => ({
-  articles: state.didYouKnow.articles,
-  loading: state.didYouKnow.loading
-});
-
-const mapDispatchToProps = {
-  fetchDYKArticles: fetchDYKArticles,
-  sortDYKArticles: sortDYKArticles
+        {I18n.t('recent_activity.show_courses')}
+      </label>
+      <ActivityTable
+        loading={loading}
+        activity={articles}
+        headers={HEADERS}
+        noActivityMessage={NO_ACTIVITY_MESSAGE}
+        onSort={dataSortKey => sortDYKArticles(dataSortKey)}
+      />
+    </div>
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(DidYouKnowHandler);
+DidYouKnowHandler.propTypes = {
+  fetchDYKArticles: PropTypes.func,
+  articles: PropTypes.array,
+  loading: PropTypes.bool
+};
+
+export default (DidYouKnowHandler);

--- a/app/assets/javascripts/components/activity/plagiarism_handler.jsx
+++ b/app/assets/javascripts/components/activity/plagiarism_handler.jsx
@@ -40,7 +40,7 @@ const PlagiarismHandler = () => {
         activity={revisions}
         headers={HEADERS}
         noActivityMessage={NO_ACTIVITY_MESSAGE}
-        onSort={dataSortKey => sortSuspectedPlagiarism(dataSortKey)}
+        onSort={dataSortKey => dispatch(sortSuspectedPlagiarism(dataSortKey))}
       />
     </div>
   );

--- a/app/assets/javascripts/components/activity/plagiarism_handler.jsx
+++ b/app/assets/javascripts/components/activity/plagiarism_handler.jsx
@@ -1,66 +1,55 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import ActivityTable from './activity_table.jsx';
 import { fetchSuspectedPlagiarism, sortSuspectedPlagiarism } from '../../actions/suspected_plagiarism_actions.js';
 
 const HEADERS = [
-      { title: I18n.t('recent_activity.article_title'), key: 'title' },
-      { title: I18n.t('recent_activity.plagiarism_report'), key: 'report_url', style: { width: 180 } },
-      { title: I18n.t('recent_activity.revision_author'), key: 'username', style: { minWidth: 142 } },
-      { title: I18n.t('recent_activity.revision_datetime'), key: 'datetime', style: { width: 200 } },
-    ];
+  { title: I18n.t('recent_activity.article_title'), key: 'title' },
+  { title: I18n.t('recent_activity.plagiarism_report'), key: 'report_url', style: { width: 180 } },
+  { title: I18n.t('recent_activity.revision_author'), key: 'username', style: { minWidth: 142 } },
+  { title: I18n.t('recent_activity.revision_datetime'), key: 'datetime', style: { width: 200 } },
+];
 
 const NO_ACTIVITY_MESSAGE = I18n.t('recent_activity.no_plagiarism');
 
+const PlagiarismHandler = () => {
+  const myCoursesRef = useRef(null);
 
-const PlagiarismHandler = createReactClass({
-  displayName: 'PlagiarismHandler',
+  const dispatch = useDispatch();
+  const revisions = useSelector(state => state.suspectedPlagiarism.revisions);
+  const loading = useSelector(state => state.suspectedPlagiarism.loading);
 
-  propTypes: {
-    fetchSuspectedPlagiarism: PropTypes.func,
-    revisions: PropTypes.array,
-    loading: PropTypes.bool
-  },
+  useEffect(() => {
+    dispatch(fetchSuspectedPlagiarism());
+  }, []);
 
-  componentDidMount() {
-    return this.props.fetchSuspectedPlagiarism();
-  },
-
-  setCourseScope(e) {
+  const setCourseScope = (e) => {
     const scoped = e.target.checked;
-    return this.props.fetchSuspectedPlagiarism({ scoped });
-  },
+    dispatch(fetchSuspectedPlagiarism({ scoped }));
+  };
 
-  render() {
-    return (
-      <div>
-        <label>
-          <input ref="myCourses" type="checkbox" onChange={this.setCourseScope} />
-          {I18n.t('recent_activity.show_courses')}
-        </label>
-        <ActivityTable
-          loading={this.props.loading}
-          activity={this.props.revisions}
-          headers={HEADERS}
-          noActivityMessage={NO_ACTIVITY_MESSAGE}
-          onSort={this.props.sortSuspectedPlagiarism}
-        />
-      </div>
-    );
-  }
-});
-
-
-const mapStateToProps = state => ({
-  revisions: state.suspectedPlagiarism.revisions,
-  loading: state.suspectedPlagiarism.loading
-});
-
-const mapDispatchToProps = {
-  fetchSuspectedPlagiarism: fetchSuspectedPlagiarism,
-  sortSuspectedPlagiarism: sortSuspectedPlagiarism
+  return (
+    <div>
+      <label>
+        <input ref={myCoursesRef} type="checkbox" onChange={setCourseScope} />
+        {I18n.t('recent_activity.show_courses')}
+      </label>
+      <ActivityTable
+        loading={loading}
+        activity={revisions}
+        headers={HEADERS}
+        noActivityMessage={NO_ACTIVITY_MESSAGE}
+        onSort={dataSortKey => sortSuspectedPlagiarism(dataSortKey)}
+      />
+    </div>
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PlagiarismHandler);
+PlagiarismHandler.propTypes = {
+  fetchSuspectedPlagiarism: PropTypes.func,
+  revisions: PropTypes.array,
+  loading: PropTypes.bool
+};
+
+export default (PlagiarismHandler);

--- a/app/assets/javascripts/components/activity/recent_edits_handler.jsx
+++ b/app/assets/javascripts/components/activity/recent_edits_handler.jsx
@@ -1,65 +1,56 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import ActivityTable from './activity_table.jsx';
 import { fetchRecentEdits, sortRecentEdits } from '../../actions/recent_edits_actions.js';
 
 const NO_ACTIVITY_MESSAGE = I18n.t('recent_activity.no_edits');
 
 const HEADERS = [
-      { title: I18n.t('recent_activity.article_title'), key: 'title' },
-      { title: I18n.t('recent_activity.revision_score'), key: 'revision_score', style: { width: 180 } },
-      { title: I18n.t('recent_activity.revision_author'), key: 'username', style: { minWidth: 142 } },
-      { title: I18n.t('recent_activity.revision_datetime'), key: 'datetime', style: { width: 200 } },
+  { title: I18n.t('recent_activity.article_title'), key: 'title' },
+  { title: I18n.t('recent_activity.revision_score'), key: 'revision_score', style: { width: 180 } },
+  { title: I18n.t('recent_activity.revision_author'), key: 'username', style: { minWidth: 142 } },
+  { title: I18n.t('recent_activity.revision_datetime'), key: 'datetime', style: { width: 200 } },
 ];
 
-const RecentEditsHandler = createReactClass({
-  displayName: 'RecentEditsHandler',
+const RecentEditsHandler = () => {
+  const myCoursesRef = useRef(null);
 
-  propTypes: {
-    fetchRecentEdits: PropTypes.func,
-    sortRecentEdits: PropTypes.func,
-    revisions: PropTypes.array,
-    loading: PropTypes.bool
-  },
+  const dispatch = useDispatch();
+  const revisions = useSelector(state => state.recentEdits.revisions);
+  const loading = useSelector(state => state.recentEdits.loading);
 
-  componentDidMount() {
-    return this.props.fetchRecentEdits();
-  },
+  useEffect(() => {
+    dispatch(fetchRecentEdits());
+  }, []);
 
-  setCourseScope(e) {
+  const setCourseScope = (e) => {
     const scoped = e.target.checked;
-    this.props.fetchRecentEdits({ scoped });
-  },
+    dispatch(fetchRecentEdits({ scoped }));
+  };
 
-  render() {
-    return (
-      <div>
-        <label>
-          <input ref="myCourses" type="checkbox" onChange={this.setCourseScope} />
-          {I18n.t('recent_activity.show_courses')}
-        </label>
-        <ActivityTable
-          loading={this.props.loading}
-          activity={this.props.revisions}
-          headers={HEADERS}
-          noActivityMessage={NO_ACTIVITY_MESSAGE}
-          onSort={this.props.sortRecentEdits}
-        />
-      </div>
-    );
-  }
-});
-
-const mapStateToProps = state => ({
-  revisions: state.recentEdits.revisions,
-  loading: state.recentEdits.loading
-});
-
-const mapDispatchToProps = {
-  fetchRecentEdits: fetchRecentEdits,
-  sortRecentEdits: sortRecentEdits
+  return (
+    <div>
+      <label>
+        <input ref={myCoursesRef} type="checkbox" onChange={setCourseScope} />
+        {I18n.t('recent_activity.show_courses')}
+      </label>
+      <ActivityTable
+        loading={loading}
+        activity={revisions}
+        headers={HEADERS}
+        noActivityMessage={NO_ACTIVITY_MESSAGE}
+        onSort={dataSortKey => dispatch(sortRecentEdits(dataSortKey))}
+      />
+    </div>
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(RecentEditsHandler);
+RecentEditsHandler.propTypes = {
+  fetchRecentEdits: PropTypes.func,
+  sortRecentEdits: PropTypes.func,
+  revisions: PropTypes.array,
+  loading: PropTypes.bool
+};
+
+export default (RecentEditsHandler);

--- a/app/assets/javascripts/components/activity/recent_uploads_handler.jsx
+++ b/app/assets/javascripts/components/activity/recent_uploads_handler.jsx
@@ -1,56 +1,45 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchRecentUploads, sortRecentUploads } from '../../actions/recent_uploads_actions.js';
 import { GALLERY_VIEW } from '../../constants';
 import UploadList from '../uploads/upload_list.jsx';
 
 
-export const RecentUploadsHandlerBase = createReactClass({
-  displayName: 'RecentUploadsHandler',
+const RecentUploadsHandlerBase = () => {
+  const dispatch = useDispatch();
+  const uploads = useSelector(state => state.recentUploads.uploads);
 
-  propTypes: {
-    fetchRecentUploads: PropTypes.func,
-    sortRecentUploads: PropTypes.func,
-    uploads: PropTypes.array,
-    loading: PropTypes.bool
-   },
+  useEffect(() => {
+    dispatch(fetchRecentUploads());
+  }, []);
 
-  componentDidMount() {
-    return this.props.fetchRecentUploads();
-  },
+  const sortBy = (e) => {
+    dispatch(sortRecentUploads(e.target.value));
+  };
 
-  sortBy(e) {
-    this.props.sortRecentUploads(e.target.value);
-  },
-
-  render() {
-    return (
-      <div id="uploads">
-        <div className="section-header">
-          <h3>{I18n.t('uploads.header')}</h3>
-          <div className="sort-select">
-            <select className="sorts" name="sorts" onChange={this.sortBy}>
-              <option value="uploaded_at">{I18n.t('uploads.uploaded_at')}</option>
-              <option value="uploader">{I18n.t('uploads.uploaded_by')}</option>
-              <option value="usage_count">{I18n.t('uploads.usage_count')}</option>
-            </select>
-          </div>
+  return (
+    <div id="uploads">
+      <div className="section-header">
+        <h3>{I18n.t('uploads.header')}</h3>
+        <div className="sort-select">
+          <select className="sorts" name="sorts" onChange={sortBy}>
+            <option value="uploaded_at">{I18n.t('uploads.uploaded_at')}</option>
+            <option value="uploader">{I18n.t('uploads.uploaded_by')}</option>
+            <option value="usage_count">{I18n.t('uploads.usage_count')}</option>
+          </select>
         </div>
-        <UploadList uploads={this.props.uploads} view={GALLERY_VIEW} />
       </div>
-    );
-  }
-});
-
-const mapStateToProps = state => ({
-  uploads: state.recentUploads.uploads
-});
-
-const mapDispatchToProps = {
-  fetchRecentUploads,
-  sortRecentUploads
+      <UploadList uploads={uploads} view={GALLERY_VIEW} />
+    </div>
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(RecentUploadsHandlerBase);
+RecentUploadsHandlerBase.propTypes = {
+  fetchRecentUploads: PropTypes.func,
+  sortRecentUploads: PropTypes.func,
+  uploads: PropTypes.array,
+  loading: PropTypes.bool
+};
+
+export default (RecentUploadsHandlerBase);


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `did_you_know_handler.jsx`, `plagiarism_handler.jsx`, `recent_edits_handler.jsx` and `recent_uploads_handler.jsx` into functional components
**Affected Pages:**
- `/recent-activity/[chosen_activity]` (for `did_you_know_handler.jsx`, `plagiarism_handler.jsx`, `recent_edits_handler.jsx` and `recent_uploads_handler.jsx`)

## Videos
Before `did_you_know_handler.jsx`, `plagiarism_handler.jsx`, `recent_edits_handler.jsx` and `recent_uploads_handler.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/db159d80-7ccb-4b9b-a40e-fa90b882ed17

After `did_you_know_handler.jsx`, `plagiarism_handler.jsx`, `recent_edits_handler.jsx` and `recent_uploads_handler.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/3c9c17e2-67f2-401d-b3bf-3ed6e7d2d6e7
