### PR TITLE
Resolved fetching revisions from wikisource.org

### DIFF
--- a/app/assets/javascripts/utils/wiki_utils.js
+++ b/app/assets/javascripts/utils/wiki_utils.js
@@ -1,8 +1,7 @@
 import ArticleUtils from './article_utils';
 
 const toWikiDomain = (wiki) => {
-  const subdomain = wiki.language || 'www';
-  return `${subdomain}.${wiki.project}.org`;
+  return `${wiki.project}.org`;
 };
 
 const formatOption = (wiki) => {

--- a/app/assets/javascripts/utils/wiki_utils.js
+++ b/app/assets/javascripts/utils/wiki_utils.js
@@ -1,12 +1,9 @@
 import ArticleUtils from './article_utils';
 
 const toWikiDomain = (wiki) => {
-  const subdomain = wiki.language;
-  let url = `${wiki.project}.org`;
-  if (subdomain) {
-    url = `${subdomain}.${wiki.project}.org`;
-  }
-  return `${url}`;
+  const language = (wiki.language) ? `${wiki.language}.` : 'www.';
+  const subdomain = (wiki.project === 'wikisource' && !wiki.language) ? '' : language;
+  return `${subdomain}${wiki.project}.org`;
 };
 
 const formatOption = (wiki) => {

--- a/app/assets/javascripts/utils/wiki_utils.js
+++ b/app/assets/javascripts/utils/wiki_utils.js
@@ -1,7 +1,12 @@
 import ArticleUtils from './article_utils';
 
 const toWikiDomain = (wiki) => {
-  return `${wiki.project}.org`;
+  const subdomain = wiki.language;
+  let url = `${wiki.project}.org`;
+  if (subdomain) {
+    url = `${subdomain}.${wiki.project}.org`;
+  }
+  return `${url}`;
 };
 
 const formatOption = (wiki) => {

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -18,7 +18,7 @@ describe('formatOption', () => {
 
 describe('url', () => {
   test(
-    'returns url format',
+    'if language is specified, return language as subdomain',
     () => {
       const wikiData = {
         language: 'en',
@@ -29,7 +29,7 @@ describe('url', () => {
     }
   );
   test(
-    'if no language specified, returns www subdomain',
+    'if no language specified and project is wikipedia, returns www as subdomain',
     () => {
       const wikiData = {
         language: null,
@@ -37,6 +37,17 @@ describe('url', () => {
       };
       const result = toWikiDomain(wikiData);
       expect(result).toStrictEqual('www.wikipedia.org');
+    }
+  );
+  test(
+    'if no language specified and project is wikisource, returns url without subdomain',
+    () => {
+      const wikiData = {
+        language: null,
+        project: 'wikisource'
+      };
+      const result = toWikiDomain(wikiData);
+      expect(result).toStrictEqual('wikisource.org');
     }
   );
 });

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -36,7 +36,7 @@ describe('url', () => {
         project: 'wikipedia'
       };
       const result = toWikiDomain(wikiData);
-      expect(result).toStrictEqual('wikipedia.org');
+      expect(result).toStrictEqual('www.wikipedia.org');
     }
   );
 });

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -36,7 +36,7 @@ describe('url', () => {
         project: 'wikipedia'
       };
       const result = toWikiDomain(wikiData);
-      expect(result).toStrictEqual('www.wikipedia.org');
+      expect(result).toStrictEqual('wikipedia.org');
     }
   );
 });


### PR DESCRIPTION
## What this PR does
Fixes #5530 
This PR resolves the CORS error that is occurring while fetching revisions from wikisource.org

## Screenshots
Before:

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/dfd68ce7-1de3-45d9-8328-f4eb2b140d66)


After:

![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/1b8bd31d-df14-4330-8654-1687d9f0c0ab)
