### PR TITLE
[WIP] [Outreachy Round 27] Use `reference-counter` html endpoint

### DIFF
--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -76,7 +76,7 @@ class ReferenceCounterApi
   end
 
   def references_query_url(rev_id)
-    "/api/v1/references/#{@project_code}/#{@language_code}/#{rev_id}"
+    "/api/v1/references/html/#{@project_code}/#{@language_code}/#{rev_id}"
   end
 
   def toolforge_server

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -38,8 +38,8 @@ describe ReferenceCounterApi do
         status_code: 403,
         content: {
             'description' =>
-            "mwapi error: permissiondenied - You don't have permission to view deleted " \
-            'text or changes between deleted revisions.'
+            "rest-permission-denied-revision - User doesn't have access to the requested " \
+            'revision (708326238).'
         }
       }
     )


### PR DESCRIPTION
## What this PR does
This PR is part of the "Improve how Wiki Education Dashboard counts references added" project (read issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5547).

It updates the Toolforge endpoint used in `ReferenceCounterApi` class to count references from html instead of wikitext. Read more context about that in phabricator task [T352177](https://phabricator.wikimedia.org/T352177).
