### PR TITLE
Add link to settings page from admin page

### DIFF
--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -33,4 +33,5 @@
       %a{href: '/update_username'} Update username
     %li
       %a{href: '/usage'} Usage
-    
+    %li
+      %a{href: '/settings'} Manage Site Settings 


### PR DESCRIPTION
closes #5894

## What this PR does

Added a link to the settings page under the 'Useful links' section on the admin page, making it easily accessible for users.

## Screenshots

Before:

![Screenshot from 2024-07-13 11-57-42](https://github.com/user-attachments/assets/90204dbc-a5fe-4027-b1c7-04b51786efbb)


After:


https://github.com/user-attachments/assets/72b3d96e-763f-45aa-bd5c-76e116a4fc6f

