### PR TITLE
Solved bug of next estimated update

### DIFF
--- a/app/assets/javascripts/components/overview/statistics_update_info.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_info.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import StatisticsUpdateModal from './statistics_update_modal';
 import { getUpdateMessage } from '../../utils/statistic_update_info_utils';
-import { isAfter, toDate } from 'date-fns';
 
 const StatisticsUpdateInfo = ({ course }) => {
   const [showModal, setShowModal] = useState(false);
@@ -27,9 +26,7 @@ const StatisticsUpdateInfo = ({ course }) => {
       />
     );
   }
-  const updatesEndMoment = toDate(course.update_until);
-  const futureUpdatesRemaining = isAfter(updatesEndMoment, new Date());
-  const updateTimesMessage = (isNextUpdateAfter && futureUpdatesRemaining) ? `${lastUpdateMessage} ${nextUpdateMessage} ` : `${lastUpdateMessage} `;
+  const updateTimesMessage = isNextUpdateAfter ? `${lastUpdateMessage} ${nextUpdateMessage} ` : `${lastUpdateMessage} `;
 
   // Render update time information and if some updates were made a 'See More' link to open modal
   return (

--- a/app/assets/javascripts/components/overview/statistics_update_info.jsx
+++ b/app/assets/javascripts/components/overview/statistics_update_info.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import StatisticsUpdateModal from './statistics_update_modal';
 import { getUpdateMessage } from '../../utils/statistic_update_info_utils';
+import { isAfter, toDate } from 'date-fns';
 
 const StatisticsUpdateInfo = ({ course }) => {
   const [showModal, setShowModal] = useState(false);
@@ -26,8 +27,9 @@ const StatisticsUpdateInfo = ({ course }) => {
       />
     );
   }
-
-  const updateTimesMessage = isNextUpdateAfter ? `${lastUpdateMessage} ${nextUpdateMessage} ` : `${lastUpdateMessage} `;
+  const updatesEndMoment = toDate(course.update_until);
+  const futureUpdatesRemaining = isAfter(updatesEndMoment, new Date());
+  const updateTimesMessage = (isNextUpdateAfter && futureUpdatesRemaining) ? `${lastUpdateMessage} ${nextUpdateMessage} ` : `${lastUpdateMessage} `;
 
   // Render update time information and if some updates were made a 'See More' link to open modal
   return (

--- a/app/assets/javascripts/utils/statistic_update_info_utils.js
+++ b/app/assets/javascripts/utils/statistic_update_info_utils.js
@@ -14,6 +14,10 @@ const lastSuccessfulUpdateMoment = (update_logs) => {
   return new Date(lastSuccessfulUpdateTime);
 };
 
+const isNextUpdateAfterUpdatesEnd = (nextUpdateExpectedTime, updatesEndMoment) => {
+  return isAfter(nextUpdateExpectedTime, new Date()) && isAfter(updatesEndMoment, new Date());
+};
+
 const getLastUpdateMessage = (course) => {
   let lastUpdateMessage = '';
   let nextUpdateMessage = '';
@@ -24,7 +28,7 @@ const getLastUpdateMessage = (course) => {
     const averageDelay = course.updates.average_delay ?? 0;
     lastUpdateMessage = `${I18n.t('metrics.last_update')}: ${formatDistanceToNow(lastUpdateMoment, { addSuffix: true })}.`;
     const nextUpdateExpectedTime = addSeconds(lastUpdateMoment, averageDelay);
-    isNextUpdateAfter = (isAfter(nextUpdateExpectedTime, new Date()) && isAfter(updatesEndMoment, new Date()));
+    isNextUpdateAfter = isNextUpdateAfterUpdatesEnd(nextUpdateExpectedTime, updatesEndMoment);
     nextUpdateMessage = `${I18n.t('metrics.next_update')}: ${formatDistanceToNow(nextUpdateExpectedTime, { addSuffix: true })}.`;
   }
   return [lastUpdateMessage, nextUpdateMessage, isNextUpdateAfter];
@@ -63,7 +67,7 @@ const getFirstUpdateMessage = (course) => {
   const updatesEndMoment = toDate(course.update_until);
   if (course.flags.first_update) {
     const nextUpdateExpectedTime = firstUpdateTime(course.flags.first_update);
-    isNextUpdateAfter = (isAfter(nextUpdateExpectedTime, new Date()) && isAfter(updatesEndMoment, new Date()));
+    isNextUpdateAfter = isNextUpdateAfterUpdatesEnd(nextUpdateExpectedTime, updatesEndMoment);
     nextUpdateMessage = `${I18n.t('metrics.first_update')}: ${formatDistanceToNow(nextUpdateExpectedTime, { addSuffix: true })}.`;
     lastUpdateMessage = `${I18n.t('metrics.enqueued_update')}`;
   } else {

--- a/app/assets/javascripts/utils/statistic_update_info_utils.js
+++ b/app/assets/javascripts/utils/statistic_update_info_utils.js
@@ -19,11 +19,12 @@ const getLastUpdateMessage = (course) => {
   let nextUpdateMessage = '';
   let isNextUpdateAfter = false;
   const lastUpdateMoment = lastSuccessfulUpdateMoment(course.flags.update_logs);
+  const updatesEndMoment = toDate(course.update_until);
   if (lastUpdateMoment) {
     const averageDelay = course.updates.average_delay ?? 0;
     lastUpdateMessage = `${I18n.t('metrics.last_update')}: ${formatDistanceToNow(lastUpdateMoment, { addSuffix: true })}.`;
     const nextUpdateExpectedTime = addSeconds(lastUpdateMoment, averageDelay);
-    isNextUpdateAfter = isAfter(nextUpdateExpectedTime, new Date());
+    isNextUpdateAfter = (isAfter(nextUpdateExpectedTime, new Date()) && isAfter(updatesEndMoment, new Date()));
     nextUpdateMessage = `${I18n.t('metrics.next_update')}: ${formatDistanceToNow(nextUpdateExpectedTime, { addSuffix: true })}.`;
   }
   return [lastUpdateMessage, nextUpdateMessage, isNextUpdateAfter];
@@ -59,9 +60,10 @@ const getFirstUpdateMessage = (course) => {
   let lastUpdateMessage = '';
   let nextUpdateMessage = '';
   let isNextUpdateAfter = false;
+  const updatesEndMoment = toDate(course.update_until);
   if (course.flags.first_update) {
     const nextUpdateExpectedTime = firstUpdateTime(course.flags.first_update);
-    isNextUpdateAfter = isAfter(nextUpdateExpectedTime, new Date());
+    isNextUpdateAfter = (isAfter(nextUpdateExpectedTime, new Date()) && isAfter(updatesEndMoment, new Date()));
     nextUpdateMessage = `${I18n.t('metrics.first_update')}: ${formatDistanceToNow(nextUpdateExpectedTime, { addSuffix: true })}.`;
     lastUpdateMessage = `${I18n.t('metrics.enqueued_update')}`;
   } else {


### PR DESCRIPTION
## What this PR does
Fixes #5489 
This PR solves the a bug of next estimated update which is misleading previously.
 I have created the same scenario as mentioned in the issue(as shown in before screenshot) and then added the logic of checking whether the calculated estimated date is within the range of 30 days (after course end date) or not.

## Screenshots
Before:

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/5f0839ed-ff28-44df-8b95-5f8078e4b823)


After:

![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/9ba3b0b2-2736-4ee4-9b49-b8c7fade5be2)

