### PR TITLE
Added Back button in 'Course Type' Form in Course Creator

### DIFF
--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -301,6 +301,12 @@ const CourseCreator = createReactClass({
     return this.setState({ isSubmitting: true, shouldRedirect: true });
   },
 
+  hideWizardForm() {
+    return this.setState({
+      showWizardForm: false,
+    });
+  },
+
 
 
   render() {
@@ -427,6 +433,7 @@ const CourseCreator = createReactClass({
               stringPrefix={this.state.course_string_prefix}
             />
             <CourseType
+              back = {this.hideWizardForm}
               wizardClass={courseWizard}
               wizardAction={this.showCourseForm}
             />

--- a/app/assets/javascripts/components/course_creator/course_type.jsx
+++ b/app/assets/javascripts/components/course_creator/course_type.jsx
@@ -3,7 +3,7 @@ import { map } from 'lodash-es';
 import SelectableBox from '../common/selectable_box';
 import { Link } from 'react-router-dom';
 
-const CourseType = ({ wizardClass, wizardAction }) => {
+const CourseType = ({ back, wizardClass, wizardAction }) => {
   const courseTypes = [
     {
       name: I18n.t('courses.creator.course_types.basic_course_name'),
@@ -31,6 +31,7 @@ const CourseType = ({ wizardClass, wizardAction }) => {
           );
         })}
       </div>
+      <button className="button dark" onClick={back}>Back</button>
       <Link className="button right" to="/" id="course_cancel">{I18n.t('application.cancel')}</Link>
     </div>
   );

--- a/app/assets/javascripts/components/course_creator/course_type.jsx
+++ b/app/assets/javascripts/components/course_creator/course_type.jsx
@@ -31,7 +31,7 @@ const CourseType = ({ back, wizardClass, wizardAction }) => {
           );
         })}
       </div>
-      <button className="button dark" onClick={back}>Back</button>
+      <button className="button dark" onClick={back}>{I18n.t('application.back')}</button>
       <Link className="button right" to="/" id="course_cancel">{I18n.t('application.cancel')}</Link>
     </div>
   );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
     number_field: This is a number field. The buttons rendered by most browsers will increment and decrement the input.
 
   application:
+    back: Back
     cancel: Cancel
     cookie_consent: This site uses cookies to keep you logged in, and stores information related to your Wikipedia account.
     cookie_consent_acknowledge: I understand

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -40,6 +40,7 @@ qqq:
     number_field: Descriptive text for screen readers to explain how the number field
       works
   application:
+    back: Button to go back
     cancel: |-
       Button to cancel an action
       {{Identical|Cancel}}


### PR DESCRIPTION
## What this PR does
The Course Creator doesn't have a back button when we choose 'course type', making it difficult for users to propagate back and forth. This PR adds a back button for proper navigation while creating an independent program for better User Experience.

## Screenshots
Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/b496a84f-36bd-41b5-847a-3e1e627bd7b1



After:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/f1e4efbe-efa9-4eca-a83b-8207d8afb435

