### PR TITLE
Improve pagination controls on Articles tab

### DIFF
--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -19,7 +19,8 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
   const filteredArticles = useSelector(getArticlesByTrackedStatus);
   const currentPage = useSelector(state => state.articles.currentPage);
   const pageRange = getPageRange(currentPage, filteredArticles.length);
-  const totalEditedArticles = useSelector(state => state.course.edited_count);
+  const totalEditedArticles = getPageRange(currentPage, filteredArticles.length).split('-')[1];
+
 
   // this is for when a filter is applied and the number of pages changes
   // we need to reset the page to the first page
@@ -31,7 +32,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
 
   return (
     <div id="articles-view-controls" className={limitReached ? 'hidden-see-more-btn' : ''}>
-      <ReactPaginate
+      { totalPages ? (<ReactPaginate
         pageCount={totalPages}
         nextLabel={nextLabel}
         previousLabel={previousLabel}
@@ -39,7 +40,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
         containerClassName={'pagination'}
         onPageChange={handlePageChange}
         forcePage={currentPage - 1}
-      />
+      />) : null }
       {!limitReached
         && (
           <button
@@ -51,7 +52,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
         )
       }
       <p className="articles-shown-label">
-        {I18n.t('articles.articles_shown', { count: pageRange, total: totalEditedArticles })}
+        { totalPages ? I18n.t('articles.articles_shown', { count: pageRange, total: totalEditedArticles }) : null}
       </p>
     </div>
   );

--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -19,7 +19,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
   const filteredArticles = useSelector(getArticlesByTrackedStatus);
   const currentPage = useSelector(state => state.articles.currentPage);
   const pageRange = getPageRange(currentPage, filteredArticles.length);
-  const totalEditedArticles = getPageRange(currentPage, filteredArticles.length).split('-')[1];
+  const totalFilteredArticles = Math.min(filteredArticles.length, currentPage * ARTICLES_PER_PAGE);
 
 
   // this is for when a filter is applied and the number of pages changes
@@ -52,7 +52,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
         )
       }
       <p className="articles-shown-label">
-        { totalPages ? I18n.t('articles.articles_shown', { count: pageRange, total: totalEditedArticles }) : null}
+        { totalPages ? I18n.t('articles.articles_shown', { count: pageRange, total: totalFilteredArticles }) : null}
       </p>
     </div>
   );

--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -19,7 +19,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
   const filteredArticles = useSelector(getArticlesByTrackedStatus);
   const currentPage = useSelector(state => state.articles.currentPage);
   const pageRange = getPageRange(currentPage, filteredArticles.length);
-  const totalFilteredArticles = Math.min(filteredArticles.length, currentPage * ARTICLES_PER_PAGE);
+  const totalFilteredArticles = Math.min(filteredArticles.length, ARTICLES_PER_PAGE);
 
 
   // this is for when a filter is applied and the number of pages changes

--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -19,8 +19,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
   const filteredArticles = useSelector(getArticlesByTrackedStatus);
   const currentPage = useSelector(state => state.articles.currentPage);
   const pageRange = getPageRange(currentPage, filteredArticles.length);
-  const totalFilteredArticles = Math.min(filteredArticles.length, ARTICLES_PER_PAGE);
-
+  const totalFilteredArticles = filteredArticles.length;
 
   // this is for when a filter is applied and the number of pages changes
   // we need to reset the page to the first page


### PR DESCRIPTION
#5446

## What this PR does
Fixes:
1. When there are no edited articles, the Prev and Next buttons are now properly hidden.
2. The "Showing" message now updates correctly when a filter is applied.


## Screenshots
Before:

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/1a5322b7-5e85-4718-a96e-0cbd011c655c)

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/fae6c885-560d-457c-996f-cf038af03fe3)


After:

![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/64f0e634-b521-43b1-88fc-dc5743230ee7)

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/5bed3efd-60ea-4815-8c89-aec172418a34)


