### PR TITLE
[Data rearchitecture] Support article scoped program and visiting scholarship courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -304,6 +304,10 @@ class Course < ApplicationRecord
     end.flatten
   end
 
+  def filter_revisions(revisions)
+    revisions
+  end
+
   def scoped_article_ids
     assigned_article_ids + category_article_ids
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -304,6 +304,8 @@ class Course < ApplicationRecord
     end.flatten
   end
 
+  # The default implemention retrieves all the revisions.
+  # A course type may override this implementation.
   def filter_revisions(revisions)
     revisions
   end

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -79,7 +79,10 @@ class ArticleScopedProgram < Course
 
   def filter_revisions(revisions)
     filtered_data = revisions.select do |_, details|
-      scoped_article_titles.include?(details['article']['title'])
+      wiki = Wiki.find(details['article']['wiki_id'])
+      article_title = details['article']['title']
+      formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
+      scoped_article_titles.include?(formatted_article_title)
     end
     filtered_data
   end

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -76,4 +76,23 @@ class ArticleScopedProgram < Course
   def passcode_required?
     false
   end
+
+  def filter_revisions(revisions)
+    filtered_data = revisions.select do |_, details|
+      scoped_article_titles.include?(details['article']['title'])
+    end
+    filtered_data
+  end
+
+  def scoped_article_titles
+    assigned_article_titles + category_article_titles
+  end
+
+  def assigned_article_titles
+    assignments.pluck(:article_title)
+  end
+
+  def category_article_titles
+    categories.inject([]) { |ids, cat| ids + cat.article_titles }
+  end
 end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -75,4 +75,19 @@ class VisitingScholarship < Course
   def multiple_roles_allowed?
     true
   end
+
+  def filter_revisions(revisions)
+    filtered_data = revisions.select do |_, details|
+      scoped_article_titles.include?(details['article']['title'])
+    end
+    filtered_data
+  end
+
+  def scoped_article_titles
+    assigned_article_titles
+  end
+
+  def assigned_article_titles
+    assignments.pluck(:article_title)
+  end
 end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -78,7 +78,10 @@ class VisitingScholarship < Course
 
   def filter_revisions(revisions)
     filtered_data = revisions.select do |_, details|
-      scoped_article_titles.include?(details['article']['title'])
+      wiki = Wiki.find(details['article']['wiki_id'])
+      article_title = details['article']['title']
+      formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
+      scoped_article_titles.include?(formatted_article_title)
     end
     filtered_data
   end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -84,10 +84,6 @@ class VisitingScholarship < Course
   end
 
   def scoped_article_titles
-    assigned_article_titles
-  end
-
-  def assigned_article_titles
     assignments.pluck(:article_title)
   end
 end

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -22,12 +22,11 @@ class UpdateCourseStatsTimeslice
     # it could be because the dates or other paramters were just changed.
     # In that case, do a full update rather than just fetching the most
     # recent revisions.
-    # @full_update = full || @course.needs_update
 
     @start_time = Time.zone.now
     import_uploads
-    timeslice_errors = UpdateCourseWikiTimeslices.new(@course).run
     update_categories
+    timeslice_errors = UpdateCourseWikiTimeslices.new(@course).run
     update_article_status if should_update_article_status?
     update_average_pageviews
     update_caches

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -57,7 +57,7 @@ class RevisionDataManager
   def get_course_revisions(users, start, end_date)
     all_sub_data = get_revisions(users, start, end_date)
     # Filter revisions based on the article type.
-    # Important for ArticleScopedProgram/VisitingScolarship courses
+    # Important for ArticleScopedProgram/VisitingScholarship courses
     @course.filter_revisions(all_sub_data)
   end
 

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -21,7 +21,7 @@ class RevisionDataManager
   # Returns an array of Revision records.
   # As a side effect, it imports Article records.
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
-    sub_data = get_revisions(@course.students, timeslice_start, timeslice_end)
+    sub_data = get_course_revisions(@course.students, timeslice_start, timeslice_end)
     @revisions = []
 
     # Extract all article data from the slice. Outputs a hash with article attrs.
@@ -54,6 +54,11 @@ class RevisionDataManager
   ###########
   private
 
+  def get_course_revisions(users, start, end_date)
+    all_sub_data = get_revisions(users, start, end_date)
+    filtered_sub_data(all_sub_data)
+  end
+
   # Get revisions made by a set of users between two dates.
   # We limit the number of usernames per query in order to avoid
   # hitting the memory limit of the Replica endpoint.
@@ -73,6 +78,12 @@ class RevisionDataManager
     when 'true'
       true
     end
+  end
+
+  # Filter revisions based on the article type.
+  # Important for ArticleScopedProgram/VisitingScolarship courses
+  def filtered_sub_data(sub_data)
+    @course.filter_revisions(sub_data)
   end
 
   def sub_data_to_article_attributes(sub_data)

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -56,7 +56,9 @@ class RevisionDataManager
 
   def get_course_revisions(users, start, end_date)
     all_sub_data = get_revisions(users, start, end_date)
-    filtered_sub_data(all_sub_data)
+    # Filter revisions based on the article type.
+    # Important for ArticleScopedProgram/VisitingScolarship courses
+    @course.filter_revisions(all_sub_data)
   end
 
   # Get revisions made by a set of users between two dates.
@@ -78,12 +80,6 @@ class RevisionDataManager
     when 'true'
       true
     end
-  end
-
-  # Filter revisions based on the article type.
-  # Important for ArticleScopedProgram/VisitingScolarship courses
-  def filtered_sub_data(sub_data)
-    @course.filter_revisions(sub_data)
   end
 
   def sub_data_to_article_attributes(sub_data)

--- a/spec/factories/categories_courses.rb
+++ b/spec/factories/categories_courses.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: categories_courses
+#
+#  id          :bigint           not null, primary key
+#  category_id :integer
+#  course_id   :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+FactoryBot.define do
+  factory :categories_courses, class: 'CategoriesCourses' do
+    nil
+  end
+end

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -6,179 +6,115 @@ require "#{Rails.root}/lib/articles_courses_cleaner"
 
 describe RevisionDataManager do
   describe '#fetch_revision_data_for_course' do
-    context 'for Regular courses' do
-      let(:course) { create(:course, start: '2018-01-01', end: '2018-12-31') }
-      let(:user) { create(:user, username: 'Ragesoss') }
-      let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-      let(:instance_class) { described_class.new(home_wiki, course) }
-      let(:subject) do
-        instance_class.fetch_revision_data_for_course('20180706', '20180707')
-      end
-      let(:revision_data) do
-        [{ 'mw_page_id' => '55345266',
-        'wiki_id' => 1,
-        'title' => 'Ragesoss/citing_sources',
-        'namespace' => '2' }]
-      end
+    let(:course) { create(:course, start: '2018-01-01', end: '2018-12-31') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+    let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:instance_class) { described_class.new(home_wiki, course) }
+    let(:subject) do
+      instance_class.fetch_revision_data_for_course('20180706', '20180707')
+    end
+    let(:revision_data) do
+      [{ 'mw_page_id' => '55345266',
+      'wiki_id' => 1,
+      'title' => 'Ragesoss/citing_sources',
+      'namespace' => '2' }]
+    end
 
-      before do
-        create(:courses_user, course:, user:)
-      end
+    before do
+      create(:courses_user, course:, user:)
+    end
 
-      it 'fetches all the revisions that occurred during the given period of time' do
-        VCR.use_cassette 'revision_importer/all' do
-          revisions = subject
-          expect(revisions.length).to eq(4)
-          # Fetches the right revision ids
-          expect(revisions[0].mw_rev_id).to eq(849116430)
-          expect(revisions[1].mw_rev_id).to eq(849116480)
-          expect(revisions[2].mw_rev_id).to eq(849116533)
-          expect(revisions[3].mw_rev_id).to eq(849116572)
+    it 'fetches all the revisions that occurred during the given period of time' do
+      VCR.use_cassette 'revision_importer/all' do
+        revisions = subject
+        expect(revisions.length).to eq(4)
+        # Fetches the right revision ids
+        expect(revisions[0].mw_rev_id).to eq(849116430)
+        expect(revisions[1].mw_rev_id).to eq(849116480)
+        expect(revisions[2].mw_rev_id).to eq(849116533)
+        expect(revisions[3].mw_rev_id).to eq(849116572)
 
-          # Fetches the scores
-          expect(revisions[0].wp10).to eq(18.287608774878528)
-          expect(revisions[0].wp10_previous).to eq(11.95948026900581)
-          expect(revisions[0].features).to eq({ 'num_ref' => 2 })
-          expect(revisions[0].features_previous).to eq({ 'num_ref' => 2 })
-          expect(revisions[0].deleted).to eq(false)
+        # Fetches the scores
+        expect(revisions[0].wp10).to eq(18.287608774878528)
+        expect(revisions[0].wp10_previous).to eq(11.95948026900581)
+        expect(revisions[0].features).to eq({ 'num_ref' => 2 })
+        expect(revisions[0].features_previous).to eq({ 'num_ref' => 2 })
+        expect(revisions[0].deleted).to eq(false)
 
-          expect(revisions[1].wp10).to eq(20.088995958732458)
-          expect(revisions[1].wp10_previous).to eq(18.287608774878528)
-          expect(revisions[1].features).to eq({ 'num_ref' => 3 })
-          expect(revisions[1].features_previous).to eq({ 'num_ref' => 2 })
-          expect(revisions[1].deleted).to eq(false)
+        expect(revisions[1].wp10).to eq(20.088995958732458)
+        expect(revisions[1].wp10_previous).to eq(18.287608774878528)
+        expect(revisions[1].features).to eq({ 'num_ref' => 3 })
+        expect(revisions[1].features_previous).to eq({ 'num_ref' => 2 })
+        expect(revisions[1].deleted).to eq(false)
 
-          expect(revisions[2].wp10).to eq(21.373269263926918)
-          expect(revisions[2].wp10_previous).to eq(20.088995958732458)
-          expect(revisions[2].features).to eq({ 'num_ref' => 3 })
-          expect(revisions[2].features_previous).to eq({ 'num_ref' => 3 })
-          expect(revisions[2].deleted).to eq(false)
+        expect(revisions[2].wp10).to eq(21.373269263926918)
+        expect(revisions[2].wp10_previous).to eq(20.088995958732458)
+        expect(revisions[2].features).to eq({ 'num_ref' => 3 })
+        expect(revisions[2].features_previous).to eq({ 'num_ref' => 3 })
+        expect(revisions[2].deleted).to eq(false)
 
-          expect(revisions[3].wp10).to eq(21.33831536670649)
-          expect(revisions[3].wp10_previous).to eq(21.373269263926918)
-          expect(revisions[3].features).to eq({ 'num_ref' => 3 })
-          expect(revisions[3].features_previous).to eq({ 'num_ref' => 3 })
-          expect(revisions[3].deleted).to eq(false)
-        end
-      end
-
-      it 'only calculates revisions scores for articles in mainspace, userspace or draftspace' do
-        allow(instance_class).to receive(:get_revisions).and_return(
-          [
-            [
-              '112',
-              {
-                'article' => {
-                  'mw_page_id' => '777',
-                  'title' => 'Some title',
-                  'namespace' => '4',
-                  'wiki_id' => 1
-                },
-                'revisions' => [
-                  { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
-                    'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
-                    'system' => 'false', 'wiki_id' => 1 }
-                ]
-              }
-            ],
-            [
-              '789',
-              {
-                'article' => {
-                  'mw_page_id' => '123',
-                  'title' => 'Draft article',
-                  'namespace' => '118',
-                  'wiki_id' => 1
-                },
-                'revisions' => [
-                  { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
-                    'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
-                    'system' => 'false', 'wiki_id' => 1 }
-                ]
-              }
-            ]
-          ]
-        )
-        VCR.use_cassette 'revision_importer/all' do
-          revisions = subject
-          # Returns all revisions
-          expect(revisions.length).to eq(2)
-          # Only the one in mainspace has scores
-          expect(revisions[0].features).to eq({})
-          expect(revisions[1].features).to eq({ 'num_ref' => 0 })
-        end
-      end
-
-      it 'calls ArticeImporter as side effect' do
-        expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
-          .once
-          .with(revision_data)
-
-        VCR.use_cassette 'revision_importer/all' do
-          subject
-        end
+        expect(revisions[3].wp10).to eq(21.33831536670649)
+        expect(revisions[3].wp10_previous).to eq(21.373269263926918)
+        expect(revisions[3].features).to eq({ 'num_ref' => 3 })
+        expect(revisions[3].features_previous).to eq({ 'num_ref' => 3 })
+        expect(revisions[3].deleted).to eq(false)
       end
     end
 
-    context 'for scoped courses' do
-      let(:course) { create(:article_scoped_program, start: '2018-01-01', end: '2018-12-31') }
-      let(:user) { create(:user, username: 'Ragesoss') }
-      let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-      let(:instance_class) { described_class.new(home_wiki, course) }
-      let(:subject) do
-        instance_class.fetch_revision_data_for_course('20180706', '20180707')
-      end
-
-      before do
-        create(:courses_user, course:, user:)
-        create(:article, id: 1, title: 'Draft_article', mw_page_id: 123, wiki_id: 1, namespace: 118)
-        create(:assignment, course:, user:, article_id: 1, article_title: 'Draft article')
-      end
-
-      it 'only returns revisions for scoped articles if article scoped course' do
-        allow(instance_class).to receive(:get_revisions).and_return(
+    it 'only calculates revisions scores for articles in mainspace, userspace or draftspace' do
+      allow(instance_class).to receive(:get_revisions).and_return(
+        [
           [
-            [
-              '112',
-              {
-                'article' => {
-                  'mw_page_id' => '777',
-                  'title' => 'Some title',
-                  'namespace' => '4',
-                  'wiki_id' => 1
-                },
-                'revisions' => [
-                  { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
-                    'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
-                    'system' => 'false', 'wiki_id' => 1 }
-                ]
-              }
-            ],
-            [
-              '789',
-              {
-                'article' => {
-                  'mw_page_id' => '123',
-                  'title' => 'Draft_article',
-                  'namespace' => '118',
-                  'wiki_id' => 1
-                },
-                'revisions' => [
-                  { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
-                    'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
-                    'system' => 'false', 'wiki_id' => 1 }
-                ]
-              }
-            ]
+            '112',
+            {
+              'article' => {
+                'mw_page_id' => '777',
+                'title' => 'Some title',
+                'namespace' => '4',
+                'wiki_id' => 1
+              },
+              'revisions' => [
+                { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
+                  'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
+                  'system' => 'false', 'wiki_id' => 1 }
+              ]
+            }
+          ],
+          [
+            '789',
+            {
+              'article' => {
+                'mw_page_id' => '123',
+                'title' => 'Draft article',
+                'namespace' => '118',
+                'wiki_id' => 1
+              },
+              'revisions' => [
+                { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
+                  'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
+                  'system' => 'false', 'wiki_id' => 1 }
+              ]
+            }
           ]
-        )
-        VCR.use_cassette 'revision_importer/all' do
-          revisions = subject
-          # Returns all revisions
-          expect(revisions.length).to eq(1)
-          # Only the one in mainspace has scores
-          expect(revisions[0].features).to eq({ 'num_ref' => 0 })
-        end
+        ]
+      )
+      VCR.use_cassette 'revision_importer/all' do
+        revisions = subject
+        # Returns all revisions
+        expect(revisions.length).to eq(2)
+        # Only the one in mainspace has scores
+        expect(revisions[0].features).to eq({})
+        expect(revisions[1].features).to eq({ 'num_ref' => 0 })
+      end
+    end
+
+    it 'calls ArticeImporter as side effect' do
+      expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
+        .once
+        .with(revision_data)
+
+      VCR.use_cassette 'revision_importer/all' do
+        subject
       end
     end
   end

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -6,100 +6,179 @@ require "#{Rails.root}/lib/articles_courses_cleaner"
 
 describe RevisionDataManager do
   describe '#fetch_revision_data_for_course' do
-    let(:course) { create(:course, start: '2018-01-01', end: '2018-12-31') }
-    let(:user) { create(:user, username: 'Ragesoss') }
-    let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-    let(:instance_class) { described_class.new(home_wiki, course) }
-    let(:subject) do
-      instance_class.fetch_revision_data_for_course('20180706', '20180707')
-    end
-    let(:revision_count) { 0 }
-    let(:revision_data) do
-      [{ 'mw_page_id' => '55345266',
-      'wiki_id' => 1,
-      'title' => 'Ragesoss/citing_sources',
-      'namespace' => '2' }]
-    end
+    context 'for Regular courses' do
+      let(:course) { create(:course, start: '2018-01-01', end: '2018-12-31') }
+      let(:user) { create(:user, username: 'Ragesoss') }
+      let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+      let(:instance_class) { described_class.new(home_wiki, course) }
+      let(:subject) do
+        instance_class.fetch_revision_data_for_course('20180706', '20180707')
+      end
+      let(:revision_data) do
+        [{ 'mw_page_id' => '55345266',
+        'wiki_id' => 1,
+        'title' => 'Ragesoss/citing_sources',
+        'namespace' => '2' }]
+      end
 
-    before do
-      create(:courses_user, course:, user:, revision_count:)
-    end
+      before do
+        create(:courses_user, course:, user:)
+      end
 
-    it 'fetches all the revisions that occurred during the given period of time' do
-      VCR.use_cassette 'revision_importer/all' do
-        revisions = subject
-        expect(revisions.length).to eq(4)
-        # Fetches the right revision ids
-        expect(revisions[0].mw_rev_id).to eq(849116430)
-        expect(revisions[1].mw_rev_id).to eq(849116480)
-        expect(revisions[2].mw_rev_id).to eq(849116533)
-        expect(revisions[3].mw_rev_id).to eq(849116572)
+      it 'fetches all the revisions that occurred during the given period of time' do
+        VCR.use_cassette 'revision_importer/all' do
+          revisions = subject
+          expect(revisions.length).to eq(4)
+          # Fetches the right revision ids
+          expect(revisions[0].mw_rev_id).to eq(849116430)
+          expect(revisions[1].mw_rev_id).to eq(849116480)
+          expect(revisions[2].mw_rev_id).to eq(849116533)
+          expect(revisions[3].mw_rev_id).to eq(849116572)
 
-        # Fetches the scores
-        expect(revisions[0].wp10).to eq(18.287608774878528)
-        expect(revisions[0].wp10_previous).to eq(11.95948026900581)
-        expect(revisions[0].features).to eq({ 'num_ref' => 2 })
-        expect(revisions[0].features_previous).to eq({ 'num_ref' => 2 })
-        expect(revisions[0].deleted).to eq(false)
+          # Fetches the scores
+          expect(revisions[0].wp10).to eq(18.287608774878528)
+          expect(revisions[0].wp10_previous).to eq(11.95948026900581)
+          expect(revisions[0].features).to eq({ 'num_ref' => 2 })
+          expect(revisions[0].features_previous).to eq({ 'num_ref' => 2 })
+          expect(revisions[0].deleted).to eq(false)
 
-        expect(revisions[1].wp10).to eq(20.088995958732458)
-        expect(revisions[1].wp10_previous).to eq(18.287608774878528)
-        expect(revisions[1].features).to eq({ 'num_ref' => 3 })
-        expect(revisions[1].features_previous).to eq({ 'num_ref' => 2 })
-        expect(revisions[1].deleted).to eq(false)
+          expect(revisions[1].wp10).to eq(20.088995958732458)
+          expect(revisions[1].wp10_previous).to eq(18.287608774878528)
+          expect(revisions[1].features).to eq({ 'num_ref' => 3 })
+          expect(revisions[1].features_previous).to eq({ 'num_ref' => 2 })
+          expect(revisions[1].deleted).to eq(false)
 
-        expect(revisions[2].wp10).to eq(21.373269263926918)
-        expect(revisions[2].wp10_previous).to eq(20.088995958732458)
-        expect(revisions[2].features).to eq({ 'num_ref' => 3 })
-        expect(revisions[2].features_previous).to eq({ 'num_ref' => 3 })
-        expect(revisions[2].deleted).to eq(false)
+          expect(revisions[2].wp10).to eq(21.373269263926918)
+          expect(revisions[2].wp10_previous).to eq(20.088995958732458)
+          expect(revisions[2].features).to eq({ 'num_ref' => 3 })
+          expect(revisions[2].features_previous).to eq({ 'num_ref' => 3 })
+          expect(revisions[2].deleted).to eq(false)
 
-        expect(revisions[3].wp10).to eq(21.33831536670649)
-        expect(revisions[3].wp10_previous).to eq(21.373269263926918)
-        expect(revisions[3].features).to eq({ 'num_ref' => 3 })
-        expect(revisions[3].features_previous).to eq({ 'num_ref' => 3 })
-        expect(revisions[3].deleted).to eq(false)
+          expect(revisions[3].wp10).to eq(21.33831536670649)
+          expect(revisions[3].wp10_previous).to eq(21.373269263926918)
+          expect(revisions[3].features).to eq({ 'num_ref' => 3 })
+          expect(revisions[3].features_previous).to eq({ 'num_ref' => 3 })
+          expect(revisions[3].deleted).to eq(false)
+        end
+      end
+
+      it 'only calculates revisions scores for articles in mainspace, userspace or draftspace' do
+        allow(instance_class).to receive(:get_revisions).and_return(
+          [
+            [
+              '112',
+              {
+                'article' => {
+                  'mw_page_id' => '777',
+                  'title' => 'Some title',
+                  'namespace' => '4',
+                  'wiki_id' => 1
+                },
+                'revisions' => [
+                  { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
+                    'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
+                    'system' => 'false', 'wiki_id' => 1 }
+                ]
+              }
+            ],
+            [
+              '789',
+              {
+                'article' => {
+                  'mw_page_id' => '123',
+                  'title' => 'Draft article',
+                  'namespace' => '118',
+                  'wiki_id' => 1
+                },
+                'revisions' => [
+                  { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
+                    'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
+                    'system' => 'false', 'wiki_id' => 1 }
+                ]
+              }
+            ]
+          ]
+        )
+        VCR.use_cassette 'revision_importer/all' do
+          revisions = subject
+          # Returns all revisions
+          expect(revisions.length).to eq(2)
+          # Only the one in mainspace has scores
+          expect(revisions[0].features).to eq({})
+          expect(revisions[1].features).to eq({ 'num_ref' => 0 })
+        end
+      end
+
+      it 'calls ArticeImporter as side effect' do
+        expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
+          .once
+          .with(revision_data)
+
+        VCR.use_cassette 'revision_importer/all' do
+          subject
+        end
       end
     end
 
-    it 'only calculates revisions scores for articles in mainspace, userspace or draftspace' do
-      allow(instance_class).to receive(:get_revisions).and_return(
-        { '112' => {
-            'article' =>
-            { 'mw_page_id' => '777', 'title' => 'Some title',
-            'namespace' => '4', 'wiki_id' => 1 },
-          'revisions' =>
-          [{ 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
-          'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
-          'system' => 'false', 'wiki_id' => 1 }]
-          },
-          '789' => {
-            'article' =>
-            { 'mw_page_id' => '123', 'title' => 'Draft article',
-            'namespace' => '118', 'wiki_id' => 1 },
-          'revisions' =>
-          [{ 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
-          'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
-          'system' => 'false', 'wiki_id' => 1 }]
-          } }
-      )
-      VCR.use_cassette 'revision_importer/all' do
-        revisions = subject
-        # Returns all revisions
-        expect(revisions.length).to eq(2)
-        # Only the one in mainspace has scores
-        expect(revisions[0].features).to eq({})
-        expect(revisions[1].features).to eq({ 'num_ref' => 0 })
+    context 'for scoped courses' do
+      let(:course) { create(:article_scoped_program, start: '2018-01-01', end: '2018-12-31') }
+      let(:user) { create(:user, username: 'Ragesoss') }
+      let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+      let(:instance_class) { described_class.new(home_wiki, course) }
+      let(:subject) do
+        instance_class.fetch_revision_data_for_course('20180706', '20180707')
       end
-    end
 
-    it 'calls ArticeImporter as side effect' do
-      expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
-        .once
-        .with(revision_data)
+      before do
+        create(:courses_user, course:, user:)
+        create(:article, id: 1, title: 'Draft_article', mw_page_id: 123, wiki_id: 1, namespace: 118)
+        create(:assignment, course:, user:, article_id: 1, article_title: 'Draft article')
+      end
 
-      VCR.use_cassette 'revision_importer/all' do
-        subject
+      it 'only returns revisions for scoped articles if article scoped course' do
+        allow(instance_class).to receive(:get_revisions).and_return(
+          [
+            [
+              '112',
+              {
+                'article' => {
+                  'mw_page_id' => '777',
+                  'title' => 'Some title',
+                  'namespace' => '4',
+                  'wiki_id' => 1
+                },
+                'revisions' => [
+                  { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
+                    'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
+                    'system' => 'false', 'wiki_id' => 1 }
+                ]
+              }
+            ],
+            [
+              '789',
+              {
+                'article' => {
+                  'mw_page_id' => '123',
+                  'title' => 'Draft_article',
+                  'namespace' => '118',
+                  'wiki_id' => 1
+                },
+                'revisions' => [
+                  { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
+                    'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
+                    'system' => 'false', 'wiki_id' => 1 }
+                ]
+              }
+            ]
+          ]
+        )
+        VCR.use_cassette 'revision_importer/all' do
+          revisions = subject
+          # Returns all revisions
+          expect(revisions.length).to eq(1)
+          # Only the one in mainspace has scores
+          expect(revisions[0].features).to eq({ 'num_ref' => 0 })
+        end
       end
     end
   end

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -52,47 +52,126 @@
 require 'rails_helper'
 
 describe ArticleScopedProgram, type: :model do
-  before do
-    asp = create(:article_scoped_program,
-                 id: 10001,
-                 start: 1.year.ago,
-                 end: Time.zone.today + 1.year)
-    editor = create(:user)
-    create(:courses_user,
-           user_id: editor.id,
-           course_id: asp.id,
-           role: CoursesUsers::Roles::STUDENT_ROLE)
-    random_article = create(:article, title: 'Random', id: 1, namespace: 0)
-    assigned_article = create(:article, title: 'Assigned', id: 2, namespace: 0)
-    create(:assignment, user_id: editor.id, course_id: asp.id,
-                        article_id: 2, article_title: 'Assigned')
-    create(:revision, id: 1, user_id: editor.id,
-                      article_id: random_article.id, date: 1.day.ago)
-    create(:revision, id: 2, user_id: editor.id,
-                      article_id: assigned_article.id, date: 1.day.ago)
-    ArticlesCourses.update_from_course(asp)
-    ArticlesCourses.update_all_caches(asp.articles_courses)
-    CoursesUsers.update_all_caches(CoursesUsers.ready_for_update)
-    Course.update_all_caches
+  describe 'update caches' do
+    before do
+      asp = create(:article_scoped_program,
+                   id: 10001,
+                   start: 1.year.ago,
+                   end: Time.zone.today + 1.year)
+      editor = create(:user)
+      create(:courses_user,
+             user_id: editor.id,
+             course_id: asp.id,
+             role: CoursesUsers::Roles::STUDENT_ROLE)
+      random_article = create(:article, title: 'Random', id: 1, namespace: 0)
+      assigned_article = create(:article, title: 'Assigned', id: 2, namespace: 0)
+      create(:assignment, user_id: editor.id, course_id: asp.id,
+                          article_id: 2, article_title: 'Assigned')
+      create(:revision, id: 1, user_id: editor.id,
+                        article_id: random_article.id, date: 1.day.ago)
+      create(:revision, id: 2, user_id: editor.id,
+                        article_id: assigned_article.id, date: 1.day.ago)
+      ArticlesCourses.update_from_course(asp)
+      ArticlesCourses.update_all_caches(asp.articles_courses)
+      CoursesUsers.update_all_caches(CoursesUsers.ready_for_update)
+      Course.update_all_caches
+    end
+
+    let(:out_of_scope_rev) { Revision.find(1) }
+    let(:in_scope_rev) { Revision.find(2) }
+    let(:asp) { Course.find(10001) }
+
+    it 'onlies count assigned articles' do
+      expect(asp.article_count).to eq(1)
+    end
+
+    it 'onlies generate ArticlesCourses for assigned articles' do
+      expect(asp.articles_courses.count).to eq(1)
+    end
+
+    it 'onlies count revisions to assigned articles' do
+      expect(asp.revision_count).to eq(1)
+    end
+
+    it 'onlies count characters for assigned articles' do
+      expect(asp.character_sum).to eq(in_scope_rev.characters)
+    end
   end
 
-  let(:out_of_scope_rev) { Revision.find(1) }
-  let(:in_scope_rev) { Revision.find(2) }
-  let(:asp) { Course.find(10001) }
+  describe '#filter_revisions' do
+    let(:course) { create(:article_scoped_program, start: '2018-01-01', end: '2018-12-31') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+    let(:revisions) do
+      [
+        [
+          '112',
+          {
+            'article' => {
+              'mw_page_id' => '777',
+              'title' => 'Some title',
+              'namespace' => '4',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
+                'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ],
+        [
+          '789',
+          {
+            'article' => {
+              'mw_page_id' => '123',
+              'title' => 'Important article',
+              'namespace' => '118',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
+                'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ],
+        [
+          '790',
+          {
+            'article' => {
+              'mw_page_id' => '1023',
+              'title' => 'False gharial',
+              'namespace' => '118',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '985', 'date' => '20180706', 'characters' => '59',
+                'mw_page_id' => '1023', 'username' => 'Ragesoss', 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ]
+      ]
+    end
+    let(:subject) do
+      course.filter_revisions(revisions)
+    end
 
-  it 'onlies count assigned articles' do
-    expect(asp.article_count).to eq(1)
-  end
+    before do
+      create(:courses_user, course:, user:)
+      create(:article, id: 1, title: 'Important article', mw_page_id: 123, wiki_id: 1,
+             namespace: 118)
+      create(:assignment, course:, user:, article_id: 1, article_title: 'Important article')
+      create(:category, id: 1, article_titles: ['False_gharial'])
+      create(:categories_courses, course:, category_id: 1)
+    end
 
-  it 'onlies generate ArticlesCourses for assigned articles' do
-    expect(asp.articles_courses.count).to eq(1)
-  end
-
-  it 'onlies count revisions to assigned articles' do
-    expect(asp.revision_count).to eq(1)
-  end
-
-  it 'onlies count characters for assigned articles' do
-    expect(asp.character_sum).to eq(in_scope_rev.characters)
+    it 'only returns revisions for assignments' do
+      revisions = subject
+      # Returns only revisions for assignments and categories
+      expect(revisions.length).to eq(2)
+      expect(revisions[0][1]['article']['title']).to eq('Important article')
+      expect(revisions[1][1]['article']['title']).to eq('False gharial')
+    end
   end
 end

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -52,47 +52,107 @@
 require 'rails_helper'
 
 describe VisitingScholarship, type: :model do
-  before do
-    vs = create(:visiting_scholarship,
-                id: 10001,
-                start: 1.year.ago,
-                end: Time.zone.today + 1.year)
-    scholar = create(:user)
-    create(:courses_user,
-           user_id: scholar.id,
-           course_id: vs.id,
-           role: CoursesUsers::Roles::STUDENT_ROLE)
-    random_article = create(:article, title: 'Random', id: 1, namespace: 0)
-    assigned_article = create(:article, title: 'Assigned', id: 2, namespace: 0)
-    create(:assignment, user_id: scholar.id, course_id: vs.id,
-                        article_id: 2, article_title: 'Assigned')
-    create(:revision, id: 1, user_id: scholar.id,
-                      article_id: random_article.id, date: 1.day.ago)
-    create(:revision, id: 2, user_id: scholar.id,
-                      article_id: assigned_article.id, date: 1.day.ago)
-    ArticlesCourses.update_from_course(vs)
-    ArticlesCourses.update_all_caches(vs.articles_courses)
-    CoursesUsers.update_all_caches(CoursesUsers.ready_for_update)
-    Course.update_all_caches
+  describe 'update caches' do
+    before do
+      vs = create(:visiting_scholarship,
+                  id: 10001,
+                  start: 1.year.ago,
+                  end: Time.zone.today + 1.year)
+      scholar = create(:user)
+      create(:courses_user,
+             user_id: scholar.id,
+             course_id: vs.id,
+             role: CoursesUsers::Roles::STUDENT_ROLE)
+      random_article = create(:article, title: 'Random', id: 1, namespace: 0)
+      assigned_article = create(:article, title: 'Assigned', id: 2, namespace: 0)
+      create(:assignment, user_id: scholar.id, course_id: vs.id,
+                          article_id: 2, article_title: 'Assigned')
+      create(:revision, id: 1, user_id: scholar.id,
+                        article_id: random_article.id, date: 1.day.ago)
+      create(:revision, id: 2, user_id: scholar.id,
+                        article_id: assigned_article.id, date: 1.day.ago)
+      ArticlesCourses.update_from_course(vs)
+      ArticlesCourses.update_all_caches(vs.articles_courses)
+      CoursesUsers.update_all_caches(CoursesUsers.ready_for_update)
+      Course.update_all_caches
+    end
+
+    let(:out_of_scope_rev) { Revision.find(1) }
+    let(:in_scope_rev) { Revision.find(2) }
+    let(:vs) { Course.find(10001) }
+
+    it 'onlies count assigned articles' do
+      expect(vs.article_count).to eq(1)
+    end
+
+    it 'onlies generate ArticlesCourses for assigned articles' do
+      expect(vs.articles_courses.count).to eq(1)
+    end
+
+    it 'onlies count revisions to assigned articles' do
+      expect(vs.revision_count).to eq(1)
+    end
+
+    it 'onlies count characters for assigned articles' do
+      expect(vs.character_sum).to eq(in_scope_rev.characters)
+    end
   end
 
-  let(:out_of_scope_rev) { Revision.find(1) }
-  let(:in_scope_rev) { Revision.find(2) }
-  let(:vs) { Course.find(10001) }
+  describe '#filter_revisions' do
+    let(:course) { create(:visiting_scholarship, start: '2018-01-01', end: '2018-12-31') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+    let(:revisions) do
+      [
+        [
+          '112',
+          {
+            'article' => {
+              'mw_page_id' => '777',
+              'title' => 'Some title',
+              'namespace' => '4',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
+                'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ],
+        [
+          '789',
+          {
+            'article' => {
+              'mw_page_id' => '123',
+              'title' => 'Important article',
+              'namespace' => '118',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
+                'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ]
+      ]
+    end
+    let(:subject) do
+      course.filter_revisions(revisions)
+    end
 
-  it 'onlies count assigned articles' do
-    expect(vs.article_count).to eq(1)
-  end
+    before do
+      create(:courses_user, course:, user:)
+      create(:article, id: 1, title: 'Important article', mw_page_id: 123, wiki_id: 1,
+             namespace: 118)
+      create(:assignment, course:, user:, article_id: 1, article_title: 'Important article')
+    end
 
-  it 'onlies generate ArticlesCourses for assigned articles' do
-    expect(vs.articles_courses.count).to eq(1)
-  end
-
-  it 'onlies count revisions to assigned articles' do
-    expect(vs.revision_count).to eq(1)
-  end
-
-  it 'onlies count characters for assigned articles' do
-    expect(vs.character_sum).to eq(in_scope_rev.characters)
+    it 'only returns revisions for assignments' do
+      revisions = subject
+      # Returns only revisions for assignments
+      expect(revisions.length).to eq(1)
+      expect(revisions[0][1]['article']['title']).to eq('Important article')
+    end
   end
 end


### PR DESCRIPTION
## What this PR does
This PR adds support for `ArticleScopedProgram` and `VisitingScholarship` courses in the timeslice updates.

It adds a `filter_revisions` method to `Course` class. The trivial implementation retrieve all the revisions. The implementation for `ArticleScopedProgram` returns only the revisions for articles belonging to 1) a category course or 2) a course assignment.  The `filter_revisions` implementation for `VisitingScholarship` returns only the revisions for articles in course assignments.

## Open questions and concerns
If an assignment is added in the middle of the course, then revisions previous to the assignment creation date won't be considered, unless a full course update is done. In a similar way, if a category is updated in the middle of the course (meaning that a new article is inside a category, or an article is removed from a category) those updates won't be reflected in the timeslices previous to that update. 
The assignment dates are present in the assignment record, while the category record would be likely updated to have a field indicating the last point in time at which the category changed (e.g., a new item was added). This way we could just put a message for the course with a disclaimer like "An assignment or category used in this course has changed, so the data may not be accurate. Schedule a full course update to resolve this."