### PR TITLE
Implemented Role-Based `No Assignment` Message in 'Assignment & Exercise'

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/NoAssignments.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/NoAssignments.jsx
@@ -2,20 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ArticleUtils from '../../../../../utils/article_utils';
 
-export const NoAssignments = ({ project }) => {
+export const NoAssignments = ({ student, current_user, project }) => {
+  let isCurrentUser;
+  if (student) { isCurrentUser = current_user.id === student.id; }
+  const instructorOrAdmin = current_user.isInstructor || current_user.admin;
+  const permitted = (isCurrentUser || instructorOrAdmin);
+
   return (
     <div className="list__wrapper">
       <h4 className="assignments-list-title">
         {I18n.t('articles.assigned')}
       </h4>
       <section className="no-assignments">
-        <p>{ I18n.t(`instructor_view.${ArticleUtils.projectSuffix(project, 'no_assignments')}`) }</p>
+        <p>{ I18n.t(`instructor_view.${ArticleUtils.projectSuffix(project, 'no_assignments')}`) } {permitted && I18n.t('instructor_view.can_assign_assignments') }</p>
       </section>
     </div>
   );
 };
 
 NoAssignments.propTypes = {
+  current_user: PropTypes.object,
+  student: PropTypes.object,
   project: PropTypes.string.isRequired
 };
 

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
@@ -68,7 +68,7 @@ export const SelectedStudent = ({
       }
 
       {
-        !assigned.length && !reviewing.length && <NoAssignments project={course.home_wiki.project} />
+        !assigned.length && !reviewing.length && <NoAssignments student={selected} current_user={current_user} project={course.home_wiki.project} />
       }
 
       {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1017,7 +1017,8 @@ en:
       submit_issue_placeholder: "The more expert perspective and detail you can provide, the better."
       thank_you: "Thank you! Contact your Wiki Expert if you have additional questions."
     exercises_and_trainings: "%{prefix} Exercises & Trainings"
-    no_assignments: "This student currently has no assigned articles. You can assign an article by using the buttons above."
+    no_assignments: "This student currently has no assigned articles."
+    can_assign_assignments: "You can assign an article by using the buttons above."
     no_assignments_wikidata: "This student currently has no assigned items. You can assign an item by using the buttons above."
     overview: "%{prefix} Overview"
     reviewing_articles: Reviewing Articles

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -604,6 +604,8 @@ qqq:
   instructor_view:
     assignments_table:
       article_name: '{{Identical|Name}}'
+    no_assignments: Message displayed when no assignment is assigned to students
+    can_assign_assignments: Message displayed when the user can assign the assignment
   metrics:
     activity: Label for activity feed.
     are_trained: Label that follows the number of users who are do not have assigned


### PR DESCRIPTION
## What this PR does
The message which was displayed earlier was wrong as `assign button` was only visible to course creator or admin. This PR fixes it by displaying the message only to course creator or admin or assigned user.


## Screenshots
### Before:

Earlier this message was displayed to everyone.

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/68b65e88-8c60-4855-9d6e-47f9afc82148)


### After:

In Non-admin mode:

![After 1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/8b6e3c75-8e80-4291-8d3c-068cb9f2ca03)

In admin mode:

![After 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/351d1835-64a4-42c6-8a0a-2b9911ff710a)

To the assigned user:

![After 3](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/3aefd56b-9c74-49a1-8b3c-24a7b558dcf4)