### PR TITLE
Avoid creating a new empty talk page when removing a template from a non-existent page

### DIFF
--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -264,13 +264,26 @@ describe WikiAssignmentOutput do
     let(:title) { 'Selfie' }
     let(:talk_title) { 'Talk:Selfie' }
 
-    context 'when the article exists but talk page does not' do
+    context 'when the article exists but talk page does not,' do
       let(:talk_title) { 'Talk:THIS PAGE DOES NOT EXIST' }
 
-      it 'returns content' do
-        VCR.use_cassette 'wiki_edits/talk_page_update' do
-          page_content = wiki_assignment_output.build_talk_page_update
-          expect(page_content).to include('{{dashboard.wikiedu.org assignment | course = ')
+      context 'adding or updating assignments' do
+        it 'returns content' do
+          VCR.use_cassette 'wiki_edits/talk_page_update' do
+            page_content = wiki_assignment_output.build_talk_page_update
+            expect(page_content).to include('{{dashboard.wikiedu.org assignment | course = ')
+          end
+        end
+      end
+
+      context 'trying to remove assignments' do
+        let(:assignments) { '' }
+
+        it 'returns nil' do
+          VCR.use_cassette 'wiki_edits/talk_page_update' do
+            page_content = wiki_assignment_output.build_talk_page_update
+            expect(page_content).to be_nil
+          end
         end
       end
     end

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -277,7 +277,7 @@ describe WikiAssignmentOutput do
       end
 
       context 'trying to remove assignments' do
-        let(:assignments) { '' }
+        let(:assignments) { [] }
 
         it 'returns nil' do
           VCR.use_cassette 'wiki_edits/talk_page_update' do


### PR DESCRIPTION
## What this PR does
In some cases, such as an assignment being added and then removed again before the edit job is run, the dashboard may create a page that doesn't exist already, but make it empty. Ideally, this should not happen.

This PR starts handing the specific situation of trying to remove a template from a page that doesn't exist in `WikiAssignmentOutput`, and add a unit spec for the new `build_talk_page_update` behavior.

The idea is to make `build_talk_page_update` return `nil` when:
1. the talk page doesn't exist already (`get_page_content` returns empty string) and,
2. the update is to remove the assignments (`@assignments` is an empty collection)

This way `update_assignments_for_article` won't make the `post_whole_page` call, avoiding the creation of the empty page.

Prior to this PR,  `build_talk_page_update` returned an empty string. This shall have caused `update_assignments_for_article` to call `post_whole_page` with empty content, resulting in the creation of an empty page.

Closes #2412
## Screenshots

## Open questions and concerns
The mentioned issue says that "edits should never create an empty page". This PR only takes into account one specific case of edits (trying to remove templates when the talk page doesn't exist).  It might make sense to keep the issue open, as there could be other instances of edits that result in creating empty pages, which have not been addressed in this PR.