### PR TITLE
Converting GreetStudentsButton, AddSpecialUserButton and AddAdminButton into functional components

### DIFF
--- a/app/assets/javascripts/components/overview/greet_students_button.jsx
+++ b/app/assets/javascripts/components/overview/greet_students_button.jsx
@@ -1,28 +1,21 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
-const GreetStudentsButton = createReactClass({
-  propTypes: {
-    course: PropTypes.object,
-    current_user: PropTypes.object,
-    greetStudents: PropTypes.func.isRequired
-  },
-
-  greetStudents() {
-    this.props.greetStudents(this.props.course.id);
-  },
-
-  render() {
-    // Render nothing if user isn't an admin, or it's not the Wiki Ed Dashboard, or not a student course
-    if (!this.props.current_user.admin || !Features.wikiEd || this.props.course.type !== 'ClassroomProgramCourse') {
-      return <div />;
-    }
-
-    return (
-      <div key="greet_students"><button onClick={this.greetStudents} className="button">Greet students</button></div>
-    );
+const GreetStudentsButton = ({ greetStudents, current_user, course }) => {
+  // Render nothing if user isn't an admin, or it's not the Wiki Ed Dashboard, or not a student course
+  if (!current_user.admin || !Features.wikiEd || course.type !== 'ClassroomProgramCourse') {
+    return <div />;
   }
-});
+
+  return (
+    <div key="greet_students"><button onClick={() => greetStudents(course.id)} className="button">Greet students</button></div>
+  );
+};
+
+GreetStudentsButton.propTypes = {
+  course: PropTypes.object,
+  current_user: PropTypes.object,
+  greetStudents: PropTypes.func.isRequired
+};
 
 export default GreetStudentsButton;

--- a/app/assets/javascripts/components/settings/views/add_admin_button.jsx
+++ b/app/assets/javascripts/components/settings/views/add_admin_button.jsx
@@ -1,35 +1,27 @@
-import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import React from 'react';
 import AddAdminForm from '../containers/add_admin_form_container';
 import Popover from '../../common/popover.jsx';
-import PopoverExpandable from '../../high_order/popover_expandable.jsx';
+import useExpandablePopover from '../../../hooks/useExpandablePopover';
 
-const AddAdminButton = createReactClass({
-  propTypes: {
-    source: PropTypes.string,
-    open: PropTypes.func,
-    is_open: PropTypes.bool
-  },
-
-  getKey() {
+const AddAdminButton = () => {
+  const getKey = () => {
     return 'add_admin_button';
-  },
+  };
 
-  render() {
-    const form = <AddAdminForm handlePopoverClose={this.props.open} />;
-    return (
-      <div className="pop__container">
-        <button className="button dark" onClick={this.props.open}>Add Admin</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={form}
-          right
-        />
-      </div>
-    );
-  }
-});
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
 
-export default PopoverExpandable(AddAdminButton);
+  const form = <AddAdminForm handlePopoverClose={open} />;
+  return (
+    <div className="pop__container" ref={ref}>
+      <button className="button dark" onClick={open}>Add Admin</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={form}
+        right
+      />
+    </div>
+  );
+};
+
+export default AddAdminButton;
 

--- a/app/assets/javascripts/components/settings/views/add_special_user_button.jsx
+++ b/app/assets/javascripts/components/settings/views/add_special_user_button.jsx
@@ -1,34 +1,27 @@
-import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import React from 'react';
 import AddSpecialUserForm from './add_special_user_form';
 import Popover from '../../common/popover.jsx';
-import PopoverExpandable from '../../high_order/popover_expandable.jsx';
+import useExpandablePopover from '../../../hooks/useExpandablePopover';
 
-const AddSpecialUserButton = createReactClass({
-  propTypes: {
-    open: PropTypes.func,
-    is_open: PropTypes.bool
-  },
-
-  getKey() {
+const AddSpecialUserButton = () => {
+  const getKey = () => {
     return 'add_special_user_button';
-  },
+  };
 
-  render() {
-    const form = <AddSpecialUserForm handlePopoverClose={this.props.open} />;
-    return (
-      <div className="pop__container">
-        <button className="button dark" onClick={this.props.open}>Add Special User</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={form}
-          right
-        />
-      </div>
-    );
-  }
-});
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
 
-export default PopoverExpandable(AddSpecialUserButton);
+  const form = <AddSpecialUserForm handlePopoverClose={open} />;
+  return (
+    <div className="pop__container" ref={ref}>
+      <button className="button dark" onClick={open}>Add Special User</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={form}
+        right
+      />
+    </div>
+  );
+};
+
+export default AddSpecialUserButton;
 


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `greet_students_button.jsx`, `add_special_user_button.jsx` and `add_admin_button.jsx` into functional components
**Affected Pages:**
- `/courses/[institution_name]/[course_name]/home` (for `greet_students_button.jsx`)
- `/settings` (for `add_special_user_button.jsx` and `add_admin_button.jsx`, admin-only)
## Videos
Before `greet_students_button.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/5ea343a9-5ae5-4c78-bf6b-035ec9b5dfd9




After `greet_students_button.jsx`


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/20a9bf6b-cf9d-4e4a-a248-89d62ea0d945


Before `add_special_user_button.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/7b2ae233-f168-4df5-a90f-4d7dd5bb3665


After `add_special_user_button.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/c6c09ba6-601f-4d08-ad54-8912cdc40299


Before `add_admin_button.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/c8da7a6f-a032-4b94-b646-2c30bbc10478


After `add_admin_button.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/5e407d0f-6906-4d5e-a145-d4e4466ea708


