### PR TITLE
Fix: Adjust pagination controls for single-page results and edge cases

### DIFF
--- a/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
+++ b/app/assets/javascripts/components/articles/PaginatedArticleControls.jsx
@@ -20,6 +20,9 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
   const currentPage = useSelector(state => state.articles.currentPage);
   const pageRange = getPageRange(currentPage, filteredArticles.length);
   const totalFilteredArticles = filteredArticles.length;
+  const hideNextButton = (totalPages === currentPage) ? 'hide-next-btn' : '';
+  const hidePrevButton = (currentPage === 1) ? 'hide-prev-btn' : '';
+  const hasLimitReached = limitReached ? 'hidden-see-more-btn' : '';
 
   // this is for when a filter is applied and the number of pages changes
   // we need to reset the page to the first page
@@ -30,7 +33,10 @@ export const PaginatedArticleControls = ({ showMore, limitReached }) => {
 
 
   return (
-    <div id="articles-view-controls" className={limitReached ? 'hidden-see-more-btn' : ''}>
+    <div
+      id="articles-view-controls"
+      className={`${hasLimitReached} ${hideNextButton} ${hidePrevButton}`}
+    >
       { totalPages ? (<ReactPaginate
         pageCount={totalPages}
         nextLabel={nextLabel}

--- a/app/assets/stylesheets/modules/_articles.styl
+++ b/app/assets/stylesheets/modules/_articles.styl
@@ -67,3 +67,11 @@
   .articles-shown-label
     grid-area: articles-shown-label
     padding-top: 0px
+
+// Hide the next li element for ReactPaginate 
+.hide-next-btn li.next 
+  display: none
+
+// Hide the previous  li element for ReactPaginate
+.hide-prev-btn li.previous 
+  display: none


### PR DESCRIPTION
closes #5873 
## What this PR does

This PR addresses the issue where the pagination controls (i.e., 'Previous' and 'Next' buttons) are displayed even when there is only a single page of results in the Articles Edited list.

Additionally, this PR enhances the pagination controls by:

Hiding the 'Previous' button when the user is on the first page.
Hiding the 'Next' button when the user is on the last page

## Changes Made


Updated the controls to ensure 'Previous' is hidden on the first page and 'Next' is hidden on the last page.

## Screenshots
Before:


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/3a5fc8ae-6383-4c7a-b7fa-40aeb6e93e1c



After:


https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/31778d4a-d912-4d82-a818-e6e852e9dcf4






