### PR TITLE
Fixed overlapping of campaign_navbar at the desktop view on Language Picker

### DIFF
--- a/app/assets/stylesheets/modules/_language_picker.styl
+++ b/app/assets/stylesheets/modules/_language_picker.styl
@@ -1,6 +1,7 @@
 .language-picker
   text-align left
   width 120px
+  z-index 1
 
   img
   	width 22px

--- a/app/assets/stylesheets/modules/_nav.styl
+++ b/app/assets/stylesheets/modules/_nav.styl
@@ -304,7 +304,6 @@ nav.ham-nav
   background #fff
   box-shadow 0px 1px 0px rgba(0,0,0,.1)
   position relative
-  z-index 1
   transition box-shadow 125ms ease
 
   &.affix


### PR DESCRIPTION
## What this PR does
Fixes #5546 

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/17984335-4b8e-4467-a17a-1314a0d13e89)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/d8a54104-9761-4d4c-99ed-c55d0d5fd31a)

