### PR TITLE
fixed issue #5552 i.e. wrong message on hovering words added on dashboard

### DIFF
--- a/app/assets/javascripts/components/campaign/detailed_campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/detailed_campaign_list.jsx
@@ -23,7 +23,7 @@ const DetailedCampaignList = ({ newest, headerText, userOnly }) => {
     word_count: {
       label: I18n.t('metrics.word_count'),
       desktop_only: false,
-      info_key: 'courses.view_doc'
+      info_key: 'courses.word_count_doc'
     },
     references_count: {
       label: I18n.t('metrics.references_count'),


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This PR fixes the wrong message that is shown when hovering over words added on the dashboard.

## Screenshots
Before:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/50093149/c655f9f5-e26a-4ed9-bedb-0fea9a8d1e67)

After:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/50093149/f0a90e8a-566f-43d3-958e-3812284d6a05)
