### PR TITLE
Fixed url to redirect to profile page

### DIFF
--- a/app/assets/javascripts/components/nav/hamburger_menu.jsx
+++ b/app/assets/javascripts/components/nav/hamburger_menu.jsx
@@ -77,7 +77,7 @@ const HamburgerMenu = ({ rootUrl, logoPath, exploreUrl, exploreName, userSignedI
                 {userSignedIn ? (
                   <span>
                     <li>
-                      <b><a href={rootUrl} className="current-user">{currentUser}</a></b>
+                      <b><a href={`/users/${encodeURIComponent(currentUser)}`} className="current-user">{currentUser}</a></b>
                     </li>
                     <li>
                       <a href={destroyUrl} className="current-user">{I18n.t('application.log_out')}</a>


### PR DESCRIPTION
## What this PR does
This PR fixes the issue #5668 When attempting to navigate to the user profile page by clicking on your {username} from the hamburger menu, it direct you to the user profile page. 

## Screenshots
![306993830-efbf6595-18f1-4138-ba0f-f7cfd8706f40](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/106299466/353b5089-9962-446b-868c-8897550d3908)


