### PR TITLE
renders dates for milestones in home tab

### DIFF
--- a/app/assets/javascripts/components/overview/milestones.jsx
+++ b/app/assets/javascripts/components/overview/milestones.jsx
@@ -4,20 +4,19 @@ import createReactClass from 'create-react-class';
 import { filter } from 'lodash-es';
 
 import CourseDateUtils from '../../utils/course_date_utils';
-import DateCalculator from '../../utils/date_calculator.js';
+import DateCalculator from '../../utils/date_calculator'; // Import DateCalculator
 
 const md = require('../../utils/markdown_it.js').default();
-
 
 const Milestones = createReactClass({
   displayName: I18n.t('blocks.milestones.title'),
 
   propTypes: {
     timelineStart: PropTypes.string.isRequired,
-    timelineEnd: PropTypes.string,
+    timelineEnd: PropTypes.string.isRequired, // Add timelineEnd prop
     weeks: PropTypes.array.isRequired,
     allWeeks: PropTypes.array.isRequired,
-    course: PropTypes.object.isRequired,
+    course: PropTypes.object.isRequired
   },
 
   milestoneBlockType: 2,
@@ -27,8 +26,6 @@ const Milestones = createReactClass({
   },
 
   render() {
-    const dateCalc = new DateCalculator(
-    this.props.timelineStart, this.props.timelineEnd, this.props.index, { zeroIndexed: false });
     const currentWeek = CourseDateUtils.currentWeekOrder(this.props.timelineStart);
     const weekNumberOffset = CourseDateUtils.weeksBeforeTimeline(this.props.course);
     const blocks = [];
@@ -36,25 +33,22 @@ const Milestones = createReactClass({
     this.props.allWeeks.map((week) => {
       if (week.empty) return null;
 
+      const datesStr = DateCalculator.calculateDates(
+        this.props.timelineStart, this.props.timelineEnd, this.props.index, { zeroIndexed: false }
+      );
+
+      const [milestoneStartDate, milestoneEndDate] = datesStr.split(' - ');
+
       const milestoneBlocks = filter(week.blocks, block => block.kind === this.milestoneBlockType);
       return milestoneBlocks.map((block) => {
         let classNames = 'module__data';
-        if (this.weekIsCompleted(week, currentWeek)) {
-          classNames += ' completed';
-        }
+        if (this.weekIsCompleted(week, currentWeek)) { classNames += ' completed'; }
         const rawHtml = md.render(block.content || '');
         const completionNote = this.weekIsCompleted(week, currentWeek) ? '- Complete' : undefined;
-
-        const milestoneStartDate = dateCalc.start();
-        const milestoneEndDate = dateCalc.end();
-
         return blocks.push(
           <div key={block.id} className="section-header">
             <div className={classNames}>
-              <p>
-                Week {week.weekNumber + weekNumberOffset} ({milestoneStartDate} - {milestoneEndDate})
-                {completionNote}
-              </p>
+              <p>Week {week.weekNumber + weekNumberOffset} ({milestoneStartDate} - {milestoneEndDate}){completionNote}</p>
               <div className="markdown" dangerouslySetInnerHTML={{ __html: rawHtml }} />
               <hr />
             </div>
@@ -75,7 +69,7 @@ const Milestones = createReactClass({
         {blocks}
       </div>
     );
-  },
+  }
 });
 
 export default Milestones;

--- a/app/assets/javascripts/components/overview/milestones.jsx
+++ b/app/assets/javascripts/components/overview/milestones.jsx
@@ -37,10 +37,12 @@ const Milestones = createReactClass({
         if (this.weekIsCompleted(week, currentWeek)) { classNames += ' completed'; }
         const rawHtml = md.render(block.content || '');
         const completionNote = this.weekIsCompleted(week, currentWeek) ? '- Complete' : undefined;
+        const weekStartDate = CourseDateUtils.getWeekStartDate(week, this.props.timelineStart);
+        const weekEndDate = CourseDateUtils.getWeekEndDate(week, this.props.timelineStart);
         return blocks.push(
           <div key={block.id} className="section-header">
             <div className={classNames}>
-              <p>Week {week.weekNumber + weekNumberOffset} {completionNote}</p>
+              <p>Week {week.weekNumber + weekNumberOffset} ({weekStartDate} to {weekEndDate}) {completionNote}</p>
               <div className="markdown" dangerouslySetInnerHTML={{ __html: rawHtml }} />
               <hr />
             </div>

--- a/app/assets/javascripts/components/overview/milestones.jsx
+++ b/app/assets/javascripts/components/overview/milestones.jsx
@@ -4,17 +4,20 @@ import createReactClass from 'create-react-class';
 import { filter } from 'lodash-es';
 
 import CourseDateUtils from '../../utils/course_date_utils';
+import DateCalculator from '../../utils/date_calculator.js';
 
 const md = require('../../utils/markdown_it.js').default();
+
 
 const Milestones = createReactClass({
   displayName: I18n.t('blocks.milestones.title'),
 
   propTypes: {
     timelineStart: PropTypes.string.isRequired,
+    timelineEnd: PropTypes.string,
     weeks: PropTypes.array.isRequired,
     allWeeks: PropTypes.array.isRequired,
-    course: PropTypes.object.isRequired
+    course: PropTypes.object.isRequired,
   },
 
   milestoneBlockType: 2,
@@ -24,6 +27,8 @@ const Milestones = createReactClass({
   },
 
   render() {
+    const dateCalc = new DateCalculator(
+    this.props.timelineStart, this.props.timelineEnd, this.props.index, { zeroIndexed: false });
     const currentWeek = CourseDateUtils.currentWeekOrder(this.props.timelineStart);
     const weekNumberOffset = CourseDateUtils.weeksBeforeTimeline(this.props.course);
     const blocks = [];
@@ -34,15 +39,22 @@ const Milestones = createReactClass({
       const milestoneBlocks = filter(week.blocks, block => block.kind === this.milestoneBlockType);
       return milestoneBlocks.map((block) => {
         let classNames = 'module__data';
-        if (this.weekIsCompleted(week, currentWeek)) { classNames += ' completed'; }
+        if (this.weekIsCompleted(week, currentWeek)) {
+          classNames += ' completed';
+        }
         const rawHtml = md.render(block.content || '');
         const completionNote = this.weekIsCompleted(week, currentWeek) ? '- Complete' : undefined;
-        const weekStartDate = CourseDateUtils.getWeekStartDate(week, this.props.timelineStart);
-        const weekEndDate = CourseDateUtils.getWeekEndDate(week, this.props.timelineStart);
+
+        const milestoneStartDate = dateCalc.start();
+        const milestoneEndDate = dateCalc.end();
+
         return blocks.push(
           <div key={block.id} className="section-header">
             <div className={classNames}>
-              <p>Week {week.weekNumber + weekNumberOffset} ({weekStartDate} to {weekEndDate}) {completionNote}</p>
+              <p>
+                Week {week.weekNumber + weekNumberOffset} ({milestoneStartDate} - {milestoneEndDate})
+                {completionNote}
+              </p>
               <div className="markdown" dangerouslySetInnerHTML={{ __html: rawHtml }} />
               <hr />
             </div>
@@ -63,7 +75,7 @@ const Milestones = createReactClass({
         {blocks}
       </div>
     );
-  }
+  },
 });
 
 export default Milestones;

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -388,16 +388,23 @@ const Timeline = createReactClass({
         navClassName += ' is-current';
       }
 
-      const dateCalc = new DateCalculator(this.props.course.timeline_start, this.props.course.timeline_end, navIndex, { zeroIndexed: true });
+      const datesStr = DateCalculator.calculateDates(
+        this.props.course.timeline_start, 
+        this.props.course.timeline_end, 
+        navIndex, 
+        { zeroIndexed: true }
+      );
+      
+      const [startDate, endDate] = datesStr.split(' - ');
+      
       const navWeekKey = `week-${navIndex}`;
       const navWeekLink = `#week-${navIndex + 1 + weeksBeforeTimeline}`;
-
+      
       // if using custom titles, show only titles, otherwise, show default titles and dates
       let navItem;
       if (usingCustomTitles) {
         let navTitle = '';
         if (weekInfo.emptyWeek) {
-          const datesStr = `${dateCalc.start()} - ${dateCalc.end()}`;
           navTitle = I18n.t('timeline.week_number', { number: datesStr });
         } else {
           navTitle = weekInfo.title ? weekInfo.title : I18n.t('timeline.week_number', { number: navIndex + 1 + weeksBeforeTimeline });
@@ -411,7 +418,7 @@ const Timeline = createReactClass({
         navItem = (
           <li className={navClassName} key={navWeekKey}>
             <a href={navWeekLink}>{I18n.t('timeline.week_number', { number: navIndex + 1 + weeksBeforeTimeline })}</a>
-            <span className="pull-right">{dateCalc.start()} - {dateCalc.end()}</span>
+            <span className="pull-right">{startDate} - {endDate}</span>
           </li>
         );
       }

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -127,6 +127,14 @@ const CourseDateUtils = {
     const timelineStart = startOfWeek(toDate(course.timeline_start));
     return differenceInWeeks(timelineStart, courseStart);
   },
+  getWeekStartDate(week, timelineStart) {
+    const weekStart = addWeeks(startOfWeek(toDate(timelineStart)), week.weekNumber - 1);
+    return this.formattedDateTime(weekStart);
+  },
+  getWeekEndDate(week, timelineStart) {
+    const weekEnd = endOfWeek(addWeeks(startOfWeek(toDate(timelineStart)), week.weekNumber - 1));
+    return this.formattedDateTime(weekEnd);
+  },
 
   // Returns array describing weekday meetings for each week
   // Ex: [["Sunday (01/09)"], ["Sunday (01/16)", "Wednesday (01/19)", "Thursday (01/20)"], []]

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -127,14 +127,6 @@ const CourseDateUtils = {
     const timelineStart = startOfWeek(toDate(course.timeline_start));
     return differenceInWeeks(timelineStart, courseStart);
   },
-  getWeekStartDate(week, timelineStart) {
-    const weekStart = addWeeks(startOfWeek(toDate(timelineStart)), week.weekNumber - 1);
-    return this.formattedDateTime(weekStart);
-  },
-  getWeekEndDate(week, timelineStart) {
-    const weekEnd = endOfWeek(addWeeks(startOfWeek(toDate(timelineStart)), week.weekNumber - 1));
-    return this.formattedDateTime(weekEnd);
-  },
 
   // Returns array describing weekday meetings for each week
   // Ex: [["Sunday (01/09)"], ["Sunday (01/16)", "Wednesday (01/19)", "Thursday (01/20)"], []]

--- a/app/assets/javascripts/utils/date_calculator.js
+++ b/app/assets/javascripts/utils/date_calculator.js
@@ -8,7 +8,11 @@ class DateCalculator {
     this.loopIndex = loopIndex;
     this.opts = opts;
   }
-
+  static calculateDates(timeline_start, timeline_end, index, options = { zeroIndexed: true }) {
+    const dateCalc = new DateCalculator(timeline_start, timeline_end, index, options);
+    const datesStr = `${dateCalc.start()} - ${dateCalc.end()}`;
+    return datesStr;
+  }
   startDate() {
     const index = this.opts.zeroIndexed === true ? this.loopIndex : this.loopIndex - 1;
     return addDays(startOfWeek(toDate(this.beginning)), 7 * (index || 0));


### PR DESCRIPTION
## What this PR does
It addresses the issue #279  Milestones section should show dates in addition to week numbers. 
I declared two functions getWeekStartDate and getWeekEndDate in my `app/assets/javascripts/utils/course_date_utils.js` that gets the start and end date of each week and they are used in `app/assets/javascripts/components/overview/milestones.jsx` to render the dates of each milestone.

## Screenshots
Before:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/122573982/dc5b57e8-ddff-4f70-a889-e9754726fe41)

After:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/122573982/e50f8a05-30af-45e3-802d-5b3aafb2a387)
## Open questions and concerns

