### PR TITLE
bug fix: Issue with Conditional Question Options Display

### DIFF
--- a/app/assets/javascripts/surveys/modules/SurveyAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAdmin.js
@@ -261,6 +261,7 @@ const SurveyAdmin = {
     this.conditional.operator = '=';
     this.$clear_conditional_button.removeClass('hidden');
     const answers = question.answer_options.split('\n');
+    this.$conditional_value_select.empty();
     this.$conditional_value_select.append("<option value='nil' slelected>Select an Answer</option>");
     answers.map((answer) => {
       const answerValue = answer.trim();


### PR DESCRIPTION
#closes #5517
## What this PR does

Fix : Issue with Conditional Question Options Display

Cause of the bug :

The bug occurs in the JavaScript code `SurveyAdmin.js` and the associated Haml file `_form.html.haml`. When adding options to a dropdown select (`this.$conditional_value_select` for `%select.hidden{"data-conditional-value-select" => ""}`), the existing options are not cleared before appending new ones. Consequently, the dropdown retains options from the previous question along with the new ones, leading to unexpected behavior.


To fix this, the solution involves adding the line `this.$conditional_value_select.empty();` before adding new options. This ensures that the dropdown is cleared of any previous options, providing a clean slate for the options related to the current question.


## Screenshots
Before:

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/3ca823a9-af10-47a3-a7f2-0d319ea88a20)


After:

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/86cad7c0-6c98-437a-b003-5a6fcc5bda9a)

