### PR TITLE
Fix 4466/convert wiki logo to svg and convert new acc btn to functional component

### DIFF
--- a/app/assets/images/wiki-logo_icon.svg
+++ b/app/assets/images/wiki-logo_icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="-10 0 70 50">
+    <path fill="#85776A"
+ d="M32 41l-6 -15l-8 15h-1l-11 -25q-1 -2 -3 -4t-3 -2v-1h13v1q-2 0 -3 1t-1 2l10 22l6 -11l-6 -12q-1 -2 -4 -2v-1h11v1l-2 1q-1 0 0 1l3 8l4 -8q1 -1 0 -1.5t-3 -0.5v-1h10v1q-1 0 -2.5 0.5t-2.5 2.5l-4 9l5 12l10 -22q-1 -1 -2 -1l-2 -1v-1h10v1q-3 0 -4 3l-13 28h-1v0z
+ " />
+ </svg>

--- a/app/assets/images/wiki-logo_icon.svg
+++ b/app/assets/images/wiki-logo_icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="-10 0 70 50">
-    <path fill="#85776A"
+    <path fill="#737381"
  d="M32 41l-6 -15l-8 15h-1l-11 -25q-1 -2 -3 -4t-3 -2v-1h13v1q-2 0 -3 1t-1 2l10 22l6 -11l-6 -12q-1 -2 -4 -2v-1h11v1l-2 1q-1 0 0 1l3 8l4 -8q1 -1 0 -1.5t-3 -0.5v-1h10v1q-1 0 -2.5 0.5t-2.5 2.5l-4 9l5 12l10 -22q-1 -1 -2 -1l-2 -1v-1h10v1q-3 0 -4 3l-13 28h-1v0z
  " />
  </svg>

--- a/app/assets/images/wiki-logo_icon_purple.svg
+++ b/app/assets/images/wiki-logo_icon_purple.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="-10 0 70 50">
+   <path fill="#676EB6"
+d="M32 41l-6 -15l-8 15h-1l-11 -25q-1 -2 -3 -4t-3 -2v-1h13v1q-2 0 -3 1t-1 2l10 22l6 -11l-6 -12q-1 -2 -4 -2v-1h11v1l-2 1q-1 0 0 1l3 8l4 -8q1 -1 0 -1.5t-3 -0.5v-1h10v1q-1 0 -2.5 0.5t-2.5 2.5l-4 9l5 12l10 -22q-1 -1 -2 -1l-2 -1v-1h10v1q-3 0 -4 3l-13 28h-1v0z
+" />
+</svg>

--- a/app/assets/images/wiki-logo_icon_white.svg
+++ b/app/assets/images/wiki-logo_icon_white.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="-10 0 70 50">
+   <path fill="#FAFAFC"
+d="M32 41l-6 -15l-8 15h-1l-11 -25q-1 -2 -3 -4t-3 -2v-1h13v1q-2 0 -3 1t-1 2l10 22l6 -11l-6 -12q-1 -2 -4 -2v-1h11v1l-2 1q-1 0 0 1l3 8l4 -8q1 -1 0 -1.5t-3 -0.5v-1h10v1q-1 0 -2.5 0.5t-2.5 2.5l-4 9l5 12l10 -22q-1 -1 -2 -1l-2 -1v-1h10v1q-3 0 -4 3l-13 28h-1v0z
+" />
+</svg>

--- a/app/assets/javascripts/components/enroll/enroll_card.jsx
+++ b/app/assets/javascripts/components/enroll/enroll_card.jsx
@@ -60,7 +60,7 @@ const EnrollCard = ({
         <p>{I18n.t('courses.invitation_username_advice')}</p>
         <div>
           <a data-method="post" href={`/users/auth/mediawiki?origin=${window.location}`} className="button auth dark">
-            <i className="icon icon-wiki-logo" /> {I18n.t('application.log_in_extended')}
+            <i className="icon icon-wiki-white" /> {I18n.t('application.log_in_extended')}
           </a>
           <NewAccountButton course={course} passcode={passcode} currentUser={user} />
         </div>

--- a/app/assets/javascripts/components/nav/hamburger_menu.jsx
+++ b/app/assets/javascripts/components/nav/hamburger_menu.jsx
@@ -89,7 +89,7 @@ const HamburgerMenu = ({ rootUrl, logoPath, exploreUrl, exploreName, userSignedI
                   // needs to become a button or form and include the authenticity token.
                   <li>
                     <a data-method="post" href={omniauthUrl}>
-                      <i className="icon icon-wiki-logo" />
+                      <i className="icon icon-wiki-white" />
                       {I18n.t('application.log_in')}
                       <span className="expand">
                         &nbsp;{I18n.t('application.sign_up_log_in_extended')}

--- a/app/assets/javascripts/components/nav/hamburger_menu.jsx
+++ b/app/assets/javascripts/components/nav/hamburger_menu.jsx
@@ -89,7 +89,7 @@ const HamburgerMenu = ({ rootUrl, logoPath, exploreUrl, exploreName, userSignedI
                   // needs to become a button or form and include the authenticity token.
                   <li>
                     <a data-method="post" href={omniauthUrl}>
-                      <i className="icon icon-wiki-white" />
+                      <i className="icon icon-wiki-white-hamburger" />
                       {I18n.t('application.log_in')}
                       <span className="expand">
                         &nbsp;{I18n.t('application.sign_up_log_in_extended')}

--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -30,6 +30,7 @@ const Nav = () => {
   const wikiEd = wikiEdStr === 'true';
   const languageSwitcherEnabled = languageSwitcherEnabledStr !== '';
 
+  const [isHovered, setIsHovered] = useState(false);
   const [dimensions, setDimensions] = useState({ width: window.innerWidth, height: window.innerHeight });
 
   const updateDimensions = () => {
@@ -150,8 +151,8 @@ const Nav = () => {
                   // a POST request based on data-method="post". Otherwise, this
                   // needs to become a button or form and include the authenticity token.
                   <li>
-                    <a data-method="post" href={omniauthUrl}>
-                      <i className="icon icon-wiki-logo" />
+                    <a data-method="post" href={omniauthUrl} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+                      <i className={`icon ${isHovered ? ' icon-wiki-purple' : ' icon-wiki'}`} />
                       {I18n.t('application.log_in')}
                       <span className="expand">
                         &nbsp;{I18n.t('application.sign_up_log_in_extended')}

--- a/app/assets/stylesheets/_icons.styl
+++ b/app/assets/stylesheets/_icons.styl
@@ -38,6 +38,10 @@
 .icon-trash_can:before { content: "\EA0D" }
 .icon-up_arrow:before { content: "\EA0E" }
 .icon-z-external-link:before { content: "\EA10" }
+  
+.icon-wiki-purple-hover
+  background url("../images/wiki-logo_icon_purple.svg") center no-repeat
+  padding 11.5px
 
 .icon-wiki-purple
   background url("../images/wiki-logo_icon_purple.svg") center no-repeat
@@ -45,11 +49,16 @@
 
 .icon-wiki
   background url("../images/wiki-logo_icon.svg") center no-repeat
-  padding 14px
+  padding 11.5px
 
 .icon-wiki-white
   background url("../images/wiki-logo_icon_white.svg") center no-repeat
   padding 14px
+
+.icon-wiki-white-hamburger
+  background url("../images/wiki-logo_icon_white.svg") center no-repeat
+  padding: 12px;
+  background-position: 4px 11px;
 
 .icon-search
   background url("../images/search_icon.svg") center no-repeat

--- a/app/assets/stylesheets/_icons.styl
+++ b/app/assets/stylesheets/_icons.styl
@@ -37,8 +37,19 @@
 .icon-sort:before { content: "\EA0C" }
 .icon-trash_can:before { content: "\EA0D" }
 .icon-up_arrow:before { content: "\EA0E" }
-.icon-wiki-logo:before { content: "\EA0F" }
 .icon-z-external-link:before { content: "\EA10" }
+
+.icon-wiki-purple
+  background url("../images/wiki-logo_icon_purple.svg") center no-repeat
+  padding 14px
+
+.icon-wiki
+  background url("../images/wiki-logo_icon.svg") center no-repeat
+  padding 14px
+
+.icon-wiki-white
+  background url("../images/wiki-logo_icon_white.svg") center no-repeat
+  padding 14px
 
 .icon-search
   background url("../images/search_icon.svg") center no-repeat

--- a/app/assets/stylesheets/modules/_controls.styl
+++ b/app/assets/stylesheets/modules/_controls.styl
@@ -190,7 +190,8 @@ nav.sub-navigation
     > .icon
       font-size 28px
       vertical-align middle
-      margin -6px 6px -4px -4px
+      margin: -6px 0px -4px -11px;
+      width: 40px;
       line-height 0
       display inline-block
 

--- a/app/assets/stylesheets/modules/_controls.styl
+++ b/app/assets/stylesheets/modules/_controls.styl
@@ -190,7 +190,7 @@ nav.sub-navigation
     > .icon
       font-size 28px
       vertical-align middle
-      margin: -6px 0px -4px -11px;
+      margin: -6px -1px -4px -11px;
       width: 40px;
       line-height 0
       display inline-block

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -106,9 +106,8 @@ nav.top-nav
     +below(desktop)
       display none
   i
-    margin-right 4px
-    margin-bottom: -1px;
-    display: inline-block;
+    margin-right 2px
+    margin-bottom: 0px;
     font-size 16px
     vertical-align middle
 

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -106,7 +106,7 @@ nav.top-nav
     +below(desktop)
       display none
   i
-    margin-right 2px
+    margin-right 0px
     margin-bottom: 0px;
     font-size 16px
     vertical-align middle


### PR DESCRIPTION
Refs #4466 
Refs #5393 

## What this PR does
Changed all icons of wiki-logo being used from font files to SVGs also converted ```/app/assets/javascripts/components/enroll/new_account_button.jsx```
to functional component -- to add hover effect on the button.

## Screenshots
Before:
![Screenshot from 2023-12-01 23-30-20](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/7ef7b605-8b87-4966-8560-5e04a8ac086a)
![Screenshot from 2023-12-01 20-58-06](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/b1bd37f6-46e1-454e-8245-43358cff50b7)
![Screenshot from 2023-12-01 20-56-01](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/74b6a037-cbcc-4406-87db-243f55f8f31d)



After:
![Screenshot from 2023-12-01 23-19-40](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/4223bade-9bc2-420e-b7dc-880a14f7bffa)
![Screenshot from 2023-12-01 23-21-58](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/6d77d648-3089-45b3-a929-430bb75dc40e)
![Screenshot from 2023-12-01 23-21-51](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/92005669/a818f16a-73ea-4ae0-a62e-18ea8578697e)