### PR TITLE
Fix LiftWingApi specs due to rounding

### DIFF
--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -34,13 +34,13 @@ describe LiftWingApi do
     it 'fetches json from api.wikimedia.org for wikipedia' do
       VCR.use_cassette 'liftwing_api/wikipedia' do
         expect(subject0).to be_a(Hash)
-        expect(subject0.dig('829840084', 'wp10').to_f).to eq(28.5936675221734978)
+        expect(subject0.dig('829840084', 'wp10').to_f).to be_within(0.01).of(28.59)
         expect(subject0.dig('829840084', 'features')).to be_a(Hash)
         expect(subject0.dig('829840084', 'deleted')).to eq(false)
         expect(subject0.dig('829840084', 'prediction')).to eq('Stub')
 
         expect(subject0).to be_a(Hash)
-        expect(subject0.dig('829840085', 'wp10').to_f).to eq(29.15228958136511656)
+        expect(subject0.dig('829840085', 'wp10').to_f).to be_within(0.01).of(29.15)
         expect(subject0.dig('829840085', 'features')).to be_a(Hash)
         expect(subject0.dig('829840085', 'deleted')).to eq(false)
         expect(subject0.dig('829840085', 'prediction')).to eq('Start')

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -12,14 +12,14 @@ describe RevisionScoreApiHandler do
       it 'returns completed scores if retrieves data without errors' do
         VCR.use_cassette 'revision_score_api_handler/en_wikipedia' do
           expect(subject).to be_a(Hash)
-          expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.805729915108664)
+          expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.81)
           expect(subject.dig('829840090', 'features')).to be_a(Hash)
           # Only num_ref feature is stored. LiftWing features are discarded.
           expect(subject.dig('829840090', 'features')).to eq({ 'num_ref' => 132 })
           expect(subject.dig('829840090', 'deleted')).to eq(false)
           expect(subject.dig('829840090', 'prediction')).to eq('B')
 
-          expect(subject.dig('829840091', 'wp10').to_f).to be_within(0.01).of(39.507631367268004)
+          expect(subject.dig('829840091', 'wp10').to_f).to be_within(0.01).of(39.51)
           expect(subject.dig('829840091', 'features')).to be_a(Hash)
           # Only num_ref feature is stored. LiftWing features are discarded.
           expect(subject.dig('829840091', 'features')).to eq({ 'num_ref' => 1 })
@@ -47,13 +47,13 @@ describe RevisionScoreApiHandler do
 
           expect(subject).to be_a(Hash)
 
-          expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.805729915108664)
+          expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.81)
           expect(subject.dig('829840090')).to have_key('features')
           expect(subject.dig('829840090', 'features')).to be_nil
           expect(subject.dig('829840090', 'deleted')).to eq(false)
           expect(subject.dig('829840090', 'prediction')).to eq('B')
 
-          expect(subject.dig('829840091', 'wp10').to_f).to be_within(0.01).of(39.507631367268004)
+          expect(subject.dig('829840091', 'wp10').to_f).to be_within(0.01).of(39.51)
           expect(subject.dig('829840091')).to have_key('features')
           expect(subject.dig('829840091', 'features')).to be_nil
           expect(subject.dig('829840091', 'deleted')).to eq(false)


### PR DESCRIPTION
## What this PR does
This PR fixes `lift_wing_api_spec.rb` specs due to rounding in `wp10` values. The spec doesn't seem to fail consistently, but I was able to reproduce the error locally and fix it.

It also removes unnecessary decimal places in `revision_score_api_handler_spec.rb spec`. If we use `be_within(0.01)` then it doesn't make a lot of sense to have more than two decimal places.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
