### PR TITLE
Fixed bug in Article Viewer

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
@@ -7,14 +7,14 @@ import { printArticleViewer } from '../../../../utils/article_viewer';
 
 export const Footer = ({
   article, colors, failureMessage, showArticleFinder, highlightedHtml, isWhocolorLang,
-  whocolorFailed, users, unhighlightedEditors, revisionId, toggleRevisionHandler
+  whocolorFailed, users, unhighlightedEditors, revisionId, toggleRevisionHandler, pendingRequest
 }) => {
   // Determine the Article Viewer Legend status based on what information
   // has returned from various API calls.
   let articleViewerLegend;
   if (!showArticleFinder) {
     let legendStatus;
-    if (highlightedHtml && unhighlightedEditors.length) {
+    if (highlightedHtml) {
       legendStatus = 'ready';
     } else if (whocolorFailed) {
       legendStatus = 'failed';
@@ -46,6 +46,7 @@ export const Footer = ({
               width: 'max-content',
             }}
             onClick={toggleRevisionHandler}
+            disabled={pendingRequest}
           >
             {revision_button_text}
           </button>

--- a/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
@@ -7,14 +7,14 @@ import { printArticleViewer } from '../../../../utils/article_viewer';
 
 export const Footer = ({
   article, colors, failureMessage, showArticleFinder, highlightedHtml, isWhocolorLang,
-  whocolorFailed, users, unhighlightedEditors, revisionId, toggleRevisionHandler, pendingRequest
+  whocolorFailed, users, unhighlightedContributors, revisionId, toggleRevisionHandler, pendingRequest
 }) => {
   // Determine the Article Viewer Legend status based on what information
   // has returned from various API calls.
   let articleViewerLegend;
   if (!showArticleFinder) {
     let legendStatus;
-    if (highlightedHtml) {
+    if (highlightedHtml && unhighlightedContributors.length) {
       legendStatus = 'ready';
     } else if (whocolorFailed) {
       legendStatus = 'failed';
@@ -29,7 +29,7 @@ export const Footer = ({
         colors={colors}
         status={legendStatus}
         failureMessage={failureMessage}
-        unhighlightedEditors={unhighlightedEditors}
+        unhighlightedContributors={unhighlightedContributors}
       />
     );
   }

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -52,7 +52,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const [userIdsFetched, setUserIdsFetched] = useState(false);
   const [whoColorHtml, setWhoColorHtml] = useState(null);
   const [parsedArticle, setParsedArticle] = useState(null);
-  const [unhighlightedEditors, setUnhighlightedEditors] = useState([]);
+  const [unhighlightedContributors, setUnhighlightedContributors] = useState([]);
   const [revisionId, setRevisionId] = useState(null);
   const [pendingRequest, setPendingRequest] = useState(false);
   const lastRevisionId = useSelector(state => state.articleDetails[article.id]?.last_revision?.mw_rev_id);
@@ -164,7 +164,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     let html = whoColorHtml;
     if (!html) { return; }
     // Array to store user IDs whose contributions couldn't be highlighted
-    const editorsID = [];
+    const unHighlightedUsers = [];
 
     forEach(usersState, (user, i) => {
       // Move spaces inside spans, so that background color is continuous
@@ -182,14 +182,18 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
         user.activeRevision = true;
       } else {
         // If highlighting failed , store the un-highlighted user's ID in the editorsID array
-        editorsID.push(user.userid);
+        unHighlightedUsers.push(user.userid);
       }
     });
 
     // Check if there are any editors whose contributions couldn't be highlighted
-    if (editorsID.length) {
+    if (unHighlightedUsers.length) {
       // If there are unhighlighted editors, call the function to check their contributions in wikitext metadata
-      usersContributionExists(editorsID);
+      usersContributionExists(unHighlightedUsers);
+    } else {
+      const status = 'No Unhighlighted Contributors';
+      // Set the status of the unhighlightedContributors state to display in the UI
+      setUnhighlightedContributors([status]);
     }
     setHighlightedHtml(html);
     setPendingRequest(false);
@@ -197,9 +201,9 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
 
   // Function to check if contributions of unhighlighted editors exist in the wikitext metadata
   const usersContributionExists = (usersID) => {
-   // Create a URL builder and API instance for fetching wikitext metadata
-   const builder = new URLBuilder({ article: article });
-   const api = new ArticleViewerAPI({ builder });
+    // Create a URL builder and API instance for fetching wikitext metadata
+    const builder = new URLBuilder({ article: article });
+    const api = new ArticleViewerAPI({ builder });
 
     // Fetch wikitext metadata for the current article revision
     api.fetchWikitextMetaData()
@@ -215,8 +219,13 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
           // If a token with a matching editor ID is found, it means the user has a contribution
           // in the current revision's wikitext
           if (foundToken) {
-            // Add the user ID to the unhighlightedEditors state to display in the UI
-            setUnhighlightedEditors(x => [...x, userID]);
+            // Add the user ID to the unhighlightedContributors state to display in the UI
+            setUnhighlightedContributors(x => [...x, userID]);
+          } else {
+            const status = `No Contributions Found in this current version for User ID', ${userID}`;
+            // If the user ID doesn't have a contribution in the current revision's wikitext,
+            // add a message to the unhighlightedContributors state to display in the UI
+            setUnhighlightedContributors(x => [...x, status]);
           }
         });
       }).catch((error) => {
@@ -296,6 +305,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     setHighlightedHtml(null);
     setWhoColorHtml(null);
     fetchParsedArticle();
+    setUnhighlightedContributors([]);
     if (isWhocolorLang()) {
       fetchWhocolorHtml();
     }
@@ -376,7 +386,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
           showArticleFinder={showArticleFinder}
           whoColorFailed={whoColorFailed}
           users={usersState}
-          unhighlightedEditors={unhighlightedEditors}
+          unhighlightedContributors={unhighlightedContributors}
           revisionId={revisionId}
           toggleRevisionHandler={toggleRevisionHandler}
         />

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -54,6 +54,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const [parsedArticle, setParsedArticle] = useState(null);
   const [unhighlightedEditors, setUnhighlightedEditors] = useState([]);
   const [revisionId, setRevisionId] = useState(null);
+  const [pendingRequest, setPendingRequest] = useState(false);
   const lastRevisionId = useSelector(state => state.articleDetails[article.id]?.last_revision?.mw_rev_id);
 
   const dispatch = useDispatch();
@@ -189,13 +190,9 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
     if (editorsID.length) {
       // If there are unhighlighted editors, call the function to check their contributions in wikitext metadata
       usersContributionExists(editorsID);
-    } else {
-      const status = 'No Highlighted Editors';
-      // Set the unhighlightedEditors state with a status message to make legendStatus ready in the
-      // Footer Component for loading the authorship data
-      setUnhighlightedEditors([status]);
     }
     setHighlightedHtml(html);
+    setPendingRequest(false);
   };
 
   // Function to check if contributions of unhighlighted editors exist in the wikitext metadata
@@ -220,9 +217,9 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
           if (foundToken) {
             // Add the user ID to the unhighlightedEditors state to display in the UI
             setUnhighlightedEditors(x => [...x, userID]);
-        }
-      });
-    }).catch((error) => {
+          }
+        });
+      }).catch((error) => {
       setFailureMessage(error.message);
     });
   };
@@ -230,6 +227,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   const fetchParsedArticle = () => {
     const builder = new URLBuilder({ article: article });
     const api = new ArticleViewerAPI({ builder });
+    setPendingRequest(true);
     api.fetchParsedArticle(revisionId)
       .then((response) => {
         setParsedArticle(response.parsedArticle.html);
@@ -369,6 +367,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
           }
         </div>
         <Footer
+          pendingRequest={pendingRequest}
           article={article}
           colors={colors}
           failureMessage={failureMessage}

--- a/app/assets/javascripts/components/common/article_viewer_legend.jsx
+++ b/app/assets/javascripts/components/common/article_viewer_legend.jsx
@@ -5,7 +5,7 @@ import UserUtils from '../../utils/user_utils.js';
 
 import ArticleScroll from '@components/common/ArticleViewer/utils/ArticleScroll';
 
-const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failureMessage, unhighlightedEditors }) => {
+const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failureMessage, unhighlightedContributors }) => {
   const [userLinks, setUserLinks] = useState('');
   const [usersStatus, setUsersStatus] = useState('');
   const Scroller = new ArticleScroll();
@@ -26,7 +26,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
         let res;
         // The 'unhighlightedContributions' keeps track of the userids of users whose contributions
         // were not successfully highlighted in the article viewer.
-        const UnhighlightedContributions = unhighlightedEditors?.find(x => x === user.userid);
+        const UnhighlightedContributions = unhighlightedContributors?.find(x => x === user.userid);
         const userLink = UserUtils.userTalkUrl(user.name, article.language, article.project);
         const fullUserRecord = allUsers.find(_user => _user.username === user.name);
         const realName = fullUserRecord && fullUserRecord.real_name;
@@ -45,7 +45,7 @@ const ArticleViewerLegend = ({ article, users, colors, status, allUsers, failure
     } else {
       setUserLinks(<div className="article-viewer-legend authorship-loading"> &nbsp; &nbsp; </div>);
     }
-  }, [users, status, unhighlightedEditors]);
+  }, [users, status, unhighlightedContributors]);
 
   useEffect(() => {
     if (status === 'loading') {

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -20,7 +20,7 @@
 
 #popup-style
   position: fixed
-  top: 99%
+  top: calc(100% - 80px)
   left: 0
   border: 0
   background: #676eb4

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1486,7 +1486,7 @@ en:
     no_articles: No articles
     no_articles_wikidata: No items
     no_revisions: (no revisions)
-    no_highlighting: "No text from the current version of the article is attributed to user %{editor}. Check the page history to see their edits."
+    no_highlighting: "No text from this version of the article is attributed to user %{editor}. Check the page history to see their edits."
     contributions_not_highlighted: "Contributions from user %{username} are present, but cannot be highlighted. This typically occurs for added references or templates. Check the page history to see their edits."
     number_of_articles:
       one: "%{count} article"


### PR DESCRIPTION
## What this PR does
Fixes #5769 
This pr fixes bugs in Article Viewer.

- [x] In the article viewer, if all of a student's work was removed from the article, the ArticleViewer will not keep showing the loading message

- [x] Switching between the 'last' and 'current' views is only allowed when there is no pending request to the WikiWho server.

## Video

After : 
For issue 1

[After1.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/8ee9e090-a94f-492a-8290-1846090b891b)


For issue 2

[After2.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/b155dc5a-e29e-4c07-ad22-d8b6ff54b5df)

