### PR TITLE
Fixed 'Course Form' Wizard UI in course creator

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_form.jsx
+++ b/app/assets/javascripts/components/course_creator/course_form.jsx
@@ -234,12 +234,14 @@ const CourseForm = (props) => {
         {expectedStudents}
         {home_wiki}
         {multi_wiki}
-        {backButton}
-        <p className="tempEduCourseIdText">
-          {props.tempCourseId || '\xa0'}
+        <div className="backButtonContainer">
+          {backButton}
+          <p className="tempEduCourseIdText">
+            {props.tempCourseId || '\xa0'}
           &nbsp;
-          <span className="red">{props.firstErrorMessage || '\xa0'}</span>
-        </p>
+            <span className="red">{props.firstErrorMessage || '\xa0'}</span>
+          </p>
+        </div>
 
       </div>
       <div className="column">

--- a/app/assets/stylesheets/modules/_wizard.styl
+++ b/app/assets/stylesheets/modules/_wizard.styl
@@ -46,7 +46,7 @@ wizard-width = 860px
     visibility hidden
     &.active
       /*@noflip*/ left 50%
-      top 90px
+      top 50px
       opacity 1
       transition left panel_speed ease-in-out, opacity .01s
       visibility visible
@@ -283,6 +283,13 @@ wizard-width = 860px
           margin-right 10px
   .section-header
     margin-bottom 10px
+
+.backButtonContainer
+  display flex
+  align-items flex-end
+  height 70px
+  gap 10px
+  flex-direction row
 
 p.red
   color warning !important


### PR DESCRIPTION
## What this PR does
This fixes back button position and also adds little space below the form to make it look better.

## Screenshots

### On P&E Dashboard:
Before:
![Before 1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/4ae55646-97f5-4ae2-9494-00f306bd68f3)

After:
![After 1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/24ea0089-351f-4354-9d52-b677f58ac40b)

### On WikiEdu Dashboard:
Before:
![Before 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/85c522cb-14bd-4700-b67d-481b3d8a99d8)

After:
![After 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/877441bd-cea0-4d1a-ba1d-3e694a1568a1)

