### PR TITLE
Fix `uploads_in_use_count` in overview stats

### DIFF
--- a/app/assets/javascripts/components/overview/overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/overview_stats.jsx
@@ -88,7 +88,7 @@ const OverviewStats = ({ course }) => {
 
   let uploadCount;
   if (course.upload_count) {
-    const infoStats = [[course.upload_usages_count, I18n.t('metrics.uploads_in_use_count', { count: course.uploads_in_use_count })],
+    const infoStats = [[course.uploads_in_use_count, I18n.t('metrics.uploads_in_use_count', { count: course.uploads_in_use_count })],
       [course.upload_usages_count, I18n.t('metrics.upload_usages_count', { count: course.upload_usages_count })]];
     uploadCount = (
       <OverviewStat


### PR DESCRIPTION
## What this PR does
While taking a fairly in-depth look at how statistics are calculated and displayed for the courses, I noticed that the "Commons Uploads" tooltip in a course page shows an incorrect number for  `uploads_in_use_count` (files used in an article). It was mistakenly using the `upload_usages_count` instead.

## Screenshots
Before:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/8717242/e7a8c923-5630-4109-a0a9-e283af4133b7)

![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/8717242/96ecd591-5121-413d-a10d-efe9226dd1ab)

After:
![image](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/8717242/6a9018d0-5fe9-4b9d-b769-eace1202037a)
