### PR TITLE
Disable editing of title, school  and term/when fields after event sync

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -143,32 +143,53 @@ const Details = createReactClass({
     const canRename = this.canRename();
     const isClassroomProgramType = this.props.course.type === 'ClassroomProgramCourse';
     const timelineDatesDiffer = this.props.course.start !== this.props.course.timeline_start || this.props.course.end !== this.props.course.timeline_end;
+    const eventSync = this.props.course.flags.event_sync;
+
     let campus;
     let staff;
     let school;
     let academic_system;
+    let online;
+    let eventSyncTooltip;
+
     if (Features.wikiEd) {
       staff = <WikiEdStaff {...this.props} />;
       campus = <CampusVolunteers {...this.props} />;
     }
-    let online;
+
     if (Features.wikiEd || this.props.course.online_volunteers_enabled) {
       online = <OnlineVolunteers {...this.props} />;
     }
 
+    if (eventSync && canRename) {
+      eventSyncTooltip = (
+        <div className="tooltip-trigger">
+          <img src="/assets/images/info.svg" alt="tooltip default logo" />
+          <div className="tooltip large dark">
+            <p>
+              {'Editing disabled: This field cannot be changed because the course is already linked to an event. Changing it would disrupt the event\'s integration.'}
+            </p>
+          </div>
+        </div>
+      );
+    }
+
     if (this.props.course.school || canRename) {
       school = (
-        <TextInput
-          id="school-input"
-          onChange={this.updateSlugPart}
-          value={this.props.course.school}
-          value_key="school"
-          validation={CourseUtils.courseSlugRegex()}
-          editable={canRename}
-          type="text"
-          label={CourseUtils.i18n('school', this.props.course.string_prefix)}
-          required={true}
-        />
+        <div className={eventSync ? 'event-sync' : ''}>
+          <TextInput
+            id="school-input"
+            onChange={this.updateSlugPart}
+            value={this.props.course.school}
+            value_key="school"
+            validation={CourseUtils.courseSlugRegex()}
+            editable={eventSync ? false : canRename}
+            type="text"
+            label={CourseUtils.i18n('school', this.props.course.string_prefix)}
+            required={true}
+          />
+          {eventSyncTooltip}
+        </div>
       );
     }
 
@@ -191,34 +212,41 @@ const Details = createReactClass({
     let title;
     if (canRename) {
       title = (
-        <TextInput
-          id="title-input"
-          onChange={this.updateSlugPart}
-          value={this.props.course.title}
-          value_key="title"
-          validation={CourseUtils.courseSlugRegex()}
-          editable={canRename}
-          type="text"
-          label={CourseUtils.i18n('title', this.props.course.string_prefix)}
-          required={true}
-        />
+        <div className={eventSync ? 'event-sync' : ''}>
+          <TextInput
+            id="title-input"
+            onChange={this.updateSlugPart}
+            value={this.props.course.title}
+            value_key="title"
+            validation={CourseUtils.courseSlugRegex()}
+            editable={eventSync ? false : canRename}
+            type="text"
+            label={CourseUtils.i18n('title', this.props.course.string_prefix)}
+            required={true}
+          />
+          {eventSyncTooltip}
+        </div>
       );
     }
 
     let term;
+
     if (this.props.course.term || canRename) {
       term = (
-        <TextInput
-          id="term-input"
-          onChange={this.updateSlugPart}
-          value={this.props.course.term}
-          value_key="term"
-          validation={CourseUtils.courseSlugRegex()}
-          editable={canRename}
-          type="text"
-          label={CourseUtils.i18n('term', this.props.course.string_prefix)}
-          required={false}
-        />
+        <div className={eventSync ? 'event-sync' : ''}>
+          <TextInput
+            id="term-input"
+            onChange={this.updateSlugPart}
+            value={this.props.course.term}
+            value_key="term"
+            validation={CourseUtils.courseSlugRegex()}
+            editable= {eventSync ? false : canRename}
+            type="text"
+            label={CourseUtils.i18n('term', this.props.course.string_prefix)}
+            required={false}
+          />
+          {eventSyncTooltip}
+        </div>
       );
     }
 

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -167,7 +167,7 @@ const Details = createReactClass({
           <img src="/assets/images/info.svg" alt="tooltip default logo" />
           <div className="tooltip large dark">
             <p>
-              {'Editing disabled: This field cannot be changed because the course is already linked to an event. Changing it would disrupt the event\'s integration.'}
+              {I18n.t('courses.event_sync')}
             </p>
           </div>
         </div>

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -151,6 +151,9 @@ rating(color)
     width 700px
     margin-top 200px
 
+.event-sync
+  display inline-flex
+
 .rating
   round-placeholder(23)
   rating(#D2D2D2)

--- a/app/assets/stylesheets/modules/_course.styl
+++ b/app/assets/stylesheets/modules/_course.styl
@@ -152,6 +152,7 @@ rating(color)
     margin-top 200px
 
 .event-sync
+  width 100%
   display inline-flex
 
 .rating

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -667,6 +667,7 @@ en:
     enrollment_edits_enabled_tooltip: >
       If enabled, the dashboard will post a template to the userpage and talk page of
       each editor who joins the program.
+    event_sync: "Editing disabled: This field cannot be changed because the course is already linked to an event. Changing it would disrupt the event's integration."
     courses_enrolled: Courses enrolled
     error:
       exists: That course already exists! Please try again with a different title, school, or term.


### PR DESCRIPTION
closes #5811 

## What this PR does

Prevent changes to the title, school and term/when fields for courses that are already linked to an event to maintain integration stability.

## Screenshots

Before:


https://github.com/user-attachments/assets/c33d4c73-b4c4-4b4a-b8f3-e792e1e8f021



After:


https://github.com/user-attachments/assets/beac4e2b-e96a-467a-a551-c09e031aff66

