### PR TITLE
Fix failing specs due to new wikipageviews API behavior when no data available

### DIFF
--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -99,23 +99,15 @@ class WikiPageviews
     return unless response
     data = Utils.parse_json(response)
     return data['items'] if data['items']
-    # As of October 2017, the data type is https://www.mediawiki.org/wiki/HyperSwitch/errors/not_found
-    return no_results if %r{errors/not_found}.match?(data['type'])
-    return no_results if no_data_available_response?(data)
+
+    # Since the API experienced some changes in the response when handling requests for which no
+    # data is available, we decided to rely only on the data status being 404 to return no results
+    return no_results if data['status'] == 404
     raise PageviewApiError, response
   end
 
   def no_results
     {}
-  end
-
-  # As of October 2023, we started to see 404 not found responses with about:blank type
-  # and a specific detail when handling requests for which no data is available
-  def no_data_available_response?(response)
-    no_data_avialable_detail = 'The date(s) you used are valid, but we either do not have data '\
-                               'for those date(s), or the project you asked for is not loaded yet.'\
-                               ' Please check documentation for more information.'
-    response['status'] == 404 && response['detail'] == no_data_avialable_detail
   end
 
   def wiki_url_param

--- a/lib/wiki_pageviews.rb
+++ b/lib/wiki_pageviews.rb
@@ -101,11 +101,21 @@ class WikiPageviews
     return data['items'] if data['items']
     # As of October 2017, the data type is https://www.mediawiki.org/wiki/HyperSwitch/errors/not_found
     return no_results if %r{errors/not_found}.match?(data['type'])
+    return no_results if no_data_available_response?(data)
     raise PageviewApiError, response
   end
 
   def no_results
     {}
+  end
+
+  # As of October 2023, we started to see 404 not found responses with about:blank type
+  # and a specific detail when handling requests for which no data is available
+  def no_data_available_response?(response)
+    no_data_avialable_detail = 'The date(s) you used are valid, but we either do not have data '\
+                               'for those date(s), or the project you asked for is not loaded yet.'\
+                               ' Please check documentation for more information.'
+    response['status'] == 404 && response['detail'] == no_data_avialable_detail
   end
 
   def wiki_url_param

--- a/spec/lib/wiki_pageviews_spec.rb
+++ b/spec/lib/wiki_pageviews_spec.rb
@@ -47,14 +47,12 @@ describe WikiPageviews do
 
       context 'beyond the allowed date range' do
         let(:start_date) { '2015-01-01'.to_date }
+        let(:end_date) { '2015-01-02'.to_date }
 
         it 'does not raise an error' do
-          stub_request(:any, /.*wikimedia.org.*/)
-            .to_return(
-              status: 404,
-              body: '{"type":"https://mediawiki.org/wiki/HyperSwitch/errors/not_found"}'
-            )
-          expect { subject }.not_to raise_error
+          VCR.use_cassette 'wiki_pageviews/views_for_article' do
+            expect { subject }.not_to raise_error
+          end
         end
       end
     end

--- a/spec/lib/wiki_pageviews_spec.rb
+++ b/spec/lib/wiki_pageviews_spec.rb
@@ -161,6 +161,8 @@ describe WikiPageviews do
       let(:title) { 'Voyages,_aventures_et_combats/Chapitre_18' }
       let(:subject) { described_class.new(article).average_views }
 
+      before { travel_to Date.new(2023, 10, 18) }
+
       it 'returns 0' do
         VCR.use_cassette 'wiki_pageviews/404_handling' do
           expect(subject).to eq(0)


### PR DESCRIPTION
## What this PR does
The behavior of the wikipageviews API has changed when handling requests for which no data is available, causing some of our specs to fail. This PR starts managing this new behavior to fix our specs.
It basically adds a new `no_data_available_response?` method to identify these specific responses.
Read more details in the proper issue.

Closes #5508
## Screenshots

## Open questions and concerns

