### PR TITLE
Add deployment file for the new data-rearchitecture-project-test instance

### DIFF
--- a/config/deploy/data-rearchitecture-project-test.rb
+++ b/config/deploy/data-rearchitecture-project-test.rb
@@ -1,0 +1,11 @@
+set :branch, 'data-rearchitecture-for-dashboard'
+set :rails_env, 'development'
+
+role :app, %w(gabina@data-rearchitecture-project-test.globaleducation.eqiad1.wikimedia.cloud)
+role :web, %w(gabina@data-rearchitecture-project-test.globaleducation.eqiad1.wikimedia.cloud)
+role :db,  %w(gabina@data-rearchitecture-project-test.globaleducation.eqiad1.wikimedia.cloud)
+
+set :user, 'gabina'
+set :address, 'data-rearchitecture-project-test.globaleducation.eqiad1.wikimedia.cloud'
+
+set :deploy_to, '/var/www/dashboard'

--- a/config/deploy/data-rearchitecture-project-test.rb
+++ b/config/deploy/data-rearchitecture-project-test.rb
@@ -1,5 +1,5 @@
 set :branch, 'data-rearchitecture-for-dashboard'
-set :rails_env, 'development'
+set :rails_env, 'production'
 
 role :app, %w(gabina@data-rearchitecture-project-test.globaleducation.eqiad1.wikimedia.cloud)
 role :web, %w(gabina@data-rearchitecture-project-test.globaleducation.eqiad1.wikimedia.cloud)


### PR DESCRIPTION
## What this PR does
This PR adds the new `config/deploy/data-rearchitecture-project-test.rb` file as part of the following instruction step in `docs/WMFLABS_DEPLOYMENT.md`:

> ON YOUR MACHINE
> Clone your forked github repo
> Get the Dashboard running locally (by installing all the necessary stuff)
> Update or create the corresponding deployment file (eg, '/config/deploy/programs-and-events.rb') to point to your new wmflabs instance, commit the changes and push to github

