### PR TITLE
Converting Intro, Permissions and Finished into functional components

### DIFF
--- a/app/assets/javascripts/components/onboarding/finished.jsx
+++ b/app/assets/javascripts/components/onboarding/finished.jsx
@@ -1,40 +1,29 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-// Finished slide
-const Finished = createReactClass({
-  propTypes: {
-    currentUser: PropTypes.object,
-    returnToParam: PropTypes.string
-  },
-
-  getInitialState() {
-    return {};
-  },
-
+const Finished = ({ returnToParam }) => {
   // When this route loads, wait a second then redirect
   // out to the return_to param (or root)
-  componentDidMount() {
-    return this.state.timeout = setTimeout(() => {
-      const returnTo = this.props.returnToParam;
-      return window.location = decodeURIComponent(returnTo);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const returnTo = returnToParam;
+      window.location = decodeURIComponent(returnTo);
     }, 750);
-  },
 
-  // clear the timeout just to be safe
-  componentWillUnmount() {
-    return clearTimeout(this.state.timeout);
-  },
+    // clear the timeout just to be safe
+    return () => { clearTimeout(timeout); };
+  }, []);
 
-  render() {
-    return (
-      <div className="intro">
-        <h1>You´re all set. Thank you.</h1>
-        <h2>Loading...</h2>
-      </div>
-    );
-  }
-});
+  return (
+    <div className="intro">
+      <h1>You´re all set. Thank you.</h1>
+      <h2>Loading...</h2>
+    </div>
+  );
+};
+
+Finished.propTypes = {
+  returnToParam: PropTypes.string
+};
 
 export default Finished;

--- a/app/assets/javascripts/components/onboarding/intro.jsx
+++ b/app/assets/javascripts/components/onboarding/intro.jsx
@@ -1,36 +1,28 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-const Intro = createReactClass({
-  propTypes: {
-    currentUser: PropTypes.object,
-    returnToParam: PropTypes.string,
-    location: PropTypes.object
-  },
+const Intro = ({ currentUser, returnToParam }) => {
+  return (
+    <div className="intro text-center">
+      <h1>Hi {currentUser.real_name || currentUser.username}</h1>
+      <p>We’re excited that you’re here!</p>
+      <Link
+        to={{
+          pathname: '/onboarding/form',
+          search: `?return_to=${returnToParam}`
+        }}
+        className="button border inverse-border"
+      >
+        Start <i className="icon icon-rt_arrow" />
+      </Link>
+    </div>
+  );
+};
 
-  getInitialState() {
-    return { user: this.props.currentUser };
-  },
-
-  render() {
-    return (
-      <div className="intro text-center">
-        <h1>Hi {this.state.user.real_name || this.state.user.username}</h1>
-        <p>We’re excited that you’re here!</p>
-        <Link
-          to={{
-            pathname: '/onboarding/form',
-            search: `?return_to=${this.props.returnToParam}`
-          }}
-          className="button border inverse-border"
-        >
-          Start <i className="icon icon-rt_arrow" />
-        </Link>
-      </div>
-    );
-  }
-});
+Intro.propTypes = {
+  currentUser: PropTypes.object,
+  returnToParam: PropTypes.string,
+};
 
 export default Intro;

--- a/app/assets/javascripts/components/onboarding/permissions.jsx
+++ b/app/assets/javascripts/components/onboarding/permissions.jsx
@@ -1,61 +1,58 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 // Permissions slide
-const Permissions = createReactClass({
-  propTypes: {
-    currentUser: PropTypes.object,
-    returnToParam: PropTypes.string
-  },
+const Permissions = ({ currentUser, returnToParam }) => {
+  let slide;
 
-  render() {
-    let slide;
-
-    if (this.props.currentUser.instructor) {
-      slide = (
-        <div className="intro permissions">
-          <h1>Permissions</h1>
-          <p>
-            Once you´ve signed in, this website will make automatic edits using your Wikipedia account, reflecting actions you take here. Your account will be used to update wiki pages when:
-          </p>
-          <ul>
-            <li>you submit a Wikipedia classroom assignment or make edits to your course page</li>
-            <li>you add or remove someone from a course</li>
-            <li>you assign articles to students</li>
-            <li>you send public messages to students</li>
-          </ul>
-          <p>All course content you contribute to this website will be freely available under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution-ShareAlike license</a> (the same one used by Wikipedia).</p>
-          <Link to={{ pathname: '/onboarding/finish', search: `?return_to=${this.props.returnToParam}` }} className="button border inverse-border">
-            Finish <i className="icon icon-rt_arrow" />
-          </Link>
-        </div>
-      );
-    } else {
-      slide = (
-        <div className="intro permissions">
-          <h1>Permissions</h1>
-          <p>
-            Once you´ve signed in, this website will make automatic edits using your Wikipedia account, reflecting actions you take here. Your account will be used to update wiki pages to:
-          </p>
-          <ul>
-            <li>set up a sandbox page where you can practice editing</li>
-            <li>adjust your account preferences to enable VisualEditor</li>
-            <li>add a standard message on your userpage so that others know what course you are part of</li>
-            <li>add standard messages to the Talk pages of articles you´re editing or reviewing</li>
-            <li>update your course´s wiki page when you join the course or choose an assignment topic</li>
-          </ul>
-          <p>All course content you contribute to this website will be freely available under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution-ShareAlike license</a> (the same one used by Wikipedia).</p>
-          <Link to={{ pathname: '/onboarding/finish', search: `?return_to=${this.props.returnToParam}` }} className="button border inverse-border">
-            Finish <i className="icon icon-rt_arrow" />
-          </Link>
-        </div>
-      );
-    }
-
-    return slide;
+  if (currentUser.instructor) {
+    slide = (
+      <div className="intro permissions">
+        <h1>Permissions</h1>
+        <p>
+          Once you´ve signed in, this website will make automatic edits using your Wikipedia account, reflecting actions you take here. Your account will be used to update wiki pages when:
+        </p>
+        <ul>
+          <li>you submit a Wikipedia classroom assignment or make edits to your course page</li>
+          <li>you add or remove someone from a course</li>
+          <li>you assign articles to students</li>
+          <li>you send public messages to students</li>
+        </ul>
+        <p>All course content you contribute to this website will be freely available under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution-ShareAlike license</a> (the same one used by Wikipedia).</p>
+        <Link to={{ pathname: '/onboarding/finish', search: `?return_to=${returnToParam}` }} className="button border inverse-border">
+          Finish <i className="icon icon-rt_arrow" />
+        </Link>
+      </div>
+    );
+  } else {
+    slide = (
+      <div className="intro permissions">
+        <h1>Permissions</h1>
+        <p>
+          Once you´ve signed in, this website will make automatic edits using your Wikipedia account, reflecting actions you take here. Your account will be used to update wiki pages to:
+        </p>
+        <ul>
+          <li>set up a sandbox page where you can practice editing</li>
+          <li>adjust your account preferences to enable VisualEditor</li>
+          <li>add a standard message on your userpage so that others know what course you are part of</li>
+          <li>add standard messages to the Talk pages of articles you´re editing or reviewing</li>
+          <li>update your course´s wiki page when you join the course or choose an assignment topic</li>
+        </ul>
+        <p>All course content you contribute to this website will be freely available under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution-ShareAlike license</a> (the same one used by Wikipedia).</p>
+        <Link to={{ pathname: '/onboarding/finish', search: `?return_to=${returnToParam}` }} className="button border inverse-border">
+          Finish <i className="icon icon-rt_arrow" />
+        </Link>
+      </div>
+    );
   }
-});
+
+  return slide;
+};
+
+Permissions.propTypes = {
+  currentUser: PropTypes.object,
+  returnToParam: PropTypes.string
+};
 
 export default Permissions;


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `intro.jsx`, `permissions.jsx` and `finished.jsx` into functional components
**Affected Pages:**
- `/onboarding` (for `intro.jsx`)
- `/onboarding/permissions?return_to=/` (for `permissions.jsx`)
- `/onboarding/finish?return_to=/` (for `finished.jsx`)

## Screenshot/Videos
Before `intro.jsx`

![before refactor Intro](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/0f2f4d1d-9cfb-42cb-8ea1-b9d906292945)

After `intro.jsx` 

![after refactor Intro](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/110b6391-2bb8-4051-ba6b-5dec395a4c11)

Before `permissions.jsx`

![before refactor Permissions](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/3726946d-e925-464f-916a-ca0cbfcf4e75)

After `permissions.jsx` 

![after refactor Permissions](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/da18a2ee-9cee-4770-bc01-330dbda96356)

Before `finished.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/185508da-a857-44c0-99fd-5bc2e8b2f403

After `finished.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/b35a6ce7-e9c3-4d5f-9d70-f0884695732b




