### PR TITLE
Refactor : migrated empty_week.jsx to functional component

### DIFF
--- a/app/assets/javascripts/components/timeline/empty_week.jsx
+++ b/app/assets/javascripts/components/timeline/empty_week.jsx
@@ -1,91 +1,96 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import CourseLink from '../common/course_link.jsx';
 import DateCalculator from '../../utils/date_calculator.js';
 
-const EmptyWeek = createReactClass({
-  displayName: 'EmptyWeek',
+const EmptyWeek = ({
+  emptyTimeline,
+  edit_permissions,
+  usingCustomTitles,
+  course,
+  timeline_start,
+  timeline_end,
+  index,
+  weeksBeforeTimeline,
+  addWeek
+}) => {
+  let week;
+  // Three types of empty weeks:
 
-  propTypes: {
-    emptyTimeline: PropTypes.bool,
-    edit_permissions: PropTypes.bool,
-    usingCustomTitles: PropTypes.bool,
-    course: PropTypes.object,
-    timeline_start: PropTypes.string,
-    timeline_end: PropTypes.string,
-    index: PropTypes.number,
-    weeksBeforeTimeline: PropTypes.number,
-    addWeek: PropTypes.func.isRequired
-  },
-
-  render() {
-    let week;
-    // Three types of empty weeks:
-
-    // 1. If timeline is empty and user can edit it, show info and links to get started.
-    if (this.props.emptyTimeline && this.props.edit_permissions) {
-      let wizardLink;
-      let wizardLinkTransition;
-      if (this.props.course.type === 'ClassroomProgramCourse') {
-        const wizardUrl = `/courses/${this.props.course.slug}/timeline/wizard`;
-        wizardLinkTransition = I18n.t('timeline.empty_week_3');
-        wizardLink = <CourseLink to={wizardUrl} className="empty-week-clickable">{I18n.t('timeline.empty_week_4')}</CourseLink>;
-      }
-
-      week = (
-        <p className="week__no-activity__get-started">
-          {I18n.t('timeline.empty_week_1')}&nbsp;
-          <span className="empty-week-clickable" onClick={this.props.addWeek}>{I18n.t('timeline.empty_week_2')}</span>&nbsp;
-          {wizardLinkTransition}&nbsp;
-          {wizardLink}
-        </p>);
-
-    // 2. If timeline is empty but user cannot edit, just note that timeline is empty.
-    } else if (this.props.emptyTimeline) {
-      week = (
-        <p className="week__no-activity__get-started">
-          {I18n.t('timeline.no_timeline')}
-        </p>);
-
-    // 3. If timeline is not empty, show the blackout week message.
-    } else {
-      week = (<h1 className="h3">{I18n.t('timeline.no_activity_this_week')}</h1>);
+  // 1. If timeline is empty and user can edit it, show info and links to get started.
+  if (emptyTimeline && edit_permissions) {
+    let wizardLink;
+    let wizardLinkTransition;
+    if (course.type === 'ClassroomProgramCourse') {
+      const wizardUrl = `/courses/${course.slug}/timeline/wizard`;
+      wizardLinkTransition = I18n.t('timeline.empty_week_3');
+      wizardLink = <CourseLink to={wizardUrl} className="empty-week-clickable">{I18n.t('timeline.empty_week_4')}</CourseLink>;
     }
 
-    const dateCalc = new DateCalculator(this.props.timeline_start, this.props.timeline_end, this.props.index, { zeroIndexed: false });
+    week = (
+      <p className="week__no-activity__get-started">
+        {I18n.t('timeline.empty_week_1')}&nbsp;
+        <span className="empty-week-clickable" onClick={addWeek}>{I18n.t('timeline.empty_week_2')}</span>&nbsp;
+        {wizardLinkTransition}&nbsp;
+        {wizardLink}
+      </p>);
 
-    const weekNumber = this.props.index + this.props.weeksBeforeTimeline;
+  // 2. If timeline is empty but user cannot edit, just note that timeline is empty.
+  } else if (emptyTimeline) {
+    week = (
+      <p className="week__no-activity__get-started">
+        {I18n.t('timeline.no_timeline')}
+      </p>);
 
-    let header;
-    const datesStr = `${dateCalc.start()} - ${dateCalc.end()}`;
-    if (this.props.usingCustomTitles) {
-      header = (
-        <div className="week__week-header">
-          <p >
-            {I18n.t('timeline.week_number', { number: datesStr })}
-          </p>
-        </div>
-      );
-    } else {
-      header = (
-        <div className="week__week-header">
-          <p >
-            {I18n.t('timeline.week_number', { number: weekNumber || 1 })} <span className="week-range"> ({datesStr})</span>
-          </p>
-        </div>
-      );
-    }
+  // 3. If timeline is not empty, show the blackout week message.
+  } else {
+    week = (<h1 className="h3">{I18n.t('timeline.no_activity_this_week')}</h1>);
+  }
 
-    return (
-      <li className={`week week-${this.props.index}`}>
-        {header}
-        <div className="week__no-activity">
-          {week}
-        </div>
-      </li>
+  const dateCalc = new DateCalculator(timeline_start, timeline_end, index, { zeroIndexed: false });
+
+  const weekNumber = index + weeksBeforeTimeline;
+
+  let header;
+  const datesStr = `${dateCalc.start()} - ${dateCalc.end()}`;
+  if (usingCustomTitles) {
+    header = (
+      <div className="week__week-header">
+        <p>
+          {I18n.t('timeline.week_number', { number: datesStr })}
+        </p>
+      </div>
+    );
+  } else {
+    header = (
+      <div className="week__week-header">
+        <p>
+          {I18n.t('timeline.week_number', { number: weekNumber || 1 })} <span className="week-range"> ({datesStr})</span>
+        </p>
+      </div>
     );
   }
-});
+
+  return (
+    <li className={`week week-${index}`}>
+      {header}
+      <div className="week__no-activity">
+        {week}
+      </div>
+    </li>
+  );
+};
+
+EmptyWeek.propTypes = {
+  emptyTimeline: PropTypes.bool,
+  edit_permissions: PropTypes.bool,
+  usingCustomTitles: PropTypes.bool,
+  course: PropTypes.object,
+  timeline_start: PropTypes.string,
+  timeline_end: PropTypes.string,
+  index: PropTypes.number,
+  weeksBeforeTimeline: PropTypes.number,
+  addWeek: PropTypes.func.isRequired
+};
 
 export default EmptyWeek;


### PR DESCRIPTION
## What this PR does
This pull request refactors the empty_week.jsx component from a class-based component to a functional component.

## Screenshots
Before
1.   If timeline is empty and user can edit it, show info and links to get started.
    
<img width="1433" alt="Screenshot 2024-07-02 at 11 08 19 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/150381737/5d3ae230-aae0-4a20-9edb-0d8b3c9538b1">

2.  If timeline is empty but user cannot edit, just note that timeline is empty.

    <img width="1436" alt="Screenshot 2024-07-02 at 11 00 31 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/150381737/b92f4ec4-e1a0-426b-ab8b-31d807838633">

3.  If timeline is not empty, show the blackout week message.

<img width="1435" alt="Screenshot 2024-07-02 at 11 10 28 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/150381737/7cf37fe7-6aa6-4781-8b9e-a8ce3fed8ac9">


  
After

1.   If timeline is empty and user can edit it, show info and links to get started.
     
<img width="1434" alt="Screenshot 2024-07-02 at 11 06 17 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/150381737/af61dcc2-e75a-415b-b295-18ab824d0d2c">

2.  If timeline is empty but user cannot edit, just note that timeline is empty.

  <img width="1435" alt="Screenshot 2024-07-02 at 11 03 59 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/150381737/3266a2f3-5d25-4f15-af99-0bf76b3af71b">

3.  If timeline is not empty, show the blackout week message.
      
<img width="1437" alt="Screenshot 2024-07-02 at 11 11 57 PM" src="https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/150381737/39450ffe-b3a3-4154-a018-299f6b17bc33">


## Open questions and concerns
I am a first-time contributor to Wikimedia and have converted empty_week.jsx to a functional component. If there are any issues with my pull request, please provide feedback, and I will address them promptly.

Thank you!
