### PR TITLE
Optimize course data refetch: Trigger only on Dashboard tab focus

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -75,6 +75,7 @@ const Details = createReactClass({
       clearInterval(this.timeout); // End it
     }
   },
+
   updateDetails(valueKey, value) {
     const updatedCourse = this.props.course;
     updatedCourse[valueKey] = value;
@@ -127,7 +128,9 @@ const Details = createReactClass({
 
   poll() {
     return setInterval(() => {
-      if (this.state.updateCount > MAX_UPDATE_COUNT) { return; }
+      const documentVisible = document.hidden;
+
+      if (documentVisible || (this.state.updateCount > MAX_UPDATE_COUNT)) { return; }
       if (!this.props.editable) {
         this.props.refetchCourse(this.props.course.slug);
         this.setState({

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -128,9 +128,9 @@ const Details = createReactClass({
 
   poll() {
     return setInterval(() => {
-      const documentVisible = document.hidden;
+      const documentHidden = document.hidden;
 
-      if (documentVisible || (this.state.updateCount > MAX_UPDATE_COUNT)) { return; }
+      if (documentHidden || (this.state.updateCount > MAX_UPDATE_COUNT)) { return; }
       if (!this.props.editable) {
         this.props.refetchCourse(this.props.course.slug);
         this.setState({


### PR DESCRIPTION
closes #5926

## What this PR does

Only re-fetch course data when Dashboard tab is focused.

## Screenshots

Before (Tab in-active for 3 minutes ):


https://github.com/user-attachments/assets/100aaa99-1f0f-466d-b59c-afe0a0df6496

After (Tab in-active for 3 minutes):


https://github.com/user-attachments/assets/8cf3d288-96a3-4a54-856e-22f0a2355aa3
