### PR TITLE
Add handling for BigInt mw_rev_id

### DIFF
--- a/db/migrate/20240515163420_change_mw_rev_id_size.rb
+++ b/db/migrate/20240515163420_change_mw_rev_id_size.rb
@@ -1,0 +1,5 @@
+class ChangeMwRevIdSize < ActiveRecord::Migration[7.0]
+  def up
+    change_column :revisions, :mw_rev_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_15_143028) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -370,7 +370,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_15_143028) do
     t.boolean "system", default: false
     t.integer "ithenticate_id"
     t.integer "wiki_id"
-    t.integer "mw_rev_id"
+    t.bigint "mw_rev_id"
     t.integer "mw_page_id"
     t.text "features"
     t.text "features_previous"

--- a/docs/analytics_scripts/ithenticate_revisions.rb
+++ b/docs/analytics_scripts/ithenticate_revisions.rb
@@ -1,0 +1,11 @@
+# Get the essential data about revisions flagged by the copyvio detection system
+# since it can't be recreated if the revisions table is cleared.
+
+Revision.where.not(ithenticate_id: nil).count
+
+CSV.open('/home/sage/ithenticate_revisions.csv', 'wb') do |csv|
+  csv << ['mw_rev_id', 'ithenticate_id', 'wiki', 'article_title']
+  Revision.where.not(ithenticate_id: nil).each do |rev|
+    csv << [rev.mw_rev_id, rev.ithenticate_id, rev.wiki.domain, rev.article.title]
+  end
+end


### PR DESCRIPTION
This is intended to fix #5802

I will truncate the revisions table with `Revision.connection.truncate('revisions')` first, and then deploy this.