### PR TITLE
Fix onboarding UI

### DIFF
--- a/app/assets/javascripts/components/nav/nav.jsx
+++ b/app/assets/javascripts/components/nav/nav.jsx
@@ -138,7 +138,7 @@ const Nav = () => {
                   </li>
                 )}
                 {userSignedIn ? (
-                  <span>
+                  <span className="user-signed-in">
                     <li>
                       <b><a href={`/users/${encodeURIComponent(currentUser)}`} className="current-user">{currentUser}</a></b>
                     </li>

--- a/app/assets/stylesheets/modules/_onboarding.styl
+++ b/app/assets/stylesheets/modules/_onboarding.styl
@@ -4,7 +4,6 @@ body.onboarding
   background-repeat no-repeat
   background-position center 75%
   background-size cover
-  overflow-y scroll
 
   color #fff
   a

--- a/app/assets/stylesheets/modules/_onboarding.styl
+++ b/app/assets/stylesheets/modules/_onboarding.styl
@@ -48,7 +48,6 @@ body.onboarding
     .top-nav__faq-search
       display none
 
-
   // Intro and permissions pages
   .intro, .permissions
     padding-top 75px
@@ -78,4 +77,8 @@ body.onboarding
 
     li
       margin-bottom 10px
+
+  // hide news and admin bell icon on onboarding page
+  .notifications
+      display: none
 


### PR DESCRIPTION
## What this PR does

a) Hide News and Admin bell icon from on `onboarding` page for admin and non-admin.
b) Remove double scrollbar on the Y-axis of onboarding page.

## Screenshots
Before:

![Screenshot from 2024-07-09 17-51-42](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/c25d9dbf-56ec-48ac-a568-ea5073603497)


After:

![Screenshot from 2024-07-10 22-08-16](https://github.com/WikiEducationFoundation/WikiEduDashboard/assets/74126284/77217ec2-232f-464a-852e-303025327e3f)




