### PR TITLE
Converting UserUploads and UserTrainingStatus into functional components

### DIFF
--- a/app/assets/javascripts/components/user_profiles/user_training_status.jsx
+++ b/app/assets/javascripts/components/user_profiles/user_training_status.jsx
@@ -1,26 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
 import TrainingStatus from '@components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx';
 
-const UserTrainingStatus = createReactClass({
-  propTypes: {
-    trainingModules: PropTypes.array.isRequired
-  },
-  render() {
-    let status;
-    if (this.props.trainingModules.length > 0) {
-      status = <TrainingStatus exercises={{}} trainingModules={this.props.trainingModules} />;
-    } else {
-      status = <span>{I18n.t('users.user_no_training_status')}</span>;
-    }
-    return (
-      <div id="training-status">
-        <h3>Training Status</h3>
-        {status}
-      </div>
-    );
+const UserTrainingStatus = ({ trainingModules }) => {
+  let status;
+  if (trainingModules.length > 0) {
+    status = <TrainingStatus exercises={{}} trainingModules={trainingModules} />;
+  } else {
+    status = <span>{I18n.t('users.user_no_training_status')}</span>;
   }
-});
+  return (
+    <div id="training-status">
+      <h3>Training Status</h3>
+      {status}
+    </div>
+  );
+};
+
+UserTrainingStatus.propTypes = {
+  trainingModules: PropTypes.array.isRequired
+};
 
 export default UserTrainingStatus;

--- a/app/assets/javascripts/components/user_profiles/user_uploads.jsx
+++ b/app/assets/javascripts/components/user_profiles/user_uploads.jsx
@@ -1,27 +1,24 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { GALLERY_VIEW } from '../../constants';
 import UploadList from '../uploads/upload_list.jsx';
 
 
-const UserUploads = createReactClass({
-  propTypes: {
-    uploads: PropTypes.array
-  },
-
-  render() {
-    let uploadList = (<UploadList uploads={this.props.uploads} view={GALLERY_VIEW} />);
-    if (this.props.uploads.length === 0) {
-      uploadList = (<span>{I18n.t('courses.user_uploads_none')}</span>);
-    }
-    return (
-      <div id="recent-uploads">
-        <h3>Recent Uploads</h3>
-        {uploadList}
-      </div>
-    );
+const UserUploads = ({ uploads }) => {
+  let uploadList = (<UploadList uploads={uploads} view={GALLERY_VIEW} />);
+  if (uploads.length === 0) {
+    uploadList = (<span>{I18n.t('courses.user_uploads_none')}</span>);
   }
-});
+  return (
+    <div id="recent-uploads">
+      <h3>Recent Uploads</h3>
+      {uploadList}
+    </div>
+  );
+};
+
+UserUploads.propTypes = {
+  uploads: PropTypes.array
+};
 
 export default UserUploads;


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `user_uploads.jsx` and `user_training_status.jsx` into functional components
**Affected Pages:**
- `/users/[username]` (for `user_uploads.jsx` and `user_training_status.jsx`)

## Videos/Screenshots
Before `user_uploads.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/126a59a7-4aca-4465-bb1c-6caeec7be128


After `user_uploads.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/7d3f5e40-df95-4c80-8241-cf5b214bfcd9


Before `user_training_status.jsx`

![before refactor UserTrainingStatus](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/fd06788a-3b6b-4cfe-a155-a3f908d3fa45)

After `user_training_status.jsx`

![after refactor UserTrainingStatus](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/3d0bcc77-9331-4de7-a485-87392afd26d9)
