### PR TITLE
[Data rearchitecture project] Add logic to create articles courses records from revisions in RAM

### DIFF
--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -57,6 +57,7 @@ class UpdateCourseStatsTimeslice
     end
     log_update_progress :revision_scores_fetched
 
+    ArticlesCourses.update_from_course_revisions(@course, @revisions.values.flatten)
     # TODO: replace the logic on ArticlesCourses.update_from_course
 
     # TODO: note this is not wiki scoped.
@@ -87,11 +88,14 @@ class UpdateCourseStatsTimeslice
 
   def update_article_course_timeslices_for_wiki(wiki)
     @revisions[wiki].group_by(&:article_id).each do |article_id, article_revisions|
-      article_course = ArticlesCourses.find_or_create_by(course: @course, article_id:)
+      article_course = ArticlesCourses.find_by(course: @course, article_id:)
+      next unless article_course
       # TODO: determine how to get the right timeslice given the start and end
       # Update cache for ArticleCorseTimeslice
       ArticleCourseTimeslice.find_or_create_by(
-        article_course_id: article_course.id
+        article_course_id: article_course.id,
+        start: @timeslice_start.to_datetime,
+        end: @timeslice_end.to_datetime
       ).update_cache_from_revisions article_revisions
     end
   end
@@ -103,7 +107,9 @@ class UpdateCourseStatsTimeslice
       # Update cache for CourseUserWikiTimeslice
       CourseUserWikiTimeslice.find_or_create_by(
         course_user_id: course_user.id,
-        wiki:
+        wiki:,
+        start: @timeslice_start.to_datetime,
+        end: @timeslice_end.to_datetime
       ).update_cache_from_revisions user_revisions
     end
   end
@@ -113,7 +119,9 @@ class UpdateCourseStatsTimeslice
     # TODO: determine how to get the right timeslice given the start and end
     # Update cache for CourseWikiTimeslice
     CourseWikiTimeslice.find_or_create_by(
-      course_wiki_id: course_wiki.id
+      course_wiki_id: course_wiki.id,
+      start: @timeslice_start.to_datetime,
+      end: @timeslice_end.to_datetime
     ).update_cache_from_revisions @revisions[wiki]
   end
 

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -58,7 +58,11 @@ class UpdateCourseStatsTimeslice
     log_update_progress :revision_scores_fetched
 
     ArticlesCourses.update_from_course_revisions(@course, @revisions.values.flatten)
-    # TODO: replace the logic on ArticlesCourses.update_from_course
+    # TODO: replace the logic on ArticlesCourses.update_from_course to remove all
+    # the ArticlesCourses that do not correspond to course revisions.
+    # That may happen if the course dates changed, so some revisions are no
+    # longer part of the course.
+    # Also remove records for articles that aren't on a tracked wiki.
 
     # TODO: note this is not wiki scoped.
     CourseUploadImporter.new(@course, update_service: self).run

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -25,28 +25,28 @@ describe ArticleCourseTimeslice, type: :model do
   let(:course) { create(:course, start: 1.month.ago, end: 1.month.from_now) }
   let(:article_course) { create(:articles_course, article:, course:) }
   let(:revision1) do
-    create(:revision, article:,
+    build(:revision, article:,
            characters: 123,
            features: { 'num_ref' => 4 },
            features_previous: { 'num_ref' => 0 },
            user_id: 25)
   end
   let(:revision2) do
-    create(:revision, article:,
+    build(:revision, article:,
            characters: -65,
            features: { 'num_ref' => 1 },
            features_previous: { 'num_ref' => 2 },
            user_id: 1)
   end
   let(:revision3) do
-    create(:revision, article:,
+    build(:revision, article:,
            characters: 225,
            features: { 'num_ref' => 3 },
            features_previous: { 'num_ref' => 3 },
            user_id: 25)
   end
   let(:revision4) do
-    create(:revision, article:,
+    build(:revision, article:,
             characters: 34,
             deleted: true, # deleted revision
             features: { 'num_ref' => 2 },

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -183,4 +183,27 @@ describe ArticlesCourses, type: :model do
       expect(described_class.exists?(501)).to eq(false)
     end
   end
+
+  describe '.update_from_course_revisions' do
+    let(:article2) { create(:article, title: 'Second Article', namespace: 0, wiki_id: 2) }
+    let(:talk_page) { create(:article, title: 'Talk page', namespace: 1) }
+    let(:array_revisions) { [] }
+
+    before do
+      create(:courses_user, user:, course:,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      array_revisions << build(:revision, article:, user:, date: 1.week.ago,
+                        system: true, new_article: true)
+      # revision for a non-tracked wiki
+      array_revisions << build(:revision, article: article2, user:, date: 6.days.ago)
+      # revision for a non-tracked namespace
+      array_revisions << build(:revision, article: talk_page, user:, date: 1.week.ago)
+    end
+
+    it 'creates new ArticlesCourses records from course revisions' do
+      expect(described_class.count).to eq(0)
+      described_class.update_from_course_revisions(Course.last, array_revisions)
+      expect(described_class.count).to eq(1)
+    end
+  end
 end

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -50,35 +50,35 @@ describe CourseUserWikiTimeslice, type: :model do
              revision_count: 23)
     end
     let(:revision0) do
-      create(:revision, article:,
+      build(:revision, article:,
              characters: 123,
              features: { 'num_ref' => 8 },
              features_previous: { 'num_ref' => 1 },
              user_id: course.id)
     end
     let(:revision1) do
-      create(:revision, article: talk_page,
+      build(:revision, article: talk_page,
              characters: 200,
              features: { 'num_ref' => 12 },
              features_previous: { 'num_ref' => 10 },
              user_id: course.id)
     end
     let(:revision2) do
-      create(:revision, article: sandbox,
+      build(:revision, article: sandbox,
              characters: -65,
              features: { 'num_ref' => 1 },
              features_previous: { 'num_ref' => 2 },
              user_id: course.id)
     end
     let(:revision3) do
-      create(:revision, article: draft,
+      build(:revision, article: draft,
              characters: 225,
              features: { 'num_ref' => 3 },
              features_previous: { 'num_ref' => 3 },
              user_id: course.id)
     end
     let(:revision4) do
-      create(:revision, article:,
+      build(:revision, article:,
               characters: 34,
               deleted: true, # deleted revision
               features: { 'num_ref' => 2 },
@@ -86,7 +86,7 @@ describe CourseUserWikiTimeslice, type: :model do
               user_id: course.id)
     end
     let(:revision5) do
-      create(:revision, article_id: -1, # revision for a non-existing article
+      build(:revision, article_id: -1, # revision for a non-existing article
               characters: 34,
               deleted: false,
               features: { 'num_ref' => 2 },

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -77,10 +77,10 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
            references_count: 4,
            revision_count: 4)
 
-    array_revisions << create(:revision, article:, user_id: 1)
-    array_revisions << create(:revision, article:, user_id: 1)
-    array_revisions << create(:revision, article:, user_id: 2)
-    array_revisions << create(:revision, article:, deleted: true, user_id: 1)
+    array_revisions << build(:revision, article:, user_id: 1)
+    array_revisions << build(:revision, article:, user_id: 1)
+    array_revisions << build(:revision, article:, user_id: 2)
+    array_revisions << build(:revision, article:, deleted: true, user_id: 1)
   end
 
   describe '#update_cache_from_revisions' do

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -32,6 +32,7 @@ describe UpdateCourseStatsTimeslice do
 
     before do
       stub_wiki_validation
+      travel_to Date.new(2018, 11, 26)
       course.campaigns << Campaign.first
       course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       JoinCourse.new(course:, user:, role: 0)
@@ -43,11 +44,9 @@ describe UpdateCourseStatsTimeslice do
     it 'imports average views of edited articles' do
       # 2 en.wiki articles
       expect(course.articles.where(wiki: enwiki).count).to eq(2)
-      # 13 wikidata articles
-      expect(course.articles.where(wiki: wikidata).count).to eq(13)
-      # TODO: fix this. Right now doesn't work because ArticleCourses records
-      # were not created for the time AverageViewsImporter.update_outdated_average_views runs
-      # expect(course.articles.where(wiki: enwiki).last.average_views).to be > 0
+      # 13 wikidata articles, but one is for Property namespace (120)
+      expect(course.articles.where(wiki: wikidata).count).to eq(12)
+      expect(course.articles.where(wiki: enwiki).last.average_views).to be > 200
     end
 
     it 'updates article course and article course timeslices caches' do
@@ -59,9 +58,7 @@ describe UpdateCourseStatsTimeslice do
       expect(article_course.character_sum).to eq(427)
       expect(article_course.references_count).to eq(-2)
       expect(article_course.user_ids).to eq([user.id])
-      # TODO: fix this.Right now doesn't work because ArticleCourses records
-      # were not created for the time AverageViewsImporter.update_outdated_average_views runs
-      # expect(article_course.view_count).to be > 0
+      expect(article_course.view_count).to eq(2)
 
       # Article course timeslice record was created for mw_page_id 6901525
       expect(article_course.article_course_timeslices.count).to eq(1)
@@ -111,12 +108,12 @@ describe UpdateCourseStatsTimeslice do
       expect(course.character_sum).to eq(7991)
       expect(course.references_count).to eq(-2)
       expect(course.revision_count).to eq(29)
-      expect(course.view_sum).to eq(0)
+      expect(course.view_sum).to eq(814)
       expect(course.user_count).to eq(1)
       expect(course.trained_count).to eq(1)
       # TODO: update recent_revision_count
       expect(course.recent_revision_count).to eq(0)
-      expect(course.article_count).to eq(15)
+      expect(course.article_count).to eq(14)
       expect(course.new_article_count).to eq(0)
       expect(course.upload_count).to eq(0)
       expect(course.uploads_in_use_count).to eq(0)

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -58,6 +58,7 @@ describe UpdateCourseStatsTimeslice do
       expect(article_course.character_sum).to eq(427)
       expect(article_course.references_count).to eq(-2)
       expect(article_course.user_ids).to eq([user.id])
+      # TODO: this value should change when implement the real timeslice start date
       expect(article_course.view_count).to eq(2)
 
       # Article course timeslice record was created for mw_page_id 6901525
@@ -108,6 +109,7 @@ describe UpdateCourseStatsTimeslice do
       expect(course.character_sum).to eq(7991)
       expect(course.references_count).to eq(-2)
       expect(course.revision_count).to eq(29)
+      # TODO: this value should change when implement the real timeslice start date
       expect(course.view_sum).to eq(814)
       expect(course.user_count).to eq(1)
       expect(course.trained_count).to eq(1)

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -59,6 +59,9 @@ describe UpdateCourseStatsTimeslice do
       expect(article_course.character_sum).to eq(427)
       expect(article_course.references_count).to eq(-2)
       expect(article_course.user_ids).to eq([user.id])
+      # TODO: fix this.Right now doesn't work because ArticleCourses records
+      # were not created for the time AverageViewsImporter.update_outdated_average_views runs
+      # expect(article_course.view_count).to be > 0
 
       # Article course timeslice record was created for mw_page_id 6901525
       expect(article_course.article_course_timeslices.count).to eq(1)


### PR DESCRIPTION
## What this PR does
This PR implements `update_from_course_revisions` class method to create `ArticlesCourses` records from revisions in RAM. It's based on the behavior for the existing `update_from_course` class method.

## Open questions and concerns

- TODO: the  `update_from_course_revisions` method only creates new `ArticlesCourses` records. We still have to add logic to remove all the `ArticlesCourses` that do not correspond to course revisions. That may happen if the course dates changed, so some revisions are no longer part of the course. Also remove records for articles that aren't on a tracked wiki. See the full `update_from_course`  definition.
- TODO: revisit view counts calculation when `TimesliceManager` is implemented.