### PR TITLE
Implemented Native confirm component instead of JavaScript confirm instance

### DIFF
--- a/app/assets/javascripts/components/articles/available_article.jsx
+++ b/app/assets/javascripts/components/articles/available_article.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-
+import { initiateConfirm } from '~/app/assets/javascripts/actions/confirm_actions';
 import CourseUtils from '../../utils/course_utils.js';
 import { deleteAssignment, claimAssignment } from '../../actions/assignment_actions.js';
 
@@ -37,8 +37,13 @@ export const AvailableArticle = ({ assignment, current_user, course, selectable 
       role: 0
     };
 
-    if (!confirm(I18n.t('assignments.confirm_deletion'))) { return; }
-    return dispatch(deleteAssignment(assignmentObj));
+    const confirmMessage = I18n.t('assignments.confirm_deletion');
+
+    const onConfirm = () => {
+      dispatch(deleteAssignment(assignmentObj));
+    };
+
+    dispatch(initiateConfirm({ confirmMessage, onConfirm }));
   };
 
   const className = 'assignment';


### PR DESCRIPTION
## What this PR does
- Implemented native confirm components instead of JavaScript confirm instances for assignments deletion.
- resolves #1038

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/e3bff6e5-84fd-43ed-8c4f-e994d64f9eab)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/3e87a8ae-3e36-4a2f-8183-1ed977ed08fb)
