### PR TITLE
Add multi-search functionality to tickets system

### DIFF
--- a/app/assets/javascripts/actions/tickets_actions.js
+++ b/app/assets/javascripts/actions/tickets_actions.js
@@ -100,16 +100,15 @@ export const readAllMessages = ticket => async (dispatch) => {
   dispatch({ type: SET_MESSAGES_TO_READ, data: json });
 };
 
-const fetchSomeTickets = async (dispatch, page, search, batchSize = 100) => {
+const fetchSomeTickets = async (dispatch, page, searchQuery, batchSize = 100) => {
   const offset = batchSize * page;
-  const paramsObj = { limit: batchSize, offset: offset };
+  let paramsObj = { limit: batchSize, offset: offset };
   // Initial display => TicketDispenser
   let path = '/td/tickets';
-  // if search param is set => search in DB
-  if (Object.keys(search).length >= 1) {
+  // if at least one search query value is not-empty => search in DB
+  if (!Object.values(searchQuery).every(val => val === '')) {
     path = '/tickets/search';
-    paramsObj.search = search.search;
-    paramsObj.what = search.what;
+    paramsObj = { ...paramsObj, ...searchQuery };
   }
   const url_query = new URLSearchParams(paramsObj).toString();
   const response = await request(`${path}?${url_query}`);
@@ -120,14 +119,14 @@ const fetchSomeTickets = async (dispatch, page, search, batchSize = 100) => {
 };
 
 // Fetch as many tickets as possible
-export const fetchTickets = (search = {}) => async (dispatch) => {
+export const fetchTickets = (searchQuery = {}) => async (dispatch) => {
   dispatch({ type: FETCH_TICKETS });
 
   const batches = Array.from({ length: 10 }, (_el, index) => index);
   // Ensures that each promise will run sequentially
   return batches.reduce(async (previousPromise, batch) => {
     await previousPromise;
-    return fetchSomeTickets(dispatch, batch, search);
+    return fetchSomeTickets(dispatch, batch, searchQuery);
   }, Promise.resolve());
 };
 

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -169,6 +169,7 @@ const TicketsHandler = () => {
           <button
             onClick={clearSearch}
             className="button"
+            name="clear_search"
           >
             Clear search
           </button>

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -121,30 +121,30 @@ const TicketsHandler = () => {
             name="tickets_search"
             value={searchQuery.by_email_or_username}
             onChange={e => updateSearchQuery(e, 'by_email_or_username')}
-            placeholder={I18n.t('tickets.search_bar_placeholder')}
+            placeholder="Search by email or username"
           />
           <input
             type="text"
             name="tickets_search"
             value={searchQuery.in_subject}
             onChange={e => updateSearchQuery(e, 'in_subject')}
-            placeholder={I18n.t('tickets.search_bar_placeholder')}
+            placeholder="Search by subject"
           />
           <input
             type="text"
             name="tickets_search"
             value={searchQuery.in_content}
             onChange={e => updateSearchQuery(e, 'in_content')}
-            placeholder={I18n.t('tickets.search_bar_placeholder')}
+            placeholder="Search by content"
           />
           <input
             type="text"
             name="tickets_search"
             value={searchQuery.by_course}
             onChange={e => updateSearchQuery(e, 'by_course')}
-            placeholder={I18n.t('tickets.search_bar_placeholder')}
+            placeholder="Search by course"
           />
-          <button onClick={doSearch} className="button dark">Search Tickets</button>
+          <button onClick={doSearch} className="button dark">{I18n.t('tickets.search_bar_placeholder')}</button>
         </div>
       </div>
       <hr />

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -95,8 +95,9 @@ const TicketsHandler = () => {
       sortable: false
     }
   };
-
   const TICKETS_PER_PAGE = 10;
+
+  const isEmptySearch = Object.values(searchQuery).every(val => val === '');
 
   const pagesLength = Math.floor((filteredTickets.length - 1) / TICKETS_PER_PAGE) + 1;
   const elements = getTickets()
@@ -160,6 +161,7 @@ const TicketsHandler = () => {
           <button
             onClick={doSearch}
             className="button dark"
+            disabled={isEmptySearch}
           >
             {I18n.t('tickets.search_bar_placeholder')}
           </button>

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -45,6 +45,12 @@ const TicketsHandler = () => {
     dispatch(fetchTickets(searchQuery));
   };
 
+  const clearSearch = () => {
+    setMode('filter');
+    setSearchQuery({ by_email_or_username: '', in_subject: '', in_content: '', by_course: '', });
+    dispatch(fetchTickets());
+  };
+
   const getTickets = () => {
     if (mode === 'filter') {
       return filteredTickets;
@@ -149,40 +155,44 @@ const TicketsHandler = () => {
             onChange={e => updateSearchQuery(e, 'by_course')}
             placeholder="Search by course"
           />
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 10 }}>
           <button
-            style={{ gridColumn: '1 / span 2' }}
             onClick={doSearch}
             className="button dark"
           >
             {I18n.t('tickets.search_bar_placeholder')}
           </button>
+          <button
+            onClick={clearSearch}
+            className="button"
+          >
+            Clear search
+          </button>
         </div>
-
-
-
       </div>
       <hr />
-      {tickets.loading
-        ? <Loading />
-        : (
-          <>
-            <List
-              className="table--expandable table--hoverable"
-              elements={elements}
-              keys={keys}
-              sortBy={key => dispatch(sortTickets(key))}
-              sortable={true}
-              table_key="tickets"
-            />
-            <Pagination
-              currentPage={page}
-              goToPage={goToPage}
-              length={pagesLength}
-            />
-          </>
-        )}
-
-
+      {
+        tickets.loading
+          ? <Loading />
+          : (
+            <>
+              <List
+                className="table--expandable table--hoverable"
+                elements={elements}
+                keys={keys}
+                sortBy={key => dispatch(sortTickets(key))}
+                sortable={true}
+                table_key="tickets"
+              />
+              <Pagination
+                currentPage={page}
+                goToPage={goToPage}
+                length={pagesLength}
+              />
+            </>
+          )
+      }
     </main >
   );
 };

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -130,28 +130,28 @@ const TicketsHandler = () => {
         >
           <input
             type="text"
-            name="tickets_search"
+            name="tickets_search_email_or_username"
             value={searchQuery.by_email_or_username}
             onChange={e => updateSearchQuery(e, 'by_email_or_username')}
             placeholder="Search by email or username"
           />
           <input
             type="text"
-            name="tickets_search"
+            name="tickets_search_subject"
             value={searchQuery.in_subject}
             onChange={e => updateSearchQuery(e, 'in_subject')}
             placeholder="Search by subject"
           />
           <input
             type="text"
-            name="tickets_search"
+            name="tickets_search_content"
             value={searchQuery.in_content}
             onChange={e => updateSearchQuery(e, 'in_content')}
             placeholder="Search by content"
           />
           <input
             type="text"
-            name="tickets_search"
+            name="tickets_search_course"
             value={searchQuery.by_course}
             onChange={e => updateSearchQuery(e, 'by_course')}
             placeholder="Search by course"
@@ -161,6 +161,7 @@ const TicketsHandler = () => {
           <button
             onClick={doSearch}
             className="button dark"
+            name="search_tickets"
             disabled={isEmptySearch}
           >
             {I18n.t('tickets.search_bar_placeholder')}

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -12,7 +12,7 @@ import { getFilteredTickets } from '../../selectors';
 
 const TicketsHandler = () => {
   const [page, setPage] = useState(0);
-  const [mode] = useState('filter');
+  const [mode, setMode] = useState('filter');
   const [searchQuery, setSearchQuery] = useState({ by_email_or_username: '', in_subject: '', in_content: '', by_course: '', });
 
   const dispatch = useDispatch();
@@ -41,6 +41,7 @@ const TicketsHandler = () => {
   };
 
   const doSearch = () => {
+    setMode('search');
     dispatch(fetchTickets(searchQuery));
   };
 
@@ -55,8 +56,6 @@ const TicketsHandler = () => {
   const goToPage = (newPage) => {
     setPage(newPage);
   };
-
-  if (tickets.loading) return <Loading />;
 
   const keys = {
     sender: {
@@ -148,19 +147,27 @@ const TicketsHandler = () => {
         </div>
       </div>
       <hr />
-      <List
-        className="table--expandable table--hoverable"
-        elements={elements}
-        keys={keys}
-        sortBy={key => dispatch(sortTickets(key))}
-        sortable={true}
-        table_key="tickets"
-      />
-      <Pagination
-        currentPage={page}
-        goToPage={goToPage}
-        length={pagesLength}
-      />
+      {tickets.loading
+        ? <Loading />
+        : (
+          <>
+            <List
+              className="table--expandable table--hoverable"
+              elements={elements}
+              keys={keys}
+              sortBy={key => dispatch(sortTickets(key))}
+              sortable={true}
+              table_key="tickets"
+            />
+            <Pagination
+              currentPage={page}
+              goToPage={goToPage}
+              length={pagesLength}
+            />
+          </>
+        )}
+
+
     </main >
   );
 };

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -114,51 +114,50 @@ const TicketsHandler = () => {
           <span className="pull-left w10">Owner: </span>
           <TicketOwnersFilter disabled={mode === 'search'} />
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '5px', marginTop: '5px' }}>
-
-          <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
-            <input
-              style={{ flex: 0.5 }}
-              type="text"
-              name="tickets_search"
-              value={searchQuery.by_email_or_username}
-              onChange={e => updateSearchQuery(e, 'by_email_or_username')}
-              placeholder="Search by email or username"
-            />
-            <input
-              style={{ flex: 0.5 }}
-              type="text"
-              name="tickets_search"
-              value={searchQuery.in_subject}
-              onChange={e => updateSearchQuery(e, 'in_subject')}
-              placeholder="Search by subject"
-            />
-          </div>
-
-          <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
-            <input
-              style={{ flex: 0.5 }}
-              type="text"
-              name="tickets_search"
-              value={searchQuery.in_content}
-              onChange={e => updateSearchQuery(e, 'in_content')}
-              placeholder="Search by content"
-            />
-            <input
-              style={{ flex: 0.5 }}
-              type="text"
-              name="tickets_search"
-              value={searchQuery.by_course}
-              onChange={e => updateSearchQuery(e, 'by_course')}
-              placeholder="Search by course"
-            />
-          </div>
-
-          <div style={{ display: 'flex', justifyContent: 'flex-start', marginTop: '10px' }}>
-            <button style={{ width: '100%' }} onClick={doSearch} className="button dark">{I18n.t('tickets.search_bar_placeholder')}</button>
-          </div>
-
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: '5px',
+          marginTop: '5px'
+        }}
+        >
+          <input
+            type="text"
+            name="tickets_search"
+            value={searchQuery.by_email_or_username}
+            onChange={e => updateSearchQuery(e, 'by_email_or_username')}
+            placeholder="Search by email or username"
+          />
+          <input
+            type="text"
+            name="tickets_search"
+            value={searchQuery.in_subject}
+            onChange={e => updateSearchQuery(e, 'in_subject')}
+            placeholder="Search by subject"
+          />
+          <input
+            type="text"
+            name="tickets_search"
+            value={searchQuery.in_content}
+            onChange={e => updateSearchQuery(e, 'in_content')}
+            placeholder="Search by content"
+          />
+          <input
+            type="text"
+            name="tickets_search"
+            value={searchQuery.by_course}
+            onChange={e => updateSearchQuery(e, 'by_course')}
+            placeholder="Search by course"
+          />
+          <button
+            style={{ gridColumn: '1 / span 2' }}
+            onClick={doSearch}
+            className="button dark"
+          >
+            {I18n.t('tickets.search_bar_placeholder')}
+          </button>
         </div>
+
 
 
       </div>

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -115,36 +115,52 @@ const TicketsHandler = () => {
           <TicketOwnersFilter disabled={mode === 'search'} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px', marginTop: '5px' }}>
-          <input
-            type="text"
-            name="tickets_search"
-            value={searchQuery.by_email_or_username}
-            onChange={e => updateSearchQuery(e, 'by_email_or_username')}
-            placeholder="Search by email or username"
-          />
-          <input
-            type="text"
-            name="tickets_search"
-            value={searchQuery.in_subject}
-            onChange={e => updateSearchQuery(e, 'in_subject')}
-            placeholder="Search by subject"
-          />
-          <input
-            type="text"
-            name="tickets_search"
-            value={searchQuery.in_content}
-            onChange={e => updateSearchQuery(e, 'in_content')}
-            placeholder="Search by content"
-          />
-          <input
-            type="text"
-            name="tickets_search"
-            value={searchQuery.by_course}
-            onChange={e => updateSearchQuery(e, 'by_course')}
-            placeholder="Search by course"
-          />
-          <button onClick={doSearch} className="button dark">{I18n.t('tickets.search_bar_placeholder')}</button>
+
+          <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
+            <input
+              style={{ flex: 0.5 }}
+              type="text"
+              name="tickets_search"
+              value={searchQuery.by_email_or_username}
+              onChange={e => updateSearchQuery(e, 'by_email_or_username')}
+              placeholder="Search by email or username"
+            />
+            <input
+              style={{ flex: 0.5 }}
+              type="text"
+              name="tickets_search"
+              value={searchQuery.in_subject}
+              onChange={e => updateSearchQuery(e, 'in_subject')}
+              placeholder="Search by subject"
+            />
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'row', gap: '5px' }}>
+            <input
+              style={{ flex: 0.5 }}
+              type="text"
+              name="tickets_search"
+              value={searchQuery.in_content}
+              onChange={e => updateSearchQuery(e, 'in_content')}
+              placeholder="Search by content"
+            />
+            <input
+              style={{ flex: 0.5 }}
+              type="text"
+              name="tickets_search"
+              value={searchQuery.by_course}
+              onChange={e => updateSearchQuery(e, 'by_course')}
+              placeholder="Search by course"
+            />
+          </div>
+
+          <div style={{ display: 'flex', justifyContent: 'flex-start', marginTop: '10px' }}>
+            <button style={{ width: '100%' }} onClick={doSearch} className="button dark">{I18n.t('tickets.search_bar_placeholder')}</button>
+          </div>
+
         </div>
+
+
       </div>
       <hr />
       {tickets.loading

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -31,7 +31,7 @@ const TicketsHandler = () => {
     if (searchByCourseParamInURL) {
       setSearchType('by_course');
       setSearchText(searchByCourseParamInURL);
-      dispatch(fetchTickets({ search: searchByCourseParamInURL, what: 'by_course' }));
+      dispatch(fetchTickets({ search: searchByCourseParamInURL, what: ['by_course'] }));
     } else if (!tickets.all.length) {
       dispatch(fetchTickets());
       dispatch(setInitialTicketFilters());
@@ -44,7 +44,7 @@ const TicketsHandler = () => {
   };
 
   const doSearch = () => {
-    dispatch(fetchTickets({ search: searchBarRef?.current.value, what: searchType }));
+    dispatch(fetchTickets({ search: searchBarRef?.current.value, what: [searchType] }));
     setSearchText(searchBarRef?.current.value);
   };
 

--- a/lib/tickets/ticket_query_object.rb
+++ b/lib/tickets/ticket_query_object.rb
@@ -2,8 +2,13 @@
 
 class TicketQueryObject
   def initialize(params)
-    @search = params[:search]
-    @whats = params[:what]
+    @whats = {
+      by_email_or_username: params[:by_email_or_username],
+      in_subject: params[:in_subject],
+      in_content: params[:in_content],
+      by_course: params[:by_course]
+    }
+    @whats.delete_if { |_, value| value.nil? || value.empty? }
     @offset = params[:offset] || 0
     @limit = params[:limit] || 100
   end
@@ -11,41 +16,42 @@ class TicketQueryObject
   def search
     query = tickets
 
-    @whats.each do |what|
-      case what
-      when 'by_email_or_username'
-        query = query.merge(search_by_username_or_by_email)
-      when 'in_subject'
-        query = query.merge(search_by_subject)
-      when 'in_content'
-        query = query.merge(search_by_content)
-      when 'by_course'
-        query = query.merge(search_by_course)
+    @whats.each do |key, value|
+
+      case key
+      when :by_email_or_username
+        query = query.merge(search_by_username_or_by_email(value))
+      when :in_subject
+        query = query.merge(search_by_subject(value))
+      when :in_content
+        query = query.merge(search_by_content(value))
+      when :by_course
+        query = query.merge(search_by_course(value))
       end
     end
 
     query.offset(@offset).limit(@limit)
   end
 
-  def search_by_username_or_by_email
-    sender_usernames = User.where(username: @search).or(User.where(email: @search)).pluck(:username)
+  def search_by_username_or_by_email(search_text)
+    sender_usernames = User.where(username: search_text).or(User.where(email: search_text)).pluck(:username)
     tickets.where(sender: { username: sender_usernames })
   end
 
-  def search_by_content
-    message_ids = TicketDispenser::Message.where('content LIKE ?', "%#{@search}%").pluck(:id)
+  def search_by_content(search_text)
+    message_ids = TicketDispenser::Message.where('content LIKE ?', "%#{search_text}%").pluck(:id)
     tickets.where(messages: { id: message_ids })
   end
 
-  def search_by_subject
+  def search_by_subject(search_text)
     message_ids = TicketDispenser::Message.all.select do |ticket|
-      ticket[:details][:subject]&.match?(/#{@search}/i)
+      ticket[:details][:subject]&.match?(/#{search_text}/i)
     end.pluck(:id)
     tickets.where(messages: { id: message_ids })
   end
 
-  def search_by_course
-    course = Course.find_by(slug: @search)
+  def search_by_course(search_text)
+    course = Course.find_by(slug: search_text)
     tickets.where(project: course)
   end
 

--- a/lib/tickets/ticket_query_object.rb
+++ b/lib/tickets/ticket_query_object.rb
@@ -17,7 +17,6 @@ class TicketQueryObject
     query = tickets
 
     @whats.each do |key, value|
-
       case key
       when :by_email_or_username
         query = query.merge(search_by_username_or_by_email(value))
@@ -34,7 +33,9 @@ class TicketQueryObject
   end
 
   def search_by_username_or_by_email(search_text)
-    sender_usernames = User.where(username: search_text).or(User.where(email: search_text)).pluck(:username)
+    sender_usernames = User.where(username: search_text)
+                           .or(User.where(email: search_text))
+                           .pluck(:username)
     tickets.where(sender: { username: sender_usernames })
   end
 

--- a/spec/features/tickets_dashboard_spec.rb
+++ b/spec/features/tickets_dashboard_spec.rb
@@ -44,33 +44,21 @@ describe 'ticket dashboard', type: :feature, js: true do
     )
   end
 
-  let(:select_from_selectbox) do
-    lambda do |txt|
-      find('#search_type_selector').click
-      within '#search_type_selector' do
-        selector = 'div[id^="react-select-search-type-option"]'
-        find(selector, text: txt).click
-      end
-    end
-  end
-
   before do
     login_as admin
     visit '/tickets/dashboard'
   end
 
-  it 'displays a select input to chose search mode' do
-    expect(page).to have_selector '#search_type_selector'
+  it 'displays all search bars' do
+    expect(page).to have_field 'tickets_search_email_or_username'
+    expect(page).to have_field 'tickets_search_subject'
+    expect(page).to have_field 'tickets_search_content'
+    expect(page).to have_field 'tickets_search_course'
   end
 
-  it 'displays a search bar' do
-    expect(page).to have_field 'tickets_search'
-  end
-
-  it 'searchs for a token' do
-    select_from_selectbox.call('Search by email or user name')
-    fill_in 'tickets_search', with: 'no one is here'
-    find('input[name="tickets_search"]').send_keys(:enter)
+  it 'searches for a token' do
+    fill_in 'tickets_search_content', with: 'no one is here'
+    click_button 'search_tickets'
 
     expect(page).to have_content 'No tickets'
   end
@@ -89,27 +77,22 @@ describe 'ticket dashboard', type: :feature, js: true do
     end
 
     it 'finds one match with email' do
-      select_from_selectbox.call('Search by email or user name')
-      fill_in 'tickets_search', with: 'aron@packers.nfl.org'
-      find('input[name="tickets_search"]').send_keys(:enter)
+      fill_in 'tickets_search_email_or_username', with: 'aron@packers.nfl.org'
+      click_button 'search_tickets'
 
       expect(page).to have_content 'arogers'
     end
 
     it 'finds one match with username' do
-      select_from_selectbox.call('Search by email or user name')
-
-      fill_in 'tickets_search', with: 'pmahomes'
-      find('input[name="tickets_search"]').send_keys(:enter)
+      fill_in 'tickets_search_email_or_username', with: 'pmahomes'
+      click_button 'search_tickets'
 
       expect(page).to have_content 'pmahomes'
     end
 
     it 'finds two matches in subject' do
-      select_from_selectbox.call('Search in subject')
-
-      fill_in 'tickets_search', with: 'subject'
-      find('input[name="tickets_search"]').send_keys(:enter)
+      fill_in 'tickets_search_subject', with: 'subject'
+      click_button 'search_tickets'
 
       nb_of_lines = within 'tbody' do
         all('tr[class^="table-row"]')
@@ -119,10 +102,8 @@ describe 'ticket dashboard', type: :feature, js: true do
     end
 
     it 'finds one match in content' do
-      select_from_selectbox.call('Search in content')
-
-      fill_in 'tickets_search', with: 'splash'
-      find('input[name="tickets_search"]').send_keys(:enter)
+      fill_in 'tickets_search_content', with: 'splash'
+      click_button 'search_tickets'
 
       nb_of_lines = within 'tbody' do
         all('tr[class^="table-row"]')
@@ -132,10 +113,8 @@ describe 'ticket dashboard', type: :feature, js: true do
     end
 
     it 'finds one match by course slug' do
-      select_from_selectbox.call('Search by course slug')
-
-      fill_in 'tickets_search', with: 'NASA_School/Fly_me_to_the_moon'
-      find('input[name="tickets_search"]').send_keys(:enter)
+      fill_in 'tickets_search_course', with: 'NASA_School/Fly_me_to_the_moon'
+      click_button 'search_tickets'
 
       nb_of_lines = within 'tbody' do
         all('tr[class^="table-row"]')
@@ -145,10 +124,8 @@ describe 'ticket dashboard', type: :feature, js: true do
     end
 
     it 'finds no match with an unknown slug' do
-      select_from_selectbox.call('Search by course slug')
-
-      fill_in 'tickets_search', with: 'Unknown_School/school_is_closed'
-      find('input[name="tickets_search"]').send_keys(:enter)
+      fill_in 'tickets_search_course', with: 'Unknown_School/school_is_closed'
+      click_button 'search_tickets'
 
       nb_of_lines = within 'tbody' do
         all('tr[class^="table-row"]')
@@ -167,7 +144,7 @@ describe 'ticket dashboard', type: :feature, js: true do
       expect(url.path).to eq '/tickets/dashboard'
       expect(param).to eq 'search_by_course'
       expect(slug).to eq course.slug
-      expect(find('input[name="tickets_search"]').value).to eq course.slug
+      expect(find('input[name="tickets_search_course"]').value).to eq course.slug
       expect(find_link(course.title).visible?).to be true
     end
 
@@ -186,7 +163,7 @@ describe 'ticket dashboard', type: :feature, js: true do
         expect(url.path).to eq '/tickets/dashboard'
         expect(param).to eq 'search_by_course'
         expect(slug).to eq course.slug
-        expect(find('input[name="tickets_search"]').value).to eq course.slug
+        expect(find('input[name="tickets_search_course"]').value).to eq course.slug
         expect(find_link(course.title).visible?).to be true
       end
     end


### PR DESCRIPTION
closes #5481 
## What this PR does
This PR adds the ability to utilize multiple search types at the same time when searching for tickets. Now users should be able to use all 4 search types at the same time.

I've gone ahead and removed the select fields that were being used before. Instead, we now have 4 inputs fields and 2 buttons, the "clear search" buttons clears the current search and makes the filters available to the user again. The "search tickets" button queries the tickets and returns the result.

I have also added a few UI tweaks such as making the loading animation only take up the tickets table and not the entire page. And making the "search tickets" button greyed out when all the input fields are empty

## Videos
Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/c91716ae-91c3-4326-b3d9-e59b475c8f94

After:
Main search functionality:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a1d045e2-db40-4a74-b11f-463b8e278177

Clearing search and getting all course tickets:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/8842593e-ab54-425f-8eff-90301f3b3670


