### PR TITLE
Fixed Edit button overlapping in Timeline wizard summary

### DIFF
--- a/app/assets/stylesheets/modules/_wizard.styl
+++ b/app/assets/stylesheets/modules/_wizard.styl
@@ -160,6 +160,8 @@ wizard-width = 860px
         margin-bottom 0
         padding 20px
         width 100%
+        > p:not(:last-child)
+          width 90%
         &:first-child
           border-top-width 1px
       .edit


### PR DESCRIPTION
## What this PR does
Fixed Edit button overlapping in Timeline wizard summary.

## Screenshots
Before:
![Before 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/9a0a7c17-19ca-4db3-9f1c-af6cdfbede51)


After:
![After 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/0d0c2cd4-75c5-4b7e-9f3f-6dc78ee50325)

