### PR TITLE
Fix ArticleViewer legend usernames #5798

### DIFF
--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -280,14 +280,14 @@ const DiffViewer = createReactClass({
     if (!this.props.first_revision) {
       formatedDate = formatDateWithTime(this.props.revision.date);
       editDate = I18n.t('revisions.edited_on', { edit_date: formatedDate });
-      finalDate = <div className="diff-viewer-legend" style={{ justifyContent: 'center' }}>{editDate}</div>;
-      charactersCount = <div className="diff-viewer-legend" style={{ justifyContent: 'flex-end' }}>{this.props.revision.characters} {I18n.t('revisions.chars_added')}</div>;
+      finalDate = <div className="diff-viewer-legend" style={{ width: '66%' }}>{editDate}</div>;
+      charactersCount = <div className="diff-viewer-legend">{this.props.revision.characters} {I18n.t('revisions.chars_added')}</div>;
     } else {
       firstRevTime = formatDateWithTime(this.state.firstRevDateTime);
       lastRevTime = formatDateWithTime(this.state.lastRevDateTime);
       timeSpan = I18n.t('revisions.edit_time_span', { first_time: firstRevTime, last_time: lastRevTime });
       editDate = <p className="diff-comment">{timeSpan}</p>;
-      finalDate = <div className="diff-viewer-legend" style={{ justifyContent: 'flex-end', width: '66%' }}>{editDate}</div>;
+      finalDate = <div className="diff-viewer-legend" style={{ width: '66%' }}>{editDate}</div>;
     }
     const final = (
       <div className="user-legend-wrap">

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -82,7 +82,7 @@
   background white
   
 .article-viewer-legend
-  margin 10px
+  margin 7px
   border-radius 15px
   display flex
   align-items center

--- a/app/assets/stylesheets/modules/_diff_viewer.styl
+++ b/app/assets/stylesheets/modules/_diff_viewer.styl
@@ -39,7 +39,8 @@
 .user-legend-wrap
   display flex
   flex-direction row
-  width 100%
+  flex-wrap: wrap
+  width 194.5rem
   background white
 
 .diff-viewer-legend

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1219,7 +1219,7 @@ en:
     diff: diff
     diff_show: Show
     diff_hide: Hide
-    edit_time_span: Edits occurred from %{first_time} to %{last_time}
+    edit_time_span: 'Edits occurred from: %{first_time} to %{last_time}'
     edited_by: Edited By
     edited_on: Edited on %{edit_date}
     loading: Loading revisions...


### PR DESCRIPTION
#5798

### **What this PR does**

This PR fixes a formatting issue in the ArticleViewer component where usernames in the legend were poorly formatted when there were many of them.

### **Cause of the Bug:**

The specific point where the bug was introduced is still unknown. I've checked previous commits where this issue was supposedly resolved, but the problem still persists in my local development environment.

### **Fix for the Bug:**

1. **Flex-wrap Property:**
   - The issue is resolved by using the `flex-wrap: wrap` property in the `.user-legend-wrap` class of `_diff_viewer.styl`.

2. **Width Adjustments:**
   - Increased the width of the first flex container in the article footer to allow more usernames to fit on a single line. The second flex container, which holds three fixed-size buttons, remains unaffected by this change. If additional buttons are added in the future, the width property of `.user-legend-wrap` may need further adjustment, as it is specified in `rem`. This approach was chosen because the three buttons have fixed sizes and will not change.

3. **UI Consistency:**
   - Fixing the `article-viewer-legend` with `flex-wrap` introduced `minor(bug)` changes in the `diff-viewer-legend` UI. These were addressed by removing some `inline styles` from `diff_viewer.jsx`, ensuring that `finalDate` and `characterCount` appear in their respective rows instead of a single row.


**Note:**

The existing `.user-legend-wrap` CSS class, which was modified to fix the bug, is only used in two places: `article-viewer-legend and diff-viewer-legend`.

## Screenshots
### **Before:**

Article Viewer Legend:

![article legend](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/3f777085-e94b-43b1-9fc5-0365689d064c)


Diff Viewer Legend (First Revision):

![diff legend (First Revision) ](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/855defbf-3f3e-4d69-98b0-5354b12dfcc4)


Diff Viewer Legend: 

![diff legend](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/94b24c01-7152-47c7-9907-fa524e805f38)


### **After:**

Article Viewer Legend:

![article legend](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/c350f0e6-d5f4-4714-a343-2ece99aeec68)


Diff Viewer Legend (First Revision):


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/15f8b3b9-9bc8-4d6b-86bb-0d8563179cbb



Diff Viewer Legend: 

![diff legend](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/6bafd619-b367-4ac8-b124-d686716e5eb8)


