### PR TITLE
[Data rearchitecture] Fix  `update_last_mw_rev_datetime` logic. 

### DIFF
--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -192,7 +192,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
       # Get the timeslice that we want to update
       timeslice = timeslices.find { |ts| ts.start <= revision.date && ts.end > revision.date }
 
-      # Next if the last_mw_rev_datetime field is
+      # Next if the last_mw_rev_datetime field is after the revision date
       if !timeslice.last_mw_rev_datetime.nil? && timeslice.last_mw_rev_datetime >= revision.date
         next
       end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -174,12 +174,10 @@ describe TimesliceManager do
         course_wiki_timeslices = course.course_wiki_timeslices.where(wiki_id: enwiki.id)
         expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(111)
         timeslice_manager.update_last_mw_rev_datetime(new_fetched_data)
-        # four course wiki timeslices were updated
+        # two course wiki timeslices were updated
         expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(109)
         expect(course_wiki_timeslices.first.last_mw_rev_datetime).to eq('20240101194045')
-        # expect(course_wiki_timeslices.second.last_mw_rev_datetime).to eq('20240103000000')
         expect(course_wiki_timeslices.third.last_mw_rev_datetime).to eq('20240103030910')
-        # expect(course_wiki_timeslices.fourth.last_mw_rev_datetime).to eq('20240104101340')
       end
     end
   end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -141,22 +141,32 @@ describe TimesliceManager do
         # update last_mw_rev_datetime
         # Update last_mw_rev_datetime for the first course_wiki_timeslice
         first_timeslice = course.course_wiki_timeslices.first
-        first_timeslice.last_mw_rev_datetime = '20240102000000'.to_datetime
+        first_timeslice.last_mw_rev_datetime = '20240101103407'.to_datetime
         first_timeslice.save
 
         # Update last_mw_rev_datetime for the second course_wiki_timeslice
         second_timeslice = course.course_wiki_timeslices.second
-        second_timeslice.last_mw_rev_datetime = '20240103000000'.to_datetime
+        second_timeslice.last_mw_rev_datetime = '20240102002146'.to_datetime
         second_timeslice.save
 
-        expect(timeslice_manager.get_last_mw_rev_datetime_for_wiki(enwiki)).to eq('20240103000000')
+        # Update last_mw_rev_datetime for the fourth course_wiki_timeslice
+        fourth_timeslice = course.course_wiki_timeslices.second
+        fourth_timeslice.last_mw_rev_datetime = '20240104131500'.to_datetime
+        fourth_timeslice.save
+
+        expect(timeslice_manager.get_last_mw_rev_datetime_for_wiki(enwiki)).to eq('20240104131500')
       end
     end
   end
 
   describe '#update_last_mw_rev_datetime' do
+    let(:revision1) { create(:revision, date: '2024-01-01 15:45:53') }
+    let(:revision2) { create(:revision, date: '2024-01-01 19:40:45') }
+    let(:revision3) { create(:revision, date: '2024-01-01 13:40:45') }
+    let(:revision4) { create(:revision, date: '2024-01-03 03:09:10') }
+    let(:revisions) { [revision1, revision2, revision3, revision4] }
     let(:new_fetched_data) do
-      { enwiki => { start: '20240101000000', end: '20240104101340', revisions: nil } }
+      { enwiki => { start: '20240101000000', end: '20240104101340', revisions: } }
     end
 
     context 'when there were updates' do
@@ -165,11 +175,11 @@ describe TimesliceManager do
         expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(111)
         timeslice_manager.update_last_mw_rev_datetime(new_fetched_data)
         # four course wiki timeslices were updated
-        expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(107)
-        expect(course_wiki_timeslices.first.last_mw_rev_datetime).to eq('20240102000000')
-        expect(course_wiki_timeslices.second.last_mw_rev_datetime).to eq('20240103000000')
-        expect(course_wiki_timeslices.third.last_mw_rev_datetime).to eq('20240104000000')
-        expect(course_wiki_timeslices.fourth.last_mw_rev_datetime).to eq('20240104101340')
+        expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(109)
+        expect(course_wiki_timeslices.first.last_mw_rev_datetime).to eq('20240101194045')
+        # expect(course_wiki_timeslices.second.last_mw_rev_datetime).to eq('20240103000000')
+        expect(course_wiki_timeslices.third.last_mw_rev_datetime).to eq('20240103030910')
+        # expect(course_wiki_timeslices.fourth.last_mw_rev_datetime).to eq('20240104101340')
       end
     end
   end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -150,7 +150,7 @@ describe UpdateCourseStatsTimeslice do
       expect(timeslice.upload_count).to eq(0)
       expect(timeslice.uploads_in_use_count).to eq(0)
       expect(timeslice.upload_usages_count).to eq(0)
-      expect(timeslice.last_mw_rev_datetime).to eq('20181130'.to_datetime)
+      expect(timeslice.last_mw_rev_datetime).to eq('20181129180841'.to_datetime)
 
       # For wikidata
       timeslice = course.course_wiki_timeslices.where(wiki: wikidata,
@@ -161,7 +161,7 @@ describe UpdateCourseStatsTimeslice do
       expect(timeslice.upload_count).to eq(0)
       expect(timeslice.uploads_in_use_count).to eq(0)
       expect(timeslice.upload_usages_count).to eq(0)
-      expect(timeslice.last_mw_rev_datetime).to eq('20181125'.to_datetime)
+      expect(timeslice.last_mw_rev_datetime).to eq('20181124045740'.to_datetime)
     end
 
     it 'rolls back the updates if something goes wrong' do


### PR DESCRIPTION
## What this PR does
Update the logic behind `update_last_mw_rev_datetime`. Now `last_mw_rev_datetime` field in `CourseWikiTimeslice` records has the datetime for the latest revision fetched for that timeslice period. The `last_mw_rev_datetime` field is `nil` if no revision was fetched for that period, either because the period hasn't been processed yet or because there were no revisions during that time.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
