### PR TITLE
Fixed Rspec Checks Failure of `assigned_articles_spec.rb`

### DIFF
--- a/spec/features/assigned_articles_spec.rb
+++ b/spec/features/assigned_articles_spec.rb
@@ -21,12 +21,12 @@ describe 'Assigned Articles view', type: :feature, js: true do
     # we need to use VCR to avoid getting stopped by WebMock
     VCR.use_cassette('assigned_articles_view') do
       visit "/courses/#{course.slug}/articles/assigned"
-      expect(page).to have_content('Nancy Tuana')
+      page.has_content?('Nancy Tuana')
       find('a', text: 'Feedback').click
-      find('textarea.feedback-form').fill_in with: 'This is a great article!'
+      find('textarea.feedback-form').fill_in(with: 'This is a great article!')
       click_button 'Add Suggestion'
       find('a', text: 'Delete').click
       expect(page).not_to have_content('This is a great article!')
-    end
+    end    
   end
 end

--- a/spec/features/assigned_articles_spec.rb
+++ b/spec/features/assigned_articles_spec.rb
@@ -27,6 +27,6 @@ describe 'Assigned Articles view', type: :feature, js: true do
       click_button 'Add Suggestion'
       find('a', text: 'Delete').click
       expect(page).not_to have_content('This is a great article!')
-    end    
+    end
   end
 end

--- a/spec/features/assigned_articles_spec.rb
+++ b/spec/features/assigned_articles_spec.rb
@@ -21,7 +21,7 @@ describe 'Assigned Articles view', type: :feature, js: true do
     # we need to use VCR to avoid getting stopped by WebMock
     VCR.use_cassette('assigned_articles_view') do
       visit "/courses/#{course.slug}/articles/assigned"
-      page.has_content?('Nancy Tuana')
+      expect(page).to have_content('Nancy Tuana', wait:20)
       find('a', text: 'Feedback').click
       find('textarea.feedback-form').fill_in(with: 'This is a great article!')
       click_button 'Add Suggestion'


### PR DESCRIPTION
## What this PR does
This PR fixes Rspec checks failure which were failing due to `assigned_articles_spec.rb` file.

Addresses Issue #5652 

## Screenshots
Before:


After:
<img width="1470" alt="Screenshot 2024-02-14 at 12 10 47 AM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/b046e76b-423b-48e3-bf6a-0223328301c0">

