### PR TITLE
Minor Fix: Footer outer line not visible in nav news

### DIFF
--- a/app/assets/stylesheets/modules/_nav_news.styl
+++ b/app/assets/stylesheets/modules/_nav_news.styl
@@ -135,8 +135,8 @@
   
 
 .padded-content__footer
-  margin-top 8px
-  margin-bottom -19px
+  margin-top 7px
+  margin-bottom -18px
 
 
 .news-container 


### PR DESCRIPTION

## What this PR does

Fixes the footer line for the navigation news, which was not visible.

## Screenshots
Before:

![Screenshot from 2024-06-30 19-26-02](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/32e52bcd-d97e-4ca1-8467-da376b90c17c)



After:

![After](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/af4b4ce2-30eb-43d5-ae9e-3d8fa249478c)


