### PR TITLE
[Data rearchitecture] Start using the new UpdateCourseStatsTimeslice class

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -182,6 +182,13 @@ class CoursesController < ApplicationController
     redirect_to "/courses/#{@course.slug}"
   end
 
+  def manual_update_timeslice
+    require_super_admin_permissions
+    @course = find_course_by_slug(params[:id])
+    UpdateCourseStatsTimeslice.new(@course)
+    redirect_to "/courses/#{@course.slug}"
+  end
+
   def needs_update
     @course = find_course_by_slug(params[:id])
     @course.update(needs_update: true)

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -35,7 +35,7 @@ class UpdateCourseStatsTimeslice
     # This needs to happen after `update_caches` because it relies on ArticlesCourses#new_article
     # to calculate new article stats for each namespace.
     # update_wiki_namespace_stats
-    # @course.update(needs_update: false)
+    @course.update(needs_update: false)
     @end_time = Time.zone.now
     UpdateLogger.update_course(@course, 'start_time' => @start_time.to_datetime,
                                          'end_time' => @end_time.to_datetime,
@@ -187,7 +187,7 @@ class UpdateCourseStatsTimeslice
   end
 
   def log_error(error)
-    Sentry.capture_message "#{@course.title} update caches erro: #{error}",
+    Sentry.capture_message "#{@course.title} update caches error: #{error}",
                            level: 'error'
   end
 

--- a/app/workers/course_data_update_worker.rb
+++ b/app/workers/course_data_update_worker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_dependency "#{Rails.root}/app/services/update_course_stats"
+require_dependency "#{Rails.root}/app/services/update_course_stats_timeslice"
 
 class CourseDataUpdateWorker
   THIRTY_DAYS = 60 * 60 * 24 * 30
@@ -16,8 +16,8 @@ class CourseDataUpdateWorker
     course = Course.find(course_id)
     return if course.very_long_update?
 
-    logger.info "Updating course: #{course.slug}"
-    UpdateCourseStats.new(course)
+    logger.info "Updating course timeslice version: #{course.slug}"
+    UpdateCourseStatsTimeslice.new(course)
   rescue StandardError => e
     Sentry.capture_exception e
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,8 @@ Rails.application.routes.draw do
 
     get 'courses/*id/manual_update' => 'courses#manual_update',
         :as => :manual_update, constraints: { id: /.*/ }
+    get 'courses/*id/manual_update_timeslice' => 'courses#manual_update_timeslice',
+        :as => :manual_update_timeslice, constraints: { id: /.*/ }
     get 'courses/*id/notify_untrained' => 'courses#notify_untrained',
         :as => :notify_untrained, constraints: { id: /.*/ }
     get 'courses/*id/needs_update' =>  'courses#needs_update',

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -37,7 +37,7 @@ describe ScheduleCourseUpdates do
     end
 
     it 'calls the revisions and articles updates on courses currently taking place' do
-      expect(UpdateCourseStats).to receive(:new).exactly(7).times
+      expect(UpdateCourseStatsTimeslice).to receive(:new).exactly(7).times
       update = described_class.new
       sentry_logs = update.instance_variable_get(:@sentry_logs)
       expect(sentry_logs.grep(/Short update latency/).any?).to eq(true)


### PR DESCRIPTION
## What this PR does
This PR allows using the new `UpdateCourseStatsTimeslice` easily.
1. Make `CourseDataUpdateWorker` use new `UpdateCourseStatsTimeslice` class. Commit 598423df24c18d9b6062d84c121d9b6334c933cb
2. Update `CopyCourse` class to create timeslices. Commit 47097bc2499e744a77ae7e80c3c5ba33d269954a
3. Create a new `manual_update_timeslice` route to trigger a manual update using the `UpdateCourseStatsTimeslice`. Commits 47097bc2499e744a77ae7e80c3c5ba33d269954a and 0e71e08c221695f142ac17d858c41772281a3585

## Open questions and concerns
Note: I got confused when I added the files in the different commits, that's why they are mixed up