### PR TITLE
Added new eslint rule to disallow string literals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -80,7 +80,7 @@
     "import/no-useless-path-segments": 0,
     "react/no-this-in-sfc": 0,
     "react/jsx-props-no-multi-spaces": 0,
-    "i18next/no-literal-string": [2, { "message": "Use I18n over string literals for localization" }]
+    "i18next/no-literal-string": [1, { "message": "Use I18n over string literals for localization" }]
   },
   "globals": {
     "I18n": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -79,7 +79,8 @@
     "react/no-access-state-in-setstate": 0,
     "import/no-useless-path-segments": 0,
     "react/no-this-in-sfc": 0,
-    "react/jsx-props-no-multi-spaces": 0
+    "react/jsx-props-no-multi-spaces": 0,
+    "i18next/no-literal-string": 2
   },
   "globals": {
     "I18n": true,
@@ -118,5 +119,6 @@
         }
       ]
     }
-  }
+  },
+  "plugins": ["i18next"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -80,7 +80,7 @@
     "import/no-useless-path-segments": 0,
     "react/no-this-in-sfc": 0,
     "react/jsx-props-no-multi-spaces": 0,
-    "i18next/no-literal-string": 2
+    "i18next/no-literal-string": [2, { "message": "Use I18n over string literals for localization" }]
   },
   "globals": {
     "I18n": true,

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "scripts": {
     "test": "jest",
+    "lint": "eslint '**/*.{jsx,js}' '*.js'",
     "lint-non-build": "eslint 'test/**/*.{jsx,js}' '*.js'",
     "start": "node prepare.js && webpack serve --env development --client-overlay --client-progress --progress",
     "start:no-lint": "node prepare.js && webpack serve --env development --env DISABLE_ESLINT --client-overlay --client-progress --progress",
@@ -117,6 +118,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "babel-plugin-root-import": "^6.5.0",
     "eslint-import-resolver-babel-plugin-root-import": "^1.1.1",
+    "eslint-plugin-i18next": "^6.0.3",
     "eslint-webpack-plugin": "^3.1.1",
     "lodash": "^4.17.21",
     "react-refresh": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
   },
   "scripts": {
     "test": "jest",
-    "lint": "eslint '**/*.{jsx,js}' '*.js'",
     "lint-non-build": "eslint 'test/**/*.{jsx,js}' '*.js'",
     "start": "node prepare.js && webpack serve --env development --client-overlay --client-progress --progress",
     "start:no-lint": "node prepare.js && webpack serve --env development --env DISABLE_ESLINT --client-overlay --client-progress --progress",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,6 +2789,7 @@ __metadata:
     eslint: ^8.10.0
     eslint-config-airbnb: ^17.1.1
     eslint-import-resolver-babel-plugin-root-import: ^1.1.1
+    eslint-plugin-i18next: ^6.0.3
     eslint-plugin-import: ^2.22.0
     eslint-plugin-jsx-a11y: ^6.2.3
     eslint-plugin-react: ^7.20.5
@@ -5359,6 +5360,16 @@ __metadata:
     debug: ^3.2.7
     find-up: ^2.1.0
   checksum: 77048263f309167a1e6a1e1b896bfb5ddd1d3859b2e2abbd9c32c432aee13d610d46e6820b1ca81b37fba437cf423a404bc6649be64ace9148a3062d1886a678
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-i18next@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "eslint-plugin-i18next@npm:6.0.3"
+  dependencies:
+    lodash: ^4.17.21
+    requireindex: ~1.1.0
+  checksum: 4138568b68fcbeccf843357d8843be7202751a30b51c3db13184799b62176704c542682c8bde1b426b5e11c0867c320b2cfa27d436ab80b623a321300d7c2828
   languageName: node
   linkType: hard
 
@@ -10818,6 +10829,13 @@ __metadata:
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
   checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
+  languageName: node
+  linkType: hard
+
+"requireindex@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "requireindex@npm:1.1.0"
+  checksum: 397057d97d7f753a3851abf0d6db94c295bd8254536f71f622b896ba08ea8c0d3e3771c8b009a557e6ce602f4245c0588836cdf59c4ce588fff721a7b855d323
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does

This PR added a new ESLint rule to disallow string literals. This will help users to prefer I18n use over string literals to promote localization.

https://github.com/edvardchen/eslint-plugin-i18next

## Screenshots

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/9862edd8-8479-417b-957c-15bb47cd4b2c)

There are two modes for it:

- `jsx-only` : validates the JSX attributes as well
- `all` : validates all literal strings

Currently its set to `jsx-only`. Let me know if you want to change.