### PR TITLE
Added cancel button on the "Create New or Clone Program" component on P&E dashboard

### DIFF
--- a/app/assets/javascripts/components/course_creator/new_or_clone.jsx
+++ b/app/assets/javascripts/components/course_creator/new_or_clone.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import CourseUtils from '../../utils/course_utils.js';
 
 const NewOrClone = ({ cloneClasss, chooseNewCourseAction, showCloneChooserAction, stringPrefix }) => {
@@ -6,6 +7,7 @@ const NewOrClone = ({ cloneClasss, chooseNewCourseAction, showCloneChooserAction
     <div className={cloneClasss}>
       <button className="button dark" onClick={chooseNewCourseAction}>{CourseUtils.i18n('creator.create_label', stringPrefix)}</button>
       <button className="button dark" onClick={showCloneChooserAction}>{CourseUtils.i18n('creator.clone_previous', stringPrefix)}</button>
+      <Link className="button right" to="/" id="course_cancel">{I18n.t('application.cancel')}</Link>
     </div>
   );
 };


### PR DESCRIPTION
## What this PR does
This adds a cancel button at the bottom right side of the "Create New or Clone Program" Component to allow users to close it.
Resolves Isuue #5604 

## Screenshots

Before:

<img width="1470" alt="Screenshot 2024-01-29 at 6 58 29 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/40c96544-e465-4157-8702-7f7f86d9bd20">

After:

<img width="1470" alt="Screenshot 2024-01-29 at 6 58 22 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/06e47fbf-d35e-4851-9f36-d486ed0a554a">