### PR TITLE
[Outreachy Round 27] Update tooltip for "references added" metric

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1049,7 +1049,7 @@ en:
     recent_updates_summary: Out of the last %{total} updates, %{failure_count} failed and %{error_count} encountered errors.
     revisions: Recent Edits
     references_count: References Added
-    references_doc: This is the number of reference tags added to articles, and can include multiple references to the same source. The data comes from the ORES article quality model, and is only available for some languages.
+    references_doc: This is the number of reference tags and shortened footnote templates added to articles, and can include multiple references to the same source. The data comes from the reference-counter Toolforge API.
     references_doc_wikidata: This is the number of reference tags added to items, and can include multiple references to the same source. The data comes from the ORES item quality model, and is only available for some languages.
     replag_info: >
       The Dashboard retrieves edit data from WMF Cloud replica databases. Sometimes these databases are missing the most recent edits


### PR DESCRIPTION
## What this PR does
This PR is part of the "Improve how Wiki Education Dashboard counts references added" project (read issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5547).

It updates the tooltip for the "References Added" so that it no longer mentions ORES.

## Screenshots
Before:

![old_tooltip](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/8717242/b2c54acb-fd01-47e0-b743-0ab054aba91e)

After:

![new_tooltip](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/8717242/30f3dbbc-f474-4825-91f6-926431993abe)
