### PR TITLE
Fixing warnings when starting `Guard`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'paper_trail' # Save histories of record changes related to surveys
 gem "kt-paperclip" # used by Course and UserProfile for file attachments.
 gem 'sidekiq' # Framework for running background worker jobs
 gem 'sidekiq-unique-jobs' # Plugin to prevent duplicate jobs in the sidekiq queue
-gem 'sidekiq-cron' # Plugin for cron-style recurring jobs in Sidekiq
+gem 'sidekiq-cron', '~> 1.12.0' # Plugin for cron-style recurring jobs in Sidekiq
 gem 'dalli' # Caching
 gem 'connection_pool'
 gem 'fuzzily_reloaded' # fuzzy search for ActiveRecord tables

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'paper_trail' # Save histories of record changes related to surveys
 gem "kt-paperclip" # used by Course and UserProfile for file attachments.
 gem 'sidekiq' # Framework for running background worker jobs
 gem 'sidekiq-unique-jobs' # Plugin to prevent duplicate jobs in the sidekiq queue
-gem 'sidekiq-cron', '~> 1.12.0' # Plugin for cron-style recurring jobs in Sidekiq
+gem 'sidekiq-cron' # Plugin for cron-style recurring jobs in Sidekiq
 gem 'dalli' # Caching
 gem 'connection_pool'
 gem 'fuzzily_reloaded' # fuzzy search for ActiveRecord tables

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     formatador (0.3.0)
-    fugit (1.5.3)
+    fugit (1.9.0)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     fuzzily_reloaded (1.0.1)
@@ -543,9 +543,10 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    sidekiq-cron (1.7.0)
-      fugit (~> 1)
-      sidekiq (>= 4.2.1)
+    sidekiq-cron (1.12.0)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     sidekiq-unique-jobs (7.1.27)
       brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -685,7 +686,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers
   sidekiq
-  sidekiq-cron
+  sidekiq-cron (~> 1.12.0)
   sidekiq-unique-jobs
   simple_form
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -686,7 +686,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers
   sidekiq
-  sidekiq-cron (~> 1.12.0)
+  sidekiq-cron
   sidekiq-unique-jobs
   simple_form
   simplecov


### PR DESCRIPTION
## What this PR does
Bumped `sidekiq-cron` from v1.7.0 to v1.12.0.

This will fix warnings caused by it.

Addresses issue #5645 

## Screenshots
Before:
<img width="1470" alt="Before" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/6592aff6-5c22-4a94-97f6-98550ecdd84d">


After:
<img width="1470" alt="After" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/8697a5e2-5f3c-4920-a521-db1d218cb754">
