### PR TITLE
Fix: Automatically Refresh 'Updated At' Timestamp When Course Stats Are Refetched

### DIFF
--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -52,7 +52,15 @@ export default function course(state = initialState, action) {
       const courseData = action.data.course;
       const newStats = CourseUtils.newCourseStats(state, courseData);
       const newKeys = CourseUtils.courseStatsToUpdate(courseData, newStats);
-      return { ...state, ...newKeys, newStats };
+
+      return {
+        ...state,
+        ...newKeys,
+        newStats,
+        flags: {
+          ...courseData.flags,
+        },
+      };
     }
     case PERSISTED_COURSE:
       return { ...state, ...action.data.course };


### PR DESCRIPTION
closes #5925 

## What this PR does

Fix: Automatically Refresh 'Updated At' Timestamp When Course Stats Are Refetched

## Cause of Bug

The `RECEIVE_COURSE_UPDATE` case in the `course reducer` was not taking in to account to update the update_logs field, even when the new data had updates for update_logs. This led to the old update_logs remaining unchanged in the Redux state.

## Screenshots

Before:


https://github.com/user-attachments/assets/5bd1ee30-1a24-45e6-9706-8bf76e21f2ea



After:



https://github.com/user-attachments/assets/1eed71e5-898a-41f4-8f6c-30d95cc23f49




