### PR TITLE
Correcting a spelling mistake in a message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1308,7 +1308,7 @@ en:
   tickets:
     none: "No tickets"
     search_bar_placeholder: Search tickets
-    chose_search_type: Chose a search type
+    chose_search_type: Choose a search type
 
   timeline:
     add_week: Add Week


### PR DESCRIPTION
(It's just an educated guess, because such messages are more likely to be infinitive or imperative. If this is actually supposed to be in the past tense, feel free to close the pull request.)