### PR TITLE
prevent subcategories from showing up in article titles

### DIFF
--- a/lib/importers/category_importer.rb
+++ b/lib/importers/category_importer.rb
@@ -61,11 +61,11 @@ class CategoryImporter
     CategoryUtils.get_titles(subcats_pages)
   end
 
-  def category_query(category, namespace=0)
+  def category_query(category, namespace)
     { list: 'categorymembers',
       cmtitle: category,
       cmlimit: 500,
-      cmnamespace: namespace, # mainspace articles by default
+      cmnamespace: namespace || 0, # mainspace articles by default
       continue: '' }
   end
 end

--- a/spec/lib/importers/category_importer_spec.rb
+++ b/spec/lib/importers/category_importer_spec.rb
@@ -9,12 +9,17 @@ describe CategoryImporter do
 
   describe '.page_titles_for_category' do
     context 'for depth 0' do
-      let(:category) { 'Category:AfD debates' }
+      let(:category) { 'Category:Earth sciences' }
       let(:depth) { 0 }
 
       it 'returns page page titles for a given category' do
         VCR.use_cassette 'category_importer/page_titles' do
-          expect(subject).to include('Category:AfD debates (Places and transportation)')
+          # this is a direct article in the category
+          expect(subject).to include('List of flood basalt provinces')
+
+          # this is a subcategory which should not be included
+          expect(subject).not_to include('Category: Earth scientists')
+          expect(subject).not_to include('Category:Earth sciences')
         end
       end
     end
@@ -29,6 +34,9 @@ describe CategoryImporter do
         VCR.use_cassette 'category_importer/page_titles' do
           expect(subject).to include(article_in_cat)
           expect(subject).to include(article_in_subcat)
+
+          # this is a subcategory which should not be included
+          expect(subject).not_to include('Category:Monty Python members')
         end
       end
     end


### PR DESCRIPTION
This was caused by the fact that we were always passing `namespace` to `category_query` - even when it was `nil`. This meant that the default `0` value for namespace was always ignored.