### PR TITLE
Fixed Course flag bug

### DIFF
--- a/app/assets/javascripts/components/common/academic_system.jsx
+++ b/app/assets/javascripts/components/common/academic_system.jsx
@@ -1,7 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 const AcademicSystem = (props) => {
   const [selectedOption, setSelectedOption] = useState(props.value || 'semester');
+
+  useEffect(() => {
+    props.updateCourseProps({ academic_system: selectedOption });
+  }, []);
 
   const handleOptionChange = (changeEvent) => {
     setSelectedOption(changeEvent.target.value);


### PR DESCRIPTION
## What this PR does

This pull request addresses a bug in the Course Creator for Wiki Education mode. The issue occurs when the AcademicSystem component defaults to nil instead of 'semester' upon course creation. The fix ensures that the default selection remains 'semester' even if unchanged by the user. This improvement enhances user experience by providing the expected default behaviour.

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/bb757ce2-a9fc-4de0-b0a9-688d8541541b)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/8d285cba-3a36-49d2-8fb9-f441c5f5a69c)
