### PR TITLE
Restored removed self-assign articles to the pool of Available Articles

### DIFF
--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -64,11 +64,31 @@ const claimAssignmentPromise = (assignment) => {
   .then(res => res.json());
 };
 
+const unclaimAssignmentPromise = (assignment) => {
+  return request(`/assignments/${assignment.id}/unclaim`, {
+    method: 'PUT',
+    body: JSON.stringify(assignment)
+  })
+  .then(res => res.json());
+};
+
 export const claimAssignment = (assignment, successNotification) => (dispatch) => {
   return claimAssignmentPromise(assignment)
     .then((resp) => {
       if (resp.assignment) {
         if (successNotification) { dispatch(addNotification(successNotification)); }
+        dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp });
+      } else {
+        dispatch({ type: types.API_FAIL, data: resp });
+      }
+    })
+    .catch(response => dispatch({ type: types.API_FAIL, data: response }));
+};
+
+export const unclaimAssignment = assignment => (dispatch) => {
+  return unclaimAssignmentPromise(assignment)
+    .then((resp) => {
+      if (resp.assignment) {
         dispatch({ type: types.UPDATE_ASSIGNMENT, data: resp });
       } else {
         dispatch({ type: types.API_FAIL, data: resp });

--- a/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/components/Categories/List/Assignment/Header/Header.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import Actions from './Actions/Actions.jsx';
 import MyArticlesAssignmentLinks from './MyArticlesAssignmentLinks.jsx';
 import { initiateConfirm } from '@actions/confirm_actions';
-import { deleteAssignment } from '@actions/assignment_actions';
+import { unclaimAssignment } from '@actions/assignment_actions';
 
 import { useDispatch } from 'react-redux';
 
@@ -33,7 +33,7 @@ const isClassroomProgram = course => (course.type === 'ClassroomProgramCourse');
 const unassign = ({ assignment, course, dispatch }) => {
   const body = { course_slug: course.slug, ...assignment };
   const confirmMessage = I18n.t('assignments.confirm_deletion');
-  const onConfirm = () => dispatch(deleteAssignment(body));
+  const onConfirm = () => dispatch(unclaimAssignment(body));
 
   return () => dispatch(initiateConfirm({ confirmMessage, onConfirm }));
 };
@@ -60,7 +60,7 @@ export const Header = ({
         isEnglishWikipedia={isEnglishWikipedia({ assignment, course })}
         isClassroomProgram={isClassroomProgram(course)}
         isComplete={isComplete}
-        unassign={unassign({ assignment, course, deleteAssignment, dispatch })}
+        unassign={unassign({ assignment, course, unclaimAssignment, dispatch })}
         username={username}
       />
     </header>

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -7,6 +7,7 @@ require_dependency "#{Rails.root}/app/workers/update_assignments_worker"
 require_dependency "#{Rails.root}/app/workers/update_course_worker"
 
 # Controller for Assignments
+# rubocop:disable Metrics/ClassLength
 class AssignmentsController < ApplicationController
   respond_to :json
   before_action :set_course, except: [:claim, :update_status]
@@ -62,6 +63,13 @@ class AssignmentsController < ApplicationController
   rescue AssignmentManager::DuplicateAssignmentError => e
     render json: { errors: e, message: I18n.t('assignments.already_exists') },
            status: :conflict
+  end
+
+  def unclaim
+    set_assignment { return }
+    check_permissions(@assignment.user_id)
+    @assignment.update(user_id: nil)
+    render partial: 'updated_assignment', locals: { assignment: @assignment }
   end
 
   def update_status
@@ -167,8 +175,9 @@ class AssignmentsController < ApplicationController
   def assignment_params
     params.permit(
       :id, :user_id, :course_id, :title, :role, :language, :project, :status,
-      :course_slug, :format,
+      :course_slug, :format, :assignment_id,
       assignment: {}
     )
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
     resources :assignment_suggestions
   end
   put '/assignments/:assignment_id/claim' => 'assignments#claim'
+  put '/assignments/:assignment_id/unclaim' => 'assignments#unclaim'
   post '/assignments/assign_reviewers_randomly' => 'assignments#assign_reviewers_randomly'
 
   get 'mass_enrollment/:course_id'  => 'mass_enrollment#index',


### PR DESCRIPTION
## What this PR does
Fixes #5549 
This pr helps in restoring the un-assigned article back to the pool of available articles.

Created action to unclaim the assignment.
Created controller and its route in backend.

## Videos
Before:


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/fa84e3b5-5e9d-4329-a49d-9412e3a68f09

After:


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/4ea3dd52-8518-4a51-8460-4cb80843a51d

