### PR TITLE
Improved layout of "subject specific guides" block in Timeline

### DIFF
--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -181,6 +181,21 @@ const Timeline = createReactClass({
   },
 
   render() {
+    const blocks = document.querySelectorAll('.block__block-content');
+
+    // Loop through each block
+    blocks.forEach((block) => {
+      // Check if the block contains any paragraphs with links
+      const hasLinks = block.querySelector('p a');
+
+      // Apply flex row if the block contains paragraphs with links
+      if (hasLinks) {
+        block.style.flexDirection = 'row';
+        block.style.flexWrap = 'wrap';
+        block.style.marginTop = '10px';
+      }
+    });
+
     if (this.props.loading) {
       return <Loading />;
     }

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -87,6 +87,8 @@
 
 .block__block-content
   color $text_dk
+  display flex
+  flex-direction column
 
 .block.block--orderable
   display flex
@@ -538,5 +540,6 @@ a.handout-link
   border-radius 3px
   text-decoration none
   padding 5px
+  margin-right 8px
   &:hover, &:focus
     border solid 1px $brand_primary


### PR DESCRIPTION
## What this PR does
Improved the layout of "subject specific guides" block in Timeline.

fixes #5707 

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/ca3c4cad-13a4-48ca-8c13-553c8c3c44e0)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/6b3e13f7-e483-460f-9ce1-8188adab09aa)
