### PR TITLE
[Data rearchitecture] No longer create course user wiki timeslices for non-students

### DIFF
--- a/app/services/join_course.rb
+++ b/app/services/join_course.rb
@@ -89,7 +89,10 @@ class JoinCourse
     # Do not try to create course user wiki timeslices if there is no course id
     # This should never happen in production but we need this check because otherwise
     # there are specs that fail.
-    create_course_user_wiki_timeslices course_user unless course_user.course_id.nil?
+    # Only create course user wiki timeslices for students.
+    if student_role? && course_user.course_id.present?
+      create_course_user_wiki_timeslices course_user
+    end
   end
 
   def create_course_user_wiki_timeslices(course_user)

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -95,7 +95,8 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
 
   # Creates empty course user wiki timeslices
   def create_empty_course_user_wiki_timeslices(courses_users: nil, courses_wikis: nil)
-    courses_users ||= @course.courses_users
+    # Only create course user wiki timeslices for students
+    courses_users ||= @course.courses_users.where(role: CoursesUsers::Roles::STUDENT_ROLE)
     courses_wikis ||= @course.courses_wikis
     new_records = start_dates.map do |start|
       courses_users.map do |c_u|

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -24,7 +24,8 @@ describe TimesliceManager do
     enwiki_course
     wikidata_course
 
-    new_course_users << create(:courses_user, id: 1, user_id: 1, course:)
+    new_course_users << create(:courses_user, id: 1, user_id: 1, course:,
+                               role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     new_course_users << create(:courses_user, id: 2, user_id: 2, course:)
     new_course_users << create(:courses_user, id: 3, user_id: 3, course:)
 
@@ -82,9 +83,10 @@ describe TimesliceManager do
         # Create wikibooks course wiki timeslices for the entire course
         expect(course.course_wiki_timeslices.last.wiki).to eq(wikibooks)
         expect(course.course_wiki_timeslices.size).to eq(228)
-        # Create all the course user wiki timeslices for the existing course users for the new wiki
+        # Create all the course user wiki timeslices for the existing course users with student role
+        # for the new wiki
         expect(course.course_user_wiki_timeslices.first.wiki).to eq(wikibooks)
-        expect(course.course_user_wiki_timeslices.size).to eq(342)
+        expect(course.course_user_wiki_timeslices.size).to eq(228)
       end
     end
   end
@@ -102,7 +104,7 @@ describe TimesliceManager do
 
     it 'deletes wiki timeslices for the entire course properly' do
       expect(course.course_wiki_timeslices.size).to eq(342)
-      expect(course.course_user_wiki_timeslices.size).to eq(1026)
+      expect(course.course_user_wiki_timeslices.size).to eq(684)
       expect(course.article_course_timeslices.size).to eq(342)
 
       timeslice_manager.delete_timeslices_for_deleted_course_wikis([wikibooks.id, wikidata.id])

--- a/spec/services/join_course_spec.rb
+++ b/spec/services/join_course_spec.rb
@@ -35,13 +35,13 @@ describe JoinCourse do
     end
 
     it 'allows a course to be joined' do
-      # 152 course user wiki timeslices for the instructor
-      expect(course.course_user_wiki_timeslices.count).to eq(155)
+      # no course user wiki timeslices were created for the instructor
+      expect(course.course_user_wiki_timeslices.count).to eq(0)
       result = subject.result
       expect(result['failure']).to be_nil
       expect(result['success']).not_to be_nil
-      # 152 course user wiki timeslices for the new student
-      expect(course.course_user_wiki_timeslices.count).to eq(310)
+      # 155 course user wiki timeslices for the new student
+      expect(course.course_user_wiki_timeslices.count).to eq(155)
     end
   end
 

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -31,9 +31,9 @@ describe UpdateCourseStatsTimeslice do
       stub_wiki_validation
       travel_to Date.new(2018, 12, 1)
       course.campaigns << Campaign.first
-      course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       JoinCourse.new(course:, user:, role: 0)
       # Create course wiki timeslices manually for wikidata
+      course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wikidata])
     end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -32,9 +32,9 @@ describe UpdateCourseWikiTimeslices do
       stub_wiki_validation
       travel_to Date.new(2018, 12, 1)
       course.campaigns << Campaign.first
-      course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       JoinCourse.new(course:, user:, role: 0)
       # Create course wiki timeslices manually for wikidata
+      course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wikidata])
     end
 


### PR DESCRIPTION
## What this PR does
This PR fixes a bug that caused duplicated course user wiki timeslices for the same course, wiki, user, and dates. The issue occurred when there were multiple course user rows for the same user ID but with different roles. This duplication led to repeated references, revision counts, etc., for the user. The solution is straightforward: we no longer create course user wiki timeslices for non-student course users (those with a role different from 0).


## Open questions and concerns
I was able to reproduce the error and test the fix locally.

Note: Some changes in commit 548061cd7fffb87347e2f3e56a97ce17b58f8b3c address a previous bug (a missing reload) that became apparent only when adding the` .where(role: CoursesUsers::Roles::STUDENT_ROLE)` query in the timeslice manager.