### PR TITLE
fix: Issue #5543 Handle case if no campaign is available when creating program

### DIFF
--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -99,11 +99,12 @@ class CourseCreationManager
     return unless Features.open_course_creation?
 
     @overrides[:campaigns] = if @initial_campaign_params.present?
-                               # rubocop:disable Layout/LineLength
-                               [Campaign.find_by(id: @initial_campaign_params[:initial_campaign_id])]
-                               # rubocop:enable Layout/LineLength
+                               [Campaign.find_by(
+                                 id: @initial_campaign_params[:initial_campaign_id]
+                               )]
                              else
-                               [Campaign.default_campaign]
+                               default_campaign = Campaign.default_campaign
+                               default_campaign ? [default_campaign] : []
                              end
   end
 

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -103,8 +103,7 @@ class CourseCreationManager
                                  id: @initial_campaign_params[:initial_campaign_id]
                                )]
                              else
-                               default_campaign = Campaign.default_campaign
-                               default_campaign ? [default_campaign] : []
+                              [Campaign.default_campaign].compact
                              end
   end
 

--- a/lib/course_creation_manager.rb
+++ b/lib/course_creation_manager.rb
@@ -103,7 +103,7 @@ class CourseCreationManager
                                  id: @initial_campaign_params[:initial_campaign_id]
                                )]
                              else
-                              [Campaign.default_campaign].compact
+                               [Campaign.default_campaign].compact
                              end
   end
 


### PR DESCRIPTION
## What this PR does

Fixes Issue #5543 

If no campaigns are created and user tries to create a course. This server throws a 500 Error in response with following log:

```
[2023-12-02 14:21:36.347 FATAL] ActiveRecord::AssociationTypeMismatch (Campaign(#117300) expected, got nil which is an instance of NilClass(#40)):
```
## Screenshots

Before:

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/17dfbaa6-6342-4737-a547-46434a741c9e)

After:

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/f1870cb8-79fc-4b1a-9b10-c8b5fe0e3991)

## Solution 
 
Added a missing case. This allows program to be created without a campaign. If this should not be the case in `wiki_education=false` then, let me know I'll update the case to throw relevant error message.
