### PR TITLE
Fixed overflow in Article Viewer

### DIFF
--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -13,6 +13,7 @@
   border-radius 3px
   box-shadow 0 0 20px 0 rgba(0, 0, 0, .6)
   transform translateX(-50%)
+  overflow auto
 
 #icon-article-viewer-desc
   display none


### PR DESCRIPTION
## What this PR does
Fixes overflow in Article Viewer

## Steps to Reproduce the Bug: 

- Go to `Edited Article` in the Article tab on any course.
- Click on Article Viewer Icon.
- Click on `Quality Problems`.
- You will be able to see the bug ( overflow of Article ).

## Video Preview
Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/845898e2-b12f-49ed-9879-d02540a1c6ad


After:


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/880a1f1b-c4db-4d83-922e-c0f709d17f38

