### PR TITLE
Added Informative Text to 'See More' Button on Hover in P&E Dashboard 'Articles' Tab of a Program

### DIFF
--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -42,12 +42,17 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
       />) : null }
       {!limitReached
         && (
-          <button
-            style={{ width: 'max-content', height: 'max-content' }}
-            className="button ghost articles-see-more-btn" onClick={showMore}
-          >
-            {I18n.t('articles.see_more')}
-          </button>
+          <div className={'tooltip-trigger'}>
+            <button
+              style={{ width: 'max-content', height: 'max-content' }}
+              className="button ghost articles-see-more-btn" onClick={showMore}
+            >
+              {I18n.t('articles.see_more')}
+            </button>
+            <div className="tooltip tooltip-center tooltip-see-more dark large">
+              <p style={{ padding: '0px', textWrap: 'balance' }}>Click &apos;See more&apos; to load the next subset of 500 articles and continue the seamless navigation through the articles with the pagination on the left.</p>
+            </div>
+          </div>
         )
       }
       <p className="articles-shown-label">

--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -50,7 +50,7 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
               {I18n.t('articles.see_more')}
             </button>
             <div className="tooltip tooltip-center tooltip-see-more dark large">
-              <p style={{ padding: '0px', textWrap: 'balance' }}>Click &apos;See more&apos; to load the next subset of 500 articles and continue the seamless navigation through the articles with the pagination on the left.</p>
+              <p style={{ padding: '0px', textWrap: 'balance' }}>{I18n.t('articles.see_more_tooltip')}</p>
             </div>
           </div>
         )

--- a/app/assets/stylesheets/modules/_tooltips.styl
+++ b/app/assets/stylesheets/modules/_tooltips.styl
@@ -38,6 +38,11 @@
       min-width 200px !important
       &:before
         margin-left 36% !important
+    &.tooltip-see-more
+      left -40%
+      min-width 200px !important
+      &:before
+        margin-left 36% !important
     &.large
       min-width 320px
       p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
       ?: Unrated — an article that hasn't yet been rated on Wikipedia's quality scale
       does_not_exist: This article does not exist on Wikipedia
     see_more: See more
-    see_more_tooltip: Click 'See more' to load the next subset of 500 articles and continue the seamless navigation through the articles with the pagination on the left.
+    see_more_tooltip: Only the first 500 edited articles are loaded initially. Click to load additional articles.
     search: Search Wikipedia for an Article
     show_cumulative_changes: Show Cumulative Changes
     show_current_version: Show Current Version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
       ?: Unrated — an article that hasn't yet been rated on Wikipedia's quality scale
       does_not_exist: This article does not exist on Wikipedia
     see_more: See more
+    see_more_tooltip: Click 'See more' to load the next subset of 500 articles and continue the seamless navigation through the articles with the pagination on the left.
     search: Search Wikipedia for an Article
     show_cumulative_changes: Show Cumulative Changes
     show_current_version: Show Current Version

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -186,7 +186,7 @@ qqq:
       does_not_exist: Explanation of the Ø  symbol, which indicates than the article
         does not exist on Wikipedia
     see_more: Message indicating that there are more articles to load
-    see_more_tooltip: Message displayed when clicking see more button to load next subsets of 500 articles
+    see_more_tooltip: Tooltip message shown when hovering on "See More" button for loading additional articles
     title: |-
       Label for an article title.
       {{Identical|Title}}

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -186,6 +186,7 @@ qqq:
       does_not_exist: Explanation of the Ø  symbol, which indicates than the article
         does not exist on Wikipedia
     see_more: Message indicating that there are more articles to load
+    see_more_tooltip: Message displayed when clicking see more button to load next subsets of 500 articles
     title: |-
       Label for an article title.
       {{Identical|Title}}


### PR DESCRIPTION
## What this PR does
Resolves issue #5569 


## Screenshots
Before:
<img width="1197" alt="Screenshot 2024-01-27 at 3 46 45 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/d5aca40d-2951-4545-afc7-94ed80fd6588">


After:
![Screenshot 2024-01-27 at 3 24 19 PM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/f01f98fe-e2bd-4361-8030-418152202cf1)
