### PR TITLE
Add a new parameter for On-wiki course pages to show all instructors.

### DIFF
--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -12,10 +12,12 @@ class WikiCourseOutput
     @course = course
     @course_meetings_manager = @course.meetings_manager
     @dashboard_url = ENV['dashboard_url']
-    @first_instructor_course_user = @course
-                                    .courses_users
-                                    .where(role: CoursesUsers::Roles::INSTRUCTOR_ROLE).first
+    @all_instructor_course_users = @course
+                                   .courses_users
+                                   .where(role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    @first_instructor_course_user = @all_instructor_course_users.first
     @first_instructor = @first_instructor_course_user&.user
+    @all_instructors = @all_instructor_course_users.map(&:user)
     @first_support_staff = @course.nonstudents.where(greeter: true).first
     @output = ''
     @templates = @course.home_wiki.edit_templates
@@ -62,6 +64,8 @@ class WikiCourseOutput
        | assignment_page = #{@course.wiki_title}
        | slug = #{@course.slug}
        | campaigns = #{@course.campaigns.pluck(:title).join(', ')}
+       | all_instructor_usernames = #{all_instructors_username}
+       | all_instructor_realnames = #{all_instructors_realname}
        | #{@dashboard_url} = yes
       }}
     COURSE_DETAILS
@@ -73,6 +77,14 @@ class WikiCourseOutput
 
   def instructor_realname
     @first_instructor_course_user&.real_name
+  end
+
+  def all_instructors_username
+    @all_instructors.map(&:username).join("\n")
+  end
+
+  def all_instructors_realname
+    @all_instructors.map(&:real_name).reject(&:blank?).join("\n")
   end
 
   def support_staff_username

--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -48,7 +48,7 @@ class WikiCourseOutput
   end
 
   def course_details
-    # TODO: add support for multiple instructors, multiple content experts.
+    # TODO: add support for multiple content experts.
     # TODO: switch this to a new template specifically for dashboard courses.
     <<~COURSE_DETAILS
       {{#{template_name(@templates, 'course')}

--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -105,7 +105,7 @@ class WikiCourseOutput
   def insert_additional_instructors(details)
     # Collect additional instructor usernames and insert them after the first instructor
     additional_instructors = @all_instructors[1..].map.with_index(2) do |instructor, index|
-      " | instructor_username_#{index} = #{instructor.username}\n"
+      "\n | instructor_username_#{index} = #{instructor.username}"
     end.join
 
     # Insert additional instructors immediately after the first instructor's real name

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -12,6 +12,7 @@ describe WikiCourseOutput do
     let(:student) { create(:user, username: 'StudentUser') }
     let(:instructor) { create(:user, username: 'InstructorUser') }
     let(:instructor2) { create(:user, username: 'InstructorUser2') }
+    let(:instructor3) { create(:user, username: 'InstructorUser3') }
     let(:course) do
       create(:course,
              title: '# Title #',
@@ -65,6 +66,7 @@ describe WikiCourseOutput do
              role: 0)
       create(:courses_user, user: instructor, course:, role: 1, real_name: 'Jacque')
       create(:courses_user, user: instructor2, course:, role: 1, real_name: 'Marie')
+      create(:courses_user, user: instructor3, course:, role: 1, real_name: 'Sarah')
       create(:assignment,
              id: 1,
              user: student,
@@ -83,7 +85,7 @@ describe WikiCourseOutput do
       expect(response).to include('[[Your article]]')
       expect(response).to include('Jacque')
       expect(response).to include('Campaign Title 1, Campaign Title 2')
-      expect(response).to include('InstructorUser', 'InstructorUser2')
+      expect(response).to include('InstructorUser', 'InstructorUser2', 'InstructorUser3')
     end
 
     context 'when the course has no weeks or users or anything' do

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -11,6 +11,7 @@ describe WikiCourseOutput do
 
     let(:student) { create(:user, username: 'StudentUser') }
     let(:instructor) { create(:user, username: 'InstructorUser') }
+    let(:instructor2) { create(:user, username: 'InstructorUser2') }
     let(:course) do
       create(:course,
              title: '# Title #',
@@ -63,6 +64,7 @@ describe WikiCourseOutput do
              course:,
              role: 0)
       create(:courses_user, user: instructor, course:, role: 1, real_name: 'Jacque')
+      create(:courses_user, user: instructor2, course:, role: 1, real_name: 'Marie')
       create(:assignment,
              id: 1,
              user: student,
@@ -81,6 +83,7 @@ describe WikiCourseOutput do
       expect(response).to include('[[Your article]]')
       expect(response).to include('Jacque')
       expect(response).to include('Campaign Title 1, Campaign Title 2')
+      expect(response).to include('InstructorUser', 'InstructorUser2')
     end
 
     context 'when the course has no weeks or users or anything' do


### PR DESCRIPTION
closes #1175

## What this PR does
Add Support for any number of additional instructors for on-wiki course page. With new parameters, so that the templates will remain backwards-compatible on-wiki.

## Screenshots

Before:


https://github.com/user-attachments/assets/5e6c2fbf-d5f5-48a2-b85e-9434130c4806



After:


https://github.com/user-attachments/assets/efa0f4b4-de54-47a3-9c84-cc206e545f99






