### PR TITLE
Fixed Capybara screenshot feature in broken tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -98,7 +98,7 @@ RSpec.configure do |config|
     # them.
     # Instead, we clear and print any after-success error
     # logs in the `before` block above.
-    Capybara::Screenshot.new.screenshot_and_save_page if example.exception
+    Capybara::Screenshot.screenshot_and_save_page if example.exception
     errors = page.driver.browser.logs.get(:browser)
 
     # pass `js_error_expected: true` to skip JS error checking


### PR DESCRIPTION
## What this PR does
This PR addresses the issue #5653  where, in the event of a failing feature test, the code in rails_helper.rb attempts to capture a screenshot using Capybara. However, due to changes in the Capybara screenshot interface, the method call for creating a screenshot results in a NoMethodError. This PR resolves the issue by updating the method call to match the changed Capybara screenshot interface, ensuring that screenshots are successfully generated when a feature spec fails.

## Open questions and concerns
 @ragesoss  please review this pull request and let me know if there are any issues that need to be addressed before it can be merged, or if it is ready to proceed.
Thank You
