### PR TITLE
Fix slow + flaky namespaces_stat spec

### DIFF
--- a/spec/features/namespace_stats_spec.rb
+++ b/spec/features/namespace_stats_spec.rb
@@ -22,22 +22,23 @@ describe 'Namespace-specific stats', type: :feature, js: true do
     JoinCourse.new(course:, user: user1, role: 0)
     JoinCourse.new(course:, user: user2, role: 0)
     login_as superadmin
+    allow(UpdateCourseStats).to receive(:new)
+    create(:course_stats,
+           stats_hash: { 'en.wikibooks.org-namespace-0':
+    { edited_count: 1, new_count: 2, revision_count: 3,
+      user_count: 4, word_count: 5, reference_count: 6, view_count: 7 },
+   'en.wikibooks.org-namespace-102':
+    { edited_count: 2, new_count: 4, revision_count: 4, user_count: 14,
+      word_count: 15, reference_count: 16, view_count: 17 } }, course_id: course.id)
   end
 
   it 'generates and renders stats for Cookbook namespace on en.wikibooks.org' do
-    pending 'Manual update sometimes takes too long and times out'
+    visit "/courses/#{course.slug}/manual_update"
+    expect(page).to have_content 'en.wikibooks.org - Mainspace'
+    expect(page).to have_content "0\nTotal Edits"
 
-    VCR.use_cassette 'cookbook' do
-      visit "/courses/#{course.slug}/manual_update"
-
-      expect(page).to have_content 'en.wikibooks.org - Mainspace'
-      expect(page).to have_content "0\nTotal Edits"
-
-      expect(page).to have_content 'en.wikibooks.org - Cookbook'
-      find('.tab', text: 'en.wikibooks.org - Cookbook').click
-      expect(page).to have_content "4\nTotal Edits"
-    end
-
-    pass_pending_spec
+    expect(page).to have_content 'en.wikibooks.org - Cookbook'
+    find('.tab', text: 'en.wikibooks.org - Cookbook').click
+    expect(page).to have_content "4\nTotal Edits"
   end
 end


### PR DESCRIPTION
## What this PR does
This PR aims to close #5660 by 

 - stubbing UpdateCourseStats to avoid real http calls
 - building test course stats to get data
 - removing now useless VCR

## Open questions and concerns
I think it might closes #5655 as well
