### PR TITLE
Fixed Add-to-watchlist feature which fails for a large class

### DIFF
--- a/app/assets/javascripts/components/students/components/AddToWatchlistButton.jsx
+++ b/app/assets/javascripts/components/students/components/AddToWatchlistButton.jsx
@@ -20,7 +20,7 @@ const AddToWatchlistButton = ({ slug, prefix = 'Students' }) => {
     request(`/courses/${slug}/students/add_to_watchlist`, { method: 'POST' })
      .then(res => res.json())
      .then((data) => {
-        if (data.message.batchcomplete) {
+        if (data.message.status === 'Success') {
         dispatch({ type: ADD_NOTIFICATION, notification: notificationMessage('Success') });
         } else {
           return Promise.reject(data);

--- a/spec/lib/watchlist_edits_spec.rb
+++ b/spec/lib/watchlist_edits_spec.rb
@@ -66,17 +66,31 @@ describe WatchlistEdits do
       before do
         allow(watchlist_edits).to receive(:retrieve_tokens).and_return(true)
         allow(access_token).to receive(:post)
-          .and_return(instance_double('response', body: '{"status": "success"}'))
+          .and_return(instance_double('response', body: '{"batchcomplete": true}'))
       end
 
       it 'calls post method on access_token with the correct data' do
-        expect(access_token).to receive(:post).with(api_url, data)
+        expected_data = data.merge(titles: 'user1')
+        expect(access_token).to receive(:post).with(api_url, expected_data)
         watchlist_edits.watch_userpages(['user1'])
       end
 
-      it 'returns the parsed response body' do
+      it 'returns the success status' do
         response = watchlist_edits.watch_userpages(['user1'])
-        expect(response).to eq({ 'status' => 'success' })
+        expect(response.stringify_keys).to eq({ 'status' => 'Success' })
+      end
+    end
+
+    context 'when API request is not successful' do
+      before do
+        allow(watchlist_edits).to receive(:retrieve_tokens).and_return(true)
+        allow(access_token).to receive(:post)
+          .and_return(instance_double('response', body: '{"batchcomplete": false}'))
+      end
+
+      it 'returns the Failed status' do
+        response = watchlist_edits.watch_userpages(['user1'])
+        expect(response.stringify_keys).to eq({ 'status' => 'Failed' })
       end
     end
   end

--- a/spec/lib/watchlist_edits_spec.rb
+++ b/spec/lib/watchlist_edits_spec.rb
@@ -75,7 +75,7 @@ describe WatchlistEdits do
         watchlist_edits.watch_userpages(['user1'])
       end
 
-      it 'returns the success status' do
+      it 'returns success status' do
         response = watchlist_edits.watch_userpages(['user1'])
         expect(response.stringify_keys).to eq({ 'status' => 'Success' })
       end


### PR DESCRIPTION
resolves #5462 

**Title**: Fix Bug to Handle Large Courses in Add-to-Watchlist Feature

**Description**:
This pull request addresses GitHub issue #5462. The add-to-watchlist feature was failing for large courses, particularly when there were too many student user pages to be handled in a single request . To address this, I have implemented batch processing and set a batch size of 50. Now, large courses are broken up into multiple requests, ensuring that the watchlist edits can handle courses of any size without causing server issues.

**Changes Made**:

* Introduced batch processing for adding users' pages to the watchlist.
* Set batch size to 50`(it can handle only 50 per request)` for reasonable handling of large courses.
* Updated watchlist_edits_spec.rb to test the batch processing functionality




 

## Screenshots
Before:

[Before (1).webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/a2e8f3d5-da45-4034-83d5-fe28c69cbf43)


After:

[After (1).webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/40151cbe-ece7-4bfe-baa5-5ddfe5a960c8)


