### PR TITLE
Implemented Timeline Copying Feature for Admin Users

### DIFF
--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -26,7 +26,7 @@ class CopyCourse
   def copy_main_course_data
     # Extract the attributes we want to copy
     params_to_copy = %w[school title term description start end subject slug timeline_start
-                        timeline_end type flags created_at weekdays]
+                        timeline_end type flags weekdays]
     copied_data = {}
     params_to_copy.each { |p| copied_data[p] = @course_data[p] }
     @home_wiki = Wiki.get_or_create(language: @course_data['home_wiki']['language'],

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -14,6 +14,8 @@ class CopyCourse
     copy_tracked_categories_data
     @users_data = retrieve_users_data
     copy_users_data
+    @timeline_data = retrieve_timeline_data
+    copy_timeline_data
     return { course: @course, error: nil }
   rescue ActiveRecord::RecordInvalid, StandardError => e
     return { course: nil, error: e.message }
@@ -24,7 +26,7 @@ class CopyCourse
   def copy_main_course_data
     # Extract the attributes we want to copy
     params_to_copy = %w[school title term description start end subject slug timeline_start
-                        timeline_end type flags]
+                        timeline_end type flags created_at weekdays]
     copied_data = {}
     params_to_copy.each { |p| copied_data[p] = @course_data[p] }
     @home_wiki = Wiki.get_or_create(language: @course_data['home_wiki']['language'],
@@ -84,6 +86,33 @@ class CopyCourse
   def retrieve_course_data
     response = get_request('/course.json')
     JSON.parse(response.body)['course']
+  end
+
+  def retrieve_timeline_data
+    response = get_request('/timeline.json')
+    JSON.parse(response.body)['course']
+  end
+
+  def copy_timeline_data
+    @timeline_data["weeks"].each do |week_data|  
+      week = Week.new(
+        course_id: @course.id,
+        title: week_data["title"],
+        order: week_data["order"],
+      )
+      week.save!
+      week_data["blocks"].each do |block_data|
+        block_attributes = {
+          week_id: week.id,
+          title: block_data["title"],
+          content: block_data["content"],
+          order: block_data["order"],
+          kind: block_data["kind"],
+        }
+        block = Block.new(block_attributes)
+        block.save!
+      end
+    end
   end
 
   def retrieve_categories_data

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -94,20 +94,17 @@ class CopyCourse
   end
 
   def copy_timeline_data
-    @timeline_data["weeks"].each do |week_data|  
+    @timeline_data['weeks'].each do |week_data|
       week = Week.new(
         course_id: @course.id,
-        title: week_data["title"],
-        order: week_data["order"],
+        title: week_data['title'],
+        order: week_data['order']
       )
       week.save!
-      week_data["blocks"].each do |block_data|
+      week_data['blocks'].each do |block_data|
         block_attributes = {
-          week_id: week.id,
-          title: block_data["title"],
-          content: block_data["content"],
-          order: block_data["order"],
-          kind: block_data["kind"],
+          week_id: week.id, title: block_data['title'], content: block_data['content'],
+          order: block_data['order'], kind: block_data['kind']
         }
         block = Block.new(block_attributes)
         block.save!

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -9,6 +9,7 @@ describe CopyCourse do
   let(:course_url) { url_base + existent_prod_course_slug + '/course.json' }
   let(:categories_url) { url_base + existent_prod_course_slug + '/categories.json' }
   let(:users_url) { url_base + existent_prod_course_slug + '/users.json' }
+  let(:timeline_url) { url_base + existent_prod_course_slug + '/timeline.json' }
   let(:course_response_body) do
     '{
       "course": {
@@ -90,6 +91,37 @@ describe CopyCourse do
       }
     }'
   end
+  let(:timeline_response_body) do
+    '{
+      "course": {
+        "weeks": [
+          {
+            "id": 57366,
+            "order": 1,
+            "start_date_raw": "2022-01-09T00:00:00.000Z",
+            "end_date_raw": "2022-01-15T23:59:59.999Z",
+            "start_date": "01/09",
+            "end_date": "01/15",
+            "title": null,
+            "blocks": [
+              {
+                "id": 127799,
+                "kind": 0,
+                "content": "Welcome to your Wikipedia assignment course timeline. This page guides you through the steps you will need to complete for your Wikipedia assignment, with links to training modules and your classmates work spaces. Your course has been assigned a Wikipedia Expert. You can reach them through the Get Help button at the top of this page.",
+                "week_id": 57366,
+                "title": "Introduction to the Wikipedia assignment",
+                "order": 1,
+                "due_date": null,
+                "points": null
+              }
+            ]
+          }
+        ]
+      }
+    }'
+  end
+  
+
   let(:subject) do
     service = described_class.new(url: url_base + existent_prod_course_slug)
     service.make_copy
@@ -136,6 +168,27 @@ describe CopyCourse do
       expect(result[:course]).to be_nil
     end
 
+    it 'returns an error if /timeline.json request fails' do
+      # Stub the response to the course request
+      stub_request(:get, course_url)
+      .to_return(status: 200, body: course_response_body, headers: {})
+
+      # Stub the response to the categories request
+      stub_request(:get, categories_url)
+        .to_return(status: 200, body: categories_response_body, headers: {})
+
+      # Stub the response to the timeline request
+      stub_request(:get, timeline_url)
+      .to_return(status: 404, body: timeline_response_body, headers: {})
+
+      # Stub the response to the users request
+      stub_request(:get, users_url)
+        .to_return(status: 200, body: users_response_body, headers: {})
+
+      result = subject
+      expect(result[:error]).to eq("Error getting data from #{timeline_url}")
+      expect(result[:course]).to be_nil
+    end
     it 'course, categories, and users are created if no error' do
       # Stub the response to the course request
       stub_request(:get, course_url)
@@ -144,6 +197,10 @@ describe CopyCourse do
       # Stub the response to the categories request
       stub_request(:get, categories_url)
         .to_return(status: 200, body: categories_response_body, headers: {})
+
+      # Stub the response to the timeline request
+      stub_request(:get, timeline_url)
+      .to_return(status: 200, body: timeline_response_body, headers: {})
 
       # Stub the response to the users request
       stub_request(:get, users_url)

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -107,7 +107,12 @@ describe CopyCourse do
               {
                 "id": 127799,
                 "kind": 0,
-                "content": "Welcome to your Wikipedia assignment course timeline. This page guides you through the steps you will need to complete for your Wikipedia assignment, with links to training modules and your classmates work spaces. Your course has been assigned a Wikipedia Expert. You can reach them through the Get Help button at the top of this page.",
+                "content": "Welcome to your Wikipedia assignment course timeline.
+                            This page guides you through the steps you will need to
+                            complete for your Wikipedia assignment, with links to training
+                            modules and your classmates work spaces. Your course has
+                            been assigned a Wikipedia Expert. You can reach them
+                            through the Get Help button at the top of this page.",
                 "week_id": 57366,
                 "title": "Introduction to the Wikipedia assignment",
                 "order": 1,
@@ -120,7 +125,6 @@ describe CopyCourse do
       }
     }'
   end
-  
 
   let(:subject) do
     service = described_class.new(url: url_base + existent_prod_course_slug)
@@ -171,7 +175,7 @@ describe CopyCourse do
     it 'returns an error if /timeline.json request fails' do
       # Stub the response to the course request
       stub_request(:get, course_url)
-      .to_return(status: 200, body: course_response_body, headers: {})
+        .to_return(status: 200, body: course_response_body, headers: {})
 
       # Stub the response to the categories request
       stub_request(:get, categories_url)
@@ -179,7 +183,7 @@ describe CopyCourse do
 
       # Stub the response to the timeline request
       stub_request(:get, timeline_url)
-      .to_return(status: 404, body: timeline_response_body, headers: {})
+        .to_return(status: 404, body: timeline_response_body, headers: {})
 
       # Stub the response to the users request
       stub_request(:get, users_url)
@@ -189,6 +193,7 @@ describe CopyCourse do
       expect(result[:error]).to eq("Error getting data from #{timeline_url}")
       expect(result[:course]).to be_nil
     end
+
     it 'course, categories, and users are created if no error' do
       # Stub the response to the course request
       stub_request(:get, course_url)
@@ -200,7 +205,7 @@ describe CopyCourse do
 
       # Stub the response to the timeline request
       stub_request(:get, timeline_url)
-      .to_return(status: 200, body: timeline_response_body, headers: {})
+        .to_return(status: 200, body: timeline_response_body, headers: {})
 
       # Stub the response to the users request
       stub_request(:get, users_url)


### PR DESCRIPTION
## What this PR does
The PR comprises methods that facilitate the Timeline copying from Wiki-Edu dashboard to P&E dashboard and vice versa.

## Screenshots
Before:
![Before](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/1c8d6197-62b6-4632-9396-92404f3df0c8)


After:
![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/65b08aa7-3851-449d-8625-bca61590c845)

