### PR TITLE
Refactored revisions_handler.jsx from class to functional component

### DIFF
--- a/app/assets/javascripts/components/revisions/revisions_handler.jsx
+++ b/app/assets/javascripts/components/revisions/revisions_handler.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import RevisionList from './revision_list.jsx';
 import { fetchRevisions, sortRevisions, fetchCourseScopedRevisions } from '../../actions/revisions_actions.js';
 import Loading from '../common/loading.jsx';
@@ -10,173 +9,141 @@ import { ARTICLE_FETCH_LIMIT } from '../../constants/revisions.js';
 import Select from 'react-select';
 import sortSelectStyles from '../../styles/sort_select';
 
-const RevisionHandler = createReactClass({
-  displayName: 'RevisionHandler',
+const RevisionHandler = ({ course, courseScopedLimit }) => {
+  const [isCourseScoped, setIsCourseScoped] = useState(false);
 
-  propTypes: {
-    course_id: PropTypes.string,
-    course: PropTypes.object,
-    courseScopedLimit: PropTypes.number,
-    courseScopedLimitReached: PropTypes.bool,
-    courseSpecificRevisions: PropTypes.array,
-    fetchRevisions: PropTypes.func,
-    limit: PropTypes.number,
-    limitReached: PropTypes.bool,
-    revisions: PropTypes.array,
-    wikidataLabels: PropTypes.object,
-    revisionsLoaded: PropTypes.bool,
-    courseScopedRevisionsLoaded: PropTypes.bool
-  },
+  const dispatch = useDispatch();
 
-  getInitialState() {
-    return {
-      isCourseScoped: false,
-      isInitialFetchCourseScoped: true
-    };
-  },
+  const revisionsDisplayed = useSelector(state => state.revisions.revisionsDisplayed);
+  const revisionsDisplayedCourseSpecific = useSelector(state => state.revisions.revisionsDisplayedCourseSpecific);
+  const courseScopedLimitReached = useSelector(state => state.revisions.courseScopedLimitReached);
+  const limitReached = useSelector(state => state.revisions.limitReached);
+  const courseSpecificAssessmentsLoaded = useSelector(state => state.revisions.courseSpecificAssessmentsLoaded);
+  const wikidataLabels = useSelector(state => state.wikidataLabels.labels);
+  const courseScopedRevisionsLoaded = useSelector(state => state.revisions.courseScopedRevisionsLoaded);
+  const revisionsLoaded = useSelector(state => state.revisions.revisionsLoaded);
+  const sort = useSelector(state => state.revisions.sort);
+  const referencesLoaded = useSelector(state => state.revisions.referencesLoaded);
+  const assessmentsLoaded = useSelector(state => state.revisions.assessmentsLoaded);
+  const courseSpecificReferencesLoaded = useSelector(state => state.revisions.courseSpecificReferencesLoaded);
 
-  componentDidMount() {
+  useEffect(() => {
     // sets the title of this tab
-    document.title = `${this.props.course.title} - ${I18n.t('application.recent_activity')}`;
-
-    if (!this.props.revisionsLoaded) {
+    document.title = `${course.title} - ${I18n.t('application.recent_activity')}`;
+    if (!revisionsLoaded) {
       // Fetching in advance initially only for all revisions
       // For Course Scoped Revisions, fetching in componentDidUpdate
       // because in most cases, users would not be using these, so we
       // will fetch only when the user initially goes there, hence saving extra queries
-      if (this.state.isCourseScoped) {
-        this.props.fetchCourseScopedRevisions(this.props.course, this.props.courseScopedLimit);
+      if (isCourseScoped) {
+        dispatch(fetchCourseScopedRevisions(course, courseScopedLimit));
       } else {
-        this.props.fetchRevisions(this.props.course);
+        dispatch(fetchRevisions(course));
       }
     }
-  },
+  }, [course, isCourseScoped, revisionsLoaded]);
 
-  getLoadingMessage() {
-    if (!this.state.isCourseScoped) {
-      if (!this.props.assessmentsLoaded) {
+  const getLoadingMessage = () => {
+    if (!isCourseScoped) {
+      if (!assessmentsLoaded) {
         return 'Loading page assessments';
       }
-      if (!this.props.referencesLoaded) {
+      if (!referencesLoaded) {
         return 'Loading references';
       }
     } else {
-      if (!this.props.courseSpecificAssessmentsLoaded) {
+      if (!courseSpecificAssessmentsLoaded) {
         return 'Loading page assessments';
       }
-      if (!this.props.courseSpecificReferencesLoaded) {
+      if (!courseSpecificReferencesLoaded) {
         return 'Loading references';
       }
     }
-  },
+  };
 
-  toggleCourseSpecific() {
-    const toggledIsCourseScoped = !this.state.isCourseScoped;
-    this.setState({ isCourseScoped: toggledIsCourseScoped });
+  const toggleCourseSpecific = () => {
+    const toggledIsCourseScoped = !isCourseScoped;
+    setIsCourseScoped(toggledIsCourseScoped);
 
     // If user reaches the course scoped part initially, and there are no
     // loaded course scoped revisions, we fetch course scoped revisions
-    if (toggledIsCourseScoped && !this.props.courseScopedRevisionsLoaded) {
-      this.props.fetchCourseScopedRevisions(this.props.course, this.props.courseScopedLimit);
+    if (toggledIsCourseScoped && !courseScopedRevisionsLoaded) {
+      dispatch(fetchCourseScopedRevisions(course, courseScopedLimit));
     }
-  },
+  };
 
-  revisionFilterButtonText() {
-    if (this.state.isCourseScoped) {
-      return I18n.t('revisions.show_all');
-    }
-    return I18n.t('revisions.show_course_specific');
-  },
+  const revisionFilterButtonText = () => {
+    return isCourseScoped ? I18n.t('revisions.show_all') : I18n.t('revisions.show_course_specific');
+  };
 
-  sortSelect(e) {
-    return this.props.sortRevisions(e.value);
-  },
+  const sortSelect = (e) => {
+    dispatch(sortRevisions(e.value));
+  };
 
   // We disable show more button if there is a request which is still resolving
   // by keeping track of revisionsLoaded and courseScopedRevisionsLoaded
-  showMore() {
-    if (this.state.isCourseScoped) {
-      return this.props.fetchCourseScopedRevisions(this.props.course, this.props.courseScopedLimit + 100);
-    }
-    return this.props.fetchRevisions(this.props.course);
-  },
-
-  render() {
-    // Boolean to indicate whether the revisions in the current section (all scoped or course scoped are loaded)
-    const loaded = (!this.state.isCourseScoped && this.props.revisionsLoaded) || (this.state.isCourseScoped && this.props.courseScopedRevisionsLoaded);
-    const revisions = this.state.isCourseScoped ? this.props.revisionsDisplayedCourseSpecific : this.props.revisionsDisplayed;
-    let metaDataLoading;
-
-    if (!this.state.isCourseScoped) {
-      metaDataLoading = !this.props.referencesLoaded || !this.props.assessmentsLoaded;
+  const showMore = () => {
+    if (isCourseScoped) {
+      dispatch(fetchCourseScopedRevisions(course, courseScopedLimit + 100));
     } else {
-      metaDataLoading = !this.props.courseSpecificReferencesLoaded || !this.props.courseSpecificAssessmentsLoaded;
+      dispatch(fetchRevisions(course));
     }
-    let showMoreButton;
-    if ((!this.state.isCourseScoped && !this.props.limitReached) || (this.state.isCourseScoped && !this.props.courseScopedLimitReached)) {
-      showMoreButton = <div><button className="button ghost stacked right" onClick={this.showMore}>{I18n.t('revisions.see_more')}</button></div>;
-    }
+  };
 
-    // we only fetch articles data for a max of 500 articles(for course specific revisions).
-    // If there are more than 500 articles, the toggle button is not shown
-    const revisionFilterButton = <div><button className="button ghost stacked right" onClick={this.toggleCourseSpecific}>{this.revisionFilterButtonText()}</button></div>;
-    const options = [
-      { value: 'rating_num', label: I18n.t('revisions.class') },
-      { value: 'title', label: I18n.t('revisions.title') },
-      { value: 'revisor', label: I18n.t('revisions.edited_by') },
-      { value: 'characters', label: I18n.t('revisions.chars_added') },
-      { value: 'references_added', label: I18n.t('revisions.references') },
-      { value: 'date', label: I18n.t('revisions.date_time') },
-    ];
-    return (
-      <div id="revisions">
-        <div className="section-header">
-          <h3>{I18n.t('application.recent_activity')}</h3>
-          {this.props.course.article_count <= ARTICLE_FETCH_LIMIT && revisionFilterButton}
-          <div className="sort-container">
-            <Select
-              name="sorts"
-              onChange={this.sortSelect}
-              options={options}
-              styles={sortSelectStyles}
-            />
-          </div>
+  // Boolean to indicate whether the revisions in the current section (all scoped or course scoped are loaded)
+  const loaded = (!isCourseScoped && revisionsLoaded) || (isCourseScoped && courseScopedRevisionsLoaded);
+  const metaDataLoading = (!isCourseScoped ? (!referencesLoaded || !assessmentsLoaded) : (!courseSpecificReferencesLoaded || !courseSpecificAssessmentsLoaded));
+  const showMoreButton = ((!isCourseScoped && !limitReached) || (isCourseScoped && !courseScopedLimitReached)) ? (
+    <div><button className="button ghost stacked right" onClick={showMore}>{I18n.t('revisions.see_more')}</button></div>
+  ) : null;
+
+  // we only fetch articles data for a max of 500 articles(for course specific revisions).
+  // If there are more than 500 articles, the toggle button is not shown
+  const revisionFilterButton = (
+    <div><button className="button ghost stacked right" onClick={toggleCourseSpecific}>{revisionFilterButtonText()}</button></div>
+  );
+
+  const options = [
+    { value: 'rating_num', label: I18n.t('revisions.class') },
+    { value: 'title', label: I18n.t('revisions.title') },
+    { value: 'revisor', label: I18n.t('revisions.edited_by') },
+    { value: 'characters', label: I18n.t('revisions.chars_added') },
+    { value: 'references_added', label: I18n.t('revisions.references') },
+    { value: 'date', label: I18n.t('revisions.date_time') },
+  ];
+
+  return (
+    <div id="revisions">
+      <div className="section-header">
+        <h3>{I18n.t('application.recent_activity')}</h3>
+        {course.article_count <= ARTICLE_FETCH_LIMIT && revisionFilterButton}
+        <div className="sort-container">
+          <Select
+            name="sorts"
+            onChange={sortSelect}
+            options={options}
+            styles={sortSelectStyles}
+          />
         </div>
-        <RevisionList
-          revisions={revisions}
-          loaded={loaded}
-          course={this.props.course}
-          sortBy={this.props.sortRevisions}
-          wikidataLabels={this.props.wikidataLabels}
-          sort={this.props.sort}
-        />
-        {!loaded && <Loading/>}
-        {loaded && showMoreButton}
-        {loaded && metaDataLoading && <ProgressIndicator message={this.getLoadingMessage()}/>}
       </div>
-    );
-  }
-});
-
-const mapStateToProps = state => ({
-  courseScopedLimitReached: state.revisions.courseScopedLimitReached,
-  limitReached: state.revisions.limitReached,
-  revisionsDisplayed: state.revisions.revisionsDisplayed,
-  revisionsDisplayedCourseSpecific: state.revisions.revisionsDisplayedCourseSpecific,
-  courseSpecificAssessmentsLoaded: state.revisions.courseSpecificAssessmentsLoaded,
-  wikidataLabels: state.wikidataLabels.labels,
-  courseScopedRevisionsLoaded: state.revisions.courseScopedRevisionsLoaded,
-  revisionsLoaded: state.revisions.revisionsLoaded,
-  sort: state.revisions.sort,
-  referencesLoaded: state.revisions.referencesLoaded,
-  assessmentsLoaded: state.revisions.assessmentsLoaded,
-  courseSpecificReferencesLoaded: state.revisions.courseSpecificReferencesLoaded
-});
-
-const mapDispatchToProps = {
-  fetchRevisions,
-  sortRevisions,
-  fetchCourseScopedRevisions
+      <RevisionList
+        revisions={isCourseScoped ? revisionsDisplayedCourseSpecific : revisionsDisplayed}
+        loaded={loaded}
+        course={course}
+        sortBy={sortRevisions}
+        wikidataLabels={wikidataLabels}
+        sort={sort}
+      />
+      {!loaded && <Loading/>}
+      {loaded && showMoreButton}
+      {loaded && metaDataLoading && <ProgressIndicator message={getLoadingMessage()}/>}
+    </div>
+  );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(RevisionHandler);
+RevisionHandler.propTypes = {
+  course: PropTypes.object,
+  courseScopedLimit: PropTypes.number,
+};
+
+export default RevisionHandler;


### PR DESCRIPTION
## What this PR does
This PR converted the revision_handler.jsx from class to functional component.

## Videos

Before:

[Before.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/f2608fcb-a759-449f-8635-bcdd91a2079a)


After:

[After.webm](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/1256b411-35e6-49f9-8e85-f9745e88a26f)