### PR TITLE
Sort by training modules in Student Overview

### DIFF
--- a/app/assets/javascripts/components/students/shared/SortButton.jsx
+++ b/app/assets/javascripts/components/students/shared/SortButton.jsx
@@ -21,6 +21,7 @@ export const SortButton = ({ current_user, sortSelect, showOverviewFilters = tru
               <option value="character_sum_us">{I18n.t('users.characters_added_userspace')}</option>
               <option value="character_sum_draft">{I18n.t('users.characters_added_draftspace')}</option>
               <option value="references_count">{I18n.t('users.references_count')}</option>
+              <option value="course_training_progress_completed_count">{I18n.t('users.training_modules')}</option>
             </>
           )
         }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,7 +134,7 @@ en:
         heading: Username rules
         avoid_offensive_usernames: Do not choose a username that is offensive, misleading, disruptive, or promotional.
         represent_individual: Usernames must represent an individual editor. Do not use the name of a school or organization.
-      additional_advice: 
+      additional_advice:
         heading: Advice
         anonymous_username_recommendation: Wiki Education recommends choosing an anonymous username, not one that includes your real name or other identifying information.
     sign_up_help: >
@@ -1446,6 +1446,7 @@ en:
     profile: profile
     recent_revisions: Recent Edits
     references_count: References Added
+    training_modules: Training Modules
     remove_confirmation: Are you sure you want to remove %{username}?
     request_confirmation: Are you sure you want to request this account?
     requested_account_status:


### PR DESCRIPTION
## What this PR does

Fixes #5702 

Added a sort option to sort by Training Modules in the student's overview.
 
## Screenshots

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/1176d9b9-5e56-4146-941b-ad90878e2566)

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/e231a6c1-8fbb-4427-83f3-510d10a588d1)
