### PR TITLE
Add fallback check for when no contributions are highlighted in ArticleViewer

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
@@ -7,7 +7,7 @@ import { printArticleViewer } from '../../../../utils/article_viewer';
 
 export const Footer = ({
   article, colors, failureMessage, showArticleFinder, highlightedHtml, isWhocolorLang,
-  whocolorFailed, users
+  whocolorFailed, users, unhighlightedContributors
 }) => {
   // Determine the Article Viewer Legend status based on what information
   // has returned from various API calls.
@@ -29,6 +29,7 @@ export const Footer = ({
         colors={colors}
         status={legendStatus}
         failureMessage={failureMessage}
+        unhighlightedContributors={unhighlightedContributors}
       />
     );
   }

--- a/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
@@ -7,14 +7,14 @@ import { printArticleViewer } from '../../../../utils/article_viewer';
 
 export const Footer = ({
   article, colors, failureMessage, showArticleFinder, highlightedHtml, isWhocolorLang,
-  whocolorFailed, users, unhighlightedContributors
+  whocolorFailed, users, unhighlightedEditors
 }) => {
   // Determine the Article Viewer Legend status based on what information
   // has returned from various API calls.
   let articleViewerLegend;
   if (!showArticleFinder) {
     let legendStatus;
-    if (highlightedHtml) {
+    if (highlightedHtml && unhighlightedEditors.length) {
       legendStatus = 'ready';
     } else if (whocolorFailed) {
       legendStatus = 'failed';
@@ -29,7 +29,7 @@ export const Footer = ({
         colors={colors}
         status={legendStatus}
         failureMessage={failureMessage}
-        unhighlightedContributors={unhighlightedContributors}
+        unhighlightedEditors={unhighlightedEditors}
       />
     );
   }

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -52,7 +52,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const [userIdsFetched, setUserIdsFetched] = useState(false);
   const [whoColorHtml, setWhoColorHtml] = useState(null);
   const [parsedArticle, setParsedArticle] = useState(null);
-  const [unhighlightedContributors, setUnhighlightedContributors] = useState([]);
+  const [unhighlightedEditors, setUnhighlightedEditors] = useState([]);
 
   const dispatch = useDispatch();
   const ref = useRef();
@@ -159,6 +159,8 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const highlightAuthors = () => {
     let html = whoColorHtml;
     if (!html) { return; }
+    // Array to store user IDs whose contributions couldn't be highlighted
+    const editorsID = [];
 
     forEach(usersState, (user, i) => {
       // Move spaces inside spans, so that background color is continuous
@@ -171,28 +173,54 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
       const styledAuthorSpan = `<span title="${user.name}" class="editor-token token-editor-${user.userid} ${colorClass}`;
       const authorSpanMatcher = new RegExp(`<span class="editor-token token-editor-${user.userid}`, 'g');
       html = html.replace(authorSpanMatcher, styledAuthorSpan);
+
       if (prevHtml !== html) {
-          user.activeRevision = true;
+        user.activeRevision = true;
       } else {
-        // If highlighting failed, verify if the user's has contributions in the article using checkFallback.
-        checkFallback(user);
+        // If highlighting failed , store the un-highlighted user's ID in the editorsID array
+        editorsID.push(user.userid);
       }
     });
+
+    // Check if there are any editors whose contributions couldn't be highlighted
+    if (editorsID.length) {
+      // If there are unhighlighted editors, call the function to check their contributions in wikitext metadata
+      usersContributionExists(editorsID);
+    } else {
+      const status = 'No Highlighted Editors';
+      // Set the unhighlightedEditors state with a status message to make legendStatus ready in the
+      // Footer Component for loading the authorship data
+      setUnhighlightedEditors([status]);
+    }
     setHighlightedHtml(html);
   };
 
-  const checkFallback = (user) => {
-    const builder = new URLBuilder({ article: article });
-    const api = new ArticleViewerAPI({ builder });
+  // Function to check if contributions of unhighlighted editors exist in the wikitext metadata
+  const usersContributionExists = (usersID) => {
+   // Create a URL builder and API instance for fetching wikitext metadata
+   const builder = new URLBuilder({ article: article });
+   const api = new ArticleViewerAPI({ builder });
+
+    // Fetch wikitext metadata for the current article revision
     api.fetchWikitextMetaData()
        .then((response) => {
-        const { tokensForRevision } = response;
-        const foundToken = tokensForRevision.find(token => token.editor = user.userid);
-        // If the user's revision is found (i.e., the user has contributions in the article),
-        // update the unhighlightedContributors state by adding the user's userid to the array.
-        if (foundToken) {
-          setUnhighlightedContributors(x => [...x, user.userid]);
-      }
+         // Extract the tokensForRevision data from the response
+         const { tokensForRevision } = response;
+
+         // Iterate through the list of user IDs whose contributions couldn't be highlighted
+         usersID.forEach((userID) => {
+          // Find a token in the metadata with a matching editor ID
+          const foundToken = tokensForRevision.find(token => token.editor === userID.toString());
+
+          // If a token with a matching editor ID is found, it means the user has a contribution
+          // in the current revision's wikitext
+          if (foundToken) {
+            // Add the user ID to the unhighlightedEditors state to display in the UI
+            setUnhighlightedEditors(x => [...x, userID]);
+        }
+      });
+    }).catch((error) => {
+      setFailureMessage(error.message);
     });
   };
 
@@ -323,7 +351,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
           showArticleFinder={showArticleFinder}
           whoColorFailed={whoColorFailed}
           users={usersState}
-          unhighlightedContributors={unhighlightedContributors}
+          unhighlightedEditors={unhighlightedEditors}
         />
       </div>
     </div>

--- a/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleViewerAPI.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleViewerAPI.js
@@ -131,6 +131,23 @@ export class ArticleViewerAPI {
       }
     }).then(response => this.__handleFetchResponse(response));
   }
+
+  fetchWikitextMetaData() {
+    const url = this.builder.wikiwhoColorRevisionURL();
+    return fetch(`${url}&origin=*`, {
+      headers: {
+        'Content-Type': 'application/javascript'
+      }
+    }).then(response => this.__handleFetchResponse(response))
+      .then((response) => {
+        if (response.error) throw new Error(this.__setException({ status: 404 }));
+        const revisionId = 'revisions'; // Get the first (and presumably only) revision ID
+        const revisionData = response[revisionId]?.[0];
+        if (!revisionData) throw new Error('Invalid response data');
+        const { tokens } = Object.values(revisionData)[0];
+        return { tokensForRevision: tokens };
+      });
+  }
 }
 
 export default ArticleViewerAPI;

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -6,7 +6,7 @@ import UserUtils from '../../utils/user_utils.js';
 
 import ArticleScroll from '@components/common/ArticleViewer/utils/ArticleScroll';
 
-const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failureMessage }) => {
+const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failureMessage, unhighlightedContributors }) => {
   const [userLinks, setUserLinks] = useState('');
   const [usersStatus, setUsersStatus] = useState('');
   const Scroller = new ArticleScroll();
@@ -25,6 +25,9 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
 
       setUserLinks(users.map((user, i) => {
         let res;
+        // The 'unhighlightedContributors' array keeps track of the userids of users whose contributions
+        // were not successfully highlighted in the article viewer.
+        const isUserHovered = unhighlightedContributors.find(x => x === user.userid);
         const userLink = UserUtils.userTalkUrl(user.name, article.language, article.project);
         const fullUserRecord = allUsers.find(_user => _user.username === user.name);
         const realName = fullUserRecord && fullUserRecord.real_name;
@@ -32,8 +35,10 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
           res = <div key={`legend-${user.name}`} className={'user-legend'}><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
         } else if (user.activeRevision === true) {
           res = <div key={`legend-${user.name}`} className={`user-legend ${colors[i]}`}><a href={userLink} title={realName} target="_blank">{user.name}</a><img className="user-legend-hover" style={{ color: 'transparent' }} src="/assets/images/arrow.svg" alt="scroll to users revisions" width="30px" height="20px" onClick={() => Scroller.scrollTo(user.name, scrollBox)} /></div >;
+        } else if (isUserHovered) {
+          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip large'} id={'popup-style'} >{I18n.t('users.contributionsNotHighlighted', { username: user.name })}</p><a href={userLink} title={realName} target="_blank">{user.name}</a>{<span className="tooltip-indicator" />}</div>;
         } else {
-          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip dark large'}>{I18n.t('users.no_highlighting')}</p><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
+          res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip large'} id={'popup-style'}>{I18n.t('users.no_highlighting', { editor: user.name })}</p><a href={userLink} title={realName} target="_blank">{user.name}</a>{<span className="tooltip-indicator" />}</div>;
         }
 
         return res;
@@ -41,7 +46,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
     } else {
       setUserLinks(<div className="user-legend authorship-loading"> &nbsp; &nbsp; </div>);
     }
-  }, [users, status]);
+  }, [users, status, unhighlightedContributors]);
 
   useEffect(() => {
     if (status === 'loading') {

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UserUtils from '../../utils/user_utils.js';
-// import Scroll from 'react-scroll';
 
 import ArticleScroll from '@components/common/ArticleViewer/utils/ArticleScroll';
 

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -5,7 +5,7 @@ import UserUtils from '../../utils/user_utils.js';
 
 import ArticleScroll from '@components/common/ArticleViewer/utils/ArticleScroll';
 
-const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failureMessage, unhighlightedContributors }) => {
+const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failureMessage, unhighlightedEditors }) => {
   const [userLinks, setUserLinks] = useState('');
   const [usersStatus, setUsersStatus] = useState('');
   const Scroller = new ArticleScroll();
@@ -24,9 +24,10 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
 
       setUserLinks(users.map((user, i) => {
         let res;
-        // The 'unhighlightedContributors' array keeps track of the userids of users whose contributions
+        // The 'unhighlightedContributions' keeps track of the userids of users whose contributions
         // were not successfully highlighted in the article viewer.
-        const isUserHovered = unhighlightedContributors.find(x => x === user.userid);
+        let UnhighlightedContributions = null;
+        if (unhighlightedEditors) { UnhighlightedContributions = unhighlightedEditors?.find(x => x === user.userid); }
         const userLink = UserUtils.userTalkUrl(user.name, article.language, article.project);
         const fullUserRecord = allUsers.find(_user => _user.username === user.name);
         const realName = fullUserRecord && fullUserRecord.real_name;
@@ -34,7 +35,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
           res = <div key={`legend-${user.name}`} className={'user-legend'}><a href={userLink} title={realName} target="_blank">{user.name}</a></div>;
         } else if (user.activeRevision === true) {
           res = <div key={`legend-${user.name}`} className={`user-legend ${colors[i]}`}><a href={userLink} title={realName} target="_blank">{user.name}</a><img className="user-legend-hover" style={{ color: 'transparent' }} src="/assets/images/arrow.svg" alt="scroll to users revisions" width="30px" height="20px" onClick={() => Scroller.scrollTo(user.name, scrollBox)} /></div >;
-        } else if (isUserHovered) {
+        } else if (UnhighlightedContributions) {
           res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip large'} id={'popup-style'} >{I18n.t('users.contributionsNotHighlighted', { username: user.name })}</p><a href={userLink} title={realName} target="_blank">{user.name}</a>{<span className="tooltip-indicator" />}</div>;
         } else {
           res = <div key={`legend-${user.name}`} className={'user-legend tooltip-trigger'}><p className={'tooltip large'} id={'popup-style'}>{I18n.t('users.no_highlighting', { editor: user.name })}</p><a href={userLink} title={realName} target="_blank">{user.name}</a>{<span className="tooltip-indicator" />}</div>;
@@ -45,7 +46,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
     } else {
       setUserLinks(<div className="user-legend authorship-loading"> &nbsp; &nbsp; </div>);
     }
-  }, [users, status, unhighlightedContributors]);
+  }, [users, status, unhighlightedEditors]);
 
   useEffect(() => {
     if (status === 'loading') {

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -26,8 +26,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
         let res;
         // The 'unhighlightedContributions' keeps track of the userids of users whose contributions
         // were not successfully highlighted in the article viewer.
-        let UnhighlightedContributions = null;
-        if (unhighlightedEditors) { UnhighlightedContributions = unhighlightedEditors?.find(x => x === user.userid); }
+        const UnhighlightedContributions = unhighlightedEditors?.find(x => x === user.userid);
         const userLink = UserUtils.userTalkUrl(user.name, article.language, article.project);
         const fullUserRecord = allUsers.find(_user => _user.username === user.name);
         const realName = fullUserRecord && fullUserRecord.real_name;

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -16,7 +16,14 @@
 
 #icon-article-viewer-desc
   display none
-  
+
+#popup-style
+  position: fixed
+  top: 99%
+  left: 0
+  border: 0
+  background: #676eb4
+
 .article-header
   border none !important
   padding 5px 10px 5px 10px
@@ -26,6 +33,7 @@
 .tooltip
   position: relative
   color: white
+
 
 .article-alert
   align-items flex-start
@@ -187,49 +195,49 @@
     vertical-align super
     font-size smaller
 
-.wikibase-statementgroupview-property-label 
+.wikibase-statementgroupview-property-label
 	padding 30px 10px
 	width 100%
 	margin-right 70px
-.wikibase-statementgroupview-property 
+.wikibase-statementgroupview-property
 	background-color #eaecf0
 	width 15em
-.wikibase-statementgroupview 
+.wikibase-statementgroupview
 	background-color #fff
 	border 1px solid #c8ccd1
 	margin-bottom 15px
 	display flex
 .wb-normal,
-.wb-preferred 
+.wb-preferred
 	border-bottom 1px solid #eaecf0
 	width 100%
 	padding 15px 25px
-.wikibase-statementlistview 
+.wikibase-statementlistview
 	width -webkit-fill-available
 	overflow auto
-.wikibase-statementview-mainsnak-container 
+.wikibase-statementview-mainsnak-container
 	margin-right 30px
-.wikibase-snakview 
+.wikibase-snakview
 	display flex
-.wikibase-statementview-qualifiers 
-	.wikibase-snakview-value 
+.wikibase-statementview-qualifiers
+	.wikibase-snakview-value
 		margin-left 12em
-.wikibase-referenceview-listview 
+.wikibase-referenceview-listview
 	padding 20px 10px
 	background-color #f8f9fa
 	overflow-x auto
-	div 
-		&.wikibase-snakview 
+	div
+		&.wikibase-snakview
 			padding 10px 5px 5px 10px
-.wikibase-referenceview 
-	.wikibase-snaklistview-listview 
-		.wikibase-snakview-value-container 
+.wikibase-referenceview
+	.wikibase-snaklistview-listview
+		.wikibase-snakview-value-container
 			margin-left 10%
 			position relative
-		.wikibase-snakview-property 
+		.wikibase-snakview-property
 			width 12em
 			font-size 90%
-wikibase-snakview-value 
+wikibase-snakview-value
 	-ms-word-break break-all
 	word-break break-all
 	word-break break-word
@@ -237,7 +245,7 @@ wikibase-snakview-value
 	-moz-hyphens auto
 	-ms-hyphens auto
 	hyphens auto
-.wikibase-sitelinkgroupview 
+.wikibase-sitelinkgroupview
 	padding 10px
 	border 1px solid #c8ccd1
 	margin-bottom 10px
@@ -245,28 +253,28 @@ wikibase-snakview-value
 	width 20%
 	min-width 22em
 	overflow auto
-.wikibase-entityview 
+.wikibase-entityview
 	display flex
 	flex-wrap wrap
-.wikibase-entityview-main 
+.wikibase-entityview-main
 	width 75%
 	max-width 760px
 	margin-right 20px
 	width 95%
 	max-width unset
 	margin-right 20px
-.wb-sitelinks-heading 
+.wb-sitelinks-heading
 	font-size 20px
-	& > span 
+	& > span
 		font-weight 500
 		font-size 80%
 		margin-left 3px
 @media screen and (max-width: 1300px)
-  .wikibase-entityview 
+  .wikibase-entityview
     display flex
     flex-wrap wrap
     flex-direction row
-  .wikibase-listview 
-    & > .wikibase-sitelinkgroupview 
+  .wikibase-listview
+    & > .wikibase-sitelinkgroupview
       float left
 

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -23,6 +23,7 @@
   left: 0
   border: 0
   background: #676eb4
+  width: 100%
 
 .article-header
   border none !important

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -897,8 +897,8 @@ en:
         categories: Categories
         categories_short_desc: The Category feature on a wiki is used to collect related articles. You can use the name of the Category to tell the Dashboard to track all the articles in that Category.
         categories_desc: >
-          Tracking a Category means that the Dashboard will count edits to any articles in that Category. By default (depth 0), only the articles that are directly in that Category will be tracked. 
-          
+          Tracking a Category means that the Dashboard will count edits to any articles in that Category. By default (depth 0), only the articles that are directly in that Category will be tracked.
+
           You can increase the depth value (up to a maximum of 3) if you want to include articles that are in sub-categories of that Category. Be sure to browse the Category first, to make sure the sub-Categories match what you intend to track.
         templates: Templates
         templates_short_desc: You can track articles based on a Template that they contain, which works whether the Template is used on article itself, or on the corresponding Talk page — such as WikiProject templates.
@@ -1124,8 +1124,8 @@ en:
     index: Index
     collection: Collection
     tracked_namespaces_info: >
-      Only the articles corresponding to Tracked Namespaces will contribute to the topline 
-      overview stats, like 'Articles Edited', 'Total Edits', 'Words Added', etc. Hence, only 
+      Only the articles corresponding to Tracked Namespaces will contribute to the topline
+      overview stats, like 'Articles Edited', 'Total Edits', 'Words Added', etc. Hence, only
       track the namespaces that your program aims to improve.
 
   recent_activity:
@@ -1401,7 +1401,8 @@ en:
     no_articles: No articles
     no_articles_wikidata: No items
     no_revisions: (no revisions)
-    no_highlighting: "No text from the current version of the article is attributed to this editor. Check the page history to see their edits."
+    no_highlighting: "No text from the current version of the article is attributed to this Editor: %{editor}. Check the page history to see their edits."
+    contributionsNotHighlighted: "Contributions from Editor: %{username} are present in the latest version of the article, but they cannot be highlighted. This may be due to the nature of the content, such as references or templates, which are not shown in the highlighting."
     number_of_articles:
       one: "%{count} article"
       other: "%{count} articles"


### PR DESCRIPTION
resolves #5461 


## What this PR does
* It Adds a fallback check for when no contributions are highlighted in ArticleViewer.
* **Bug-Fix** - It also Fixes a `CSS bug` in the ArticleViewer  when a `popover` is supposed to be shown for when the contributions made by the editor is not  `highlighted `  or  when the editor doesn't have a extant wikitext contributions in the `wikitext metadata` of the current version.


## Changes Made
- **article_viewer.jsx :**
 a) The primary changes in this file are related to the addition of the `fallback mechanism` for users whose contributions could not be highlighted. 
 - **article_viewer_api.js :**
    a) In this file, the method `fetchWikitextMetaData` has been added to the ArticleViewerAPI class. This method is responsible for fetching the wikitext metadata.
   
- **article_viewer_legend.jsx** :
     a) The unhighlightedContributors prop has been added to the ArticleViewerLegend component.
     b) CSS has been added `popup-style` to fix the `Bug` related to the `popup`.


## Screenshots
Before:
a) Related to the Bug: 

[Before Popover Bugfix.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/c39f16f5-1fea-4afa-91e3-32ce369390a9)



b) Before Adding a fallback check

[Before(Enhancement).webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/dca20267-a590-4cc1-ba90-4696d441b47f)



After:
a) After Bugfix

[After Bugfix.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/235146c6-78a8-4dae-92d8-704002882b31)



b)After Adding a fallback check

[After-enhancement.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/e42dde0b-9d99-4627-9409-8042fd947266)



