### PR TITLE
Fixed Missing Icon of Search Bar

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder_search_bar.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_search_bar.jsx
@@ -7,7 +7,7 @@ import { fetchArticleAutocompleteResults } from '../../utils/article_finder_util
 function ArticleFinderSearchBar({ value, onChange, onSearch, disabled, wiki }) {
   const [suggestions, setSuggestions] = useState([]);
   const [isAutocompleteLoading, setAutocompleteLoading] = useState(false);
-  let searchClass = 'search-bar';
+  let searchClass = 'article-finder-search-bar';
 
   if (suggestions.length > 0) {
     searchClass += ' autocomplete-on';

--- a/app/assets/stylesheets/modules/_article_finder.styl
+++ b/app/assets/stylesheets/modules/_article_finder.styl
@@ -17,13 +17,13 @@
 .revScore
   text-align center
 
-.search-bar.autocomplete-on
+.article-finder-search-bar.autocomplete-on
   input[type=text]
     border-radius 5px 5px 5px 0
   .autocomplete
     display block
 
-.search-bar
+.article-finder-search-bar
   display flex
   flex-direction row
   align-items end
@@ -33,7 +33,7 @@
     font-size 15px
     width 100%
     border-radius 5px 5px 5px 5px
-    padding 1rem 8rem 1rem 2rem
+    padding 1rem 11rem 1rem 2rem
     transition border-radius linear 0.1s
   button:disabled
     opacity 50%
@@ -76,6 +76,21 @@
 
 .article-finder-options
   text-align: center
+
+.search-bar
+  display flex
+  flex-direction row
+  align-items end
+  .search-type
+    display flex
+    justify-content space-around
+  input[type=text]
+    width 50rem
+    padding 10px 50px 10px 15px
+  button
+    margin-bottom 8px
+    height 2.8rem
+    margin-left 2rem
 
 .article-wiki-selector-block
   max-width 250px


### PR DESCRIPTION
## What this PR does
- This PR Fixes the missing Icon of Search Bar at various pages like `/explore`
- This also fixes the overlapping of loader icon & Text in article finder.

fixes #5771 

## Screenshots
Before:
![Before 1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/6329f408-5bab-407d-adaf-738fb2498d20)


After:
![After 1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/75421b0f-8a0b-4ace-b35e-3663b592630e)

**Also fixed the overlapping of loader icon & Text:**

Before:

![Before 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/290969e3-7821-42af-8176-1cb2477116e9)

After:



![After 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/f29dfd9c-451b-4480-9da8-c8b1f32c15dc)
