### PR TITLE
Added "Delayed Real-Time Counts" Informative Text on Hover to P&E Dashboard on "Home" Tab of Program

### DIFF
--- a/app/assets/javascripts/components/overview/my_exercises/containers/Container.jsx
+++ b/app/assets/javascripts/components/overview/my_exercises/containers/Container.jsx
@@ -28,7 +28,7 @@ const MyExercisesContainer = ({ trainingLibrarySlug }) => {
   if (!incomplete.length) return null;
   if (exercises.loading) {
     return (
-      <div className="module my-exercises" style={{ marginTop: '55px' }}>
+      <div className="module my-exercises">
         <h3>Loading...</h3>
       </div>
     );
@@ -40,14 +40,14 @@ const MyExercisesContainer = ({ trainingLibrarySlug }) => {
   });
   if (!latest) {
     return (
-      <div className="module my-exercises" style={{ marginTop: '55px' }}>
+      <div className="module my-exercises">
         <Header completed={true} course={course} text="Completed all exercises" />
       </div>
     );
   }
 
   return (
-    <div className="module my-exercises" style={{ marginTop: '55px' }}>
+    <div className="module my-exercises">
       <Header course={course} remaining={remaining} text="Upcoming Exercises" />
       <UpcomingExercise exercise={latest} trainingLibrarySlug={trainingLibrarySlug} />
     </div>

--- a/app/assets/javascripts/components/overview/my_exercises/containers/Container.jsx
+++ b/app/assets/javascripts/components/overview/my_exercises/containers/Container.jsx
@@ -28,7 +28,7 @@ const MyExercisesContainer = ({ trainingLibrarySlug }) => {
   if (!incomplete.length) return null;
   if (exercises.loading) {
     return (
-      <div className="module my-exercises">
+      <div className="module my-exercises" style={{ marginTop: '55px' }}>
         <h3>Loading...</h3>
       </div>
     );
@@ -40,14 +40,14 @@ const MyExercisesContainer = ({ trainingLibrarySlug }) => {
   });
   if (!latest) {
     return (
-      <div className="module my-exercises">
+      <div className="module my-exercises" style={{ marginTop: '55px' }}>
         <Header completed={true} course={course} text="Completed all exercises" />
       </div>
     );
   }
 
   return (
-    <div className="module my-exercises">
+    <div className="module my-exercises" style={{ marginTop: '55px' }}>
       <Header course={course} remaining={remaining} text="Upcoming Exercises" />
       <UpcomingExercise exercise={latest} trainingLibrarySlug={trainingLibrarySlug} />
     </div>

--- a/app/assets/javascripts/components/overview/statistics_update_info.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_info.jsx
@@ -35,6 +35,18 @@ const StatisticsUpdateInfo = ({ course }) => {
       <small>
         {updateTimesMessage} {(course.flags.first_update || course.flags.update_logs) && <a onClick={toggleModal} href="#">{I18n.t('metrics.update_statistics_link')}</a>}
       </small>
+      <div className="tooltip-trigger" style={{ cursor: 'default' }}>
+        <small className="statistics-delayed-info">
+          {(course.flags.first_update || course.flags.update_logs) && 'Delayed real-time counts'}
+        </small>
+        <div className="tooltip dark tooltip-right large">
+          <p>
+            While the counts are still 0 or not reflective of the activity level
+            on this event, within 24 hours the activity level and reflected
+            counts will sync.
+          </p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/assets/javascripts/components/overview/statistics_update_info.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_info.jsx
@@ -37,7 +37,7 @@ const StatisticsUpdateInfo = ({ course }) => {
       </small>
       <div className="tooltip-trigger" style={{ cursor: 'default' }}>
         <small className="statistics-delayed-info">
-          {(course.flags.first_update || course.flags.update_logs) && 'Delayed real-time counts'}
+          {(course.flags.first_update || course.flags.update_logs) && I18n.t('metrics.delayed_info')}
         </small>
         <div className="tooltip dark tooltip-right large">
           <p>

--- a/app/assets/javascripts/components/overview/statistics_update_info.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_info.jsx
@@ -41,9 +41,7 @@ const StatisticsUpdateInfo = ({ course }) => {
         </small>
         <div className="tooltip dark tooltip-right large">
           <p>
-            While the counts are still 0 or not reflective of the activity level
-            on this event, within 24 hours the activity level and reflected
-            counts will sync.
+            {I18n.t('metrics.update_statistics_tooltip')}
           </p>
         </div>
       </div>

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -132,6 +132,10 @@ rating(color)
     color color
 
 .statistics-update-info
+  display flex
+  flex-direction column
+  align-items flex-end
+  position relative
   a
     color inherit
 

--- a/app/assets/stylesheets/modules/_my_articles.styl
+++ b/app/assets/stylesheets/modules/_my_articles.styl
@@ -1,4 +1,5 @@
 .my-articles
+  margin-top 55px
   margin-bottom 0
 
   .peer-review-count

--- a/app/assets/stylesheets/modules/_my_exercises.styl
+++ b/app/assets/stylesheets/modules/_my_exercises.styl
@@ -1,4 +1,5 @@
 .module.my-exercises
+  margin-top 55px
   h3.completed
     margin 0
   h3 small

--- a/app/assets/stylesheets/modules/_tooltips.styl
+++ b/app/assets/stylesheets/modules/_tooltips.styl
@@ -38,6 +38,11 @@
       min-width 200px !important
       &:before
         margin-left 36% !important
+    &.tooltip-right
+      left -145%
+      min-width 200px !important
+      &:before
+        margin-left 75% !important
     &.large
       min-width 320px
       p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1059,6 +1059,7 @@ en:
     total_updates: Total number of updates till now
     update_status_heading: Update status
     update_statistics_link: See more
+    delayed_info: Delayed real-time counts
     update_statistics_tooltip: While the counts are still 0 or not reflective of the activity level on this event, within 24 hours the activity level and reflected counts will sync.
     upload_count: Commons Uploads
     uploads_in_use_count:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1059,6 +1059,7 @@ en:
     total_updates: Total number of updates till now
     update_status_heading: Update status
     update_statistics_link: See more
+    update_statistics_tooltip: While the counts are still 0 or not reflective of the activity level on this event, within 24 hours the activity level and reflected counts will sync.
     upload_count: Commons Uploads
     uploads_in_use_count:
       one: file used in an article

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -626,6 +626,7 @@ qqq:
     view_count_description: Long label for the number of views for the article or
       articles involved.
     update_statistics_tooltip: Message displaying that the counts will synchronize.
+    delayed_info: Label showing users that the real time counts are delayed.
     view: Label for the number of article views.
     descriptions: '{{identical|Description}}'
     labels: '{{identical|Label}}'

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -625,6 +625,7 @@ qqq:
       used across all languages and projects. Preceded by %{count}.
     view_count_description: Long label for the number of views for the article or
       articles involved.
+    update_statistics_tooltip: Message displaying that the counts will synchronize.
     view: Label for the number of article views.
     descriptions: '{{identical|Description}}'
     labels: '{{identical|Label}}'


### PR DESCRIPTION
## What this PR does
This PR addresses the issue #5566 

## Screenshots
### Before:
<img width="1470" alt="befor" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/8bf92c9b-119e-4af0-8302-f1930d67727e">


### After:

Without hover:
<img width="1470" alt="afftr 1" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/7df20b2f-3dd4-4898-8f9d-541a7dc237a4">

When hovered over 'Delayed time counts':
<img width="1470" alt="aftr 2" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/cd5e73a9-dbf3-4c19-bbbd-b34d328630da">
