### PR TITLE
[Data rearchitecture] Allow deleting tracked course wikis

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -333,10 +333,12 @@ class Course < ApplicationRecord
   def update_wikis(updated_wikis)
     existing_wiki_ids = courses_wikis.map(&:wiki_id)
     new_wikis = updated_wikis.reject { |wiki| existing_wiki_ids.include?(wiki.id) }
+    deleted_wiki_ids = existing_wiki_ids.reject do |wiki_id|
+      updated_wikis.map(&:id).include?(wiki_id)
+    end
     update(wikis: updated_wikis)
     ensure_home_wiki_in_courses_wikis
-    # Onnly creates course wiki timeslice records for new wikis
-    TimesliceManager.new(self).create_timeslices_for_new_course_wiki_records new_wikis
+    TimesliceManager.new(self).update_wikis(new_wikis, deleted_wiki_ids)
   end
 
   # The url for the on-wiki version of the course.

--- a/app/workers/course_wiki_updater_worker.rb
+++ b/app/workers/course_wiki_updater_worker.rb
@@ -16,9 +16,11 @@ class CourseWikiUpdaterWorker
     # Be sure the courses wikis were deleted
     current_course_wiki_ids = course.courses_wikis(&:wiki_id)
     deleted_wiki_ids = wiki_ids - current_course_wiki_ids
-    # Deletes timeslices for the deleted wikis
+    # Delete timeslices for the deleted wikis
     TimesliceManager.new(course).delete_timeslices_for_deleted_course_wikis deleted_wiki_ids
-    # Deletes articles courses
+    # Delete articles courses
     ArticlesCoursesCleanerTimeslice.remove_bad_articles_courses(course, deleted_wiki_ids)
+    # Update course cache
+    course.update_cache
   end
 end

--- a/app/workers/course_wiki_updater_worker.rb
+++ b/app/workers/course_wiki_updater_worker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+
+class CourseWikiUpdaterWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  def self.schedule_deletion(course:, wiki_ids:)
+    perform_async(course.id, wiki_ids)
+  end
+
+  def perform(course_id, wiki_ids)
+    course = Course.find(course_id)
+    # Be sure the courses wikis were deleted
+    current_course_wiki_ids = course.courses_wikis(&:wiki_id)
+    deleted_wiki_ids = wiki_ids - current_course_wiki_ids
+    # Deletes timeslices for the deleted wikis
+    TimesliceManager.new(course).delete_timeslices_for_deleted_course_wikis deleted_wiki_ids
+    # Deletes articles courses
+    ArticlesCoursesCleanerTimeslice.remove_bad_articles_courses(course, deleted_wiki_ids)
+  end
+end

--- a/lib/articles_courses_cleaner_timeslice.rb
+++ b/lib/articles_courses_cleaner_timeslice.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#= Cleaner for ArticlesCourses that are not part of a course anymore
+# This class has to be renamed to ArticlesCoursesCleaner when deleting
+# the existing ArticlesCoursesCleaner class.
+class ArticlesCoursesCleanerTimeslice
+  ################
+  # Entry points #
+  ################
+
+  def self.remove_bad_articles_courses(course, wiki_ids)
+    new(course).remove_bad_articles_courses_for_wiki_ids(wiki_ids)
+  end
+
+  #######################
+  # Main repair routine #
+  #######################
+
+  def initialize(course)
+    @course = course
+  end
+
+  def remove_bad_articles_courses_for_wiki_ids(wiki_ids)
+    # Collect the ids of articles to be deleted
+    article_ids = @course.articles.where(wiki_id: wiki_ids).pluck(:id)
+
+    # Collect the ids of timeslices to be deleted
+    timeslice_ids = ArticlesCourses.where(course_id: @course.id,
+                                          article_id: article_ids).pluck(:id)
+
+    return if timeslice_ids.empty?
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      ArticlesCourses.where(id: timeslice_id_slice).delete_all
+    end
+    Rails.logger.info "Deleted #{timeslice_ids.size} ArticlesCourses from #{@course.title}"
+  end
+end

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -6,6 +6,13 @@ class TimesliceManager
     @course = course
   end
 
+  def update_wikis(new_wikis, deleted_wikis)
+    # Only creates course wiki timeslice records for new wikis
+    create_timeslices_for_new_course_wiki_records new_wikis
+    # Removes timeslices records for deleted wikis
+    delete_timeslices_for_deleted_course_wikis deleted_wikis
+  end
+
   # Creates article course timeslices records for new articles courses
   # Takes an array like the following:
   # [{:article_id=>115, :course_id=>72},..., {:article_id=>116, :course_id=>72}]

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -28,6 +28,17 @@ class TimesliceManager
     create_empty_course_user_wiki_timeslices(courses_wikis:)
   end
 
+  # Deletes course wiki timeslices records for removed course wikis
+  # Deletes course user timeslices records for removed course wiki
+  # Deletes article course timeslices records for removed course wiki
+  # Takes a collection of wiki ids
+  def delete_timeslices_for_deleted_course_wikis(wiki_ids)
+    return if wiki_ids.empty?
+    delete_existing_course_wiki_timeslices(wiki_ids)
+    delete_existing_course_user_wiki_timeslices(wiki_ids)
+    delete_existing_article_course_timeslices(wiki_ids)
+  end
+
   # Returns a string with the date to start getting revisions.
   # For example: '20181124000000'
   def get_last_mw_rev_datetime_for_wiki(wiki)
@@ -119,6 +130,50 @@ class TimesliceManager
     # Do this in batches to avoid running the MySQL server out of memory
     new_records.each_slice(5000) do |new_record_slice|
       CourseWikiTimeslice.import new_record_slice, on_duplicate_key_ignore: true
+    end
+  end
+
+  # Deletes existing course wiki timeslices for a collection of wiki ids
+  def delete_existing_course_wiki_timeslices(wiki_ids)
+    # Collect the ids of timeslices to be deleted
+    timeslice_ids = CourseWikiTimeslice.where(course_id: @course.id, wiki_id: wiki_ids).pluck(:id)
+
+    return if timeslice_ids.empty?
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      CourseWikiTimeslice.where(id: timeslice_id_slice).delete_all
+    end
+  end
+
+  # Deletes existing course user wiki timeslices for a collection of wiki ids
+  def delete_existing_course_user_wiki_timeslices(wiki_ids)
+    # Collect the ids of timeslices to be deleted
+    timeslice_ids = CourseUserWikiTimeslice.where(course_id: @course.id,
+                                                  wiki_id: wiki_ids).pluck(:id)
+
+    return if timeslice_ids.empty?
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      CourseUserWikiTimeslice.where(id: timeslice_id_slice).delete_all
+    end
+  end
+
+  # Deletes existing article course timeslices for a collection of wiki ids
+  def delete_existing_article_course_timeslices(wiki_ids)
+    # Collect the ids of articles to be deleted
+    article_ids = @course.articles.where(wiki_id: wiki_ids).pluck(:id)
+
+    # Collect the ids of timeslices to be deleted
+    timeslice_ids = ArticleCourseTimeslice.where(course_id: @course.id,
+                                                 article_id: article_ids).pluck(:id)
+
+    return if timeslice_ids.empty?
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      ArticleCourseTimeslice.where(id: timeslice_id_slice).delete_all
     end
   end
 

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
-#= Adds new ArticleCourseTimeslice, CourseUserWikiTimeslice and CourseWikiTimeslice records.
+#= Creates/Removes/Updates ArticleCourseTimeslice, CourseUserWikiTimeslice
+# and CourseWikiTimeslice records.
 class TimesliceManager
   def initialize(course)
     @course = course
   end
 
-  def update_wikis(new_wikis, deleted_wikis)
-    # Only creates course wiki timeslice records for new wikis
-    create_timeslices_for_new_course_wiki_records new_wikis
-    # Removes timeslices records for deleted wikis
-    delete_timeslices_for_deleted_course_wikis deleted_wikis
+  # Deletes course wiki timeslices records for removed course wikis
+  # Deletes course user timeslices records for removed course wiki
+  # Deletes article course timeslices records for removed course wiki
+  # Takes a collection of wiki ids
+  def delete_timeslices_for_deleted_course_wikis(wiki_ids)
+    return if wiki_ids.empty?
+    delete_existing_course_wiki_timeslices(wiki_ids)
+    delete_existing_course_user_wiki_timeslices(wiki_ids)
+    delete_existing_article_course_timeslices(wiki_ids)
   end
 
   # Creates article course timeslices records for new articles courses
@@ -33,17 +38,6 @@ class TimesliceManager
     courses_wikis = @course.courses_wikis.where(wiki: wikis)
     create_empty_course_wiki_timeslices(courses_wikis)
     create_empty_course_user_wiki_timeslices(courses_wikis:)
-  end
-
-  # Deletes course wiki timeslices records for removed course wikis
-  # Deletes course user timeslices records for removed course wiki
-  # Deletes article course timeslices records for removed course wiki
-  # Takes a collection of wiki ids
-  def delete_timeslices_for_deleted_course_wikis(wiki_ids)
-    return if wiki_ids.empty?
-    delete_existing_course_wiki_timeslices(wiki_ids)
-    delete_existing_course_user_wiki_timeslices(wiki_ids)
-    delete_existing_article_course_timeslices(wiki_ids)
   end
 
   # Returns a string with the date to start getting revisions.

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -170,6 +170,7 @@ describe CoursesController, type: :request do
       put "/courses/#{course.slug}", params: params, as: :json
       expect(course.wikis.count).to eq(2)
       course.reload
+      expect(CourseWikiUpdaterWorker).to receive(:schedule_deletion)
       course_params[:wikis].pop
       put "/courses/#{course.slug}", params: params, as: :json
       expect(course.wikis.count).to eq(1)
@@ -181,6 +182,7 @@ describe CoursesController, type: :request do
       put "/courses/#{course.slug}", params: params, as: :json
       expect(course.wikis.count).to eq(2)
       course.reload
+      expect(CourseWikiUpdaterWorker).to receive(:schedule_deletion)
       course_params[:wikis][0][:language] = 'fr'
       put "/courses/#{course.slug}", params: params, as: :json
       expect(course.wikis.last.language).to eq('fr')
@@ -206,6 +208,7 @@ describe CoursesController, type: :request do
       course_params[:namespaces] =
         ['en.wikipedia.org-namespace-0', 'en.wikibooks.org-namespace-102']
       params = { id: course.slug, course: course_params }
+      expect(CourseWikiUpdaterWorker).to receive(:schedule_deletion)
       put "/courses/#{course.slug}", params: params, as: :json
       expect(course.course_wiki_namespaces.count).to eq(2)
       course.reload

--- a/spec/lib/articles_courses_cleaner_timeslice_spec.rb
+++ b/spec/lib/articles_courses_cleaner_timeslice_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+
+describe ArticlesCoursesCleanerTimeslice do
+  let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
+  let(:wikidata) { Wiki.get_or_create(project: 'wikidata', language: nil) }
+  let(:course) { create(:course, start: '2024-01-01', end: '2024-04-20') }
+  # let(:enwiki_course) { create(:courses_wiki, course:, wiki: enwiki) }
+  # let(:wikidata_course) { create(:courses_wiki, course:, wiki: wikidata) }
+  let(:article1) { create(:article, wiki: enwiki) }
+  let(:article2) { create(:article, wiki: wikidata) }
+  let(:article3) { create(:article, wiki: wikidata) }
+
+  describe '.remove_bad_articles_courses' do
+    before do
+      stub_wiki_validation
+      create(:articles_course, course:, article: article1)
+      create(:articles_course, course:, article: article2)
+      create(:articles_course, course:, article: article3)
+    end
+
+    it 'removes ArticlesCourses that belong to a deleted wiki' do
+      expect(course.articles_courses.size).to eq(3)
+      # Wikidata courses_wikis record was deleted
+      described_class.remove_bad_articles_courses(course, wikidata.id)
+      expect(course.articles_courses.size).to eq(1)
+    end
+  end
+end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -100,7 +100,7 @@ describe TimesliceManager do
       )
     end
 
-    it 'deletes wiki timeslices for the entire course' do
+    it 'deletes wiki timeslices for the entire course properly' do
       expect(course.course_wiki_timeslices.size).to eq(333)
       expect(course.course_user_wiki_timeslices.size).to eq(999)
       expect(course.article_course_timeslices.size).to eq(333)
@@ -108,10 +108,12 @@ describe TimesliceManager do
       timeslice_manager.delete_timeslices_for_deleted_course_wikis([wikibooks.id, wikidata.id])
       course.reload
       # Course wiki timeslices for wikibooks and wikidata were deleted
-      expect(course.course_wiki_timeslices.size).to eq(111)
+      expect(course.course_wiki_timeslices.where(wiki_id: wikibooks.id).size).to eq(0)
+      expect(course.course_wiki_timeslices.where(wiki_id: wikidata.id).size).to eq(0)
       # Course user wiki timeslices for wikibooks and wikidata were deleted
-      expect(course.course_user_wiki_timeslices.size).to eq(333)
-      # article course timeslices for wikibooks and wikidata were deleted
+      expect(course.course_user_wiki_timeslices.where(wiki_id: wikibooks.id).size).to eq(0)
+      expect(course.course_user_wiki_timeslices.where(wiki_id: wikidata.id).size).to eq(0)
+      # Article course timeslices for wikibooks and wikidata were deleted
       expect(course.article_course_timeslices.size).to eq(111)
     end
   end


### PR DESCRIPTION
## What this PR does
This PR implements the ability to remove tracked wikis for a course.

When a new tracked wiki is added, we create the given timeslices (already implemented before this PR).

When existing tracked wikis get removed for a course, we want to:
1. Remove existing timeslices for those wikis. This is done through the new `TimesliceManager.delete_timeslices_for_deleted_course_wikis` (commit d943064313035db381b436ea954da58d9bb2bc57)
2. Remove articles courses records for those wikis. This is done through the new `ArticlesCoursesCleanerTimeslice` class (commit 12e024f8b2935ab13087f3691d88a62ed548c562)
3. Update course cache.

These things need to be done through a worker in an asynchronous way, because they can potentially take some time, and we don't want to leave the web-app user waiting. See new `CourseWikiUpdaterWorker` class.

## Screenshots

### Delete `es.wikipedia.org`
Before deleting  `es.wikipedia.org` there is one article course for that wiki and 62 edited articles in total.
When deleting the es.wikipedia wiki, an asynchronous task is queued.

[delete_es_wikipedia.webm](https://github.com/user-attachments/assets/6d25147c-c669-40a6-b390-bd8cf22f5b1d)

### Re-add `es.wikipedia.org` once deleted
After the asynchronous task runs, there are 61 edited articles in total for the course, because the one associated to the es.wikipedia was removed. Then, we re-add it through the web-app.

[re_add_es_wikipedia.webm](https://github.com/user-attachments/assets/95fa05ee-eb7b-43ac-bc08-09ed8c83f510)

### Next course update runs
After the next `UpdateCourseStatsTimeslice` task runs again, the es.wikipedia data is ingested again, and the course has 62 articles in total.

![image](https://github.com/user-attachments/assets/b41c75c9-09f1-4fe8-b896-7c031c4087e8)


## Open questions and concerns
Note: Article records not used in any other course should be deleted too, but I don't think there is any nice way to do that (it would involve non course-scoped queries).