### PR TITLE
[Data rearchitecture] support different timeslice durations

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -43,7 +43,7 @@ class ArticleCourseTimeslice < ApplicationRecord
   def self.update_article_course_timeslices(course, article_id, revisions)
     rev_start = revisions[:start]
     rev_end = revisions[:end]
-    # Course wiki timeslices to update
+    # Article course timeslices to update
     article_course_timeslices = ArticleCourseTimeslice.for_course_and_article(course,
                                                                               article_id)
                                                       .for_revisions_between(rev_start, rev_end)
@@ -52,7 +52,7 @@ class ArticleCourseTimeslice < ApplicationRecord
       revisions_in_timeslice = revisions[:revisions].select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
-      # Update cache for CourseWikiTimeslice
+      # Update cache for ArticleCourseTimeslice
       timeslice.update_cache_from_revisions revisions_in_timeslice
     end
   end

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -24,6 +24,43 @@ class CourseUserWikiTimeslice < ApplicationRecord
   belongs_to :course
   belongs_to :user
   belongs_to :wiki
+  scope :for_course_user_and_wiki, ->(course, user, wiki) { where(course:, user:, wiki:) }
+  # Returns the timeslice to which a datetime belongs (it should be a single timeslice)
+  scope :for_datetime, ->(datetime) { where('start <= ? AND end > ?', datetime, datetime) }
+  # Returns all the timeslices in a given period
+  scope :in_period, lambda { |period_start, period_end|
+                      where('start >= ? AND end <= ?', period_start, period_end)
+                    }
+  scope :for_revisions_between, lambda { |period_start, period_end|
+    in_period(period_start, period_end).or(for_datetime(period_start)).or(for_datetime(period_end))
+  }
+
+  serialize :user_ids, Array # This text field only stores user ids as text
+
+  #################
+  # Class methods #
+  #################
+
+  # Given a course, a user_id, a wiki and a hash of revisions like the following:
+  # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
+  # updates the article course timeslices based on the revisions.
+  def self.update_course_user_wiki_timeslices(course, user_id, wiki, revisions)
+    rev_start = revisions[:start]
+    rev_end = revisions[:end]
+    # Course user wiki timeslices to update
+    course_user_wiki_timeslices = CourseUserWikiTimeslice.for_course_user_and_wiki(course,
+                                                                                   user_id,
+                                                                                   wiki)
+                                                         .for_revisions_between(rev_start, rev_end)
+    course_user_wiki_timeslices.each do |timeslice|
+      # Group revisions that belong to the timeslice
+      revisions_in_timeslice = revisions[:revisions].select do |revision|
+        timeslice.start <= revision.date && revision.date < timeslice.end
+      end
+      # Update cache for CourseUserWikiTimeslice
+      timeslice.update_cache_from_revisions revisions_in_timeslice
+    end
+  end
 
   ####################
   # Instance methods #

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -223,16 +223,8 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
                                on_duplicate_key_update: ['last_mw_rev_datetime']
   end
 
-  def get_course_wiki_timeslice(wiki, datetime)
-    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).for_datetime(datetime)
-  end
-
   def get_course_wiki_timeslices(wiki, period_start, period_end)
-    in_period = CourseWikiTimeslice.for_course_and_wiki(@course, wiki).in_period(period_start,
+    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).for_revisions_between(period_start,
                                                                                  period_end)
-    for_period_start = get_course_wiki_timeslice(wiki, period_start)
-    for_period_end = get_course_wiki_timeslice(wiki, period_end)
-
-    (for_period_start + in_period + for_period_end).uniq(&:id)
   end
 end

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -23,28 +23,32 @@ require "#{Rails.root}/lib/articles_courses_cleaner"
 describe ArticleCourseTimeslice, type: :model do
   let(:article) { create(:article) }
   let(:user) { create(:user) }
-  let(:course) { create(:course, start: 1.month.ago, end: 1.month.from_now) }
+  let(:start) { 1.month.ago.beginning_of_day }
+  let(:course) { create(:course, start:, end: 1.month.from_now.beginning_of_day) }
   let(:article_course) { create(:articles_course, article:, course:) }
   let(:revision1) do
     build(:revision, article:,
            characters: 123,
            features: { 'num_ref' => 4 },
            features_previous: { 'num_ref' => 0 },
-           user_id: 25)
+           user_id: 25,
+           date: start + 1.hour)
   end
   let(:revision2) do
     build(:revision, article:,
            characters: -65,
            features: { 'num_ref' => 1 },
            features_previous: { 'num_ref' => 2 },
-           user_id: 1)
+           user_id: 1,
+           date: start + 10.hours)
   end
   let(:revision3) do
     build(:revision, article:,
            characters: 225,
            features: { 'num_ref' => 3 },
            features_previous: { 'num_ref' => 3 },
-           user_id: 25)
+           user_id: 25,
+           date: start + 12.hours)
   end
   let(:revision4) do
     build(:revision, article:,
@@ -52,7 +56,8 @@ describe ArticleCourseTimeslice, type: :model do
             deleted: true, # deleted revision
             features: { 'num_ref' => 2 },
             features_previous: { 'num_ref' => 0 },
-            user_id: 6)
+            user_id: 6,
+            date: start + 16.hours)
   end
   let(:revisions) { [revision1, revision2, revision3, revision4] }
   let(:article_course_timeslice) do
@@ -64,6 +69,43 @@ describe ArticleCourseTimeslice, type: :model do
            user_ids: [2, 4])
   end
   let(:subject) { article_course_timeslice.update_cache_from_revisions revisions }
+
+  describe '.update_article_course_timeslices' do
+    before do
+      revisions << build(:revision, article:, user_id: 1, date: start + 26.hours)
+      revisions << build(:revision, article:, user_id: 3, date: start + 50.hours)
+      revisions << build(:revision, article:, user_id: 7, date: start + 51.hours)
+
+      create(:article_course_timeslice, course:, article:, start:, end: start + 1.day)
+      create(:article_course_timeslice, course:, article:, start: start + 1.day,
+             end: start + 2.days)
+      create(:article_course_timeslice, course:, article:, start: start + 2.days,
+            end: start + 3.days)
+    end
+
+    it 'updates the right article timeslices based on the revisions' do
+      article_course_timeslice_0 = described_class.find_by(course:, article:, start:)
+      article_course_timeslice_1 = described_class.find_by(course:, article:, start: start + 1.day)
+      article_course_timeslice_2 = described_class.find_by(course:, article:, start: start + 2.days)
+
+      expect(article_course_timeslice_0.user_ids).to eq([])
+      expect(article_course_timeslice_1.user_ids).to eq([])
+      expect(article_course_timeslice_2.user_ids).to eq([])
+
+      start_period = start.strftime('%Y%m%d%H%M%S')
+      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      revisions2 = { start: start_period, end: end_period, revisions: }
+      described_class.update_article_course_timeslices(course, article.id, revisions2)
+
+      article_course_timeslice_0 = described_class.find_by(course:, article:, start:)
+      article_course_timeslice_1 = described_class.find_by(course:, article:, start: start + 1.day)
+      article_course_timeslice_2 = described_class.find_by(course:, article:, start: start + 2.days)
+
+      expect(article_course_timeslice_0.user_ids).to eq([25, 1])
+      expect(article_course_timeslice_1.user_ids).to eq([1])
+      expect(article_course_timeslice_2.user_ids).to eq([3, 7])
+    end
+  end
 
   describe '#update_cache_from_revisions' do
     it 'updates cache correctly' do

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -94,8 +94,8 @@ describe ArticleCourseTimeslice, type: :model do
 
       start_period = start.strftime('%Y%m%d%H%M%S')
       end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
-      revisions2 = { start: start_period, end: end_period, revisions: }
-      described_class.update_article_course_timeslices(course, article.id, revisions2)
+      revision_data = { start: start_period, end: end_period, revisions: }
+      described_class.update_article_course_timeslices(course, article.id, revision_data)
 
       article_course_timeslice_0 = described_class.find_by(course:, article:, start:)
       article_course_timeslice_1 = described_class.find_by(course:, article:, start: start + 1.day)


### PR DESCRIPTION
## What this PR does
This PR makes the `UpdateCourseStatsTimeslice` class work independently on the timeslice duration. Right now the timeslice duration is defined at the level code, based on the `TIMESLICE_DURATION` constant in the `TimesliceManager` class. It's not possible to dynamically change that value for now, but the update course stats process would work for any `TIMESLICE_DURATION` value. Before this PR, it only worked for daily timeslices, as the one-day timeslice duration was hard-coded in some parts of the update course stats process.

Right now, every timeslice model (`ArticleCourseTimeslice`, `CourseUserWikiTimeslice` and `CourseWikiTimeslice`) has a new class method that, given a collection of revisions and a course (and some other parameters according to the model), it updates the right timeslices.

## Open questions and concerns
I tested it locally. Changed the `TIMESLICE_DURATION` constant to `6.hours` and run an update for a course. Course cache values were the same as if the `TIMESLICE_DURATION` constant is set to `1.day`.