### PR TITLE
Fixed 500 link limit for loading training slides (ISSUE: #5588)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,8 @@ GEM
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -604,6 +606,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activerecord-import

--- a/lib/training/wiki_training_loader.rb
+++ b/lib/training/wiki_training_loader.rb
@@ -96,12 +96,12 @@ class WikiTrainingLoader
     # To handle more than 500 pages linked from the source page,
     # we'll need to update this to use 'continue'.
     query_params = { prop: 'links', titles: @wiki_base_page, pllimit: 500 }
-    links = []
+    finalLinks = []
     begin
       response = WikiApi.new(MetaWiki.new).query(query_params)
       loop do
         current_links = response.dig('pages', @wiki_base_page, 'links') || []
-        links.concat(current_links.map { |page| page['title'] })
+        finalLinks.concat(current_links.map { |page| page['title'] })
 
         @continue = response['continue']&.fetch('plcontinue', 'done')
         break if @continue == 'done'
@@ -111,7 +111,7 @@ class WikiTrainingLoader
     rescue StandardError => e
       raise InvalidWikiContentError, "could not get links from '#{@wiki_base_page}': #{e.message}"
     end
-    links
+    finalLinks
   end
 
   def listed_wiki_source_pages

--- a/lib/training/wiki_training_loader.rb
+++ b/lib/training/wiki_training_loader.rb
@@ -96,12 +96,22 @@ class WikiTrainingLoader
     # To handle more than 500 pages linked from the source page,
     # we'll need to update this to use 'continue'.
     query_params = { prop: 'links', titles: @wiki_base_page, pllimit: 500 }
-    response = WikiApi.new(MetaWiki.new).query(query_params)
+    links = []
     begin
-      response.data['pages'].values[0]['links'].map { |page| page['title'] }
-    rescue StandardError
-      raise InvalidWikiContentError, "could not get links from '#{@wiki_base_page}'"
+      response = WikiApi.new(MetaWiki.new).query(query_params)
+      loop do
+        current_links = response.dig('pages', @wiki_base_page, 'links') || []
+        links.concat(current_links.map { |page| page['title'] })
+
+        @continue = response['continue']&.fetch('plcontinue', 'done')
+        break if @continue == 'done'
+
+        response = WikiApi.new(MetaWiki.new).query(query_params.merge(plcontinue: @continue))
+      end
+    rescue StandardError => e
+      raise InvalidWikiContentError, "could not get links from '#{@wiki_base_page}': #{e.message}"
     end
+    links
   end
 
   def listed_wiki_source_pages


### PR DESCRIPTION
## What this PR does
This pull request adds the ability to load links from the wiki without limiting them to 500.

## Screenshots
Before:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/50093149/f3ed5e3e-c6f6-4be7-9064-3d209a9d7cb7)

After:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/50093149/11feb76d-b1a9-4051-91d6-a554039327c3)
