### PR TITLE
Integrate Redux Toolkit and optimize store configuration

### DIFF
--- a/app/assets/javascripts/components/util/create_store.js
+++ b/app/assets/javascripts/components/util/create_store.js
@@ -1,6 +1,5 @@
-import { createStore, applyMiddleware, compose } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
 import reducer from '../../reducers';
-import thunk from 'redux-thunk';
 
 export const getStore = () => {
   const reactRoot = document.getElementById('react_root');
@@ -30,12 +29,24 @@ export const getStore = () => {
     };
   }
 
-  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-  const store = createStore(
+  // Determine if mutation checks should be enabled
+  const enableMutationChecks = false;
+
+  const store = configureStore({
     reducer,
     preloadedState,
-    composeEnhancers(applyMiddleware(thunk))
-  );
+    middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      // Temporarily disable mutation checks feature to facilitate Redux Toolkit migration.
+      // TODO: Gradually resolve state mutations and re-enable these checks in the future.
+      // Enable mutation checks when resolving or detecting these issues by setting enableMutationChecks to true.
+      immutableCheck: enableMutationChecks,
+      serializableCheck: enableMutationChecks,
+    }),
+    // Enable Redux DevTools only in development mode
+    devTools: process.env.NODE_ENV !== 'production'
+  });
+
   return store;
 };
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/register": "^7.18.9",
     "@rails/ujs": "^7.0.3-1",
+    "@reduxjs/toolkit": "^2.2.6",
     "@sentry/browser": "^6.18.1",
     "@tinymce/tinymce-react": "^3.12.6",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reduxjs/toolkit@npm:^2.2.6":
+  version: 2.2.6
+  resolution: "@reduxjs/toolkit@npm:2.2.6"
+  dependencies:
+    immer: ^10.0.3
+    redux: ^5.0.1
+    redux-thunk: ^3.1.0
+    reselect: ^5.1.0
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: 9cd02df5c7f2a40ce9ea41c74a7684a9be2b4adf75c2ad897375fb64b57c039e4fa7f2b74c86588434f795f3ab90b71a14ab6768ace8fd5c6d0153a6ed93ba83
+  languageName: node
+  linkType: hard
+
 "@sentry/browser@npm:^6.18.1":
   version: 6.19.7
   resolution: "@sentry/browser@npm:6.19.7"
@@ -2765,6 +2785,7 @@ __metadata:
     "@babel/register": ^7.18.9
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     "@rails/ujs": ^7.0.3-1
+    "@reduxjs/toolkit": ^2.2.6
     "@sentry/browser": ^6.18.1
     "@tinymce/tinymce-react": ^3.12.6
     "@wojtekmaj/enzyme-adapter-react-17": ^0.6.6
@@ -6845,6 +6866,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^10.0.3":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 07c67970b7d22aded73607193d84861bf786f07d47f7d7c98bb10016c7a88f6654ad78ae1e220b3c623695b133aabbf24f5eb8d9e8060cff11e89ccd81c9c10b
+  languageName: node
+  linkType: hard
+
 "import-fresh@npm:^3.0.0, import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -10645,12 +10673,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redux-thunk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "redux-thunk@npm:3.1.0"
+  peerDependencies:
+    redux: ^5.0.0
+  checksum: bea96f8233975aad4c9f24ca1ffd08ac7ec91eaefc26e7ba9935544dc55d7f09ba2aa726676dab53dc79d0c91e8071f9729cddfea927f4c41839757d2ade0f50
+  languageName: node
+  linkType: hard
+
 "redux@npm:^4.0.0, redux@npm:^4.0.5, redux@npm:^4.2.0":
   version: 4.2.0
   resolution: "redux@npm:4.2.0"
   dependencies:
     "@babel/runtime": ^7.9.2
   checksum: 75f3955c89b3f18edf5411e5fb482aa2e4f41a416183e8802a6bf6472c4fc3d47675b8b321d147f8af8e0f616436ac507bf5a25f1c4d6180e797b549c7db2c1d
+  languageName: node
+  linkType: hard
+
+"redux@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "redux@npm:5.0.1"
+  checksum: e74affa9009dd5d994878b9a1ce30d6569d986117175056edb003de2651c05b10fe7819d6fa94aea1a94de9a82f252f986547f007a2fbeb35c317a2e5f5ecf2c
   languageName: node
   linkType: hard
 
@@ -10850,6 +10894,13 @@ __metadata:
   version: 4.1.6
   resolution: "reselect@npm:4.1.6"
   checksum: 3ea1058422904063ec93c8f4693fe33dcb2178bbf417ace8db5b2c797a5875cf357d9308d11ed3942ee22507dd34ecfbf1f3a21340a4f31c206cab1d36ceef31
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "reselect@npm:5.1.1"
+  checksum: 5d32d48be29071ddda21a775945c2210cf4ca3fccde1c4a0e1582ac3bf99c431c6c2330ef7ca34eae4c06feea617e7cb2c275c4b33ccf9a930836dfc98b49b13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Redux Toolkit Integration

## What this PR does
This PR updates our Redux store configuration to use Redux Toolkit, simplifying our setup and leveraging built-in optimizations.

## Changes
- Replace `createStore` with `configureStore` from Redux Toolkit
- Remove explicit `thunk` middleware import (now included by default)
- Simplify middleware configuration
- Add conditional Redux DevTools enablement
- Remove manual compose enhancers setup

## Open questions and concerns

For now, I have simply replaced `createStore` with `configureStore`. This follows the suggestion from the Redux migration guide on the official Redux website, which states:

> "You should always start by replacing the legacy `createStore` call with `configureStore`. This is a one-time step, and all of the existing reducers and middleware will continue to work as-is. `configureStore includes development-mode checks for common mistakes like accidental mutations and non-serializable values`, so having those in place will help identify any areas of the codebase where those mistakes are happening."

For more details, refer to the Redux documentation:
https://redux.js.org/usage/migrating-to-modern-redux#modernizing-redux-logic-with-redux-toolkit

### a) Immutable and Serializable Checks
I have currently set `immutableCheck` and `serializableCheck` (provided by Redux Toolkit) to `false`. This decision was made because state mutations and non-serializable values were detected in our existing code, as shown in the screenshots below:

![Screenshot from 2024-06-30 15-51-05](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/41d667f2-e814-4b91-92a5-6f06aedc2dde)
![Screenshot from 2024-06-30 16-20-11](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/c3950efc-cb29-48d1-9b69-0ecab8f3f055)
![Screenshot from 2024-06-30 16-24-16](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/b6a3ea4d-ec0f-4495-ba1f-45e8f2e226ee)

I chose this approach for the following reasons:
1. It allows us to complete the migration to Redux Toolkit without immediately addressing these issues.
2. With these checks disabled, there are no errors or warnings, and the `dashboard functions as intended`.
3. The development-mode checks provided by Redux Toolkit are temporarily disabled to prevent disruption to our current workflow.

### b) Addressing Mutation and Serialization Issues
An important question to consider is whether we should address these mutation and serialization issues now or in the future, especially given the large number of reducers and actions that need to be checked for state mutations.

For example, we can enable mutation checks when resolving or detecting these issues by setting `enableMutationChecks` to `true`. Then, pick an existing slice reducer and its associated actions, and ensure there is no state mutation (RTK will automatically detect it). Replace them with RTK's `createSlice`. Repeat this process for one reducer at a time. After resolving all the state mutations, we can then `permanently re-enable these checks` i.e (development-mode checks for common mistakes like accidental mutations and non-serializable values).

### c) Redux DevTools in Production
I have also disabled Redux DevTools for production, but I'm not sure if this will be helpful.

Any suggestions regarding these three issues would be greatly appreciated. Thank you.
