### PR TITLE
[Data rearchitecture project] Implement Course caches

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -130,6 +130,8 @@ class Course < ApplicationRecord
 
   has_many :course_wiki_namespaces, class_name: 'CourseWikiNamespaces', through: :courses_wikis
 
+  has_many :course_wiki_timeslices, through: :courses_wikis
+
   serialize :flags, Hash
 
   module ClonedStatus
@@ -499,6 +501,10 @@ class Course < ApplicationRecord
 
   def update_cache
     CourseCacheManager.new(self).update_cache
+  end
+
+  def update_cache_from_timeslices
+    CourseCacheManager.new(self).update_cache_from_timeslices course_wiki_timeslices
   end
 
   #################

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -49,7 +49,7 @@ class CourseWikiTimeslice < ApplicationRecord
     @students.each do |student|
       character_sum += student.course_user_wiki_timeslices.where(wiki: @wiki).sum(:character_sum_ms)
     end
-    self.character_sum = character_sum
+    self.character_sum += character_sum
   end
 
   def update_references_count
@@ -61,7 +61,7 @@ class CourseWikiTimeslice < ApplicationRecord
                           .where(wiki: @wiki)
                           .sum(:references_count)
     end
-    self.references_count = references_count
+    self.references_count += references_count
   end
 
   def update_revision_count
@@ -70,7 +70,7 @@ class CourseWikiTimeslice < ApplicationRecord
       excluded_article_ids.include?(revision.article_id)
     end
 
-    self.revision_count = tracked_revisions.count { |rev| !rev.deleted }
+    self.revision_count += tracked_revisions.count { |rev| !rev.deleted }
   end
 
   def update_upload_count

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -19,5 +19,72 @@
 #  updated_at           :datetime         not null
 #
 class CourseWikiTimeslice < ApplicationRecord
-  belongs_to :courses_wikis
+  belongs_to :courses_wikis, foreign_key: 'course_wiki_id'
+
+  # Assumes that the revisions are for their own course wiki
+  def update_cache_from_revisions(revisions)
+    @revisions = revisions
+    @course = courses_wikis.course
+    @wiki = courses_wikis.wiki
+    @students = @course.courses_users.where(role: CoursesUsers::Roles::STUDENT_ROLE)
+
+    update_character_sum
+    update_references_count
+    update_revision_count
+    update_upload_count
+    update_uploads_in_use_count
+    update_upload_usages_count
+    save
+  end
+
+  private
+
+  ##################
+  # Cache updaters #
+  ##################
+
+  def update_character_sum
+    # Count character sum in tracked spaces from course user wiki timeslices
+    character_sum = 0
+    @students.each do |student|
+      character_sum += student.course_user_wiki_timeslices.where(wiki: @wiki).sum(:character_sum_ms)
+    end
+    self.character_sum = character_sum
+  end
+
+  def update_references_count
+    # Count character sum in tracked spaces from course user wiki timeslices
+    references_count = 0
+    @students.each do |student|
+      references_count += student
+                          .course_user_wiki_timeslices
+                          .where(wiki: @wiki)
+                          .sum(:references_count)
+    end
+    self.references_count = references_count
+  end
+
+  def update_revision_count
+    excluded_article_ids = @course.articles_courses.not_tracked.pluck(:article_id)
+    tracked_revisions = @revisions.reject do |revision|
+      excluded_article_ids.include?(revision.article_id)
+    end
+
+    self.revision_count = tracked_revisions.count { |rev| !rev.deleted }
+  end
+
+  def update_upload_count
+    # TODO: count only uploads updated at during the timeslice range
+    self.upload_count = @course.uploads.count
+  end
+
+  def update_uploads_in_use_count
+    # TODO: count only uploads updated at during the timeslice range
+    self.uploads_in_use_count = @course.uploads_in_use.count
+  end
+
+  def update_upload_usages_count
+    # TODO: count only uploads updated at during the timeslice range
+    self.upload_usages_count = @course.uploads_in_use.sum(:usage_count)
+  end
 end

--- a/app/models/courses_wikis.rb
+++ b/app/models/courses_wikis.rb
@@ -16,7 +16,7 @@ class CoursesWikis < ApplicationRecord
   belongs_to :course
   belongs_to :wiki
   has_many :course_wiki_namespaces, class_name: 'CourseWikiNamespaces', dependent: :destroy
-  has_many :course_wiki_timeslices
+  has_many :course_wiki_timeslices, foreign_key: 'course_wiki_id'
 
   def update_namespaces(namespaces)
     update(course_wiki_namespaces: namespaces)

--- a/lib/course_cache_manager.rb
+++ b/lib/course_cache_manager.rb
@@ -25,6 +25,25 @@ class CourseCacheManager
     @course.save
   end
 
+  # Expects a CourseWikiTimeslice::ActiveRecord_Associations_CollectionProxy to
+  # calculate course caches
+  def update_cache_from_timeslices(course_wiki_timeslices)
+    @course.character_sum = course_wiki_timeslices.sum(&:character_sum)
+    @course.references_count = course_wiki_timeslices.sum(&:references_count)
+    @course.revision_count = course_wiki_timeslices.sum(&:revision_count)
+    update_view_sum
+    update_user_count
+    update_trained_count
+    # TODO: count recent revisions based on revision_count field from last timeslices
+    # update_recent_revision_count
+    update_article_count
+    update_new_article_count
+    update_upload_count
+    update_uploads_in_use_count
+    update_upload_usages_count
+    @course.save
+  end
+
   def update_user_count
     @course.user_count = @course.students.size
     @course.save

--- a/spec/factories/course_wiki_timeslices.rb
+++ b/spec/factories/course_wiki_timeslices.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: course_wiki_timeslices
+#
+#  id                   :bigint           not null, primary key
+#  course_wiki_id       :integer          not null
+#  start                :datetime
+#  end                  :datetime
+#  last_mw_rev_id       :integer
+#  character_sum        :integer          default(0)
+#  references_count     :integer          default(0)
+#  revision_count       :integer          default(0)
+#  upload_count         :integer          default(0)
+#  uploads_in_use_count :integer          default(0)
+#  upload_usages_count  :integer          default(0)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+
+FactoryBot.define do
+    factory :course_wiki_timeslice, class: 'CourseWikiTimeslice' do
+      nil
+    end
+  end

--- a/spec/factories/course_wiki_timeslices.rb
+++ b/spec/factories/course_wiki_timeslices.rb
@@ -20,7 +20,7 @@
 #
 
 FactoryBot.define do
-    factory :course_wiki_timeslice, class: 'CourseWikiTimeslice' do
-      nil
-    end
+  factory :course_wiki_timeslice, class: 'CourseWikiTimeslice' do
+    nil
   end
+end

--- a/spec/lib/course_cache_manager_spec.rb
+++ b/spec/lib/course_cache_manager_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/course_cache_manager"
+
+describe CourseCacheManager do
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:article) { create(:article, id: 1, namespace: 0) }
+  let(:course) do
+    create(:course, start: Time.zone.today - 1.month, end: Time.zone.today + 1.month)
+  end
+
+  before do
+    create(:user, id: 1, username: 'Ragesoss')
+    create(:user, id: 2, username: 'Gatoespecie')
+
+    create(:articles_course, id: 1, article:, course:, view_count: 4, new_article: true)
+    create(:articles_course, id: 2, article:, course:, view_count: 3)
+
+    create(:courses_user, id: 1, course:, user_id: 1)
+    create(:courses_user, id: 2, course:, user_id: 2)
+    create(:courses_user, id: 3, course:, user_id: 2, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+
+    create(:commons_upload, user_id: 1, uploaded_at: 10.days.ago, usage_count: 3)
+    create(:commons_upload, user_id: 2, uploaded_at: 10.days.ago, usage_count: 4)
+
+    course_wiki = CoursesWikis.find_by(course:, wiki:)
+
+    create(:course_wiki_timeslice,
+           course_wiki_id: course_wiki.id,
+           start: 10.days.ago,
+           end: 9.days.ago,
+           character_sum: 9000,
+           references_count: 4,
+           revision_count: 5,
+           upload_count: 400,
+           uploads_in_use_count: 200,
+           upload_usages_count: 200)
+    create(:course_wiki_timeslice,
+           course_wiki_id: course_wiki.id,
+           start: 9.days.ago,
+           end: 8.days.ago,
+           character_sum: 10,
+           references_count: 3,
+           revision_count: 1,
+           upload_count: 30,
+           uploads_in_use_count: 200,
+           upload_usages_count: 200)
+    create(:course_wiki_timeslice,
+           course_wiki_id: course_wiki.id,
+           start: 8.days.ago,
+           end: 7.days.ago,
+           character_sum: 100,
+           references_count: 4,
+           revision_count: 4,
+           upload_count: 330,
+           uploads_in_use_count: 100,
+           upload_usages_count: 200)
+  end
+
+  describe '#update_cache_from_timeslices' do
+    it 'updates caches based on timeslices records' do
+      described_class.new(course).update_cache_from_timeslices course.course_wiki_timeslices
+      expect(course.character_sum).to eq(9110)
+      expect(course.references_count).to eq(11)
+      expect(course.revision_count).to eq(10)
+    end
+
+    it 'updates caches based on existing articles courses records' do
+      described_class.new(course).update_cache_from_timeslices []
+      expect(course.view_sum).to eq(7)
+      expect(course.article_count).to eq(2)
+      expect(course.new_article_count).to eq(1)
+    end
+
+    it 'updates user_count based on existing course students' do
+      described_class.new(course).update_cache_from_timeslices []
+      expect(course.user_count).to eq(2)
+    end
+
+    it 'updates trained_count based on existing course students' do
+      described_class.new(course).update_cache_from_timeslices []
+      expect(course.trained_count).to eq(2)
+    end
+
+    it 'updates uploads based on existing article courses records' do
+      described_class.new(course).update_cache_from_timeslices []
+      # TODO: modify to be calculated from course wiki timeslices values
+      expect(course.upload_count).to eq(2)
+      expect(course.uploads_in_use_count).to eq(2)
+      expect(course.upload_usages_count).to eq(7)
+    end
+  end
+end

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -90,14 +90,20 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
       # Make a course wiki timeslice
       create(:course_wiki_timeslice,
              id: 1,
-             course_wiki_id: course_wiki.id)
+             course_wiki_id: course_wiki.id,
+             character_sum: 1,
+             references_count: 1,
+             revision_count: 1,
+             upload_count: 100,
+             uploads_in_use_count: 100,
+             upload_usages_count: 100)
 
       course_wiki_timeslice = described_class.find(1)
       course_wiki_timeslice.update_cache_from_revisions array_revisions
 
-      expect(course_wiki_timeslice.character_sum).to eq(9010)
-      expect(course_wiki_timeslice.references_count).to eq(7)
-      expect(course_wiki_timeslice.revision_count).to eq(3)
+      expect(course_wiki_timeslice.character_sum).to eq(9011)
+      expect(course_wiki_timeslice.references_count).to eq(8)
+      expect(course_wiki_timeslice.revision_count).to eq(4)
       expect(course_wiki_timeslice.upload_count).to eq(2)
       expect(course_wiki_timeslice.uploads_in_use_count).to eq(2)
       expect(course_wiki_timeslice.upload_usages_count).to eq(7)
@@ -111,14 +117,21 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
       # Make a course wiki timeslice
       create(:course_wiki_timeslice,
              id: 1,
-             course_wiki_id: course_wiki.id)
+             course_wiki_id: course_wiki.id,
+             character_sum: 1,
+             references_count: 1,
+             revision_count: 1,
+             upload_count: 100,
+             uploads_in_use_count: 100,
+             upload_usages_count: 100)
 
       course_wiki_timeslice = described_class.find(1)
       course_wiki_timeslice.update_cache_from_revisions array_revisions
 
-      expect(course_wiki_timeslice.character_sum).to eq(9010)
-      expect(course_wiki_timeslice.references_count).to eq(7)
-      expect(course_wiki_timeslice.revision_count).to eq(0)
+      expect(course_wiki_timeslice.character_sum).to eq(9011)
+      expect(course_wiki_timeslice.references_count).to eq(8)
+      # Don't add any new revision count
+      expect(course_wiki_timeslice.revision_count).to eq(1)
       expect(course_wiki_timeslice.upload_count).to eq(2)
       expect(course_wiki_timeslice.uploads_in_use_count).to eq(2)
       expect(course_wiki_timeslice.upload_usages_count).to eq(7)

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: course_wiki_timeslices
+#
+#  id                   :bigint           not null, primary key
+#  course_wiki_id       :integer          not null
+#  start                :datetime
+#  end                  :datetime
+#  last_mw_rev_id       :integer
+#  character_sum        :integer          default(0)
+#  references_count     :integer          default(0)
+#  revision_count       :integer          default(0)
+#  upload_count         :integer          default(0)
+#  uploads_in_use_count :integer          default(0)
+#  upload_usages_count  :integer          default(0)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+require 'rails_helper'
+
+describe CourseWikiTimeslice, type: :model do
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:array_revisions) { [] }
+  let(:article) { create(:article, id: 1, namespace: 0) }
+  let(:course) do
+    create(:course, start: Time.zone.today - 1.month, end: Time.zone.today + 1.month)
+  end
+
+  before do
+    create(:user, id: 1, username: 'Ragesoss')
+    create(:user, id: 2, username: 'Gatoespecie')
+
+    create(:articles_course, id: 1, article_id: 1, course:)
+
+    create(:courses_user, id: 1, course:, user_id: 1)
+    create(:courses_user, id: 2, course:, user_id: 2)
+    create(:courses_user, id: 3, course:, user_id: 2,
+role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+
+    create(:commons_upload, user_id: 1, uploaded_at: 10.days.ago, usage_count: 3)
+    create(:commons_upload, user_id: 2, uploaded_at: 10.days.ago, usage_count: 4)
+
+    create(:course_user_wiki_timeslice,
+           course_user_id: 1,
+           wiki:,
+           start: 10.days.ago,
+           end: 9.days.ago,
+           character_sum_ms: 9000,
+           character_sum_us: 500,
+           character_sum_draft: 400,
+           total_uploads: 200,
+           references_count: 4,
+           revision_count: 5)
+    create(:course_user_wiki_timeslice,
+           course_user_id: 2,
+           wiki:,
+           start: 10.days.ago,
+           end: 9.days.ago,
+           character_sum_ms: 10,
+           character_sum_us: 20,
+           character_sum_draft: 30,
+           total_uploads: 200,
+           references_count: 3,
+           revision_count: 1)
+    # Course user wiki timeslice for non-student
+    create(:course_user_wiki_timeslice,
+           course_user_id: 3,
+           wiki:,
+           start: 10.days.ago,
+           end: 9.days.ago,
+           character_sum_ms: 100,
+           character_sum_us: 200,
+           character_sum_draft: 330,
+           total_uploads: 100,
+           references_count: 4,
+           revision_count: 4)
+
+    array_revisions << create(:revision, article:, user_id: 1)
+    array_revisions << create(:revision, article:, user_id: 1)
+    array_revisions << create(:revision, article:, user_id: 2)
+    array_revisions << create(:revision, article:, deleted: true, user_id: 1)
+  end
+
+  describe '#update_cache_from_revisions' do
+    it 'caches revision data for students' do
+      # Get the CoursesWikis record automatically created
+      course_wiki = CoursesWikis.find_by(course:, wiki:)
+      # Make a course wiki timeslice
+      create(:course_wiki_timeslice,
+             id: 1,
+             course_wiki_id: course_wiki.id)
+
+      course_wiki_timeslice = described_class.find(1)
+      course_wiki_timeslice.update_cache_from_revisions array_revisions
+
+      expect(course_wiki_timeslice.character_sum).to eq(9010)
+      expect(course_wiki_timeslice.references_count).to eq(7)
+      expect(course_wiki_timeslice.revision_count).to eq(3)
+      expect(course_wiki_timeslice.upload_count).to eq(2)
+      expect(course_wiki_timeslice.uploads_in_use_count).to eq(2)
+      expect(course_wiki_timeslice.upload_usages_count).to eq(7)
+    end
+
+    it 'revision count cache only considers tracked articles courses' do
+      # Untrack articles courses record
+      ArticlesCourses.find(1).update(tracked: 0)
+      # Get the CoursesWikis record automatically created
+      course_wiki = CoursesWikis.find_by(course:, wiki:)
+      # Make a course wiki timeslice
+      create(:course_wiki_timeslice,
+             id: 1,
+             course_wiki_id: course_wiki.id)
+
+      course_wiki_timeslice = described_class.find(1)
+      course_wiki_timeslice.update_cache_from_revisions array_revisions
+
+      expect(course_wiki_timeslice.character_sum).to eq(9010)
+      expect(course_wiki_timeslice.references_count).to eq(7)
+      expect(course_wiki_timeslice.revision_count).to eq(0)
+      expect(course_wiki_timeslice.upload_count).to eq(2)
+      expect(course_wiki_timeslice.uploads_in_use_count).to eq(2)
+      expect(course_wiki_timeslice.upload_usages_count).to eq(7)
+    end
+  end
+end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -68,7 +68,7 @@ describe UpdateCourseStatsTimeslice do
       expect(article_course.article_course_timeslices.first.user_ids).to eq([user.id])
     end
 
-    it 'updates course user and course user timeslices caches' do
+    it 'updates course user and course user wiki timeslices caches' do
       # Check caches for course user
       course_user = CoursesUsers.find_by(course:, user:)
       # The course user caches were updated
@@ -99,6 +99,45 @@ describe UpdateCourseStatsTimeslice do
       expect(course_user.course_user_wiki_timeslices.second.character_sum_draft).to eq(0)
       expect(course_user.course_user_wiki_timeslices.second.revision_count).to eq(27)
       expect(course_user.course_user_wiki_timeslices.second.references_count).to eq(-2)
+    end
+
+    it 'updates course and course wiki timeslices caches' do
+      # Check caches for course
+
+      # Course caches were updated
+      expect(course.character_sum).to eq(7991)
+      expect(course.references_count).to eq(-2)
+      expect(course.revision_count).to eq(29)
+      expect(course.view_sum).to eq(0)
+      expect(course.user_count).to eq(1)
+      expect(course.trained_count).to eq(1)
+      # TODO: update recent_revision_count
+      expect(course.recent_revision_count).to eq(0)
+      expect(course.article_count).to eq(15)
+      expect(course.new_article_count).to eq(0)
+      expect(course.upload_count).to eq(0)
+      expect(course.uploads_in_use_count).to eq(0)
+      expect(course.upload_usages_count).to eq(0)
+
+      # Two course timeslice records were created: one for enwiki and other for wikidata
+      expect(course.course_wiki_timeslices.count).to eq(2)
+
+      # Course user timeslices caches were updated
+      # For enwiki
+      expect(course.course_wiki_timeslices.first.character_sum).to eq(124)
+      expect(course.course_wiki_timeslices.first.references_count).to eq(0)
+      expect(course.course_wiki_timeslices.first.revision_count).to eq(2)
+      expect(course.course_wiki_timeslices.first.upload_count).to eq(0)
+      expect(course.course_wiki_timeslices.first.uploads_in_use_count).to eq(0)
+      expect(course.course_wiki_timeslices.first.upload_usages_count).to eq(0)
+
+      # For wikidata
+      expect(course.course_wiki_timeslices.second.character_sum).to eq(7867)
+      expect(course.course_wiki_timeslices.second.references_count).to eq(-2)
+      expect(course.course_wiki_timeslices.second.revision_count).to eq(27)
+      expect(course.course_wiki_timeslices.second.upload_count).to eq(0)
+      expect(course.course_wiki_timeslices.second.uploads_in_use_count).to eq(0)
+      expect(course.course_wiki_timeslices.second.upload_usages_count).to eq(0)
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR makes the following changes:
- Implements `CourseWikiTimeslice.update_cache_from_revisions` based on existing `CourseCacheManager`
- Implements `Course.update_cache_from_timeslices`
- Implements `CourseCacheManager.update_cache_from_timeslices`
- Updates course caches in existing `UpdateCourseStatsTimeslices` class.

## Open questions and concerns

- Caches related to uploads raw data (`update_upload_count`, `update_uploads_in_use_count`, `update_upload_usages_count`) are not specific to the range of time defined by the timeslice. There is a TODO comment to improve this in the future. Not doing it right now as it's not related to revisions data.
- Implement `recent_revisions` based on `revision_count` field from last timeslices. There is a TODO comment.