### PR TITLE
Feature 5693 - Training Data in Editors CSV

### DIFF
--- a/lib/course_training_progress_manager.rb
+++ b/lib/course_training_progress_manager.rb
@@ -56,6 +56,18 @@ class CourseTrainingProgressManager
     modules.sort_by(&:due_date)
   end
 
+  def completed_training_modules_names(user)
+    @user = user
+    completed_modules = TrainingModulesUsers
+                        .joins(:training_module)
+                        .select('training_modules.name')
+                        .where(training_modules_users: { user_id: @user.id })
+                        .where(training_module_id: training_modules_for_course)
+                        .where.not(completed_at: nil)
+                        .pluck('training_modules.name')
+    completed_modules
+  end
+
   private
 
   def off_dashboard_training?


### PR DESCRIPTION
## What this PR does

Fixes #5693 

It populates the training data in the editor's CSV file.

Added three fields in the last:

- completed_training_modules_count
- assigned_training_modules_count
- completed_training_modules

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/fcf0e6df-f0d2-4332-a23f-65c8d661806e)