### PR TITLE
In Article Viewer, added option to show the last student revision

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
@@ -7,7 +7,7 @@ import { printArticleViewer } from '../../../../utils/article_viewer';
 
 export const Footer = ({
   article, colors, failureMessage, showArticleFinder, highlightedHtml, isWhocolorLang,
-  whocolorFailed, users, unhighlightedEditors
+  whocolorFailed, users, unhighlightedEditors, revisionId, toggleRevisionHandler
 }) => {
   // Determine the Article Viewer Legend status based on what information
   // has returned from various API calls.
@@ -34,6 +34,26 @@ export const Footer = ({
     );
   }
 
+  const revision_button_text = revisionId ? I18n.t('application.show_current_revision') : I18n.t('application.show_last_revision');
+  const revision_button = !showArticleFinder && (
+    <div>
+      {
+        !showArticleFinder && (
+          <button
+            className="button dark small"
+            style={{
+              height: 'max-content',
+              width: 'max-content',
+            }}
+            onClick={toggleRevisionHandler}
+          >
+            {revision_button_text}
+          </button>
+        )
+      }
+    </div>
+  );
+
   return (
     <div
       className="article-footer"
@@ -44,28 +64,40 @@ export const Footer = ({
     }}
     >
       {articleViewerLegend}
-      <a
-        className="button dark small pull-right article-viewer-button"
-        href={article.url}
-        target="_blank"
+      <div
         style={{
-          height: 'max-content',
-          width: 'max-content',
-          whiteSpace: 'nowrap'
+          display: 'flex',
+          alignItems: 'center',
+          gap: '1em',
+          width: '100%',
+          justifyContent: 'flex-end',
         }}
       >
-        {I18n.t('articles.view_on_wiki')}
-      </a>
-      <button
-        className="button dark small"
-        style={{
-          height: 'max-content',
-          width: 'max-content',
-        }}
-        onClick={printArticleViewer}
-      >
-        {I18n.t('application.print')}
-      </button>
+        {revision_button}
+        <a
+          className="button dark small pull-right article-viewer-button"
+          href={article.url}
+          target="_blank"
+          style={{
+            height: 'max-content',
+            width: 'max-content',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {I18n.t('articles.view_on_wiki')}
+        </a>
+        <button
+          className="button dark small"
+          style={{
+            height: 'max-content',
+            width: 'max-content',
+            margin: '0em 0em',
+          }}
+          onClick={printArticleViewer}
+        >
+          {I18n.t('application.print')}
+        </button>
+      </div>
     </div>
   );
 };

--- a/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleViewerAPI.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleViewerAPI.js
@@ -53,8 +53,8 @@ export class ArticleViewerAPI {
 
   // This function sets up a timer for the request to the highlighting
   // API endpoint so that we can make requests on a delay.
-  __wikiwhoColorURLTimedRequestPromise(timeout) {
-    const url = this.builder.wikiwhoColorURL();
+  __wikiwhoColorURLTimedRequestPromise(timeout, lastRevisionId) {
+    const url = this.builder.wikiwhoColorURL(lastRevisionId);
     return new Promise((resolve, reject) => {
       const headers = { 'Content-Type': 'application/javascript' };
       setTimeout(() => {
@@ -64,8 +64,8 @@ export class ArticleViewerAPI {
     });
   }
 
-  fetchParsedArticle() {
-    const url = this.builder.parsedArticleURL();
+  fetchParsedArticle(lastRevisionId) {
+    const url = this.builder.parsedArticleURL(lastRevisionId);
     // Adding `origin=*` allows for requests to go to en.wikipedia.org
     // as referenced by this URL:
     // https://www.mediawiki.org/wiki/API:Cross-site_requests#CORS_usage
@@ -93,14 +93,14 @@ export class ArticleViewerAPI {
     }).then(response => this.__handleFetchResponse(response));
   }
 
-  fetchWhocolorHtml() {
+  fetchWhocolorHtml(lastRevisionId) {
     let attempts = 0;
     const MAX_RETRY_ATTEMPTS = 5;
 
     // This function is defined in this way so that the variable name
     // will be hoisted, allowing it to call itself.
     function colorURLRequest(timeout = 0) {
-      return this.__wikiwhoColorURLTimedRequestPromise(timeout)
+      return this.__wikiwhoColorURLTimedRequestPromise(timeout, lastRevisionId)
         .then(response => response.json())
         .then((response) => {
           if (response.success) return Promise.resolve(response);

--- a/app/assets/javascripts/components/common/ArticleViewer/utils/URLBuilder.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/URLBuilder.js
@@ -6,14 +6,19 @@ export class URLBuilder {
     this.users = users;
   }
 
-  parsedArticleURL() {
+  parsedArticleURL(lastRevisionId) {
     const { title } = this.article;
     if (!title) throw new TypeError('Article title is missing!');
 
     const base = this.wikiURL();
-    const query = `${base}/w/api.php?action=parse&disableeditsection=true&format=json`;
-    const url = `${query}&page=${encodeURIComponent(title)}`;
-
+    let url;
+    if (lastRevisionId) {
+      const query = `${base}/w/api.php?action=parse&oldid=${lastRevisionId}&disableeditsection=true&format=json`;
+      url = `${query}`;
+    } else {
+      const query = `${base}/w/api.php?action=parse&disableeditsection=true&format=json`;
+      url = `${query}&page=${encodeURIComponent(title)}`;
+    }
     return url;
   }
 
@@ -27,7 +32,7 @@ export class URLBuilder {
     return encodeURI(url);
   }
 
-  wikiwhoColorURL() {
+  wikiwhoColorURL(lastRevisionId) {
     const { language, title } = this.article;
 
     if (!language) throw new TypeError('Article language is missing!');
@@ -35,7 +40,8 @@ export class URLBuilder {
 
     // Add `/0` to the end of the URL to work around wikiwho API bug with article titles that include slashes.
     // See https://github.com/wikimedia/wikiwho_api/pull/4/commits/8f421a20c62288a1a29bcef75fffa0a21d2c92a6
-    const url = `${WIKIWHO_DOMAIN}/${language}/whocolor/v1.0.0-beta/${encodeURIComponent(title)}/0/`;
+    const revisionId = lastRevisionId || 0;
+    const url = `${WIKIWHO_DOMAIN}/${language}/whocolor/v1.0.0-beta/${encodeURIComponent(title)}/${revisionId}/`;
     return url;
   }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,8 @@ en:
       one: "%{count} Result for: '%{search_terms}'"
       other: "%{count} Results for: '%{search_terms}'"
     no_results: "No results found for '%{query}'"
+    show_current_revision: Show current version
+    show_last_revision: Show last revision
     sign_up_extended: Sign up with Wikipedia
     sign_up_wikipedia: Or sign up on Wikipedia
 


### PR DESCRIPTION
## What this PR does
Fixes #5729 
This will help users toggle between the current and last student revisions of an article.
For better clarification of the issue : [Link](https://excalidraw.com/#json=dNJxoSJ-C6H_u1USHh9-M,J88rNl_xPtXyrxioZ4dluw)

## Screenshot / Video
Before:

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/8592c4e5-f8c5-4549-900d-dec89ebf23a9)


After:

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/4a5f45b0-33c3-42ba-a4d9-6ff2be6fd29f)
