### PR TITLE
Implement `CourseUserWikiTimeslice.update_cache_from_revisions`

### DIFF
--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -20,6 +20,98 @@
 #  updated_at          :datetime         not null
 #
 class CourseUserWikiTimeslice < ApplicationRecord
-  belongs_to :courses_users
+  belongs_to :courses_users, foreign_key: 'course_user_id'
   belongs_to :wiki
+
+  ####################
+  # Instance methods #
+  ####################
+
+  # Assumes that the revisions are for their own course user wiki
+  def update_cache_from_revisions(revisions)
+    @revisions = revisions
+    @liverevisions = live_revisions
+    tracked_namespace_revisions = live_revisions_in_tracked_namespaces
+    self.total_uploads += courses_users.course.uploads.where(user_id: courses_users.user_id).count
+    update_character_sum(@liverevisions, tracked_namespace_revisions)
+    self.references_count += references_sum(tracked_namespace_revisions)
+
+    self.revision_count += filtered_live_revisions.size || 0
+    save
+  end
+
+  private
+
+  # Returns tracked revisions (revisions for tracked article courses)
+  # for which already exists an article record
+  # made for user_id. Notice that revisions are already made for a given user_id
+  def live_revisions
+    excluded_article_ids = courses_users.course.articles_courses.not_tracked.pluck(:article_id)
+    tracked_revisions = @revisions.reject do |revision|
+      excluded_article_ids.include?(revision.article_id)
+    end
+    # Ensure that article record exists for article_ids
+    article_ids = tracked_revisions.map(&:article_id)
+    articles_ids_with_article_records = Article.where(id: article_ids).pluck(:id)
+    filtered_tracked_revisions = tracked_revisions.select do |revision|
+      articles_ids_with_article_records.include?(revision.article_id)
+    end
+    filtered_tracked_revisions.reject(&:deleted)
+  end
+
+  def live_revisions_in_tracked_namespaces
+    course_article_ids = courses_users.course.articles.pluck(:id)
+    live_revisions.select do |revision|
+      course_article_ids.include?(revision.article_id)
+    end
+  end
+
+  def filtered_live_revisions
+    article_ids = @liverevisions.map(&:article_id)
+    articles = Article.where(id: article_ids, deleted: false)
+
+    # Filter revisions based on the fetched articles
+    live_article_ids = articles.pluck(:id)
+    @liverevisions.select do |rev|
+      live_article_ids.include?(rev.article_id)
+    end
+  end
+
+  def update_character_sum(revisions, tracked_namespace_revisions)
+    self.character_sum_ms += character_sum(tracked_namespace_revisions,
+                                           Article::Namespaces::MAINSPACE)
+    self.character_sum_us += character_sum(revisions, Article::Namespaces::USER)
+    self.character_sum_draft += character_sum(revisions, Article::Namespaces::DRAFT)
+  end
+
+  ##################
+  # Helper methods #
+  ##################
+
+  def character_sum(revisions, namespace)
+    article_ids = revisions.map(&:article_id)
+    articles = Article.where(id: article_ids, namespace:, deleted: false)
+
+    # Filter revisions based on the fetched articles
+    article_ids_in_namespace = articles.pluck(:id)
+    filtered_revisions = revisions.select do |rev|
+      article_ids_in_namespace.include?(rev.article_id) && rev.characters >= 0
+    end
+
+    # Sum characters
+    filtered_revisions.sum(&:characters)
+  end
+
+  def references_sum(revisions)
+    article_ids = revisions.map(&:article_id)
+    articles = Article.where(id: article_ids, namespace: Article::Namespaces::MAINSPACE,
+                             deleted: false)
+
+    # Filter revisions based on the fetched articles
+    article_ids_in_mainspace = articles.pluck(:id)
+    filtered_revisions = revisions.select do |rev|
+      article_ids_in_mainspace.include?(rev.article_id)
+    end
+    filtered_revisions.sum(&:references_added)
+  end
 end

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -32,7 +32,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
     @revisions = revisions
     @liverevisions = live_revisions
     tracked_namespace_revisions = live_revisions_in_tracked_namespaces
-    self.total_uploads += courses_users.course.uploads.where(user_id: courses_users.user_id).count
+    self.total_uploads = courses_users.course.uploads.where(user_id: courses_users.user_id).count
     update_character_sum(@liverevisions, tracked_namespace_revisions)
     self.references_count += references_sum(tracked_namespace_revisions)
 

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -5,7 +5,7 @@ require_dependency "#{Rails.root}/lib/errors/api_error_handling"
 
 #= Fetches wiki revision data from an endpoint that provides SQL query
 #= results from a replica wiki database on wmflabs:
-#=   https://dashboard-replica-endpoint.wmcloud.org/
+#=   https://replica-revision-tools.wmcloud.org/
 #= For what's going on at the other end, see:
 #=   https://github.com/WikiEducationFoundation/WikiEduDashboardTools
 class Replica
@@ -97,7 +97,7 @@ class Replica
   # query appropriate to that endpoint, return the parsed json response.
   #
   # Example revisions.php query:
-  #   https://dashboard-replica-endpoint.wmcloud.org//revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
+  #   ttps://replica-revision-tools.wmcloud.org/revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
   #
   # Example revisions.php parsed response:
   # [{"page_id"=>"44962463",
@@ -162,7 +162,7 @@ class Replica
     Net::HTTP::get_response(URI.parse(url))
   end
 
-  REPLICA_TOOL_URL = 'https://dashboard-replica-endpoint.wmcloud.org/'
+  REPLICA_TOOL_URL = 'https://replica-revision-tools.wmcloud.org/'
 
   def do_post(endpoint, key, data)
     url = "#{REPLICA_TOOL_URL}#{endpoint}"

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -97,7 +97,7 @@ class Replica
   # query appropriate to that endpoint, return the parsed json response.
   #
   # Example revisions.php query:
-  #   ttps://replica-revision-tools.wmcloud.org/revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
+  # https://replica-revision-tools.wmcloud.org/revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
   #
   # Example revisions.php parsed response:
   # [{"page_id"=>"44962463",

--- a/spec/factories/course_user_wiki_timeslices.rb
+++ b/spec/factories/course_user_wiki_timeslices.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: course_user_wiki_timeslices
+#
+#  id                  :bigint           not null, primary key
+#  course_user_id      :integer          not null
+#  wiki_id             :integer          not null
+#  start               :datetime
+#  end                 :datetime
+#  last_mw_rev_id      :integer
+#  total_uploads       :integer          default(0)
+#  character_sum_ms    :integer          default(0)
+#  character_sum_us    :integer          default(0)
+#  character_sum_draft :integer          default(0)
+#  references_count    :integer          default(0)
+#  revision_count      :integer          default(0)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
+FactoryBot.define do
+  factory :course_user_wiki_timeslice, class: 'CourseUserWikiTimeslice' do
+    nil
+  end
+end

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -260,35 +260,35 @@ describe Replica do
     let(:subject) { described_class.new(en_wiki).get_revisions(all_users, rev_start, rev_end) }
 
     it 'handles timeout errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ECONNREFUSED)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles failed queries' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles server errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 500, body: '', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles successful empty responses' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
       expect_any_instance_of(described_class).not_to receive(:log_error)
       expect(subject).to be_empty
@@ -300,35 +300,35 @@ describe Replica do
     let(:result) { described_class.new(en_wiki).post_existing_articles_by_title(article_titles) }
 
     it 'handles timeout errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ECONNREFUSED)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles failed queries' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles server errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 500, body: '', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles successful empty responses' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
       expect(result).to be_empty
     end

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -63,7 +63,7 @@ describe ArticleCourseTimeslice, type: :model do
   end
   let(:subject) { article_course_timeslice.update_cache_from_revisions revisions }
 
-  describe '.update_cache_from_revisions' do
+  describe '#update_cache_from_revisions' do
     it 'updates cache correctly' do
       expect(article_course_timeslice.character_sum).to eq(100)
       expect(article_course_timeslice.references_count).to eq(3)

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: course_user_wiki_timeslices
+#
+#  id                  :bigint           not null, primary key
+#  course_user_id      :integer          not null
+#  wiki_id             :integer          not null
+#  start               :datetime
+#  end                 :datetime
+#  last_mw_rev_id      :integer
+#  total_uploads       :integer          default(0)
+#  character_sum_ms    :integer          default(0)
+#  character_sum_us    :integer          default(0)
+#  character_sum_draft :integer          default(0)
+#  references_count    :integer          default(0)
+#  revision_count      :integer          default(0)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
+require 'rails_helper'
+
+describe CourseUserWikiTimeslice, type: :model do
+  # before { stub_wiki_validation }
+
+  describe '#update_cache_from_revisions' do
+    let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:refs_tags_key) { 'feature.wikitext.revision.ref_tags' }
+    let(:user) { create(:user, username: 'User') }
+    let(:course) { create(:course, start: '2015-01-01'.to_date, end: '2015-07-01'.to_date) }
+    let(:article) { create(:article, title: 'Selfie') }
+    let(:talk_page) { create(:article, title: 'Selfie', namespace: Article::Namespaces::TALK) }
+    let(:sandbox) { create(:article, title: 'User/Selfie', namespace: Article::Namespaces::USER) }
+    let(:draft) { create(:article, title: 'Selfie', namespace: Article::Namespaces::DRAFT) }
+    let(:courses_user) do
+      create(:courses_user,
+             course:,
+             user:)
+    end
+    let(:course_user_wiki_timeslice) do
+      create(:course_user_wiki_timeslice,
+             course_user_id: courses_user.id,
+             wiki_id: enwiki.id,
+             total_uploads: 100,
+             character_sum_ms: 3,
+             character_sum_us: 4,
+             character_sum_draft: 2,
+             references_count: 13,
+             revision_count: 23)
+    end
+    let(:revision0) do
+      create(:revision, article:,
+             characters: 123,
+             features: { 'num_ref' => 8 },
+             features_previous: { 'num_ref' => 1 },
+             user_id: course.id)
+    end
+    let(:revision1) do
+      create(:revision, article: talk_page,
+             characters: 200,
+             features: { 'num_ref' => 12 },
+             features_previous: { 'num_ref' => 10 },
+             user_id: course.id)
+    end
+    let(:revision2) do
+      create(:revision, article: sandbox,
+             characters: -65,
+             features: { 'num_ref' => 1 },
+             features_previous: { 'num_ref' => 2 },
+             user_id: course.id)
+    end
+    let(:revision3) do
+      create(:revision, article: draft,
+             characters: 225,
+             features: { 'num_ref' => 3 },
+             features_previous: { 'num_ref' => 3 },
+             user_id: course.id)
+    end
+    let(:revision4) do
+      create(:revision, article:,
+              characters: 34,
+              deleted: true, # deleted revision
+              features: { 'num_ref' => 2 },
+              features_previous: { 'num_ref' => 0 },
+              user_id: course.id)
+    end
+    let(:revision5) do
+      create(:revision, article_id: -1, # revision for a non-existing article
+              characters: 34,
+              deleted: false,
+              features: { 'num_ref' => 2 },
+              features_previous: { 'num_ref' => 0 },
+              user_id: course.id)
+    end
+    let(:revisions) { [revision0, revision1, revision2, revision3, revision4, revision5] }
+    let(:subject) { course_user_wiki_timeslice.update_cache_from_revisions revisions }
+
+    before do
+      # Make an article-course.
+      create(:articles_course,
+             article:,
+             course:)
+
+      # Create a common upload for the user
+      create(:commons_upload, user:, uploaded_at: '2015-02-01'.to_date)
+
+      # create the CoursesUsers record
+      courses_user
+    end
+
+    it 'updates caches respecting the namespaces' do
+      # Update caches
+      subject
+
+      # Fetch the created CourseUserWikiTimeslice entry
+      course_user_wiki_timeslice = described_class.all.first
+
+      expect(course_user_wiki_timeslice.total_uploads).to eq(101)
+      # Don't consider deleted revisions or revisions for articles that don't exist
+      expect(course_user_wiki_timeslice.revision_count).to eq(27)
+      # Only consider revision0 (mainspace)
+      expect(course_user_wiki_timeslice.character_sum_ms).to eq(126)
+      # Only consider revision2 (sandbox)
+      expect(course_user_wiki_timeslice.character_sum_us).to eq(4)
+      # Only consider revision3 (draft)
+      expect(course_user_wiki_timeslice.character_sum_draft).to eq(227)
+      # Only consider revision0 (mainspace)
+      expect(course_user_wiki_timeslice.references_count).to eq(20)
+    end
+
+    it 'only updates cache from tracked revisions' do
+      ArticlesCourses.first.update(tracked: false)
+      subject
+
+      # Fetch the created CourseUserWikiTimeslice entry
+      course_user_wiki_timeslice = described_class.all.first
+
+      # Only considers revisions for sandbox, talk_page and draft articles
+      expect(course_user_wiki_timeslice.revision_count).to eq(26)
+      # No revision is taken into account for character_sum_ms
+      expect(course_user_wiki_timeslice.character_sum_ms).to eq(3)
+      # Negative characters for sanbox revision don't change the sum
+      expect(course_user_wiki_timeslice.character_sum_us).to eq(4)
+      # Characters from raft revision is considered
+      expect(course_user_wiki_timeslice.character_sum_draft).to eq(227)
+      # No revision is taken into account for references_count
+      expect(course_user_wiki_timeslice.references_count).to eq(13)
+    end
+  end
+end

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -42,7 +42,7 @@ describe CourseUserWikiTimeslice, type: :model do
       create(:course_user_wiki_timeslice,
              course_user_id: courses_user.id,
              wiki_id: enwiki.id,
-             total_uploads: 100,
+             total_uploads: 0,
              character_sum_ms: 3,
              character_sum_us: 4,
              character_sum_draft: 2,
@@ -116,7 +116,7 @@ describe CourseUserWikiTimeslice, type: :model do
       # Fetch the created CourseUserWikiTimeslice entry
       course_user_wiki_timeslice = described_class.all.first
 
-      expect(course_user_wiki_timeslice.total_uploads).to eq(101)
+      expect(course_user_wiki_timeslice.total_uploads).to eq(1)
       # Don't consider deleted revisions or revisions for articles that don't exist
       expect(course_user_wiki_timeslice.revision_count).to eq(27)
       # Only consider revision0 (mainspace)

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -82,7 +82,7 @@ describe UpdateCourseStats do
       allow(Sentry).to receive(:capture_exception)
 
       # Raising errors only in Replica
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
       VCR.use_cassette 'course_update/replica' do
         subject
       end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -114,7 +114,7 @@ describe UpdateCourseStatsTimeslice do
       allow(Sentry).to receive(:capture_exception)
 
       # Raising errors only in Replica
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
       VCR.use_cassette 'course_update/replica' do
         subject
       end


### PR DESCRIPTION
## What this PR does
This PR implements the `update_cache_from_revisions` instance method for `CourseUserWikiTimeslice` and specs for it.
The behavior for the new method and its specs are based on the `update_cache` instance method for `CoursesUsers`.

In addition, this PR implements class method `update_all_caches_from_timeslices` for `CoursesUsers`, which involves calculating caches for `CoursesUsers` records based on the existing timeslices for them.

Finally, it updates the existing `UpdateCourseStatsTimeslice` class to update caches for `CourseUserWikiTimeslice` and `CoursesUsers`. I adds specs for it.

## Open questions and concerns
- As part of this PR, opened issue #[5865](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5865).
- `update_cache_from_revisions` assumes that revisions are already filtered by that specific course user wiki (similar approach I followed for `ArticleCourseWikiTimeslice.update_cache_from_revisions`). We could add some checks later.
- I had to replace a lot of `where` queries. We may want to make some performance improvements in the future.
- `CourseUserWikiTimeslice.total_uploads` is not really implemented yet. We're counting all the uploads for the course user in every run (it's not aggregated by wiki/dates).