### PR TITLE
Fixed Alignment issue on Article Finder Page

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/TitleOpener.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/TitleOpener.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export const TitleOpener = ({ showArticle, showButtonClass, showButtonLabel, title }) => (
   <div className={`tooltip-trigger ${showButtonClass || ''}`}>
-    <button onClick={showArticle} aria-describedby="icon-article-viewer-desc">{title}</button>
+    <button style={{ textAlign: 'left' }} onClick={showArticle} aria-describedby="icon-article-viewer-desc">{title}</button>
     <p id="icon-article-viewer-desc">Open Article Viewer</p>
     <div className="tooltip tooltip-title dark large">
       <p>{showButtonLabel()}</p>


### PR DESCRIPTION
## What this PR does
When we search for articles then in the list some Articles having long names are misaligned. This will fix it.

## Screenshots
Before:

<img width="1470" alt="before 5" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/e1693129-98ca-4fe0-8d9a-0c6057f2e18a">





After:

<img width="1470" alt="After 5" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/fd827fea-1d2a-404a-b43b-0f36a47aa95d">
