### PR TITLE
Fix: Resolve authorship data loading hang for deleted revisions

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/Footer.jsx
@@ -7,7 +7,7 @@ import { printArticleViewer } from '../../../../utils/article_viewer';
 
 export const Footer = ({
   article, colors, failureMessage, showArticleFinder, highlightedHtml, isWhocolorLang,
-  whocolorFailed, users, unhighlightedContributors, revisionId, toggleRevisionHandler, pendingRequest
+  whoColorFailed, users, unhighlightedContributors, revisionId, toggleRevisionHandler, pendingRequest
 }) => {
   // Determine the Article Viewer Legend status based on what information
   // has returned from various API calls.
@@ -16,7 +16,7 @@ export const Footer = ({
     let legendStatus;
     if (highlightedHtml && unhighlightedContributors.length) {
       legendStatus = 'ready';
-    } else if (whocolorFailed) {
+    } else if (whoColorFailed) {
       legendStatus = 'failed';
     } else if (isWhocolorLang()) {
       legendStatus = 'loading';

--- a/app/assets/stylesheets/modules/_article_viewer.styl
+++ b/app/assets/stylesheets/modules/_article_viewer.styl
@@ -69,7 +69,6 @@
   width 100%
   div
     float left
-    overflow hidden
 
 .authorship-loading
   background url('../images/loader.gif') no-repeat 50% white

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1453,7 +1453,7 @@ en:
     assigned_wikidata: Assigned Items
     assignees: Assignee(s)
     loading_authorship_data: loading authorship data
-    authorship_data_not_fetched: could not fetch authorship data
+    authorship_data_not_fetched: Could not fetch authorship data
     character_doc: >
       The total amount of content a user has added to this namespace,
       calculated by adding up the added characters for all edits that


### PR DESCRIPTION
closes #5882 

## What this PR does
Fix: Deleted revisions cause authorship highlighting to hang on 'loading' UI

## Cause of Bug

Typo error.

## Screenshots

Before:

![Screenshot from 2024-07-07 21-35-26](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/b115046f-40bd-4255-bb8d-89cf9ab23ded)


After:

![Screenshot from 2024-07-07 21-36-20](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/7952a244-b291-4c27-a90f-4e12cd32e1d8)



https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/929daa2e-b778-4e72-8b83-d8436e543368





