### PR TITLE
Improved the layout of "subject specific guides" block in Timeline.

### DIFF
--- a/app/assets/javascripts/components/common/text_area_input.jsx
+++ b/app/assets/javascripts/components/common/text_area_input.jsx
@@ -90,7 +90,7 @@ const TextAreaInput = createReactClass({
               plugins: 'lists link code',
               toolbar: [
                 'undo redo | styleselect | bold italic',
-                'alignleft aligncenter alignright alignleft',
+                'alignleft alignright',
                 'bullist numlist outdent indent',
                 'link'
               ],

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -87,6 +87,9 @@
 
 .block__block-content
   color $text_dk
+  display flex
+  flex-wrap wrap
+
 
 .block.block--orderable
   display flex
@@ -533,6 +536,7 @@ a.timeline-exercise
     float right
 
 a.handout-link
+  margin-right 8px
   color #6a6a6a
   border solid 1px #ddd
   border-radius 3px

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -540,3 +540,10 @@ a.handout-link
   padding 5px
   &:hover, &:focus
     border solid 1px $brand_primary
+
+.handout-link-container
+  display flex
+  flex-wrap wrap
+  margin-top 10px
+  > p
+    margin-right 8px

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -540,10 +540,3 @@ a.handout-link
   padding 5px
   &:hover, &:focus
     border solid 1px $brand_primary
-
-.handout-link-container
-  display flex
-  flex-wrap wrap
-  margin-top 10px
-  > p
-    margin-right 8px

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -147,8 +147,9 @@ class WizardTimelineManager
       next unless @logic.include?(logic_key)
       content += link_to_handout(logic_key)
     end
+    content = "<div class='handout-link-container'>#{content}</div>"
     # Remove the block if it's empty; otherwise, update with content
-    content.blank? ? block.destroy : block.update(content:)
+        content.blank? ? block.destroy : block.update(content:)
   end
 
   def link_to_handout(logic_key)

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -149,7 +149,7 @@ class WizardTimelineManager
     end
     content = "<div class='handout-link-container'>#{content}</div>"
     # Remove the block if it's empty; otherwise, update with content
-    content.blank? ? block.destroy : block.update(content:)
+        content.blank? ? block.destroy : block.update(content:)
   end
 
   def link_to_handout(logic_key)

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -149,7 +149,7 @@ class WizardTimelineManager
     end
     content = "<div class='handout-link-container'>#{content}</div>"
     # Remove the block if it's empty; otherwise, update with content
-        content.blank? ? block.destroy : block.update(content:)
+    content.blank? ? block.destroy : block.update(content:)
   end
 
   def link_to_handout(logic_key)

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -147,9 +147,8 @@ class WizardTimelineManager
       next unless @logic.include?(logic_key)
       content += link_to_handout(logic_key)
     end
-    content = "<div class='handout-link-container'>#{content}</div>"
     # Remove the block if it's empty; otherwise, update with content
-        content.blank? ? block.destroy : block.update(content:)
+    content.blank? ? block.destroy : block.update(content:)
   end
 
   def link_to_handout(logic_key)


### PR DESCRIPTION
## What this PR does
Improved the layout of "subject specific guides" block in Timeline.

This is the other method which adds div with classname on block creation. This is only added to the handout section. Hence this will be added to only newly created courses.

fixes #5707 

## Screenshots
### Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/27bc8f60-f536-4f4e-bf26-b82b24b6c7e0)
![Screenshot 2024-03-21 at 1 35 51 AM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/7ef105e7-33d7-49e5-88a6-9423406850f8)
![Screenshot 2024-03-20 at 4 12 04 AM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/842cffb3-22a2-4bc0-965e-72f317096407)




### After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/97a358a6-bb00-4dbf-8c4a-5ca3f354dc05)
![Screenshot 2024-03-21 at 1 35 34 AM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/3fdb5419-e743-4b65-b5d6-e138e974fa38)
![Screenshot 2024-03-20 at 4 12 12 AM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/ad35b884-77a9-478f-99c4-2c504046daaf)
