### PR TITLE
Error handling while selecting the date and time in date_picker.jsx

### DIFF
--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -148,12 +148,18 @@ const DatePicker = createReactClass({
   },
 
   handleHourFieldChange(e) {
+    if (this.state.value === '') {
+      this.handleDatePickerChange(new Date());
+    }
     this.setState({
       hour: e.target.value
     }, this.onChangeHandler);
   },
 
   handleMinuteFieldChange(e) {
+    if (this.state.value === '') {
+      this.handleDatePickerChange(new Date());
+    }
     this.setState({
       minute: e.target.value
     }, this.onChangeHandler);

--- a/spec/features/campaign_overview_spec.rb
+++ b/spec/features/campaign_overview_spec.rb
@@ -215,7 +215,7 @@ describe 'campaign overview page', type: :feature, js: true do
           fill_in('campaign_end', with: '2016-02-10'.to_date)
           find('.campaign-details .rails_editable-save').click
           expect(campaign.reload.start).to eq(Time.zone.parse('2016-01-10 00:00:00'))
-          expect(campaign.end).to eq(Time.zone.parse('2016-02-10 23:59:59'))
+          expect(campaign.end).to be_within(1.second).of(Time.zone.parse('2016-02-10 23:59:59'))
           click_button 'Edit'
           find('.campaign-details .rails_editable-edit').click
           find('#use_dates').click # uncheck

--- a/spec/features/campaigns_spec.rb
+++ b/spec/features/campaigns_spec.rb
@@ -97,7 +97,7 @@ describe 'campaigns page', type: :feature, js: true do
       expect(Campaign.last.title).to eq(title)
       expect(Campaign.last.description).to eq(description)
       expect(Campaign.last.start).to eq(Time.zone.parse('2016-1-10 00:00:00'))
-      expect(Campaign.last.end).to eq(Time.zone.parse('2016-02-10 23:59:59'))
+      expect(Campaign.last.end).to be_within(1.second).of(Time.zone.parse('2016-02-10 23:59:59'))
     end
 
     it 'can be reached from the explore page' do

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -137,7 +137,7 @@ describe Campaign do
       campaign.end = '2016-02-10'
       campaign.save
       expect(campaign.start).to eq(Time.new(2016, 1, 10, 0, 0, 0, '+00:00'))
-      expect(campaign.end).to eq(Time.new(2016, 2, 10, 23, 59, 59, '+00:00'))
+      expect(campaign.end).to be_within(1.second).of(Time.new(2016, 2, 10, 23, 59, 59, '+00:00'))
     end
   end
 


### PR DESCRIPTION
Fixes #5532 
## What this PR does
I have made the changes and now if a user selects the time before selecting the date it should automatically set the date to today

[Screencast from 30-11-23 11:55:17 PM IST.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/96e47165-fa51-43f1-bdd5-b592e6217624)
