### PR TITLE
[WIP] Data rearchitecure proof of concept

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -15,8 +15,9 @@
 #  updated_at        :datetime         not null
 #
 class ArticleCourseTimeslice < ApplicationRecord
-  belongs_to :articles_courses
+  belongs_to :articles_courses, foreign_key: 'article_course_id'
 
+  scope :non_empty, -> { where.not(user_ids: nil) }
   serialize :user_ids, Array # This text field only stores user ids as text
 
   ####################

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -10,7 +10,7 @@
 #  last_mw_rev_id    :integer
 #  character_sum     :integer          default(0)
 #  references_count  :integer          default(0)
-#  user_ids          :text(65535)      default("")
+#  user_ids          :text(65535)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: article_course_timeslices
@@ -17,4 +16,25 @@
 #
 class ArticleCourseTimeslice < ApplicationRecord
   belongs_to :articles_courses
+
+  serialize :user_ids, Array # This text field only stores user ids as text
+
+  ####################
+  # Instance methods #
+  ####################
+
+  # Takes an array of revisions for the article_course_timeslice
+  def update_cache_from_revisions(revisions)
+    self.character_sum += revisions.sum { |r| r.characters.to_i.positive? ? r.characters : 0 }
+    self.references_count += revisions.sum(&:references_added)
+    self.user_ids += associated_user_ids(revisions)
+    save
+  end
+
+  private
+
+  def associated_user_ids(revisions)
+    return [] if revisions.blank?
+    revisions.filter_map(&:user_id).uniq
+  end
 end

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -25,9 +25,11 @@ class ArticleCourseTimeslice < ApplicationRecord
 
   # Takes an array of revisions for the article_course_timeslice
   def update_cache_from_revisions(revisions)
-    self.character_sum += revisions.sum { |r| r.characters.to_i.positive? ? r.characters : 0 }
-    self.references_count += revisions.sum(&:references_added)
-    self.user_ids += associated_user_ids(revisions)
+    # Filter the deleted revisions
+    live_revisions = revisions.reject(&:deleted)
+    self.character_sum += live_revisions.sum { |r| r.characters.to_i.positive? ? r.characters : 0 }
+    self.references_count += live_revisions.sum(&:references_added)
+    self.user_ids += associated_user_ids(live_revisions)
     save
   end
 

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -92,11 +92,14 @@ class UpdateCourseStatsTimeslice
       @revisions[wiki].group_by(&:article_id).each do |article_id, article_revisions|
         article_course = ArticlesCourses.find_or_create_by(course: @course, article_id:)
         # TODO: determine how to get the right timeslice given the start and end
-        ArticleCourseTimeslice.find_or_create_by(article_course_id: article_course.id).update_cache_from_revisions article_revisions
+        # Update cache for ArticleCorseTimeslice
+        ArticleCourseTimeslice.find_or_create_by(
+          article_course_id: article_course.id
+        ).update_cache_from_revisions article_revisions
       end
     end
 
-    # ArticlesCourses.update_all_caches(@course.articles_courses)
+    ArticlesCourses.update_all_caches_from_timeslices(@course.articles_courses)
     # log_update_progress :articles_courses_updated
     # CoursesUsers.update_all_caches(@course.courses_users)
     # log_update_progress :courses_users_updated

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/course_revision_updater"
+require_dependency "#{Rails.root}/lib/article_status_manager"
+require_dependency "#{Rails.root}/lib/importers/course_upload_importer"
+require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
+require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
+require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
+require_dependency "#{Rails.root}/lib/importers/average_views_importer"
+require_dependency "#{Rails.root}/lib/errors/update_service_error_helper"
+require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
+require_dependency "#{Rails.root}/lib/revision_data_manager"
+
+#= Pulls in new revisions for a single course wiki timeslice and updates the corresponding records
+class UpdateCourseStatsTimeslice
+  include UpdateServiceErrorHelper
+  include CourseQueueSorting
+
+  def initialize(course, wiki, timeslice_start, timeslice_end)
+    @course = course
+    @wiki = wiki
+    @timeslice_start = timeslice_start
+    @timeslice_end = timeslice_end
+    # If the upate was explicitly requested by a user,
+    # it could be because the dates or other paramters were just changed.
+    # In that case, do a full update rather than just fetching the most
+    # recent revisions.
+    # @full_update = full || @course.needs_update
+
+    @start_time = Time.zone.now
+    fetch_data
+    update_categories
+    update_article_status if should_update_article_status?
+    update_average_pageviews
+    update_caches
+    # update_wikidata_stats if wikidata
+    # This needs to happen after `update_caches` because it relies on ArticlesCourses#new_article
+    # to calculate new article stats for each namespace.
+    # update_wiki_namespace_stats
+    # @course.update(needs_update: false)
+    @end_time = Time.zone.now
+    UpdateLogger.update_course(@course, 'start_time' => @start_time.to_datetime,
+                                         'end_time' => @end_time.to_datetime,
+                                         'sentry_tag_uuid' => sentry_tag_uuid,
+                                         'error_count' => error_count)
+  end
+
+  private
+
+  def fetch_data
+    log_update_progress :start
+    # Fetchs revision for each wiki
+    @revisions = {}
+    @course.wikis.each do |wiki|
+      @revisions[wiki] = RevisionDataManager
+                         .new(wiki, @course, update_service: self)
+                         .fetch_revision_data_for_course(@timeslice_start, @timeslice_end)
+    end
+    log_update_progress :revision_scores_fetched
+
+    # TODO: replace the logic on ArticlesCourses.update_from_course
+
+    # TODO: note this is not wiki scoped.
+    CourseUploadImporter.new(@course, update_service: self).run
+    log_update_progress :uploads_imported
+  end
+
+  def update_categories
+    # TODO: note this is not wiki scoped.
+    Category.refresh_categories_for(@course)
+    log_update_progress :categories_updated
+  end
+
+  def update_article_status
+    # TODO: note this is not wiki scoped.
+    ArticleStatusManager.update_article_status_for_course(@course)
+    log_update_progress :article_status_updated
+
+    # TODO: replace the logic on ModifiedRevisionsManager.new(@wiki).move_or_delete_revisions
+  end
+
+  def update_average_pageviews
+    # TODO: note this is not wiki scoped. ArticlesCourses records were not created
+    # by the time this runs.
+    AverageViewsImporter.update_outdated_average_views(@course.articles)
+    log_update_progress :average_pageviews_updated
+  end
+
+  def update_caches
+    @course.wikis.each do |wiki|
+      next if @revisions[wiki].length.zero?
+      @revisions[wiki].group_by(&:article_id).each do |article_id, article_revisions|
+        article_course = ArticlesCourses.find_or_create_by(course: @course, article_id:)
+        # TODO: determine how to get the right timeslice given the start and end
+        ArticleCourseTimeslice.find_or_create_by(article_course_id: article_course.id).update_cache_from_revisions article_revisions
+      end
+    end
+
+    # ArticlesCourses.update_all_caches(@course.articles_courses)
+    # log_update_progress :articles_courses_updated
+    # CoursesUsers.update_all_caches(@course.courses_users)
+    # log_update_progress :courses_users_updated
+    # @course.update_cache
+    HistogramPlotter.delete_csv(course: @course) # clear cached structural completeness data
+    log_update_progress :course_cache_updated
+  end
+
+  def update_wikidata_stats
+    UpdateWikidataStatsWorker.new.perform(@course)
+    log_update_progress :wikidata_stats_updated
+  end
+
+  def update_wiki_namespace_stats
+    # Update each of the tracked namespaces
+    @course.course_wiki_namespaces.each do |course_wiki_ns|
+      wiki = course_wiki_ns.courses_wikis.wiki
+      namespace = course_wiki_ns.namespace
+      UpdateWikiNamespaceStats.new(@course, wiki, namespace)
+    end
+    # Remove stats data for any namespaces that were previously
+    # tracked but are no longer tracked.
+    UpdateWikiNamespaceStats.clear_untracked_namespace_data(@course)
+  end
+
+  def wikidata
+    @course.wikis.find { |wiki| wiki.project == 'wikidata' }
+  end
+
+  def log_update_progress(step)
+    return unless debug?
+    @sentry_logs ||= {}
+    @sentry_logs[step] = Time.zone.now
+    Sentry.capture_message "#{@course.title} update: #{step}",
+                           level: 'warning',
+                           extra: { logs: @sentry_logs }
+  end
+
+  TEN_MINUTES = 600
+  def should_update_article_status?
+    return true if Features.wiki_ed?
+    # To cut down on overwhelming the system
+    # for courses with huge numbers of articles
+    # to check, we skip this on Programs & Events Dashboard
+    # for slow-updating courses.
+    # This means we miss cases of article deletion
+    # and namespace changes unless the article
+    longest_update_time(@course).to_i < TEN_MINUTES
+  end
+
+  def debug?
+    @course.flags[:debug_updates]
+  end
+end

--- a/db/migrate/20240617164324_change_user_ids_default_in_article_course_timeslices.rb
+++ b/db/migrate/20240617164324_change_user_ids_default_in_article_course_timeslices.rb
@@ -1,0 +1,5 @@
+class ChangeUserIdsDefaultInArticleCourseTimeslices < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :article_course_timeslices, :user_ids, nil
+  end
+end

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -35,6 +35,11 @@ class ArticleImporter
     end
   end
 
+  # Takes an array like the following:
+  # [{"mw_page_id"=>"69830902", "wiki_id"=>5, "title"=>"Ar00", "namespace"=>"2"},
+  # ...
+  # {"mw_page_id"=>"69834562", "wiki_id"=>1, "title"=>"Some article", "namespace"=>"1"}]
+  # Creates article records with that data.
   def import_articles_from_revision_data(data)
     # We rely on the unique index here, mw_page_id and wiki_id
     Article.import data, on_duplicate_key_update: [:title, :namespace]

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -35,6 +35,11 @@ class ArticleImporter
     end
   end
 
+  def import_articles_from_revision_data(data)
+    # We rely on the unique index here, mw_page_id and wiki_id
+    Article.import data, on_duplicate_key_update: [:title, :namespace]
+  end
+
   private
 
   def import_articles_from_replica_data(articles_data)

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -47,7 +47,8 @@ class RevisionScoreImporter
 
   # Takes an array of Revision records, and returns an array of Revisions records
   # with scores completed.
-  def get_revision_scores(new_revisions)
+  def get_revision_scores(new_revisions) # rubocop:disable Metrics/AbcSize
+    return [] unless new_revisions
     scores = {}
     parent_scores = {}
     parent_revisions = {}

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -9,7 +9,7 @@ class LiftWingApi
   include ApiErrorHandling
   include WeightedScoreCalculator
 
-  DELETED_REVISION_ERRORS = %w[TextDeleted RevisionNotFound].freeze
+  DELETED_REVISION_ERRORS = %w[TextDeleted deletion].freeze
 
   LIFT_WING_SERVER_URL = 'https://api.wikimedia.org'
 

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -16,6 +16,9 @@ class RevisionDataManager
     @importer = RevisionScoreImporter.new(wiki:, course:, update_service:)
   end
 
+  # This method gets revisions and scores for them from different APIs.
+  # Returns an array of Revision records.
+  # As a side effect, it imports Article records.
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
     sub_data = get_revisions(@course.students, timeslice_start, timeslice_end)
     @revisions = []
@@ -44,7 +47,7 @@ class RevisionDataManager
   ###########
   # Helpers #
   ###########
-  # private
+  private
 
   # Get revisions made by a set of users between two dates.
   # We limit the number of usernames per query in order to avoid

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/replica"
+require_dependency "#{Rails.root}/lib/importers/article_importer"
+require_dependency "#{Rails.root}/app/helpers/encoding_helper"
+require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
+
+#= Fetches revision data from API
+class RevisionDataManager
+  include EncodingHelper
+
+  def initialize(wiki, course, update_service: nil)
+    @wiki = wiki
+    @course = course
+    @update_service = update_service
+    @importer = RevisionScoreImporter.new(wiki:, course:, update_service:)
+  end
+
+  def fetch_revision_data_for_course(timeslice_start, timeslice_end)
+    sub_data = get_revisions(@course.students, timeslice_start, timeslice_end)
+    @revisions = []
+
+    # Extract all article data from the slice. Outputs a hash with article attrs.
+    articles = sub_data_to_article_attributes(sub_data)
+
+    # Import articles. We do this here to avoid saving article data in memory.
+    ArticleImporter.new(@wiki).import_articles_from_revision_data(articles)
+    @articles = Article.where(wiki_id: @wiki.id, mw_page_id: articles.map { |a| a['mw_page_id'] })
+
+    # Prep: get a user dictionary for all users referred to by revisions.
+    users = user_dict_from_sub_data(sub_data)
+
+    # Now get all the revisions
+    # We need a slightly different article dictionary format here
+    article_dict = @articles.each_with_object({}) { |a, memo| memo[a.mw_page_id] = a.id }
+    revisions = sub_data_to_revision_attributes(sub_data, users, article_dict)
+
+    # TODO: resolve duplicates
+    # DuplicateArticleDeleter.new(@wiki).resolve_duplicates(@articles)
+
+    @importer.get_revision_scores(revisions)
+  end
+
+  ###########
+  # Helpers #
+  ###########
+  # private
+
+  # Get revisions made by a set of users between two dates.
+  # We limit the number of usernames per query in order to avoid
+  # hitting the memory limit of the Replica endpoint.
+  # TODO: For some reason, this returns duplicated mw_rev_id in the revisions data.
+  # We should check if it's feasible to return unique mw_rev_id here.
+  MAX_USERNAMES = 10
+  def get_revisions(users, start, end_date)
+    Utils.chunk_requests(users, MAX_USERNAMES) do |block|
+      Replica.new(@wiki, @update_service).get_revisions block, start, end_date
+    end
+  end
+
+  def string_to_boolean(string)
+    case string
+    when 'false'
+      false
+    when 'true'
+      true
+    end
+  end
+
+  def sub_data_to_article_attributes(sub_data)
+    sub_data.map do |_a_id, article_data|
+      {
+        'mw_page_id' => article_data['article']['mw_page_id'],
+        'wiki_id' => @wiki.id,
+        'title' => sanitize_4_byte_string(article_data['article']['title']),
+        'namespace' => article_data['article']['namespace']
+      }
+    end
+  end
+
+  def user_dict_from_sub_data(sub_data)
+    users = sub_data.flat_map do |_a_id, article_data|
+      article_data['revisions'].map { |rev_data| rev_data['username'] }
+    end
+    users.uniq!
+    # Returns e.g. {"Nalumc"=>4, "Twkpassmore"=>3}
+    User.where(username: users).pluck(:username, :id).to_h
+  end
+
+  def sub_data_to_revision_attributes(sub_data, users, articles)
+    sub_data.flat_map do |_a_id, article_data|
+      article_data['revisions'].map do |rev_data|
+        mw_page_id = rev_data['mw_page_id'].to_i
+        Revision.new({
+          mw_rev_id: rev_data['mw_rev_id'],
+          date: rev_data['date'],
+          characters: rev_data['characters'],
+          article_id: articles[mw_page_id],
+          mw_page_id:,
+          user_id: users[rev_data['username']],
+          new_article: string_to_boolean(rev_data['new_article']),
+          system: string_to_boolean(rev_data['system']),
+          wiki_id: rev_data['wiki_id']
+        })
+      end
+    end.uniq(&:mw_rev_id)
+  end
+end

--- a/spec/factories/article_course_timeslices.rb
+++ b/spec/factories/article_course_timeslices.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: article_course_timeslices
+#
+#  id                :bigint           not null, primary key
+#  article_course_id :integer          not null
+#  start             :datetime
+#  end               :datetime
+#  last_mw_rev_id    :integer
+#  character_sum     :integer          default(0)
+#  references_count  :integer          default(0)
+#  user_ids          :text(65535)      default("")
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+
+FactoryBot.define do
+  factory :article_course_timeslice, class: 'ArticleCourseTimeslice' do
+    nil
+  end
+end

--- a/spec/factories/article_course_timeslices.rb
+++ b/spec/factories/article_course_timeslices.rb
@@ -10,7 +10,7 @@
 #  last_mw_rev_id    :integer
 #  character_sum     :integer          default(0)
 #  references_count  :integer          default(0)
-#  user_ids          :text(65535)      default("")
+#  user_ids          :text(65535)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/lib/importers/article_importer_spec.rb
+++ b/spec/lib/importers/article_importer_spec.rb
@@ -68,4 +68,27 @@ describe ArticleImporter do
       end
     end
   end
+
+  describe '.import_articles_from_revision_data' do
+    let(:revision_data) do
+      [{ 'mw_page_id' => '69830902', 'wiki_id' => 5, 'title' => 'Ar00', 'namespace' => '2' },
+       { 'mw_page_id' => '69830903', 'wiki_id' => 5, 'title' => 'Any title', 'namespace' => '1' }]
+    end
+
+    it 'creates all the Article records' do
+      VCR.use_cassette 'article_importer/article_importer' do
+        expect(Article.find_by(mw_page_id: 69830902)).to be_nil
+        expect(Article.find_by(mw_page_id: 69830903)).to be_nil
+        described_class.new(es_wiki).import_articles_from_revision_data revision_data
+        article_1 = Article.find_by(mw_page_id: 69830902)
+        expect(article_1.title).to eq('Ar00')
+        expect(article_1.wiki_id).to eq(5)
+        expect(article_1.namespace).to eq(2)
+        article_2 = Article.find_by(mw_page_id: 69830903)
+        expect(article_2.title).to eq('Any title')
+        expect(article_2.wiki_id).to eq(5)
+        expect(article_2.namespace).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -92,7 +92,7 @@ describe RevisionScoreImporter do
   end
 
   it 'marks RevisionNotFound revisions as deleted' do
-    VCR.use_cassette 'revision_scores/deleted_revision' do
+    VCR.use_cassette 'revision_scores/notfound_revision' do
       article = Article.find(678)
       described_class.new.update_revision_scores
       revision = article.revisions.first
@@ -225,7 +225,7 @@ describe RevisionScoreImporter do
     end
 
     it 'marks RevisionNotFound revisions as deleted' do
-      VCR.use_cassette 'revision_scores/deleted_revision' do
+      VCR.use_cassette 'revision_scores/notfound_revision' do
         revisions = described_class.new.get_revision_scores(array_revisions)
         expect(revisions[3].deleted).to eq(true)
         expect(revisions[3].wp10).to be_nil

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/revision_data_manager"
+require "#{Rails.root}/lib/articles_courses_cleaner"
+
+describe RevisionDataManager do
+  describe '#fetch_revision_data_for_course' do
+    let(:course) { create(:course, start: '2018-01-01', end: '2018-12-31') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+    let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:subject) do
+      described_class.new(home_wiki, course).fetch_revision_data_for_course('20180706', '20180707')
+    end
+    let(:revision_count) { 0 }
+    let(:revision_data) do
+      [{ 'mw_page_id' => '55345266',
+      'wiki_id' => 1,
+      'title' => 'Ragesoss/citing_sources',
+      'namespace' => '2' }]
+    end
+
+    before do
+      create(:courses_user, course:, user:, revision_count:)
+    end
+
+    it 'fetchs all the revisions that occurred during the given period of time' do
+      VCR.use_cassette 'revision_importer/all' do
+        revisions = subject
+        expect(revisions.length).to eq(4)
+        # Fetches the right revision ids
+        expect(revisions[0].mw_rev_id).to eq(849116430)
+        expect(revisions[1].mw_rev_id).to eq(849116480)
+        expect(revisions[2].mw_rev_id).to eq(849116533)
+        expect(revisions[3].mw_rev_id).to eq(849116572)
+
+        # Fetches the scores
+        expect(revisions[0].wp10).to eq(18.287608774878528)
+        expect(revisions[0].wp10_previous).to eq(11.95948026900581)
+        expect(revisions[0].features).to eq({ 'num_ref' => 2 })
+        expect(revisions[0].features_previous).to eq({ 'num_ref' => 2 })
+        expect(revisions[0].deleted).to eq(false)
+
+        expect(revisions[1].wp10).to eq(20.088995958732458)
+        expect(revisions[1].wp10_previous).to eq(18.287608774878528)
+        expect(revisions[1].features).to eq({ 'num_ref' => 3 })
+        expect(revisions[1].features_previous).to eq({ 'num_ref' => 2 })
+        expect(revisions[1].deleted).to eq(false)
+
+        expect(revisions[2].wp10).to eq(21.373269263926918)
+        expect(revisions[2].wp10_previous).to eq(20.088995958732458)
+        expect(revisions[2].features).to eq({ 'num_ref' => 3 })
+        expect(revisions[2].features_previous).to eq({ 'num_ref' => 3 })
+        expect(revisions[2].deleted).to eq(false)
+
+        expect(revisions[3].wp10).to eq(21.33831536670649)
+        expect(revisions[3].wp10_previous).to eq(21.373269263926918)
+        expect(revisions[3].features).to eq({ 'num_ref' => 3 })
+        expect(revisions[3].features_previous).to eq({ 'num_ref' => 3 })
+        expect(revisions[3].deleted).to eq(false)
+      end
+    end
+
+    it 'calls ArticeImporter as side effect' do
+      expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
+        .once
+        .with(revision_data)
+
+      VCR.use_cassette 'revision_importer/all' do
+        subject
+      end
+    end
+  end
+end

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: article_course_timeslices
+#
+#  id                :bigint           not null, primary key
+#  article_course_id :integer          not null
+#  start             :datetime
+#  end               :datetime
+#  last_mw_rev_id    :integer
+#  character_sum     :integer          default(0)
+#  references_count  :integer          default(0)
+#  user_ids          :text(65535)      default("")
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+
+require 'rails_helper'
+require "#{Rails.root}/lib/importers/article_importer"
+require "#{Rails.root}/lib/articles_courses_cleaner"
+
+describe ArticleCourseTimeslice, type: :model do
+  let(:article) { create(:article) }
+  let(:user) { create(:user) }
+  let(:course) { create(:course, start: 1.month.ago, end: 1.month.from_now) }
+  let(:article_course) { create(:articles_course, article:, course:) }
+  let(:revision1) do
+    create(:revision, article:,
+           characters: 123,
+           features: { 'num_ref' => 4 },
+           features_previous: { 'num_ref' => 0 },
+           user_id: 25)
+  end
+  let(:revision2) do
+    create(:revision, article:,
+           characters: -65,
+           features: { 'num_ref' => 1 },
+           features_previous: { 'num_ref' => 2 },
+           user_id: 1)
+  end
+  let(:revision3) do
+    create(:revision, article:,
+           characters: 225,
+           features: { 'num_ref' => 3 },
+           features_previous: { 'num_ref' => 3 },
+           user_id: 25)
+  end
+  let(:revisions) { [revision1, revision2, revision3] }
+  let(:article_course_timeslice) do
+    create(:article_course_timeslice,
+           article_course_id: article_course.id,
+           character_sum: 100,
+           references_count: 3,
+           user_ids: [2, 4])
+  end
+  let(:subject) { article_course_timeslice.update_cache_from_revisions revisions }
+
+  describe '.update_cache_from_revisions' do
+    it 'updates cache correctly' do
+      expect(article_course_timeslice.character_sum).to eq(100)
+      expect(article_course_timeslice.references_count).to eq(3)
+      expect(article_course_timeslice.user_ids).to eq([2, 4])
+      subject
+      expect(article_course_timeslice.character_sum).to eq(448)
+      expect(article_course_timeslice.references_count).to eq(6)
+      expect(article_course_timeslice.user_ids).to eq([2, 4, 25, 1])
+    end
+  end
+end

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -10,7 +10,7 @@
 #  last_mw_rev_id    :integer
 #  character_sum     :integer          default(0)
 #  references_count  :integer          default(0)
-#  user_ids          :text(65535)      default("")
+#  user_ids          :text(65535)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -45,7 +45,15 @@ describe ArticleCourseTimeslice, type: :model do
            features_previous: { 'num_ref' => 3 },
            user_id: 25)
   end
-  let(:revisions) { [revision1, revision2, revision3] }
+  let(:revision4) do
+    create(:revision, article:,
+            characters: 34,
+            deleted: true, # deleted revision
+            features: { 'num_ref' => 2 },
+            features_previous: { 'num_ref' => 0 },
+            user_id: 6)
+  end
+  let(:revisions) { [revision1, revision2, revision3, revision4] }
   let(:article_course_timeslice) do
     create(:article_course_timeslice,
            article_course_id: article_course.id,

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -49,6 +49,24 @@ describe UpdateCourseStatsTimeslice do
       # were not created for the time AverageViewsImporter.update_outdated_average_views runs
       # expect(course.articles.where(wiki: enwiki).last.average_views).to be > 0
     end
+
+    it 'updates article course and article course timeslices caches' do
+      # Check caches for mw_page_id 6901525
+      article = Article.find_by(mw_page_id: 6901525)
+      # The article course exists
+      article_course = ArticlesCourses.find_by(article_id: article.id)
+      # The article course caches were updated
+      expect(article_course.character_sum).to eq(427)
+      expect(article_course.references_count).to eq(-2)
+      expect(article_course.user_ids).to eq([user.id])
+
+      # Article course timeslice record was created for mw_page_id 6901525
+      expect(article_course.article_course_timeslices.count).to eq(1)
+      # Article course timeslices caches were updated
+      expect(article_course.article_course_timeslices.first.character_sum).to eq(427)
+      expect(article_course.article_course_timeslices.first.references_count).to eq(-2)
+      expect(article_course.article_course_timeslices.first.user_ids).to eq([user.id])
+    end
   end
 
   context 'sentry course update error tracking' do

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdateCourseStatsTimeslice do
+  let(:course) { create(:course, flags:) }
+  let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
+  let(:subject) { described_class.new(course, enwiki, '20181124000000', '20181129190000') }
+
+  context 'when debugging is not enabled' do
+    let(:flags) { nil }
+
+    it 'posts no Sentry logs' do
+      expect(Sentry).not_to receive(:capture_message)
+      subject
+    end
+  end
+
+  context 'when :debug_updates flag is set' do
+    let(:flags) { { debug_updates: true } }
+
+    it 'posts debug info to Sentry' do
+      expect(Sentry).to receive(:capture_message).at_least(6).times.and_call_original
+      subject
+    end
+  end
+
+  context 'when there are revisions' do
+    let(:course) { create(:course, start: '2018-11-23', end: '2018-11-30') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+
+    before do
+      stub_wiki_validation
+      course.campaigns << Campaign.first
+      course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
+      JoinCourse.new(course:, user:, role: 0)
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+    end
+
+    it 'imports average views of edited articles' do
+      # 2 en.wiki articles
+      expect(course.articles.where(wiki: enwiki).count).to eq(2)
+      # 13 wikidata articles
+      expect(course.articles.where(wiki: wikidata).count).to eq(13)
+      # TODO: fix this. Right now doesn't work because ArticleCourses records
+      # were not created for the time AverageViewsImporter.update_outdated_average_views runs
+      # expect(course.articles.where(wiki: enwiki).last.average_views).to be > 0
+    end
+  end
+
+  context 'sentry course update error tracking' do
+    let(:flags) { { debug_updates: true } }
+    let(:user) { create(:user, username: 'Ragesoss') }
+
+    before do
+      create(:courses_user, course_id: course.id, user_id: user.id)
+    end
+
+    it 'tracks update errors properly in Replica' do
+      allow(Sentry).to receive(:capture_exception)
+
+      # Raising errors only in Replica
+      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
+      VCR.use_cassette 'course_update/replica' do
+        subject
+      end
+      sentry_tag_uuid = subject.sentry_tag_uuid
+      expect(course.flags['update_logs'][1]['error_count']).to eq 1
+      expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
+
+      # Checking whether Sentry receives correct error and tags as arguments
+      expect(Sentry).to have_received(:capture_exception).once.with(Errno::ECONNREFUSED, anything)
+      expect(Sentry).to have_received(:capture_exception)
+        .once.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
+                                                    course: course.slug })
+    end
+
+    it 'tracks update errors properly in LiftWing' do
+      allow(Sentry).to receive(:capture_exception)
+
+      # Raising errors only in LiftWing
+      stub_request(:any, %r{https://api.wikimedia.org/service/lw.*}).to_raise(Faraday::ConnectionFailed)
+      VCR.use_cassette 'course_update/lift_wing_api' do
+        subject
+      end
+      sentry_tag_uuid = subject.sentry_tag_uuid
+      expect(course.flags['update_logs'][1]['error_count']).to eq 2
+      expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
+
+      # Checking whether Sentry receives correct error and tags as arguments
+      expect(Sentry).to have_received(:capture_exception)
+        .exactly(2).times.with(Faraday::ConnectionFailed, anything)
+      expect(Sentry).to have_received(:capture_exception)
+        .exactly(2).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
+                                                                course: course.slug })
+    end
+
+    it 'tracks update errors properly in WikiApi' do
+      allow(Sentry).to receive(:capture_exception)
+      allow_any_instance_of(described_class).to receive(:update_article_status).and_return(nil)
+
+      # Raising errors only in WikiApi
+      allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+        .and_raise(MediawikiApi::ApiError)
+      VCR.use_cassette 'course_update/wiki_api' do
+        subject
+      end
+      sentry_tag_uuid = subject.sentry_tag_uuid
+      expect(course.flags['update_logs'][1]['error_count']).to be_positive
+      expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
+
+      # Checking whether Sentry receives correct error and tags as arguments
+      expect(Sentry).to have_received(:capture_exception)
+        .at_least(2).times.with(MediawikiApi::ApiError, anything)
+      expect(Sentry).to have_received(:capture_exception)
+        .at_least(2).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
+                                                                course: course.slug })
+    end
+
+    context 'when a Programs & Events Dashboard course has a potentially long update time' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 1.year.from_now,
+                        flags: { longest_update: 1.hour.to_i })
+      end
+
+      before do
+        allow(Features).to receive(:wiki_ed?).and_return(false)
+      end
+
+      it 'skips article status updates' do
+        expect_any_instance_of(described_class).not_to receive(:update_article_status)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR makes a small proof of concept for the data re-architecture project. Basically:

- It adds a new `RevisionDataManager` class that given a course, a wiki and a specific period of time (in the future, a timeslice), it fetches revision and revision scores from different APIs, and returns an array with all that data.
- It adds the client of the  `RevisionDataManager` class: `UpdateCourseStatsTimeslice` class that updates timeslices from this revision data in RAM (not commited yet).
- It implements the `update_cache_from_revisions` method for the `ArticleCourseTimeslice`, which updates an  `ArticleCourseTimeslice` record with the new revisions in memory.
- It updates the existing `update_cache` method for the `ArticleCourse`, to update caches based on the `ArticleCourseTimeslice` records instead of the revision table (`ArticlesCourses.update_cache_from_timeslices`).

This PR adds specs for all the new behaviors.
## Open questions and concerns
There are a lot of TODO comments that will be handled in the future.
A similar process should be done for `CourseWikiTimeslice` and `CourseUserWikiTimeslice` timeslices.

For `ArticlesCourses` records, now `view_count` is calculated  based on the first non-empty article course timeslice record `start` date (instead of using the first revision). We estimate the first non-empty record checking `user_ids` field is not null. This should lead to the same results.
