### PR TITLE
[Outreachy Round 27] Stop storing liftwing features for non-wikidata wikis.

### DIFF
--- a/app/controllers/revision_feedback_controller.rb
+++ b/app/controllers/revision_feedback_controller.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/revision_feedback_service"
-require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
+require_dependency "#{Rails.root}/lib/lift_wing_api"
 
 class RevisionFeedbackController < ApplicationController
   def index
     set_latest_revision_id
     return if @rev_id.nil?
-    revision_data = RevisionScoreImporter.new.fetch_data_for_revision_id(@rev_id)
-    @feedback = RevisionFeedbackService.new(revision_data[:features]).feedback
+    revision_data = LiftWingApi.new(@wiki).get_revision_data([@rev_id])[@rev_id.to_s]
+    @feedback = RevisionFeedbackService.new(revision_data['features']).feedback
     @user_feedback = Assignment.find(params['assignment_id']).assignment_suggestions
-    @rating = revision_data[:rating]
+    @rating = revision_data['prediction']
   end
 
   private

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -23,16 +23,19 @@ class RevisionScoreApiHandler
   # The response has the following format:
   # { "rev_0"=>
   #     { "wp10"=>0.296976285416441736e2,
-  #       "features"=> { "feature.wikitext.revision.chars"=>5781.0,...,"num_ref"=>0 },
+  #       "features"=> { "num_ref"=>0 },
   #       "deleted"=>false,
   #       "prediction"=>"Start" },
   #   ...,
   #   "rev_n"=>
   #     { "wp10"=>0.2929458626376752846e2,
-  #       "features"=> { "feature.wikitext.revision.chars"=>4672.0,...,"num_ref"=>0 },
+  #       "features"=> nil,
   #       "deleted"=>false,
   #       "prediction"=>"Start" }
   # }
+  #
+  # For wikidata, "features" key contains Liftwing features. For other wikis, "features"
+  # key contains reference-counter response (or nil).
   def get_revision_data(rev_batch)
     scores = maybe_get_lift_wing_data rev_batch
     scores.deep_merge!(maybe_get_reference_data(rev_batch))
@@ -65,13 +68,14 @@ class RevisionScoreApiHandler
     # Fetch the value for 'deleted, or default to 'false if not present.
     completed_score['deleted'] = score.fetch('deleted', false)
 
-    # Ensure 'features' is a hash or nil.
-    # For Wikidata, use the 'features' key in the score. Otherwise, use 'num_ref' key.
+    # Ensure 'features' has the correct value (hash or nil).
+    # For Wikidata, 'features' has to contain the LiftWing features.
     completed_score['features'] =
       if @wiki.project == 'wikidata'
         score.fetch('features', nil)
       else
-        # If there was an error hitting the API, set features to nil. Otherwise, use the 'num_ref'.
+        # For other wikis, 'features' has to contain the reference-counter scores if
+        # different from nil. Otherwise, it should be nil.
         score.fetch('num_ref').nil? ? nil : { 'num_ref' => score['num_ref'] }
       end
 

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -65,9 +65,16 @@ class RevisionScoreApiHandler
     # Fetch the value for 'deleted, or default to 'false if not present.
     completed_score['deleted'] = score.fetch('deleted', false)
 
-    # Ensure 'features' is a hash.
-    features = score.fetch('features', {}) || {}
-    completed_score['features'] = features.deep_merge({ 'num_ref' => score.fetch('num_ref', nil) })
+    # Ensure 'features' is a hash or nil.
+    # For Wikidata, use the 'features' key in the score. Otherwise, use 'num_ref' key.
+    completed_score['features'] =
+      if @wiki.project == 'wikidata'
+        score.fetch('features', nil)
+      else
+        # If there was an error hitting the API, set features to nil. Otherwise, use the 'num_ref'.
+        score.fetch('num_ref').nil? ? nil : { 'num_ref' => score['num_ref'] }
+      end
+
     completed_score
   end
 

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -53,7 +53,6 @@ describe RevisionScoreImporter do
       later_score = later_revision.wp10.to_f
       expect(early_score).to be_between(0, 100)
       expect(later_score).to be_between(early_score, 100)
-      expect(later_revision.features['feature.wikitext.revision.external_links']).to eq(12)
       expect(later_revision.features['num_ref']).to eq(13)
     end
   end
@@ -74,7 +73,7 @@ describe RevisionScoreImporter do
       revision = article.revisions.first
       expect(revision.deleted).to eq(true)
       expect(revision.wp10).to be_nil
-      expect(revision.features).to eq({ 'num_ref' => nil })
+      expect(revision.features).to eq({})
     end
   end
 
@@ -93,7 +92,7 @@ describe RevisionScoreImporter do
       revision = article.revisions.first
       expect(revision.deleted).to eq(true)
       expect(revision.wp10).to be_nil
-      expect(revision.features).to eq({ 'num_ref' => nil })
+      expect(revision.features).to eq({})
     end
   end
 
@@ -124,7 +123,7 @@ describe RevisionScoreImporter do
     # no value changed for the revision
     revision = Revision.find_by(mw_rev_id: 662106477)
     expect(revision.wp10).to be_nil
-    expect(revision.features).to eq({ 'num_ref' => nil })
+    expect(revision.features).to eq({})
     expect(revision.deleted).to eq(false)
   end
 
@@ -169,7 +168,7 @@ describe RevisionScoreImporter do
 
     it 'returns a hash with a predicted rating and features' do
       VCR.use_cassette 'revision_scores/single_revision' do
-        expect(subject[:features]).to have_key('feature.wikitext.revision.wikilinks')
+        expect(subject[:features]).to have_key(Revision::REFERENCE_COUNT)
         expect(subject[:rating]).to eq('Stub')
       end
     end

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -14,17 +14,15 @@ describe RevisionScoreApiHandler do
           expect(subject).to be_a(Hash)
           expect(subject.dig('829840090', 'wp10').to_f).to eq(62.805729915108664)
           expect(subject.dig('829840090', 'features')).to be_a(Hash)
-          expect(subject.dig('829840090', 'features',
-                             'feature.wikitext.revision.ref_tags')).to eq(132)
-          expect(subject.dig('829840090', 'features', 'num_ref')).to eq(132)
+          # Only num_ref feature is stored. LiftWing features are discarded.
+          expect(subject.dig('829840090', 'features')).to eq({ 'num_ref' => 132 })
           expect(subject.dig('829840090', 'deleted')).to eq(false)
           expect(subject.dig('829840090', 'prediction')).to eq('B')
 
           expect(subject.dig('829840091', 'wp10').to_f).to eq(39.507631367268004)
           expect(subject.dig('829840091', 'features')).to be_a(Hash)
-          expect(subject.dig('829840091', 'features',
-                             'feature.wikitext.revision.ref_tags')).to eq(1)
-          expect(subject.dig('829840091', 'features', 'num_ref')).to eq(1)
+          # Only num_ref feature is stored. LiftWing features are discarded.
+          expect(subject.dig('829840091', 'features')).to eq({ 'num_ref' => 1 })
           expect(subject.dig('829840091', 'deleted')).to eq(false)
           expect(subject.dig('829840091', 'prediction')).to eq('C')
         end
@@ -48,21 +46,16 @@ describe RevisionScoreApiHandler do
             .to_raise(Errno::ETIMEDOUT)
 
           expect(subject).to be_a(Hash)
+
           expect(subject.dig('829840090', 'wp10').to_f).to eq(62.805729915108664)
-          expect(subject.dig('829840090', 'features')).to be_a(Hash)
-          expect(subject.dig('829840090', 'features',
-                             'feature.wikitext.revision.ref_tags')).to eq(132)
-          expect(subject.dig('829840090', 'features').key?('num_ref')).to eq(true)
-          expect(subject.dig('829840090', 'features', 'num_ref')).to eq(nil)
+          expect(subject.dig('829840090')).to have_key('features')
+          expect(subject.dig('829840090', 'features')).to be_nil
           expect(subject.dig('829840090', 'deleted')).to eq(false)
           expect(subject.dig('829840090', 'prediction')).to eq('B')
 
           expect(subject.dig('829840091', 'wp10').to_f).to eq(39.507631367268004)
-          expect(subject.dig('829840091', 'features')).to be_a(Hash)
-          expect(subject.dig('829840091', 'features',
-                             'feature.wikitext.revision.ref_tags')).to eq(1)
-          expect(subject.dig('829840091', 'features').key?('num_ref')).to eq(true)
-          expect(subject.dig('829840091', 'features', 'num_ref')).to eq(nil)
+          expect(subject.dig('829840091')).to have_key('features')
+          expect(subject.dig('829840091', 'features')).to be_nil
           expect(subject.dig('829840091', 'deleted')).to eq(false)
           expect(subject.dig('829840091', 'prediction')).to eq('C')
         end
@@ -76,9 +69,9 @@ describe RevisionScoreApiHandler do
         .to_raise(Errno::ETIMEDOUT)
       expect(subject).to be_a(Hash)
       expect(subject.dig('829840090')).to eq({ 'wp10' => nil,
-      'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+      'features' => nil, 'deleted' => false, 'prediction' => nil })
       expect(subject.dig('829840091')).to eq({ 'wp10' => nil,
-      'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+      'features' => nil, 'deleted' => false, 'prediction' => nil })
     end
   end
 
@@ -97,8 +90,8 @@ describe RevisionScoreApiHandler do
           expect(subject.dig('144495297', 'features')).to be_a(Hash)
           expect(subject.dig('144495297', 'features',
                              'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(2)
-          expect(subject.dig('144495297', 'features').key?('num_ref')).to eq(true)
-          expect(subject.dig('144495297', 'features', 'num_ref')).to eq(nil)
+          # 'num_ref' key doesn't exist for wikidata features
+          expect(subject.dig('144495297', 'features').key?('num_ref')).to eq(false)
           expect(subject.dig('144495297', 'deleted')).to eq(false)
           expect(subject.dig('144495297', 'prediction')).to eq('D')
 
@@ -106,8 +99,8 @@ describe RevisionScoreApiHandler do
           expect(subject.dig('144495298', 'features')).to be_a(Hash)
           expect(subject.dig('144495298', 'features',
                              'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(0)
-          expect(subject.dig('144495298', 'features').key?('num_ref')).to eq(true)
-          expect(subject.dig('144495298', 'features', 'num_ref')).to eq(nil)
+          # 'num_ref' key doesn't exist for wikidata features
+          expect(subject.dig('144495298', 'features').key?('num_ref')).to eq(false)
           expect(subject.dig('144495298', 'deleted')).to eq(false)
           expect(subject.dig('144495298', 'prediction')).to eq('E')
         end
@@ -118,9 +111,9 @@ describe RevisionScoreApiHandler do
           .to_raise(Errno::ETIMEDOUT)
         expect(subject).to be_a(Hash)
         expect(subject.dig('144495297')).to eq({ 'wp10' => nil,
-        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+        'features' => nil, 'deleted' => false, 'prediction' => nil })
         expect(subject.dig('144495298')).to eq({ 'wp10' => nil,
-        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+        'features' => nil, 'deleted' => false, 'prediction' => nil })
       end
     end
   end
@@ -148,9 +141,9 @@ describe RevisionScoreApiHandler do
           .to_raise(Errno::ETIMEDOUT)
         expect(subject).to be_a(Hash)
         expect(subject.dig('157412237')).to eq({ 'wp10' => nil,
-        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+        'features' => nil, 'deleted' => false, 'prediction' => nil })
         expect(subject.dig('157417768')).to eq({ 'wp10' => nil,
-        'features' => { 'num_ref' => nil }, 'deleted' => false, 'prediction' => nil })
+        'features' => nil, 'deleted' => false, 'prediction' => nil })
       end
     end
   end


### PR DESCRIPTION
## What this PR does
This PR is part of the "Improve how Wiki Education Dashboard counts references added" project (read issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5547).

Before this PR, wikis supported by liftwing and reference-counter API had both API responses stored in the `features`/`features_previous` fields.
After this PR, only wikidata wikis (just supported by the liftwing API) have liftwing features stored in the `features`/`features_previous` fields. Other non-wikidata wikis, like `fr.wikipedia` or `es.wiktionary ` will only store reference-counter response in their `features`/`features_previous` fields.

**Context on why we're changing this**
The revision score importing process is conducted through automatic jobs as part of the course updates. The RevisionScoreImporter class is responsible for selecting "unscored" revisions and querying the API to populate the revision score fields (such as features, wp10, etc.). It determines if a revision is "unscored" by checking if the features or features_previous fields are nil.
Based on my understanding, previously, if the process of querying the LiftWing API failed for any reason, the features field remained nil. Consequently, the RevisionScoreImporter would attempt to populate that field during the next run, as the revision would still be considered "unscored".
Now, with the introduction of two APIs (LiftWing and reference-counter), and storing values from both in the features field, this behavior has changed. For instance, if a LiftWing API request fails unexpectedly, the features field will not be nil because it will contain the response from the reference-counter API. As a result, during the subsequent course update run, the revision score importer will not attempt to query the LiftWing API again to complete the features field.
Although we have implemented a retry strategy when querying APIs, prolonged downtime of one API could lead to many revisions remaining without complete data.

## Open questions and concerns
Liftwing features keeps being stored in the `features`/`features_previous` fields for wikidata wikis because they're not supported by the new reference-counter API, so references have to be calculated through liftwing features. However, I'm not sure if wikidata uses a completely different approach to count references. In that case, maybe wikidata doesn't need features at all.
