### PR TITLE
Converting EmbedStatsButton into functional component

### DIFF
--- a/app/assets/javascripts/components/overview/embed_stats_button.jsx
+++ b/app/assets/javascripts/components/overview/embed_stats_button.jsx
@@ -1,56 +1,42 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-const EmbedStatsButton = createReactClass({
-  displayName: 'EmbedStatsButton',
+const EmbedStatsButton = ({ title }) => {
+  const [show, setShow] = useState(false);
+  const [status, setStatus] = useState('');
 
-  propTypes: {
-    title: PropTypes.string
-  },
-
-  getInitialState() {
-    return { show: false, status: '' };
-  },
-
-  copyToClipboard(e) {
+  const copyToClipboard = (e) => {
     const el = e.target;
-    el.select();
-    document.execCommand('copy');
-    this.setState({ status: 'Copied!' });
-  },
+    navigator.clipboard.writeText(el.value).then(() => {
+      setStatus('Copied!');
+    });
+  };
 
-  show() {
-    this.setState({ show: true });
-  },
-
-  hide() {
-    this.setState({ show: false });
-  },
-
-  render() {
-    if (!this.state.show) {
-      return (<button onClick={this.show} className="button">{I18n.t('courses.embed_course_stats')}</button>);
-    }
-
-    const url = location.href.replace('courses', 'embed/course_stats');
-
-    return (
-      <div className="basic-modal course-stats-download-modal embed_stats">
-        <button onClick={this.hide} className="pull-right article-viewer-button icon-close" />
-        <h4>{I18n.t('courses.embed_course_stats_description')} <code>&lt;body&gt;</code></h4>
-        <textarea
-          id="embed"
-          readOnly
-          value={
-`<a href="${location.href}">${this.props.title}</a><!-- This is optional -->
-<iframe src="${url}" style="width:100%;border:0px none transparent;"></iframe>`}
-          onClick={this.copyToClipboard}
-        />
-        <small>{this.state.status}</small>
-      </div>
-    );
+  if (!show) {
+    return (<button onClick={() => setShow(true)} className="button">{I18n.t('courses.embed_course_stats')}</button>);
   }
-});
+
+  const url = location.href.replace('courses', 'embed/course_stats');
+
+  return (
+    <div className="basic-modal course-stats-download-modal embed_stats">
+      <button onClick={() => setShow(false)} className="pull-right article-viewer-button icon-close" />
+      <h4>{I18n.t('courses.embed_course_stats_description')} <code>&lt;body&gt;</code></h4>
+      <textarea
+        id="embed"
+        readOnly
+        value={
+          `<a href="${location.href}">${title}</a><!-- This is optional -->
+<iframe src="${url}" style="width:100%;border:0px none transparent;"></iframe>`}
+        onClick={copyToClipboard}
+      />
+      <small>{status}</small>
+    </div>
+  );
+};
+
+EmbedStatsButton.propTypes = {
+  title: PropTypes.string
+};
 
 export default EmbedStatsButton;


### PR DESCRIPTION
With reference to #5393
## What this PR does
Converts `embed_stats_button.jsx` into a functional component
**Affected Pages:**
- `/courses/[institution_name]/[course_name]` (for `/embed_stats_button.jsx`)

## Videos
Before `embed_stats_button.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/d4184366-448e-43d7-aaa5-d34e31641881

After `embed_stats_button.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/107a4a61-1b8b-415b-aadf-c3481c401160

## Clarifications
I replaced the execCommand method since it was deprecated, my choice of replacement was to use the native javascript clipboard API (supported in all major browsers)

