### PR TITLE
Extended i18n over string literals for localization

### DIFF
--- a/app/assets/javascripts/components/activity/activity_table_row.jsx
+++ b/app/assets/javascripts/components/activity/activity_table_row.jsx
@@ -34,7 +34,7 @@ const ActivityTableRow = ({ isOpen, diffUrl, revisionDateTime,
   if (reportUrl) {
     col2 = (
       <td>
-        <a href={reportUrl} target="_blank">Report</a>
+        <a href={reportUrl} target="_blank">{I18n.t('recent_activity.report')}</a>
       </td>
     );
   }

--- a/app/assets/javascripts/components/alerts/alert.jsx
+++ b/app/assets/javascripts/components/alerts/alert.jsx
@@ -17,7 +17,7 @@ const Alert = ({ alert, adminAlert, resolveAlert }) => {
     }
     if (alert.resolvable && !alert.resolved) {
       resolveButton = (
-        <button className="button small danger dark" onClick={() => resolveAlert(alert.id)}>Resolve</button>
+        <button className="button small danger dark" onClick={() => resolveAlert(alert.id)}>{I18n.t('campaign.resolve')}</button>
       );
     }
     resolveCell = (

--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -62,7 +62,7 @@ const ArticleFinderRow = (props) => {
     if (props.article.pageviews) {
       pageviews = Math.round(props.article.pageviews);
     } else if (props.article.fetchState === 'PAGEVIEWS_RECEIVED') {
-      pageviews = <div>Page Views not found!</div>;
+      pageviews = <div>{I18n.t('article_finder.page_views_not_found')}</div>;
     }
     let revScore;
     if (
@@ -77,7 +77,7 @@ const ArticleFinderRow = (props) => {
       } else if (props.article.revScore) {
         revScore = <td className="revScore">{Math.round(props.article.revScore)}</td>;
       } else if (fetchStates[props.article.fetchState] >= fetchStates.REVISIONSCORE_RECEIVED) {
-        revScore = <td><div>Estimation Score not found!</div></td>;
+        revScore = <td><div>{I18n.t('article_finder.estimation_score_not_found')}</div></td>;
       } else {
         revScore = <td />;
       }

--- a/app/assets/javascripts/components/articles/article_list.jsx
+++ b/app/assets/javascripts/components/articles/article_list.jsx
@@ -251,7 +251,7 @@ const ArticleList = createReactClass({
 
     let filterLabel;
     if (!!filterWikis || !!filterArticlesSelect || !!filterTracked) {
-      filterLabel = <b>Filters:</b>;
+      filterLabel = <b>{I18n.t('articles.filter_text')}</b>;
     }
 
     const articleSort = (

--- a/app/assets/javascripts/components/campaign/campaign_row.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_row.jsx
@@ -4,19 +4,19 @@ const CampaignRow = ({ campaign }) => {
   return (
     <tr>
       <td className="title"><a href={`/campaigns/${campaign.slug}/overview`} >{campaign.title}</a></td>
-      <td><a href={`/campaigns/${campaign.slug}/students.csv`}>students</a></td>
-      <td><a href={`/campaigns/${campaign.slug}/students.csv?course=true`}>students by course</a></td>
+      <td><a href={`/campaigns/${campaign.slug}/students.csv`}>{I18n.t('campaign.students_small')}</a></td>
+      <td><a href={`/campaigns/${campaign.slug}/students.csv?course=true`}>{I18n.t('campaign.student_course')}</a></td>
       <td>
-        <a href={`/campaigns/${campaign.slug}/instructors.csv?course=true`}>instructors by course</a>
+        <a href={`/campaigns/${campaign.slug}/instructors.csv?course=true`}>{I18n.t('campaign.instructors_course')}</a>
       </td>
       <td>
-        <a href={`/campaigns/${campaign.slug}/courses.csv`}>course data</a>
+        <a href={`/campaigns/${campaign.slug}/courses.csv`}>{I18n.t('campaign.course_data')}</a>
       </td>
       <td>
-        <a href={`/campaigns/${campaign.slug}/articles_csv.csv`}>pages edited</a>
+        <a href={`/campaigns/${campaign.slug}/articles_csv.csv`}>{I18n.t('campaign.pages_edited_small')}</a>
       </td>
       <td>
-        <a href={`/campaigns/${campaign.slug}/revisions_csv.csv`}>revision data</a>
+        <a href={`/campaigns/${campaign.slug}/revisions_csv.csv`}>{I18n.t('campaign.revision_data')}</a>
       </td>
     </tr>
   );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,6 +183,7 @@ en:
       tracked: Tracked
       untracked: Untracked
       tracked_and_untracked: Tracked and Untracked
+    filter_text: "Filters:"
     find: Find Articles
     how_to_find: How to find articles
     hide: Hide
@@ -373,6 +374,7 @@ en:
     confirm_course_removal: Are you sure you want to remove "%{title}" from the "%{campaign_title}" campaign?
     course_already_removed: '"%{title}" was already removed from the "%{campaign_title}" campaign'
     course: Course
+    course_data: course data
     course_removed: '"%{title}" has been removed from the "%{campaign_title}" campaign'
     course_removed_and_deleted: '"%{title}" has been deleted and removed from the "%{campaign_title}" campaign'
     course_removed_but_not_deleted: '"%{title}" has been removed from the "%{campaign_title}" but has not been deleted as it is present in other campaigns as well'
@@ -404,12 +406,14 @@ en:
     enable_account_requests: Enable account requests
     newest_campaigns: Newest Campaigns
     featured_campaigns: Featured Campaigns
+    instructors_course: instructors by course
     no_alerts: This campaign has no alerts
     no_passcode: no passcode
     none: None
     organizers: Organizers
     organizer_added: '%{user} is now an organizer of the "%{title}" campaign'
     organizer_removed: '%{user} has been removed as an organizer of the "%{title}" campaign'
+    pages_edited_small: pages edited
     program_template: Program Template
     program_template_tooltip: >
       When an organizer creates a program in this campaign,
@@ -417,6 +421,10 @@ en:
     random_passcode: a random passcode
     remove_course_tooltip: Remove from campaign.
     requested_accounts: Requested accounts
+    resolve: Resolve
+    revision_data: revision data
+    students_small: students
+    student_course: students by course
     title: Title
     too_many_articles: The edited article list for this campaign is too long to be displayed. Please view individual courses/programs/events to see the articles edited.
     slug: Slug
@@ -1191,6 +1199,7 @@ en:
       the entire article — is not accessible, the content may have been deleted for copyright reasons.)
     recent_edits: Recent Edits
     recent_uploads: Recent Uploads
+    report: Report
     revision_author: Revision Author
     revision_datetime: Revision Date/Time
     revision_score: Revision Score
@@ -1688,6 +1697,7 @@ en:
     average_views: "Average views per day"
     category_search: "Category Search"
     completeness_estimate: "Completeness Score"
+    estimation_score_not_found: "Estimation Score not found!"
     fetching_assessments: "Fetching Page Assessments"
     fetching_scores: "Fetching Completeness Score"
     fetching_pageviews: "Fetching Page Views"
@@ -1703,6 +1713,7 @@ en:
     no_article_found: "No articles found in this category"
     no_article_found_wikidata: "No items found in this category"
     page_assessment_class: "Class"
+    page_views_not_found: "Page Views not found!"
     relevanceIndex: "Relevance Index"
     remove_article: "Remove article"
     remove_article_wikidata: "Remove items"


### PR DESCRIPTION
Fixes #5748 
This pr extended i18n over string literals.

## Screenshot(of change in activity_table_row) :

Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/4b039a6f-d600-472d-80dd-c1628882ac5b)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/e6da15cc-04a3-408c-a50c-fe68f68d8ab6)

