### PR TITLE
Fixed wrong text of button in Available Articles page

### DIFF
--- a/app/assets/javascripts/components/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/articles/available_articles.jsx
@@ -38,7 +38,7 @@ const AvailableArticles = (props) => {
   if (Features.wikiEd && current_user.isAdvancedRole) {
     findingArticlesTraining = (
       <a href="/training/instructors/finding-articles" target="_blank" className="button ghost-button small">
-        {ArticleUtils.I18n('find', project)}
+        {ArticleUtils.I18n('how_to_find', project)}
       </a>
     );
   }


### PR DESCRIPTION
## What this PR does
This PR fixes wrong text of button in Available Articles page. There are two buttons with same name.

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/7189dfed-4956-4446-958f-1ec1142ef9dd)

After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/7d449eb6-eb19-4a57-b948-4f5625109be5)

