### PR TITLE
Refactored revision_list.jsx from class to functional component

### DIFF
--- a/app/assets/javascripts/components/revisions/revision_list.jsx
+++ b/app/assets/javascripts/components/revisions/revision_list.jsx
@@ -1,97 +1,87 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import List from '../common/list.jsx';
 import Revision from './revision.jsx';
 import CourseUtils from '../../utils/course_utils.js';
-import createReactClass from 'create-react-class';
 import ArticleUtils from '../../utils/article_utils.js';
 
-const RevisionList = createReactClass({
-  displayName: 'RevisionList',
+const RevisionList = ({ revisions, course, sortBy, wikidataLabels, sort, loaded }) => {
+  const [selectedIndex, setSelectedIndex] = useState(-1);
 
-  propTypes: {
-    revisions: PropTypes.array,
-    course: PropTypes.object,
-    sortBy: PropTypes.func,
-    wikidataLabels: PropTypes.object,
-    sort: PropTypes.object
-  },
+  const showDiff = (index) => {
+    setSelectedIndex(index);
+  };
 
-  getInitialState() {
-    return {
-      selectedIndex: -1,
-    };
-  },
+  const elements = revisions.map((revision, index) => (
+    <Revision
+      revision={revision}
+      key={revision.id}
+      index={index}
+      wikidataLabel={wikidataLabels[CourseUtils.removeNamespace(revision.title)]}
+      course={course}
+      setSelectedIndex={showDiff}
+      lastIndex={revisions.length}
+      selectedIndex={selectedIndex}
+    />
+  ));
 
-  showDiff(index) {
-    this.setState({
-      selectedIndex: index
-    });
-  },
-
-  render() {
-    const elements = this.props.revisions.map((revision, index) => {
-      return <Revision
-        revision={revision}
-        key={revision.id}
-        index={index}
-        wikidataLabel={this.props.wikidataLabels[CourseUtils.removeNamespace(revision.title)]}
-        course={this.props.course}
-        setSelectedIndex={this.showDiff}
-        lastIndex={this.props.revisions.length}
-        selectedIndex={this.state.selectedIndex}
-      />;
-    });
-
-    const keys = {
-      rating_num: {
-        label: I18n.t('revisions.class'),
-        desktop_only: true
-      },
-      title: {
-        label: I18n.t('revisions.title'),
-        desktop_only: false
-      },
-      revisor: {
-        label: I18n.t('revisions.edited_by'),
-        desktop_only: true
-      },
-      characters: {
-        label: I18n.t('revisions.chars_added'),
-        desktop_only: true
-      },
-      references_added: {
-        label: I18n.t('revisions.references'),
-        desktop_only: true,
-        info_key: `metrics.${ArticleUtils.projectSuffix(this.props.course.home_wiki.project, 'references_doc')}`
-      },
-      date: {
-        label: I18n.t('revisions.date_time'),
-        desktop_only: true,
-        info_key: 'revisions.time_doc'
-      }
-    };
-    if (this.props.sort.key) {
-      const order = (this.props.sort.sortKey) ? 'asc' : 'desc';
-      keys[this.props.sort.key].order = order;
+  const keys = {
+    rating_num: {
+      label: I18n.t('revisions.class'),
+      desktop_only: true
+    },
+    title: {
+      label: I18n.t('revisions.title'),
+      desktop_only: false
+    },
+    revisor: {
+      label: I18n.t('revisions.edited_by'),
+      desktop_only: true
+    },
+    characters: {
+      label: I18n.t('revisions.chars_added'),
+      desktop_only: true
+    },
+    references_added: {
+      label: I18n.t('revisions.references'),
+      desktop_only: true,
+      info_key: `metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'references_doc')}`
+    },
+    date: {
+      label: I18n.t('revisions.date_time'),
+      desktop_only: true,
+      info_key: 'revisions.time_doc'
     }
+  };
+  if (sort.key) {
+    const order = sort.sortKey ? 'asc' : 'desc';
+    keys[sort.key].order = order;
+  }
 
-    // Until the revisions are loaded, we do not pass the none_message prop
-    // This is done to avoid showing the none_message when the revisions are loading
-    // initially because at that time the revisions is an empty array
-    // Whether or not the revisions is really an empty array is confirmed after the revisions
-    // are successfully loaded
-    return (
-      <List
-        elements={elements}
-        keys={keys}
-        table_key="revisions"
-        none_message={this.props.loaded ? CourseUtils.i18n('revisions_none', this.props.course.string_prefix) : ''}
-        sortBy={this.props.sortBy}
-        sortable={true}
-      />
-    );
-  },
-});
+  // Until the revisions are loaded, we do not pass the none_message prop
+  // This is done to avoid showing the none_message when the revisions are loading
+  // initially because at that time the revisions is an empty array
+  // Whether or not the revisions is really an empty array is confirmed after the revisions
+  // are successfully loaded
+  return (
+    <List
+      elements={elements}
+      keys={keys}
+      table_key="revisions"
+      none_message={loaded ? CourseUtils.i18n('revisions_none', course.string_prefix) : ''}
+      sortBy={sortBy}
+      sortable={true}
+    />
+  );
+};
+
+RevisionList.propTypes = {
+  revisions: PropTypes.array,
+  course: PropTypes.object,
+  sortBy: PropTypes.func,
+  wikidataLabels: PropTypes.object,
+  sort: PropTypes.object,
+  loaded: PropTypes.bool
+};
 
 export default RevisionList;


### PR DESCRIPTION
## What this PR does
This PR converted the revision_list.jsx from class to functional component.

## Screenshots

Before:

![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/58569161-7e19-4e4f-88f1-d0835eeaff37)


After:

![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/c3eff8c6-13af-4920-aa0f-24bf00731ba1)
