### PR TITLE
Added Course Copying Feature for Non-Admins on Programs & Events Dashboard

### DIFF
--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -149,7 +149,7 @@ const CourseClonedModal = createReactClass({
   saveEnabled() {
     // You must be logged in and have permission to edit the course.
     // This will be the case if you created it (and are therefore the instructor) or if you are an admin.
-    if (!this.props.currentUser.isAdvancedRole) { return false; }
+    if (!this.props.currentUser.isAdvancedRole && this.props.course.cloned_status !== 3) { return false; }
     return true;
   },
 
@@ -163,7 +163,7 @@ const CourseClonedModal = createReactClass({
       errorMessage = <div className="warning">{this.props.firstErrorMessage}</div>;
     } else if (!this.props.currentUser.id) {
       errorMessage = <div className="warning">{I18n.t('courses.please_log_in')}</div>;
-    } else if (!this.props.currentUser.isAdvancedRole) {
+    } else if (!this.props.currentUser.isAdvancedRole && this.props.course.cloned_status !== 3) {
       errorMessage = <div className="warning">{CourseUtils.i18n('not_permitted', i18nPrefix)}</div>;
     }
 

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -348,14 +348,23 @@ const CourseClonedModal = createReactClass({
         {infoIcon}
       </div>
     );
+    let heading;
+    let para;
+    if (this.state.course.cloned_status === 3) {
+      heading = <h3 id="clone_modal_header">{CourseUtils.i18n('creator.copy_successful', i18nPrefix)}</h3>;
+      para = <p>{CourseUtils.i18n('creator.copy_successful_details', i18nPrefix)}</p>;
+    } else {
+      heading = <h3 id="clone_modal_header">{CourseUtils.i18n('creator.clone_successful', i18nPrefix)}</h3>;
+      para = <p>{CourseUtils.i18n('creator.clone_successful_details', i18nPrefix)}</p>;
+    }
 
     return (
       <Modal>
         <div className="container">
           <div className="wizard__panel active cloned-course">
             {specialNotice}
-            <h3 id="clone_modal_header">{CourseUtils.i18n('creator.clone_successful', i18nPrefix)}</h3>
-            <p>{CourseUtils.i18n('creator.clone_successful_details', i18nPrefix)}</p>
+            {heading}
+            {para}
             {errorMessage}
             <div className="wizard__form">
               <div className="column" id="details_column">

--- a/app/assets/javascripts/components/overview/overview_handler.jsx
+++ b/app/assets/javascripts/components/overview/overview_handler.jsx
@@ -63,7 +63,7 @@ const Overview = createReactClass({
   render() {
     const { course, current_user } = this.props;
 
-    if (course.cloned_status === 1) {
+    if (course.cloned_status === 1 || course.cloned_status === 3) {
       return (
         <CourseClonedModal
           course={course}

--- a/app/assets/stylesheets/modules/_explore.styl
+++ b/app/assets/stylesheets/modules/_explore.styl
@@ -6,5 +6,22 @@
 .explore-courses
   padding-bottom: 20px
   position relative
-  input
+  input[type='text']
+    border-color: hsl(0, 0%, 80%)
+    border-radius: 4px
     width 100%
+  input[type='text']::placeholder
+    color: hsl(0, 0%, 50%)
+  input[type='text']:hover
+    border-color: #676EB4
+  .checkbox-group
+    padding: 10px 0px 20px 0px
+    display: flex
+    flex-direction: row
+    align-items: center
+    label
+      user-select: none
+    input[type="checkbox"]
+      width: 15px
+      height: 15px
+      margin-right: 8px

--- a/app/controllers/copy_course_controller.rb
+++ b/app/controllers/copy_course_controller.rb
@@ -3,7 +3,7 @@
 #= Controller for Copy Course tool
 class CopyCourseController < ApplicationController
   respond_to :html
-  before_action :require_admin_permissions if Features.wiki_ed?
+  before_action :require_admin_if_wiki_ed
   def index; end
 
   def copy
@@ -22,5 +22,9 @@ class CopyCourseController < ApplicationController
       )
       redirect_to "/courses/#{course.slug}"
     end
+  end
+
+  def require_admin_if_wiki_ed
+    require_admin_permissions if Features.wiki_ed?
   end
 end

--- a/app/controllers/copy_course_controller.rb
+++ b/app/controllers/copy_course_controller.rb
@@ -7,16 +7,20 @@ class CopyCourseController < ApplicationController
   def index; end
 
   def copy
-    service = CopyCourse.new(url: params[:url])
+    service = CopyCourse.new(url: params[:url], user_data: params[:user_data])
     response = service.make_copy
     if response[:error].present?
       redirect_to(copy_course_path,
                   flash: { error: "Course not created: #{response[:error]}" })
     else
       course = response[:course]
-      redirect_to copy_course_path,
-                  notice: "Course #{course.title} was created."\
-                          "&nbsp;<a href=\"/courses/#{course.slug}\">Go to course</a>"
+      course.update(
+        flags: { timeline_enabled: true },
+        cloned_status: 3,
+        expected_students: course.expected_students || 0,
+        term: ""
+      )
+      redirect_to "/courses/#{course.slug}"
     end
   end
 end

--- a/app/controllers/copy_course_controller.rb
+++ b/app/controllers/copy_course_controller.rb
@@ -18,7 +18,7 @@ class CopyCourseController < ApplicationController
         flags: { timeline_enabled: true },
         cloned_status: 3,
         expected_students: course.expected_students || 0,
-        term: ""
+        term: ''
       )
       redirect_to "/courses/#{course.slug}"
     end

--- a/app/controllers/copy_course_controller.rb
+++ b/app/controllers/copy_course_controller.rb
@@ -3,7 +3,7 @@
 #= Controller for Copy Course tool
 class CopyCourseController < ApplicationController
   respond_to :html
-  before_action :require_admin_permissions
+  before_action :require_admin_permissions if Features.wiki_ed?
   def index; end
 
   def copy

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -227,7 +227,7 @@ class CoursesController < ApplicationController
   def validate
     slug = params[:id].gsub(/\.json$/, '')
     @course = find_course_by_slug(slug)
-    course_cloned_status = @course.cloned_status === 3
+    course_cloned_status = @course.cloned_status == 3
     raise NotPermittedError unless current_user&.can_edit?(@course) || course_cloned_status
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -227,7 +227,8 @@ class CoursesController < ApplicationController
   def validate
     slug = params[:id].gsub(/\.json$/, '')
     @course = find_course_by_slug(slug)
-    raise NotPermittedError unless current_user&.can_edit?(@course)
+    course_cloned_status = @course.cloned_status === 3
+    raise NotPermittedError unless current_user&.can_edit?(@course) || course_cloned_status
   end
 
   def handle_course_announcement(instructor)

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# this file needed to be edited.
 #= Copy course from another server
 class CopyCourse
   def initialize(url:, user_data:)

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-
+# this file needed to be edited.
 #= Copy course from another server
 class CopyCourse
-  def initialize(url:)
+  def initialize(url:, user_data:)
     @url = url
+    @user_data = user_data
   end
 
   def make_copy
@@ -12,8 +13,10 @@ class CopyCourse
     add_tracked_wikis
     @cat_data = retrieve_categories_data
     copy_tracked_categories_data
-    @users_data = retrieve_users_data
-    copy_users_data
+    if @user_data.present? && @user_data != '0'
+      @users_data = retrieve_users_data
+      copy_users_data
+    end
     @timeline_data = retrieve_timeline_data
     copy_timeline_data
     return { course: @course, error: nil }

--- a/app/views/copy_course/index.html.haml
+++ b/app/views/copy_course/index.html.haml
@@ -1,5 +1,3 @@
-- content_for :before_title, 'Admin - '
-
 .container.dashboard
   %header
     %h1
@@ -12,5 +10,9 @@
 .container
   = form_tag copy_course_path, class: 'explore-courses', method: :post do
     = text_field_tag(:url, '', placeholder: 'Copy course URL here...')
+    %div.checkbox-group
+      = check_box_tag(:user_data, '1', true)
+      %label{for: 'user_data'} Copy User Data
     %button{type: 'submit'}
-      %i.icon.icon-check
+      %div.button.dark
+        Copy Course

--- a/app/views/dashboard/_open_course_creation.html.haml
+++ b/app/views/dashboard/_open_course_creation.html.haml
@@ -15,6 +15,10 @@
       = t("courses_generic.creator.create_new")
       %i.icon.icon-plus
   %div
+    = link_to copy_course_path, class: 'button stacked dark dashboard-cta' do
+      = "Copy Course from another Server"
+      %i.icon.icon-plus
+  %div
     = link_to explore_path, class: 'button stacked dark dashboard-cta' do
       = t("courses_generic.creator.find")
       %span.icon.icon-rt_arrow

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,12 +912,8 @@ en:
       clone_this: Clone This Program
       clone_successful: Program Successfully Cloned
       clone_successful_details: >
-        Your program has been cjhbjhbjloned.
+        Your program has been cloned.
         Click 'Save' below to finalize it.
-      copy_successful_details: >
-        Your coujhbjhbrse5 mnbjhbjhbjhb has been cloned, including the elements of the timeline
-        (weeks and blocks). Be sure to add the dates, which are not carried over.
-        Has anything else about your course changed? Feel free to update it now.
       course_when: Add something in the 'When' field (for example, the month and year) to differentiate it from the original.
       course_dates_info: >
         Enter the starting and ending dates for your program. You may wish to extend the end to several hours or days beyond

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,8 +551,13 @@ en:
         The cloned timeline will automatically adjust the dates to account for
         weeks that have no scheduled meetings.
       clone_successful: Update Details for Cloned Course
+      copy_successful: Update Details for Copied Course
       clone_successful_details: >
         Your course has been cloned, including the elements of the timeline
+        (weeks and blocks). Be sure to add the dates, which are not carried over.
+        Has anything else about your course changed? Feel free to update it now.
+      copy_successful_details: >
+        Your course has been copied, including the elements of the timeline
         (weeks and blocks). Be sure to add the dates, which are not carried over.
         Has anything else about your course changed? Feel free to update it now.
       course_dates_info: Enter the starting and ending dates for your course. In the next step, you can choose when to begin the Wikipedia assignment within that timeframe.
@@ -907,8 +912,12 @@ en:
       clone_this: Clone This Program
       clone_successful: Program Successfully Cloned
       clone_successful_details: >
-        Your program has been cloned.
+        Your program has been cjhbjhbjloned.
         Click 'Save' below to finalize it.
+      copy_successful_details: >
+        Your coujhbjhbrse5 mnbjhbjhbjhb has been cloned, including the elements of the timeline
+        (weeks and blocks). Be sure to add the dates, which are not carried over.
+        Has anything else about your course changed? Feel free to update it now.
       course_when: Add something in the 'When' field (for example, the month and year) to differentiate it from the original.
       course_dates_info: >
         Enter the starting and ending dates for your program. You may wish to extend the end to several hours or days beyond

--- a/spec/controllers/copy_course_controller_spec.rb
+++ b/spec/controllers/copy_course_controller_spec.rb
@@ -59,10 +59,7 @@ describe CopyCourseController, type: :request do
 
       it 'renders the success message' do
         subject
-        expect(response).to redirect_to(copy_course_path)
-        expect(flash[:notice]).to eq('Course Black life matters was created.'\
-                                     '&nbsp;<a href="/courses/none/Black_life_'\
-                                     'matters_(none)">Go to course</a>')
+        expect(response).to redirect_to(/courses\/none\/Black_life_matters_\(none\)/)
       end
     end
   end

--- a/spec/controllers/copy_course_controller_spec.rb
+++ b/spec/controllers/copy_course_controller_spec.rb
@@ -59,7 +59,7 @@ describe CopyCourseController, type: :request do
 
       it 'renders the success message' do
         subject
-        expect(response).to redirect_to(/courses\/none\/Black_life_matters_\(none\)/)
+        expect(response).to redirect_to(%r{courses/none/Black_life_matters_\(none\)})
       end
     end
   end

--- a/spec/features/course_copying_spec.rb
+++ b/spec/features/course_copying_spec.rb
@@ -51,11 +51,9 @@ describe 'course copying', type: :feature, js: true do
     find('input#no_holidays').click
     expect(page).not_to have_content 'Mark the holidays'
     click_button 'Save New Course'
-
-    sleep 0.5
+    expect(page).to have_current_path('/courses/New_School/New_Course_Title_(Spring2016)')
 
     new_course = Course.last
-    expect(page).to have_current_path('/courses/New_School/New_Course_Title_(Spring2016)')
     expect(new_course.term).to eq('Spring2016')
     expect(new_course.weekdays).not_to eq('0000000')
     expect(new_course.subject).to eq('New Subject')

--- a/spec/features/course_copying_spec.rb
+++ b/spec/features/course_copying_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'course copying', type: :feature, js: true do
+  let(:user) { create(:user) }
+  let(:course_url) do
+    'https://dashboard.wikiedu.org/courses/Riverside_City_College' \
+      '/4A_Wikipedia_Assignment_(Spring_2024)'
+  end
+
+  before do
+    login_as(user, scope: :user)
+    stub_oauth_edit
+    stub_course
+    allow(Features).to receive(:wiki_ed?).and_return(false)
+    allow(Features).to receive(:open_course_creation?).and_return(true)
+  end
+
+  let(:new_term) { 'Spring2016' }
+  let(:subject) { 'Advanced Foo' }
+
+  it 'checks copying of course across server' do
+    visit root_path
+    click_link 'Copy Course from another Server'
+    fill_in 'url', with: course_url
+    click_button 'Copy Course'
+
+    within('.wizard__panel.active.cloned-course') do
+      fill_in 'course_title', with: 'New Course Title'
+      fill_in 'course_school', with: 'New School'
+      fill_in 'course_subject', with: 'New Subject'
+      fill_in 'course_description', with: 'New Course Description'
+    end
+    find('input#course_term').click
+    fill_in 'course_term', with: new_term
+
+    within '#details_column' do
+      find('input#course_start').click
+      find('div.DayPicker-Day', text: 13).click
+      find('input#course_end').click
+      find('div.DayPicker-Day', text: 28).click
+      find('input#timeline_start').click
+      find('div.DayPicker-Day', text: 14).click
+      find('input#timeline_end').click
+      find('div.DayPicker-Day', text: 27).click
+    end
+
+    find('h3#clone_modal_header').click # This is just too close the datepicker
+    omniclick find('span', text: 'MO')
+    click_button 'Save New Course'
+    expect(page).to have_content 'Mark the holidays' # Error message upon click.
+    find('input#no_holidays').click
+    expect(page).not_to have_content 'Mark the holidays'
+    click_button 'Save New Course'
+
+    new_course = Course.last
+    expect(page).to have_current_path('/courses/New_School/New_Course_Title_(Spring2016)')
+    expect(new_course.term).to eq('Spring2016')
+    expect(new_course.weekdays).not_to eq('0000000')
+    expect(new_course.subject).to eq('New Subject')
+    expect(Week.count).to eq(1)
+  end
+end

--- a/spec/features/course_copying_spec.rb
+++ b/spec/features/course_copying_spec.rb
@@ -9,11 +9,10 @@ describe 'course copying', type: :feature, js: true do
   end
 
   before do
-    login_as(user, scope: :user)
-    stub_oauth_edit
-    stub_course
     allow(Features).to receive(:wiki_ed?).and_return(false)
     allow(Features).to receive(:open_course_creation?).and_return(true)
+    stub_course
+    login_as(user, scope: :user)
   end
 
   let(:new_term) { 'Spring2016' }
@@ -52,6 +51,8 @@ describe 'course copying', type: :feature, js: true do
     find('input#no_holidays').click
     expect(page).not_to have_content 'Mark the holidays'
     click_button 'Save New Course'
+
+    sleep 0.5
 
     new_course = Course.last
     expect(page).to have_current_path('/courses/New_School/New_Course_Title_(Spring2016)')

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -127,7 +127,7 @@ describe CopyCourse do
   end
 
   let(:subject) do
-    service = described_class.new(url: url_base + existent_prod_course_slug)
+    service = described_class.new(url: url_base + existent_prod_course_slug, user_data: true)
     service.make_copy
   end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -315,4 +315,243 @@ module RequestHelpers
     stub_request(:get, /.*wikipedia.*/)
       .to_return(status: 200, body: response, headers: {})
   end
+
+  def stub_course_response_body
+    response =
+      '{
+      "course": {
+        "id": 17794,
+        "title": "4A Wikipedia Assignment",
+        "description": "Students will edit science articles-primarily physics.
+        They will add content, images and references",
+        "start": "2024-02-12T00: 00: 00.000Z",
+        "end": "2024-06-14T23: 59: 59.000Z",
+        "school": "Riverside City College",
+        "subject": "Science Communication",
+        "slug": "Riverside_City_College/4A_Wikipedia_Assignment_(Spring_2024)",
+        "url": "https: //en.wikipedia.org/wiki/Wikipedia:Wiki_Ed/Riverside_City_College
+        4A_Wikipedia_Assignment_(Spring_2024)",
+        "submitted": true,
+        "expected_students": 36,
+        "timeline_start": "2024-02-12T00:00:00.000Z",
+        "timeline_end": "2024-06-14T23:59:59.000Z",
+        "day_exceptions": ",20240219",
+        "weekdays": "0101000",
+        "no_day_exceptions": false,
+        "updated_at": "2024-06-18T21:20:34.000Z",
+        "string_prefix": "courses",
+        "use_start_and_end_times": false,
+        "type": "ClassroomProgramCourse",
+        "home_wiki": { "id": 1, "language": "en", "project": "wikipedia" },
+        "character_sum": 8225,
+        "upload_count": 0,
+        "uploads_in_use_count": 0,
+        "upload_usages_count": 0,
+        "cloned_status": null,
+        "flags": {
+          "academic_system": null,
+          "format": "In-person",
+          "timeline_enabled": true,
+          "wiki_edits_enabled": true,
+          "online_volunteers_enabled": false,
+          "disable_student_emails": false,
+          "stay_in_sandbox": false,
+          "retain_available_articles": true,
+          "edit_settings": {
+            "wiki_course_page_enabled": true,
+            "assignment_edits_enabled": true,
+            "enrollment_edits_enabled": true
+          },
+          "peer_review_count": 1,
+          "longest_update": 301,
+          "first_update": {
+            "enqueued_at": "2023-12-03T15:44:56.633Z",
+            "queue_name": "medium_update",
+            "queue_latency": 0.007666349411010742
+          },
+          "update_logs": {
+            "14960": {
+              "start_time": "2024-06-18T20:35:26.690+00:00",
+              "end_time": "2024-06-18T20:35:29.216+00:00",
+              "sentry_tag_uuid": "69e140e9-11de-4651-8d19-1d5fcd3b663b",
+              "error_count": 0
+            }
+          },
+          "average_update_delay": 300,
+          "salesforce_id": "a0fVR000000CwBV",
+          "recap_sent_at": "2024-06-15T11:30:04.078Z"
+        },
+        "level": "Introductory",
+        "format": "In-person",
+        "private": false,
+        "closed?": false,
+        "training_library_slug": "students",
+        "peer_review_count": 1,
+        "needs_update": false,
+        "update_until": "2024-07-14T23:59:59.000Z",
+        "withdrawn": false,
+        "created_at": "2023-12-03T15:22:55.000Z",
+        "wikis": [{ "language": "en", "project": "wikipedia" }],
+        "namespaces": [],
+        "timeline_enabled": true,
+        "disable_student_emails": false,
+        "academic_system": null,
+        "home_wiki_bytes_per_word": 5.175,
+        "home_wiki_edits_enabled": true,
+        "wiki_edits_enabled": true,
+        "assignment_edits_enabled": true,
+        "wiki_course_page_enabled": true,
+        "enrollment_edits_enabled": true,
+        "account_requests_enabled": false,
+        "online_volunteers_enabled": false,
+        "progress_tracker_enabled": true,
+        "stay_in_sandbox": false,
+        "no_sandboxes": false,
+        "retain_available_articles": true,
+        "review_bibliography": false,
+        "term": "Spring 2024",
+        "legacy": false,
+        "ended": true,
+        "published": true,
+        "closed": false,
+        "enroll_url": "https: //dashboard.wikiedu.org/courses/Riverside_City_College
+        /4A_Wikipedia_Assignment_(Spring_2024)/enroll/",
+        "wiki_string_prefix": "articles",
+        "returning_instructor": true,
+        "created_count": "0",
+        "edited_count": "10",
+        "article_count": 10,
+        "edit_count": "177",
+        "student_count": 36,
+        "trained_count": 9,
+        "word_count": "1.59K",
+        "references_count": "13",
+        "view_count": "275K",
+        "character_sum_human": "8.23K",
+        "updates": {
+          "average_delay": 300,
+          "last_update": {
+            "start_time": "2024-06-18T21:20:31.489+00:00",
+            "end_time": "2024-06-18T21:20:34.301+00:00",
+            "sentry_tag_uuid": "64ae491f-2e54-4059-880d-b479cc81adac",
+            "error_count": 0
+          }
+        },
+        "passcode": "****",
+        "canUploadSyllabus": false
+      }
+    }'
+
+    url = 'https://dashboard.wikiedu.org/courses/Riverside_City_College' \
+          '/4A_Wikipedia_Assignment_(Spring_2024)/course.json'
+    stub_request(:get, url)
+      .to_return(status: 200, body: response, headers: {})
+  end
+
+  def stub_categories
+    categories_response_body =
+      '{
+      "course": {
+        "categories": [
+          {
+            "name": "Category 0",
+            "depth": 0,
+            "source": "Source 0",
+            "wiki": {
+              "id": 1,
+              "language": "en",
+              "project": "wikipedia"
+            }
+          }
+        ]
+      }
+    }'
+
+    url = 'https://dashboard.wikiedu.org/courses/Riverside_City_College' \
+          '/4A_Wikipedia_Assignment_(Spring_2024)/categories.json'
+    stub_request(:get, url)
+      .to_return(status: 200, body: categories_response_body, headers: {})
+  end
+
+  def stub_timeline
+    timeline_response_body =
+      '{
+      "course": {
+        "weeks": [
+          {
+            "id": 57366,
+            "order": 1,
+            "start_date_raw": "2022-01-09T00:00:00.000Z",
+            "end_date_raw": "2022-01-15T23:59:59.999Z",
+            "start_date": "01/09",
+            "end_date": "01/15",
+            "title": null,
+            "blocks": [
+              {
+                "id": 127799,
+                "kind": 0,
+                "content": "Welcome to your Wikipedia assignment course timeline.
+                            This page guides you through the steps you will need to
+                            complete for your Wikipedia assignment, with links to training
+                            modules and your classmates work spaces. Your course has
+                            been assigned a Wikipedia Expert. You can reach them
+                            through the Get Help button at the top of this page.",
+                "week_id": 57366,
+                "title": "Introduction to the Wikipedia assignment",
+                "order": 1,
+                "due_date": null,
+                "points": null
+              }
+            ]
+          }
+        ]
+      }
+    }'
+    url = 'https://dashboard.wikiedu.org/courses/Riverside_City_College' \
+          '/4A_Wikipedia_Assignment_(Spring_2024)/timeline.json'
+    stub_request(:get, url)
+      .to_return(status: 200, body: timeline_response_body, headers: {})
+  end
+
+  def stub_users
+    users_response_body =
+      '{
+      "course": {
+        "users": [
+          {
+            "role": 1,
+            "id": 28451264,
+            "username": "Joshua Stone"
+          },
+          {
+            "role": 4,
+            "id": 22694295,
+            "username": "Helaine (Wiki Ed)"
+          },
+          {
+            "role": 0,
+            "id": 28515697,
+            "username": "CharlieJ385"
+          },
+          {
+            "role": 0,
+            "id": 28515751,
+            "username": "Diqi Yan"
+          }
+        ]
+      }
+    }'
+
+    url = 'https://dashboard.wikiedu.org/courses/Riverside_City_College' \
+          '/4A_Wikipedia_Assignment_(Spring_2024)/users.json'
+    stub_request(:get, url)
+      .to_return(status: 200, body: users_response_body, headers: {})
+  end
+
+  def stub_course
+    stub_course_response_body
+    stub_categories
+    stub_timeline
+    stub_users
+  end
 end


### PR DESCRIPTION
## What this PR does

This PR adds the functionality of copying a course, along with its timeline for `Non-Admins` from Wiki-Edu dashboard to Programs & Events Dashboard.  Additionally, it makes copying of `user data` optional for both dashboards and provides an option to update course details after the course is copied.

Detailed Changes:

- [X] Improved UI of the copy_course page.
- [X] Added `Copy Course from another Server` button on Homepage.
- [X] Made copying of `User_data` optional for both the Dashboards.
- [X] Added permission for non-admins to access 'copy course' page on P&E dashboard.
- [X] Added cloned modal to update details after copying of a course.
- [X] Added permission for non-admins to update the copied course.
- [X] Added Tests.

## Screenshots
Before:
![Screenshot 2024-06-24 at 7 17 28 PM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/b5627cb9-cb6f-4e1a-99ae-953879510a4a)

After:
![Screenshot 2024-06-24 at 7 17 59 PM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/d0302c1c-172a-4dca-98e4-731ac0d035e4)

![Screen Shot 2024-06-24 at 19 28 10](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/e21d43d1-a79a-4b1b-9ce4-2920a3b2a52e)



