### PR TITLE
Attempt at fixing ruby selenium driver issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ group :test do
   gem 'rake', '>= 11.0'
   gem 'capybara'
   gem 'capybara-screenshot'
-  gem 'webdrivers' # automatable browser drivers used by Capybara
+  gem 'selenium-webdriver'
   gem 'webmock'
   gem 'vcr' # Saves external web requests and replays them in tests
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       tzinfo (~> 2.0)
     acts_as_list (1.0.4)
       activerecord (>= 4.2)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
@@ -158,7 +158,7 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capybara (3.37.1)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -171,7 +171,6 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     chartkick (4.2.1)
-    childprocess (3.0.0)
     choice (0.2.0)
     climate_control (0.2.0)
     coderay (1.1.3)
@@ -335,7 +334,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.8.4)
     minitest (5.17.0)
     msgpack (1.5.4)
     multipart-post (2.2.3)
@@ -361,8 +360,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.13.1)
     nio4r (2.5.8)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -400,12 +399,12 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.0)
+    public_suffix (5.0.3)
     puma (5.6.5)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.6.1)
-    rack (2.2.6.2)
+    racc (1.7.1)
+    rack (2.2.7)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
@@ -414,7 +413,7 @@ GEM
       rack
     rack-proxy (0.7.6)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4)
       actioncable (= 7.0.4)
@@ -460,7 +459,7 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.1)
     redis (4.8.0)
-    regexp_parser (2.5.0)
+    regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -478,7 +477,7 @@ GEM
       faraday-net_http (< 3.0.0)
       hashie (>= 1.2.0, < 6.0)
       jwt (>= 1.5.6)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -530,9 +529,10 @@ GEM
     ruby_parser (3.17.0)
       sexp_processor (~> 4.15, >= 4.15.1)
     rubyzip (2.3.2)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentimental (1.5.0)
     sentry-rails (5.3.1)
       railties (>= 5.0)
@@ -592,14 +592,11 @@ GEM
     vcr (6.1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (4.6.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -685,6 +682,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  selenium-webdriver
   sentimental
   sentry-rails
   sentry-ruby
@@ -699,7 +697,6 @@ DEPENDENCIES
   ticket_dispenser!
   validates_email_format_of
   vcr
-  webdrivers
   webmock
   will_paginate
   x25519

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,8 +13,6 @@ require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 
 Capybara.register_driver :selenium do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities
-                 .chrome(chromeOptions: { w3c: false })
   options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[headless no-sandbox disable-gpu --window-size=1200,1200]
   )
@@ -22,7 +20,7 @@ Capybara.register_driver :selenium do |app|
                                  browser: :chrome,
                                  options:,
                                  clear_local_storage: false, # Persist local storage across tests
-                                 desired_capabilities: capabilities)
+                                 )
 end
 
 Rails.cache.clear
@@ -86,7 +84,8 @@ RSpec.configure do |config|
 
   config.before(:each, type: :feature, js: true) do
     # Make sure any logs from the previous test get
-    errors = page.driver.browser.manage.logs.get(:browser)
+    errors = page.driver.browser.logs.get(:browser)
+
     warn errors
   end
 
@@ -95,12 +94,16 @@ RSpec.configure do |config|
     dump_js_coverage
     # `Capybara.reset_sessions!` here would ensure that any error
     # logs from this session can be captured now, by closing any open connections.
-    # Otherwise, if they show up after the `manage.logs.get` step, they
+    # Otherwise, if they show up after the `browser.logs.get` step, they
     # will cause the next spec to fail instead of the one that generated
     # them.
     # Instead, we clear and print any after-success error
     # logs in the `before` block above.
-    errors = page.driver.browser.manage.logs.get(:browser)
+    if example.exception
+      Capybara::Screenshot.new.screenshot_and_save_page
+    end
+    errors = page.driver.browser.logs.get(:browser)
+
     # pass `js_error_expected: true` to skip JS error checking
     next if example.metadata[:js_error_expected]
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,8 +19,7 @@ Capybara.register_driver :selenium do |app|
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
                                  options:,
-                                 clear_local_storage: false, # Persist local storage across tests
-                                 )
+                                 clear_local_storage: false) # Persist local storage across tests
 end
 
 Rails.cache.clear
@@ -99,9 +98,7 @@ RSpec.configure do |config|
     # them.
     # Instead, we clear and print any after-success error
     # logs in the `before` block above.
-    if example.exception
-      Capybara::Screenshot.new.screenshot_and_save_page
-    end
+    Capybara::Screenshot.new.screenshot_and_save_page if example.exception
     errors = page.driver.browser.logs.get(:browser)
 
     # pass `js_error_expected: true` to skip JS error checking

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@
 # require 'codeclimate-test-reporter'
 # CodeClimate::TestReporter.start
 require 'simplecov'
-require 'webdrivers'
 require_relative 'simplecov_uncovered_formatter'
 
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
@@ -126,12 +125,6 @@ RSpec.configure do |config|
   # rubocop:enable Style/BlockComments
 end
 
-# Workaround for requests made by webdrivers to check for updates
-# https://github.com/titusfortner/webdrivers/wiki/Using-with-VCR-or-WebMock#vcr
-driver_hosts = (
-  ObjectSpace.each_object(Webdrivers::Common.singleton_class).to_a - [Webdrivers::Common]
-).map { |driver| URI(driver.base_url).host }
-VCR.configure { |config| config.ignore_hosts(*driver_hosts) }
 
 VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,7 +125,6 @@ RSpec.configure do |config|
   # rubocop:enable Style/BlockComments
 end
 
-
 VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = false
   c.cassette_library_dir = 'fixtures/vcr_cassettes'


### PR DESCRIPTION
Following this issue: https://github.com/titusfortner/webdrivers/issues/247

It looks like our ruby tests broke due to some changes that have been made to the chrome driver distribution. Causing our webdrivers library to break. According to the issue mentioned above. A good long-term fix for this is removing the webdrivers gem and instead using selenium-webdriver which now has bult-in support for browser drivers. Updating capybara is also a part of this process.

After the updates, some methods got deprecated so I have replaced them. I have also removed the webdriver workaround we were using as that looks like it's no longer an issue with the new selenium-webdriver gem.
