### PR TITLE
Converting StatisticsUpdateInfo, BlockTypeSelect and CourseDetails into functional components

### DIFF
--- a/app/assets/javascripts/components/overview/statistics_update_info.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_info.jsx
@@ -1,58 +1,46 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import StatisticsUpdateModal from './statistics_update_modal';
 import { getUpdateMessage } from '../../utils/statistic_update_info_utils';
 
-const StatisticsUpdateInfo = createReactClass({
-  displayName: 'StatisticsUpdateInfo',
+const StatisticsUpdateInfo = ({ course }) => {
+  const [showModal, setShowModal] = useState(false);
 
-  propTypes: {
-    course: PropTypes.object.isRequired,
-  },
+  const toggleModal = () => {
+    setShowModal(!showModal);
+  };
 
-  getInitialState() {
-    return {
-      showModal: false
-    };
-  },
+  if (Features.wikiEd && !course.ended) {
+    return <div />;
+  }
 
-  toggleModal() {
-    this.setState({
-      showModal: !this.state.showModal
-    });
-  },
+  const [lastUpdateMessage, nextUpdateMessage, isNextUpdateAfter] = getUpdateMessage(course);
 
-  render() {
-    const course = this.props.course;
-    if (Features.wikiEd && !course.ended) {
-      return <div />;
-    }
-
-    const [lastUpdateMessage, nextUpdateMessage, isNextUpdateAfter] = getUpdateMessage(course);
-
-    if (this.state.showModal) {
-      return (
-        <StatisticsUpdateModal
-          course={course}
-          isNextUpdateAfter={isNextUpdateAfter}
-          nextUpdateMessage={nextUpdateMessage}
-          toggleModal={this.toggleModal}
-        />
-      );
-    }
-
-    const updateTimesMessage = isNextUpdateAfter ? `${lastUpdateMessage} ${nextUpdateMessage} ` : `${lastUpdateMessage} `;
-
-    // Render update time information and if some updates were made a 'See More' link to open modal
+  if (showModal) {
     return (
-      <div className="statistics-update-info pull-right mb2">
-        <small>
-          {updateTimesMessage} {(course.flags.first_update || course.flags.update_logs) && <a onClick={this.toggleModal} href="#">{I18n.t('metrics.update_statistics_link')}</a>}
-        </small>
-      </div>
+      <StatisticsUpdateModal
+        course={course}
+        isNextUpdateAfter={isNextUpdateAfter}
+        nextUpdateMessage={nextUpdateMessage}
+        toggleModal={toggleModal}
+      />
     );
   }
-});
+
+  const updateTimesMessage = isNextUpdateAfter ? `${lastUpdateMessage} ${nextUpdateMessage} ` : `${lastUpdateMessage} `;
+
+  // Render update time information and if some updates were made a 'See More' link to open modal
+  return (
+    <div className="statistics-update-info pull-right mb2">
+      <small>
+        {updateTimesMessage} {(course.flags.first_update || course.flags.update_logs) && <a onClick={toggleModal} href="#">{I18n.t('metrics.update_statistics_link')}</a>}
+      </small>
+    </div>
+  );
+};
+
+StatisticsUpdateInfo.propTypes = {
+  course: PropTypes.object.isRequired,
+};
 
 export default StatisticsUpdateInfo;

--- a/app/assets/javascripts/components/timeline/block_type_select.jsx
+++ b/app/assets/javascripts/components/timeline/block_type_select.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Conditional from '../high_order/conditional.jsx';
 import InputHOC from '../high_order/input_hoc.jsx';
@@ -8,53 +7,50 @@ import selectStyles from '../../styles/single_select';
 
 const KINDS = ['In Class', 'Assignment', 'Milestone', 'Custom', 'Handouts', 'Resources'];
 
-const BlockTypeSelect = createReactClass({
-  displayName: 'BlockTypeSelect',
-
-  propTypes: {
-    value: PropTypes.any,
-    editable: PropTypes.bool,
-  },
-
-  handleClick(selectedOption) {
+const BlockTypeSelect = ({ onChange, editable, id, value }) => {
+  const handleClick = (selectedOption) => {
     const e = { target: selectedOption };
-    this.props.onChange(e);
-  },
+    onChange(e);
+  };
 
-  render() {
-    const labelClass = 'tooltip-trigger';
-    const label = 'Block type:';
-    const tooltip = (
-      <div className="tooltip dark">
-        <p>{I18n.t('timeline.block_type')}</p>
+  const labelClass = 'tooltip-trigger';
+  const label = 'Block type:';
+  const tooltip = (
+    <div className="tooltip dark">
+      <p>{I18n.t('timeline.block_type')}</p>
+    </div>
+  );
+
+  const options = KINDS.map((option, i) => {
+    return { value: i, label: option };
+  });
+
+  if (editable) {
+    return (
+      <div className="react-select_dropdown">
+        <div className="form-group">
+          <label htmlFor={id} className={labelClass}>
+            {label}
+            {tooltip}
+          </label>
+          <Select
+            id={id}
+            value={options.find(option => option.value === value)}
+            onChange={handleClick}
+            options={options}
+            styles={selectStyles}
+          />
+        </div>
       </div>
     );
-
-    const options = KINDS.map((option, i) => {
-      return { value: i, label: option };
-    });
-
-    if (this.props.editable) {
-      return (
-        <div className="react-select_dropdown">
-          <div className="form-group">
-            <label htmlFor={this.props.id} className={labelClass}>
-              {label}
-              {tooltip}
-            </label>
-            <Select
-              id={this.props.id}
-              value={options.find(option => option.value === this.props.value)}
-              onChange={this.handleClick}
-              options={options}
-              styles={selectStyles}
-            />
-          </div>
-        </div>
-      );
-    }
-    return <span>{KINDS[this.props.value]}</span>;
   }
-});
+  return <span>{KINDS[value]}</span>;
+};
+
+
+BlockTypeSelect.propTypes = {
+  value: PropTypes.any,
+  editable: PropTypes.bool,
+};
 
 export default Conditional(InputHOC(BlockTypeSelect));

--- a/app/assets/javascripts/components/user_profiles/course_details.jsx
+++ b/app/assets/javascripts/components/user_profiles/course_details.jsx
@@ -1,49 +1,44 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
-
-const CourseDetails = createReactClass({
-  propTypes: {
-    courses: PropTypes.array
-  },
-
-  render() {
-    const elements = this.props.courses.map((course) => {
-      return (
-        <a className="course" key={`${course.course_slug}-${course.user_role}`} href={`/courses/${course.course_slug}`}>
-          <div className="button border">{I18n.t('courses.view_page')}</div>
-          <div className="course-title">{course.course_title}</div>
-          <div className="course-details">
-            <div className="col">
-              <div className="course-details_title">{I18n.t('courses.school')}</div>
-              <div className="course-details_value">{course.course_school}</div>
-            </div>
-            <div className="col">
-              <div className="course-details_title">{I18n.t('courses.term')}</div>
-              <div className="course-details_value">{course.course_term}</div>
-            </div>
-            <div className="col">
-              <div className="course-details_title">{I18n.t('courses.students_count')}</div>
-              <div className="course-details_value">{course.user_count}</div>
-            </div>
-            <div className="col">
-              <div className="course-details_title">{I18n.t('courses.user_role')}</div>
-              <div className="course-details_value">{course.user_role}</div>
-            </div>
-          </div>
-        </a>
-      );
-    });
-
+const CourseDetails = ({ courses }) => {
+  const elements = courses.map((course) => {
     return (
-      <div id="course-details">
-        <h3>{I18n.t('courses.course_details')}</h3>
-        {elements}
-      </div>
+      <a className="course" key={`${course.course_slug}-${course.user_role}`} href={`/courses/${course.course_slug}`}>
+        <div className="button border">{I18n.t('courses.view_page')}</div>
+        <div className="course-title">{course.course_title}</div>
+        <div className="course-details">
+          <div className="col">
+            <div className="course-details_title">{I18n.t('courses.school')}</div>
+            <div className="course-details_value">{course.course_school}</div>
+          </div>
+          <div className="col">
+            <div className="course-details_title">{I18n.t('courses.term')}</div>
+            <div className="course-details_value">{course.course_term}</div>
+          </div>
+          <div className="col">
+            <div className="course-details_title">{I18n.t('courses.students_count')}</div>
+            <div className="course-details_value">{course.user_count}</div>
+          </div>
+          <div className="col">
+            <div className="course-details_title">{I18n.t('courses.user_role')}</div>
+            <div className="course-details_value">{course.user_role}</div>
+          </div>
+        </div>
+      </a>
     );
-  }
-});
+  });
 
+  return (
+    <div id="course-details">
+      <h3>{I18n.t('courses.course_details')}</h3>
+      {elements}
+    </div>
+  );
+};
+
+CourseDetails.propTypes = {
+  courses: PropTypes.array
+};
 
 export default CourseDetails;


### PR DESCRIPTION
With reference to #5393

## What this PR does

Converts `statistics_update_info.jsx`, `block_type_select.jsx` and `course_details.jsx` into functional components
**Affected Pages:**
- `/courses/[institution_name]/[course_name]` (for `statistics_update_info.jsx`)
- `/courses/[institution_name]/[course_name]/timeline` (for `block_type_select.jsx`)
- `/users/[username]` (for `course_details.jsx`)

## Videos/Screenshots
Before `statistics_update_info.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/5de4c0c0-0c8a-4710-8f43-5dfba76afacc

After `statistics_update_info.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/d3e1bc8e-c50f-49e8-8b10-4bd65903f01c

Before `block_type_select.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/00415809-01e2-483e-84d3-774aa6c5a722

After `block_type_select.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/bb41e2fb-5784-4d66-8b92-97e3437cc930

Before `course_details.jsx`

![before refactor CourseDetails](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/63bbf646-fe7b-40c5-970e-8046bb51af51)

After `course_details.jsx`

![after refactor CourseDetails](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/0c34217d-7c2a-40c5-a712-3700e79c27ec)
