### PR TITLE
Fixed left spacing in training page

### DIFF
--- a/app/assets/stylesheets/training_modules/_training.styl
+++ b/app/assets/stylesheets/training_modules/_training.styl
@@ -185,3 +185,7 @@
     flex-direction column
     .training-libraries__individual-library, .training-library-focus
       width 100%
+
+@media only screen and (min-width: ($desktop))
+  .container.training
+    padding-left 20px


### PR DESCRIPTION

## What this PR does
This PR fixes the padding issue in this specific range screen width (920px to 1110px ) on left side, causing a visual consistency in the layout in Training page, as it was addressed in Issue #5589 

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/106299466/7439b169-29f5-45f9-9f2a-4a8ce0788770)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/106299466/e6e32594-e405-4c12-b6fa-630bd7a1fabe)

## Open questions and concerns
@ragesoss , please review this pull request and let me know if there are any issues that need to be addressed before it can be merged, or if it is ready to proceed.
Thank You
