### PR TITLE
Fixed Namespace-specific Stats Label

### DIFF
--- a/app/assets/javascripts/components/common/OverviewStats/namespace_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/OverviewStats/namespace_overview_stats.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import OverviewStat from './overview_stat';
 
-const NamespaceOverviewStats = ({ statistics }) => {
+const NamespaceOverviewStats = ({ course, statistics }) => {
+  let student_editors_stat_msg;
+  if (course.type === 'ClassroomProgramCourse') {
+    student_editors_stat_msg = I18n.t('courses.student_editors');
+  } else {
+    student_editors_stat_msg = I18n.t('courses_generic.student_editors');
+  }
   return (
     <div className="stat-display">
       <OverviewStat
@@ -30,7 +36,7 @@ const NamespaceOverviewStats = ({ statistics }) => {
         id="student-editors"
         className="stat-display__value"
         stat={statistics.user_count}
-        statMsg={I18n.t('courses.student_editors')}
+        statMsg={student_editors_stat_msg}
         renderZero={false}
       />
       <OverviewStat

--- a/app/assets/javascripts/components/common/OverviewStats/namespace_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/OverviewStats/namespace_overview_stats.jsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import OverviewStat from './overview_stat';
+import CourseUtils from '../../../utils/course_utils';
 
 const NamespaceOverviewStats = ({ course, statistics }) => {
-  let student_editors_stat_msg;
-  if (course.type === 'ClassroomProgramCourse') {
-    student_editors_stat_msg = I18n.t('courses.student_editors');
-  } else {
-    student_editors_stat_msg = I18n.t('courses_generic.student_editors');
-  }
+  const student_editors_stat_msg = CourseUtils.i18n('student_editors', course.string_prefix);
   return (
     <div className="stat-display">
       <OverviewStat

--- a/app/assets/javascripts/components/common/OverviewStats/overview_stats_content.jsx
+++ b/app/assets/javascripts/components/common/OverviewStats/overview_stats_content.jsx
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types';
 import WikidataOverviewStats from '../wikidata_overview_stats';
 import NamespaceOverviewStats from './namespace_overview_stats';
 
-const OverviewStatsContent = ({ content }) => {
+const OverviewStatsContent = ({ course, content }) => {
   const title = content.statsTitle;
   const data = content.statsData;
   const statistics = (title === 'www.wikidata.org')
     ? <WikidataOverviewStats statistics={data} isCourseOverview={true}/>
-    : <NamespaceOverviewStats statistics={data} />;
+    : <NamespaceOverviewStats course={course} statistics={data} />;
 
   return (
     <div className="content-container">

--- a/app/assets/javascripts/components/common/overview_stats_tabs.jsx
+++ b/app/assets/javascripts/components/common/overview_stats_tabs.jsx
@@ -7,7 +7,7 @@ import OverviewStatsContent from './OverviewStats/overview_stats_content';
 import { wikiNamespaceLabel } from '../../utils/wiki_utils';
 
 
-const OverviewStatsTabs = ({ statistics }) => {
+const OverviewStatsTabs = ({ course, statistics }) => {
   if (Object.keys(statistics).length === 0) { return null; }
 
   const [currentTabId, setCurrentTabId] = useState(0);
@@ -44,7 +44,7 @@ const OverviewStatsTabs = ({ statistics }) => {
     index += 1;
   });
 
-  const content = <OverviewStatsContent content={statsList[currentTabId]} />;
+  const content = <OverviewStatsContent course={course} content={statsList[currentTabId]} />;
   // Hide tabs container if there is only one tab
   const tabsClass = `tabs-container${(tabsList.length === 1) ? ' hide' : ''}`;
 

--- a/app/assets/javascripts/components/overview/overview_handler.jsx
+++ b/app/assets/javascripts/components/overview/overview_handler.jsx
@@ -167,7 +167,7 @@ const Overview = createReactClass({
 
     let overviewStatsTabs;
     if (course.course_stats && course.course_stats.stats_hash) {
-      overviewStatsTabs = <OverviewStatsTabs statistics={course.course_stats.stats_hash} />;
+      overviewStatsTabs = <OverviewStatsTabs course={course} statistics={course.course_stats.stats_hash} />;
     }
 
     return (


### PR DESCRIPTION
## What this PR does
The label for the main stats is 'editors' (based on course type), but the label within the namespace stats is 'student editors'.

This PR fixes Namespace-specific Stats Label based on the course Type. 
fixes #5703 

## Screenshots

Before:
![before PE](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/4626c825-8d7a-46ac-8d78-dc32985b52bc)


After:
![after PE](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/fa89eef5-5f31-409c-a778-17d22f21f999)
