### PR TITLE
Fixed Text overflow in assigned article

### DIFF
--- a/app/assets/stylesheets/modules/_assignments.styl
+++ b/app/assets/stylesheets/modules/_assignments.styl
@@ -1,6 +1,8 @@
 .table tr.assignment td
   border none
   padding 10px 20px
+  .title
+    overflow-wrap anywhere
 
 .table tr.assignment-section-header td
   border none


### PR DESCRIPTION
## What this PR does
Fixed Text overflow in assigned article
The issue can be [seen here.](https://dashboard.wikiedu.org/courses/California_State_University_Northridge/Gender_and_Culture_(Fall_2023)/articles/assigned)

## Screenshots
Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/6eb6156f-f8ac-4553-9e8b-4ba3adca1692



After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/c226627e-46bb-4a70-9806-19e8ecff7fdb)
