### PR TITLE
Added  an option to close Program Creation Component on P&E dashboard explicitly

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_type.jsx
+++ b/app/assets/javascripts/components/course_creator/course_type.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { map } from 'lodash-es';
 import SelectableBox from '../common/selectable_box';
+import { Link } from 'react-router-dom';
 
 const CourseType = ({ wizardClass, wizardAction }) => {
   const courseTypes = [
@@ -23,11 +24,14 @@ const CourseType = ({ wizardClass, wizardAction }) => {
 
   return (
     <div className={wizardClass}>
-      {map(courseTypes, (program) => {
-        return (
-          <SelectableBox key={program.name} onClick={wizardAction.bind(null, program.type)} heading={program.name} description={program.description} />
-        );
-      })}
+      <div className={wizardClass} style={{ paddingBottom: '20px' }}>
+        {map(courseTypes, (program) => {
+          return (
+            <SelectableBox key={program.name} onClick={wizardAction.bind(null, program.type)} heading={program.name} description={program.description} />
+          );
+        })}
+      </div>
+      <Link className="button right" to="/" id="course_cancel">{I18n.t('application.cancel')}</Link>
     </div>
   );
 };


### PR DESCRIPTION
## What this PR does
This adds a cancel button at the bottom right side of the program creation component to allow users to close it.
Resolves Issue #5602 

## Screenshots
Before:

<img width="1470" alt="Screenshot 2024-01-29 at 6 33 14 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/7e50ba8e-33f9-4180-bf5c-4302ed97d212">

After:

<img width="1470" alt="Screenshot 2024-01-29 at 6 42 43 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/6fe31ddc-1a48-4d90-827f-0246c7f0f1a6">