### PR TITLE
Improvements in debian setup script #1709

### DIFF
--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -131,7 +131,7 @@ fi
 printf "[*] Creating Databases... \n"
 echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
       CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      exit" | sudo mysql -p && print_success "${CLEAR_LINE}[+] Databases created\n"
+      exit" | sudo mysql && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'
 if [ -f config/database.yml ]; then
@@ -150,7 +150,7 @@ else
   echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
       GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
       GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
-      exit" | sudo mysql -p > /dev/null && print_success "${CLEAR_LINE}[+] User created\n"
+      exit" | sudo mysql > /dev/null && print_success "${CLEAR_LINE}[+] User created\n"
 fi
 
 printf '[*] Migrating databases... \n'

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -20,13 +20,13 @@ output_line()
   if [ -z ${2+x} ];then
     while read -r line
     do
-      printf "${CLEAR_LINE}$line"
+      printf "${CLEAR_LINE}%s" "$line"
       echo $line &>> setup/log.txt
     done < <(eval $1)
   else
     while read -r line
     do
-      printf "${CLEAR_LINE}$line"
+      printf "${CLEAR_LINE}%s" "$line"
     done < <(eval $1 | $2)
   fi
 }
@@ -107,7 +107,7 @@ else
 fi
 
 printf '[*] Installing mariadbclient dependencies... \n'
-output_line "sudo apt-get install -y libmariadbclient-dev" && print_success "${CLEAR_LINE}[+] Dependencies installed\n"
+output_line "sudo apt-get install -y libmariadbclient-dev || sudo apt-get install -y libmariadb-dev" && print_success "${CLEAR_LINE}[+] Dependencies installed\n"
 
 printf '[*] Installing bundler... \n'
 if which bundler > /dev/null; then


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
Improvements in Debian Setup Script. As discussed in Issue #1709.

## Changes

1. Added a fallback package `libmariadb-dev` to support latest debian versions where alternate package `libmariadbclient-dev` was not available by default respositories.
2. Improved Bash Function output_line :  used `%s` formatting over direct concatenation so that special characters like `%` can also be printed without conflicting with formatters.
3. Optimized the execution of MySQL commands by removing the redundant `-p` flag. Since `sudo` is used to execute SQL commands with root privileges, there is no need for the additional `-p` flag, avoiding repetitive password prompts.

## Open questions and concerns

1. Was the `-p` flag in `mysql` command serving any purpose that I missed?
2. Should I also update other os scripts as well? 
