### PR TITLE
Fixed overlap of Training module navbar with breadcrumbs

### DIFF
--- a/app/assets/stylesheets/training_modules/_nav.styl
+++ b/app/assets/stylesheets/training_modules/_nav.styl
@@ -18,9 +18,10 @@ body.training nav.top-nav
 
 .training__slide-header
   padding 12px 0 16px 0
-  height 55px
+  height auto
   background $training_primary
-  ol.breadcrumbs
+  ol.breadcrumbs 
+    width 85%
     @extends .breadcrumbs
     color $breadcrumb_light_text
     text-align left


### PR DESCRIPTION
## What this PR does
Fixed overlap of Training module navbar with breadcrumbs.

## To Reproduce
1. Go to [this page](https://outreachdashboard.wmflabs.org/training/learning-and-evaluation/get-activity-from-multiple-wikis/what-is-tracked-by-default)
2. You can see the navbar overlapping on the breadcrumbs

## Screenshots
Before:
<img width="1470" alt="Before" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/226d39ae-b788-4430-ab55-ad2bf9d55e44">


After:
<img width="1470" alt="After" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/3bb1d0b6-2468-4614-a615-613cfb7d5959">


