### PR TITLE
Converting CustomLink, UpdateDefaultCampaignSetting, UpdateSalesforceCredentials and UpdateCourseCreationSettings into functional component

### DIFF
--- a/app/assets/javascripts/components/nav/CustomLink.jsx
+++ b/app/assets/javascripts/components/nav/CustomLink.jsx
@@ -1,31 +1,21 @@
-// Replacement for non-custom Link component. The react Link component doesn't highlight the active link if it is not handeled by react router, CustomLink is used to provide that functioning.
+// Replacement for non-custom Link component. The react Link component doesn't highlight the active link if it is not handled by react router
+// CustomLink is used to provide that functioning.
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
-const CustomLink = createReactClass({
-  displayName: 'CustomLink',
-
-  propTypes: {
-    to: PropTypes.string,
-    location: PropTypes.object,
-    name: PropTypes.string,
-    clickedElement: PropTypes.string,
-    target: PropTypes.string
-  },
-  isActive() {
-    let bool;
+const CustomLink = ({ clickedElement, to, target, name }) => {
+  const isActive = () => {
     const path = location.pathname.split('/')[1];
-    if (path === this.props.clickedElement) {
-      bool = true;
-    } else {
-      bool = false;
-    }
-    return bool;
-  },
-  render() {
-    return <a href = {this.props.to} className={this.isActive() ? 'active' : ''} target={this.props.target}> {this.props.name} </a>;
-  }
-});
+    return path === clickedElement;
+  };
+  return <a href={to} className={isActive() ? 'active' : ''} target={target}> {name} </a>;
+};
+
+CustomLink.propTypes = {
+  to: PropTypes.string,
+  name: PropTypes.string,
+  clickedElement: PropTypes.string,
+  target: PropTypes.string
+};
 
 export default CustomLink;

--- a/app/assets/javascripts/components/settings/views/update_course_creation_settings.jsx
+++ b/app/assets/javascripts/components/settings/views/update_course_creation_settings.jsx
@@ -1,34 +1,29 @@
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import React from 'react';
 import CourseCreationSettingsForm from '../containers/course_creation_settings_form_container.jsx';
 import Popover from '../../common/popover.jsx';
-import PopoverExpandable from '../../high_order/popover_expandable.jsx';
+import useExpandablePopover from '../../../hooks/useExpandablePopover';
 
-const UpdateCourseCreationSettings = createReactClass({
-  propTypes: {
-    open: PropTypes.func,
-    is_open: PropTypes.bool,
-    settings: PropTypes.object
-  },
-
-  getKey() {
+const UpdateCourseCreationSettings = ({ settings }) => {
+  const getKey = () => {
     return 'update_course_creation_settings';
-  },
+  };
 
-  render() {
-    const form = <CourseCreationSettingsForm handlePopoverClose={this.props.open} settings={this.props.settings} />;
-    return (
-      <div className="pop__container">
-        <button className="button dark" onClick={this.props.open}>Update course creation settings</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={form}
-          right
-        />
-      </div>
-    );
-  }
-});
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
 
-export default PopoverExpandable(UpdateCourseCreationSettings);
+  const form = <CourseCreationSettingsForm handlePopoverClose={open} settings={settings} />;
+  return (
+    <div className="pop__container" ref={ref}>
+      <button className="button dark" onClick={open}>Update course creation settings</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={form}
+        right
+      />
+    </div>
+  );
+};
+UpdateCourseCreationSettings.propTypes = {
+  settings: PropTypes.object
+};
+export default UpdateCourseCreationSettings;

--- a/app/assets/javascripts/components/settings/views/update_default_campaign_setting.jsx
+++ b/app/assets/javascripts/components/settings/views/update_default_campaign_setting.jsx
@@ -1,33 +1,26 @@
-import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import React from 'react';
 import DefaultCampaignForm from '../containers/default_campaign_form_container.jsx';
 import Popover from '../../common/popover.jsx';
-import PopoverExpandable from '../../high_order/popover_expandable.jsx';
+import useExpandablePopover from '../../../hooks/useExpandablePopover';
 
-const UpdateDefaultCampaignSetting = createReactClass({
-  propTypes: {
-    open: PropTypes.func,
-    is_open: PropTypes.bool
-  },
-
-  getKey() {
+const UpdateDefaultCampaignSetting = () => {
+  const getKey = () => {
     return 'update_default_campaign_button';
-  },
+  };
 
-  render() {
-    const form = <DefaultCampaignForm handlePopoverClose={this.props.open} />;
-    return (
-      <div className="pop__container">
-        <button className="button dark" onClick={this.props.open}>Update Default Campaign</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={form}
-          right
-        />
-      </div>
-    );
-  }
-});
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
 
-export default PopoverExpandable(UpdateDefaultCampaignSetting);
+  const form = <DefaultCampaignForm handlePopoverClose={open} />;
+  return (
+    <div className="pop__container" ref={ref}>
+      <button className="button dark" onClick={open}>Update Default Campaign</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={form}
+        right
+      />
+    </div>
+  );
+};
+
+export default UpdateDefaultCampaignSetting;

--- a/app/assets/javascripts/components/settings/views/update_salesforce_credentials.jsx
+++ b/app/assets/javascripts/components/settings/views/update_salesforce_credentials.jsx
@@ -1,33 +1,26 @@
-import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import React from 'react';
 import SalesforceCredentialsForm from '../containers/salesforce_credentials_form_container';
 import Popover from '../../common/popover.jsx';
-import PopoverExpandable from '../../high_order/popover_expandable.jsx';
+import useExpandablePopover from '../../../hooks/useExpandablePopover';
 
-const UpdateSalesforceCredentials = createReactClass({
-  propTypes: {
-    open: PropTypes.func,
-    is_open: PropTypes.bool
-  },
-
-  getKey() {
+const UpdateSalesforceCredentials = () => {
+  const getKey = () => {
     return 'update_salesforce_credentials_button';
-  },
+  };
 
-  render() {
-    const form = <SalesforceCredentialsForm handlePopoverClose={this.props.open} />;
-    return (
-      <div className="pop__container">
-        <button className="button dark" onClick={this.props.open}>Update Salesforce Credentials</button>
-        <Popover
-          is_open={this.props.is_open}
-          edit_row={form}
-          right
-        />
-      </div>
-    );
-  }
-});
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
 
-export default PopoverExpandable(UpdateSalesforceCredentials);
+  const form = <SalesforceCredentialsForm handlePopoverClose={open} />;
+  return (
+    <div className="pop__container" ref={ref}>
+      <button className="button dark" onClick={open}>Update Salesforce Credentials</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={form}
+        right
+      />
+    </div>
+  );
+};
+
+export default UpdateSalesforceCredentials;


### PR DESCRIPTION
With reference to #5393

## What this PR does
Converts `CustomLink.jsx`, `update_default_campaign_setting.jsx`, `update_salesforce_credentials.jsx` and `update_course_creation_settings.jsx` into functional components
**Affected Pages:**
- `/settings` (for `update_default_campaign_setting.jsx`, `update_salesforce_credentials.jsx` and `update_course_creation_settings.jsx`)
- Any page that has the main navbar (for `CustomLink.jsx`)
## Videos
Before `CustomLink.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/83bbdda7-2727-4b29-a75b-f2ae5874b835

After `CustomLink.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/c7c26859-6fd6-49d3-bb69-1c26e3b0718b

Before `update_default_campaign_setting.jsx`, `update_salesforce_credentials.jsx` and `update_course_creation_settings.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/9a637b67-0531-4430-a318-c29babab29b3

After `update_default_campaign_setting.jsx`, `update_salesforce_credentials.jsx` and `update_course_creation_settings.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/2cdbaf68-95b3-47eb-8cb2-4d64616291b8


