### PR TITLE
Improved UI and fixed text overflow in 'assignments & exercises'

### DIFF
--- a/app/assets/stylesheets/modules/_assignments.styl
+++ b/app/assets/stylesheets/modules/_assignments.styl
@@ -10,6 +10,16 @@ tr.assignment-section-header h3
   font-size 16px
   margin-bottom 0
 
+tr.assignment
+  td
+    display flex
+    a
+      max-width 500px
+      display block
+      white-space nowrap
+      overflow hidden
+      text-overflow ellipsis
+
 .find-articles-section
   background athens
   border-top 1px solid darken(athens, 10%)

--- a/app/assets/stylesheets/modules/_students.styl
+++ b/app/assets/stylesheets/modules/_students.styl
@@ -17,6 +17,7 @@
 .users-articles
   align-items flex-start
   display flex
+  width 100%
   aside.student-selection
     border-bottom 1px solid #DDDDDD
     border-top 1px solid #DDDDDD
@@ -47,7 +48,7 @@
           font-weight bold
   article.student-details
     flex 4
-    padding 5px 30px
+    padding 5px 0px 5px 30px
     section.assignments
       h4
         color #6A6A6A
@@ -87,6 +88,7 @@
     tr.article-row
       .article-title
         max-width 200px
+        overflow-wrap anywhere
       &:hover
         cursor default
 .sort-select.users


### PR DESCRIPTION
## What this PR does
Improved UI and fixed text overflow in 'assignments & exercises'

- Now, The Page is more Aligned [Part 1]
- Fixed overflow in pop up and table for long Text [Part 2]

## Screenshots

### Part 1

Before:
![Before 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/0b6f651b-1a7a-4333-8a4c-5f04c2ba0ab1)


After:
![After 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/a8f962dd-ef65-4994-87ac-f198213bbf42)

### Part 2

Before:

https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/ba93d957-171a-4b03-9e49-75b5aced47e4



After:


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/037d3cb8-df3c-4c13-b18d-a334087ba7c4


