### PR TITLE
Fixed UI of Training module path overlaping with Table of contents

### DIFF
--- a/app/assets/stylesheets/training_modules/_nav.styl
+++ b/app/assets/stylesheets/training_modules/_nav.styl
@@ -42,6 +42,7 @@ body.training nav.top-nav
 
 .training__show
   ol.breadcrumbs
+    width 66%
     @extends .breadcrumbs
     margin-bottom -23px
     li


### PR DESCRIPTION
## What this PR does
This PR Fixes UI of Training module path overlaping with Table of contents

## To Reproduce

1. Go to [Trainings](https://outreachdashboard.wmflabs.org/training)
2. Find and click `Learning and Evaluation`
3. Click on the module : `Get activity from multiple wikis`
4. Here you can see that Table of contents is overlapping with Training module path.

Alternatively you can [click here to go directly](https://outreachdashboard.wmflabs.org/training/learning-and-evaluation/get-activity-from-multiple-wikis) 

## Screenshots
Before:
<img width="1470" alt="Before" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/55bb054c-041d-4213-9fbc-bb4b70c3d3df">


After:
<img width="1470" alt="After" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/6d78ecd1-ae38-4fcc-8e05-e1bed2605983">
