### PR TITLE
Converting Campaign, UserProfile and AssignmentList into functional components, removing unnecessary CampaignOverviewHandler component

### DIFF
--- a/app/assets/javascripts/components/assignments/assignment_list.jsx
+++ b/app/assets/javascripts/components/assignments/assignment_list.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { sortBy, groupBy, compact } from 'lodash-es';
 
@@ -8,87 +7,81 @@ import Assignment from './assignment.jsx';
 import { getFiltered } from '../../utils/model_utils.js';
 import ArticleUtils from '../../utils/article_utils.js';
 
-const AssignmentList = createReactClass({
-  displayName: 'AssignmentList',
-
-  propTypes: {
-    articles: PropTypes.array,
-    assignments: PropTypes.array,
-    course: PropTypes.object,
-    current_user: PropTypes.object,
-    wikidataLabels: PropTypes.object
-  },
-
-  componentDidMount() {
+const AssignmentList = ({ course, assignments, articles, current_user, wikidataLabels, }) => {
+  useEffect(() => {
     // sets the title of this tab
-    const project = this.props.course.home_wiki.project;
-    document.title = `${this.props.course.title} - ${ArticleUtils.I18n('assigned', project)}`;
-  },
+    const project = course.home_wiki.project;
+    document.title = `${course.title} - ${ArticleUtils.I18n('assigned', project)}`;
+  }, []);
 
-  hasAssignedUser(group) {
+  const hasAssignedUser = (group) => {
     return group.some((assignment) => {
       return assignment.user_id;
     });
-  },
+  };
 
-  render() {
-    const allAssignments = this.props.assignments;
-    const sortedAssignments = sortBy(allAssignments, assignment => assignment.article_title);
-    const grouped = groupBy(sortedAssignments, assignment => assignment.article_title);
-    let elements = Object.keys(grouped).map((title) => {
-      const group = grouped[title];
-      if (!this.hasAssignedUser(group)) { return null; }
-      const article = getFiltered(this.props.articles, { title })[0];
-      return (
-        <Assignment
-          key={group[0].id}
-          assignmentGroup={group}
-          article={article || null}
-          course={this.props.course}
-          current_user={this.props.current_user}
-          wikidataLabel={this.props.wikidataLabels[title]}
-        />
-      );
-    });
-    elements = compact(elements);
-
-    const keys = {
-      rating_num: {
-        label: I18n.t('articles.rating'),
-        desktop_only: true
-      },
-      title: {
-        label: I18n.t('articles.title'),
-        desktop_only: false
-      },
-      assignee: {
-        label: I18n.t('assignments.assignees'),
-        desktop_only: true
-      },
-      reviewer: {
-        label: I18n.t('assignments.reviewers'),
-        desktop_only: true
-      }
-    };
-
-    const project = this.props.course.home_wiki.project;
-
+  const sortedAssignments = sortBy(assignments, assignment => assignment.article_title);
+  const grouped = groupBy(sortedAssignments, assignment => assignment.article_title);
+  let elements = Object.keys(grouped).map((title) => {
+    const group = grouped[title];
+    if (!hasAssignedUser(group)) { return null; }
+    const article = getFiltered(articles, { title })[0];
     return (
-      <div id="assignments" className="mt4">
-        <div className="section-header">
-          <h3>{ArticleUtils.I18n('assigned', project)}</h3>
-        </div>
-        <List
-          elements={elements}
-          keys={keys}
-          table_key={'assignments'}
-          none_message={ArticleUtils.I18n('assignments_none', project)}
-          sortable={false}
-        />
-      </div>
+      <Assignment
+        key={group[0].id}
+        assignmentGroup={group}
+        article={article || null}
+        course={course}
+        current_user={current_user}
+        wikidataLabel={wikidataLabels[title]}
+      />
     );
-  }
-}
-);
+  });
+  elements = compact(elements);
+
+  const keys = {
+    rating_num: {
+      label: I18n.t('articles.rating'),
+      desktop_only: true
+    },
+    title: {
+      label: I18n.t('articles.title'),
+      desktop_only: false
+    },
+    assignee: {
+      label: I18n.t('assignments.assignees'),
+      desktop_only: true
+    },
+    reviewer: {
+      label: I18n.t('assignments.reviewers'),
+      desktop_only: true
+    }
+  };
+
+  const project = course.home_wiki.project;
+
+  return (
+    <div id="assignments" className="mt4">
+      <div className="section-header">
+        <h3>{ArticleUtils.I18n('assigned', project)}</h3>
+      </div>
+      <List
+        elements={elements}
+        keys={keys}
+        table_key={'assignments'}
+        none_message={ArticleUtils.I18n('assignments_none', project)}
+        sortable={false}
+      />
+    </div>
+  );
+};
+
+AssignmentList.propTypes = {
+  articles: PropTypes.array,
+  assignments: PropTypes.array,
+  course: PropTypes.object,
+  current_user: PropTypes.object,
+  wikidataLabels: PropTypes.object
+};
 
 export default AssignmentList;

--- a/app/assets/javascripts/components/campaign/campaign.jsx
+++ b/app/assets/javascripts/components/campaign/campaign.jsx
@@ -1,73 +1,55 @@
-import { Route, Routes } from 'react-router-dom';
-import withRouter from '../util/withRouter';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { Route, Routes, useParams } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { getCampaign } from '../../actions/campaign_view_actions';
 import CampaignAlerts from '../alerts/campaign_alerts.jsx';
 import CampaignOresPlot from './campaign_ores_plot.jsx';
-import CampaignOverviewHandler from './campaign_overview_handler';
 import CampaignNavbar from '../common/campaign_navbar';
 import CampaignStats from './campaign_stats';
 import WikidataOverviewStats from '../common/wikidata_overview_stats';
+import CampaignStatsDownloadModal from './campaign_stats_download_modal';
 
-export const Campaign = createReactClass({
-  displayName: 'Campaign',
+export const Campaign = () => {
+  const dispatch = useDispatch();
+  const campaign = useSelector(state => state.campaign);
 
-  propTypes: {
-    campaign: PropTypes.object.isRequired,
-    match: PropTypes.object,
-  },
+  const { campaign_slug } = useParams();
 
-  componentDidMount() {
-    const campaignSlug = this.props.router.params.campaign_slug;
-    return this.props.getCampaign(campaignSlug);
-  },
+  useEffect(() => { dispatch(getCampaign(campaign_slug)); }, []);
 
-  render() {
-    if (this.props.campaign.loading) {
-      return <div />;
-    }
+  if (campaign.loading) {
+    return <div />;
+  }
 
-    let campaignHandler;
-    if (window.location.href.match(/overview/)) {
-      campaignHandler = (
-        <div className="high-modal">
-          <CampaignOverviewHandler {...this.props} />
-        </div>
-        );
-    }
-
-    return (
-      <div>
-        <CampaignNavbar
-          campaign={this.props.campaign}
-        />
-        <div className="container campaign_main">
-          <section className="overview container">
-            <CampaignStats campaign={this.props.campaign} />
-            {this.props.campaign.course_stats && <WikidataOverviewStats
-              statistics={this.props.campaign.course_stats['www.wikidata.org']}
-            />}
-          </section>
-          {campaignHandler}
-          <Routes>
-            <Route path="ores_plot" element={<CampaignOresPlot />} />
-            <Route path="alerts" element={<CampaignAlerts />} />
-          </Routes>
-        </div>
-      </div >
+  let campaignHandler;
+  if (window.location.href.match(/overview/)) {
+    campaignHandler = (
+      <div className="high-modal">
+        <CampaignStatsDownloadModal campaign_slug />
+      </div>
     );
   }
-});
 
-const mapStateToProps = state => ({
-  campaign: state.campaign,
-});
-
-const mapDispatchToProps = {
-  getCampaign
+  return (
+    <div>
+      <CampaignNavbar
+        campaign={campaign}
+      />
+      <div className="container campaign_main">
+        <section className="overview container">
+          <CampaignStats campaign={campaign} />
+          {campaign.course_stats && <WikidataOverviewStats
+            statistics={campaign.course_stats['www.wikidata.org']}
+          />}
+        </section>
+        {campaignHandler}
+        <Routes>
+          <Route path="ores_plot" element={<CampaignOresPlot />} />
+          <Route path="alerts" element={<CampaignAlerts />} />
+        </Routes>
+      </div>
+    </div >
+  );
 };
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Campaign));
+export default (Campaign);

--- a/app/assets/javascripts/components/campaign/campaign.jsx
+++ b/app/assets/javascripts/components/campaign/campaign.jsx
@@ -25,7 +25,7 @@ export const Campaign = () => {
   if (window.location.href.match(/overview/)) {
     campaignHandler = (
       <div className="high-modal">
-        <CampaignStatsDownloadModal campaign_slug />
+        <CampaignStatsDownloadModal campaign_slug={campaign_slug} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/campaign/campaign_overview_handler.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_overview_handler.jsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import CampaignStatsDownloadModal from './campaign_stats_download_modal';
-
-const CampaignOverviewHandler = (props) => {
-    return <CampaignStatsDownloadModal {...props} />;
-};
-
-export default CampaignOverviewHandler;

--- a/app/assets/javascripts/components/campaign/campaign_stats_download_modal.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_stats_download_modal.jsx
@@ -1,18 +1,15 @@
 import React, { useState } from 'react';
 
-const CampaignStatsDownloadModal = ({ router }) => {
+const CampaignStatsDownloadModal = ({ campaign_slug }) => {
   const [show, setShow] = useState(false);
 
-  const campaignSlug = router.params.campaign_slug;
-
-  const courseDataLink = `/campaigns/${campaignSlug}/courses.csv`;
-  const articlesEditedLink = `/campaigns/${campaignSlug}/articles_csv.csv`;
-  const RevisionsLink = `/campaigns/${campaignSlug}/revisions_csv.csv`;
-  const editorsLink = `/campaigns/${campaignSlug}/students.csv`;
-  const editorsByCourseLink = `/campaigns/${campaignSlug}/students.csv?course=true`;
-  const instructorsLink = `/campaigns/${campaignSlug}/instructors.csv?course=true`;
-  const wikidataLink = `/campaigns/${campaignSlug}/wikidata.csv`;
-
+  const courseDataLink = `/campaigns/${campaign_slug}/courses.csv`;
+  const articlesEditedLink = `/campaigns/${campaign_slug}/articles_csv.csv`;
+  const RevisionsLink = `/campaigns/${campaign_slug}/revisions_csv.csv`;
+  const editorsLink = `/campaigns/${campaign_slug}/students.csv`;
+  const editorsByCourseLink = `/campaigns/${campaign_slug}/students.csv?course=true`;
+  const instructorsLink = `/campaigns/${campaign_slug}/instructors.csv?course=true`;
+  const wikidataLink = `/campaigns/${campaign_slug}/wikidata.csv`;
 
   if (!show) {
     return (


### PR DESCRIPTION
With reference to #5393

## What this PR does

Converts `campaign.jsx`, `user_profile.jsx` and `assignment_list.jsx` into functional components and removes unnecessary `campaign_overview_handler.jsx` component
**Affected Pages:**

- `/campaigns/[campaign_slug]/[chosen_nav_page]` (for `campaign.jsx` )
- `/users/[username]` (for `user_profile.jsx` )
- `/courses/[institution_name]/[course_name]/articles/assigned` (for `assignment_list.jsx` )

## Videos/Screenshots
Before `campaign.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/ba951229-c913-4741-ae65-685aa273d4f8

After `campaign.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/a941cd15-ac2f-4d94-81a6-a397fd6b56ff

Before `user_profile.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/0c2df4b7-ecc1-4d6a-ba2f-90c047e5b438

After `user_profile.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/586a1d3a-eb6d-41ce-9fc4-872de1fe1a10

Before `assignment_list.jsx`

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/39212a66-700b-4490-a66c-f4605b6bed53

After `assignment_list.jsx` 

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/39999898/4eb31d36-d9da-40f8-8964-3c3414c3dc87



