### PR TITLE
Made 'impact_stats' editable from /settings

### DIFF
--- a/app/assets/javascripts/actions/settings_actions.js
+++ b/app/assets/javascripts/actions/settings_actions.js
@@ -431,3 +431,26 @@ export const updateDefaultCampaign = campaignSlug => (dispatch) => {
     })
     .catch(data => dispatch({ type: API_FAIL, data }));
 };
+
+const updateImpactStatsPromise = async (impactStats) => {
+  const body = {
+    impactStats: impactStats,
+  };
+  const response = await request('/settings/update_impact_stats', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.text();
+    response.responseText = data;
+    throw response;
+  }
+  return response.json();
+};
+
+export const updateImpactStats = impactStats => (dispatch) => {
+  return updateImpactStatsPromise(impactStats)
+    .then(data => dispatch({ type: ADD_NOTIFICATION, notification: { ...data, type: 'success', closable: true } }))
+    .catch(data => dispatch({ type: API_FAIL, data }));
+};

--- a/app/assets/javascripts/components/settings/settings_handler.jsx
+++ b/app/assets/javascripts/components/settings/settings_handler.jsx
@@ -40,21 +40,24 @@ export const SettingsHandler = createReactClass({
   },
 
   render() {
-    const otherSettings = (
-      <React.Fragment>
-        <h1 className="mx2 mt4">Other settings</h1>
-        <hr />
-        <h2 className="mx2">Update</h2>
-        <UpdateImpactStats />
-        <br /> <br />
-        <h2 className="mx2">Salesforce</h2>
-        <UpdateSalesforceCredentials />
-        <br /> <br />
-        <CourseCreationSettings settings={this.props.courseCreation}/>
-        <br />
-        <DefaultCampaignSetting defaultCampaign={this.props.defaultCampaign}/>
-      </React.Fragment>
-    );
+    let otherSettings;
+    if (Features.wikiEd) {
+      otherSettings = (
+        <React.Fragment>
+          <h1 className="mx2 mt4">Other settings</h1>
+          <hr />
+          <h2 className="mx2">Update</h2>
+          <UpdateImpactStats />
+          <br /> <br />
+          <h2 className="mx2">Salesforce</h2>
+          <UpdateSalesforceCredentials />
+          <br /> <br />
+          <CourseCreationSettings settings={this.props.courseCreation}/>
+          <br />
+          <DefaultCampaignSetting defaultCampaign={this.props.defaultCampaign}/>
+        </React.Fragment>
+      );
+    }
     return (
       <div id="settings" className="mt4 container">
         <Notifications />

--- a/app/assets/javascripts/components/settings/settings_handler.jsx
+++ b/app/assets/javascripts/components/settings/settings_handler.jsx
@@ -12,6 +12,7 @@ import SpecialUserList from './special_users_list';
 import UpdateSalesforceCredentials from './views/update_salesforce_credentials';
 import CourseCreationSettings from './course_creation_settings';
 import DefaultCampaignSetting from './default_campaign_setting';
+import UpdateImpactStats from './views/update_impact_stats';
 
 export const SettingsHandler = createReactClass({
   propTypes: {
@@ -39,21 +40,21 @@ export const SettingsHandler = createReactClass({
   },
 
   render() {
-    let otherSettings;
-    if (Features.wikiEd) {
-      otherSettings = (
-        <React.Fragment>
-          <h1 className="mx2">Other settings</h1>
-          <hr />
-          <h2 className="mx2">Salesforce</h2>
-          <UpdateSalesforceCredentials />
-          <br />
-          <CourseCreationSettings settings={this.props.courseCreation}/>
-          <br />
-          <DefaultCampaignSetting defaultCampaign={this.props.defaultCampaign}/>
-        </React.Fragment>
-      );
-    }
+    const otherSettings = (
+      <React.Fragment>
+        <h1 className="mx2 mt4">Other settings</h1>
+        <hr />
+        <h2 className="mx2">Update</h2>
+        <UpdateImpactStats />
+        <br /> <br />
+        <h2 className="mx2">Salesforce</h2>
+        <UpdateSalesforceCredentials />
+        <br /> <br />
+        <CourseCreationSettings settings={this.props.courseCreation}/>
+        <br />
+        <DefaultCampaignSetting defaultCampaign={this.props.defaultCampaign}/>
+      </React.Fragment>
+    );
     return (
       <div id="settings" className="mt4 container">
         <Notifications />

--- a/app/assets/javascripts/components/settings/settings_handler.jsx
+++ b/app/assets/javascripts/components/settings/settings_handler.jsx
@@ -46,7 +46,7 @@ export const SettingsHandler = createReactClass({
         <React.Fragment>
           <h1 className="mx2 mt4">Other settings</h1>
           <hr />
-          <h2 className="mx2">Update</h2>
+          <h2 className="mx2">Impact Stats</h2>
           <UpdateImpactStats />
           <br /> <br />
           <h2 className="mx2">Salesforce</h2>

--- a/app/assets/javascripts/components/settings/views/impact_stats_form.jsx
+++ b/app/assets/javascripts/components/settings/views/impact_stats_form.jsx
@@ -27,7 +27,7 @@ const ImpactStatsForm = (props) => {
               value={stats.wiki_edu_courses}
               value_key="wiki_edu_courses"
               type="text"
-              label="Wiki Education Courses"
+              label="Wiki education courses"
             />
             <TextInput
               id="students"
@@ -45,7 +45,7 @@ const ImpactStatsForm = (props) => {
               value={stats.worked_articles}
               value_key="worked_articles"
               type="text"
-              label="Articles Worked On"
+              label="Articles worked on"
             />
             <TextInput
               id="added_words"
@@ -54,7 +54,7 @@ const ImpactStatsForm = (props) => {
               value={stats.added_words}
               value_key="added_words"
               type="text"
-              label="Added words"
+              label="Added words (in millions)"
             />
             <TextInput
               id="total_pages"
@@ -63,7 +63,7 @@ const ImpactStatsForm = (props) => {
               value={stats.total_pages}
               value_key="total_pages"
               type="text"
-              label="Total Pages"
+              label="Total pages"
             />
             <TextInput
               id="volumes"
@@ -81,7 +81,7 @@ const ImpactStatsForm = (props) => {
               value={stats.article_views}
               value_key="article_views"
               type="text"
-              label="Article Views in a single term"
+              label="Article views (in millions)"
             />
             <TextInput
               id="universities"

--- a/app/assets/javascripts/components/settings/views/impact_stats_form.jsx
+++ b/app/assets/javascripts/components/settings/views/impact_stats_form.jsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import TextInput from '../../common/text_input';
+import { updateImpactStats } from '../../../actions/settings_actions';
+import { connect } from 'react-redux';
+
+const ImpactStatsForm = (props) => {
+    const [stats, setStats] = useState({});
+
+    const handleChange = (key, value) => {
+        setStats({ ...stats, [key]: value });
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        props.updateImpactStats(stats);
+        props.handlePopoverClose(e);
+    };
+
+    return (
+      <tr>
+        <td>
+          <form onSubmit={handleSubmit}>
+            <TextInput
+              id="wiki_edu_courses"
+              editable
+              onChange={handleChange}
+              value={stats.wiki_edu_courses}
+              value_key="wiki_edu_courses"
+              type="text"
+              label="Wiki Education Courses"
+            />
+            <TextInput
+              id="students"
+              editable
+              onChange={handleChange}
+              value={stats.students}
+              value_key="students"
+              type="text"
+              label="Students"
+            />
+            <TextInput
+              id="worked_articles"
+              editable
+              onChange={handleChange}
+              value={stats.worked_articles}
+              value_key="worked_articles"
+              type="text"
+              label="Articles Worked On"
+            />
+            <TextInput
+              id="added_words"
+              editable
+              onChange={handleChange}
+              value={stats.added_words}
+              value_key="added_words"
+              type="text"
+              label="Added words"
+            />
+            <TextInput
+              id="total_pages"
+              editable
+              onChange={handleChange}
+              value={stats.total_pages}
+              value_key="total_pages"
+              type="text"
+              label="Total Pages"
+            />
+            <TextInput
+              id="volumes"
+              editable
+              onChange={handleChange}
+              value={stats.volumes}
+              value_key="volumes"
+              type="text"
+              label="Volumes"
+            />
+            <TextInput
+              id="article_views"
+              editable
+              onChange={handleChange}
+              value={stats.article_views}
+              value_key="article_views"
+              type="text"
+              label="Article Views in a single term"
+            />
+            <TextInput
+              id="universities"
+              editable
+              onChange={handleChange}
+              value={stats.universities}
+              value_key="universities"
+              type="text"
+              label="Universities"
+            />
+            <button className="button border" type="submit" value="Submit">{I18n.t('application.submit')}</button>
+          </form>
+        </td>
+      </tr>
+    );
+};
+
+const mapDispatchToProps = {
+    updateImpactStats,
+};
+
+export default connect(null, mapDispatchToProps)(ImpactStatsForm);

--- a/app/assets/javascripts/components/settings/views/update_impact_stats.jsx
+++ b/app/assets/javascripts/components/settings/views/update_impact_stats.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ImpactStatsForm from './impact_stats_form.jsx';
+import Popover from '../../common/popover.jsx';
+import useExpandablePopover from '../../../hooks/useExpandablePopover';
+
+const UpdateImpactStats = () => {
+  const getKey = () => {
+    return 'update_impact_stats';
+  };
+
+  const { isOpen, ref, open } = useExpandablePopover(getKey);
+
+  const form = <ImpactStatsForm handlePopoverClose={open} />;
+  return (
+    <div className="pop__container" ref={ref}>
+      <button className="button dark" onClick={open}>Update Impact Stats</button>
+      <Popover
+        is_open={isOpen}
+        edit_row={form}
+        right
+      />
+    </div>
+  );
+};
+
+export default UpdateImpactStats;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,5 +8,12 @@ class HomeController < ApplicationController
   def index
     campaign_slug = CampaignsPresenter.default_campaign_slug
     @presenter = CoursesPresenter.new(current_user:, campaign_param: campaign_slug)
+    @stats = fetch_statistics
+  end
+
+  def fetch_statistics
+    impact_stats = Setting.find_by(key: 'impact_stats').value
+    raise 'Impact stats not found' if impact_stats.nil?
+    impact_stats
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,8 +12,10 @@ class HomeController < ApplicationController
   end
 
   def fetch_statistics
-    impact_stats = Setting.find_by(key: 'impact_stats').value
-    raise 'Impact stats not found' if impact_stats.nil?
-    impact_stats
+    Rails.cache.fetch('impact_stats', expires_in: 12.hours) do
+      impact_stats = Setting.find_by(key: 'impact_stats')&.value
+      raise ActiveRecord::RecordNotFound, 'Impact stats not found' if impact_stats.nil?
+      impact_stats
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,24 +9,11 @@ class HomeController < ApplicationController
     campaign_slug = CampaignsPresenter.default_campaign_slug
     @presenter = CoursesPresenter.new(current_user:, campaign_param: campaign_slug)
     @stats = fetch_statistics
-    if @stats.nil?
-      # Dummy data when stats are not available initially or while running rspec tests
-      @stats = {
-        wiki_edu_courses: '6,200',
-        students: '126,000',
-        worked_articles: '141,000',
-        added_words: '106',
-        total_pages: '361,000',
-        volumes: '77',
-        article_views: '438',
-        universities: '800'
-      }
-    end
   end
 
   def fetch_statistics
-    Rails.cache.fetch('impact_stats', expires_in: 12.hours) do
-      impact_stats = Setting.find_by(key: 'impact_stats')&.value
+    Rails.cache.fetch('impact_stats') do
+      impact_stats = Setting.find_by(key: 'impact_stats')&.value.presence || {}
       impact_stats
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,12 +9,24 @@ class HomeController < ApplicationController
     campaign_slug = CampaignsPresenter.default_campaign_slug
     @presenter = CoursesPresenter.new(current_user:, campaign_param: campaign_slug)
     @stats = fetch_statistics
+    if @stats.nil?
+      # Dummy data when stats are not available initially or while running rspec tests
+      @stats = {
+        wiki_edu_courses: '6,200',
+        students: '126,000',
+        worked_articles: '141,000',
+        added_words: '106',
+        total_pages: '361,000',
+        volumes: '77',
+        article_views: '438',
+        universities: '800'
+      }
+    end
   end
 
   def fetch_statistics
     Rails.cache.fetch('impact_stats', expires_in: 12.hours) do
       impact_stats = Setting.find_by(key: 'impact_stats')&.value
-      raise ActiveRecord::RecordNotFound, 'Impact stats not found' if impact_stats.nil?
       impact_stats
     end
   end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -7,7 +7,7 @@ class SettingsController < ApplicationController # rubocop:disable Metrics/Class
   before_action :require_super_admin_permissions,
                 only: [:upgrade_admin, :downgrade_admin,
                        :upgrade_special_user, :downgrade_special_user,
-                       :update_salesforce_credentials, :update_impact_stats,]
+                       :update_salesforce_credentials, :update_impact_stats]
 
   layout 'application'
 
@@ -116,6 +116,7 @@ class SettingsController < ApplicationController # rubocop:disable Metrics/Class
     updated_stats.each do |key, value|
       Setting.set_hash('impact_stats', key, value)
     end
+    Rails.cache.delete('impact_stats')
     render json: { message: 'Impact Stats Updated Successfully.' }, status: :ok
   end
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -7,7 +7,7 @@ class SettingsController < ApplicationController # rubocop:disable Metrics/Class
   before_action :require_super_admin_permissions,
                 only: [:upgrade_admin, :downgrade_admin,
                        :upgrade_special_user, :downgrade_special_user,
-                       :update_salesforce_credentials]
+                       :update_salesforce_credentials, :update_impact_stats,]
 
   layout 'application'
 
@@ -109,6 +109,14 @@ class SettingsController < ApplicationController # rubocop:disable Metrics/Class
   def update_default_campaign
     CampaignsPresenter.update_default_campaign(params[:default_campaign])
     render json: { message: 'Default campaign updated.' }, status: :ok
+  end
+
+  def update_impact_stats
+    updated_stats = params[:impactStats]
+    updated_stats.each do |key, value|
+      Setting.set_hash('impact_stats', key, value)
+    end
+    render json: { message: 'Impact Stats Updated Successfully.' }, status: :ok
   end
 
   private

--- a/app/views/home/_wiki_ed_impact.html.haml
+++ b/app/views/home/_wiki_ed_impact.html.haml
@@ -27,36 +27,42 @@
     %h2.h1 Impact since 2010:
 
     %h3 Wiki Education Courses
-    %h4 6,250
+    %h4= @stats['wiki_edu_courses']
 
     %div
       .col
         %h3 Students
-        %h4 126,000
+        %h4= @stats['students']
 
       .col
         %h3 Articles worked on
-        %h4 141,000
+        %h4= @stats['worked_articles']
 
     %div
       .col
         %h3 Words added
-        %h4 106 Million
+        %h4= @stats['added_words']
         %p
-          The number of words students have donated to the world. That’s 361,000 pages – the equivalent of 77 volumes of a printed encyclopedia, shared with everyone, for free.
+          The number of words students have donated to the world. That’s 
+          = @stats['total_pages']
+          pages – the equivalent of 
+          = @stats['volumes']
+          volumes of a printed encyclopedia, shared with everyone, for free.
 
       .col
         %h3 Article views, in a single term
-        %h4 438 Million
+        %h4= @stats['article_views']
         %p
-          How many people have read the Wikipedia articles these students have edited? In a single term, 438 million. That's six times larger than the population of France.
+          How many people have read the Wikipedia articles these students have edited? In a single term,
+          = @stats['article_views']
+          million. That's six times larger than the population of France.
 
 %section.universities
   .container
     %h2
       Wiki Education staff have supported instructors and students in more than
-      %b 800 universities
-      across the United States and Canada
+      %b= @stats['universities']
+      universities across the United States and Canada
 
     .logos
       = image_tag "/assets/images/university-logo-1.png"

--- a/app/views/home/_wiki_ed_impact.html.haml
+++ b/app/views/home/_wiki_ed_impact.html.haml
@@ -41,7 +41,7 @@
     %div
       .col
         %h3 Words added
-        %h4= @stats['added_words']
+        %h4= "#{@stats['added_words']} Million"
         %p
           The number of words students have donated to the world. That’s 
           = @stats['total_pages']
@@ -51,7 +51,7 @@
 
       .col
         %h3 Article views, in a single term
-        %h4= @stats['article_views']
+        %h4= "#{@stats['article_views']} Million"
         %p
           How many people have read the Wikipedia articles these students have edited? In a single term,
           = @stats['article_views']
@@ -61,8 +61,8 @@
   .container
     %h2
       Wiki Education staff have supported instructors and students in more than
-      %b= @stats['universities']
-      universities across the United States and Canada
+      %b= "#{@stats['universities']} universities"
+      across the United States and Canada
 
     .logos
       = image_tag "/assets/images/university-logo-1.png"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
   get '/settings/default_campaign' => 'settings#default_campaign'
   post '/settings/update_default_campaign' => 'settings#update_default_campaign'
 
+  post '/settings/update_impact_stats' => 'settings#update_impact_stats'
+
   # Griddler allows us to receive incoming emails. By default,
   # the path for incoming emails is /email_processor
   mount_griddler


### PR DESCRIPTION
## What this PR does
Fixes #5658 
This PR allow users with super admin permission to update/edit the 'impact stats' of  _wiki_ed_impact.html.haml through settings page.

## Screenshots/Videos
Before:

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/fbb08016-7dec-4832-bb42-04041636d2a8)


After:

[After(Compressed).webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/18df97d4-74d6-40e1-aa2d-2949b8b73e2a)
