### PR TITLE
[Data rearchitecture] Fix bug in `update_last_mw_rev_datetime`

### DIFF
--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -221,10 +221,15 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   end
 
   def get_course_wiki_timeslice(wiki, datetime)
-    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).for_datetime(datetime).first
+    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).for_datetime(datetime)
   end
 
   def get_course_wiki_timeslices(wiki, period_start, period_end)
-    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).in_period(period_start, period_end)
+    in_period = CourseWikiTimeslice.for_course_and_wiki(@course, wiki).in_period(period_start,
+                                                                                 period_end)
+    for_period_start = get_course_wiki_timeslice(wiki, period_start)
+    for_period_end = get_course_wiki_timeslice(wiki, period_end)
+
+    (for_period_start + in_period + for_period_end).uniq(&:id)
   end
 end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -166,7 +166,7 @@ describe TimesliceManager do
     let(:revision4) { create(:revision, date: '2024-01-03 03:09:10') }
     let(:revisions) { [revision1, revision2, revision3, revision4] }
     let(:new_fetched_data) do
-      { enwiki => { start: '20240101000000', end: '20240104101340', revisions: } }
+      { enwiki => { start: '20240101090035', end: '20240104101340', revisions: } }
     end
 
     context 'when there were updates' do


### PR DESCRIPTION
## What this PR does
This PR fixes an existing bug in `update_last_mw_rev_datetime`, which causes "No timeslice found for revision date" logs and processing the same revision multiple times.

It also updates a spec to reproduce the previous error.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
