### PR TITLE
Solved Error of Adding and Removing articles through Article Finder

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { includes } from 'lodash-es';
 
 import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
@@ -9,6 +9,7 @@ import ArticleUtils from '../../utils/article_utils.js';
 
 const ArticleFinderRow = (props) => {
     const [isLoading, setIsLoading] = useState(false);
+    const prevPropsRef = useRef();
 
     // Note: This comment is applicable for the article finder row of a course
     // There are two scenarios in which we use isLoading:
@@ -19,10 +20,11 @@ const ArticleFinderRow = (props) => {
     // button is disabled. On completion of request, this.props.assignment changes and
     // button is enabled again after isLoading is set to false
 
-    useEffect((prevProps) => {
-      if (isLoading && prevProps.assignment !== props.assignment) {
+    useEffect(() => {
+      if (isLoading && prevPropsRef.current.assignment !== props.assignment) {
         setIsLoading(false);
       }
+      prevPropsRef.current = props;
     }, [isLoading, props.assignment]);
 
     const assignArticle = (userId = null) => {

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -165,6 +165,10 @@ class AssignmentsController < ApplicationController
   end
 
   def assignment_params
-    params.permit(:id, :user_id, :course_id, :title, :role, :language, :project, :status)
+    params.permit(
+      :id, :user_id, :course_id, :title, :role, :language, :project, :status,
+      :course_slug, :format,
+      assignment: {}
+    )
   end
 end


### PR DESCRIPTION
## What this PR does
Fixes #5608 
This pr solves the error that was arising while adding or removing the articles through Article Finder.
I have used useRef() hook to store the reference of previous Props that was undefined before(root cause of error). 


## Videos
Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/261a0d5b-1071-47df-a252-6bdbeae7a01b

After:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/0632bd44-4ca1-491c-95c2-830aa31942b5

