### PR TITLE
[Data rearchitecture] Stop deleting articles courses as part of the daily update

### DIFF
--- a/app/workers/daily_update/clean_articles_courses_worker.rb
+++ b/app/workers/daily_update/clean_articles_courses_worker.rb
@@ -7,6 +7,7 @@ class CleanArticlesCoursesWorker
   sidekiq_options lock: :until_executed
 
   def perform
-    ArticlesCoursesCleaner.rebuild_articles_courses
+    # TODO: think how to clean articles courses without persisted revisions
+    # ArticlesCoursesCleaner.rebuild_articles_courses
   end
 end

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -19,7 +19,8 @@ describe DailyUpdate do
       worker_double = class_double(WikiDiscouragedArticleWorker)
       expect(UserImporter).to receive(:update_users)
       expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
-      expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
+      # TODO: modify this when implementing the rebuilding articles courses without revisions
+      # expect(ArticlesCoursesCleaner).to receive(:rebuild_articles_courses)
       expect(RatingImporter).to receive(:update_all_ratings)
       expect(UploadImporter).to receive(:find_deleted_files)
       expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)


### PR DESCRIPTION
## What this PR does
This PR comments out the `rebuild_articles_courses` call in `CleanArticlesCoursesWorker`.
As part of the daily update, we clean articles courses based on the persisted revisions. Since
we don't have revisions at all in our data base now, this causes all the existing articles courses to be deleted.

## Open questions and concerns
TODO: implement a mechanism to clean articles courses without needing persisted revisions.