### PR TITLE
Fixed overflow of buttons for smaller screen sizes in articles-header

### DIFF
--- a/app/assets/stylesheets/modules/_my_articles.styl
+++ b/app/assets/stylesheets/modules/_my_articles.styl
@@ -227,3 +227,11 @@
 
 hr.assignment-divider
   margin-bottom 4px
+
+@media screen and (max-width: 486px)
+ .controls
+  display flex
+  flex-direction column
+
+ .controls > *
+  margin 5px


### PR DESCRIPTION
## What this PR does
This PR fixes the issue #5694 

## Screenshots
Before:
![before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/106299466/6ef9c8d3-0f4a-437d-888f-743eaea50367)


After:
![after](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/106299466/e6607efa-d961-4493-9ac3-bf6a61f4bc4b)

This PR is ready to review.
Thank You 
