### PR TITLE
fixed an error in js code of  assets/javascript/campaign.js file

### DIFF
--- a/app/assets/javascripts/campaigns.js
+++ b/app/assets/javascripts/campaigns.js
@@ -93,6 +93,6 @@ window.onload = () => {
   });
 
   if (createModalWrapper?.classList.contains('show-create-modal')) {
-    createCampaignButton.click();
+    createCampaignButton?.click();
   }
 };


### PR DESCRIPTION
With previous code I was getting this error (screenshot attached) after clicking on Create Campaign button
![error](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/135260908/70403d76-42bd-4c35-9ffa-14fd9271062e)
 Now with the changes I did in the campain.js file ,no longer error exits.
