### PR TITLE
Remove timelines from on-wiki course pages

### DIFF
--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -31,10 +31,6 @@ class WikiCourseOutput
     # Table of students, assigned articles, and reviews
     @output += students_table
 
-    # Timeline
-    @output += course_timeline unless @course.weeks.empty?
-
-    # TODO: grading
     @output
   end
 
@@ -81,48 +77,6 @@ class WikiCourseOutput
 
   def support_staff_username
     @first_support_staff&.username
-  end
-
-  def course_timeline
-    timeline = "{{#{template_name(@templates, 'timeline')}}}\r"
-    week_number = @course_meetings_manager.weeks_before_timeline
-    @course.weeks.each do |week|
-      week_number += 1
-      timeline += course_week(week, week_number)
-    end
-    timeline
-  end
-
-  def course_week(week, week_number)
-    week_output = week_header(week, week_number)
-
-    week.blocks.each do |block|
-      week_output += content_block(block)
-    end
-
-    week_output += "{{#{template_name(@templates, 'end_of_week')}}}\r"
-    week_output
-  end
-
-  def week_header(week, week_number)
-    header_output = "=== Week #{week_number} ===\r"
-
-    header_output += "{{#{template_name(@templates, 'start_of_week')}"
-    meeting_dates = @course_meetings_manager.meeting_dates_of(week).map(&:to_s)
-    header_output += '|' + meeting_dates.join('|') if meeting_dates.present?
-    header_output += "}}\r"
-    header_output
-  end
-
-  def content_block(block)
-    block_types = ['in class|In class - ',
-                   'assignment|Assignment - ',
-                   'assignment milestones|',
-                   'assignment|'] # TODO: get the custom value
-    block_type = block_types[block.kind] || 'assignment|' # fallback
-    block_output = "{{#{block_type}#{block.title}}}\r"
-    block_output += Wikitext.html_to_mediawiki(block.content)
-    block_output
   end
 
   def students_table

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -77,13 +77,8 @@ describe WikiCourseOutput do
              article_title: 'Your article')
       response = described_class.new(course.reload).translate_course_to_wikitext
       expect(response).to include('The course description')
-      expect(response).to include('{{start of course timeline')
-      expect(response).to include('Block 1 title')
-      expect(response).to include('* Overview of the course')
-      expect(response).to include('[http://wikiedu.org/editingwikipedia Editing Wikipedia]')
       expect(response).to include('[[My article]]')
       expect(response).to include('[[Your article]]')
-      expect(response).to include('{{start of course week|2016-01-11|2016-01-13|2016-01-15}}')
       expect(response).to include('Jacque')
       expect(response).to include('Campaign Title 1, Campaign Title 2')
     end


### PR DESCRIPTION
We can't easily ensure that timeline content translated from the Dashboard into wikicode will pass the Mediawiki linter, and having a copy of the course timeline isn't particularly useful in most cases, so I'm just ditching that feature.