### PR TITLE
Implemented React Select in Course Cloning Wizard 

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -24,6 +24,9 @@ import { fetchAssignments } from '../../actions/assignment_actions';
 import CourseScoping from './course_scoping_methods';
 import { getScopingMethods } from '../util/scoping_methods';
 
+import Select from 'react-select';
+import selectStyles from '../../styles/single_select.js';
+
 const CourseCreator = createReactClass({
   displayName: 'CourseCreator',
 
@@ -62,6 +65,7 @@ const CourseCreator = createReactClass({
       copyCourseAssignments: false,
       showingCreateCourseButton: false,
       onLastScoping: false,
+      courseCloneId: null,
     };
   },
 
@@ -75,7 +79,10 @@ const CourseCreator = createReactClass({
     },
 
   onDropdownChange(event) {
-    this.props.fetchAssignments(event.target.value);
+    this.setState({
+      courseCloneId: event.id,
+    });
+    this.props.fetchAssignments(event.value);
   },
   setCopyCourseAssignments(e) {
     return this.setState({
@@ -289,8 +296,7 @@ const CourseCreator = createReactClass({
   },
 
   useThisClass() {
-    const select = this.courseSelect;
-    const courseId = select.options[select.selectedIndex].getAttribute('data-id-key');
+    const courseId = this.state.courseCloneId;
     this.props.cloneCourse(courseId, this.campaignParam(), this.state.copyCourseAssignments);
     return this.setState({ isSubmitting: true, shouldRedirect: true });
   },
@@ -369,11 +375,27 @@ const CourseCreator = createReactClass({
 
     const cloneOptions = showNewOrClone ? '' : ' hidden';
     const selectClass = showCloneChooser ? '' : ' hidden';
-    const options = this.props.cloneableCourses.map((course, i) => <option key={i} data-id-key={course.id} value={course.slug}>{course.title}</option>);
+    const options = [
+      ...this.props.cloneableCourses.map(course => ({
+        value: course.slug,
+        label: course.title,
+        id: course.id
+      }))
+    ];
     const selectClassName = `select-container ${selectClass}`;
     const eventFormClass = this.state.showEventDates ? '' : 'hidden';
     const eventClass = `${eventFormClass}`;
-    const reuseCourseSelect = <select id="reuse-existing-course-select" ref={(dropdown) => { this.courseSelect = dropdown; }} onChange={this.onDropdownChange}>{options}</select>;
+    const reuseCourseSelect = (
+      <div style={{ width: '70%', marginBottom: '20px' }}>
+        <Select
+          id="reuse-existing-course-select"
+          styles={selectStyles}
+          onChange={this.onDropdownChange}
+          options={options}
+          ref={(dropdown) => { this.courseSelect = dropdown; }}
+        />
+      </div>
+    );
 
     let showCheckbox;
     if (this.props.assignmentsWithoutUsers.length > 0) {

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -386,7 +386,7 @@ const CourseCreator = createReactClass({
     const eventFormClass = this.state.showEventDates ? '' : 'hidden';
     const eventClass = `${eventFormClass}`;
     const reuseCourseSelect = (
-      <div style={{ width: '70%', marginBottom: '20px' }}>
+      <div style={{ display: 'inline-block', width: '60%', marginRight: '10px' }}>
         <Select
           id="reuse-existing-course-select"
           styles={selectStyles}

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -390,6 +390,7 @@ const CourseCreator = createReactClass({
         <Select
           id="reuse-existing-course-select"
           styles={selectStyles}
+          placeholder={'Select a course'}
           onChange={this.onDropdownChange}
           options={options}
           ref={(dropdown) => { this.courseSelect = dropdown; }}

--- a/spec/features/course_cloning_spec.rb
+++ b/spec/features/course_cloning_spec.rb
@@ -62,7 +62,10 @@ describe 'cloning a course', js: true do
     visit root_path
     click_link 'Create Course'
     click_button 'Clone Previous Course'
-    select course.title, from: 'reuse-existing-course-select'
+    find('#reuse-existing-course-select').click
+    within '#reuse-existing-course-select' do
+      all('div', text: course.title)[2].click
+    end
     click_button 'Clone This Course'
 
     expect(page).to have_content 'Update Details for Cloned Course'
@@ -123,7 +126,10 @@ describe 'cloning a course', js: true do
     visit root_path
     click_link 'Create Course'
     click_button 'Clone Previous Course'
-    select course.title, from: 'reuse-existing-course-select'
+    find('#reuse-existing-course-select').click
+    within '#reuse-existing-course-select' do
+      all('div', text: course.title)[2].click
+    end
     find('input#copy_cloned_articles').click
     click_button 'Clone This Course'
 


### PR DESCRIPTION
## What this PR does
Substituted the native select element with react-select in the course cloning wizard for selecting courses to be cloned.
Addresses issue #2263 

## Screenshots
Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/8433cd5a-86f9-4d08-b1e4-3888f17084bc



After:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/2ff26368-6067-4f55-a585-24cb8f3cf19e

