### PR TITLE
[Outreachy Round 27] Calculate number of references using reference-counter API values

### DIFF
--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -71,14 +71,22 @@ class Revision < ApplicationRecord
     "/recent-activity/plagiarism/report?ithenticate_id=#{ithenticate_id}"
   end
 
+  # reference-counter API value
+  REFERENCE_COUNT = 'num_ref'
+  # LiftWing API values
   WIKITEXT_REF_TAGS = 'feature.wikitext.revision.ref_tags'
   WIKIDATA_REFERENCES = 'feature.len(<datasource.wikidatawiki.revision.references>)'
   WIKI_SHORTENED_REF_TAGS = 'feature.enwiki.revision.shortened_footnote_templates'
 
-  def references_count(ores_features)
-    return nil if ores_features.empty?
-    (ores_features[WIKITEXT_REF_TAGS] || ores_features[WIKIDATA_REFERENCES] || 0) +
-      (ores_features[WIKI_SHORTENED_REF_TAGS] || 0)
+  # Returns the number of references for a given revision id, based on its features.
+  # If REFERENCE_COUNT field is present, then use it. This number of references comes from
+  # the reference-counter API.
+  # Otherwise, it uses values from the LiftWing API.
+  def references_count(rev_features)
+    return nil if rev_features.empty?
+    rev_features[REFERENCE_COUNT] ||
+      ((rev_features[WIKITEXT_REF_TAGS] || rev_features[WIKIDATA_REFERENCES] || 0) +
+        (rev_features[WIKI_SHORTENED_REF_TAGS] || 0))
   end
 
   def references_added

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -227,17 +227,17 @@ describe Revision, type: :model do
       before do
         stub_wiki_validation
         create(:revision,
-                mw_rev_id:,
-                article_id: 55012289,
-                mw_page_id: 55012289,
-                features: {
-                  reference_count_key => nil,
-                  refs_tags_key => 56
-                },
-                features_previous: {
-                  reference_count_key => nil,
-                  refs_tags_key => 7
-                })
+               mw_rev_id:,
+               article_id: 55012289,
+               mw_page_id: 55012289,
+               features: {
+                 reference_count_key => nil,
+                 refs_tags_key => 56
+               },
+               features_previous: {
+                 reference_count_key => nil,
+                 refs_tags_key => 7
+               })
       end
 
       it 'uses the ref tag from Lift Wing API' do
@@ -252,19 +252,19 @@ describe Revision, type: :model do
       before do
         stub_wiki_validation
         create(:revision,
-                mw_rev_id:,
-                article_id: 55012289,
-                mw_page_id: 55012289,
-                features: {
-                  reference_count_key => 57,
-                  refs_tags_key => 56,
-                  shortened_refs_tags_key => 14
-                },
-                features_previous: {
-                  reference_count_key => 6,
-                  refs_tags_key => 7,
-                  shortened_refs_tags_key => 1
-                })
+               mw_rev_id:,
+               article_id: 55012289,
+               mw_page_id: 55012289,
+               features: {
+                 reference_count_key => 57,
+                 refs_tags_key => 56,
+                 shortened_refs_tags_key => 14
+               },
+               features_previous: {
+                 reference_count_key => 6,
+                 refs_tags_key => 7,
+                 shortened_refs_tags_key => 1
+               })
       end
 
       it 'uses the reference count key from reference-counter API' do

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -29,6 +29,7 @@ require 'rails_helper'
 
 describe Revision, type: :model do
   describe '#references_added' do
+    let(:reference_count_key) { 'num_ref' }
     let(:refs_tags_key) { 'feature.wikitext.revision.ref_tags' }
     let(:wikidata_refs_tags_key) { 'feature.len(<datasource.wikidatawiki.revision.references>)' }
     let(:shortened_refs_tags_key) { 'feature.enwiki.revision.shortened_footnote_templates' }
@@ -217,6 +218,58 @@ describe Revision, type: :model do
       it 'includes the shortened footnote template references' do
         val = described_class.find_by(mw_rev_id: 902872698).references_added
         expect(val).to eq(134)
+      end
+    end
+
+    context 'has reference count key set as nil' do
+      let(:mw_rev_id) { 902872698 }
+
+      before do
+        stub_wiki_validation
+        create(:revision,
+                mw_rev_id:,
+                article_id: 55012289,
+                mw_page_id: 55012289,
+                features: {
+                  reference_count_key => nil,
+                  refs_tags_key => 56
+                },
+                features_previous: {
+                  reference_count_key => nil,
+                  refs_tags_key => 7
+                })
+      end
+
+      it 'uses the ref tag from Lift Wing API' do
+        val = described_class.find_by(mw_rev_id: 902872698).references_added
+        expect(val).to eq(49)
+      end
+    end
+
+    context 'has complete features' do
+      let(:mw_rev_id) { 902872698 }
+
+      before do
+        stub_wiki_validation
+        create(:revision,
+                mw_rev_id:,
+                article_id: 55012289,
+                mw_page_id: 55012289,
+                features: {
+                  reference_count_key => 57,
+                  refs_tags_key => 56,
+                  shortened_refs_tags_key => 14
+                },
+                features_previous: {
+                  reference_count_key => 6,
+                  refs_tags_key => 7,
+                  shortened_refs_tags_key => 1
+                })
+      end
+
+      it 'uses the reference count key from reference-counter API' do
+        val = described_class.find_by(mw_rev_id: 902872698).references_added
+        expect(val).to eq(51)
       end
     end
   end


### PR DESCRIPTION
## What this PR does
This PR is part of the "Improve how Wiki Education Dashboard counts references added" project (read issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5547).

This PR modifies `Revision::references_count` method to calculate number of references using reference-counter API values if available. This means that if `num_ref` key in `features` (or `features_previous`) field is a number, it uses that value to count references in a given revision id. Otherwise, it uses Lift Wing API values (in the same way as before).

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
