### PR TITLE
[Data Rearchitecture Project] Switch to new replica endpoint server

### DIFF
--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -5,7 +5,7 @@ require_dependency "#{Rails.root}/lib/errors/api_error_handling"
 
 #= Fetches wiki revision data from an endpoint that provides SQL query
 #= results from a replica wiki database on wmflabs:
-#=   https://dashboard-replica-endpoint.wmcloud.org/
+#=   https://replica-revision-tools.wmcloud.org/
 #= For what's going on at the other end, see:
 #=   https://github.com/WikiEducationFoundation/WikiEduDashboardTools
 class Replica
@@ -97,7 +97,7 @@ class Replica
   # query appropriate to that endpoint, return the parsed json response.
   #
   # Example revisions.php query:
-  #   https://dashboard-replica-endpoint.wmcloud.org//revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
+  #   ttps://replica-revision-tools.wmcloud.org/revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
   #
   # Example revisions.php parsed response:
   # [{"page_id"=>"44962463",
@@ -162,7 +162,7 @@ class Replica
     Net::HTTP::get_response(URI.parse(url))
   end
 
-  REPLICA_TOOL_URL = 'https://dashboard-replica-endpoint.wmcloud.org/'
+  REPLICA_TOOL_URL = 'https://replica-revision-tools.wmcloud.org/'
 
   def do_post(endpoint, key, data)
     url = "#{REPLICA_TOOL_URL}#{endpoint}"

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -97,7 +97,7 @@ class Replica
   # query appropriate to that endpoint, return the parsed json response.
   #
   # Example revisions.php query:
-  #   ttps://replica-revision-tools.wmcloud.org/revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
+  # https://replica-revision-tools.wmcloud.org/revisions.php?lang=en&project=wikipedia&usernames[]=Ragesoss&start=20140101003430&end=20171231003430
   #
   # Example revisions.php parsed response:
   # [{"page_id"=>"44962463",

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -260,35 +260,35 @@ describe Replica do
     let(:subject) { described_class.new(en_wiki).get_revisions(all_users, rev_start, rev_end) }
 
     it 'handles timeout errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ECONNREFUSED)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles failed queries' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles server errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 500, body: '', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles successful empty responses' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
       expect_any_instance_of(described_class).not_to receive(:log_error)
       expect(subject).to be_empty
@@ -300,35 +300,35 @@ describe Replica do
     let(:result) { described_class.new(en_wiki).post_existing_articles_by_title(article_titles) }
 
     it 'handles timeout errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_raise(Errno::ECONNREFUSED)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles failed queries' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles server errors' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 500, body: '', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles successful empty responses' do
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*})
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
       expect(result).to be_empty
     end

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -82,7 +82,7 @@ describe UpdateCourseStats do
       allow(Sentry).to receive(:capture_exception)
 
       # Raising errors only in Replica
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
       VCR.use_cassette 'course_update/replica' do
         subject
       end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -81,7 +81,7 @@ describe UpdateCourseStatsTimeslice do
       allow(Sentry).to receive(:capture_exception)
 
       # Raising errors only in Replica
-      stub_request(:any, %r{https://dashboard-replica-endpoint.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
+      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
       VCR.use_cassette 'course_update/replica' do
         subject
       end


### PR DESCRIPTION
## What this PR does
Cherry pick commit https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/75427ab06c4dceb0fff35e85fe118d97f556b75d to make specs pass

> I'm working on rebuilding and reshuffling the older servers on Wikimedia Cloud. The new location of the replica tool is going to be https://replica-revision-tools.wmcloud.org/

