### PR TITLE
[Data rearchitecture] Do not count system revisions

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -64,7 +64,7 @@ class ArticleCourseTimeslice < ApplicationRecord
   # Takes an array of revisions for the article_course_timeslice
   def update_cache_from_revisions(revisions)
     # Filter the deleted revisions
-    live_revisions = revisions.reject(&:deleted)
+    live_revisions = revisions.reject { |r| r.deleted || r.system }
     self.character_sum = live_revisions.sum { |r| r.characters.to_i.positive? ? r.characters : 0 }
     self.references_count = live_revisions.sum(&:references_added)
     self.user_ids = associated_user_ids(live_revisions)

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -82,8 +82,8 @@ class CourseUserWikiTimeslice < ApplicationRecord
   private
 
   # Returns tracked revisions (revisions for tracked article courses)
-  # for which already exists an article record
-  # made for user_id. Notice that revisions are already made for a given user_id
+  # for which already exists an article record made for user_id.
+  # Notice that revisions are already made for a given user_id
   def live_revisions
     excluded_article_ids = course.articles_courses.not_tracked.pluck(:article_id)
     tracked_revisions = @revisions.reject do |revision|
@@ -95,7 +95,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
     filtered_tracked_revisions = tracked_revisions.select do |revision|
       articles_ids_with_article_records.include?(revision.article_id)
     end
-    filtered_tracked_revisions.reject(&:deleted)
+    filtered_tracked_revisions.reject { |r| r.deleted || r.system }
   end
 
   def live_revisions_in_tracked_namespaces

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -111,7 +111,7 @@ class CourseWikiTimeslice < ApplicationRecord
       excluded_article_ids.include?(revision.article_id)
     end
 
-    self.revision_count = tracked_revisions.count { |rev| !rev.deleted }
+    self.revision_count = tracked_revisions.count { |rev| !rev.deleted && !rev.system }
   end
 
   def update_upload_count

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -59,7 +59,16 @@ describe ArticleCourseTimeslice, type: :model do
             user_id: 6,
             date: start + 16.hours)
   end
-  let(:revisions) { [revision1, revision2, revision3, revision4] }
+  let(:revision5) do
+    build(:revision, article:,
+           characters: 120,
+           features: { 'num_ref' => 3 },
+           features_previous: { 'num_ref' => 3 },
+           user_id: 25,
+           date: start + 12.hours,
+           system: true) # revision made automatically
+  end
+  let(:revisions) { [revision1, revision2, revision3, revision4, revision5] }
   let(:article_course_timeslice) do
     create(:article_course_timeslice,
            article:,

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -94,7 +94,15 @@ describe CourseUserWikiTimeslice, type: :model do
             features_previous: { 'num_ref' => 0 },
             user_id: user.id)
   end
-  let(:revisions) { [revision0, revision1, revision2, revision3, revision4, revision5] }
+  let(:revision6) do
+    build(:revision, article: draft, date: start,
+           characters: 220,
+           features: { 'num_ref' => 1 },
+           features_previous: { 'num_ref' => 0 },
+           user_id: user.id,
+           system: true) # revision made by the system
+  end
+  let(:revisions) { [revision0, revision1, revision2, revision3, revision4, revision5, revision6] }
   let(:subject) { course_user_wiki_timeslice.update_cache_from_revisions revisions }
 
   describe '.update_course_user_wiki_timeslices' do
@@ -160,7 +168,8 @@ describe CourseUserWikiTimeslice, type: :model do
       course_user_wiki_timeslice = described_class.all.first
 
       expect(course_user_wiki_timeslice.total_uploads).to eq(1)
-      # Don't consider deleted revisions or revisions for articles that don't exist
+      # Don't consider deleted revisions, automatic revisions, or revisions for
+      # articles that don't exist
       expect(course_user_wiki_timeslice.revision_count).to eq(4)
       # Only consider revision0 (mainspace)
       expect(course_user_wiki_timeslice.character_sum_ms).to eq(123)

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -87,6 +87,7 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     array_revisions << build(:revision, article:, user_id: 1, date: start)
     array_revisions << build(:revision, article:, user_id: 1, date: start + 2.hours)
     array_revisions << build(:revision, article:, user_id: 2, date: start + 3.hours)
+    array_revisions << build(:revision, article:, user_id: 2, date: start + 3.hours, system: true)
     array_revisions << build(:revision, article:, deleted: true, user_id: 1, date: start + 8.hours)
   end
 


### PR DESCRIPTION
## What this PR does
This PR updates the timeslices behavior to exclude revisions where the `system` field is set to `true`.
After debugging course stats discrepancies between Latinx Past Wiki Scholars in [production](https://dashboard.wikiedu.org/courses/Wiki_Education/Latinx_Past_Wiki_Scholars_(Fall_2024)/home) and in the [data-rearchitecture instance](https://data-rearchitecture-test.wmcloud.org/courses/Wiki_Education/Latinx_Past_Wiki_Scholars_(September_2024)/home) having access to the production db, I discovered that production version was excluding system revisions from metrics while the timeslice version doesn't.
This PR also modifies the specs to guarantee that system revisions are now discarded.

## Open questions and concerns
I was able to test the changes locally using the Latinx Past Wiki Scholars course and I got the same results as in production. However, I noticed something pretty important. The [revision query](https://github.com/WikiEducationFoundation/WikiEduDashboardTools/blob/master/public_html/revisions.php) that we make against the replica to retrieve revisions takes a `tags`  parameter, which is determined in the dashboard side based on the `oauth_ids` env variable. 
The system value is defined in the revisions query as follows:
`case when ct.ct_tag_id IS NULL then 'false' else 'true' end as system`
 The tags parameter is used in a LEFT JOIN:
```
LEFT JOIN change_tag_def ctd
	  ON ctd.ctd_name IN ($tags)
LEFT JOIN change_tag ct
	ON ct.ct_rev_id = c.rev_id
	AND ct.ct_tag_id = ctd.ctd_id
```
This means that the revision query results (particularly, the `system` value) depend on the `tags` parameter. This is something pretty important to take into account when comparing course stats from different instances (if they have `oauth_ids` env variable set to different values, then stats will differ).

Last but not least, if the `oauth_ids` is set to multiple values (for example, '218,306,542,4978'), then the revision raw data has duplicated `mw_rev_id` records. For example, when we retrieve [rev 1239145084 for en.wikipedia](https://en.wikipedia.org/w/index.php?title=User:Agritodeguerra&oldid=1239145084) with `oauth_ids` set to 218,306,542,4978, we get the revision 4 times, while only one has `system` set to `true`.  This is due to the `Tag: dashboard.wikiedu.org [2.3]` which is related to OAuth CID 4978 according to [tag definitions](https://en.wikipedia.org/wiki/Special:Tags).

![image](https://github.com/user-attachments/assets/b21cecf4-9d9f-440e-8583-9f911ed9aab0)

**If we use multiple values for `oauth_ids` in production, then we should guarantee that always keep the revision version that has `system` set to `true` (if any).**
```
[
  [
    "77560761",
    {
      "article" => {
        "mw_page_id" => "77560761",
        "title" => "Agritodeguerra",
        "namespace" => "2",
        "wiki_id" => 1
      },
      "revisions" => [
        {
          "mw_rev_id" => "1239145084",
          "date" => Wed, 07 Aug 2024 15:54:10 +0000,
          "characters" => "136",
          "mw_page_id" => "77560761",
          "username" => "Agritodeguerra",
          "new_article" => "true",
          "system" => "false",
          "wiki_id" => 1
        },
        {
          "mw_rev_id" => "1239145084",
          "date" => Wed, 07 Aug 2024 15:54:10 +0000,
          "characters" => "136",
          "mw_page_id" => "77560761",
          "username" => "Agritodeguerra",
          "new_article" => "true",
          "system" => "false",
          "wiki_id" => 1
        },
        {
          "mw_rev_id" => "1239145084",
          "date" => Wed, 07 Aug 2024 15:54:10 +0000,
          "characters" => "136",
          "mw_page_id" => "77560761",
          "username" => "Agritodeguerra",
          "new_article" => "true",
          "system" => "true",
          "wiki_id" => 1
        },
        {
          "mw_rev_id" => "1239145084",
          "date" => Wed, 07 Aug 2024 15:54:10 +0000,
          "characters" => "136",
          "mw_page_id" => "77560761",
          "username" => "Agritodeguerra",
          "new_article" => "true",
          "system" => "false",
          "wiki_id" => 1
        }
      ]
    }
  ]
]
```