### PR TITLE
Converting AlertsHandler, Article and AvailableArticle into functional components

### DIFF
--- a/app/assets/javascripts/components/alerts/alerts_handler.jsx
+++ b/app/assets/javascripts/components/alerts/alerts_handler.jsx
@@ -70,11 +70,9 @@ const AlertsHandler = ({ alertLabel, noAlertsLabel, adminAlert }) => {
 
 
 AlertsHandler.propTypes = {
-  alerts: PropTypes.array,
   alertLabel: PropTypes.string,
   noAlertsLabel: PropTypes.string,
   adminAlert: PropTypes.bool,
-  alertTypes: PropTypes.array,
 };
 
 export default (AlertsHandler);

--- a/app/assets/javascripts/components/alerts/alerts_handler.jsx
+++ b/app/assets/javascripts/components/alerts/alerts_handler.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import AlertsList from './alerts_list.jsx';
 import { sortAlerts, filterAlerts } from '../../actions/alert_actions';
@@ -28,64 +27,54 @@ const transformAlertsIntoOptions = (alertsArray) => {
   });
 };
 
-const AlertsHandler = createReactClass({
-  displayName: 'AlertsHandler',
+const AlertsHandler = ({ alertLabel, noAlertsLabel, adminAlert }) => {
+  const dispatch = useDispatch();
+  const alerts = useSelector(state => state.alerts.alerts);
+  const selectedFilters = useSelector(state => state.alerts.selectedFilters);
+  const selectedAlerts = useSelector(state => getFilteredAlerts(state));
+  const alertTypes = useSelector(state => transformAlertsIntoOptions(state.alerts.alerts));
 
-  propTypes: {
-    alerts: PropTypes.array,
-    alertLabel: PropTypes.string,
-    noAlertsLabel: PropTypes.string,
-    adminAlert: PropTypes.bool,
-    alertTypes: PropTypes.array,
-  },
+  const sortSelect = (e) => {
+    return dispatch(sortAlerts(e.target.value));
+  };
 
-  sortSelect(e) {
-    return this.props.sortAlerts(e.target.value);
-  },
-
-  filterAlerts(selectedFilters) {
-    return this.props.filterAlerts(selectedFilters);
-  },
-
-  render() {
-    let alertList;
-    if (this.props.alerts) {
-      alertList = (
-        <div id="alerts" className="campaign_main alerts container">
-          <div className="section-header">
-            <h3>{this.props.alertLabel}</h3>
-            <MultiSelectField options={this.props.alertTypes} label={I18n.t('campaign.alert_select_label')} selected={this.props.selectedFilters} setSelectedFilters={this.filterAlerts} />
-            <div className="sort-select">
-              <select className="sorts" name="sorts" onChange={this.sortSelect}>
-                <option value="type">{I18n.t('campaign.alert_type')}</option>
-                <option value="course">{I18n.t('campaign.course')}</option>
-                <option value="user">{I18n.t('campaign.alert_user_id')}</option>
-                <option value="created_at">{I18n.t('campaign.created_at')}</option>
-              </select>
-            </div>
+  let alertList;
+  if (alerts) {
+    alertList = (
+      <div id="alerts" className="campaign_main alerts container">
+        <div className="section-header">
+          <h3>{alertLabel}</h3>
+          <MultiSelectField options={alertTypes} label={I18n.t('campaign.alert_select_label')} selected={selectedFilters} setSelectedFilters={value => dispatch(filterAlerts(value))} />
+          <div className="sort-select">
+            <select className="sorts" name="sorts" onChange={sortSelect}>
+              <option value="type">{I18n.t('campaign.alert_type')}</option>
+              <option value="course">{I18n.t('campaign.course')}</option>
+              <option value="user">{I18n.t('campaign.alert_user_id')}</option>
+              <option value="created_at">{I18n.t('campaign.created_at')}</option>
+            </select>
           </div>
-          <AlertsList
-            alerts={this.props.selectedAlerts}
-            sortBy={this.props.sortAlerts}
-            noAlertsLabel={this.props.noAlertsLabel}
-            adminAlert={this.props.adminAlert ? this.props.adminAlert : false}
-          />
         </div>
-      );
-    }
-    return (
-      <div>{alertList}</div>
+        <AlertsList
+          alerts={selectedAlerts}
+          sortBy={key => dispatch(sortAlerts(key))}
+          noAlertsLabel={noAlertsLabel}
+          adminAlert={adminAlert || false}
+        />
+      </div>
     );
-    }
-});
+  }
+  return (
+    <div>{alertList}</div>
+  );
+};
 
-const mapStateToProps = state => ({
-  alerts: state.alerts.alerts,
-  selectedFilters: state.alerts.selectedFilters,
-  selectedAlerts: getFilteredAlerts(state),
-  alertTypes: transformAlertsIntoOptions(state.alerts.alerts),
- });
 
-const mapDispatchToProps = { sortAlerts, filterAlerts };
+AlertsHandler.propTypes = {
+  alerts: PropTypes.array,
+  alertLabel: PropTypes.string,
+  noAlertsLabel: PropTypes.string,
+  adminAlert: PropTypes.bool,
+  alertTypes: PropTypes.array,
+};
 
-export default connect(mapStateToProps, mapDispatchToProps)(AlertsHandler);
+export default (AlertsHandler);

--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import CourseUtils from '../../utils/course_utils.js';
 import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
@@ -9,152 +8,145 @@ import Switch from 'react-switch';
 import { toWikiDomain } from '../../utils/wiki_utils.js';
 import { stringify } from 'query-string';
 
-const Article = createReactClass({
-  displayName: 'Article',
+const Article = ({ article, index, course, fetchArticleDetails, updateArticleTrackedStatus, articleDetails, wikidataLabel,
+  showOnMount, setSelectedIndex, lastIndex, selectedIndex, pageLogsMessage, deletedMessage, current_user }) => {
+  const [tracked, setTracked] = useState(article.tracked);
 
-  propTypes: {
-    article: PropTypes.object.isRequired,
-    index: PropTypes.number,
-    course: PropTypes.object.isRequired,
-    fetchArticleDetails: PropTypes.func.isRequired,
-    updateArticleTrackedStatus: PropTypes.func,
-    articleDetails: PropTypes.object,
-    wikidataLabel: PropTypes.string,
-    showOnMount: PropTypes.bool,
-    setSelectedIndex: PropTypes.func,
-    lastIndex: PropTypes.number,
-    selectedIndex: PropTypes.number,
-    deletedMessage: PropTypes.string
-  },
-
-  getInitialState() {
-    return {
-      tracked: this.props.article.tracked
-    };
-  },
-
-  fetchArticleDetails() {
-    if (!this.props.articleDetails) {
-      this.props.fetchArticleDetails(this.props.article.id, this.props.course.id);
+  const fetchMissingArticleDetails = () => {
+    if (!articleDetails) {
+      fetchArticleDetails(article.id, course.id);
     }
-  },
+  };
 
-  handleTrackedChange(tracked) {
-    this.props.updateArticleTrackedStatus(this.props.article.id, this.props.course.id, tracked);
-    this.setState({ tracked });
-  },
+  const handleTrackedChange = (checked) => {
+    updateArticleTrackedStatus(article.id, course.id, checked);
+    setTracked(checked);
+  };
 
-  render() {
-    const ratingClass = `rating ${this.props.article.rating}`;
-    const ratingMobileClass = `${ratingClass} tablet-only`;
-    const isDeleted = this.props.article.deleted;
-    const wiki = {
-      language: this.props.article.language,
-      project: this.props.article.project
-    };
-    const pageLogURL = `https://${toWikiDomain(wiki)}/wiki/Special:Log?${stringify({
-      page: this.props.article.title
-    })}`;
-    // Uses Course Utils Helper
-    const formattedTitle = CourseUtils.formattedArticleTitle(this.props.article, this.props.course.home_wiki, this.props.wikidataLabel);
-    const historyUrl = `${this.props.article.url}?action=history`;
+  const ratingClass = `rating ${article.rating}`;
+  const ratingMobileClass = `${ratingClass} tablet-only`;
+  const isDeleted = article.deleted;
+  const wiki = {
+    language: article.language,
+    project: article.project
+  };
+  const pageLogURL = `https://${toWikiDomain(wiki)}/wiki/Special:Log?${stringify({
+    page: article.title
+  })}`;
+  // Uses Course Utils Helper
+  const formattedTitle = CourseUtils.formattedArticleTitle(article, course.home_wiki, wikidataLabel);
+  const historyUrl = `${article.url}?action=history`;
 
-    const trackedEditable = this.props.current_user && this.props.current_user.isAdvancedRole;
+  const trackedEditable = current_user && current_user.isAdvancedRole;
 
-    let tracked;
-    if (this.props.course.type !== 'ClassroomProgramCourse' && trackedEditable) {
-      tracked = (
-        <td className="tracking">
-          <Switch onChange={this.handleTrackedChange} checked={this.state.tracked} onColor="#676eb4" />
-        </td>
-      );
-    }
-
-    let contentAdded;
-    if (this.props.course.home_wiki_bytes_per_word) {
-      const wordsAdded = Math.round(this.props.article.character_sum / this.props.course.home_wiki_bytes_per_word);
-      contentAdded = <td className="desktop-only-tc">{wordsAdded}</td>;
-    } else {
-      contentAdded = <td className="desktop-only-tc">{this.props.article.character_sum}</td>;
-    }
-
-    const { project, title } = this.props.article;
-    let { language } = this.props.article;
-    if (project === 'wikidata') language = 'www';
-    const pageviewUrl = `https://pageviews.toolforge.org/?project=${language}.${project}.org&platform=all-access&agent=user&range=latest-90&pages=${title}`;
-
-    const isWikipedia = project === 'wikipedia';
-
-    return (
-      <tr className={`article ${isDeleted ? 'deleted' : ' '}`}>
-        <td className="tooltip-trigger desktop-only-tc">
-          {isWikipedia && <p className="rating_num hidden">{this.props.article.rating_num}</p>}
-          {isWikipedia && <div className={ratingClass}><p>{!isDeleted ? (this.props.article.pretty_rating || '-') : 'DE'}</p></div>}
-          {isWikipedia && <div className="tooltip dark">
-            <p>
-              {
-                !isDeleted ? I18n.t(`articles.rating_docs.${this.props.article.rating || '?'}`, { class: this.props.article.rating || '' }) : this.props.deletedMessage
-              }
-            </p>
-            {/* eslint-disable-next-line */}
-          </div>}
-        </td>
-        <td>
-          {isWikipedia && <div className={ratingMobileClass}><p>{!isDeleted ? (this.props.article.pretty_rating || '-') : 'DE'}</p></div>}
-          {isWikipedia && <div />}
-          <div className="title">
-            <a href={this.props.article.url} target="_blank" className="inline">{formattedTitle} {(this.props.article.new_article ? ` ${I18n.t('articles.new')}` : '')}</a>
-            <br />
-            {!isDeleted
-              ? (
-                <small>
-                  <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a> | <ArticleGraphs article={this.props.article} />
-                </small>
-              )
-              : (
-                <small>
-                  <a href={pageLogURL} target="_blank" className="inline">{this.props.pageLogsMessage}</a>
-                </small>
-              )
-            }
-          </div>
-        </td>
-        {contentAdded}
-        <td className="desktop-only-tc">{this.props.article.references_count || ''}</td>
-        <td className="desktop-only-tc">
-          <a href={pageviewUrl} target="_blank" className="inline">{this.props.article.view_count}</a>
-        </td>
-        <td>
-          <ArticleViewer
-            article={this.props.article}
-            course={this.props.course}
-            current_user={this.props.current_user}
-            users={this.props.articleDetails && this.props.articleDetails.editors}
-            fetchArticleDetails={this.fetchArticleDetails}
-            showButtonClass="pull-left"
-            showOnMount={this.props.showOnMount}
-          />
-          <DiffViewer
-            fetchArticleDetails={this.fetchArticleDetails}
-            index={this.props.index}
-            revision={this.props.articleDetails && this.props.articleDetails.last_revision}
-            first_revision={this.props.articleDetails && this.props.articleDetails.first_revision}
-            showButtonLabel={I18n.t('articles.show_cumulative_changes')}
-            showButtonClass="pull-right"
-            editors={this.props.articleDetails && this.props.articleDetails.editors}
-            showSalesforceButton={Boolean(Features.wikiEd && this.props.current_user.admin)}
-            course={this.props.course}
-            article={this.props.article}
-            articleTitle={this.props.article.title}
-            setSelectedIndex={this.props.setSelectedIndex}
-            lastIndex={this.props.lastIndex}
-            selectedIndex={this.props.selectedIndex}
-          />
-        </td>
-        {tracked}
-      </tr>
+  let trackedComponent;
+  if (course.type !== 'ClassroomProgramCourse' && trackedEditable) {
+    trackedComponent = (
+      <td className="tracking">
+        <Switch onChange={handleTrackedChange} checked={tracked} onColor="#676eb4" />
+      </td>
     );
   }
-});
+
+  let contentAdded;
+  if (course.home_wiki_bytes_per_word) {
+    const wordsAdded = Math.round(article.character_sum / course.home_wiki_bytes_per_word);
+    contentAdded = <td className="desktop-only-tc">{wordsAdded}</td>;
+  } else {
+    contentAdded = <td className="desktop-only-tc">{article.character_sum}</td>;
+  }
+
+  const { project, title } = article;
+  let { language } = article;
+  if (project === 'wikidata') language = 'www';
+  const pageviewUrl = `https://pageviews.toolforge.org/?project=${language}.${project}.org&platform=all-access&agent=user&range=latest-90&pages=${title}`;
+
+  const isWikipedia = project === 'wikipedia';
+
+  return (
+    <tr className={`article ${isDeleted ? 'deleted' : ' '}`}>
+      <td className="tooltip-trigger desktop-only-tc">
+        {isWikipedia && <p className="rating_num hidden">{article.rating_num}</p>}
+        {isWikipedia && <div className={ratingClass}><p>{!isDeleted ? (article.pretty_rating || '-') : 'DE'}</p></div>}
+        {isWikipedia && <div className="tooltip dark">
+          <p>
+            {
+              !isDeleted ? I18n.t(`articles.rating_docs.${article.rating || '?'}`, { class: article.rating || '' }) : deletedMessage
+            }
+          </p>
+          {/* eslint-disable-next-line */}
+        </div>}
+      </td>
+      <td>
+        {isWikipedia && <div className={ratingMobileClass}><p>{!isDeleted ? (article.pretty_rating || '-') : 'DE'}</p></div>}
+        {isWikipedia && <div />}
+        <div className="title">
+          <a href={article.url} target="_blank" className="inline">{formattedTitle} {(article.new_article ? ` ${I18n.t('articles.new')}` : '')}</a>
+          <br />
+          {!isDeleted
+            ? (
+              <small>
+                <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a> | <ArticleGraphs article={article} />
+              </small>
+            )
+            : (
+              <small>
+                <a href={pageLogURL} target="_blank" className="inline">{pageLogsMessage}</a>
+              </small>
+            )
+          }
+        </div>
+      </td>
+      {contentAdded}
+      <td className="desktop-only-tc">{article.references_count || ''}</td>
+      <td className="desktop-only-tc">
+        <a href={pageviewUrl} target="_blank" className="inline">{article.view_count}</a>
+      </td>
+      <td>
+        <ArticleViewer
+          article={article}
+          course={course}
+          current_user={current_user}
+          users={articleDetails && articleDetails.editors}
+          fetchArticleDetails={fetchMissingArticleDetails}
+          showButtonClass="pull-left"
+          showOnMount={showOnMount}
+        />
+        <DiffViewer
+          fetchArticleDetails={fetchMissingArticleDetails}
+          index={index}
+          revision={articleDetails && articleDetails.last_revision}
+          first_revision={articleDetails && articleDetails.first_revision}
+          showButtonLabel={I18n.t('articles.show_cumulative_changes')}
+          showButtonClass="pull-right"
+          editors={articleDetails && articleDetails.editors}
+          showSalesforceButton={Boolean(Features.wikiEd && current_user.admin)}
+          course={course}
+          article={article}
+          articleTitle={article.title}
+          setSelectedIndex={setSelectedIndex}
+          lastIndex={lastIndex}
+          selectedIndex={selectedIndex}
+        />
+      </td>
+      {trackedComponent}
+    </tr>
+  );
+};
+
+Article.propTypes = {
+  article: PropTypes.object.isRequired,
+  index: PropTypes.number,
+  course: PropTypes.object.isRequired,
+  fetchArticleDetails: PropTypes.func.isRequired,
+  updateArticleTrackedStatus: PropTypes.func,
+  articleDetails: PropTypes.object,
+  wikidataLabel: PropTypes.string,
+  showOnMount: PropTypes.bool,
+  setSelectedIndex: PropTypes.func,
+  lastIndex: PropTypes.number,
+  selectedIndex: PropTypes.number,
+  deletedMessage: PropTypes.string
+};
 
 export default Article;

--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -1,124 +1,115 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import CourseUtils from '../../utils/course_utils.js';
 import { deleteAssignment, claimAssignment } from '../../actions/assignment_actions.js';
 
-export const AvailableArticle = createReactClass({
-  displayName: 'AvailableArticle',
+export const AvailableArticle = ({ assignment, current_user, course, selectable }) => {
+  const dispatch = useDispatch();
 
-  propTypes: {
-    assignment: PropTypes.object,
-    current_user: PropTypes.object,
-    course: PropTypes.object,
-    deleteAssignment: PropTypes.func,
-    claimAssignment: PropTypes.func,
-    selectable: PropTypes.bool
-  },
-
-  onSelectHandler() {
-    const assignment = {
-      id: this.props.assignment.id,
-      user_id: this.props.current_user.id,
+  const onSelectHandler = () => {
+    const assignmentObj = {
+      id: assignment.id,
+      user_id: current_user.id,
       role: 0
     };
 
-    const title = this.props.assignment.article_title;
+    const title = assignment.article_title;
     const successNotification = {
       message: I18n.t('assignments.article', { title }),
       closable: true,
       type: 'success'
     };
 
-    return this.props.claimAssignment(assignment, successNotification);
-  },
+    return dispatch(claimAssignment(assignmentObj, successNotification));
+  };
 
-  onRemoveHandler(e) {
+  const onRemoveHandler = (e) => {
     e.preventDefault();
 
-    const assignment = {
-      id: this.props.assignment.id,
-      course_slug: this.props.course.slug,
-      language: this.props.assignment.language,
-      project: this.props.assignment.project,
-      article_title: this.props.assignment.article_title,
+    const assignmentObj = {
+      id: assignment.id,
+      course_slug: course.slug,
+      language: assignment.language,
+      project: assignment.project,
+      article_title: assignment.article_title,
       role: 0
     };
 
     if (!confirm(I18n.t('assignments.confirm_deletion'))) { return; }
-    return this.props.deleteAssignment(assignment);
-  },
+    return dispatch(deleteAssignment(assignmentObj));
+  };
 
-  render() {
-    const className = 'assignment';
-    const { assignment } = this.props;
+  const className = 'assignment';
 
-    const article = CourseUtils.articleFromAssignment(assignment, this.props.course.home_wiki);
-    const ratingClass = `rating ${assignment.article_rating}`;
-    const ratingMobileClass = `${ratingClass} tablet-only`;
-    const articleLink = (
-      <a
-        onClick={this.stop}
-        href={article.url}
-        target="_blank"
-        className="inline"
-        style={{
-          color:
-            assignment.article_rating === 'does_not_exist'
-              ? '#dd3333'
-              : '#3366cc',
-        }}
-      >
-        {article.formatted_title}
-      </a>
-    );
-    const isWikipedia = article.project === 'wikipedia';
+  const article = CourseUtils.articleFromAssignment(assignment, course.home_wiki);
+  const ratingClass = `rating ${assignment.article_rating}`;
+  const ratingMobileClass = `${ratingClass} tablet-only`;
+  const articleLink = (
+    <a
+      onClick={stop}
+      href={article.url}
+      target="_blank"
+      className="inline"
+      style={{
+        color:
+          assignment.article_rating === 'does_not_exist'
+            ? '#dd3333'
+            : '#3366cc',
+      }}
+    >
+      {article.formatted_title}
+    </a>
+  );
+  const isWikipedia = article.project === 'wikipedia';
 
-    let actionSelect;
-    let actionRemove;
-    if (this.props.current_user.isStudent && this.props.selectable) {
-      actionSelect = (
-        <button className="button dark" onClick={this.onSelectHandler}>{I18n.t('assignments.select')}</button>
-      );
-    }
-
-    if (this.props.current_user.isAdvancedRole) {
-      actionRemove = (
-        <button className="button dark" onClick={this.onRemoveHandler}>{I18n.t('assignments.remove')}</button>
-      );
-    }
-
-    return (
-      <tr className={className}>
-        <td className="tooltip-trigger desktop-only-tc">
-          {isWikipedia && <p className="rating_num hidden">{article.rating_num}</p>}
-          {isWikipedia && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
-          {isWikipedia && <div className="tooltip dark">
-            <p>{I18n.t(`articles.rating_docs.${assignment.article_rating || '?'}`, { class: assignment.article_rating || '' })}</p>
-            {/* eslint-disable-next-line */}
-          </div>}
-        </td>
-        <td>
-          {isWikipedia && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
-          <p className="title">
-            {articleLink}
-          </p>
-        </td>
-        <td className="table-action-cell">
-          {actionSelect}
-          {actionRemove}
-        </td>
-      </tr>
+  let actionSelect;
+  let actionRemove;
+  if (current_user.isStudent && selectable) {
+    actionSelect = (
+      <button className="button dark" onClick={onSelectHandler}>{I18n.t('assignments.select')}</button>
     );
   }
-}
-);
 
-const mapDispatchToProps = {
-  deleteAssignment,
-  claimAssignment
+  if (current_user.isAdvancedRole) {
+    actionRemove = (
+      <button className="button dark" onClick={onRemoveHandler}>{I18n.t('assignments.remove')}</button>
+    );
+  }
+
+  return (
+    <tr className={className}>
+      <td className="tooltip-trigger desktop-only-tc">
+        {isWikipedia && <p className="rating_num hidden">{article.rating_num}</p>}
+        {isWikipedia && <div className={ratingClass}><p>{article.pretty_rating || '-'}</p></div>}
+        {isWikipedia && (
+          <div className="tooltip dark">
+            <p>
+              {I18n.t(`articles.rating_docs.${assignment.article_rating || '?'}`, { class: assignment.article_rating || '' })}
+            </p>
+          </div>
+        )}
+      </td>
+      <td>
+        {isWikipedia && <div className={ratingMobileClass}><p>{article.pretty_rating}</p></div>}
+        <p className="title">
+          {articleLink}
+        </p>
+      </td>
+      <td className="table-action-cell">
+        {actionSelect}
+        {actionRemove}
+      </td>
+    </tr>
+  );
 };
 
-export default connect(null, mapDispatchToProps)(AvailableArticle);
+AvailableArticle.propTypes = {
+  assignment: PropTypes.object,
+  current_user: PropTypes.object,
+  course: PropTypes.object,
+  selectable: PropTypes.bool
+};
+
+export default (AvailableArticle);


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `alerts_handler.jsx`, `articles.jsx` and `available_article.jsx` into functional components
**Affected Pages:**
- `/tagged_courses/[tag]/alerts` (for `alerts_handler.jsx`)
- `/alerts_list` (for `alerts_handler.jsx`)
- `/campaigns/[campaign_title]/alerts` (for `alerts_handler.jsx`)
- `/courses/[institution_id]/[course_id]/activity/alerts` (for `alerts_handler.jsx`)
- `/courses/[institution_id]/[course_id]/articles/edited` (for `articles.jsx`)
- `/courses/[institution_id]/[course_id]/articles/available` (for `available_article.jsx`)

## Videos
Before `alerts_handler.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/5f9371ca-45f6-4d26-8e77-e1203d2106b0

After `alerts_handler.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/b59bf9af-1c8c-44c2-82fd-52e6dfc24212

Before `articles.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/1cff3c6c-db33-49c4-9c15-9059202dc4e5

After `articles.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/d585e4f6-4142-471f-bc5b-3ebd4aff4931

Before `available_article.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/d72cbfa5-a458-439e-bc48-dd6f3dead4a9

After `available_article.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/fbaa48f0-92d4-4fcd-bd65-d352abd876f8



