### PR TITLE
Fix disruptive pile-up of success notifications

### DIFF
--- a/app/assets/javascripts/reducers/notifications.js
+++ b/app/assets/javascripts/reducers/notifications.js
@@ -41,9 +41,27 @@ const handleErrorNotification = function (data) {
 export default function notifications(state = initialState, action) {
   switch (action.type) {
     case ADD_NOTIFICATION: {
-      const newState = [...state];
-      newState.push(action.notification);
-      return newState;
+      const newState = [...state, action.notification];
+
+      // Set the maximum number of notifications allowed for each type
+      const maxNotifications = 3;
+
+      // Process the state for each notification type (error and success)
+      return ['error', 'success'].reduce((acc, type) => {
+        // Filter notifications of the current type
+        const typeNotifications = acc.filter(x => x.type === type);
+
+        // If we have more than the maximum allowed notifications of this type
+        if (typeNotifications.length > maxNotifications) {
+          // Find the index of the oldest notification of this type
+          const indexToRemove = acc.findIndex(x => x.type === type);
+          // Remove the oldest notification by creating a new array without it
+          return [...acc.slice(0, indexToRemove), ...acc.slice(indexToRemove + 1)];
+        }
+
+        // If we don't need to remove any, return the accumulator unchanged
+        return acc;
+      }, newState);
     }
     case REMOVE_NOTIFICATION: {
       const newState = [...state];


### PR DESCRIPTION
closes #5927

## What this PR does

Implement max limit of 3 notifications per type (error/success) to prevent pile-up of `success/error` notifications.

## Screenshots

**Before:**

For Error Notification:

https://github.com/user-attachments/assets/90423a6e-42aa-4ad8-b6fe-77d1cb9705a1

For Success Notification:

https://github.com/user-attachments/assets/8960cb33-4e98-47c3-91d8-54c4ff8c224e


**After:**


For Error Notification:

https://github.com/user-attachments/assets/b36aa13f-eb2c-4dfe-a0ef-d56557178a21

For Success Notification:

https://github.com/user-attachments/assets/d9ebc4d8-8a65-4297-9dab-e1350caf0141




