### PR TITLE
Converting AcademicSystem, Description and CategoryHandler into functional components

### DIFF
--- a/app/assets/javascripts/components/categories/category_handler.jsx
+++ b/app/assets/javascripts/components/categories/category_handler.jsx
@@ -1,48 +1,32 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import CategoryList from './category_list.jsx';
-import { fetchCategories, removeCategory, addCategory } from '../../actions/category_actions.js';
+import { fetchCategories, addCategory } from '../../actions/category_actions.js';
 
-const CategoryHandler = createReactClass({
-  displayName: 'CategoryHandler',
+const CategoryHandler = ({ course, current_user }) => {
+  const dispatch = useDispatch();
 
-  propTypes: {
-    fetchCategories: PropTypes.func,
-    removeCategory: PropTypes.func,
-    course: PropTypes.object,
-    current_user: PropTypes.object
-  },
+  const categories = useSelector(state => state.categories.categories);
+  const loading = useSelector(state => state.categories.loading);
 
-  componentDidMount() {
-    this.props.fetchCategories(this.props.course.slug);
-  },
+  useEffect(() => { dispatch(fetchCategories(course.slug)); }, []);
 
-  render() {
-    const editable = this.props.current_user.isAdvancedRole;
-    return (
-      <CategoryList
-        course={this.props.course}
-        categories={this.props.categories}
-        loading={this.props.loading}
-        removeCategory={this.props.removeCategory}
-        addCategory={this.props.addCategory}
-        editable={editable}
-      />
-    );
-  }
-});
-
-const mapStateToProps = state => ({
-  categories: state.categories.categories,
-  loading: state.categories.loading
-});
-
-const mapDispatchToProps = {
-  fetchCategories: fetchCategories,
-  removeCategory: removeCategory,
-  addCategory: addCategory
+  const editable = current_user.isAdvancedRole;
+  return (
+    <CategoryList
+      course={course}
+      categories={categories}
+      loading={loading}
+      addCategory={payload => dispatch(addCategory(payload))}
+      editable={editable}
+    />
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(CategoryHandler);
+CategoryHandler.propTypes = {
+  course: PropTypes.object,
+  current_user: PropTypes.object
+};
+
+export default (CategoryHandler);

--- a/app/assets/javascripts/components/categories/category_list.jsx
+++ b/app/assets/javascripts/components/categories/category_list.jsx
@@ -96,7 +96,6 @@ const CategoryList = ({ course, editable, categories, loading, addCategory }) =>
 CategoryList.propTypes = {
   course: PropTypes.object,
   categories: PropTypes.array,
-  removeCategory: PropTypes.func,
   addCategory: PropTypes.func
 };
 

--- a/app/assets/javascripts/components/categories/category_list.jsx
+++ b/app/assets/javascripts/components/categories/category_list.jsx
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import Category from './category';
 import AddCategoryButton from './add_category_button';
 import List from '../common/list.jsx';
+import { removeCategory } from '@actions/category_actions.js';
 
-const CategoryList = ({ course, editable, categories, loading, removeCategory, addCategory }) => {
+import { useDispatch } from 'react-redux';
+
+const CategoryList = ({ course, editable, categories, loading, addCategory }) => {
   const keys = {
     category_name: {
       label: I18n.t('categories.name')
@@ -22,8 +25,10 @@ const CategoryList = ({ course, editable, categories, loading, removeCategory, a
     },
   };
 
+  const dispatch = useDispatch();
+
   const elements = categories.map((cat) => {
-    const remove = () => { removeCategory(course.id, cat.id); };
+    const remove = () => { dispatch(removeCategory(course.id, cat.id)); };
     return <Category key={cat.id} course={course} category={cat} remove={remove} editable={editable} />;
   });
 

--- a/app/assets/javascripts/components/common/academic_system.jsx
+++ b/app/assets/javascripts/components/common/academic_system.jsx
@@ -1,47 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const createReactClass = require('create-react-class');
+const AcademicSystem = (props) => {
+  const [selectedOption, setSelectedOption] = useState(props.value || 'semester');
 
-const AcademicSystem = createReactClass({
+  const handleOptionChange = (changeEvent) => {
+    setSelectedOption(changeEvent.target.value);
+    props.updateCourseProps({ academic_system: changeEvent.target.value });
+  };
 
-  getInitialState: function () {
-    this.props.updateCourseProps({ academic_system: this.props.value || 'semester' });
-    return {
-      selectedOption: this.props.value || 'semester'
-    };
-  },
-
-  handleOptionChange: function (changeEvent) {
-    this.setState({
-      selectedOption: changeEvent.target.value
-    });
-    this.props.updateCourseProps({ academic_system: changeEvent.target.value });
-  },
-
-  render: function () {
-    const options = ['semester', 'quarter', 'other'];
-    let i;
-    const academic_system = [];
-    for (i = 0; i < options.length; i += 1) {
-      academic_system.push(
-        <label className="radio-inline" key={options[i]}>
-          <input
-            type="radio"
-            name="academic_system"
-            value={options[i]}
-            style={{ display: 'inline-block', width: '30px' }}
-            defaultChecked={this.state.selectedOption === options[i]}
-            onChange={this.handleOptionChange}
-          />
-          {options[i]}
-        </label>);
-    }
-    return (
-      <div>
-        {academic_system}
-      </div>
-    );
+  const options = ['semester', 'quarter', 'other'];
+  let i;
+  const academic_system = [];
+  for (i = 0; i < options.length; i += 1) {
+    academic_system.push(
+      <label className="radio-inline" key={options[i]}>
+        <input
+          type="radio"
+          name="academic_system"
+          value={options[i]}
+          style={{ display: 'inline-block', width: '30px' }}
+          defaultChecked={selectedOption === options[i]}
+          onChange={handleOptionChange}
+        />
+        {options[i]}
+      </label>);
   }
-});
+  return (
+    <div>
+      {academic_system}
+    </div>
+  );
+};
 
 export default AcademicSystem;

--- a/app/assets/javascripts/components/overview/description.jsx
+++ b/app/assets/javascripts/components/overview/description.jsx
@@ -1,48 +1,42 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import EditableRedux from '../high_order/editable_redux.jsx';
 import TextAreaInput from '../common/text_area_input.jsx';
 
-const Description = createReactClass({
-  displayName: 'Description',
+const Description = ({ updateCourse, title, controls, description, editable }) => {
+  const updateDescription = (_valueKey, value) => {
+    return updateCourse({ description: value });
+  };
 
-  propTypes: {
-    description: PropTypes.string,
-    title: PropTypes.string,
-    editable: PropTypes.bool,
-    controls: PropTypes.any,
-    updateCourse: PropTypes.func.isRequired, // used by EditableRedux
-    resetState: PropTypes.func.isRequired, // used by EditableRedux
-    persistCourse: PropTypes.func.isRequired // used by EditableRedux
-  },
-
-  updateDescription(_valueKey, value) {
-    return this.props.updateCourse({ description: value });
-  },
-
-  render() {
-    return (
-      <div className="module course-description">
-        <div className="section-header">
-          <h3>{this.props.title}</h3>
-          {this.props.controls()}
-        </div>
-        <div className="module__data">
-          <TextAreaInput
-            onChange={this.updateDescription}
-            value={this.props.description}
-            placeholder={I18n.t('courses.creator.course_description')}
-            value_key={'description'}
-            editable={this.props.editable}
-            markdown={true}
-            autoExpand={true}
-          />
-        </div>
+  return (
+    <div className="module course-description" >
+      <div className="section-header">
+        <h3>{title}</h3>
+        {controls()}
       </div>
-    );
-  }
-}
-);
+      <div className="module__data">
+        <TextAreaInput
+          onChange={updateDescription}
+          value={description}
+          placeholder={I18n.t('courses.creator.course_description')}
+          value_key={'description'}
+          editable={editable}
+          markdown={true}
+          autoExpand={true}
+        />
+      </div>
+    </div >
+  );
+};
+
+Description.propTypes = {
+  description: PropTypes.string,
+  title: PropTypes.string,
+  editable: PropTypes.bool,
+  controls: PropTypes.any,
+  updateCourse: PropTypes.func.isRequired, // used by EditableRedux
+  resetState: PropTypes.func.isRequired, // used by EditableRedux
+  persistCourse: PropTypes.func.isRequired // used by EditableRedux
+};
 
 export default EditableRedux(Description, I18n.t('editable.edit_description'));


### PR DESCRIPTION
With reference to #5393

## What this PR does

Converts `academic_system.jsx`, `category_handler.jsx` and `description.jsx` into functional components
**Affected Pages:**
- `/course_creator` (for `academic_system.jsx.jsx.jsx`)
- `/courses/[institution_name]/[course_name]` (for `academic_system.jsx` and `description.jsx`)
- `/courses/[institution_name]/[course_name]/articles/edited` (for `category_handler.jsx`)
## Videos
Before `academic_system.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a9e75aa5-60a6-4ec9-8da4-0d50e420dd93

After `academic_system.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/ed30fa81-4d06-47c5-bda6-550f9fe1d09e
	
Before `category_handler.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/379caac2-7218-4dc4-95fb-b10d6482e97a

After `category_handler.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/374c3215-5067-4b4d-b67c-275f7e355cb6
	
Before `description.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/671816d8-5c96-4ca1-9dae-dade7801f5b7

After `description.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/6deae594-8d6c-4669-a254-4345b8fbd0b9


