### PR TITLE
Fix Default Sorting of Students List and Retain Sorting State

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/ExercisesList/StudentExerciseRow.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/ExercisesList/StudentExerciseRow.jsx
@@ -5,20 +5,12 @@ import StudentExercise from './StudentExercise/StudentExercise.jsx';
 import { useDispatch } from 'react-redux';
 import { toggleUI } from '@actions/index.js';
 
-// Helper Functions
-const setRealName = (student) => {
-  const nameParts = student.real_name.trim().toLowerCase().split(' ');
-  student.first_name = nameParts[0];
-  student.last_name = nameParts.slice().pop();
-};
-
 export const StudentExerciseRow = ({
   assignments, course, current_user, editAssignments,
   openKey, showRecent, student, wikidataLabels,
 }) => {
   const dispatch = useDispatch();
 
-  if (student.real_name) setRealName(student);
   const isOpen = openKey === `drawer_${student.id}`;
   return (
     <StudentExercise

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentRow.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentRow.jsx
@@ -3,17 +3,9 @@ import PropTypes from 'prop-types';
 
 import Student from './Student/Student.jsx';
 
-// Helper Functions
-const setRealName = (student) => {
-  const nameParts = student.real_name.trim().toLowerCase().split(' ');
-  student.first_name = nameParts[0];
-  student.last_name = nameParts.slice().pop();
-};
-
 export const StudentRow = ({
   assignments, course, current_user, editAssignments, showRecent, student, wikidataLabels
 }) => {
-  if (student.real_name) setRealName(student);
   return (
     <Student
       assignments={assignments}

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -1,5 +1,5 @@
 import { RECEIVE_USERS, SORT_USERS, ADD_USER, REMOVE_USER } from '../constants';
-import { sortByKey } from '../utils/model_utils';
+import { sortByKey, transformUsers } from '../utils/model_utils';
 
 const initialState = {
   users: [],
@@ -33,12 +33,9 @@ export default function users(state = initialState, action) {
 
        // Check if the user list is empty in the state and if any user in the action data has 'real_name'
        if (!state.users.length && action.data.course.users.some(user => user.real_name)) {
-         // Perform data transformation on the user list: Split 'real_name' into 'first_name' and the rest of the name ('rest')
-         user_list = action.data.course.users.map((user) => {
-           const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
-            // Return the user object with updated 'first_name' and 'last_name' properties
-           return { ...user, first_name, last_name: rest.join(' ') };
-         });
+        // If any users have 'real_name', transform the 'real_name' into separate
+        // 'first_name' and 'last_name' properties and update the user list
+        user_list = transformUsers(action.data.course.users);
        } else if (!state?.users.length) {
          // If there are no users in the state and none of the users in the action data have 'real_name',
         // set the sorting key to 'username'

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -24,7 +24,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-       // Transform the 'real_name' for users in 'action' into separate 'first_name'
+      // Transform the 'real_name' for users in 'action' into separate 'first_name'
       // and 'last_name' properties if 'real_name' is available by using transformUsers.
       let user_list = transformUsers(action.data.course.users);
 

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -6,7 +6,7 @@ const initialState = {
   sort: {
     sortKey: null,
     key: null,
-    previousKey: null,
+    previousSortKey: null,
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -67,7 +67,7 @@ export default function users(state = initialState, action) {
           sortKey: sorted.newKey,
           key: action.key,
           // store the previous sortKey to use if the instructor switches between tabs and comes back to the students/editors tab
-          previousKey: state.sort.sortKey,
+          previousSortKey: state.sort.sortKey,
         }
       };
     }

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -24,8 +24,8 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      // Transform the 'real_name' in 'action' into separate 'first_name' and 'last_name' properties
-      // if 'real_name' is available by using transformUsers.
+       // Transform the 'real_name' for users in 'action' into separate 'first_name'
+      // and 'last_name' properties if 'real_name' is available by using transformUsers.
       let user_list = transformUsers(action.data.course.users);
 
       // Get the sorting 'key' if available from Redux store or else use last_name or

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -24,7 +24,7 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      // Get the sorting key from if available from Redux store or else use last_name
+      // Get the sorting key if available from Redux store or else use last_name
       let sort_key = state.sort.key || 'last_name';
       let previousKey = null;
       // Initialize a variable to hold the user list.

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -6,7 +6,6 @@ const initialState = {
   sort: {
     sortKey: null,
     key: null,
-    previousSortKey: null,
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -27,7 +26,7 @@ export default function users(state = initialState, action) {
     case RECEIVE_USERS: {
       // Get the sorting key from if available from Redux store or else use last_name
       let sort_key = state.sort.key || 'last_name';
-
+      let previousKey = null;
       // Initialize a variable to hold the user list.
       let user_list = action.data.course.users;
 
@@ -41,8 +40,10 @@ export default function users(state = initialState, action) {
           sort_key = 'username';
         }
 
+        if (state.sort.key) { previousKey = state.sort.sortKey ? null : sort_key; }
+
         // Sort the 'user_list' array based on the 'sort_key'
-        user_list = sortByKey(user_list, sort_key, state.sort.previousSortKey, SORT_DESCENDING[sort_key]);
+        user_list = sortByKey(user_list, sort_key, previousKey, SORT_DESCENDING[sort_key]);
     return {
       ...state,
       users: user_list.newModels, // Update 'users' with the sorted user list.
@@ -66,8 +67,6 @@ export default function users(state = initialState, action) {
         sort: {
           sortKey: sorted.newKey,
           key: action.key,
-          // store the previous sortKey to use if the instructor switches between tabs and comes back to the students/editors tab
-          previousSortKey: state.sort.sortKey,
         }
       };
     }

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -5,7 +5,7 @@ const initialState = {
   users: [],
   sort: {
     sortKey: null,
-    key: null,
+    key: 'last_name',
   },
   isLoaded: false,
   lastRequestTimestamp: 0 // UNIX timestamp of last request - in milliseconds
@@ -23,12 +23,38 @@ const SORT_DESCENDING = {
 
 export default function users(state = initialState, action) {
   switch (action.type) {
-    case RECEIVE_USERS: return {
+    case RECEIVE_USERS: {
+      // Get the sorting key from the Redux store
+      let sort_key = state.sort.key;
+
+       // Initialize a variable to hold the user list. If there are existing users in the state,
+      //  use that list; otherwise, use the user list from the action data.
+      let user_list = state.users.length ? state.users : action.data.course.users;
+
+       // Check if the user list is empty in the state and if any user in the action data has 'real_name'
+       if (!state.users.length && action.data.course.users.some(user => user.real_name)) {
+         // Perform data transformation on the user list: Split 'real_name' into 'first_name' and the rest of the name ('rest')
+         user_list = action.data.course.users.map((user) => {
+           const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+            // Return the user object with updated 'first_name' and 'last_name' properties
+           return { ...user, first_name, last_name: rest.join(' ') };
+         });
+       } else if (!state?.users.length) {
+         // If there are no users in the state and none of the users in the action data have 'real_name',
+        // set the sorting key to 'username'
+         sort_key = 'username';
+        }
+
+      // Sort the 'user_list' array based on the 'sort_key' if the user list is empty in the state.
+      if (!state.users.length) user_list = sortByKey(user_list, sort_key);
+
+    return {
       ...state,
-      users: action.data.course.users,
+      users: user_list.newModels ? user_list.newModels : user_list, // Update 'users' with the sorted user list if available, or use the original 'user_list'.
       isLoaded: true,
       lastRequestTimestamp: Date.now()
     };
+  }
     case ADD_USER:
     case REMOVE_USER:
       return {

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -24,33 +24,19 @@ const SORT_DESCENDING = {
 export default function users(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_USERS: {
-      // Get the sorting key if available from Redux store or else use last_name
-      let sort_key = state.sort.key || 'last_name';
-      /* Use the previousKey to determine the directions of sorting.
-         Note: Direction of the sorting only matter after the user/instructor sort the students/editors
-         list using the dropdown menu or one of the student/editors header and then navigates between
-         tabs and then a data refresh occurs(usually after one minute).
-      */
-      let previousKey = null;
-      // Initialize a variable to hold the user list.
-      let user_list = action.data.course.users;
+      // Transform the 'real_name' in 'action' into separate 'first_name' and 'last_name' properties
+      // if 'real_name' is available by using transformUsers.
+      let user_list = transformUsers(action.data.course.users);
 
-      // Transform the 'real_name' in user_list into separate 'first_name' and 'last_name' properties
-      // if 'real_name' is available by using transformUsers
-      user_list = transformUsers(user_list);
+      // Get the sorting 'key' if available from Redux store or else use last_name or
+      // username as fallback if last_name not available.
+      const sort_key = state.sort.key || (!user_list.some(user => user.last_name) ? 'username' : 'last_name');
 
-      // If there are no users with last_name and key in the store is null then set sort_key by username
-      if (!state.sort.key && !user_list.some(user => user.last_name)) {
-        sort_key = 'username';
-      }
-
-      /* If 'key' in the store is not null which implies instructor/user had sort the student/editors list either using
-      the dropdown menu or one of the student/editor tab and if 'sortKey' state is null it means sorting was done in
-      reverse so set the previousKey to the 'sort_key' or else null. */
-      if (state.sort.key) { previousKey = state.sort.sortKey ? null : sort_key; }
+      // Determine if sorting direction should be in reversed or not
+      const isReversed = (state.sort.key && !state.sort.sortKey) ? sort_key : null;
 
       // Sort the 'user_list' array based on the 'sort_key'
-      user_list = sortByKey(user_list, sort_key, previousKey, SORT_DESCENDING[sort_key]);
+      user_list = sortByKey(user_list, sort_key, isReversed, SORT_DESCENDING[sort_key]);
 
     return {
       ...state,

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -42,7 +42,7 @@ export default function users(state = initialState, action) {
         }
 
         // Sort the 'user_list' array based on the 'sort_key'
-        user_list = sortByKey(user_list, sort_key, state.sort.previousKey, SORT_DESCENDING[sort_key]);
+        user_list = sortByKey(user_list, sort_key, state.sort.previousSortKey, SORT_DESCENDING[sort_key]);
     return {
       ...state,
       users: user_list.newModels, // Update 'users' with the sorted user list.

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -35,21 +35,18 @@ export default function users(state = initialState, action) {
       // Initialize a variable to hold the user list.
       let user_list = action.data.course.users;
 
-      // Check if any user in the user_list has 'real_name'
-      if (user_list.some(user => user.real_name)) {
-        // If any users have 'real_name', transform the 'real_name' into separate
-        // 'first_name' and 'last_name' properties and update the user list
-        user_list = transformUsers(user_list);
-      } else if (!state.sort.key) {
-        // If there are no users with real_name and key in the store is null then set sort_key by username
+      // Transform the 'real_name' in user_list into separate 'first_name' and 'last_name' properties
+      // if 'real_name' is available by using transformUsers
+      user_list = transformUsers(user_list);
+
+      // If there are no users with last_name and key in the store is null then set sort_key by username
+      if (!state.sort.key && !user_list.some(user => user.last_name)) {
         sort_key = 'username';
       }
 
       /* If 'key' in the store is not null which implies instructor/user had sort the student/editors list either using
-         the dropdown menu or one of the student/editor tab and if 'sortKey' state is null it means sorting was done in
-         reverse so set the previousKey to the 'sort_key' or else null.
-         Note: If 'key' in the store is null it means student/editors list is being loaded for the first time.
-      */
+      the dropdown menu or one of the student/editor tab and if 'sortKey' state is null it means sorting was done in
+      reverse so set the previousKey to the 'sort_key' or else null. */
       if (state.sort.key) { previousKey = state.sort.sortKey ? null : sort_key; }
 
       // Sort the 'user_list' array based on the 'sort_key'

--- a/app/assets/javascripts/reducers/users.js
+++ b/app/assets/javascripts/reducers/users.js
@@ -26,24 +26,35 @@ export default function users(state = initialState, action) {
     case RECEIVE_USERS: {
       // Get the sorting key if available from Redux store or else use last_name
       let sort_key = state.sort.key || 'last_name';
+      /* Use the previousKey to determine the directions of sorting.
+         Note: Direction of the sorting only matter after the user/instructor sort the students/editors
+         list using the dropdown menu or one of the student/editors header and then navigates between
+         tabs and then a data refresh occurs(usually after one minute).
+      */
       let previousKey = null;
       // Initialize a variable to hold the user list.
       let user_list = action.data.course.users;
 
-       // Check if any user in the user_list has 'real_name'
-       if (user_list.some(user => user.real_name)) {
-         // If any users have 'real_name', transform the 'real_name' into separate
-         // 'first_name' and 'last_name' properties and update the user list
-         user_list = transformUsers(user_list);
-        } else if (!state.sort.key) {
-          // If there are no users with real_name and key in the store is null then set sort_key by username
-          sort_key = 'username';
-        }
+      // Check if any user in the user_list has 'real_name'
+      if (user_list.some(user => user.real_name)) {
+        // If any users have 'real_name', transform the 'real_name' into separate
+        // 'first_name' and 'last_name' properties and update the user list
+        user_list = transformUsers(user_list);
+      } else if (!state.sort.key) {
+        // If there are no users with real_name and key in the store is null then set sort_key by username
+        sort_key = 'username';
+      }
 
-        if (state.sort.key) { previousKey = state.sort.sortKey ? null : sort_key; }
+      /* If 'key' in the store is not null which implies instructor/user had sort the student/editors list either using
+         the dropdown menu or one of the student/editor tab and if 'sortKey' state is null it means sorting was done in
+         reverse so set the previousKey to the 'sort_key' or else null.
+         Note: If 'key' in the store is null it means student/editors list is being loaded for the first time.
+      */
+      if (state.sort.key) { previousKey = state.sort.sortKey ? null : sort_key; }
 
-        // Sort the 'user_list' array based on the 'sort_key'
-        user_list = sortByKey(user_list, sort_key, previousKey, SORT_DESCENDING[sort_key]);
+      // Sort the 'user_list' array based on the 'sort_key'
+      user_list = sortByKey(user_list, sort_key, previousKey, SORT_DESCENDING[sort_key]);
+
     return {
       ...state,
       users: user_list.newModels, // Update 'users' with the sorted user list.

--- a/app/assets/javascripts/utils/model_utils.js
+++ b/app/assets/javascripts/utils/model_utils.js
@@ -62,12 +62,35 @@ export const sortByKey = (models, sortKey, previousKey = null, desc = false, abs
   return { newModels, newKey };
 };
 
-// transformUsers: Transforms user objects by splitting 'real_name' into 'first_name' and 'last_name'
+// Transforms an array of user objects by splitting the 'real_name' property
+// into 'first_name' and 'last_name' properties.
 export const transformUsers = (users) => {
-  return users.map((user) => {
-    // Extract 'real_name' property and split into 'first_name' and 'rest'
-    // If 'real_name' exists, it's trimmed and converted to lowercase; if not, an empty string is used
-    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
-    return { ...user, first_name, last_name: rest.join(' ') };
+  // Initialize arrays to hold users with and without real names
+  const usersWithRealName = [];
+  const usersWithoutRealName = [];
+
+  users.forEach((user) => {
+    // If the user has a 'real_name', split it into 'first_name' and 'last_name'
+    if (user.real_name) {
+      const [first_name, ...middle_last_name] = user.real_name.trim().split(' ');
+      const last_name = middle_last_name.pop(); // Get the last name from the split
+      usersWithRealName.push({
+        ...user,
+        first_name: first_name,
+        ...(last_name && { last_name: last_name }),
+      });
+    } else {
+      usersWithoutRealName.push(user);
+    }
   });
+
+  /* Concatenate the array of users with real names and the array of users without real names.
+   This order ensures that users without real names are placed after users with real names.
+
+   Note: The reason for adding users without real names after users with real names is to
+   ensure that if the data returned by transformUsers is sorted by 'last_name' or 'first_name'
+   using sortByKey, proper sorting is maintained. Otherwise, sorting might fail in case some users
+   don't have real names while others do.
+*/
+  return usersWithRealName.concat(usersWithoutRealName);
 };

--- a/app/assets/javascripts/utils/model_utils.js
+++ b/app/assets/javascripts/utils/model_utils.js
@@ -61,3 +61,13 @@ export const sortByKey = (models, sortKey, previousKey = null, desc = false, abs
   }
   return { newModels, newKey };
 };
+
+// transformUsers: Transforms user objects by splitting 'real_name' into 'first_name' and 'last_name'
+export const transformUsers = (users) => {
+  return users.map((user) => {
+    // Extract 'real_name' property and split into 'first_name' and 'rest'
+    // If 'real_name' exists, it's trimmed and converted to lowercase; if not, an empty string is used
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+};

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -412,10 +412,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.last.username)
+      expect(page).to have_content(User.first.username)
       student_row = 'table.users tbody tr.students:first-child'
       within(student_row) do
-        expect(page).to have_content User.first.username
+        expect(page).to have_content User.last.username
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -412,10 +412,10 @@ describe 'the course page', type: :feature, js: true do
     it 'shows a number of most recent revisions for a student' do
       js_visit "/courses/#{slug}/students"
       sleep 1
-      expect(page).to have_content(User.first.username)
-      student_row = 'table.users tbody tr.students:first-child'
+      expect(page).to have_content(User.last.username)
+      student_row = 'table.users tbody tr.students:nth-child(2)'
       within(student_row) do
-        expect(page).to have_content User.last.username
+        expect(page).to have_content User.first.username
         within 'td:nth-of-type(4)' do
           expect(page.text).to eq('1')
         end

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -127,8 +127,8 @@ describe 'Instructor users', type: :feature, js: true do
       click_button 'OK'
       sleep 1
       visit "/courses/#{Course.first.slug}/students"
-      expect(page).to have_content 'Student B'
-      expect(page).not_to have_content 'Student A'
+      expect(page).to have_content 'Student A'
+      expect(page).not_to have_content 'Student B'
     end
 
     it 'is able to assign articles' do

--- a/spec/features/instructor_role_spec.rb
+++ b/spec/features/instructor_role_spec.rb
@@ -127,8 +127,8 @@ describe 'Instructor users', type: :feature, js: true do
       click_button 'OK'
       sleep 1
       visit "/courses/#{Course.first.slug}/students"
-      expect(page).to have_content 'Student A'
-      expect(page).not_to have_content 'Student B'
+      expect(page).to have_content 'Student B'
+      expect(page).not_to have_content 'Student A'
     end
 
     it 'is able to assign articles' do

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -19,50 +19,65 @@ describe('users reducer', () => {
     }
   );
 
-  test(
-    'returns the previous state and updates users array from action via RECEIVE_USERS, ADD_USER and REMOVE_USER',
-    () => {
-      const initialState = users(undefined, { type: null });
-      deepFreeze(initialState);
+  test('returns the previous state and updates users array from action via RECEIVE_USERS, ADD_USER, and REMOVE_USER', () => {
+  const initialState = users(undefined, { type: null });
+  deepFreeze(initialState);
 
-      const action = (type, users_array) => ({
-        type: type,
-        data: {
-          course: {
-            users: users_array
-          }
-        }
-      });
-
-      let users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' }
-      ];
-      const mockedReceivedAction = action(RECEIVE_USERS, users_array);
-      const receiveUserState = users(initialState, mockedReceivedAction);
-      expect(receiveUserState.users).toEqual(users_array);
-      expect(receiveUserState.isLoaded).toBe(true);
-
-      users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' },
-        { id: 3, username: 'buzz', role: 'student' }
-      ];
-      const mockedAddAction = action(ADD_USER, users_array);
-      const addUserState = users(receiveUserState, mockedAddAction);
-      expect(addUserState.users).toEqual(users_array);
-      expect(addUserState.isLoaded).toBe(true);
-
-      users_array = [
-        { id: 1, username: 'foo', role: 'student' },
-        { id: 2, username: 'bar', role: 'admin' }
-      ];
-      const mockedRemoveAction = action(REMOVE_USER, users_array);
-      const removeUserState = users(addUserState, mockedRemoveAction);
-      expect(removeUserState.users).toEqual(users_array);
-      expect(removeUserState.isLoaded).toBe(true);
+  const action = (type, users_array) => ({
+    type: type,
+    data: {
+      course: {
+        users: users_array
+      }
     }
-  );
+  });
+
+  let users_array = [
+    { id: 1, real_name: 'John Doe', role: 'student' },
+    { id: 2, real_name: 'Jane Smith', role: 'admin' }
+  ];
+
+  users_array = users_array.map((user) => {
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+
+  const mockedReceivedAction = action(RECEIVE_USERS, users_array);
+  const receiveUserState = users(initialState, mockedReceivedAction);
+  expect(receiveUserState.users).toEqual(users_array);
+  expect(receiveUserState.isLoaded).toBe(true);
+
+  users_array = [
+    { id: 3, real_name: 'Bob Johnson', role: 'student' },
+    { id: 4, real_name: 'Alice Williams', role: 'admin' },
+    { id: 5, real_name: 'Eve Brown', role: 'student' }
+  ];
+
+  users_array = users_array.map((user) => {
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+
+  const mockedAddAction = action(ADD_USER, users_array);
+  const addUserState = users(receiveUserState, mockedAddAction);
+  expect(addUserState.users).toEqual(users_array);
+  expect(addUserState.isLoaded).toBe(true);
+
+  users_array = [
+    { id: 4, real_name: 'Alice Williams', role: 'admin' },
+    { id: 5, real_name: 'Eve Brown', role: 'student' }
+  ];
+
+  users_array = users_array.map((user) => {
+    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    return { ...user, first_name, last_name: rest.join(' ') };
+  });
+
+  const mockedRemoveAction = action(REMOVE_USER, users_array);
+  const removeUserState = users(addUserState, mockedRemoveAction);
+  expect(removeUserState.users).toEqual(users_array);
+  expect(removeUserState.isLoaded).toBe(true);
+});
 
   test('sorts users given a key by action via SORT_USERS', () => {
     const initialState = {

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -38,7 +38,7 @@ describe('users reducer', () => {
   ];
 
   users_array = users_array.map((user) => {
-    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+    const [first_name, ...rest] = (user.real_name?.trim() || '').split(' ');
     return { ...user, first_name, last_name: rest.join(' ') };
   });
 

--- a/test/utils/model_utils.spec.js
+++ b/test/utils/model_utils.spec.js
@@ -1,0 +1,25 @@
+import { transformUsers } from '../../app/assets/javascripts/utils/model_utils';
+
+describe('transformUsers', () => {
+  it('transforms user names correctly', () => {
+    const users = [
+      { real_name: 'John Doe Smith' },
+      { real_name: 'Bob Charles Johnson' },
+      { real_name: 'Alice' },
+      { real_name: 'Smith Time' },
+      { real_name: '' },
+    ];
+
+    const transformedUsers = transformUsers(users);
+
+    const expectedTransformedUsers = [
+      { real_name: 'John Doe Smith', first_name: 'John', last_name: 'Smith' },
+      { real_name: 'Bob Charles Johnson', first_name: 'Bob', last_name: 'Johnson' },
+      { real_name: 'Alice', first_name: 'Alice' },
+      { real_name: 'Smith Time', first_name: 'Smith', last_name: 'Time' },
+      { real_name: '' },
+    ];
+
+    expect(transformedUsers).toEqual(expectedTransformedUsers);
+  });
+});

--- a/test/utils/model_utils.spec.js
+++ b/test/utils/model_utils.spec.js
@@ -1,25 +1,21 @@
 import { transformUsers } from '../../app/assets/javascripts/utils/model_utils';
 
-describe('transformUsers', () => {
-  it('transforms user names correctly', () => {
+describe('transformUsers function', () => {
+  it('transforms users with real names and maintains sorting order', () => {
     const users = [
-      { real_name: 'John Doe Smith' },
-      { real_name: 'Bob Charles Johnson' },
-      { real_name: 'Alice' },
-      { real_name: 'Smith Time' },
-      { real_name: '' },
+      { id: 1, real_name: 'John Doe' },
+      { id: 2, real_name: 'Alice Mary Smith' },
+      { id: 3, real_name: 'Bob Johnson' },
+      { id: 4 },
     ];
 
     const transformedUsers = transformUsers(users);
 
-    const expectedTransformedUsers = [
-      { real_name: 'John Doe Smith', first_name: 'John', last_name: 'Smith' },
-      { real_name: 'Bob Charles Johnson', first_name: 'Bob', last_name: 'Johnson' },
-      { real_name: 'Alice', first_name: 'Alice' },
-      { real_name: 'Smith Time', first_name: 'Smith', last_name: 'Time' },
-      { real_name: '' },
-    ];
-
-    expect(transformedUsers).toEqual(expectedTransformedUsers);
+    expect(transformedUsers).toEqual([
+      { id: 1, real_name: 'John Doe', first_name: 'John', last_name: 'Doe' },
+      { id: 2, real_name: 'Alice Mary Smith', first_name: 'Alice', last_name: 'Smith' },
+      { id: 3, real_name: 'Bob Johnson', first_name: 'Bob', last_name: 'Johnson' },
+      { id: 4 },
+    ]);
   });
 });

--- a/test/utils/model_utils.spec.js
+++ b/test/utils/model_utils.spec.js
@@ -5,8 +5,9 @@ describe('transformUsers function', () => {
     const users = [
       { id: 1, real_name: 'John Doe' },
       { id: 2, real_name: 'Alice Mary Smith' },
+      { id: 5 },
       { id: 3, real_name: 'Bob Johnson' },
-      { id: 4 },
+      { id: 4, real_name: 'Jack' },
     ];
 
     const transformedUsers = transformUsers(users);
@@ -15,7 +16,8 @@ describe('transformUsers function', () => {
       { id: 1, real_name: 'John Doe', first_name: 'John', last_name: 'Doe' },
       { id: 2, real_name: 'Alice Mary Smith', first_name: 'Alice', last_name: 'Smith' },
       { id: 3, real_name: 'Bob Johnson', first_name: 'Bob', last_name: 'Johnson' },
-      { id: 4 },
+      { id: 4, real_name: 'Jack', first_name: 'Jack' },
+      { id: 5 },
     ]);
   });
 });


### PR DESCRIPTION
resolves #5343 

### What this PR does
<hr>


**FixBug:**

On the Students (aka Editors) tab of a course page, the default sorting of students was not ideal, as they were listed based on the order of joining the course. The default sorting method was not considered optimal, and the sorting state was not retained when users navigated between tabs and data refresh occurs (which happens when you change course tabs and it's been more than a minute since the last fetch).

**Solution:**

* Updated the default sorting to be based on the student's  `last names` when receiving users' data for the first time.
* Implemented sorting retention when users manually re-sort the list. The sorting state is now preserved when users navigate between tabs or when data gets refreshed.

**Changes Made:**

* Modified the users reducer `user.js` to handle sorting of students based on `last name` when receiving users' data for the first time.
* If the `state.users` array is empty, check if any user has a `real_name` in the received data. If so, transform the user list to include `first_name` and `last_name` properties based on `real_name`.
* If `state.users` is empty and no user has `real_name`, sort the user list by `username`.
* Retained sorting state by using the existing users in the state in the Redux store when applicable.

### **Screenshots**

Before:

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/efe7e22e-7c72-469a-954f-14fd4c8fd619)

After: 

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/7ccf84ef-e58d-4712-b7d8-e31d16ce2dee)

