### PR TITLE
Bump nokogiri to 1.16.5 to see if this fixes the data-rearchitecture-project-test deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'browser'
 ### Email
 gem 'validates_email_format_of' # Email format validation, used in User model
 gem 'premailer-rails' # used for enabling CSS for mailer emails
-gem 'nokogiri' # expected by premailer-rails but not required
+gem 'nokogiri', '~> 1.16.5' # expected by premailer-rails but not required
 gem 'mailgun-ruby' # email sending service
 
 ### Incoming Mail

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.7)
     minitest (5.17.0)
     msgpack (1.5.4)
     multipart-post (2.2.3)
@@ -353,7 +353,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.13.1)
     nio4r (2.5.8)
-    nokogiri (1.15.4)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -396,7 +396,7 @@ GEM
     puma (5.6.5)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.7.1)
+    racc (1.8.0)
     rack (2.2.7)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
@@ -649,7 +649,7 @@ DEPENDENCIES
   memory_profiler
   mysql2
   newrelic_rpm
-  nokogiri
+  nokogiri (~> 1.16.5)
   oj
   omniauth-mediawiki!
   omniauth-rails_csrf_protection


### PR DESCRIPTION
## What this PR does
This PR forces to use nokogiri 1.16.5 to see if updating the mini_portile version fixes the data-rearchitecture deployment.
It's currently failing with the following error:
`Could not spawn process for application /var/www/dashboard/current: The application encountered the following error: Could not find mini_portile2-2.8.2 in any of the sources (Bundler::GemNotFound)`

