### PR TITLE
Filter workflow steps depending on file changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,6 @@
+backend:
+      - '!app/assets/**'
+      - '!app/views/**'
+      - '!public/**'
+      - '!training_content/**'
+      - '!.github/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,38 +6,45 @@ on: ['push', 'pull_request', 'workflow_dispatch']
 jobs:
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
 
     steps:
       # checks-out your repository under $GITHUB_WORKSPACE , so that workflow can access it.
       - name: checkout
         uses: actions/checkout@v2
-      
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+              backend:
+                  - '!(app/assets|app/views|public|training_content)/**'
+
       - name: install Pandoc
         uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: '2.9.2.1'
-      
+
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0
-      
+
       # Setting up MariaDB based upon 'config/database.example.yml'
       - name: setup MariaDB server
-        uses: getong/mariadb-action@v1.1  
+        uses: getong/mariadb-action@v1.1
         with:
-          host port: 3306 
-          mariadb version: '10.5' 
-          mysql database: 'dashboard_testing' 
+          host port: 3306
+          mariadb version: '10.5'
+          mysql database: 'dashboard_testing'
           mysql user: 'wiki'
           mysql password: 'wikiedu'
-          
-      # Starting ruby 
+
+      # Starting ruby
       - name: setup Ruby
-        uses: ruby/setup-ruby@v1    
+        uses: ruby/setup-ruby@v1
         with:
            ruby-version: 3.1.2
            bundler-cache: true
-     
+
       - name: setup Node
         uses: actions/setup-node@v3
         with:
@@ -53,26 +60,27 @@ jobs:
             cp config/application.example.yml config/application.yml
             cp config/database.example.yml config/database.yml
             bin/rails db:migrate RAILS_ENV=test
-        
+
       - name: Cache Webpack cache
         id: cache-webpack
         uses: actions/cache@v3
         with:
           path: node_modules/.cache/
           key: ${{ runner.os }}-webpack
-          
+
       #Testing the pushed code onwards
-      
-      - name: JavaScript test suite 
+
+      - name: JavaScript test suite
         run: |
             yarn install --immutable
             yarn coverage
-            yarn run test 
-      
+            yarn run test
+
       - name: JavaScript linting
         run: yarn lint-non-build
 
       - name: Ruby rspec test suite
+        if: ${{ steps.filter.outputs.backend == 'true' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           COVERAGE: true
@@ -81,6 +89,7 @@ jobs:
           coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
           coverageLocations: |
             ${{github.workspace}}/public/js_coverage/lcov.info:lcov
-            
+
       - name: Ruby linting
+        if: ${{ steps.filter.outputs.backend == 'true' }}
         run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          filters: |
-              backend:
-                  - '!(app/assets|app/views|public|training_content)/**'
+          base: ${{ github.ref }}
+          filters: .github/file-filters.yml
+          predicate-quantifier: 'every'
 
       - name: install Pandoc
         uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION
## What this PR does

Fixes #5720 

This is an optimization on the CI workflow `ci.yml`. By filtering some steps based on file changes we can reduce the workflow execution time.

**For Example:** If only a javascript file is changed then there is no need to run Ruby tests.

## Changes

- I have updated the ci.yml to use [dorny/paths-filter@v3](https://github.com/dorny/paths-filter) github action.
- Created file-filters.yml that will have all the filter tags that can be used to check if a step should run or not.

Current `file-filters.yml` contents are:

```
backend:
      - '!app/assets/**'
      - '!app/views/**'
      - '!public/**'
      - '!training_content/**'
      - '!.github/**'

```

Here a backend filter is defined. The codebase has ruby files everywhere so I have defined the backend is everything other than frontend code, `.github` and `training_content`. The more definite this list will be the better it is. Let me know any other paths that needed to be defined here. (One can be all the markdowns `*.md`)

Ruby tests that took 30 mins will be skipped on all these folders. I have taken inspiration from how [sentry repository used this](https://github.com/getsentry/sentry/blob/2ebe01feab863d89aa7564e6d243b6d80c230ddc/.github/workflows/backend.yml#L36).

I have tested the workflow on my fork [at this branch](https://github.com/prathamVaidya/WikiEduDashboard/tree/optimize-workflow).

Here are some examples of successful workflows:

On Push -> https://github.com/prathamVaidya/WikiEduDashboard/actions/runs/8403231749
On Pull Request -> https://github.com/prathamVaidya/WikiEduDashboard/actions/runs/8403275731 (It failed because it ran flaky RSpecs which it should have because there was a modified ruby file)

@ragesoss Let me know if there is a breaking change associated with this feature. Especially on my assumption that the files in `training_content`, `app/assets` do not affect the ruby tests.