### PR TITLE
Added "Start Date" column in Programs tab of Campaign and its sorting feature based on date and timing

### DIFF
--- a/app/assets/javascripts/utils/course.js
+++ b/app/assets/javascripts/utils/course.js
@@ -23,7 +23,7 @@ document.onreadystatechange = () => {
       page: 500,
       valueNames: [
         'title', 'school', 'revisions', 'characters', 'references', 'average-words', 'views',
-        'reviewed', 'students', 'creation-date', 'ungreeted', 'untrained'
+        'reviewed', 'students', 'creation-date', 'ungreeted', 'untrained', 'start-date'
       ]
     });
   }
@@ -36,7 +36,7 @@ document.onreadystatechange = () => {
       page: 500,
       valueNames: [
         'title', 'school', 'revisions', 'characters', 'references', 'average-words', 'views',
-        'reviewed', 'students', 'creation-date', 'ungreeted', 'untrained'
+        'reviewed', 'students', 'creation-date', 'ungreeted', 'untrained', 'start-date'
       ]
     });
   }

--- a/app/views/campaigns/_course_row.html.haml
+++ b/app/views/campaigns/_course_row.html.haml
@@ -48,6 +48,14 @@
         %span.creation-date
           = I18n.localize course.created_at.to_date
   %td{:class => "table-link-cell"}
+    %a.course-link{:href => "#{course_slug_path(course.slug)}"}
+      - if course.start.present?
+        %span.start-date
+          = I18n.localize course.start.to_date
+      - else
+        %span.no-start-date
+          N/A
+  %td{:class => "table-link-cell"}
     - if @presenter&.campaign_organizer?
       %a.course-link{:href => "#{course_slug_path(course.slug)}", style: "padding-bottom: 0;"}
         = form_for(@campaign, url: course_clone_path(course.id), method: :post, id: "clone_course-#{course.id}", html: { class: 'remove-program-form' }) do

--- a/app/views/campaigns/programs.html.haml
+++ b/app/views/campaigns/programs.html.haml
@@ -30,6 +30,8 @@
           - unless Features.wiki_ed?
             %option{rel: 'desc', value: 'creation-date'}
               = t("courses.creation_date")
+          %option{rel: 'asc', value: 'start-date'}
+            = t("courses.start_date")
 
     %table.table.table--hoverable.table--sortable
       %thead
@@ -78,6 +80,10 @@
               = t('courses.creation_date')
               %span.sortable-indicator
 
+          %th.sort.sortable{style: 'width: 160px;', 'data-default-order' => 'desc', 'data-sort' => 'start-date'}
+            = t('courses.start_date')
+            %span.sortable-indicator
+          
           - if @presenter.can_remove_course?
             %th{style: 'width:100px'}
               = t('courses.actions')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,6 +501,7 @@ en:
     courses: Courses
     courses_taught: Courses Taught
     creation_date: Creation Date
+    start_date: Start Date
     creator:
       already_exists: This course already exists. Consider changing the name, school, or term to make it unique.
       assignment_end: Assignment end


### PR DESCRIPTION
## What this PR does
Fixes #5572 
This pr add the column  of "Start Date" in programs tab of Campaign. And this list can also be sorted based on the date and time of programs/courses in ascending order.

## Video

Before:

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/8d26d48e-e087-4605-955c-4a0e27615dd4)


After:

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/4e5c09c4-0dc7-4991-9643-2f002af8d964)

