### PR TITLE
[Outreachy Round 27] Make `RevisionScoreImporter`  import data from both LiftWing API and reference-counter API.

### DIFF
--- a/app/controllers/revision_feedback_controller.rb
+++ b/app/controllers/revision_feedback_controller.rb
@@ -7,10 +7,10 @@ class RevisionFeedbackController < ApplicationController
   def index
     set_latest_revision_id
     return if @rev_id.nil?
-    liftwing_data = RevisionScoreImporter.new.fetch_liftwing_data_for_revision_id(@rev_id)
-    @feedback = RevisionFeedbackService.new(liftwing_data[:features]).feedback
+    revision_data = RevisionScoreImporter.new.fetch_data_for_revision_id(@rev_id)
+    @feedback = RevisionFeedbackService.new(revision_data[:features]).feedback
     @user_feedback = Assignment.find(params['assignment_id']).assignment_suggestions
-    @rating = liftwing_data[:rating]
+    @rating = revision_data[:rating]
   end
 
   private

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency "#{Rails.root}/lib/lift_wing_api"
+require_dependency "#{Rails.root}/lib/revision_score_api_handler"
 require_dependency "#{Rails.root}/lib/wiki_api"
 
 #= Imports revision scoring data from Lift Wing
@@ -12,11 +12,9 @@ class RevisionScoreImporter
   ################
   def self.update_revision_scores_for_course(course, update_service: nil)
     course.wikis.each do |wiki|
-      next unless LiftWingApi.valid_wiki?(wiki)
-      new(wiki:, course:, update_service:)
-        .update_revision_scores
-      new(wiki:, course:, update_service:)
-        .update_previous_revision_scores
+      importer = new(wiki:, course:, update_service:)
+      importer.update_revision_scores
+      importer.update_previous_revision_scores
     end
   end
 
@@ -24,12 +22,12 @@ class RevisionScoreImporter
     @course = course
     @update_service = update_service
     @wiki = wiki || Wiki.get_or_create(language:, project:)
-    @lift_wing_api = LiftWingApi.new(@wiki, @update_service)
+    @api_handler = RevisionScoreApiHandler.new(wiki: @wiki, update_service:)
   end
 
   # assumes a mediawiki rev_id from the correct Wikipedia
-  def fetch_liftwing_data_for_revision_id(rev_id)
-    result = @lift_wing_api.get_revision_data([rev_id])
+  def fetch_data_for_revision_id(rev_id)
+    result = @api_handler.get_revision_data([rev_id])
     features = result.dig(rev_id.to_s, 'features')
     rating = result.dig(rev_id.to_s, 'prediction')
     return { features:, rating: }
@@ -59,14 +57,15 @@ class RevisionScoreImporter
   private
 
   def get_and_save_scores(rev_batch)
-    scores = @lift_wing_api.get_revision_data rev_batch.map(&:mw_rev_id)
+    scores = @api_handler.get_revision_data rev_batch.map(&:mw_rev_id)
     save_scores(scores)
   end
 
   def get_and_save_previous_scores(rev_batch)
     parent_revisions = get_parent_revisions(rev_batch)
     return unless parent_revisions&.any?
-    scores = @lift_wing_api.get_revision_data parent_revisions.values.map(&:to_i)
+
+    scores = @api_handler.get_revision_data parent_revisions.values.map(&:to_i)
     save_parent_scores(parent_revisions, scores)
   end
 

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -56,6 +56,7 @@ class LiftWingApi
   # Returns a hash with wp10, features, deleted, and prediction, or empty hash if
   # there is an error.
   def get_single_revision_parsed_data(rev_id)
+    tries ||= 5
     body = { rev_id:, extended_output: true }.to_json
     response = lift_wing_server.post(quality_query_url, body)
     parsed_response = Oj.load(response.body)
@@ -67,6 +68,8 @@ class LiftWingApi
 
     build_successful_response(rev_id, parsed_response)
   rescue StandardError => e
+    tries -= 1
+    retry unless tries.zero?
     @errors << e
     return { 'wp10' => nil, 'features' => nil, 'deleted' => false, 'prediction' => nil }
   end

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -61,13 +61,14 @@ class LiftWingApi
     parsed_response = Oj.load(response.body)
     # If the responses contain an error, do not try to calculate wp10 or features.
     if parsed_response.key? 'error'
-      return { 'wp10' => nil, 'features' => nil, 'deleted' => deleted?(parsed_response) }
+      return { 'wp10' => nil, 'features' => nil, 'deleted' => deleted?(parsed_response),
+      'prediction' => nil }
     end
 
     build_successful_response(rev_id, parsed_response)
   rescue StandardError => e
     @errors << e
-    return {}
+    return { 'wp10' => nil, 'features' => nil, 'deleted' => false, 'prediction' => nil }
   end
 
   class InvalidProjectError < StandardError

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -63,11 +63,11 @@ class ReferenceCounterApi
                              level: 'warning', extra: { project_code: @project_code,
                              language_code: @language_code, rev_id:,
                              status_code: response.status, content: parsed_response }
-      return {}
+      return { 'num_ref' => nil }
     end
   rescue StandardError => e
     @errors << e
-    return {}
+    return { 'num_ref' => nil }
   end
 
   class InvalidProjectError < StandardError

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -3,6 +3,10 @@
 require_dependency "#{Rails.root}/lib/lift_wing_api"
 require_dependency "#{Rails.root}/lib/reference_counter_api"
 
+#= Handles the logic to decide how to retrieve revision data for a given wiki.
+# This involves to determine if the given wiki is supported for both Lift Wing API and
+# reference-counter API (e.g en.wikipedia), only for Lift Wing API (wikidata),
+# or only for reference-counter API (e.g es.wikipedia).
 class RevisionScoreApiHandler
   def initialize(language: 'en', project: 'wikipedia', wiki: nil, update_service: nil)
     @update_service = update_service

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -54,6 +54,7 @@ describe RevisionScoreImporter do
       expect(early_score).to be_between(0, 100)
       expect(later_score).to be_between(early_score, 100)
       expect(later_revision.features['feature.wikitext.revision.external_links']).to eq(12)
+      expect(later_revision.features['num_ref']).to eq(13)
     end
   end
 
@@ -73,7 +74,7 @@ describe RevisionScoreImporter do
       revision = article.revisions.first
       expect(revision.deleted).to eq(true)
       expect(revision.wp10).to be_nil
-      expect(revision.features).to be_empty
+      expect(revision.features).to eq({ 'num_ref' => nil })
     end
   end
 
@@ -92,7 +93,7 @@ describe RevisionScoreImporter do
       revision = article.revisions.first
       expect(revision.deleted).to eq(true)
       expect(revision.wp10).to be_nil
-      expect(revision.features).to be_empty
+      expect(revision.features).to eq({ 'num_ref' => nil })
     end
   end
 
@@ -114,12 +115,16 @@ describe RevisionScoreImporter do
 
     stub_request(:any, %r{https://api.wikimedia.org/service/lw/.*})
       .to_raise(Errno::ECONNREFUSED)
+
+    stub_request(:any, /.*reference-counter.toolforge.org*/)
+      .to_raise(Errno::ECONNREFUSED)
+
     described_class.new.update_revision_scores
 
     # no value changed for the revision
     revision = Revision.find_by(mw_rev_id: 662106477)
     expect(revision.wp10).to be_nil
-    expect(revision.features).to eq({})
+    expect(revision.features).to eq({ 'num_ref' => nil })
     expect(revision.deleted).to eq(false)
   end
 
@@ -151,7 +156,7 @@ describe RevisionScoreImporter do
     end
   end
 
-  describe '#fetch_liftwing_data_for_revision_id' do
+  describe '#fetch_data_for_revision_id' do
     let(:rev_id) { 860858080 }
     # https://en.wikipedia.org/w/index.php?title=Hamlin_Park&oldid=860858080
     # https://www.wikidata.org/w/index.php?title=Q61734980&oldid=860858080
@@ -159,7 +164,7 @@ describe RevisionScoreImporter do
     let(:project) { 'wikipedia' }
     let(:subject) do
       described_class.new(language:, project:)
-                     .fetch_liftwing_data_for_revision_id(rev_id)
+                     .fetch_data_for_revision_id(rev_id)
     end
 
     it 'returns a hash with a predicted rating and features' do
@@ -175,18 +180,11 @@ describe RevisionScoreImporter do
 
       it 'returns a hash with features' do
         VCR.use_cassette 'revision_scores/single_revision' do
+          puts subject[:features]
           expect(subject[:features]).to have_key(Revision::WIKIDATA_REFERENCES)
           expect(subject[:rating]).to eq('D')
         end
       end
-    end
-  end
-
-  context 'for a wiki without the articlequality model' do
-    it 'raises an error' do
-      stub_wiki_validation
-      expect { described_class.new(language: 'zh').update_revision_scores }
-        .to raise_error(LiftWingApi::InvalidProjectError)
     end
   end
 end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -72,30 +72,32 @@ describe LiftWingApi do
       end
     end
 
-    it 'handles timeout errors' do
-      stub_request(:any, /.*api.wikimedia.org.*/)
-        .to_raise(Errno::ETIMEDOUT)
-      expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-      expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
-      'features' => nil, 'deleted' => false, 'prediction' => nil })
-    end
-
-    it 'handles connection refused errors' do
-      stub_request(:any, /.*api.wikimedia.org.*/)
-        .to_raise(Faraday::ConnectionFailed)
-      expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-      expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
-      'features' => nil, 'deleted' => false, 'prediction' => nil })
-    end
-
-    it 'logs the error if something unexpected happens when building the successful response' do
-      VCR.use_cassette 'liftwing_api/logs_unexpected_error' do
-        allow(lift_wing_api_class_en_wiki)
-          .to receive(:build_successful_response)
-          .and_raise(StandardError)
+    context 'if the same error happens several times' do
+      it 'logs timeout error once' do
+        stub_request(:any, /.*api.wikimedia.org.*/)
+          .to_raise(Errno::ETIMEDOUT)
         expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
         expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
         'features' => nil, 'deleted' => false, 'prediction' => nil })
+      end
+
+      it 'logs connection refused once' do
+        stub_request(:any, /.*api.wikimedia.org.*/)
+          .to_raise(Faraday::ConnectionFailed)
+        expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
+        expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
+        'features' => nil, 'deleted' => false, 'prediction' => nil })
+      end
+
+      it 'logs unexpected error once' do
+        VCR.use_cassette 'liftwing_api/logs_unexpected_error' do
+          allow(lift_wing_api_class_en_wiki)
+            .to receive(:build_successful_response)
+            .and_raise(StandardError)
+          expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
+          expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
+          'features' => nil, 'deleted' => false, 'prediction' => nil })
+        end
       end
     end
   end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -50,11 +50,13 @@ describe LiftWingApi do
     it 'fetches json from api.wikimedia.org for wikidata' do
       VCR.use_cassette 'liftwing_api/wikidata' do
         expect(subject1).to be_a(Hash)
+        expect(subject1.dig('829840084')).to have_key('wp10')
         expect(subject1.dig('829840084', 'wp10')).to eq(nil)
         expect(subject1.dig('829840084', 'features')).to be_a(Hash)
         expect(subject1.dig('829840084', 'deleted')).to eq(false)
         expect(subject1.dig('829840084', 'prediction')).to eq('D')
 
+        expect(subject1.dig('829840084')).to have_key('wp10')
         expect(subject1.dig('829840085', 'wp10')).to eq(nil)
         expect(subject1.dig('829840085', 'features')).to be_a(Hash)
         expect(subject1.dig('829840085', 'deleted')).to eq(false)
@@ -65,36 +67,36 @@ describe LiftWingApi do
     it 'returns deleted equal to true if the revision was deleted' do
       VCR.use_cassette 'liftwing_api/deleted_revision' do
         expect(subject2).to be_a(Hash)
-        expect(subject2.dig('708326238', 'wp10')).to eq(nil)
-        expect(subject2.dig('708326238', 'features')).to eq(nil)
-        expect(subject2.dig('708326238', 'deleted')).to eq(true)
-        expect(subject2.dig('708326238', 'prediction')).to eq(nil)
+        expect(subject2.dig('708326238')).to eq({ 'wp10' => nil,
+        'features' => nil, 'deleted' => true, 'prediction' => nil })
       end
     end
 
     it 'handles timeout errors' do
-      stub_request(:any, 'https://api.wikimedia.org')
+      stub_request(:any, /.*api.wikimedia.org.*/)
         .to_raise(Errno::ETIMEDOUT)
       expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-      expect(subject0.dig('829840085')).to be_a(Hash)
-      expect(subject0.dig('829840085')).to be_empty
+      expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
+      'features' => nil, 'deleted' => false, 'prediction' => nil })
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, 'https://api.wikimedia.org')
+      stub_request(:any, /.*api.wikimedia.org.*/)
         .to_raise(Faraday::ConnectionFailed)
       expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-      expect(subject0.dig('829840085')).to be_a(Hash)
-      expect(subject0.dig('829840085')).to be_empty
+      expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
+      'features' => nil, 'deleted' => false, 'prediction' => nil })
     end
 
     it 'logs the error if something unexpected happens when building the successful response' do
-      allow(lift_wing_api_class_en_wiki)
-        .to receive(:build_successful_response)
-        .and_raise(StandardError)
-      expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-      expect(subject0.dig('829840085')).to be_a(Hash)
-      expect(subject0.dig('829840085')).to be_empty
+      VCR.use_cassette 'liftwing_api/logs_unexpected_error' do
+        allow(lift_wing_api_class_en_wiki)
+          .to receive(:build_successful_response)
+          .and_raise(StandardError)
+        expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
+        expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
+        'features' => nil, 'deleted' => false, 'prediction' => nil })
+      end
     end
   end
 end

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -26,7 +26,7 @@ describe ReferenceCounterApi do
     expect(response.dig('5006946', 'num_ref')).to eq(2)
   end
 
-  it 'returns empty hash and logs the message if response is not 200 OK', vcr: true do
+  it 'logs the message if response is not 200 OK', vcr: true do
     ref_counter_api = described_class.new(en_wikipedia)
     expect(Sentry).to receive(:capture_message).with(
       'Non-200 response hitting references counter API',
@@ -43,10 +43,10 @@ describe ReferenceCounterApi do
       }
     )
     response = ref_counter_api.get_number_of_references_from_revision_ids deleted_rev_ids
-    expect(response.dig('708326238')).to eq({})
+    expect(response.dig('708326238')).to eq({ 'num_ref' => nil })
   end
 
-  it 'returns empty hash and logs the error if an unexpected error raises', vcr: true do
+  it 'logs the error if an unexpected error raises', vcr: true do
     reference_counter_api = described_class.new(es_wiktionary)
 
     allow_any_instance_of(Faraday::Connection).to receive(:get)
@@ -63,8 +63,8 @@ describe ReferenceCounterApi do
      }
     )
     response = reference_counter_api.get_number_of_references_from_revision_ids rev_ids
-    expect(response.dig('5006940')).to eq({})
-    expect(response.dig('5006942')).to eq({})
-    expect(response.dig('5006946')).to eq({})
+    expect(response.dig('5006940')).to eq({ 'num_ref' => nil })
+    expect(response.dig('5006942')).to eq({ 'num_ref' => nil })
+    expect(response.dig('5006946')).to eq({ 'num_ref' => nil })
   end
 end

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/revision_score_api_handler"
+
+describe RevisionScoreApiHandler do
+  context 'when the wiki works for both lift wing and reference-counter APIs' do
+    let(:handler) { described_class.new(wiki: Wiki.find(1)) }
+    let(:subject) { handler.get_revision_data [829840090, 829840091] }
+
+    describe '#get_revision_data' do
+      it 'returns completed scores if retrieves data without errors' do
+        VCR.use_cassette 'revision_score_api_handler/en_wikipedia' do
+          expect(subject).to be_a(Hash)
+          expect(subject.dig('829840090', 'wp10').to_f).to eq(62.805729915108664)
+          expect(subject.dig('829840090', 'features')).to be_a(Hash)
+          expect(subject.dig('829840090', 'features',
+                             'feature.wikitext.revision.ref_tags')).to eq(132)
+          expect(subject.dig('829840090', 'features', 'num_ref')).to eq(132)
+          expect(subject.dig('829840090', 'deleted')).to eq(false)
+          expect(subject.dig('829840090', 'prediction')).to eq('B')
+
+          expect(subject.dig('829840091', 'wp10').to_f).to eq(39.507631367268004)
+          expect(subject.dig('829840091', 'features')).to be_a(Hash)
+          expect(subject.dig('829840091', 'features',
+                             'feature.wikitext.revision.ref_tags')).to eq(1)
+          expect(subject.dig('829840091', 'features', 'num_ref')).to eq(1)
+          expect(subject.dig('829840091', 'deleted')).to eq(false)
+          expect(subject.dig('829840091', 'prediction')).to eq('C')
+        end
+      end
+
+      it 'returns completed scores if there is an error hitting LiftWingApi' do
+        VCR.use_cassette 'revision_score_api_handler/en_wikipedia_liftwing_error' do
+          stub_request(:any, /.*api.wikimedia.org.*/)
+            .to_raise(Errno::ETIMEDOUT)
+          expect(subject).to be_a(Hash)
+          expect(subject.dig('829840090')).to eq({ 'wp10' => nil,
+          'features' => { 'num_ref' => 132 }, 'deleted' => false, 'prediction' => nil })
+          expect(subject.dig('829840091')).to eq({ 'wp10' => nil,
+          'features' => { 'num_ref' => 1 }, 'deleted' => false, 'prediction' => nil })
+        end
+      end
+
+      it 'returns completed scores if there is an error hitting ReferenceCounterApi' do
+        VCR.use_cassette 'revision_score_api_handler/en_wikipedia_reference_counter_error' do
+          stub_request(:any, /.*reference-counter.toolforge.org*/)
+            .to_raise(Errno::ETIMEDOUT)
+
+          expect(subject).to be_a(Hash)
+          expect(subject.dig('829840090', 'wp10').to_f).to eq(62.805729915108664)
+          expect(subject.dig('829840090', 'features')).to be_a(Hash)
+          expect(subject.dig('829840090', 'features',
+                             'feature.wikitext.revision.ref_tags')).to eq(132)
+          expect(subject.dig('829840090', 'features').key?('num_ref')).to eq(true)
+          expect(subject.dig('829840090', 'features', 'num_ref')).to eq(nil)
+          expect(subject.dig('829840090', 'deleted')).to eq(false)
+          expect(subject.dig('829840090', 'prediction')).to eq('B')
+
+          expect(subject.dig('829840091', 'wp10').to_f).to eq(39.507631367268004)
+          expect(subject.dig('829840091', 'features')).to be_a(Hash)
+          expect(subject.dig('829840091', 'features',
+                             'feature.wikitext.revision.ref_tags')).to eq(1)
+          expect(subject.dig('829840091', 'features').key?('num_ref')).to eq(true)
+          expect(subject.dig('829840091', 'features', 'num_ref')).to eq(nil)
+          expect(subject.dig('829840091', 'deleted')).to eq(false)
+          expect(subject.dig('829840091', 'prediction')).to eq('C')
+        end
+      end
+    end
+
+    it 'returns completed scores if there is an error hitting both apis' do
+      stub_request(:any, /.*api.wikimedia.org.*/)
+        .to_raise(Errno::ETIMEDOUT)
+      stub_request(:any, /.*reference-counter.toolforge.org*/)
+        .to_raise(Errno::ETIMEDOUT)
+      expect(subject).to be_a(Hash)
+      expect(subject.dig('829840090')).to eq({ 'wp10' => nil,
+      'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+      expect(subject.dig('829840091')).to eq({ 'wp10' => nil,
+      'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+    end
+  end
+
+  context 'when the wiki is available only for LiftWing API' do
+    before { stub_wiki_validation }
+
+    let(:wiki) { create(:wiki, project: 'wikidata', language: nil) }
+    let(:handler) { described_class.new(wiki:) }
+    let(:subject) { handler.get_revision_data [144495297, 144495298] }
+
+    describe '#get_revision_data' do
+      it 'returns completed scores if retrieves data without errors' do
+        VCR.use_cassette 'revision_score_api_handler/wikidata' do
+          expect(subject).to be_a(Hash)
+          expect(subject.dig('144495297', 'wp10').to_f).to eq(0)
+          expect(subject.dig('144495297', 'features')).to be_a(Hash)
+          expect(subject.dig('144495297', 'features',
+                             'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(2)
+          expect(subject.dig('144495297', 'features').key?('num_ref')).to eq(true)
+          expect(subject.dig('144495297', 'features', 'num_ref')).to eq(nil)
+          expect(subject.dig('144495297', 'deleted')).to eq(false)
+          expect(subject.dig('144495297', 'prediction')).to eq('D')
+
+          expect(subject.dig('144495298', 'wp10').to_f).to eq(0)
+          expect(subject.dig('144495298', 'features')).to be_a(Hash)
+          expect(subject.dig('144495298', 'features',
+                             'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(0)
+          expect(subject.dig('144495298', 'features').key?('num_ref')).to eq(true)
+          expect(subject.dig('144495298', 'features', 'num_ref')).to eq(nil)
+          expect(subject.dig('144495298', 'deleted')).to eq(false)
+          expect(subject.dig('144495298', 'prediction')).to eq('E')
+        end
+      end
+
+      it 'returns completed scores if there is an error hitting LiftWingApi' do
+        stub_request(:any, /.*api.wikimedia.org.*/)
+          .to_raise(Errno::ETIMEDOUT)
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('144495297')).to eq({ 'wp10' => nil,
+        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('144495298')).to eq({ 'wp10' => nil,
+        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+      end
+    end
+  end
+
+  context 'when the wiki is available only for reference-counter API' do
+    before { stub_wiki_validation }
+
+    let(:wiki) { create(:wiki, project: 'wikipedia', language: 'es') }
+    let(:handler) { described_class.new(wiki:) }
+    let(:subject) { handler.get_revision_data [157412237, 157417768] }
+
+    describe '#get_revision_data' do
+      it 'returns completed scores if retrieves data without errors' do
+        VCR.use_cassette 'revision_score_api_handler/es_wikipedia' do
+          expect(subject).to be_a(Hash)
+          expect(subject.dig('157412237')).to eq({ 'wp10' => nil,
+          'features' => { 'num_ref' => 111 }, 'deleted' => false, 'prediction' => nil })
+          expect(subject.dig('157417768')).to eq({ 'wp10' => nil,
+          'features' => { 'num_ref' => 42 }, 'deleted' => false, 'prediction' => nil })
+        end
+      end
+
+      it 'returns completed scores if there is an error hitting reference-counter api' do
+        stub_request(:any, /.*reference-counter.toolforge.org*/)
+          .to_raise(Errno::ETIMEDOUT)
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('157412237')).to eq({ 'wp10' => nil,
+        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('157417768')).to eq({ 'wp10' => nil,
+        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR is part of the "Improve how Wiki Education Dashboard counts references added" project (read issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5547).

The purpose of this PR is to modify the existing `RevisionScoreImporter` class to not only use the Lift Wing API, but also to hit the new reference-counter one. Notice that these APIs are not available for every wiki:

- Lift Wing API only works for 1) wikidata and 2) wikipedia for articlequality model languages (en, eu, fa, fr, gl, nl, pt, ru, sv, tr, and uk).
- reference-counter API works for every wiki, except for wikidata.

To abstract the logic related to deciding which API/APIs hit to get revisions data for a given wiki, this PR adds a new `RevisionScoreApiHandler` intermediate class that deal with it.

When merging and deploying this PR, `features` and  `features_previous` fields in `revisions` table will store a hash with not only the data from Lift Wing API (if any), but also a `num_ref` key with the number of references got from the reference-counter API (if applicable). 

Notice that even though this PR populates the `features` and  `features_previous` fields with `num_ref` data, this it not used when calculating the references added in `Revision.references_added method`. So no change should be visible from the user's point of view.

## Open questions and concerns
One idea to evaluate before deploying this is to make the process of starting to use the new reference-counter API more progressive. One easy way to do this could be to temporarily modify the `valid_wiki?` definition for the `ReferenceCounterApi`. This way we could enable this new API only for some specific wikis, for example es.wikipedia. That way we can monitor the new process taking less risk. After the updates of some courses, if everything works as expected, we can enable the `ReferenceCounterApi` for every wiki except for wikidata.