### PR TITLE
[Outreachy Round 27] Refactor `LiftWingApi`  and `RevisionScoreImporter`

### DIFF
--- a/app/controllers/revision_feedback_controller.rb
+++ b/app/controllers/revision_feedback_controller.rb
@@ -7,10 +7,10 @@ class RevisionFeedbackController < ApplicationController
   def index
     set_latest_revision_id
     return if @rev_id.nil?
-    ores_data = RevisionScoreImporter.new.fetch_ores_data_for_revision_id(@rev_id)
-    @feedback = RevisionFeedbackService.new(ores_data[:features]).feedback
+    liftwing_data = RevisionScoreImporter.new.fetch_liftwing_data_for_revision_id(@rev_id)
+    @feedback = RevisionFeedbackService.new(liftwing_data[:features]).feedback
     @user_feedback = Assignment.find(params['assignment_id']).assignment_suggestions
-    @rating = ores_data[:rating]
+    @rating = liftwing_data[:rating]
   end
 
   private

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -58,10 +58,6 @@ class RevisionScoreImporter
   ##################
   private
 
-  def model_key
-    @model_key ||= @wiki.project == 'wikidata' ? 'itemquality' : 'articlequality'
-  end
-
   def get_and_save_scores(rev_batch)
     scores = @lift_wing_api.get_revision_data rev_batch.map(&:mw_rev_id)
     save_scores(scores)
@@ -89,10 +85,10 @@ class RevisionScoreImporter
   def save_parent_scores(parent_revisions, scores)
     parent_revisions.each do |mw_rev_id, parent_id|
       next unless scores.key? parent_id
-      article_completeness = scores.dig(parent_id, 'wp10')
+      wp10_previous = scores.dig(parent_id, 'wp10')
       features_previous = scores.dig(parent_id, 'features')
       Revision.find_by(mw_rev_id: mw_rev_id.to_i, wiki: @wiki)
-              .update(wp10_previous: article_completeness, features_previous:)
+              .update(wp10_previous:, features_previous:)
     end
   end
 

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -39,10 +39,9 @@ class RevisionScoreImporter
 
   # assumes a mediawiki rev_id from the correct Wikipedia
   def fetch_ores_data_for_revision_id(rev_id)
-    articlequality_data = @lift_wing_api.get_revision_data([rev_id])
-    features = articlequality_data.dig(wiki_key, 'scores', rev_id.to_s, model_key, 'features')
-    rating = articlequality_data.dig(wiki_key, 'scores', rev_id.to_s, model_key,
-                                     'score', 'prediction')
+    result = @lift_wing_api.get_single_revision_parsed_data(rev_id)
+    features = result.dig('features')
+    rating = result.dig('prediction')
     return { features:, rating: }
   end
 
@@ -69,39 +68,31 @@ class RevisionScoreImporter
   ##################
   private
 
-  # The top-level key representing the wiki in LiftWing data
-  def wiki_key
-    # This assumes the project is Wikipedia, which is true for all wikis with the articlequality
-    # or the language is nil, which is the case for Wikidata.
-    @wiki_key ||= "#{@wiki.language || @wiki.project}wiki"
-  end
-
   def model_key
     @model_key ||= @wiki.project == 'wikidata' ? 'itemquality' : 'articlequality'
   end
 
   def get_and_save_scores(rev_batch)
-    scores_data = @lift_wing_api.get_revision_data rev_batch.map(&:mw_rev_id)
-    scores = scores_data.dig(wiki_key, 'scores') || {}
-    save_scores(scores)
+    rev_batch.each do |rev|
+      result = @lift_wing_api.get_single_revision_parsed_data(rev.mw_rev_id)
+      save_score(rev.mw_rev_id, result)
+    end
   end
 
   def get_and_save_previous_scores(rev_batch)
     parent_revisions = get_parent_revisions(rev_batch)
     return unless parent_revisions&.any?
-    parent_quality_data = @lift_wing_api.get_revision_data parent_revisions.values.map(&:to_i)
-    scores = parent_quality_data.dig(wiki_key, 'scores') || {}
-    save_parent_scores(parent_revisions, scores)
+    parent_revisions.each do |rev_id, parent_id|
+      parent_score = @lift_wing_api.get_single_revision_parsed_data(parent_id)
+      save_parent_score(rev_id, parent_score)
+    end
   end
 
-  def save_parent_scores(parent_revisions, scores)
-    parent_revisions.each do |mw_rev_id, parent_id|
-      next unless scores.key? parent_id
-      article_completeness = weighted_mean_score(scores[parent_id])
-      features_previous = scores[parent_id]&.dig(model_key, 'features')
-      Revision.find_by(mw_rev_id: mw_rev_id.to_i, wiki: @wiki)
-              .update(wp10_previous: article_completeness, features_previous:)
-    end
+  def save_parent_score(rev_id, parent_score)
+    return unless parent_score
+    Revision.find_by(mw_rev_id: rev_id.to_i, wiki: @wiki)
+            .update(wp10_previous: parent_score.dig('wp10'),
+                    features_previous: parent_score.dig('features'))
   end
 
   def mainspace_userspace_and_draft_revisions
@@ -119,15 +110,13 @@ class RevisionScoreImporter
     mainspace_userspace_and_draft_revisions.where(features_previous: nil, new_article: false)
   end
 
-  def save_scores(scores)
-    scores.each do |mw_rev_id, score|
-      revision = Revision.find_by(mw_rev_id: mw_rev_id.to_i, wiki_id: @wiki.id)
-      next unless revision
-      revision.wp10 = weighted_mean_score(score)
-      revision.features = score.dig(model_key, 'features')
-      revision.deleted = true if deleted?(score)
-      revision.save
-    end
+  def save_score(rev_id, score)
+    revision = Revision.find_by(mw_rev_id: rev_id.to_i, wiki_id: @wiki.id)
+    return unless revision
+    revision.wp10 = score.dig('wp10')
+    revision.features = score.dig('features')
+    revision.deleted = score.dig('deleted')
+    revision.save
   end
 
   def get_parent_revisions(rev_batch)
@@ -157,90 +146,6 @@ class RevisionScoreImporter
     { prop: 'revisions',
       revids: rev_ids,
       rvprop: 'ids' }
-  end
-
-  # ORES articlequality ratings are often derived from the en.wiki system,
-  # so this is the fallback scheme.
-  ENWIKI_WEIGHTING = { 'FA'    => 100,
-                       'GA'    => 80,
-                       'B'     => 60,
-                       'C'     => 40,
-                       'Start' => 20,
-                       'Stub'  => 0 }.freeze
-  FRWIKI_WEIGHTING = { 'adq' => 100,
-                       'ba' => 80,
-                       'a' => 60,
-                       'b' => 40,
-                       'bd' => 20,
-                       'e' => 0 }.freeze
-  TRWIKI_WEIGHTING = { 'sm' => 100,
-                       'km' => 80,
-                       'b' => 60,
-                       'c' => 40,
-                       'baslagıç' => 20,
-                       'taslak' => 0 }.freeze
-  RUWIKI_WEIGHTING = { 'ИС' => 100,
-                       'ДС' => 80,
-                       'ХС' => 80,
-                       'I' => 60,
-                       'II' => 40,
-                       'III' => 20,
-                       'IV' => 0 }.freeze
-  PTWIKI_WEIGHTING = { '6' => 100,
-                       '5' => 80,
-                       '4' => 60,
-                       '3' => 40,
-                       '2' => 20,
-                       '1' => 0 }.freeze
-  UKWIKI_WEIGHTING = { 'ДС' => 100,
-                       'ВС' => 80,
-                       'I' => 60,
-                       'II' => 40,
-                       'III' => 20,
-                       'IV' => 0 }.freeze
-  # SV wiki has three high ratings, all of which are rare:
-  # This is just a guess at appropriate weighting for the case where almost
-  # all articles are the lowest tier.
-  SVWIKI_WEIGHTING = { 'u' => 100,
-                       'b' => 90,
-                       'r' => 80,
-                       's' => 0 }.freeze
-  NLWIKI_WEIGHTING = { 'A' => 100,
-                       'B' => 75,
-                       'C' => 50,
-                       'D' => 25,
-                       'E' => 0 }.freeze
-  WEIGHTING_BY_LANGUAGE = {
-    'en' => ENWIKI_WEIGHTING,
-    'simple' => ENWIKI_WEIGHTING,
-    'fa' => ENWIKI_WEIGHTING,
-    'eu' => ENWIKI_WEIGHTING,
-    'fr' => FRWIKI_WEIGHTING,
-    'tr' => TRWIKI_WEIGHTING,
-    'ru' => RUWIKI_WEIGHTING,
-    'uk' => UKWIKI_WEIGHTING,
-    'gl' => ENWIKI_WEIGHTING,
-    'sv' => SVWIKI_WEIGHTING,
-    'nl' => NLWIKI_WEIGHTING,
-    'pt' => PTWIKI_WEIGHTING
-  }.freeze
-
-  def weighting
-    @weighting ||= WEIGHTING_BY_LANGUAGE[@wiki.language]
-  end
-
-  def weighted_mean_score(score)
-    probability = score&.dig('articlequality', 'score', 'probability')
-    return unless probability
-    mean = 0
-    weighting.each do |rating, weight|
-      mean += probability[rating] * weight
-    end
-    mean
-  end
-
-  def deleted?(score)
-    LiftWingApi::DELETED_REVISION_ERRORS.include? score.dig(model_key, 'error', 'type')
   end
 
   class InvalidWikiError < StandardError; end

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -10,16 +10,6 @@ class RevisionScoreImporter
   ################
   # Entry points #
   ################
-  def self.update_revision_scores_for_all_wikis
-    LiftWingApi::AVAILABLE_WIKIPEDIAS.each do |language|
-      new(language:).update_revision_scores
-      new(language:).update_previous_revision_scores
-    end
-
-    new(language: nil, project: 'wikidata').update_revision_scores
-    new(language: nil, project: 'wikidata').update_previous_revision_scores
-  end
-
   def self.update_revision_scores_for_course(course, update_service: nil)
     course.wikis.each do |wiki|
       next unless LiftWingApi.valid_wiki?(wiki)

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -28,7 +28,7 @@ class RevisionScoreImporter
   end
 
   # assumes a mediawiki rev_id from the correct Wikipedia
-  def fetch_ores_data_for_revision_id(rev_id)
+  def fetch_liftwing_data_for_revision_id(rev_id)
     result = @lift_wing_api.get_revision_data([rev_id])
     features = result.dig(rev_id.to_s, 'features')
     rating = result.dig(rev_id.to_s, 'prediction')

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -115,7 +115,7 @@ class RevisionScoreImporter
     return unless revision
     revision.wp10 = score.dig('wp10')
     revision.features = score.dig('features')
-    revision.deleted = score.dig('deleted')
+    revision.deleted = true if score.dig('deleted') # only modify the value if revision was deleted
     revision.save
   end
 

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -80,7 +80,8 @@ class RevisionScoreImporter
       next unless revision
       revision.wp10 = score.dig('wp10')
       revision.features = score.dig('features')
-      revision.deleted = true if score.dig('deleted') # only modify the value if revision was deleted
+      # only modify the existing deleted value if revision was deleted
+      revision.deleted = true if score.dig('deleted')
       revision.save
     end
   end

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -27,6 +27,15 @@ class LiftWingApi # rubocop:disable Metrics/ClassLength
     @errors = []
   end
 
+  # Given an array of revision ids, it returns an array with useful metrics for those
+  # revision ids.
+  # Format result example:
+  # { 'rev_id0' => { 'wp10' => 0.2915228958136511656e2, 'features' => features_value,
+  #                 'deleted' => false, 'prediction' => 'Stub' }
+  #   ...
+  #   'rev_idn' => { 'wp10' => 0.285936675221734978e2, 'features' => features_value,
+  #                 'deleted' => false, 'prediction' => 'D' }
+  # }
   def get_revision_data(rev_ids)
     results = {}
     rev_ids.each do |rev_id|
@@ -40,7 +49,8 @@ class LiftWingApi # rubocop:disable Metrics/ClassLength
 
   private
 
-  # Returns wp10, features, and deleted
+  # Returns a has with wp10, features, deleted, and prediction, or empty hash if
+  # there is an error.
   def get_single_revision_parsed_data(rev_id)
     body = { rev_id:, extended_output: true }.to_json
     response = lift_wing_server.post(quality_query_url, body)

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -2,7 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/errors/api_error_handling"
 
-# Gets data from Lift Wing
+# Gets and processes data from Lift Wing
 # https://wikitech.wikimedia.org/wiki/Machine_Learning/LiftWing
 class LiftWingApi # rubocop:disable Metrics/ClassLength
   include ApiErrorHandling

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -119,7 +119,7 @@ class LiftWingApi # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # ORES articlequality ratings are often derived from the en.wiki system,
+  # LiftWing articlequality ratings are often derived from the en.wiki system,
   # so this is the fallback scheme.
   ENWIKI_WEIGHTING = { 'FA'    => 100,
                        'GA'    => 80,

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -37,6 +37,8 @@ class LiftWingApi # rubocop:disable Metrics/ClassLength
   #                 'deleted' => false, 'prediction' => 'D' }
   # }
   def get_revision_data(rev_ids)
+    # Restart errors array
+    @errors = []
     results = {}
     rev_ids.each do |rev_id|
       results.deep_merge!({ rev_id.to_s => get_single_revision_parsed_data(rev_id) })

--- a/lib/weighted_score_calculator.rb
+++ b/lib/weighted_score_calculator.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Turns articlequality prediction probabilities into a single score
+module WeightedScoreCalculator
+  # Given a hash of articlequality probabilities and a wiki language, it calculates
+  # the weighted mean score. Notice that language is necessary because the raiting
+  # and weighting depend on it.
+  # The probabilities hash is expected to be something like
+  # { "B" => 0.09784360827036567, "C" => 0.22955840375169326, "FA" => 0.003933867294088992,
+  #   "GA" => 0.011813817865728837, "Start" => 0.6380422388204124, "Stub" => 0.018808063997710744 }
+  def weighted_mean_score(probabilities, language)
+    return unless probabilities
+    return unless WEIGHTING_BY_LANGUAGE[language]
+    mean = 0
+    WEIGHTING_BY_LANGUAGE[language].each do |rating, weight|
+      mean += probabilities[rating] * weight
+    end
+    mean
+  end
+
+  # LiftWing articlequality ratings are often derived from the en.wiki system,
+  # so this is the fallback scheme.
+  ENWIKI_WEIGHTING = { 'FA'    => 100,
+                       'GA'    => 80,
+                       'B'     => 60,
+                       'C'     => 40,
+                       'Start' => 20,
+                       'Stub'  => 0 }.freeze
+  FRWIKI_WEIGHTING = { 'adq' => 100,
+                       'ba' => 80,
+                       'a' => 60,
+                       'b' => 40,
+                       'bd' => 20,
+                       'e' => 0 }.freeze
+  TRWIKI_WEIGHTING = { 'sm' => 100,
+                       'km' => 80,
+                       'b' => 60,
+                       'c' => 40,
+                       'baslagıç' => 20,
+                       'taslak' => 0 }.freeze
+  RUWIKI_WEIGHTING = { 'ИС' => 100,
+                       'ДС' => 80,
+                       'ХС' => 80,
+                       'I' => 60,
+                       'II' => 40,
+                       'III' => 20,
+                       'IV' => 0 }.freeze
+  PTWIKI_WEIGHTING = { '6' => 100,
+                       '5' => 80,
+                       '4' => 60,
+                       '3' => 40,
+                       '2' => 20,
+                       '1' => 0 }.freeze
+  UKWIKI_WEIGHTING = { 'ДС' => 100,
+                       'ВС' => 80,
+                       'I' => 60,
+                       'II' => 40,
+                       'III' => 20,
+                       'IV' => 0 }.freeze
+  # SV wiki has three high ratings, all of which are rare:
+  # This is just a guess at appropriate weighting for the case where almost
+  # all articles are the lowest tier.
+  SVWIKI_WEIGHTING = { 'u' => 100,
+                       'b' => 90,
+                       'r' => 80,
+                       's' => 0 }.freeze
+  NLWIKI_WEIGHTING = { 'A' => 100,
+                       'B' => 75,
+                       'C' => 50,
+                       'D' => 25,
+                       'E' => 0 }.freeze
+  WEIGHTING_BY_LANGUAGE = {
+    'en' => ENWIKI_WEIGHTING,
+    'simple' => ENWIKI_WEIGHTING,
+    'fa' => ENWIKI_WEIGHTING,
+    'eu' => ENWIKI_WEIGHTING,
+    'fr' => FRWIKI_WEIGHTING,
+    'tr' => TRWIKI_WEIGHTING,
+    'ru' => RUWIKI_WEIGHTING,
+    'uk' => UKWIKI_WEIGHTING,
+    'gl' => ENWIKI_WEIGHTING,
+    'sv' => SVWIKI_WEIGHTING,
+    'nl' => NLWIKI_WEIGHTING,
+    'pt' => PTWIKI_WEIGHTING
+  }.freeze
+end

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -141,7 +141,7 @@ describe RevisionScoreImporter do
     end
   end
 
-  describe '#fetch_ores_data_for_revision_id' do
+  describe '#fetch_liftwing_data_for_revision_id' do
     let(:rev_id) { 860858080 }
     # https://en.wikipedia.org/w/index.php?title=Hamlin_Park&oldid=860858080
     # https://www.wikidata.org/w/index.php?title=Q61734980&oldid=860858080
@@ -149,7 +149,7 @@ describe RevisionScoreImporter do
     let(:project) { 'wikipedia' }
     let(:subject) do
       described_class.new(language:, project:)
-                     .fetch_ores_data_for_revision_id(rev_id)
+                     .fetch_liftwing_data_for_revision_id(rev_id)
     end
 
     it 'returns a hash with a predicted rating and features' do

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -107,10 +107,20 @@ describe RevisionScoreImporter do
   end
 
   it 'handles network errors gracefully' do
+    revision = Revision.find_by(mw_rev_id: 662106477)
+    expect(revision.wp10).to be_nil
+    expect(revision.features).to eq({})
+    expect(revision.deleted).to eq(false)
+
     stub_request(:any, %r{https://api.wikimedia.org/service/lw/.*})
       .to_raise(Errno::ECONNREFUSED)
     described_class.new.update_revision_scores
-    expect(Revision.find_by(mw_rev_id: 662106477).wp10).to be_nil
+
+    # no value changed for the revision
+    revision = Revision.find_by(mw_rev_id: 662106477)
+    expect(revision.wp10).to be_nil
+    expect(revision.features).to eq({})
+    expect(revision.deleted).to eq(false)
   end
 
   # This probably represents buggy behavior from ores.

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -1,24 +1,67 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require "#{Rails.root}/lib/lift_wing_api"
+require_dependency "#{Rails.root}/lib/lift_wing_api.rb"
 
 describe LiftWingApi do
-  let(:rev_ids) { [641962088, 675892696] }
+  context 'when the wiki is not a wikipedia or wikidata' do
+    before { stub_wiki_validation }
 
-  it 'returns the basically the same data as ORES used to', vcr: true do
-    lift_wing_output = described_class.new(Wiki.first).get_revision_data rev_ids
-    digger = ['enwiki', 'scores', '641962088', 'articlequality',
-              'features', 'feature.english.stemmed.revision.stems_length']
-    first_rev_liftwing = lift_wing_output.dig(*digger)
-    expect(first_rev_liftwing).to be_positive
+    let!(:wiki) { create(:wiki, project: 'wikivoyage', language: 'en') }
+    let(:subject0) { described_class.new(wiki) }
+
+    it 'raises an error' do
+      expect { subject0 }.to raise_error LiftWingApi::InvalidProjectError
+    end
   end
 
-  it 'handles TextDeleted revs similarly', vcr: true do
-    lift_wing_output = described_class.new(Wiki.first).get_revision_data [708326238]
-    # It doesn't need to have the exact same response,
-    # but it does need the error type in the same place.
-    digger = %w[enwiki scores 708326238 articlequality error type]
-    expect(lift_wing_output.dig(*digger)).to include('TextDeleted')
+  describe '#get_single_revision_parsed_data' do
+    let(:rev_id) { 829840085 }
+    let(:deleted_rev_id) { 708326238 }
+    let(:wiki) { create(:wiki, project: 'wikidata', language: nil) }
+
+    let(:subject0) { described_class.new(Wiki.find(1)).get_single_revision_parsed_data(rev_id) }
+    let(:subject1) { described_class.new(wiki).get_single_revision_parsed_data(rev_id) }
+    let(:subject2) do
+      described_class.new(Wiki.find(1)).get_single_revision_parsed_data(deleted_rev_id)
+    end
+
+    it 'fetches json from api.wikimedia.org for wikipedia', vcr: true do
+      expect(subject0).to be_a(Hash)
+      expect(subject0.dig('wp10').to_f).to eq(29.15228958136511656)
+      expect(subject0.dig('features')).to be_a(Hash)
+      expect(subject0.dig('deleted')).to eq(false)
+      expect(subject0.dig('prediction')).to eq('Start')
+    end
+
+    it 'fetches json from api.wikimedia.org for wikidata', vcr: true do
+      expect(subject1).to be_a(Hash)
+      expect(subject1.dig('wp10')).to eq(nil)
+      expect(subject1.dig('features')).to be_a(Hash)
+      expect(subject1.dig('deleted')).to eq(false)
+      expect(subject1.dig('prediction')).to eq('D')
+    end
+
+    it 'returns deleted equal to true if the revision was deleted', vcr: true do
+      expect(subject2).to be_a(Hash)
+      expect(subject2.dig('wp10')).to eq(nil)
+      expect(subject2.dig('features')).to eq(nil)
+      expect(subject2.dig('deleted')).to eq(true)
+      expect(subject2.dig('prediction')).to eq(nil)
+    end
+
+    it 'handles timeout errors' do
+      stub_request(:any, 'https://api.wikimedia.org')
+        .to_raise(Errno::ETIMEDOUT)
+      expect_any_instance_of(described_class).to receive(:log_error).once
+      expect(subject0).to be_empty
+    end
+
+    it 'handles connection refused errors' do
+      stub_request(:any, 'https://api.wikimedia.org')
+        .to_raise(Faraday::ConnectionFailed)
+      expect_any_instance_of(described_class).to receive(:log_error).once
+      expect(subject0).to be_empty
+    end
   end
 end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -15,53 +15,53 @@ describe LiftWingApi do
     end
   end
 
-  describe '#get_single_revision_parsed_data' do
+  describe '#get_revision_data' do
     let(:rev_id) { 829840085 }
     let(:deleted_rev_id) { 708326238 }
     let(:wiki) { create(:wiki, project: 'wikidata', language: nil) }
 
-    let(:subject0) { described_class.new(Wiki.find(1)).get_single_revision_parsed_data(rev_id) }
-    let(:subject1) { described_class.new(wiki).get_single_revision_parsed_data(rev_id) }
+    let(:subject0) { described_class.new(Wiki.find(1)).get_revision_data([rev_id]) }
+    let(:subject1) { described_class.new(wiki).get_revision_data([rev_id]) }
     let(:subject2) do
-      described_class.new(Wiki.find(1)).get_single_revision_parsed_data(deleted_rev_id)
+      described_class.new(Wiki.find(1)).get_revision_data([deleted_rev_id])
     end
 
     it 'fetches json from api.wikimedia.org for wikipedia', vcr: true do
       expect(subject0).to be_a(Hash)
-      expect(subject0.dig('wp10').to_f).to eq(29.15228958136511656)
-      expect(subject0.dig('features')).to be_a(Hash)
-      expect(subject0.dig('deleted')).to eq(false)
-      expect(subject0.dig('prediction')).to eq('Start')
+      expect(subject0.dig('829840085', 'wp10').to_f).to eq(29.15228958136511656)
+      expect(subject0.dig('829840085', 'features')).to be_a(Hash)
+      expect(subject0.dig('829840085', 'deleted')).to eq(false)
+      expect(subject0.dig('829840085', 'prediction')).to eq('Start')
     end
 
     it 'fetches json from api.wikimedia.org for wikidata', vcr: true do
       expect(subject1).to be_a(Hash)
-      expect(subject1.dig('wp10')).to eq(nil)
-      expect(subject1.dig('features')).to be_a(Hash)
-      expect(subject1.dig('deleted')).to eq(false)
-      expect(subject1.dig('prediction')).to eq('D')
+      expect(subject1.dig('829840085', 'wp10')).to eq(nil)
+      expect(subject1.dig('829840085', 'features')).to be_a(Hash)
+      expect(subject1.dig('829840085', 'deleted')).to eq(false)
+      expect(subject1.dig('829840085', 'prediction')).to eq('D')
     end
 
     it 'returns deleted equal to true if the revision was deleted', vcr: true do
       expect(subject2).to be_a(Hash)
-      expect(subject2.dig('wp10')).to eq(nil)
-      expect(subject2.dig('features')).to eq(nil)
-      expect(subject2.dig('deleted')).to eq(true)
-      expect(subject2.dig('prediction')).to eq(nil)
+      expect(subject2.dig('708326238', 'wp10')).to eq(nil)
+      expect(subject2.dig('708326238', 'features')).to eq(nil)
+      expect(subject2.dig('708326238', 'deleted')).to eq(true)
+      expect(subject2.dig('708326238', 'prediction')).to eq(nil)
     end
 
     it 'handles timeout errors' do
       stub_request(:any, 'https://api.wikimedia.org')
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
-      expect(subject0).to be_empty
+      expect(subject0.dig('829840085')).to be_empty
     end
 
     it 'handles connection refused errors' do
       stub_request(:any, 'https://api.wikimedia.org')
         .to_raise(Faraday::ConnectionFailed)
       expect_any_instance_of(described_class).to receive(:log_error).once
-      expect(subject0).to be_empty
+      expect(subject0.dig('829840085')).to be_empty
     end
   end
 end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -16,44 +16,62 @@ describe LiftWingApi do
   end
 
   describe '#get_revision_data' do
-    let(:rev_id) { 829840085 }
+    let(:rev_ids) { [829840084, 829840085] }
     let(:deleted_rev_id) { 708326238 }
     let(:wiki) { create(:wiki, project: 'wikidata', language: nil) }
 
-    let(:subject0) { described_class.new(Wiki.find(1)).get_revision_data([rev_id]) }
-    let(:subject1) { described_class.new(wiki).get_revision_data([rev_id]) }
+    let(:subject0) { described_class.new(Wiki.find(1)).get_revision_data(rev_ids) }
+    let(:subject1) { described_class.new(wiki).get_revision_data(rev_ids) }
     let(:subject2) do
       described_class.new(Wiki.find(1)).get_revision_data([deleted_rev_id])
     end
 
-    it 'fetches json from api.wikimedia.org for wikipedia', vcr: true do
-      expect(subject0).to be_a(Hash)
-      expect(subject0.dig('829840085', 'wp10').to_f).to eq(29.15228958136511656)
-      expect(subject0.dig('829840085', 'features')).to be_a(Hash)
-      expect(subject0.dig('829840085', 'deleted')).to eq(false)
-      expect(subject0.dig('829840085', 'prediction')).to eq('Start')
+    it 'fetches json from api.wikimedia.org for wikipedia' do
+      VCR.use_cassette 'liftwing_api/wikipedia' do
+        expect(subject0).to be_a(Hash)
+        expect(subject0.dig('829840084', 'wp10').to_f).to eq(28.5936675221734978)
+        expect(subject0.dig('829840084', 'features')).to be_a(Hash)
+        expect(subject0.dig('829840084', 'deleted')).to eq(false)
+        expect(subject0.dig('829840084', 'prediction')).to eq('Stub')
+
+        expect(subject0).to be_a(Hash)
+        expect(subject0.dig('829840085', 'wp10').to_f).to eq(29.15228958136511656)
+        expect(subject0.dig('829840085', 'features')).to be_a(Hash)
+        expect(subject0.dig('829840085', 'deleted')).to eq(false)
+        expect(subject0.dig('829840085', 'prediction')).to eq('Start')
+      end
     end
 
-    it 'fetches json from api.wikimedia.org for wikidata', vcr: true do
-      expect(subject1).to be_a(Hash)
-      expect(subject1.dig('829840085', 'wp10')).to eq(nil)
-      expect(subject1.dig('829840085', 'features')).to be_a(Hash)
-      expect(subject1.dig('829840085', 'deleted')).to eq(false)
-      expect(subject1.dig('829840085', 'prediction')).to eq('D')
+    it 'fetches json from api.wikimedia.org for wikidata' do
+      VCR.use_cassette 'liftwing_api/wikidata' do
+        expect(subject1).to be_a(Hash)
+        expect(subject1.dig('829840084', 'wp10')).to eq(nil)
+        expect(subject1.dig('829840084', 'features')).to be_a(Hash)
+        expect(subject1.dig('829840084', 'deleted')).to eq(false)
+        expect(subject1.dig('829840084', 'prediction')).to eq('D')
+
+        expect(subject1.dig('829840085', 'wp10')).to eq(nil)
+        expect(subject1.dig('829840085', 'features')).to be_a(Hash)
+        expect(subject1.dig('829840085', 'deleted')).to eq(false)
+        expect(subject1.dig('829840085', 'prediction')).to eq('D')
+      end
     end
 
-    it 'returns deleted equal to true if the revision was deleted', vcr: true do
-      expect(subject2).to be_a(Hash)
-      expect(subject2.dig('708326238', 'wp10')).to eq(nil)
-      expect(subject2.dig('708326238', 'features')).to eq(nil)
-      expect(subject2.dig('708326238', 'deleted')).to eq(true)
-      expect(subject2.dig('708326238', 'prediction')).to eq(nil)
+    it 'returns deleted equal to true if the revision was deleted' do
+      VCR.use_cassette 'liftwing_api/deleted_revision' do
+        expect(subject2).to be_a(Hash)
+        expect(subject2.dig('708326238', 'wp10')).to eq(nil)
+        expect(subject2.dig('708326238', 'features')).to eq(nil)
+        expect(subject2.dig('708326238', 'deleted')).to eq(true)
+        expect(subject2.dig('708326238', 'prediction')).to eq(nil)
+      end
     end
 
     it 'handles timeout errors' do
       stub_request(:any, 'https://api.wikimedia.org')
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
+      expect(subject0.dig('829840085')).to be_a(Hash)
       expect(subject0.dig('829840085')).to be_empty
     end
 
@@ -61,6 +79,7 @@ describe LiftWingApi do
       stub_request(:any, 'https://api.wikimedia.org')
         .to_raise(Faraday::ConnectionFailed)
       expect_any_instance_of(described_class).to receive(:log_error).once
+      expect(subject0.dig('829840085')).to be_a(Hash)
       expect(subject0.dig('829840085')).to be_empty
     end
   end

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -106,14 +106,14 @@ describe UpdateCourseStats do
         subject
       end
       sentry_tag_uuid = subject.sentry_tag_uuid
-      expect(course.flags['update_logs'][1]['error_count']).to eq 8
+      expect(course.flags['update_logs'][1]['error_count']).to eq 328
       expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
 
       # Checking whether Sentry receives correct error and tags as arguments
       expect(Sentry).to have_received(:capture_exception)
-        .exactly(8).times.with(Faraday::ConnectionFailed, anything)
+        .exactly(328).times.with(Faraday::ConnectionFailed, anything)
       expect(Sentry).to have_received(:capture_exception)
-        .exactly(8).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
+        .exactly(328).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
                                                                 course: course.slug })
     end
 

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -106,14 +106,14 @@ describe UpdateCourseStats do
         subject
       end
       sentry_tag_uuid = subject.sentry_tag_uuid
-      expect(course.flags['update_logs'][1]['error_count']).to eq 328
+      expect(course.flags['update_logs'][1]['error_count']).to eq 8
       expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
 
       # Checking whether Sentry receives correct error and tags as arguments
       expect(Sentry).to have_received(:capture_exception)
-        .exactly(328).times.with(Faraday::ConnectionFailed, anything)
+        .exactly(8).times.with(Faraday::ConnectionFailed, anything)
       expect(Sentry).to have_received(:capture_exception)
-        .exactly(328).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
+        .exactly(8).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
                                                                 course: course.slug })
     end
 


### PR DESCRIPTION
## What this PR does
This PR is part of the "Improve how Wiki Education Dashboard counts references added" project (read issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5547).

It makes some refactors on `LiftWingApi`  and `RevisionScoreImporter` classes.

The `RevisionScoreImporter` is responsible for populating fields such as `wp10`, `features`, `wp10_previous`, `features_previous`, and `deleted` in the revisions. Currently, this involves using the LiftWing API to retrieve data. However, as part of the "Improve how Wiki Education Dashboard counts references added" project, we also need to use the new reference-counter API (see #5565).

The primary idea is to maintain the `RevisionScoreImporter` as the class responsible for populating all revision score fields, regardless of whether the values come from the LiftWing API or the Toolforge reference-counter API. This approach offers benefits, as there is valuable logic that should be shared in the population process, irrespective of the data source. For example, the `get_parent_revisions` method retrieves parent revision IDs, necessary for updating both `wp10_previous` (from the LiftWing API) and `features_previous` (from the Toolforge reference-counter API).

Before this PR, the importer contained a lot of logic specific to the articlequality model data and how to process it (such as calculating the `wp10` value from the scores).

The purpose of this refactor is to move elements too specific to the LiftWing API into the existing `LiftWingApi` class. This way, `RevisionScoreImporter` becomes a class with the logic to populate fields from both `LiftWingApi` and `ReferenceCounterApi`.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
