### PR TITLE
Integration of Wikidata-Diff-Analyzer Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'chartkick' # Used for plots in Rails views
 gem 'rack-cors', require: 'rack/cors' # Used for allowing cross-domain requests
 ### System utilities
 gem 'pandoc-ruby' # Text converter, for markdown<->html<->wikitext conversions
-gem 'wikidata-diff-analyzer', '~> 2.0' # for analyzing wikidata-edits
+gem 'wikidata-diff-analyzer', '~> 2.0', '>= 2.0.1'
 
 ### Platform-specific fixes
 # You might need to uncomment these on Windows if you aren't using WSL.

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem 'chartkick' # Used for plots in Rails views
 gem 'rack-cors', require: 'rack/cors' # Used for allowing cross-domain requests
 ### System utilities
 gem 'pandoc-ruby' # Text converter, for markdown<->html<->wikitext conversions
+gem 'wikidata-diff-analyzer', '~> 2.0' # for analyzing wikidata-edits
 
 ### Platform-specific fixes
 # You might need to uncomment these on Windows if you aren't using WSL.

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'chartkick' # Used for plots in Rails views
 gem 'rack-cors', require: 'rack/cors' # Used for allowing cross-domain requests
 ### System utilities
 gem 'pandoc-ruby' # Text converter, for markdown<->html<->wikitext conversions
-gem 'wikidata-diff-analyzer', '~> 2.0', '>= 2.0.1'
+gem 'wikidata-diff-analyzer' # Used for analyzing Wikidata edits
 
 ### Platform-specific fixes
 # You might need to uncomment these on Windows if you aren't using WSL.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -704,7 +704,7 @@ DEPENDENCIES
   validates_email_format_of
   vcr
   webmock
-  wikidata-diff-analyzer (~> 2.0, >= 2.0.1)
+  wikidata-diff-analyzer
   will_paginate
   x25519
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,8 +600,12 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wikidata-diff-analyzer (2.0.0)
+    wikidata-diff-analyzer (2.0.1)
       json (~> 2.1)
+      mediawiki_api (~> 0.7.0)
+      rake (~> 13.0)
+      rspec (~> 3.0)
+      rubocop (~> 1.21)
     will_paginate (3.3.1)
     x25519 (1.0.10)
     xpath (3.2.0)
@@ -700,7 +704,7 @@ DEPENDENCIES
   validates_email_format_of
   vcr
   webmock
-  wikidata-diff-analyzer (~> 2.0)
+  wikidata-diff-analyzer (~> 2.0, >= 2.0.1)
   will_paginate
   x25519
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -603,6 +603,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wikidata-diff-analyzer (2.0.0)
+      json (~> 2.1)
     will_paginate (3.3.1)
     x25519 (1.0.10)
     xpath (3.2.0)
@@ -701,6 +703,7 @@ DEPENDENCIES
   vcr
   webdrivers
   webmock
+  wikidata-diff-analyzer (~> 2.0)
   will_paginate
   x25519
 

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -86,4 +86,15 @@ class Revision < ApplicationRecord
     return 0 unless references_count(features) && references_count(features_previous)
     references_count(features) - references_count(features_previous)
   end
+
+  def edit_summary
+    return summary unless diff_stats # If diff_stats is nil, then summary is the edit summary
+    nil # Otherwise, it's diff_stats and returns nil
+  end
+
+  def diff_stats
+    JSON.parse(summary) if summary.present? && summary.start_with?('{', '[')
+  rescue JSON::ParserError
+    nil # Return nil if parsing fails (i.e., not diff_stats)
+  end
 end

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -87,11 +87,20 @@ class Revision < ApplicationRecord
     references_count(features) - references_count(features_previous)
   end
 
+  # Generally, the summary field captured edit summary comment of an edit until August 2023
+  # This code is for a switch to save diff_stats instead(stats hash created from wikidata-diff-analyzer gem)
+  # used in update_wikidata_stats.rb
+  # These two methods find out if the content in summary field is a stats hash or not
+  # Edits made before August 2023 will be handled through WikidataSummaryParser and
+  # the later edits will be handled by stats collected from wikidata-diff-analyzer
+
   def edit_summary
     return summary unless diff_stats # If diff_stats is nil, then summary is the edit summary
     nil # Otherwise, it's diff_stats and returns nil
   end
 
+  # This function parses the serialized stats saved in the summary field, in case of any errors
+  # it returns nil meaning the field contains an edit summary
   def diff_stats
     JSON.parse(summary) if summary.present? && summary.start_with?('{', '[')
   rescue JSON::ParserError

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -24,7 +24,7 @@
 #  features_previous :text(65535)
 #  summary           :text(65535)
 #
-
+require 'json'
 #= Revision model
 class Revision < ApplicationRecord
   belongs_to :user

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -88,9 +88,8 @@ class Revision < ApplicationRecord
   end
 
   # Generally, the summary field captured edit summary comment of an edit until August 2023
-  # This code is for a switch to save diff_stats instead(stats hash created from wikidata-diff-analyzer gem)
-  # used in update_wikidata_stats.rb
-  # These two methods find out if the content in summary field is a stats hash or not
+  # This code is for a switch to save diff_stats instead(output hash generated from wikidata-diff-analyzer gem)
+  # These two methods find out if the content in summary field is a stats_hash or not
   # Edits made before August 2023 will be handled through WikidataSummaryParser and
   # the later edits will be handled by stats collected from wikidata-diff-analyzer
 

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -88,7 +88,8 @@ class Revision < ApplicationRecord
   end
 
   # Generally, the summary field captured edit summary comment of an edit until August 2023
-  # This code is for a switch to save diff_stats instead(output hash generated from wikidata-diff-analyzer gem)
+  # This code is for a switch to save diff_stats instead(output hash generated from
+  # wikidata-diff-analyzer gem)
   # These two methods find out if the content in summary field is a stats_hash or not
   # Edits made before August 2023 will be handled through WikidataSummaryParser and
   # the later edits will be handled by stats collected from wikidata-diff-analyzer

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -5,7 +5,7 @@ require_dependency "#{Rails.root}/lib/importers/wikidata_summary_importer"
 require 'wikidata-diff-analyzer'
 
 class UpdateWikidataStats
-  STATS_CLASSIFICAYION = [
+  STATS_CLASSIFICATION = [
     'claims created', 'claims removed', 'claims changed',
     'references added', 'references removed', 'references changed',
     'qualifiers added', 'qualifiers removed', 'qualifiers changed',
@@ -112,7 +112,7 @@ class UpdateWikidataStats
   end
 
   def get_stats_from_serialized_stats(revisions_with_serialized_stats)
-    stats = strings.index_with { 0 }
+    stats = STATS_CLASSIFICATION.index_with { 0 }
 
     # create a sum of stats after deserializing the stats for each revision object
     revisions_with_serialized_stats.each do |revision|
@@ -120,7 +120,7 @@ class UpdateWikidataStats
       deserialized_stat = revision.diff_stats
       # create a stats which sums up each field of the deserialized_stat and create a stats hash
       deserialized_stat.each_with_index do |(_key, value), index|
-        stats[strings[index]] += value
+        stats[STATS_CLASSIFICATION[index]] += value
       end
     end
     stats

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -123,6 +123,7 @@ class UpdateWikidataStats
         stats[STATS_CLASSIFICATION[index]] += value
       end
     end
+    stats['total revisions'] = stats.values.sum
     stats
   end
 

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -5,24 +5,75 @@ require_dependency "#{Rails.root}/lib/importers/wikidata_summary_importer"
 require 'wikidata-diff-analyzer'
 
 class UpdateWikidataStats
+  # This hash contains the keys of the final stats hash which maintains the order of
+  # wikidata-diff-analyzer's output so that it's easier to create the stats hash
   STATS_CLASSIFICATION = [
-    'claims created', 'claims removed', 'claims changed',
-    'references added', 'references removed', 'references changed',
-    'qualifiers added', 'qualifiers removed', 'qualifiers changed',
-    'aliases added', 'aliases removed', 'aliases changed',
-    'labels added', 'labels removed', 'labels changed',
-    'descriptions added', 'descriptions removed', 'descriptions changed',
-    'interwiki links added', 'interwiki links removed', 'interwiki links updated',
-    'merged to', 'merged from', 'redirects created',
-    'reverts performed', 'restorations performed', 'items cleared',
-    'items created', 'lemmas added', 'lemmas removed', 'lemmas changed',
-    'forms added', 'forms removed', 'forms changed',
-    'senses added', 'senses removed', 'senses changed',
-    'properties created', 'lexeme items created',
-    'representations added', 'representations removed', 'representations changed',
-    'glosses added', 'glosses removed', 'glosses changed',
-    'form claims added', 'form claims removed', 'form claims changed',
-    'sense claims added', 'sense claims removed', 'sense claims changed'
+    # UI section: claims
+    'claims created', 
+    'claims removed', 
+    'claims changed',
+    # UI section: Others
+    'references added', 
+    # UI section: not added yet
+    'references removed', 
+    'references changed',
+    # UI section: Others
+    'qualifiers added', 
+    # UI section: not added yet
+    'qualifiers removed', 
+    'qualifiers changed',
+    # UI section: Aliases
+    'aliases added', 
+    'aliases removed', 
+    'aliases changed',
+    # UI section: Labels
+    'labels added', 
+    'labels removed', 
+    'labels changed',
+    # UI section: Descriptions
+    'descriptions added', 
+    'descriptions removed', 
+    'descriptions changed',
+    # UI section: General
+    'interwiki links added', 
+    # UI section: not added yet
+    'interwiki links removed', 
+    'interwiki links updated',
+    # UI section: General
+    'merged to', 
+    # UI section: not added yet
+    'merged from', 
+    # UI section: Others
+    'redirects created',
+    'reverts performed', 
+    'restorations performed', 
+    # UI section: Items
+    'items cleared',
+    'items created', 
+    # UI section: not added yet (for lexeme and properties)
+    'lemmas added', 
+    'lemmas removed', 
+    'lemmas changed',
+    'forms added', 
+    'forms removed', 
+    'forms changed',
+    'senses added', 
+    'senses removed', 
+    'senses changed',
+    'properties created', 
+    'lexeme items created',
+    'representations added', 
+    'representations removed', 
+    'representations changed',
+    'glosses added', 
+    'glosses removed', 
+    'glosses changed',
+    'form claims added', 
+    'form claims removed', 
+    'form claims changed',
+    'sense claims added', 
+    'sense claims removed', 
+    'sense claims changed'
   ].freeze
 
   def initialize(course)
@@ -123,7 +174,7 @@ class UpdateWikidataStats
         stats[STATS_CLASSIFICATION[index]] += value
       end
     end
-    stats['total revisions'] = stats.values.sum
+    stats['total revisions'] = revisions_with_serialized_stats.count
     stats
   end
 

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
-
 require_dependency "#{Rails.root}/lib/wikidata_summary_parser"
 require_dependency "#{Rails.root}/lib/importers/wikidata_summary_importer"
 # require the installed wikidata-diff-analyzer gem
-require 'wikidata_diff_analyzer'
+require 'wikidata-diff-analyzer'
 
 class UpdateWikidataStats
   def initialize(course)

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -2,16 +2,41 @@
 
 require_dependency "#{Rails.root}/lib/wikidata_summary_parser"
 require_dependency "#{Rails.root}/lib/importers/wikidata_summary_importer"
+# require the installed wikidata-diff-analyzer gem
+require 'wikidata_diff_analyzer'
 
 class UpdateWikidataStats
   def initialize(course)
     @course = course
-    import_summaries
+    #import_summaries
+    update_summary_with_stats
     update_wikidata_statistics
   end
 
   private
 
+  # When summary is nil, instead of fetching edit summaries for each revision, I want to use
+  # wikidata-diff-analyzer to get the stats saved in the database after serializing.
+  # That means while UpdateWikidataStats will be called for a course, all the revisions which
+  # had edit summaries in the summary field be processed with WikidataSummaryParser
+  # if summary is nil, then the stats would be saved in the summary
+
+  def update_summary_with_stats
+    return if wikidata_revisions_without_summaries.empty?
+    revision_ids = wikidata_revisions_without_summaries.pluck(:mw_rev_id)
+    analyzed_revisions = WikidataDiffAnalyzer.analyze(revision_ids)[:diffs]
+    revision_ids.each do |rev_id|
+      individual_stat = analyzed_revisions[rev_id]
+      # Serialize the individual_stat to JSON format
+      serialized_stat = individual_stat.to_json
+
+      # Find the revision object by mw_rev_id
+      revision = course_revisions.find_by(mw_rev_id: rev_id)
+
+      # Update the summary field with the serialized_stat
+      revision.update(summary: serialized_stat)
+    end
+  end
   def import_summaries
     return if wikidata_revisions_without_summaries.empty?
     WikidataSummaryImporter.new.import_missing_summaries wikidata_revisions_without_summaries
@@ -21,10 +46,117 @@ class UpdateWikidataStats
 
   def update_wikidata_statistics
     return if course_revisions.empty?
-    stats = WikidataSummaryParser.analyze_revisions(course_revisions)
     crs_stat = CourseStat.find_by(course_id: @course.id) || CourseStat.create(course_id: @course.id)
-    crs_stat.stats_hash[wikidata.domain] = stats
+    # crs_stat.stats_hash[wikidata.domain] = stats
+    # crs_stat.save
+    stats_hash = crs_stat.stats_hash || {}
+
+    # Initialize arrays to store revisions with edit summaries and serialized stats
+    revisions_with_summary = []
+    revisions_with_serialized_stats = []
+
+    # Divide revisions based on edit summaries or serialized stats
+    course_revisions.each do |revision|
+      if revision.summary.present? && revision.summary.start_with?('{', '[')
+        # If JSON data is present in the summary, add it to the revisions_with_serialized_stats array
+        revisions_with_serialized_stats << revision
+      else
+        # If the summary contains an edit summary, add it to the revisions_with_summary array
+        revisions_with_summary << revision
+      end
+    end
+
+    summary_stats = WikidataSummaryParser.analyze_revisions(revisions_with_summary)
+    serialized_stats = get_stats_from_serialized_stats(revisions_with_serialized_stats)
+    stats_hash = merge_stats(summary_stats, serialized_stats)
+    # Update the stats_hash in the CourseStat model and save it
+    crs_stat.stats_hash = stats_hash
     crs_stat.save
+
+  end
+
+  def merge_stats(summary_stats, serialized_stats)
+    # Create a set of all unique keys from both 'summary_stats' and 'serialized_stats'
+    all_keys = summary_stats.keys.concat(serialized_stats.keys).uniq
+  
+    # Initialize a new hash to store the merged stats
+    merged_stats = {}
+  
+    # Iterate through all unique keys and add the values from 'summary_stats' and 'serialized_stats'
+    all_keys.each do |key|
+      summary_value = summary_stats[key].to_i # gracefully handle nil values
+      serialized_value = serialized_stats[key].to_i
+      merged_stats[key] = summary_value + serialized_value
+    end
+  
+    merged_stats
+  end
+  
+
+  def get_stats_from_serialized_stats(revisions_with_serialized_stats)
+    strings = [
+    'claims created','claims removed','claims changed','references added',
+    'references removed',
+    'references changed',
+    'qualifiers added',
+    'qualifiers removed',
+    'qualifiers changed',
+    'aliases added',
+    'aliases removed',
+    'aliases changed',
+    'labels added',
+    'labels removed',
+    'labels changed',
+    'descriptions added',
+    'descriptions removed',
+    'descriptions changed',
+    'interwiki links added',
+    'interwiki links removed',
+    'interwiki links updated',
+    'merged to',
+    'merged from',
+    'redirects created',
+    'reverts performed',
+    'restorations performed',
+    'items cleared',
+    'items created',
+    'lemmas added',
+    'lemmas removed',
+    'lemmas changed',
+    'forms added',
+    'forms removed',
+    'forms changed',
+    'senses added',
+    'senses removed',
+    'senses changed',
+    'properties created',
+    'lexeme items created',
+    'representations added',
+    'representations removed',
+    'representations changed',
+    'glosses added',
+    'glosses removed',
+    'glosses changed',
+    'form claims added',
+    'form claims removed',
+    'form claims changed',
+    'sense claims added',
+    'sense claims removed',
+    'sense claims changed'
+    ]
+    stats = Hash[strings.map { |string| [string, 0] }]
+
+    # create a sum of stats after deserilizing the stats for each revision object
+
+    revisions_with_serialized_stats.each do |revision|
+      # Deserialize the summary field to get the stats
+      deserialized_stat = JSON.parse(revision.summary)
+      # create a stats which sums up each field of the deserialized_stat and create a stats hash
+      deserialized_stat.each_with_index do |(key, value), index|
+        stats[strings[index]] += value
+      end
+    end
+    stats
   end
 
   def wikidata_revisions_without_summaries

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -5,68 +5,68 @@ require_dependency "#{Rails.root}/lib/importers/wikidata_summary_importer"
 require 'wikidata-diff-analyzer'
 
 class UpdateWikidataStats
-  # This hash contains uses the keys of the wikidata-diff-analyzer output hash 
+  # This hash contains uses the keys of the wikidata-diff-analyzer output hash
   # and maps them to the values used in the UI and CourseStat Hash
   STATS_CLASSIFICATION = {
     # UI section: General
-    "merge_to" => 'merged to',
-    "added_sitelinks" => 'interwiki links added',
+    'merge_to' => 'merged to',
+    'added_sitelinks' => 'interwiki links added',
     # UI section: Claims
-    "added_claims" => 'claims created',
-    "removed_claims" => 'claims removed',
-    "changed_claims" => 'claims changed',
+    'added_claims' => 'claims created',
+    'removed_claims' => 'claims removed',
+    'changed_claims' => 'claims changed',
     # UI section: Items
-    "clear_item" => 'items cleared',
-    "create_item" => 'items created',
+    'clear_item' => 'items cleared',
+    'create_item' => 'items created',
     # UI section: Labels
-    "added_labels" => 'labels added',
-    "removed_labels" => 'labels removed',
-    "changed_labels" => 'labels changed',
+    'added_labels' => 'labels added',
+    'removed_labels' => 'labels removed',
+    'changed_labels' => 'labels changed',
     # UI section: Descriptions
-    "added_descriptions" => 'descriptions added',
-    "removed_descriptions" => 'descriptions removed',
-    "changed_descriptions" => 'descriptions changed',
+    'added_descriptions' => 'descriptions added',
+    'removed_descriptions' => 'descriptions removed',
+    'changed_descriptions' => 'descriptions changed',
     # UI section: Aliases
-    "added_aliases" => 'aliases added',
-    "removed_aliases" => 'aliases removed',
-    "changed_aliases" => 'aliases changed',
+    'added_aliases' => 'aliases added',
+    'removed_aliases' => 'aliases removed',
+    'changed_aliases' => 'aliases changed',
     # UI section: Others
-    "added_references" => 'references added',
-    "added_qualifiers" => 'qualifiers added',
-    "redirect" => 'redirects created',
-    "undo" => 'reverts performed',
-    "restore" => 'restorations performed',
+    'added_references' => 'references added',
+    'added_qualifiers' => 'qualifiers added',
+    'redirect' => 'redirects created',
+    'undo' => 'reverts performed',
+    'restore' => 'restorations performed',
     # UI section: Not added yet
-    "removed_references" => 'references removed',
-    "changed_references" => 'references changed',
-    "removed_qualifiers" => 'qualifiers removed',
-    "changed_qualifiers" => 'qualifiers changed',
-    "removed_sitelinks" => 'interwiki links removed',
-    "changed_sitelinks" => 'interwiki links updated',
-    "merge_from" => 'merged from',
-    "added_lemmas" => 'lemmas added',
-    "removed_lemmas" => 'lemmas removed',
-    "changed_lemmas" => 'lemmas changed',
-    "added_forms" => 'forms added',
-    "removed_forms" => 'forms removed',
-    "changed_forms" => 'forms changed',
-    "added_senses" => 'senses added',
-    "removed_senses" => 'senses removed',
-    "changed_senses" => 'senses changed',
-    "create_property" => 'properties created',
-    "create_lexeme" => 'lexeme items created',
-    "added_representations" => 'representations added',
-    "removed_representations" => 'representations removed',
-    "changed_representations" => 'representations changed',
-    "added_glosses" => 'glosses added',
-    "removed_glosses" => 'glosses removed',
-    "changed_glosses" => 'glosses changed',
-    "added_formclaims" => 'form claims added',
-    "removed_formclaims" => 'form claims removed',
-    "changed_formclaims" => 'form claims changed',
-    "added_senseclaims" => 'sense claims added',
-    "removed_senseclaims" => 'sense claims removed',
-    "changed_senseclaims" => 'sense claims changed'
+    'removed_references' => 'references removed',
+    'changed_references' => 'references changed',
+    'removed_qualifiers' => 'qualifiers removed',
+    'changed_qualifiers' => 'qualifiers changed',
+    'removed_sitelinks' => 'interwiki links removed',
+    'changed_sitelinks' => 'interwiki links updated',
+    'merge_from' => 'merged from',
+    'added_lemmas' => 'lemmas added',
+    'removed_lemmas' => 'lemmas removed',
+    'changed_lemmas' => 'lemmas changed',
+    'added_forms' => 'forms added',
+    'removed_forms' => 'forms removed',
+    'changed_forms' => 'forms changed',
+    'added_senses' => 'senses added',
+    'removed_senses' => 'senses removed',
+    'changed_senses' => 'senses changed',
+    'create_property' => 'properties created',
+    'create_lexeme' => 'lexeme items created',
+    'added_representations' => 'representations added',
+    'removed_representations' => 'representations removed',
+    'changed_representations' => 'representations changed',
+    'added_glosses' => 'glosses added',
+    'removed_glosses' => 'glosses removed',
+    'changed_glosses' => 'glosses changed',
+    'added_formclaims' => 'form claims added',
+    'removed_formclaims' => 'form claims removed',
+    'changed_formclaims' => 'form claims changed',
+    'added_senseclaims' => 'sense claims added',
+    'removed_senseclaims' => 'sense claims removed',
+    'changed_senseclaims' => 'sense claims changed'
   }.freeze
 
   def initialize(course)
@@ -82,22 +82,19 @@ class UpdateWikidataStats
   # wikidata-diff-analyzer gem is used to get the stats saved in the database after serializing.
   # That means while UpdateWikidataStats will be called for a course, all the revisions which
   # had edit summaries in the summary field be processed with WikidataSummaryParser
-  # and the revisions which didn't have edit summaries will be processed 
+  # and the revisions which didn't have edit summaries will be processed
   # with wikidata-diff-analyzer gem.
   # if summary is nil, then the stats would be created and saved in the summary
 
   def update_summary_with_stats
     return if wikidata_revisions_without_summaries.empty?
-  
     revision_ids = wikidata_revisions_without_summaries.pluck(:mw_rev_id)
     analyzed_revisions = WikidataDiffAnalyzer.analyze(revision_ids)[:diffs]
-  
     Revision.transaction do
       wikidata_revisions_without_summaries.each do |revision|
         rev_id = revision.mw_rev_id
         individual_stat = analyzed_revisions[rev_id]
         serialized_stat = individual_stat.to_json
-  
         revision.summary = serialized_stat
         revision.save!
       end
@@ -170,7 +167,6 @@ class UpdateWikidataStats
       deserialized_stat.each do |key, value|
         stats[STATS_CLASSIFICATION[key]] += value
       end
-      
     end
     stats['total revisions'] = revisions_with_serialized_stats.count
     stats

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -5,6 +5,26 @@ require_dependency "#{Rails.root}/lib/importers/wikidata_summary_importer"
 require 'wikidata-diff-analyzer'
 
 class UpdateWikidataStats
+  STATS_CLASSIFICAYION = [
+    'claims created', 'claims removed', 'claims changed',
+    'references added', 'references removed', 'references changed',
+    'qualifiers added', 'qualifiers removed', 'qualifiers changed',
+    'aliases added', 'aliases removed', 'aliases changed',
+    'labels added', 'labels removed', 'labels changed',
+    'descriptions added', 'descriptions removed', 'descriptions changed',
+    'interwiki links added', 'interwiki links removed', 'interwiki links updated',
+    'merged to', 'merged from', 'redirects created',
+    'reverts performed', 'restorations performed', 'items cleared',
+    'items created', 'lemmas added', 'lemmas removed', 'lemmas changed',
+    'forms added', 'forms removed', 'forms changed',
+    'senses added', 'senses removed', 'senses changed',
+    'properties created', 'lexeme items created',
+    'representations added', 'representations removed', 'representations changed',
+    'glosses added', 'glosses removed', 'glosses changed',
+    'form claims added', 'form claims removed', 'form claims changed',
+    'sense claims added', 'sense claims removed', 'sense claims changed'
+  ].freeze
+
   def initialize(course)
     @course = course
     # import_summaries
@@ -92,25 +112,6 @@ class UpdateWikidataStats
   end
 
   def get_stats_from_serialized_stats(revisions_with_serialized_stats)
-    # Initialize a hash with the same order of attributes like they exist in the serialized stats
-    strings = [
-    'claims created', 'claims removed', 'claims changed',
-    'references added', 'references removed', 'references changed',
-    'qualifiers added', 'qualifiers removed', 'qualifiers changed',
-    'aliases added', 'aliases removed', 'aliases changed',
-    'labels added', 'labels removed', 'labels changed',
-    'descriptions added', 'descriptions removed', 'descriptions changed',
-    'interwiki links added', 'interwiki links removed', 'interwiki links updated',
-    'merged to', 'merged from', 'redirects created',
-    'reverts performed', 'restorations performed', 'items cleared',
-    'items created', 'lemmas added', 'lemmas removed', 'lemmas changed',
-    'forms added', 'forms removed', 'forms changed',
-    'senses added', 'senses removed', 'senses changed',
-    'properties created', 'lexeme items created',
-    'representations added', 'representations removed', 'representations changed',
-    'glosses added', 'glosses removed', 'glosses changed',
-    'form claims added', 'form claims removed', 'form claims changed',
-    'sense claims added', 'sense claims removed', 'sense claims changed']
     stats = strings.index_with { 0 }
 
     # create a sum of stats after deserializing the stats for each revision object
@@ -137,4 +138,3 @@ class UpdateWikidataStats
     @wikidata ||= Wiki.get_or_create(language: nil, project: 'wikidata')
   end
 end
-

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -7,7 +7,7 @@ require 'wikidata-diff-analyzer'
 class UpdateWikidataStats
   def initialize(course)
     @course = course
-    #import_summaries
+    # import_summaries
     update_summary_with_stats
     update_wikidata_statistics
   end
@@ -22,8 +22,10 @@ class UpdateWikidataStats
 
   def update_summary_with_stats
     return if wikidata_revisions_without_summaries.empty?
+
     revision_ids = wikidata_revisions_without_summaries.pluck(:mw_rev_id)
     analyzed_revisions = WikidataDiffAnalyzer.analyze(revision_ids)[:diffs]
+
     revision_ids.each do |rev_id|
       individual_stat = analyzed_revisions[rev_id]
       # Serialize the individual_stat to JSON format
@@ -36,19 +38,19 @@ class UpdateWikidataStats
       revision.update(summary: serialized_stat)
     end
   end
+
   def import_summaries
     return if wikidata_revisions_without_summaries.empty?
-    WikidataSummaryImporter.new.import_missing_summaries wikidata_revisions_without_summaries
+
+    WikidataSummaryImporter.new.import_missing_summaries(wikidata_revisions_without_summaries)
   end
 
   # Get Wikidata stats based on revision's summaries
 
   def update_wikidata_statistics
     return if course_revisions.empty?
+
     crs_stat = CourseStat.find_by(course_id: @course.id) || CourseStat.create(course_id: @course.id)
-    # crs_stat.stats_hash[wikidata.domain] = stats
-    # crs_stat.save
-    stats_hash = crs_stat.stats_hash || {}
 
     # Initialize arrays to store revisions with edit summaries and serialized stats
     revisions_with_summary = []
@@ -66,41 +68,57 @@ class UpdateWikidataStats
 
     summary_stats = WikidataSummaryParser.analyze_revisions(revisions_with_summary)
     serialized_stats = get_stats_from_serialized_stats(revisions_with_serialized_stats)
-    stats_hash = merge_stats(summary_stats, serialized_stats)
+    stats = merge_stats(summary_stats, serialized_stats)
     # Update the stats_hash in the CourseStat model and save it
-    crs_stat.stats_hash = stats_hash
+    crs_stat.stats_hash[wikidata.domain] = stats
     crs_stat.save
   end
 
   def merge_stats(summary_stats, serialized_stats)
     # Create a set of all unique keys from both 'summary_stats' and 'serialized_stats'
     all_keys = summary_stats.keys.concat(serialized_stats.keys).uniq
-  
+
     # Initialize a new hash to store the merged stats
     merged_stats = {}
-  
+
     # Iterate through all unique keys and add the values from 'summary_stats' and 'serialized_stats'
     all_keys.each do |key|
       summary_value = summary_stats[key].to_i # gracefully handle nil values
       serialized_value = serialized_stats[key].to_i
       merged_stats[key] = summary_value + serialized_value
     end
-  
+
     merged_stats
   end
-  
 
   def get_stats_from_serialized_stats(revisions_with_serialized_stats)
     # Initialize a hash with the same order of attributes like they exist in the serialized stats
-    strings = ['claims created', 'claims removed', 'claims changed', 'references added', 'references removed', 'references changed', 'qualifiers added', 'qualifiers removed', 'qualifiers changed', 'aliases added', 'aliases removed', 'aliases changed', 'labels added', 'labels removed', 'labels changed', 'descriptions added', 'descriptions removed', 'descriptions changed', 'interwiki links added', 'interwiki links removed', 'interwiki links updated', 'merged to', 'merged from', 'redirects created', 'reverts performed', 'restorations performed', 'items cleared', 'items created', 'lemmas added', 'lemmas removed', 'lemmas changed', 'forms added', 'forms removed', 'forms changed', 'senses added', 'senses removed', 'senses changed', 'properties created', 'lexeme items created', 'representations added', 'representations removed', 'representations changed', 'glosses added', 'glosses removed', 'glosses changed', 'form claims added', 'form claims removed', 'form claims changed', 'sense claims added', 'sense claims removed', 'sense claims changed']
-    stats = Hash[strings.map { |string| [string, 0] }]
+    strings = [
+    'claims created', 'claims removed', 'claims changed',
+    'references added', 'references removed', 'references changed',
+    'qualifiers added', 'qualifiers removed', 'qualifiers changed',
+    'aliases added', 'aliases removed', 'aliases changed',
+    'labels added', 'labels removed', 'labels changed',
+    'descriptions added', 'descriptions removed', 'descriptions changed',
+    'interwiki links added', 'interwiki links removed', 'interwiki links updated',
+    'merged to', 'merged from', 'redirects created',
+    'reverts performed', 'restorations performed', 'items cleared',
+    'items created', 'lemmas added', 'lemmas removed', 'lemmas changed',
+    'forms added', 'forms removed', 'forms changed',
+    'senses added', 'senses removed', 'senses changed',
+    'properties created', 'lexeme items created',
+    'representations added', 'representations removed', 'representations changed',
+    'glosses added', 'glosses removed', 'glosses changed',
+    'form claims added', 'form claims removed', 'form claims changed',
+    'sense claims added', 'sense claims removed', 'sense claims changed']
+    stats = strings.index_with { 0 }
 
-    # create a sum of stats after deserilizing the stats for each revision object
+    # create a sum of stats after deserializing the stats for each revision object
     revisions_with_serialized_stats.each do |revision|
       # Deserialize the summary field to get the stats
       deserialized_stat = revision.diff_stats
       # create a stats which sums up each field of the deserialized_stat and create a stats hash
-      deserialized_stat.each_with_index do |(key, value), index|
+      deserialized_stat.each_with_index do |(_key, value), index|
         stats[strings[index]] += value
       end
     end
@@ -119,3 +137,4 @@ class UpdateWikidataStats
     @wikidata ||= Wiki.get_or_create(language: nil, project: 'wikidata')
   end
 end
+

--- a/app/services/update_wikidata_stats.rb
+++ b/app/services/update_wikidata_stats.rb
@@ -85,11 +85,13 @@ class UpdateWikidataStats
 
   private
 
-  # When summary is nil, instead of fetching edit summaries for each revision, I want to use
-  # wikidata-diff-analyzer to get the stats saved in the database after serializing.
+  # When summary is nil, instead of fetching edit summaries for each revision
+  # wikidata-diff-analyzer gem is used to get the stats saved in the database after serializing.
   # That means while UpdateWikidataStats will be called for a course, all the revisions which
   # had edit summaries in the summary field be processed with WikidataSummaryParser
-  # if summary is nil, then the stats would be saved in the summary
+  # and the revisions which didn't have edit summaries will be processed 
+  # with wikidata-diff-analyzer gem.
+  # if summary is nil, then the stats would be created and saved in the summary
 
   def update_summary_with_stats
     return if wikidata_revisions_without_summaries.empty?


### PR DESCRIPTION

## What this PR does
This PR integrates https://rubygems.org/gems/wikidata-diff-analyzer gem in the Dashboard.

Approach:
Currently uses both the edit summaries(previous revisions)  and output of the gem (new revisions)
Using the summary field of the revision object to save stats from the gem after serializing


