### PR TITLE
[WIP] [Data rearchitecture] Avoid processing the same revision multiple times

### DIFF
--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -132,6 +132,8 @@ describe CourseRevisionUpdater do
     it 'includes revisions on the final day of a course up to the end time' do
       VCR.use_cassette 'course_revision_updater' do
         revision_data = described_class.fetch_revisions_and_scores(course)
+        wiki = Wiki.find_by(language: 'en', project: 'Wikipedia')
+        expect(revision_data[wiki][:end]).to eq('20160331195054')
         revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
         expect(revisions.count).to eq(3)
 
@@ -153,9 +155,12 @@ describe CourseRevisionUpdater do
       VCR.use_cassette 'course_revision_updater' do
         travel_to Date.new(2016, 3, 28)
         revision_data = described_class.fetch_revisions_and_scores(course)
+        wiki = Wiki.find_by(language: 'en', project: 'Wikipedia')
         revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
         # no revision during that period
         expect(revisions.count).to eq(0)
+        # end is the same date as start
+        expect(revision_data[wiki][:end]).to eq('20160320000000')
       end
     end
 

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -85,11 +85,11 @@ describe UpdateCourseStatsTimeslice do
       # The course user caches were updated
       # All the revisions were done in mainspace = 0,
       # except for one revision in mainspace = 120, which is ommited
-      expect(course_user.character_sum_ms).to eq(7991)
+      expect(course_user.character_sum_ms).to eq(7497)
       expect(course_user.character_sum_us).to eq(0)
       expect(course_user.character_sum_draft).to eq(0)
-      # expect(course_user.references_count).to eq(-2)
-      expect(course_user.revision_count).to eq(29)
+      expect(course_user.references_count).to eq(-2)
+      expect(course_user.revision_count).to eq(27)
       expect(course_user.recent_revisions).to eq(0)
       expect(course_user.total_uploads).to eq(0)
 
@@ -108,10 +108,10 @@ describe UpdateCourseStatsTimeslice do
       # For wikidata
       timeslice = course_user.course_user_wiki_timeslices.where(wiki: wikidata,
                                                                 start: '2018-11-24').first
-      expect(timeslice.character_sum_ms).to eq(7867)
+      expect(timeslice.character_sum_ms).to eq(7451)
       expect(timeslice.character_sum_us).to eq(0)
       expect(timeslice.character_sum_draft).to eq(0)
-      expect(timeslice.revision_count).to eq(27)
+      expect(timeslice.revision_count).to eq(26)
       expect(timeslice.references_count).to eq(-2)
     end
 
@@ -122,11 +122,11 @@ describe UpdateCourseStatsTimeslice do
 
       # Check caches for course
       # Course caches were updated
-      expect(course.character_sum).to eq(7991)
+      expect(course.character_sum).to eq(7497)
       expect(course.references_count).to eq(-2)
-      expect(course.revision_count).to eq(29)
-      # TODO: view_sum should be 918. See issue #5911
-      expect(course.view_sum).to eq(912)
+      expect(course.revision_count).to eq(27)
+      # TODO: view_sum may be wrong. See issue #5911
+      expect(course.view_sum).to eq(122)
       expect(course.user_count).to eq(1)
       expect(course.trained_count).to eq(1)
       # TODO: update recent_revision_count
@@ -143,21 +143,21 @@ describe UpdateCourseStatsTimeslice do
       # Course user timeslices caches were updated
       # For enwiki
       timeslice = course.course_wiki_timeslices.where(wiki: enwiki,
-                                                      start: '2018-11-29').first
-      expect(timeslice.character_sum).to eq(78)
+                                                      start: '2018-11-24').first
+      expect(timeslice.character_sum).to eq(46)
       expect(timeslice.references_count).to eq(0)
       expect(timeslice.revision_count).to eq(1)
       expect(timeslice.upload_count).to eq(0)
       expect(timeslice.uploads_in_use_count).to eq(0)
       expect(timeslice.upload_usages_count).to eq(0)
-      expect(timeslice.last_mw_rev_datetime).to eq('20181129180841'.to_datetime)
+      expect(timeslice.last_mw_rev_datetime).to eq('20181124050431'.to_datetime)
 
       # For wikidata
       timeslice = course.course_wiki_timeslices.where(wiki: wikidata,
                                                       start: '2018-11-24').first
-      expect(timeslice.character_sum).to eq(7867)
+      expect(timeslice.character_sum).to eq(7451)
       expect(timeslice.references_count).to eq(-2)
-      expect(timeslice.revision_count).to eq(27)
+      expect(timeslice.revision_count).to eq(26)
       expect(timeslice.upload_count).to eq(0)
       expect(timeslice.uploads_in_use_count).to eq(0)
       expect(timeslice.upload_usages_count).to eq(0)


### PR DESCRIPTION
## What this PR does
This PR fixes an existing bug that caused revisions occurring exactly at `last_mw_rev_datetime` to be fetched multiple times during `CourseRevisionUpdater.fetch_revisions_and_scores` and thus processed more than once.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
