### PR TITLE
Implemented a new feature to support course URLs with additional suffixes

### DIFF
--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -90,10 +90,19 @@ class CopyCourse
   end
 
   def get_request(path)
-    uri = URI(@url + path)
+    sanitized_url = sanitize_url(@url)
+    uri = URI(sanitized_url + path)
     response = Net::HTTP.get_response(uri)
     raise "Error getting data from #{uri}" unless response.is_a?(Net::HTTPSuccess)
     response
+  end
+
+  def sanitize_url(input_url)
+    uri = URI.parse(input_url)
+    path_segments = uri.path.split('/')
+    desired_path = path_segments[0..3].join('/')
+    sanitized_url = "https://#{uri.host}#{desired_path}"
+    return sanitized_url
   end
 
   def retrieve_course_data


### PR DESCRIPTION
## What this PR does
- [x] Implemented new feature to support course URLs with additional suffixes, such as '/home'.
- [x] This feature also supports URLs both with and without the "https://" prefix.

## Screenshots

Before:
![Before 1](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/de4b6ec2-00f7-4b79-8dcf-979edc6fcf40)

After:
![After 2](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/46ddbe01-8485-490f-9eff-a10e111c1ffa)


![After 3](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/96368921/5387a86a-fd64-4174-aff7-bb2b1302f0c3)
