### PR TITLE
Added functionality for handling duplicate slugs when copying courses

### DIFF
--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -47,7 +47,7 @@ class CopyCourse
   end
 
   def modify_course_slug
-    @course_data['term'] = 'CLONED FROM ' + @course_data['term']
+    @course_data['term'] = 'COPIED FROM ' + @course_data['term']
     school = @course_data['school']
     title = @course_data['title']
     term = @course_data['term']

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -19,6 +19,8 @@ class CopyCourse
     @timeline_data = retrieve_timeline_data
     copy_timeline_data
     return { course: @course, error: nil }
+  rescue ActiveRecord::RecordNotUnique
+    return { course: Course.find_by(slug: @course_data['slug']), error: nil }
   rescue ActiveRecord::RecordInvalid, StandardError => e
     return { course: nil, error: e.message }
   end
@@ -29,6 +31,7 @@ class CopyCourse
     # Extract the attributes we want to copy
     params_to_copy = %w[school title term description start end subject slug timeline_start
                         timeline_end type flags weekdays]
+    modify_course_slug
     copied_data = {}
     params_to_copy.each { |p| copied_data[p] = @course_data[p] }
     @home_wiki = Wiki.get_or_create(language: @course_data['home_wiki']['language'],
@@ -41,6 +44,14 @@ class CopyCourse
     end
     # Create the course
     @course = Course.create!(copied_data)
+  end
+
+  def modify_course_slug
+    @course_data['term'] = 'CLONED FROM ' + @course_data['term']
+    school = @course_data['school']
+    title = @course_data['title']
+    term = @course_data['term']
+    @course_data['slug'] = "#{school}/#{title}_(#{term})".tr(' ', '_')
   end
 
   # When parsing update_logs from flags, keys are set as strings instead of integers

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe CopyCourse do
   let(:url_base) { 'https://dashboard.wikiedu.org/courses/' }
   let(:existent_prod_course_slug) do
-    'University_of_South_Carolina/Invertebrate_Zoology_(CLONED_FROM_Spring_2022)'
+    'University_of_South_Carolina/Invertebrate_Zoology_(COPIED_FROM_Spring_2022)'
   end
   let(:course_url) { url_base + existent_prod_course_slug + '/course.json' }
   let(:categories_url) { url_base + existent_prod_course_slug + '/categories.json' }

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe CopyCourse do
   let(:url_base) { 'https://dashboard.wikiedu.org/courses/' }
   let(:existent_prod_course_slug) do
-    'University_of_South_Carolina/Invertebrate_Zoology_(Spring_2022)'
+    'University_of_South_Carolina/Invertebrate_Zoology_(CLONED_FROM_Spring_2022)'
   end
   let(:course_url) { url_base + existent_prod_course_slug + '/course.json' }
   let(:categories_url) { url_base + existent_prod_course_slug + '/categories.json' }


### PR DESCRIPTION
## What this PR does
This PR adds the functionality of handling duplicate slugs when copying courses across servers. 
This works for both the servers.


## Screenshots
Before:
![Screenshot 2024-07-03 at 9 17 09 PM](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/e41f4125-b5a9-404a-a2fd-9e31b67cd496)


After:

No Such Error Now