### PR TITLE
Fixing navigation bar highlighting issue with react-router NavLink

### DIFF
--- a/app/assets/javascripts/components/common/campaign_navbar.jsx
+++ b/app/assets/javascripts/components/common/campaign_navbar.jsx
@@ -13,22 +13,22 @@ const CampaignNavbar = ({ campaign }) => {
           </a>
           <nav>
             <div className="nav__item" id="overview-link">
-              <p><a href={`/campaigns/${campaign.slug}/overview`} >{I18n.t('courses.overview')}</a>
+              <p><NavLink to={`/campaigns/${campaign.slug}/overview`} >{I18n.t('courses.overview')}</NavLink>
               </p>
             </div>
             <div className="nav__item">
               <p>
-                <a href={`/campaigns/${campaign.slug}/programs`}>{CourseUtils.i18n('courses', campaign.course_string_prefix)}</a>
+                <NavLink to={`/campaigns/${campaign.slug}/programs`}>{CourseUtils.i18n('courses', campaign.course_string_prefix)}</NavLink>
               </p>
             </div>
             <div className="nav__item" id="articles-link">
               <p>
-                <a href={`/campaigns/${campaign.slug}/articles`}>{I18n.t('courses.articles')}</a>
+                <NavLink to={`/campaigns/${campaign.slug}/articles`}>{I18n.t('courses.articles')}</NavLink>
               </p>
             </div>
             <div className="nav__item">
               <p>
-                <a href={`/campaigns/${campaign.slug}/users`}>{CourseUtils.i18n('students', campaign.course_string_prefix)}</a>
+                <NavLink to={`/campaigns/${campaign.slug}/users`}>{CourseUtils.i18n('students', campaign.course_string_prefix)}</NavLink>
               </p>
             </div>
             <div className="nav__item">


### PR DESCRIPTION
### Description:

This pull request addresses the issue where the navigation bar fails to consistently indicate the current page the user is viewing. The problem was related to incorrect behavior in the active link highlighting, which occurred due to page reload when clicking on certain navigation items.

### Changes Made:

To resolve this issue, I replaced anchor tags with React-Router's NavLink components. This change prevents the page from reloading when navigating between pages within the campaign. As a result, the active link now consistently highlights the current page the user is viewing.

### Related Issue:

Closes #5514