### PR TITLE
Fixes 500 links loading issue

### DIFF
--- a/lib/training/wiki_training_loader.rb
+++ b/lib/training/wiki_training_loader.rb
@@ -91,18 +91,25 @@ class WikiTrainingLoader
     full_content
   end
 
-  # Gets a list of page titles linked from the base page
-  def wiki_source_pages
-    # To handle more than 500 pages linked from the source page,
-    # we'll need to update this to use 'continue'.
-    query_params = { prop: 'links', titles: @wiki_base_page, pllimit: 500 }
-    response = WikiApi.new(MetaWiki.new).query(query_params)
-    begin
-      response.data['pages'].values[0]['links'].map { |page| page['title'] }
-    rescue StandardError
-      raise InvalidWikiContentError, "could not get links from '#{@wiki_base_page}'"
+# Gets a list of page titles linked from the base page
+def wiki_source_pages
+  # To handle more than 500 pages linked from the source page,
+  # we'll need to update this to use 'continue'.
+  query_params = { prop: 'links', titles: @wiki_base_page, pllimit: 500 }
+  response = WikiApi.new(MetaWiki.new).query(query_params)
+  @query.merge! @continue unless @continue.nil?
+  begin
+    page_titles = response.data['pages'].values[0]['links'].map { |page| page['title'] }
+    while response['continue']
+      query_params[:plcontinue] = response['continue']['plcontinue']
+      response = WikiApi.new(MetaWiki.new).query(query_params)
+      page_titles += response.data['pages'].values[0]['links'].map { |page| page['title'] }
     end
+    page_titles
+  rescue StandardError
+    raise InvalidWikiContentError, "could not get links from '#{@wiki_base_page}'"
   end
+end
 
   def listed_wiki_source_pages
     wiki_source_pages.select { |page| @slug_list.include? slug_from(page) }


### PR DESCRIPTION
fixes #5588 

## What this PR does
Implements continue in  wiki_source_pages method in `lib/training/wiki_training_loader.rb` which is responsible for fetching the links and earlier it was only fetching 500 links and now it fetches till continue parameter becomes nil.
## Screenshots
Before:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/122573982/e672b677-0da6-4516-9b04-7ee73e954e86)
After:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/122573982/059556b9-e5f8-41af-94c6-e21031d207a5)
