### PR TITLE
Optimized 'Training' Page for Mobile Responsiveness

### DIFF
--- a/app/assets/stylesheets/training_modules/_cards.styl
+++ b/app/assets/stylesheets/training_modules/_cards.styl
@@ -17,6 +17,8 @@
   padding 10px 11px
   width 50px
   height 50px
+  position absolute
+  right 0px 
 .action-card-icon
   transition left 0.125s
   color #fff

--- a/app/assets/stylesheets/training_modules/_training.styl
+++ b/app/assets/stylesheets/training_modules/_training.styl
@@ -178,3 +178,10 @@
 .wait
   padding 2px 5px 2px 5px
   background url('../images/loader.gif') no-repeat 50% transparent
+
+@media only screen and (max-width: 550px)
+  .training-libraries
+    display flex
+    flex-direction column
+    .training-libraries__individual-library, .training-library-focus
+      width 100%


### PR DESCRIPTION
## What this PR does
This will make the '[Training Page](https://dashboard.wikiedu.org/training)' Responsive for mobile view.

Fixes issue #5558

## Screenshots
Before:

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/b567fce2-aa2a-407c-a4c3-3cfd4335262d)

After:

![Pasted Graphic](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/c07c976a-c211-419b-86af-304dd6905b3e)
