### PR TITLE
Converting CampaignEditable and TagEditable into functional components + fixed duplicate campaign and tag lookup

### DIFF
--- a/app/assets/javascripts/components/overview/campaign_editable.jsx
+++ b/app/assets/javascripts/components/overview/campaign_editable.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import Select from 'react-select';
 
@@ -133,12 +132,6 @@ const CampaignEditable = ({ course_id }) => {
       />
     </div>
   );
-};
-
-CampaignEditable.propTypes = {
-  campaigns: PropTypes.array,
-  availableCampaigns: PropTypes.array,
-  fetchAllCampaigns: PropTypes.func
 };
 
 export default (Conditional(CampaignEditable));

--- a/app/assets/javascripts/components/overview/tag_editable.jsx
+++ b/app/assets/javascripts/components/overview/tag_editable.jsx
@@ -1,139 +1,118 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import React, { useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import CreatableSelect from 'react-select/creatable';
 
 import { getAvailableTags } from '../../selectors';
 import selectStyles from '../../styles/select';
 
-import PopoverExpandable from '../high_order/popover_expandable.jsx';
 import Popover from '../common/popover.jsx';
 import Conditional from '../high_order/conditional.jsx';
 
 import { removeTag, fetchAllTags, addTag } from '../../actions/tag_actions';
+import useExpandablePopover from '../../hooks/useExpandablePopover';
 
 
-const TagEditable = createReactClass({
-  displayName: 'TagEditable',
+const TagEditable = ({ course_id }) => {
+  const availableTags = useSelector(state => getAvailableTags(state));
+  const tags = useSelector(state => state.tags.tags);
+  const dispatch = useDispatch();
 
-  propTypes: {
-    tags: PropTypes.array.isRequired,
-    availableTags: PropTypes.array.isRequired,
-    fetchAllTags: PropTypes.func.isRequired,
-    addTag: PropTypes.func.isRequired
-  },
+  const [createdTagOption, setCreatedTagOption] = useState([]);
+  const [selectedTag, setSelectedTag] = useState();
+  const tagSelectRef = useRef(null);
 
-  getInitialState() {
-    return { createdTagOption: [] };
-  },
+  useEffect(() => { dispatch(fetchAllTags()); }, []);
 
-  componentDidMount() {
-    return this.props.fetchAllTags();
-  },
-
-  getKey() {
+  const getKey = () => {
     return 'add_tag';
-  },
+  };
 
-  handleChangeTag(val) {
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
+
+  const handleChangeTag = (val) => {
     if (!val) {
-      return this.setState({ selectedTag: null });
+      setSelectedTag(null);
+      return;
     }
 
     // The value includes `__isNew__: true` if it's a user-created option.
     // In that case, we need to add it to the list of options, so that it shows up as selected.
     const isNew = val.__isNew__;
     if (isNew) {
-      this.setState({ createdTagOption: [val] });
+      setCreatedTagOption([val]);
     }
-    this.setState({ selectedTag: val });
-  },
+    setSelectedTag(val);
+  };
 
-  openPopover(e) {
-    if (!this.props.is_open) {
-      this.refs.tagSelect.focus();
+  const openPopover = (e) => {
+    if (!isOpen) {
+      tagSelectRef.current.focus();
     }
-    return this.props.open(e);
-  },
+    return open(e);
+  };
 
-  removeTag(tagId) {
-    this.props.removeTag(this.props.course_id, tagId);
-  },
+  const removeTagHandler = (tagId) => {
+    dispatch(removeTag(course_id, tagId));
+  };
 
-  addTag() {
-    this.props.addTag(this.props.course_id, this.state.selectedTag.value);
-    this.setState({ selectedTag: null });
-  },
+  const addTagHandler = () => {
+    dispatch(addTag(course_id, selectedTag.value));
+    setSelectedTag(null);
+  };
 
-  render() {
-    // In editable mode we'll show a list of tags and a remove button plus a selector to add new tags
-    const tagList = this.props.tags.map((tag) => {
-      const removeButton = (
-        <button className="button border plus" aria-label="Remove tag" onClick={this.removeTag.bind(this, tag.tag)}>-</button>
-      );
-      return (
-        <tr key={`${tag.id}_tag`}>
-          <td>{tag.tag}{removeButton}</td>
-        </tr>
-      );
-    });
-
-    const availableOptions = this.props.availableTags.map((tag) => {
-      return { label: tag, value: tag };
-    });
-    const tagOptions = [...this.state.createdTagOption, ...availableOptions];
-    let addTagButtonDisabled = true;
-    if (this.state.selectedTag) {
-      addTagButtonDisabled = false;
-    }
-    const tagSelect = (
-      <tr>
-        <th>
-          <div className="select-with-button">
-            <CreatableSelect
-              className="fixed-width"
-              ref="tagSelect"
-              name="tag"
-              value={this.state.selectedTag}
-              placeholder={I18n.t('courses.tag_select')}
-              onChange={this.handleChangeTag}
-              options={tagOptions}
-              styles={selectStyles}
-              isClearable
-            />
-            <button type="submit" className="button dark" disabled={addTagButtonDisabled} onClick={this.addTag}>
-              Add
-            </button>
-          </div>
-        </th>
+  // In editable mode we'll show a list of tags and a remove button plus a selector to add new tags
+  const tagList = tags.map((tag) => {
+    const removeButton = (
+      <button className="button border plus" aria-label="Remove tag" onClick={() => removeTagHandler(tag.tag)}>-</button>
+    );
+    return (
+      <tr key={`${tag.id}_tag`}>
+        <td>{tag.tag}{removeButton}</td>
       </tr>
     );
+  });
 
-    return (
-      <div key="tags" className="pop__container tags open" onClick={this.stop}>
-        <button className="button border plus open" onClick={this.openPopover}>+</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={tagSelect}
-          rows={tagList}
-        />
-      </div>
-    );
+  const availableOptions = availableTags.map((tag) => {
+    return { label: tag, value: tag };
+  });
+  const tagOptions = [...createdTagOption, ...availableOptions];
+  let addTagButtonDisabled = true;
+  if (selectedTag) {
+    addTagButtonDisabled = false;
   }
-});
+  const tagSelect = (
+    <tr>
+      <th>
+        <div className="select-with-button">
+          <CreatableSelect
+            className="fixed-width"
+            ref={tagSelectRef}
+            name="tag"
+            value={selectedTag}
+            placeholder={I18n.t('courses.tag_select')}
+            onChange={handleChangeTag}
+            options={tagOptions}
+            styles={selectStyles}
+            isClearable
+          />
+          <button type="submit" className="button dark" disabled={addTagButtonDisabled} onClick={addTagHandler}>
+            Add
+          </button>
+        </div>
+      </th>
+    </tr>
+  );
 
-const mapStateToProps = state => ({
-  availableTags: getAvailableTags(state),
-  tags: state.tags.tags
-});
-
-const mapDispatchToProps = {
-  removeTag,
-  addTag,
-  fetchAllTags
+  return (
+    <div key="tags" className="pop__container tags open" ref={ref}>
+      <button className="button border plus open" onClick={openPopover}>+</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={tagSelect}
+        rows={tagList}
+      />
+    </div>
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  Conditional(PopoverExpandable(TagEditable))
-);
+export default (Conditional(TagEditable));


### PR DESCRIPTION
With reference to #5393
fixes #5041
## What this PR does
Converts `campaign_editable.jsx` and `tag_editable.jsx` into functional components
**Affected Pages:**
- `/courses/[institution_name]/[course_name]` (for `campaign_editable.jsx` and `tag_editable.jsx`)

## Videos
Before `campaign_editable.jsx` and `tag_editable.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/4377aab9-5e0b-482f-a9b8-46f921ba82ab

After `campaign_editable.jsx` and `tag_editable.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/c8b7bb78-2eb3-40e2-a454-d9e9ab3fbd07

## Clarifications
This also fixes the duplicate campaign.json and tag.json lookup issue as seen in the videos above (I know I only showed the redux actions being dispatched, but the network calls also don't get duplicated anymore).