### PR TITLE
[Data rearchitecture] support full timeslice updates

### DIFF
--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -22,11 +22,11 @@ class UpdateCourseStatsTimeslice
     # it could be because the dates or other paramters were just changed.
     # In that case, do a full update rather than just fetching the most
     # recent revisions.
-    # @full_update = full || @course.needs_update
+    @full_update = @course.needs_update
 
     @start_time = Time.zone.now
     import_uploads
-    timeslice_errors = UpdateCourseWikiTimeslices.new(@course).run
+    timeslice_errors = UpdateCourseWikiTimeslices.new(@course).run(all_time: @full_update)
     update_categories
     update_article_status if should_update_article_status?
     update_average_pageviews

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -18,11 +18,19 @@ class UpdateCourseWikiTimeslices
   end
 
   def run(all_time:)
+    clean_timeslices if all_time
     fetch_data_and_process_timeslices_for_every_wiki(all_time)
     error_count
   end
 
   private
+
+  # Delete and recreate timeslices
+  def clean_timeslices
+    wiki_ids = @course.wikis.pluck(:wiki_id)
+    @timeslice_manager.delete_timeslices_for_deleted_course_wikis(wiki_ids)
+    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
+  end
 
   def fetch_data_and_process_timeslices_for_every_wiki(all_time)
     @course.wikis.each do |wiki|

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -17,17 +17,21 @@ class UpdateCourseWikiTimeslices
     @timeslice_manager = TimesliceManager.new(@course)
   end
 
-  def run
-    fetch_data_and_process_timeslices_for_every_wiki
+  def run(all_time:)
+    fetch_data_and_process_timeslices_for_every_wiki(all_time)
     error_count
   end
 
   private
 
-  def fetch_data_and_process_timeslices_for_every_wiki
+  def fetch_data_and_process_timeslices_for_every_wiki(all_time)
     @course.wikis.each do |wiki|
       # Get start time from first timeslice to update
-      first_start = @timeslice_manager.get_ingestion_start_time_for_wiki(wiki)
+      first_start = if all_time
+                      @course.start.strftime('%Y%m%d%H%M%S')
+                    else
+                      @timeslice_manager.get_ingestion_start_time_for_wiki(wiki)
+                    end
       # Get start time from latest timeslice to update
       latest_start = get_latest_start_time_for_wiki(wiki)
 

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -29,6 +29,8 @@ class UpdateCourseWikiTimeslices
   def clean_timeslices
     wiki_ids = @course.wikis.pluck(:wiki_id)
     @timeslice_manager.delete_timeslices_for_deleted_course_wikis(wiki_ids)
+    # Destroy articles courses records to re-create article courses timeslices
+    @course.articles_courses.destroy_all
     @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
   end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -7,7 +7,7 @@ describe UpdateCourseWikiTimeslices do
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
   let(:updater) { described_class.new(course) }
-  let(:subject) { updater.run }
+  let(:subject) { updater.run(all_time: 0) }
   let(:flags) { nil }
   let(:user) { create(:user, username: 'Ragesoss') }
 


### PR DESCRIPTION
## What this PR does
This PR provides an easy way to make a full course stats timeslice update. Manually set `needs_update` course field to true and then use the `manual_update_timeslice` route. This will fetch revisions from the course start and overwrite timeslices.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
