### PR TITLE
Fix sorting of Students list and retaining state when navigating between tabs #5343

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/ExercisesList/StudentExerciseRow.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/ExercisesList/StudentExerciseRow.jsx
@@ -5,20 +5,12 @@ import StudentExercise from './StudentExercise/StudentExercise.jsx';
 import { useDispatch } from 'react-redux';
 import { toggleUI } from '@actions/index.js';
 
-// Helper Functions
-const setRealName = (student) => {
-  const nameParts = student.real_name.trim().toLowerCase().split(' ');
-  student.first_name = nameParts[0];
-  student.last_name = nameParts.slice().pop();
-};
-
 export const StudentExerciseRow = ({
   assignments, course, current_user, editAssignments,
   openKey, showRecent, student, wikidataLabels,
 }) => {
   const dispatch = useDispatch();
 
-  if (student.real_name) setRealName(student);
   const isOpen = openKey === `drawer_${student.id}`;
   return (
     <StudentExercise

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentRow.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentRow.jsx
@@ -3,17 +3,9 @@ import PropTypes from 'prop-types';
 
 import Student from './Student/Student.jsx';
 
-// Helper Functions
-const setRealName = (student) => {
-  const nameParts = student.real_name.trim().toLowerCase().split(' ');
-  student.first_name = nameParts[0];
-  student.last_name = nameParts.slice().pop();
-};
-
 export const StudentRow = ({
   assignments, course, current_user, editAssignments, showRecent, student, wikidataLabels
 }) => {
-  if (student.real_name) setRealName(student);
   return (
     <Student
       assignments={assignments}

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -5,7 +5,7 @@ const initialState = {
   users: [],
   sort: {
     sortKey: null,
-    key: null,
+    key: 'last_name',
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -24,20 +24,32 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      // Get the sorting key from the Redux store, defaulting to 'last_name' if not set
-      const sort_key = state.sort.sortKey || 'last_name';
-      // Transform the user data to include 'first_name' and 'last_name' properties based on 'real_name'
-      const updatedUsers = action.data.course.users.map((user) => {
-        const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
-        return { ...user, first_name, last_name: rest.join(' ') };
-      }).sort((a, b) => {
-          // Compare the 'sort_key' properties (e.g., 'last_name') using 'localeCompare'
-          // If the 'sort_key' values are equal or falsy, compare 'username' as a fallback
-          return (a[sort_key] || '').localeCompare(b[sort_key] || '') || a.username.localeCompare(b.username);
-      });
+      // Get the sorting key from the Redux store
+      let sort_key = state.sort.key;
+      let updatedUsers;
+      // Get the user list from the action's data
+      const user_list = action.data.course.users;
+
+      // Check if at least one user has a 'real_name', if so, perform data transformation
+       if (user_list.some(user => user.real_name)) {
+         updatedUsers = user_list.map((user) => {
+          // Split 'real_name' into 'first_name' and the rest of the name ('rest')
+           const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+           // Return the user object with updated 'first_name' and 'last_name' properties
+           return { ...user, first_name, last_name: rest.join(' ') };
+         });
+       } else {
+         // If no user has 'real_name', use the original user list as-is and sort by 'username'
+         updatedUsers = action.data.course.users;
+         sort_key = state.sort.key === 'last_name' ? 'username' : state.sort.key;
+        }
+
+      // Sort the 'updatedUsers' array based on the 'sort_key'
+      const sorted = sortByKey(updatedUsers, sort_key, null, SORT_DESCENDING[sort_key]);
+
     return {
       ...state,
-      users: updatedUsers,
+      users: sorted.newModels,
       isLoaded: true,
       lastRequestTimestamp: Date.now()
     };

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -26,30 +26,31 @@ export default function users(state = initialState, action) {
     case RECEIVE_USERS: {
       // Get the sorting key from the Redux store
       let sort_key = state.sort.key;
-      let updatedUsers;
-      // Get the user list from the action's data
-      const user_list = action.data.course.users;
 
-      // Check if at least one user has a 'real_name', if so, perform data transformation
-       if (user_list.some(user => user.real_name)) {
-         updatedUsers = user_list.map((user) => {
-          // Split 'real_name' into 'first_name' and the rest of the name ('rest')
+       // Initialize a variable to hold the user list. If there are existing users in the state,
+      //  use that list; otherwise, use the user list from the action data.
+      let user_list = state.users.length ? state.users : action.data.course.users;
+
+       // Check if the user list is empty in the state and if any user in the action data has 'real_name'
+       if (!state.users.length && action.data.course.users.some(user => user.real_name)) {
+         // Perform data transformation on the user list: Split 'real_name' into 'first_name' and the rest of the name ('rest')
+         user_list = action.data.course.users.map((user) => {
            const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
-           // Return the user object with updated 'first_name' and 'last_name' properties
+            // Return the user object with updated 'first_name' and 'last_name' properties
            return { ...user, first_name, last_name: rest.join(' ') };
          });
-       } else {
-         // If no user has 'real_name', use the original user list as-is and sort by 'username'
-         updatedUsers = action.data.course.users;
-         sort_key = state.sort.key === 'last_name' ? 'username' : state.sort.key;
+       } else if (!state?.users.length) {
+         // If there are no users in the state and none of the users in the action data have 'real_name',
+        // set the sorting key to 'username'
+         sort_key = 'username';
         }
 
-      // Sort the 'updatedUsers' array based on the 'sort_key'
-      const sorted = sortByKey(updatedUsers, sort_key, null, SORT_DESCENDING[sort_key]);
+      // Sort the 'user_list' array based on the 'sort_key' if the user list is empty in the state.
+      if (!state.users.length) user_list = sortByKey(user_list, sort_key, null, SORT_DESCENDING[sort_key]);
 
     return {
       ...state,
-      users: sorted.newModels,
+      users: user_list.newModels ? user_list.newModels : user_list,
       isLoaded: true,
       lastRequestTimestamp: Date.now()
     };

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -46,7 +46,7 @@ export default function users(state = initialState, action) {
         }
 
       // Sort the 'user_list' array based on the 'sort_key' if the user list is empty in the state.
-      if (!state.users.length) user_list = sortByKey(user_list, sort_key, null, SORT_DESCENDING[sort_key]);
+      if (!state.users.length) user_list = sortByKey(user_list, sort_key);
 
     return {
       ...state,

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -50,7 +50,7 @@ export default function users(state = initialState, action) {
 
     return {
       ...state,
-      users: user_list.newModels ? user_list.newModels : user_list,
+      users: user_list.newModels ? user_list.newModels : user_list, // Update 'users' with the sorted user list if available, or use the original 'user_list'.
       isLoaded: true,
       lastRequestTimestamp: Date.now()
     };

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -23,12 +23,25 @@ const SORT_DESCENDING = {
 
 export default function users(state = initialState, action) {
   switch (action.type) {
-    case RECEIVE_USERS: return {
+    case RECEIVE_USERS: {
+      // Get the sorting key from the Redux store, defaulting to 'last_name' if not set
+      const sort_key = state.sort.sortKey || 'last_name';
+      // Transform the user data to include 'first_name' and 'last_name' properties based on 'real_name'
+      const updatedUsers = action.data.course.users.map((user) => {
+        const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+        return { ...user, first_name, last_name: rest.join(' ') };
+      }).sort((a, b) => {
+          // Compare the 'sort_key' properties (e.g., 'last_name') using 'localeCompare'
+          // If the 'sort_key' values are equal or falsy, compare 'username' as a fallback
+          return (a[sort_key] || '').localeCompare(b[sort_key] || '') || a.username.localeCompare(b.username);
+      });
+    return {
       ...state,
-      users: action.data.course.users,
+      users: updatedUsers,
       isLoaded: true,
       lastRequestTimestamp: Date.now()
     };
+  }
     case ADD_USER:
     case REMOVE_USER:
       return {

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -399,29 +399,29 @@ describe 'the course page', type: :feature, js: true do
     end
   end
 
-  describe 'students view' do
-    before do
-      Revision.last.update(date: 2.days.ago, user_id: User.first.id)
-      CoursesUsers.last.update(
-        course_id: Course.find_by(slug:).id,
-        user_id: User.first.id
-      )
-      CoursesUsers.update_all_caches CoursesUsers.all
-    end
+  # describe 'students view' do
+  #   before do
+  #     Revision.last.update(date: 2.days.ago, user_id: User.first.id)
+  #     CoursesUsers.last.update(
+  #       course_id: Course.find_by(slug:).id,
+  #       user_id: User.first.id
+  #     )
+  #     CoursesUsers.update_all_caches CoursesUsers.all
+  #   end
 
-    it 'shows a number of most recent revisions for a student' do
-      js_visit "/courses/#{slug}/students"
-      sleep 1
-      expect(page).to have_content(User)
-      student_row = 'table.users tbody tr.students:first-child'
-      within(student_row) do
-        expect(page).to have_content(User)
-        within 'td:nth-of-type(4)' do
-          expect(page.text).to eq('1')
-        end
-      end
-    end
-  end
+  #   it 'shows a number of most recent revisions for a student' do
+  #     js_visit "/courses/#{slug}/students"
+  #     sleep 1
+  #     expect(page).to have_content(User)
+  #     student_row = 'table.users tbody tr.students:first-child'
+  #     within(student_row) do
+  #       expect(page).to have_content(User)
+  #       within 'td:nth-of-type(4)' do
+  #         expect(page.text).to eq('1')
+  #       end
+  #     end
+  #   end
+  # end
 
   describe 'uploads view' do
     before do

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -412,10 +412,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.username)
+      expect(page).to have_content(User)
       student_row = 'table.users tbody tr.students:first-child'
       within(student_row) do
-        expect(page).to have_content(User.username)
+        expect(page).to have_content(User)
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -409,19 +409,19 @@ describe 'the course page', type: :feature, js: true do
   #     CoursesUsers.update_all_caches CoursesUsers.all
   #   end
 
-  #   it 'shows a number of most recent revisions for a student' do
-  #     js_visit "/courses/#{slug}/students"
-  #     sleep 1
-  #     expect(page).to have_content(User)
-  #     student_row = 'table.users tbody tr.students:first-child'
-  #     within(student_row) do
-  #       expect(page).to have_content(User)
-  #       within 'td:nth-of-type(4)' do
-  #         expect(page.text).to eq('1')
-  #       end
-  #     end
-  #   end
-  # end
+    it 'shows a number of most recent revisions for a student' do
+      js_visit "/courses/#{slug}/students"
+      sleep 1
+      expect(page).to have_content(User.first.username)
+      student_row = 'table.users tbody tr.students:first-child'
+      within(student_row) do
+        expect(page).to have_content User.last.username
+        within 'td:nth-of-type(4)' do
+          expect(page.text).to eq('1')
+        end
+      end
+    end
+  end
 
   describe 'uploads view' do
     before do

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -412,10 +412,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.last.username)
+      expect(page).to have_content(User.last_name.username)
       student_row = 'table.users tbody tr.students:first-child'
       within(student_row) do
-        expect(page).to have_content User.first.username
+        expect(page).to have_content User.first_name.username
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -412,10 +412,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.last.username)
+      expect(page).to have_content(User.username)
       student_row = 'table.users tbody tr.students:first-child'
       within(student_row) do
-        expect(page).to have_content(User.first.username)
+        expect(page).to have_content(User.username)
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -412,10 +412,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.last_name.username)
+      expect(page).to have_content(User.last.username)
       student_row = 'table.users tbody tr.students:first-child'
       within(student_row) do
-        expect(page).to have_content User.first_name.username
+        expect(page).to have_content(User.first.username)
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -127,8 +127,8 @@ describe 'Instructor users', type: :feature, js: true do
       click_button 'OK'
       sleep 1
       visit "/courses/#{Course.first.slug}/students"
-      expect(page).to have_content 'Student B'
-      expect(page).not_to have_content 'Student A'
+      expect(page).to have_content 'Student A'
+      expect(page).not_to have_content 'Student B'
     end
 
     it 'is able to assign articles' do

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -127,8 +127,8 @@ describe 'Instructor users', type: :feature, js: true do
       click_button 'OK'
       sleep 1
       visit "/courses/#{Course.first.slug}/students"
-      expect(page).to have_content 'Student A'
-      expect(page).not_to have_content 'Student B'
+      expect(page).to have_content 'Student B'
+      expect(page).not_to have_content 'Student A'
     end
 
     it 'is able to assign articles' do

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -19,50 +19,65 @@ describe('users reducer', () => {
     }
   );
 
-  test(
-    'returns the previous state and updates users array from action via RECEIVE_USERS, ADD_USER and REMOVE_USER',
-    () => {
-      const initialState = users(undefined, { type: null });
-      deepFreeze(initialState);
+  test('returns the previous state and updates users array from action via RECEIVE_USERS, ADD_USER, and REMOVE_USER', () => {
+  const initialState = users(undefined, { type: null });
+  deepFreeze(initialState);
 
-      const action = (type, users_array) => ({
-        type: type,
-        data: {
-          course: {
-            users: users_array
-          }
-        }
-      });
-
-      let users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' }
-      ];
-      const mockedReceivedAction = action(RECEIVE_USERS, users_array);
-      const receiveUserState = users(initialState, mockedReceivedAction);
-      expect(receiveUserState.users).toEqual(users_array);
-      expect(receiveUserState.isLoaded).toBe(true);
-
-      users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' },
-        { id: 3, username: 'buzz', role: 'student' }
-      ];
-      const mockedAddAction = action(ADD_USER, users_array);
-      const addUserState = users(receiveUserState, mockedAddAction);
-      expect(addUserState.users).toEqual(users_array);
-      expect(addUserState.isLoaded).toBe(true);
-
-      users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' }
-      ];
-      const mockedRemoveAction = action(REMOVE_USER, users_array);
-      const removeUserState = users(addUserState, mockedRemoveAction);
-      expect(removeUserState.users).toEqual(users_array);
-      expect(removeUserState.isLoaded).toBe(true);
+  const action = (type, users_array) => ({
+    type: type,
+    data: {
+      course: {
+        users: users_array
+      }
     }
-  );
+  });
+
+  let users_array = [
+    { id: 1, real_name: 'John Doe', role: 'student' },
+    { id: 2, real_name: 'Jane Smith', role: 'admin' }
+  ];
+
+  users_array = users_array.map((user) => {
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+
+  const mockedReceivedAction = action(RECEIVE_USERS, users_array);
+  const receiveUserState = users(initialState, mockedReceivedAction);
+  expect(receiveUserState.users).toEqual(users_array);
+  expect(receiveUserState.isLoaded).toBe(true);
+
+  users_array = [
+    { id: 3, real_name: 'Bob Johnson', role: 'student' },
+    { id: 4, real_name: 'Alice Williams', role: 'admin' },
+    { id: 5, real_name: 'Eve Brown', role: 'student' }
+  ];
+
+  users_array = users_array.map((user) => {
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+
+  const mockedAddAction = action(ADD_USER, users_array);
+  const addUserState = users(receiveUserState, mockedAddAction);
+  expect(addUserState.users).toEqual(users_array);
+  expect(addUserState.isLoaded).toBe(true);
+
+  users_array = [
+    { id: 4, real_name: 'Alice Williams', role: 'admin' },
+    { id: 5, real_name: 'Eve Brown', role: 'student' }
+  ];
+
+  users_array = users_array.map((user) => {
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+
+  const mockedRemoveAction = action(REMOVE_USER, users_array);
+  const removeUserState = users(addUserState, mockedRemoveAction);
+  expect(removeUserState.users).toEqual(users_array);
+  expect(removeUserState.isLoaded).toBe(true);
+});
 
   test('sorts users given a key by action via SORT_USERS', () => {
     const initialState = {


### PR DESCRIPTION
resolves #5343 

## What this PR does
**Fix Bug:**

On the Students (aka Editors) tab of a course page, the default sorting of students was not ideal, as they were listed based on the order of joining the course. The default sorting method was not considered optimal, and the sorting state was not retained when users navigated between tabs and data refresh occurs (which happens when you change course tabs and it's been more than a minute since the last fetch).

**Solution:**

* Updated the default sorting to be based on the students ' `last names` when receiving users' data for the first time.
* Implemented sorting retention when users manually re-sort the list. The sorting state is now preserved when users navigate between tabs or when data gets refreshed.

**Changes Made:**

* Modified the users reducer `user.js` to handle sorting of students based on last name when receiving users' data for the first time.
* If the `state.users` array is empty, check if any user has a `real_name` in the received data. If so, transform the user list to include `first_name` and `last_name` properties based on `real_name`.
* If `state.users` is empty and no user has `real_name`, sort the user list by `username`.
* Retained sorting state by using the existing users in the state in the Redux store when applicable.





## Screenshots
Before:

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/7d505fc8-b401-4ab8-bed5-5618d50c566e)


After:

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/12b5abba-91dc-4583-bfeb-5f7cfa0c65c1)

