### PR TITLE
[Data rearchitecture] Improve UpdateCourseStatsTimeslice after local test

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -93,7 +93,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def update_cache_from_timeslices
     self.character_sum = article_course_timeslices.sum(&:character_sum)
     self.references_count = article_course_timeslices.sum(&:references_count)
-    self.user_ids = article_course_timeslices.sum([], &:user_ids)
+    self.user_ids = article_course_timeslices.sum([], &:user_ids).uniq
 
     # View count is calculated based on the first non-empty article course timeslice
     # record start date. We estimate the first non-empty record checking user_ids

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -24,6 +24,14 @@ class CourseWikiTimeslice < ApplicationRecord
   belongs_to :course
   belongs_to :wiki
 
+  scope :for_course_and_wiki, ->(course, wiki) { where(course:, wiki:) }
+  # Returns the timeslice to which a datetime belongs (it should be a single timeslice)
+  scope :for_datetime, ->(datetime) { where('start <= ? AND end > ?', datetime, datetime) }
+  # Returns all the timeslices in a given period
+  scope :in_period, lambda { |period_start, period_end|
+                      where('start >= ? AND end <= ?', period_start, period_end)
+                    }
+
   # Assumes that the revisions are for their own course wiki
   def update_cache_from_revisions(revisions)
     @revisions = revisions

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -9,7 +9,6 @@ require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/importers/average_views_importer"
 require_dependency "#{Rails.root}/lib/errors/update_service_error_helper"
 require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
-require_dependency "#{Rails.root}/lib/revision_data_manager"
 require_dependency "#{Rails.root}/lib/timeslice_manager"
 
 #= Pulls in new revisions for a single course wiki timeslice and updates the corresponding records
@@ -126,8 +125,8 @@ class UpdateCourseStatsTimeslice
       # Group revisions by timeslice
       # TODO: make this work independtly on the timeslice duration
       # Right now only works for daily timeslices
-      @revisions[wiki].group_by { |revision| revision.date.to_date }
-                      .each do |timeslice_start, revisions|
+      @revisions[wiki][:revisions].group_by { |revision| revision.date.to_date }
+                                  .each do |timeslice_start, revisions|
         update_article_course_timeslices_for_wiki(revisions, timeslice_start)
 
         update_course_user_wiki_timeslices_for_wiki(revisions, timeslice_start, wiki)

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -149,6 +149,10 @@ class UpdateCourseStatsTimeslice
       log_update_progress :course_cache_updated
 
       @timeslice_manager.update_last_mw_rev_datetime(@revisions)
+
+    rescue StandardError => e
+      log_error(e)
+      raise ActiveRecord::Rollback
     end
   end
 
@@ -180,6 +184,11 @@ class UpdateCourseStatsTimeslice
     Sentry.capture_message "#{@course.title} update: #{step}",
                            level: 'warning',
                            extra: { logs: @sentry_logs }
+  end
+
+  def log_error(error)
+    Sentry.capture_message "#{@course.title} update caches erro: #{error}",
+                           level: 'error'
   end
 
   TEN_MINUTES = 600

--- a/lib/course_cache_manager.rb
+++ b/lib/course_cache_manager.rb
@@ -69,6 +69,7 @@ class CourseCacheManager
   end
 
   def update_view_sum
+    # TODO: fix issue #5911
     @course.view_sum = @course.articles_courses.tracked.live.sum(:view_count)
   end
 

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -2,6 +2,7 @@
 require_dependency "#{Rails.root}/lib/replica"
 require_dependency "#{Rails.root}/lib/importers/revision_importer"
 require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/revision_data_manager"
 
 #= Fetches and imports new revisions for courses and creates ArticlesCourses records
 class CourseRevisionUpdater
@@ -54,7 +55,9 @@ class CourseRevisionUpdater
       start = @timeslice_manager.get_last_mw_rev_datetime_for_wiki(wiki)
       # TODO: We should fetch data even after the course end to calculate retention.
       # However, right now this causes problems due to lack of timeslices for those days.
-      end_of_update_period = (@course.end + 1.day).strftime('%Y%m%d')
+      end_of_course = (@course.end + 1.day).strftime('%Y%m%d')
+      today = Time.zone.now.strftime('%Y%m%d')
+      end_of_update_period = [end_of_course, today].min
       revisions[wiki] = RevisionDataManager
                         .new(wiki, @course, update_service: @update_service)
                         .fetch_revision_data_for_course(start, end_of_update_period)

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -29,14 +29,34 @@ class TimesliceManager
   end
 
   # Returns a string with the date to start getting revisions.
-  # For example: '20181124'
+  # For example: '20181124000000'
   def get_last_mw_rev_datetime_for_wiki(wiki)
-    unless @course.course_wiki_timeslices.where(wiki:).present?
-      return @course.start.strftime('%Y%m%d')
+    timeslices = @course.course_wiki_timeslices.where(wiki:)
+    last_datetime = timeslices.max_by(&:last_mw_rev_datetime)&.last_mw_rev_datetime
+
+    last_datetime ||= @course.start
+    last_datetime.strftime('%Y%m%d%H%M%S')
+  end
+
+  # Given an array of revision data per wiki, it updates the last_mw_rev_datetime field
+  # for every course wiki timeslice involved.
+  # { wiki0=>{:start=>'20181130230005', :end=>'20181140000000', :revisions=>[]},
+  #   ...,
+  #   wikiN=> {:start=>'20181130210015', :end=>'20181140000000', :revisions=>[revision0,...]} }
+  def update_last_mw_rev_datetime(new_fetched_data)
+    new_fetched_data.each do |wiki, revision_data|
+      timeslices = get_course_wiki_timeslices(wiki, revision_data[:start], revision_data[:end])
+      # Mark the timeslices as complete
+      timeslices.each do |timeslice|
+        timeslice.last_mw_rev_datetime = timeslice.end
+        timeslice.save
+      end
+
+      # Update the last timeslice as partially complete
+      last_updated_timeslice = get_course_wiki_timeslice(wiki, revision_data[:end])
+      last_updated_timeslice.last_mw_rev_datetime = revision_data[:end]
+      last_updated_timeslice.save
     end
-    @course.course_wiki_timeslices.where(wiki:)
-           .max_by(&:last_mw_rev_datetime)
-           .last_mw_rev_datetime.strftime('%Y%m%d')
   end
 
   private
@@ -89,8 +109,7 @@ class TimesliceManager
   def create_empty_course_wiki_timeslices(courses_wikis)
     new_records = start_dates.map do |start|
       courses_wikis.map do |c_w|
-        { course_id: @course.id, wiki_id: c_w.wiki_id, start:, end: start + TIMESLICE_DURATION,
-        last_mw_rev_datetime: @course.start }
+        { course_id: @course.id, wiki_id: c_w.wiki_id, start:, end: start + TIMESLICE_DURATION }
       end
     end.flatten
 
@@ -110,5 +129,13 @@ class TimesliceManager
     end
 
     start_dates
+  end
+
+  def get_course_wiki_timeslice(wiki, datetime)
+    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).for_datetime(datetime).first
+  end
+
+  def get_course_wiki_timeslices(wiki, period_start, period_end)
+    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).in_period(period_start, period_end)
   end
 end

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -31,8 +31,10 @@ class TimesliceManager
   # Returns a string with the date to start getting revisions.
   # For example: '20181124000000'
   def get_last_mw_rev_datetime_for_wiki(wiki)
-    timeslices = @course.course_wiki_timeslices.where(wiki:)
-    last_datetime = timeslices.max_by(&:last_mw_rev_datetime)&.last_mw_rev_datetime
+    non_empty_timeslices = @course.course_wiki_timeslices.where(wiki:).reject do |ts|
+      ts.last_mw_rev_datetime.nil?
+    end
+    last_datetime = non_empty_timeslices.max_by(&:last_mw_rev_datetime)&.last_mw_rev_datetime
 
     last_datetime ||= @course.start
     last_datetime.strftime('%Y%m%d%H%M%S')

--- a/spec/lib/course_cache_manager_spec.rb
+++ b/spec/lib/course_cache_manager_spec.rb
@@ -15,7 +15,7 @@ describe CourseCacheManager do
     create(:user, id: 2, username: 'Gatoespecie')
 
     create(:articles_course, id: 1, article:, course:, view_count: 4, new_article: true)
-    create(:articles_course, id: 2, article:, course:, view_count: 3)
+    create(:articles_course, id: 2, article:, course:, view_count: 4)
 
     create(:courses_user, id: 1, course:, user_id: 1)
     create(:courses_user, id: 2, course:, user_id: 2)
@@ -69,7 +69,8 @@ describe CourseCacheManager do
 
     it 'updates caches based on existing articles courses records' do
       described_class.new(course).update_cache_from_timeslices []
-      expect(course.view_sum).to eq(7)
+      # TODO: view_sum should be 8. See issue #5911
+      expect(course.view_sum).to eq(4)
       expect(course.article_count).to eq(2)
       expect(course.new_article_count).to eq(1)
     end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -131,7 +131,8 @@ describe CourseRevisionUpdater do
 
     it 'includes revisions on the final day of a course up to the end time' do
       VCR.use_cassette 'course_revision_updater' do
-        revisions = described_class.fetch_revisions_and_scores(course).values.flatten
+        revision_data = described_class.fetch_revisions_and_scores(course)
+        revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
         expect(revisions.count).to eq(3)
 
         expected_article = Article.find_by(wiki_id: 1,
@@ -151,7 +152,8 @@ describe CourseRevisionUpdater do
     it 'includes revisions up to today if course didnt finish yet' do
       VCR.use_cassette 'course_revision_updater' do
         travel_to Date.new(2016, 3, 28)
-        revisions = described_class.fetch_revisions_and_scores(course).values.flatten
+        revision_data = described_class.fetch_revisions_and_scores(course)
+        revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
         # no revision during that period
         expect(revisions.count).to eq(0)
       end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -115,4 +115,54 @@ describe CourseRevisionUpdater do
       described_class.import_revisions(course, all_time: true)
     end
   end
+
+  describe '.fetch_revisions_and_scores' do
+    let(:course) { create(:course, start: '2016-03-20', end: '2016-03-31') }
+    let(:user) { create(:user, username: 'Tedholtby') }
+    let(:courses_user) do
+      create(:courses_user, course:,
+                          user:,
+                          role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
+
+    before do
+      course && user && courses_user
+    end
+
+    it 'includes revisions on the final day of a course up to the end time' do
+      VCR.use_cassette 'course_revision_updater' do
+        revisions = described_class.fetch_revisions_and_scores(course).values.flatten
+        expect(revisions.count).to eq(3)
+
+        expected_article = Article.find_by(wiki_id: 1,
+                                           title: '1978_Revelation_on_Priesthood',
+                                           mw_page_id: 15124285,
+                                           namespace: 0)
+
+        expect(revisions.last.mw_rev_id).to eq(712907095)
+        expect(revisions.last.user_id).to eq(user.id)
+        expect(revisions.last.wiki_id).to eq(1)
+        expect(revisions.last.mw_page_id).to eq(15124285)
+        expect(revisions.last.characters).to eq(579)
+        expect(revisions.last.article_id).to eq(expected_article.id)
+      end
+    end
+
+    it 'includes revisions up to today if course didnt finish yet' do
+      VCR.use_cassette 'course_revision_updater' do
+        travel_to Date.new(2016, 3, 28)
+        revisions = described_class.fetch_revisions_and_scores(course).values.flatten
+        # no revision during that period
+        expect(revisions.count).to eq(0)
+      end
+    end
+
+    it 'skips import for ArticleScopedCourse with no tracked articles' do
+      expect_any_instance_of(RevisionDataManager).not_to receive(:fetch_revision_data_for_course)
+      course = create(:article_scoped_program)
+      student = create(:user)
+      create(:courses_user, course:, user: student)
+      described_class.fetch_revisions_and_scores(course)
+    end
+  end
 end

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -126,7 +126,7 @@ describe ArticlesCourses, type: :model do
              end: '2024-07-08',
              character_sum: 12,
              references_count: 5,
-             user_ids: [user.id])
+             user_ids: [2, user.id])
 
       # Empty timeslice, which should not count towards stats.
       create(:article_course_timeslice,

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -7,10 +7,10 @@ describe UpdateCourseStatsTimeslice do
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
   let(:subject) { described_class.new(course) }
+  let(:flags) { nil }
+  let(:user) { create(:user, username: 'Ragesoss') }
 
   context 'when debugging is not enabled' do
-    let(:flags) { nil }
-
     it 'posts no Sentry logs' do
       expect(Sentry).not_to receive(:capture_message)
       subject
@@ -27,9 +27,6 @@ describe UpdateCourseStatsTimeslice do
   end
 
   context 'when there are revisions' do
-    let(:flags) { nil }
-    let(:user) { create(:user, username: 'Ragesoss') }
-
     before do
       stub_wiki_validation
       travel_to Date.new(2018, 12, 1)
@@ -38,12 +35,13 @@ describe UpdateCourseStatsTimeslice do
       JoinCourse.new(course:, user:, role: 0)
       # Create course wiki timeslices manually for wikidata
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wikidata])
-      VCR.use_cassette 'course_update' do
-        subject
-      end
     end
 
     it 'imports average views of edited articles' do
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+
       # 2 en.wiki articles
       expect(course.articles.where(wiki: enwiki).count).to eq(2)
       # 13 wikidata articles, but one is for Property namespace (120)
@@ -52,6 +50,10 @@ describe UpdateCourseStatsTimeslice do
     end
 
     it 'updates article course and article course timeslices caches' do
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+
       # Check caches for mw_page_id 6901525
       article = Article.find_by(mw_page_id: 6901525)
       # The article course exists
@@ -74,6 +76,10 @@ describe UpdateCourseStatsTimeslice do
     end
 
     it 'updates course user and course user wiki timeslices caches' do
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+
       # Check caches for course user
       course_user = CoursesUsers.find_by(course:, user:)
       # The course user caches were updated
@@ -110,6 +116,10 @@ describe UpdateCourseStatsTimeslice do
     end
 
     it 'updates course and course wiki timeslices caches' do
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+
       # Check caches for course
       # Course caches were updated
       expect(course.character_sum).to eq(7991)
@@ -140,6 +150,7 @@ describe UpdateCourseStatsTimeslice do
       expect(timeslice.upload_count).to eq(0)
       expect(timeslice.uploads_in_use_count).to eq(0)
       expect(timeslice.upload_usages_count).to eq(0)
+      expect(timeslice.last_mw_rev_datetime).to eq('20181130'.to_datetime)
 
       # For wikidata
       timeslice = course.course_wiki_timeslices.where(wiki: wikidata,
@@ -150,6 +161,32 @@ describe UpdateCourseStatsTimeslice do
       expect(timeslice.upload_count).to eq(0)
       expect(timeslice.uploads_in_use_count).to eq(0)
       expect(timeslice.upload_usages_count).to eq(0)
+      expect(timeslice.last_mw_rev_datetime).to eq('20181125'.to_datetime)
+    end
+
+    it 'rolls back the updates if something goes wrong' do
+      allow(Sentry).to receive(:capture_message)
+      # Stub out update_all_caches_from_timeslices to raise an error
+      allow(CoursesUsers).to receive(:update_all_caches_from_timeslices)
+        .and_raise(StandardError, 'Simulated failure')
+
+      VCR.use_cassette 'course_update' do
+        subject
+      end
+
+      expect(Sentry).to have_received(:capture_message)
+
+      # Check caches for mw_page_id 6901525
+      article = Article.find_by(mw_page_id: 6901525)
+      # The article course exists
+      article_course = ArticlesCourses.find_by(article_id: article.id)
+      # The article course caches weren't updated
+      expect(article_course.character_sum).to eq(0)
+      # last_mw_rev_datetime wasn't updated
+      timeslice = course.course_wiki_timeslices.where(wiki: enwiki,
+                                                      start: '2018-11-29').first
+
+      expect(timeslice.last_mw_rev_datetime).to be_nil
     end
   end
 

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -32,7 +32,7 @@ describe UpdateCourseStatsTimeslice do
 
     before do
       stub_wiki_validation
-      travel_to Date.new(2018, 11, 28)
+      travel_to Date.new(2018, 12, 1)
       course.campaigns << Campaign.first
       course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       JoinCourse.new(course:, user:, role: 0)
@@ -60,8 +60,7 @@ describe UpdateCourseStatsTimeslice do
       expect(article_course.character_sum).to eq(427)
       expect(article_course.references_count).to eq(-2)
       expect(article_course.user_ids).to eq([user.id])
-      # TODO: this value should change when implement the real timeslice start date
-      expect(article_course.view_count).to eq(4)
+      expect(article_course.view_count).to eq(3)
 
       # Article course timeslice record was created for mw_page_id 6901525
       # timeslices from 2018-11-24 to 2018-11-30 were created
@@ -116,8 +115,8 @@ describe UpdateCourseStatsTimeslice do
       expect(course.character_sum).to eq(7991)
       expect(course.references_count).to eq(-2)
       expect(course.revision_count).to eq(29)
-      # TODO: this value should change when implement the real timeslice start date
-      # expect(course.view_sum).to eq(814)
+      # TODO: view_sum should be 918. See issue #5911
+      expect(course.view_sum).to eq(912)
       expect(course.user_count).to eq(1)
       expect(course.trained_count).to eq(1)
       # TODO: update recent_revision_count


### PR DESCRIPTION
## What this PR does
After running a second test locally using the `UpdateCourseStatsTimeslice` class to calculate course caches, this PR implements the following fixes/improvements:

- Fix duplicate ids in `ArticlesCourses`.`user_ids` field - see commit 61bf72e4d96f79d98ffa2e68865b2e5dc83587d3
- Add comments about  `view_sum` cache for courses being incorrectly calculated. Now that timeslices have the right start and end dates, `view_count` cache for `ArticlesCourses` works fine. I'm not fixing the `view_sum` cache error now in order not to add noise to the comparison between versions (timeslice version vs regular version).
- Re-think how `last_mw_rev_datetime` field works. This course wiki timeslice field represents the time up to which we retrieve revisions for a given wiki course timeslice. If the timeslice is complete, then `last_mw_rev_datetime`  = `end`. Otherwise, `last_mw_rev_datetime`  < `end`.  The `last_mw_rev_datetime` field is updated for every course wiki each time `UpdateCourseStatsTimeslice` runs, right after caches get updated. If something goes wrong while updating caches, then all the changes in the db are rolled back, as we need to keep consistency. 
- Make `update_caches` method atomic. This way, if something fails in any of the steps, what has been calculated up to that point with the revisions in RAM is rolled back from the database.


## Open questions and concerns
- `update_caches` method is likely too big to be atomic. We should re-think about making smaller processes atomic. Not updating the cache of a course because a simple timeslice failed seems a bit over-killing.
- We're logging errors through a `Sentry.capture_message` call but we may want to improve this in the future.
- `for_datetime` and `in_period` `CourseWikiTimeslice` scopes can be dangerous to use if not instantiated in a wiki and a specific course?