### PR TITLE
Converting ContributionStats, InstructorStats, Notifications and MainspaceChecklist into functional components

### DIFF
--- a/app/assets/javascripts/components/common/mainspace_checklist.jsx
+++ b/app/assets/javascripts/components/common/mainspace_checklist.jsx
@@ -1,67 +1,57 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
-import OnClickOutside from 'react-onclickoutside';
+import React, { useState } from 'react';
+import useOutsideClick from '../../hooks/useOutsideClick';
 
-const MainspaceChecklist = createReactClass({
-  displayName: 'MainspaceChecklist',
+const MainspaceChecklist = () => {
+  const [isVisible, setIsVisible] = useState(false);
 
-  getInitialState() {
-    return {
-      show: false
-    };
-  },
+  const show = () => {
+    setIsVisible(true);
+  };
 
-  show() {
-    this.setState({ show: true });
-  },
+  const hide = () => {
+    setIsVisible(false);
+  };
 
-  hide() {
-    this.setState({ show: false });
-  },
+  const ref = useOutsideClick(hide);
 
-  handleClickOutside() {
-    this.hide();
-  },
 
-  render() {
-    let button;
-    if (this.state.show) {
-      button = <button onClick={this.hide} className="button dark small">Okay</button>;
-    } else {
-      button = <a onClick={this.show} className="button dark small">Quality checklist</a>;
-    }
+  let button;
+  if (isVisible) {
+    button = <button onClick={hide} className="button dark small">Okay</button>;
+  } else {
+    button = <a onClick={show} className="button dark small">Quality checklist</a>;
+  }
 
-    let modal;
-    if (!this.state.show) {
-      modal = <div className="empty" />;
-    } else {
-      modal = (
-        <div className="article-viewer my-assignment-checklist">
-          <h2>Quality checklist</h2>
-          <p>
-            Before your article can become a live Wikipedia
-            article, make sure meets all these criteria.
-          </p>
-          <dl>
-            <dd><input type="checkbox" /> It starts with a clear definition of the topic, with the title in the first sentence in <strong>bold</strong>.</dd>
-            <dd><input type="checkbox" /> It has a lead section — which comes before any section headers — that provides an overview of the topic.</dd>
-            <dd><input type="checkbox" /> If it has additional sections after the lead, they have content, not just a placeholder.</dd>
-            <dd><input type="checkbox" /> The content has inline citations, not just a bibliography.</dd>
-            <dd><input type="checkbox" /> It has a &quot;References&quot; section after the body of the article.</dd>
-            <dd><input type="checkbox" /> All comments, notes, and outlines have been removed from the draft.</dd>
-          </dl>
-          {button}
-        </div>
-      );
-    }
-
-    return (
-      <div>
+  let modal;
+  if (!isVisible) {
+    modal = <div className="empty" />;
+  } else {
+    modal = (
+      <div ref={ref} className="article-viewer my-assignment-checklist">
+        <h2>Quality checklist</h2>
+        <p>
+          Before your article can become a live Wikipedia
+          article, make sure meets all these criteria.
+        </p>
+        <dl>
+          <dd><input type="checkbox" /> It starts with a clear definition of the topic, with the title in the first sentence in <strong>bold</strong>.</dd>
+          <dd><input type="checkbox" /> It has a lead section — which comes before any section headers — that provides an overview of the topic.</dd>
+          <dd><input type="checkbox" /> If it has additional sections after the lead, they have content, not just a placeholder.</dd>
+          <dd><input type="checkbox" /> The content has inline citations, not just a bibliography.</dd>
+          <dd><input type="checkbox" /> It has a &quot;References&quot; section after the body of the article.</dd>
+          <dd><input type="checkbox" /> All comments, notes, and outlines have been removed from the draft.</dd>
+        </dl>
         {button}
-        {modal}
       </div>
     );
   }
-});
 
-export default OnClickOutside(MainspaceChecklist);
+  return (
+    <div>
+      {button}
+      {modal}
+    </div>
+  );
+};
+
+export default MainspaceChecklist;

--- a/app/assets/javascripts/components/common/notifications.jsx
+++ b/app/assets/javascripts/components/common/notifications.jsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { removeNotification } from '../../actions/notification_actions.js';
 
-export const Notifications = createReactClass({
-  displayName: 'Notifications',
+export const Notifications = () => {
+  const dispatch = useDispatch();
+  const notifications = useSelector(state => state.notifications);
 
+  const _handleClose = (notification) => {
+    dispatch(removeNotification(notification));
+  };
 
-  _handleClose(notification) {
-    return this.props.removeNotification(notification);
-  },
-
-  _renderNotification(notification, i) {
+  const _renderNotification = (notification, i) => {
     let message;
     let className = 'notice';
     if (notification.type === 'error') {
@@ -35,7 +34,7 @@ export const Notifications = createReactClass({
     let closeIcon;
     if (notification.closable) {
       closeIcon = (
-        <svg tabIndex="0" onClick={this._handleClose.bind(this, notification)} viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" style={{ fill: 'currentcolor', verticalAlign: 'middle', width: '32px', height: '32px' }}><g><path d="M19 6.41l-1.41-1.41-5.59 5.59-5.59-5.59-1.41 1.41 5.59 5.59-5.59 5.59 1.41 1.41 5.59-5.59 5.59 5.59 1.41-1.41-5.59-5.59z" /></g></svg>
+        <svg tabIndex="0" onClick={() => _handleClose(notification)} viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" style={{ fill: 'currentcolor', verticalAlign: 'middle', width: '32px', height: '32px' }}><g><path d="M19 6.41l-1.41-1.41-5.59 5.59-5.59-5.59-1.41 1.41 5.59 5.59-5.59 5.59 1.41 1.41 5.59-5.59 5.59 5.59 1.41-1.41-5.59-5.59z" /></g></svg>
       );
     }
 
@@ -47,23 +46,15 @@ export const Notifications = createReactClass({
         </div>
       </div>
     );
-  },
+  };
 
-  render() {
-    const notifications = this.props.notifications.map((n, i) => this._renderNotification(n, i));
+  const renderedNotifs = notifications.map((n, i) => _renderNotification(n, i));
 
-    return (
-      <div className="notifications">
-        {notifications}
-      </div>
-    );
-  }
-});
+  return (
+    <div className="notifications">
+      {renderedNotifs}
+    </div>
+  );
+};
 
-const mapStateToProps = state => ({
-  notifications: state.notifications
-});
-
-const mapDispatchToProps = { removeNotification };
-
-export default connect(mapStateToProps, mapDispatchToProps)(Notifications);
+export default (Notifications);

--- a/app/assets/javascripts/components/user_profiles/contribution_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/contribution_stats.jsx
@@ -1,65 +1,51 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import InstructorStats from './instructor_stats.jsx';
 import StudentStats from './student_stats.jsx';
 
-const getState = function () {
-  const isStudent = JSON.parse(document.querySelector('#react_root')?.dataset.isstudent);
-  const isInstructor = JSON.parse(document.querySelector('#react_root')?.dataset.isinstructor);
-  return {
-    isStudent: isStudent,
-    isInstructor: isInstructor,
-    statsGraphsData: null
-  };
-};
+const ContributionStats = ({ params, stats, statsGraphsData }) => {
+  const [isStudent] = useState(JSON.parse(document.querySelector('#react_root')?.dataset.isstudent));
+  const [isInstructor] = useState(JSON.parse(document.querySelector('#react_root')?.dataset.isinstructor));
 
-const ContributionStats = createReactClass({
-  propTypes: {
-    params: PropTypes.object,
-    stats: PropTypes.object.isRequired
-  },
-
-  getInitialState() {
-    return getState();
-  },
-
-  render() {
-    let contriStats;
-    const graphWidth = 800;
-    const graphHeight = 250;
-    if (this.state.isInstructor.instructor) {
-      contriStats = (
-        <InstructorStats
-          username = {this.props.params.username}
-          stats = {this.props.stats}
-          isStudent = {this.state.isStudent.student}
-          statsGraphsData = {this.props.statsGraphsData}
-          graphWidth = {graphWidth}
-          graphHeight={graphHeight}
-          maxProject = {this.props.stats.max_project}
-        />
-      );
-    } else if (this.state.isStudent.student) {
-      contriStats = (
-        <StudentStats
-          username = {this.props.params.username}
-          stats = {this.props.stats.as_student}
-          statsGraphsData = {this.props.statsGraphsData}
-          graphWidth = {graphWidth}
-          graphHeight={graphHeight}
-          maxProject = {this.props.stats.max_project}
-        />
+  let contriStats;
+  const graphWidth = 800;
+  const graphHeight = 250;
+  if (isInstructor.instructor) {
+    contriStats = (
+      <InstructorStats
+        username={params.username}
+        stats={stats}
+        isStudent={isStudent.student}
+        statsGraphsData={statsGraphsData}
+        graphWidth={graphWidth}
+        graphHeight={graphHeight}
+        maxProject={stats.max_project}
+      />
     );
-    }
-
-    return (
-      <div id="statistics">
-        <h3>{I18n.t('users.contribution_statistics')}</h3>
-        {contriStats}
-      </div>
+  } else if (isStudent.student) {
+    contriStats = (
+      <StudentStats
+        username={params.username}
+        stats={stats.as_student}
+        statsGraphsData={statsGraphsData}
+        graphWidth={graphWidth}
+        graphHeight={graphHeight}
+        maxProject={stats.max_project}
+      />
     );
   }
-});
+
+  return (
+    <div id="statistics">
+      <h3>{I18n.t('users.contribution_statistics')}</h3>
+      {contriStats}
+    </div>
+  );
+};
+
+ContributionStats.propTypes = {
+  params: PropTypes.object,
+  stats: PropTypes.object.isRequired
+};
 
 export default ContributionStats;

--- a/app/assets/javascripts/components/user_profiles/instructor_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/instructor_stats.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import ByStudentsStats from './by_students_stats.jsx';
 import StudentStats from './student_stats.jsx';
@@ -7,123 +6,113 @@ import CoursesTaughtGraph from './graphs/as_instructor_graphs/courses_taught_gra
 import StudentsTaughtGraph from './graphs/as_instructor_graphs/students_taught_graph.jsx';
 import Loading from '../common/loading.jsx';
 
-const InstructorStats = createReactClass({
-  propTypes: {
-    username: PropTypes.string,
-    stats: PropTypes.object,
-    isStudent: PropTypes.bool,
-    statsGraphsData: PropTypes.object,
-    graphWidth: PropTypes.number,
-    graphHeight: PropTypes.number,
-    maxProject: PropTypes.string
-  },
+const InstructorStats = ({ username, stats, maxProject, statsGraphsData, graphWidth, graphHeight, isStudent }) => {
+  const [selectedGraph, setSelectedGraph] = useState('courses_count');
+  const [coursesGraph, setCoursesGraph] = useState(true);
 
-  getInitialState() {
-    return {
-      selectedGraph: 'courses_count',
-      coursesGraph: true
-    };
-  },
+  const setCoursesCountGraph = () => {
+    setSelectedGraph('courses_count');
+    setCoursesGraph(true);
+  };
 
-  setCoursesCountGraph() {
-    this.setState({
-      selectedGraph: 'courses_count',
-      coursesGraph: true
-    });
-  },
+  const setStudentsCountGraph = () => {
+    setSelectedGraph('students_count');
+    setCoursesGraph(false);
+  };
 
-  setStudentsCountGraph() {
-    this.setState({
-      selectedGraph: 'students_count',
-      coursesGraph: false
-    });
-  },
-
-  render() {
-    let asStudent;
-    let statsVisualizations;
-    const byStudents = (
-      <ByStudentsStats
-        username = {this.props.username}
-        stats={this.props.stats.by_students}
-        maxProject={this.props.maxProject}
-      />
-    );
-    if (this.state.selectedGraph === 'courses_count') {
-      if (this.props.statsGraphsData != null) {
-        statsVisualizations = (
-          <CoursesTaughtGraph
-            statsData = {this.props.statsGraphsData.instructor_stats}
-            graphWidth = {this.props.graphWidth}
-            graphHeight = {this.props.graphHeight}
-            courseStringPrefix = {this.props.stats.as_instructor.course_string_prefix}
-          />
-         );
-      } else {
-        statsVisualizations = <Loading />;
-      }
-    } else if (this.state.selectedGraph === 'students_count') {
+  let asStudent;
+  let statsVisualizations;
+  const byStudents = (
+    <ByStudentsStats
+      username={username}
+      stats={stats.by_students}
+      maxProject={maxProject}
+    />
+  );
+  if (selectedGraph === 'courses_count') {
+    if (statsGraphsData != null) {
       statsVisualizations = (
-        <StudentsTaughtGraph
-          statsData = {this.props.statsGraphsData.student_count}
-          graphWidth = {this.props.graphWidth}
-          graphHeight = {this.props.graphHeight}
-          courseStringPrefix = {this.props.stats.as_instructor.course_string_prefix}
-        />
-       );
-    }
-    if (this.props.isStudent) {
-      asStudent = (
-        <StudentStats
-          username = {this.props.username}
-          stats={this.props.stats.as_student}
-          maxProject = {this.props.maxProject}
+        <CoursesTaughtGraph
+          statsData={statsGraphsData.instructor_stats}
+          graphWidth={graphWidth}
+          graphHeight={graphHeight}
+          courseStringPrefix={stats.as_instructor.course_string_prefix}
         />
       );
+    } else {
+      statsVisualizations = <Loading />;
     }
-    return (
-      <div className= "user_stats">
-        <div id = "instructor-profile-stats">
-          <h5>
-            {I18n.t('user_profiles.instructor_impact', { username: this.props.username })}
-          </h5>
-          <div className= "stat-display">
-            <div onClick={this.setCoursesCountGraph} className={`stat-display__stat button${this.state.coursesGraph ? ' active-button' : ''}`}>
-              <div className="stat-display__value">
-                {this.props.stats.as_instructor.courses_count}
-              </div>
-              <small>
-                {I18n.t(`${this.props.stats.as_instructor.course_string_prefix}.courses_taught`)}
-              </small>
-            </div>
-            <div onClick={this.setStudentsCountGraph} className ={`stat-display__stat tooltip-trigger button${this.state.coursesGraph ? '' : ' active-button'}`}>
-              <div className="stat-display__value">
-                {this.props.stats.as_instructor.user_count}
-                <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
-              </div>
-              <small>
-                {I18n.t(`${this.props.stats.as_instructor.course_string_prefix}.students`)}
-              </small>
-              <div className="tooltip dark">
-                <h4>
-                  {this.props.stats.as_instructor.trained_percent}
-                  %
-                </h4>
-                <p>
-                  {I18n.t('users.up_to_date_with_training')}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div id="visualizations">
-            {statsVisualizations}
-          </div>
-        </div>
-        {byStudents}
-        {asStudent}
-      </div>
+  } else if (selectedGraph === 'students_count') {
+    statsVisualizations = (
+      <StudentsTaughtGraph
+        statsData={statsGraphsData.student_count}
+        graphWidth={graphWidth}
+        graphHeight={graphHeight}
+        courseStringPrefix={stats.as_instructor.course_string_prefix}
+      />
     );
   }
-});
+  if (isStudent) {
+    asStudent = (
+      <StudentStats
+        username={username}
+        stats={stats.as_student}
+        maxProject={maxProject}
+      />
+    );
+  }
+  return (
+    <div className="user_stats">
+      <div id="instructor-profile-stats">
+        <h5>
+          {I18n.t('user_profiles.instructor_impact', { username: username })}
+        </h5>
+        <div className="stat-display">
+          <div onClick={setCoursesCountGraph} className={`stat-display__stat button${coursesGraph ? ' active-button' : ''}`}>
+            <div className="stat-display__value">
+              {stats.as_instructor.courses_count}
+            </div>
+            <small>
+              {I18n.t(`${stats.as_instructor.course_string_prefix}.courses_taught`)}
+            </small>
+          </div>
+          <div onClick={setStudentsCountGraph} className={`stat-display__stat tooltip-trigger button${coursesGraph ? '' : ' active-button'}`}>
+            <div className="stat-display__value">
+              {stats.as_instructor.user_count}
+              <img src="/assets/images/info.svg" alt="tooltip default logo" />
+            </div>
+            <small>
+              {I18n.t(`${stats.as_instructor.course_string_prefix}.students`)}
+            </small>
+            <div className="tooltip dark">
+              <h4>
+                {stats.as_instructor.trained_percent}
+                %
+              </h4>
+              <p>
+                {I18n.t('users.up_to_date_with_training')}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div id="visualizations">
+          {statsVisualizations}
+        </div>
+      </div>
+      {byStudents}
+      {asStudent}
+    </div>
+  );
+};
+
+InstructorStats.propTypes = {
+  username: PropTypes.string,
+  stats: PropTypes.object,
+  isStudent: PropTypes.bool,
+  statsGraphsData: PropTypes.object,
+  graphWidth: PropTypes.number,
+  graphHeight: PropTypes.number,
+  maxProject: PropTypes.string
+};
 
 export default InstructorStats;


### PR DESCRIPTION
With reference to #5393

## What this PR does

Converts `contribution_stats.jsx`, `instructor_stats.jsx`, `notifications.jsx` and `mainspace_checklist.jsx` into functional components
**Affected Pages:**

- `/users/[username]` (for `contribution_stats.jsx` and `instructor_stats.jsx`)
- All pages that use notifications (for `notifications.jsx`)
- `/courses/[institution_name]/[course_name]` (for `mainspace_checklist.jsx`)

## Videos/Screenshots
Before `contribution_stats.jsx` and `instructor_stats.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/9b23d850-e7c0-4647-9a54-8027a4faccc0

After `contribution_stats.jsx` and `instructor_stats.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/8cfcf181-9942-482e-8d5c-b77863d1122a

Before `notifications.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/7ecea8a9-de54-4359-8606-d2e57673e6aa

After `notifications.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/9d71300d-acac-419e-aeba-39bc0e04d1ca

Before `mainspace_checklist.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/325319d9-51bd-4012-b975-281f99a059d4

After `mainspace_checklist.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/2593f43c-6ab9-47bc-9b3f-7ed73f57c790


## Clarifications
The `notifications.jsx` change affects around 6 different pages, I decided to just show one of the pages in the above video, I have manually tested the other pages though.