### PR TITLE
added: bcc to salesforce by default

### DIFF
--- a/app/mailers/instructor_notification_mailer.rb
+++ b/app/mailers/instructor_notification_mailer.rb
@@ -10,11 +10,12 @@ class InstructorNotificationMailer < ApplicationMailer
     @alert = alert
     set_email_parameters
     params = { to: @instructors.pluck(:email),
-               subject: @alert.subject }
+               subject: @alert.subject,
+               bcc: [
+                 @alert.sender_email,
+                 @alert.bcc_to_salesforce_email
+               ] }
     params[:reply_to] = @alert.sender_email unless @alert.sender_email.nil?
-    unless @alert.sender_email.nil?
-      params[:bcc] = @alert.sender_email # sender_email gives user email of the sender
-    end
     mail(params)
   end
 


### PR DESCRIPTION
## What this PR does
Fixes #5700 

- Added salesforce email to the BCC list by default.

## Screenshots

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/61202986/e27a137a-a633-4097-9dcd-ed9bbaf96066)
