### PR TITLE
3. feature/add-module-to-training-library-using-dashboard

### DIFF
--- a/app/assets/javascripts/actions/training_modification_actions.js
+++ b/app/assets/javascripts/actions/training_modification_actions.js
@@ -48,6 +48,12 @@ const categoryValidationRules = [
   { keyword: 'description', field: 'description' }
 ];
 
+const moduleValidationRules = [
+  { keyword: 'name', field: 'name' },
+  { keyword: 'slug', field: 'slug' },
+  { keyword: 'description', field: 'description' }
+];
+
 const performValidation = (error, dispatch, validationRules) => {
   const errorMessages = error.responseText.errorMessages;
   let apiFailDispatched = false;
@@ -132,5 +138,33 @@ export const createCategory = (library_id, category, setSubmitting, toggleModal)
   })
   .catch((error) => {
     performValidation(error, dispatch, categoryValidationRules);
+  });
+};
+
+const addModulePromise = async (library_id, category_id, module, setSubmitting) => {
+  const response = await request(`/training/${library_id}/${category_id}/add_module`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ module }),
+  });
+  setSubmitting(false);
+  if (!response.ok) {
+    logErrorMessage(response);
+    const data = await response.json();
+    response.responseText = data;
+    throw response;
+  }
+  return response.json();
+};
+
+export const addModule = (library_id, category_id, module, setSubmitting) => (dispatch) => {
+  return addModulePromise(library_id, category_id, module, setSubmitting)
+  .then(() => {
+    window.location.href = `/training/${library_id}`;
+  })
+  .catch((error) => {
+    performValidation(error, dispatch, moduleValidationRules);
   });
 };

--- a/app/assets/javascripts/training/components/modals/add_module.jsx
+++ b/app/assets/javascripts/training/components/modals/add_module.jsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import Modal from '../../../components/common/modal.jsx';
+import TextInput from '../../../components/common/text_input.jsx';
+import TextAreaInput from '../../../components/common/text_area_input.jsx';
+import { addModule } from '../../../actions/training_modification_actions.js';
+import { setValid, setInvalid, activateValidations, resetValidations } from '../../../actions/validation_actions.js';
+import { firstValidationErrorMessage } from '../../../selectors';
+
+const AddModule = (props) => {
+  const [submitting, setSubmitting] = useState(false);
+  const [module, setModule] = useState({
+    name: '',
+    slug: '',
+    description: ''
+  });
+  const firstErrorMessage = useSelector(state => firstValidationErrorMessage(state));
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { library_id, category_id } = useParams();
+  const libraryPath = location.pathname.split('/').slice(0, 3).join('/');
+
+  const handleInputChange = (key, value) => {
+    setModule(prevModule => ({
+      ...prevModule,
+      [key]: value
+    }));
+  };
+
+  useEffect(() => {
+    dispatch(resetValidations());
+  }, [props.editMode]);
+
+  const validateFields = () => {
+    let valid = true;
+    const message = I18n.t('training.validation_message');
+    if (!module.name.trim()) {
+      dispatch(setInvalid('name', message));
+      valid = false;
+    } else {
+      dispatch(setValid('name'));
+    }
+
+    if (!module.slug.trim()) {
+      dispatch(setInvalid('slug', message));
+      valid = false;
+    } else {
+      dispatch(setValid('slug'));
+    }
+
+    if (!module.description.trim()) {
+      dispatch(setInvalid('description', message));
+      valid = false;
+    } else {
+      dispatch(setValid('description'));
+    }
+
+    return valid;
+  };
+
+  const submitHandler = () => {
+    dispatch(activateValidations());
+
+    if (validateFields()) {
+      setSubmitting(true);
+      dispatch(addModule(library_id, category_id, module, setSubmitting));
+    }
+  };
+
+  const handleCancelClick = () => {
+    navigate(libraryPath);
+  };
+
+  let formStyle;
+  if (submitting) {
+    formStyle = { pointerEvents: 'none', opacity: '0.5' };
+  }
+
+  if (!props.editMode) {
+    return null;
+  }
+
+  return (
+    <div className="training-modification container lib-container">
+      <Modal>
+        <div className="container">
+          <div className="wizard__panel active training_modal" style={formStyle}>
+            <h3>{I18n.t('training.add_new_module')}</h3>
+            <p>{I18n.t('training.add_module_msg')}</p>
+            <div className="column">
+              <TextInput
+                id="name"
+                onChange={handleInputChange}
+                value={module.name}
+                value_key="name"
+                required
+                editable
+                label={I18n.t('training.module_name')}
+                placeholder={`${I18n.t('training.enter')} ${I18n.t('training.module_name')}`}
+              />
+              <TextInput
+                id="slug"
+                onChange={handleInputChange}
+                value={module.slug}
+                value_key="slug"
+                required
+                editable
+                label={I18n.t('training.module_slug')}
+                placeholder={`${I18n.t('training.enter')} ${I18n.t('training.module_slug')}`}
+              />
+              <button className="button light" onClick={handleCancelClick}>{I18n.t('training.cancel')}</button>
+              <span className="validation-error"> &nbsp; {firstErrorMessage || '\xa0'}</span>
+            </div>
+            <div className="column form-group">
+              <TextAreaInput
+                id="description"
+                onChange={handleInputChange}
+                value={module.description}
+                value_key="description"
+                required
+                editable
+                label={I18n.t('training.module_description')}
+                placeholder={`${I18n.t('training.enter')} ${I18n.t('training.module_description')}`}
+              />
+              <button className="button dark right" onClick={submitHandler}>{I18n.t('training.add')}</button>
+            </div>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default AddModule;

--- a/app/assets/javascripts/training/components/training_app.jsx
+++ b/app/assets/javascripts/training/components/training_app.jsx
@@ -9,6 +9,7 @@ import TrainingModuleHandler from './training_module_handler.jsx';
 import TrainingSlideHandler from './training_slide_handler.jsx';
 import { getCurrentUser } from '../../selectors/index.js';
 import { getTrainingMode } from '../../actions/training_modification_actions.js';
+import AddModule from './modals/add_module.jsx';
 
 const TrainingApp = () => {
   const dispatch = useDispatch();
@@ -26,6 +27,7 @@ const TrainingApp = () => {
         <Route path=":library_id" element={<TrainingLibraryHandler editMode={editMode}/>}/>
         <Route path=":library_id/:module_id" element={<TrainingModuleHandler />} />
         <Route path=":library_id/:module_id/:slide_id" element={<TrainingSlideHandler />} />
+        <Route path=":library_id/edit/:category_id/add_module" element={<AddModule editMode={editMode} />} />
       </Routes>
     </div>
   );

--- a/app/controllers/training_modules_controller.rb
+++ b/app/controllers/training_modules_controller.rb
@@ -14,8 +14,79 @@ class TrainingModulesController < ApplicationController
 
   def find
     training_module = TrainingModule.find(params[:module_id])
-    # Use a specific training library for the module, or a default library if it is not found
     training_library = training_module.find_or_default_library
     redirect_to "/training/#{training_library.slug}/#{training_module.slug}"
+  end
+
+  def add_module
+    @library = find_library
+    return unless @library
+
+    category = find_category(@library)
+    return unless category
+
+    @module = create_module
+    return unless @module.persisted?
+
+    associate_module_with_category(category)
+    save_library_with_module
+  end
+
+  private
+
+  def find_library
+    library_slug = params[:library_id]
+    library = TrainingLibrary.find_by(slug: library_slug)
+    unless library
+      render json: { status: 'error',
+                     errorMessages: ["Training library with slug '#{library_slug}' not found."] },
+             status: :not_found
+    end
+    library
+  end
+
+  def find_category(library)
+    category_title = params[:category_id]
+    category = library.categories.find { |cat| cat['title'] == category_title }
+    unless category
+      render json: { status: 'error',
+                     errorMessages: [
+                       "Category '#{category_title}' not exist in library '#{library.slug}'."
+                     ] },
+             status: :not_found
+    end
+    category
+  end
+
+  def create_module
+    training_module = TrainingModule.new(training_module_params)
+    unless training_module.save
+      render json: { status: 'error', errorMessages: training_module.errors.full_messages },
+             status: :unprocessable_entity
+    end
+    training_module
+  end
+
+  def associate_module_with_category(category)
+    category['modules'] ||= []
+    category['modules'] << {
+      'name' => @module.name,
+      'slug' => @module.slug,
+      'description' => @module.description
+    }
+  end
+
+  def save_library_with_module
+    if @library.save
+      render json: { status: 'success', data: @module }, status: :created
+    else
+      render json: { status: 'error', errorMessages: @library.errors.full_messages },
+             status: :unprocessable_entity
+    end
+  end
+
+  # Strong parameters method to permit necessary fields for module creation
+  def training_module_params
+    params.require(:module).permit(:name, :slug, :description)
   end
 end

--- a/app/views/training/show.html.haml
+++ b/app/views/training/show.html.haml
@@ -37,6 +37,7 @@
                   %span= lib_module.description
           - if @current_training_mode['editMode']
             .training-modification.training-modification-buttons
+              = link_to t("training.add_module"), add_module_training_path(@library.slug, category_id: lib_category['title']), class: 'button dark'
               - if lib_category.modules.empty?
                 = link_to delete_category_path(library_id: @library.slug, category_id: lib_category['title']), method: :delete, data: { confirm: t('training.confirmation.delete_category') }, class: 'button danger' do
                   = t("training.delete_category")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1369,7 +1369,12 @@ en:
     week_number: "Week %{number}"
 
   training:
+    add: Add
     add_module: Add Module
+    add_module_msg: >
+      This is where you can add a new module to the library.
+      Once this module is created, you can add slides to it.
+    add_new_module: Add New Module
     cancel: Cancel
     category: Category
     category_title: Category Title
@@ -1378,9 +1383,9 @@ en:
       delete_category: Are you sure you want to delete this category?
     create: Create
     create_category: Create New Category
-    create_library: Create New Library
     create_category_msg: >
       Once this category is created, users are able to add modules and slides under this category
+    create_library: Create New Library
     create_library_msg: >
       This is where you can create a new library.
       Once this library is created, user can add modules and slides to it and
@@ -1401,6 +1406,9 @@ en:
     library_slug: Library Slug
     library_introduction: Library Introduction
     logged_out: "You are logged out. You will not receive credit for completing this module unless you log in."
+    module_name: Module Name
+    module_slug: Module Slug
+    module_description: Module Description
     next: Next Page
     notice:
       created: Created Successfully
@@ -1414,6 +1422,9 @@ en:
     reload_from_source: reload from source
     search_training_resources: Search for training resources
     start: Start
+    success_message:
+      library_created: Library created successfully
+      category_created: Category created successfully
     switch_edit: Switch to Edit Mode
     switch_view: Switch to View Mode
     table_of_contents: Table of Contents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,7 +342,7 @@ Rails.application.routes.draw do
   get 'user_training_status' => 'training_status#user'
 
   # for React
-  get 'training/:library_id/:module_id(/*any)' => 'training#slide_view'
+  get 'training/:library_id/:module_id/:slide_id' => 'training#slide_view'
 
   # API for slides for a module
   get 'training_modules' => 'training_modules#index'
@@ -362,6 +362,10 @@ Rails.application.routes.draw do
   # Create
   post 'training/create_library' => 'training_library#create_library'
   post 'training/:library_id/create_category' => 'training_library#create_category'
+  post 'training/:library_id/:category_id/add_module' => 'training_modules#add_module'
+
+  # Read
+  get 'training/:library_id/edit/:category_id/add_module', to: 'training#show', as: :add_module_training
 
   # Delete
   delete 'training/:library_id/categories/:category_id', to: 'training_library#delete_category', as: :delete_category

--- a/spec/features/training_modification_spec.rb
+++ b/spec/features/training_modification_spec.rb
@@ -8,8 +8,8 @@ describe 'TrainingContent', type: :feature, js: true do
   let(:training_library) do
     create(:training_library,
            name: 'Example-Library',
-             slug: 'example-library',
-             introduction: 'For Testing')
+           slug: 'example-library',
+           introduction: 'For Testing')
   end
 
   before(:all) do
@@ -148,6 +148,33 @@ describe 'TrainingContent', type: :feature, js: true do
 
       expect(page).not_to have_content('Testing Category')
       expect(page).not_to have_content('This category is only created for testing purposes.')
+    end
+  end
+
+  describe 'TrainingModule' do
+    before do
+      login_as(user, scope: :user)
+      visit '/training'
+      click_button 'Switch to Edit Mode'
+      visit "/training/#{training_library.slug}"
+    end
+
+    it 'add module after creating a category' do
+      visit "/training/#{training_library.slug}"
+      click_button 'Create New Category'
+
+      fill_in 'title', with: 'Testing Category'
+      fill_in 'description', with: 'This category is only created for testing purposes.'
+      click_button 'Create'
+      expect(page).to have_content('Testing Category')
+
+      click_link 'Add Module'
+      fill_in 'Module Name', with: 'Testing Module'
+      fill_in 'Module Slug', with: 'testing-module'
+      fill_in 'Module Description', with: 'This module is only created for testing purposes.'
+      click_button 'Add'
+      expect(page).to have_content('Testing Module')
+      expect(page).to have_content('This module is only created for testing purposes.')
     end
   end
 end


### PR DESCRIPTION
## What this PR does
This pr added functionality for creating new Training Modules using dashboard.

## Screenshots

### Before:
Library Page
![0  Library Page (Before)](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/dfc97233-712a-4997-87fd-a38594b05349)

### After:
1. Add Module button on library page
![1  Add modules button on library page](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/9cdd58bf-43f5-4860-b8e9-3c71b81ca624)

2. Modal to gather data from user
![2  Add modules modal](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/5188e192-91f1-4ec3-ac0b-b66bded9280f)

3. Successfull addition of new module 
![3  Module Created Successfuly](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/18be45a8-904d-4707-ac7c-8fc300ee679b)

4. New Module Page
![4  New Module Page](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/119471995/81ca69be-6a9f-41bc-906b-828cff8ae97e)




