### PR TITLE
Enable additional javascript style linting rules #1408 -   [WIP]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,7 +53,7 @@
     "no-prototype-builtins": 0,
     "global-require": 0,
     "no-restricted-globals": 0,
-    "indent": 0,
+    "indent": 2,
     "function-paren-newline": 0,
     "react/no-find-dom-node": 0,
     "object-curly-newline": 0,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,25 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
-  create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "admin_course_notes", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
+    t.integer "courses_id"
+    t.string "title"
+    t.text "text"
+    t.string "edited_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["courses_id"], name: "index_admin_course_notes_on_courses_id"
+  end
+
+  create_table "alerts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
     t.integer "article_id"
     t.integer "revision_id"
     t.string "type"
-    t.datetime "email_sent_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "email_sent_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "message"
     t.integer "target_user_id"
     t.integer "subject_id"
@@ -31,25 +41,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["target_user_id"], name: "index_alerts_on_target_user_id"
     t.index ["user_id"], name: "index_alerts_on_user_id"
   end
-  
-  create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.integer "courses_id"
+
+  create_table "articles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "title"
-    t.text "text"
-    t.string "edited_by"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["courses_id"], name: "index_admin_course_notes_on_courses_id"
-  end
-  
-  create_table "articles", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.string "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.date "views_updated_at"
     t.integer "namespace"
     t.string "rating"
-    t.datetime "rating_updated_at"
+    t.datetime "rating_updated_at", precision: nil
     t.boolean "deleted", default: false
     t.string "language", limit: 10
     t.float "average_views"
@@ -62,9 +62,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["namespace", "wiki_id", "title"], name: "index_articles_on_namespace_and_wiki_id_and_title"
   end
 
-  create_table "articles_courses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "articles_courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "article_id"
     t.integer "course_id"
     t.bigint "view_count", default: 0
@@ -77,18 +77,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["course_id"], name: "index_articles_courses_on_course_id"
   end
 
-  create_table "assignment_suggestions", charset: "utf8mb4", force: :cascade do |t|
+  create_table "assignment_suggestions", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.text "text"
     t.bigint "assignment_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
     t.index ["assignment_id"], name: "index_assignment_suggestions_on_assignment_id"
   end
 
-  create_table "assignments", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.integer "course_id"
     t.integer "article_id"
@@ -101,12 +101,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
-  create_table "blocks", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "blocks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "kind"
     t.text "content"
     t.integer "week_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "title"
     t.integer "order"
     t.date "due_date"
@@ -115,76 +115,76 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["week_id"], name: "index_blocks_on_week_id"
   end
 
-  create_table "campaigns", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "title"
     t.string "slug"
     t.string "url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "description"
-    t.datetime "start"
-    t.datetime "end"
+    t.datetime "start", precision: nil
+    t.datetime "end", precision: nil
     t.text "template_description"
     t.string "default_course_type"
     t.string "default_passcode"
     t.boolean "register_accounts", default: false
   end
 
-  create_table "campaigns_courses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns_courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "campaign_id"
     t.integer "course_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["course_id", "campaign_id"], name: "index_campaigns_courses_on_course_id_and_campaign_id", unique: true
   end
 
-  create_table "campaigns_survey_assignments", id: false, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns_survey_assignments", id: false, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "survey_assignment_id"
     t.integer "campaign_id"
     t.index ["campaign_id"], name: "index_campaigns_survey_assignments_on_campaign_id"
     t.index ["survey_assignment_id"], name: "index_campaigns_survey_assignments_on_survey_assignment_id"
   end
 
-  create_table "campaigns_users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns_users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "campaign_id"
     t.integer "user_id"
     t.integer "role", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["campaign_id"], name: "index_campaigns_users_on_campaign_id"
     t.index ["user_id"], name: "index_campaigns_users_on_user_id"
   end
 
-  create_table "categories", charset: "utf8mb4", force: :cascade do |t|
+  create_table "categories", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "wiki_id"
     t.text "article_titles", size: :medium
     t.string "name"
     t.integer "depth", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "source", default: "category"
     t.index ["name"], name: "index_categories_on_name"
     t.index ["wiki_id", "name", "depth", "source"], name: "index_categories_on_wiki_id_and_name_and_depth_and_source", unique: true
     t.index ["wiki_id"], name: "index_categories_on_wiki_id"
   end
 
-  create_table "categories_courses", charset: "utf8mb4", force: :cascade do |t|
+  create_table "categories_courses", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "category_id"
     t.integer "course_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["category_id"], name: "index_categories_courses_on_category_id"
     t.index ["course_id", "category_id"], name: "index_categories_courses_on_course_id_and_category_id", unique: true
     t.index ["course_id"], name: "index_categories_courses_on_course_id"
   end
 
-  create_table "commons_uploads", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "commons_uploads", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "file_name", limit: 2000
-    t.datetime "uploaded_at"
+    t.datetime "uploaded_at", precision: nil
     t.integer "usage_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "thumburl", limit: 2000
     t.string "thumbwidth"
     t.string "thumbheight"
@@ -192,8 +192,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["user_id"], name: "index_commons_uploads_on_user_id"
   end
 
-
-  create_table "course_stats", charset: "utf8mb4", force: :cascade do |t|
+  create_table "course_stats", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.text "stats_hash"
     t.integer "course_id"
     t.datetime "created_at", null: false
@@ -201,7 +200,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["course_id"], name: "index_course_stats_on_course_id"
   end
 
-  create_table "course_wiki_namespaces", charset: "utf8mb4", force: :cascade do |t|
+  create_table "course_wiki_namespaces", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "namespace"
     t.bigint "courses_wikis_id"
     t.datetime "created_at", null: false
@@ -209,10 +208,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["courses_wikis_id"], name: "index_course_wiki_namespaces_on_courses_wikis_id"
   end
 
-  create_table "courses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.datetime "start"
     t.datetime "end"
     t.string "school"
@@ -243,7 +242,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.string "syllabus_file_name"
     t.string "syllabus_content_type"
     t.bigint "syllabus_file_size"
-    t.datetime "syllabus_updated_at"
+    t.datetime "syllabus_updated_at", precision: nil
     t.integer "home_wiki_id"
     t.integer "recent_revision_count", default: 0
     t.boolean "needs_update", default: false
@@ -256,9 +255,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 
-  create_table "courses_users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "courses_users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "course_id"
     t.integer "user_id"
     t.integer "character_sum_ms", default: 0
@@ -277,77 +276,77 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["user_id"], name: "index_courses_users_on_user_id"
   end
 
-  create_table "courses_wikis", charset: "utf8mb4", force: :cascade do |t|
+  create_table "courses_wikis", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "course_id"
     t.integer "wiki_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["course_id", "wiki_id"], name: "index_courses_wikis_on_course_id_and_wiki_id", unique: true
     t.index ["course_id"], name: "index_courses_wikis_on_course_id"
     t.index ["wiki_id"], name: "index_courses_wikis_on_wiki_id"
   end
 
-  create_table "faqs", charset: "utf8mb4", force: :cascade do |t|
+  create_table "faqs", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
     t.text "content"
   end
 
-  create_table "feedback_form_responses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "feedback_form_responses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "subject"
     t.text "body"
     t.integer "user_id"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
   end
 
-  create_table "question_group_conditionals", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "question_group_conditionals", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "rapidfire_question_group_id"
     t.integer "campaign_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["campaign_id"], name: "index_question_group_conditionals_on_campaign_id"
     t.index ["rapidfire_question_group_id"], name: "index_question_group_conditionals_on_rapidfire_question_group_id"
   end
 
-  create_table "rapidfire_answer_groups", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_answer_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "question_group_id"
     t.string "user_type"
     t.integer "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "course_id"
     t.index ["question_group_id"], name: "index_rapidfire_answer_groups_on_question_group_id"
     t.index ["user_id", "user_type"], name: "index_rapidfire_answer_groups_on_user_id_and_user_type"
   end
 
-  create_table "rapidfire_answers", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_answers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "answer_group_id"
     t.integer "question_id"
     t.text "answer_text"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "follow_up_answer_text"
     t.index ["answer_group_id"], name: "index_rapidfire_answers_on_answer_group_id"
     t.index ["question_id"], name: "index_rapidfire_answers_on_question_id"
   end
 
-  create_table "rapidfire_question_groups", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_question_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "tags"
   end
 
-  create_table "rapidfire_questions", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_questions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "question_group_id"
     t.string "type"
     t.text "question_text"
     t.integer "position"
     t.text "answer_options"
     t.text "validation_rules"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "follow_up_question_text"
     t.text "conditionals"
     t.boolean "multiple", default: false
@@ -358,22 +357,22 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["question_group_id"], name: "index_rapidfire_questions_on_question_group_id"
   end
 
-  create_table "requested_accounts", charset: "utf8mb4", force: :cascade do |t|
+  create_table "requested_accounts", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "username"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "revisions", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "revisions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "characters", default: 0
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.integer "article_id"
     t.bigint "views", default: 0
-    t.datetime "date"
+    t.datetime "date", precision: nil
     t.boolean "new_article", default: false
     t.boolean "deleted", default: false
     t.float "wp10"
@@ -392,18 +391,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["wiki_id", "mw_rev_id"], name: "index_revisions_on_wiki_id_and_mw_rev_id", unique: true
   end
 
-  create_table "settings", charset: "utf8mb4", force: :cascade do |t|
+  create_table "settings", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "key"
     t.text "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["key"], name: "index_settings_on_key", unique: true
   end
 
-  create_table "survey_assignments", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "survey_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "courses_user_role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "send_date_days"
     t.integer "survey_id"
     t.boolean "send_before", default: true
@@ -417,26 +416,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["survey_id"], name: "index_survey_assignments_on_survey_id"
   end
 
-  create_table "survey_notifications", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "survey_notifications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "courses_users_id"
     t.integer "course_id"
     t.integer "survey_assignment_id"
     t.boolean "dismissed", default: false
-    t.datetime "email_sent_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "email_sent_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "completed", default: false
-    t.datetime "last_follow_up_sent_at"
+    t.datetime "last_follow_up_sent_at", precision: nil
     t.integer "follow_up_count", default: 0
     t.index ["course_id"], name: "index_survey_notifications_on_course_id"
     t.index ["courses_users_id"], name: "index_survey_notifications_on_courses_users_id"
     t.index ["survey_assignment_id"], name: "index_survey_notifications_on_survey_assignment_id"
   end
 
-  create_table "surveys", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "intro"
     t.text "thanks"
     t.boolean "open", default: false
@@ -445,48 +444,48 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.text "optout"
   end
 
-  create_table "surveys_question_groups", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "surveys_question_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "survey_id"
     t.integer "rapidfire_question_group_id"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["rapidfire_question_group_id"], name: "index_surveys_question_groups_on_rapidfire_question_group_id"
     t.index ["survey_id"], name: "index_surveys_question_groups_on_survey_id"
   end
 
-  create_table "tags", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "tags", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "tag"
     t.string "key"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["course_id", "key"], name: "index_tags_on_course_id_and_key", unique: true
   end
 
-  create_table "ticket_dispenser_messages", charset: "utf8mb4", force: :cascade do |t|
+  create_table "ticket_dispenser_messages", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "kind", limit: 1, default: 0
     t.integer "sender_id"
     t.bigint "ticket_id"
     t.boolean "read", default: false, null: false
     t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "details"
     t.index ["ticket_id"], name: "index_ticket_dispenser_messages_on_ticket_id"
   end
 
-  create_table "ticket_dispenser_tickets", charset: "utf8mb4", force: :cascade do |t|
+  create_table "ticket_dispenser_tickets", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.bigint "project_id"
     t.integer "owner_id"
     t.integer "status", limit: 1, default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["owner_id"], name: "index_ticket_dispenser_tickets_on_owner_id"
     t.index ["project_id"], name: "index_ticket_dispenser_tickets_on_project_id"
   end
 
-  create_table "training_libraries", charset: "utf8mb4", force: :cascade do |t|
+  create_table "training_libraries", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "name"
     t.string "wiki_page"
     t.string "slug"
@@ -494,12 +493,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.text "categories", size: :medium
     t.text "translations", size: :medium
     t.boolean "exclude_from_index", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["slug"], name: "index_training_libraries_on_slug", unique: true
   end
 
-  create_table "training_modules", charset: "utf8mb4", force: :cascade do |t|
+  create_table "training_modules", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "name"
     t.string "estimated_ttc"
     t.string "wiki_page"
@@ -507,20 +506,20 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.text "slide_slugs"
     t.text "description"
     t.text "translations", size: :medium
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "kind", limit: 1, default: 0
     t.text "settings"
     t.index ["slug"], name: "index_training_modules_on_slug", unique: true
   end
 
-  create_table "training_modules_users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "training_modules_users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "training_module_id"
     t.string "last_slide_completed"
-    t.datetime "completed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "completed_at", precision: nil
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "flags"
     t.index ["user_id", "training_module_id"], name: "index_training_modules_users_on_user_id_and_training_module_id", unique: true
   end
@@ -531,16 +530,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.string "summary"
     t.string "button_text"
     t.string "wiki_page"
-    t.text "assessment"
+    t.text "assessment", size: :medium
     t.text "content"
-    t.text "translations", size: :medium
+    t.text "translations", size: :long
     t.string "slug"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["slug"], name: "index_training_slides_on_slug", unique: true, length: 191
   end
 
-  create_table "trigrams", charset: "utf8mb4", force: :cascade do |t|
+  create_table "trigrams", charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "trigram", limit: 3
     t.integer "score", limit: 2
     t.integer "owner_id"
@@ -550,26 +549,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.index ["owner_id", "owner_type"], name: "index_by_owner"
   end
 
-  create_table "user_profiles", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_profiles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.text "bio"
     t.integer "user_id"
     t.string "image_file_name"
     t.string "image_content_type"
     t.bigint "image_file_size"
-    t.datetime "image_updated_at"
+    t.datetime "image_updated_at", precision: nil
     t.string "location"
     t.string "institution"
     t.text "email_preferences"
     t.string "image_file_link"
   end
 
-  create_table "users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "username"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.boolean "trained", default: false
     t.integer "global_id"
-    t.datetime "remember_created_at"
+    t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
     t.string "wiki_token"
     t.string "wiki_secret"
@@ -582,31 +581,31 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.string "locale"
     t.string "chat_password"
     t.string "chat_id"
-    t.datetime "registered_at"
-    t.datetime "first_login"
+    t.datetime "registered_at", precision: nil
+    t.datetime "first_login", precision: nil
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "versions", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "versions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object", size: :long
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "weeks", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "weeks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "title"
     t.integer "course_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "order", default: 1, null: false
     t.index ["course_id"], name: "index_weeks_on_course_id"
   end
 
-  create_table "wikis", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "wikis", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "language", limit: 16
     t.string "project", limit: 16
     t.index ["language", "project"], name: "index_wikis_on_language_and_project", unique: true

--- a/test/actions/settings_actions.spec.js
+++ b/test/actions/settings_actions.spec.js
@@ -18,7 +18,7 @@ describe('SettingsActions', () => {
   beforeEach(() => {
     sinon.stub(requestModule, 'default').resolves(
       { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
-      );
+    );
   });
 
   afterEach(() => {
@@ -44,10 +44,10 @@ describe('upgradeAdmin', () => {
     sinon.stub(requestModule, 'default')
       .onCall(0).resolves(
         { status: 200, ok: true, json: sinon.fake.returns({}) }
-        )
+      )
       .onCall(1).resolves(
         { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
-        );
+      );
   });
 
   afterEach(() => {
@@ -94,11 +94,11 @@ describe('downgradeAdmin', () => {
   beforeEach(() => {
     cannedResponse = { spam: 'eggs' };
     sinon.stub(requestModule, 'default')
-    .onCall(0).resolves(
-      { status: 200, ok: true, json: sinon.fake.returns({}) }
+      .onCall(0).resolves(
+        { status: 200, ok: true, json: sinon.fake.returns({}) }
       )
-    .onCall(1).resolves(
-      { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
+      .onCall(1).resolves(
+        { status: 200, ok: true, json: sinon.fake.returns({ spam: 'eggs' }) }
       );
   });
 

--- a/test/reducers/active_courses.spec.js
+++ b/test/reducers/active_courses.spec.js
@@ -1,104 +1,104 @@
 import deepFreeze from 'deep-freeze';
 import active_courses from '../../app/assets/javascripts/reducers/active_courses';
 import {
-    RECEIVE_ACTIVE_COURSES,
-    SORT_ACTIVE_COURSES,
-    RECEIVE_CAMPAIGN_ACTIVE_COURSES,
+  RECEIVE_ACTIVE_COURSES,
+  SORT_ACTIVE_COURSES,
+  RECEIVE_CAMPAIGN_ACTIVE_COURSES,
 } from '../../app/assets/javascripts/constants';
 
 describe('active_course reducer', () => {
-    test('should return initial state when no action nor state is provided', () => {
-        const newState = active_courses(undefined, { type: null });
-        expect(newState.courses).toEqual([]);
-        expect(newState.isLoaded).toBe(false);
-    });
+  test('should return initial state when no action nor state is provided', () => {
+    const newState = active_courses(undefined, { type: null });
+    expect(newState.courses).toEqual([]);
+    expect(newState.isLoaded).toBe(false);
+  });
 
-    test('should return the same state when RECEIVE_ACTIVE_COURSES is dispatched multiple times with the same data', () => {
-        const initialState = {
-            courses: [],
-            isLoaded: false,
-            sort: { key: null, sortKey: null },
-        };
-        deepFreeze(initialState);
-        const mockedAction = {
-            type: RECEIVE_ACTIVE_COURSES,
-            data: { courses: [{ id: 1, title: 'Course 1' }] },
-        };
-        const firstState = active_courses(initialState, mockedAction);
-        const secondState = active_courses(firstState, mockedAction);
-        expect(firstState).toEqual(secondState);
-        expect(secondState.courses).toEqual([{ id: 1, title: 'Course 1' }]);
-        expect(secondState.isLoaded).toBe(true);
-    });
+  test('should return the same state when RECEIVE_ACTIVE_COURSES is dispatched multiple times with the same data', () => {
+    const initialState = {
+      courses: [],
+      isLoaded: false,
+      sort: { key: null, sortKey: null },
+    };
+    deepFreeze(initialState);
+    const mockedAction = {
+      type: RECEIVE_ACTIVE_COURSES,
+      data: { courses: [{ id: 1, title: 'Course 1' }] },
+    };
+    const firstState = active_courses(initialState, mockedAction);
+    const secondState = active_courses(firstState, mockedAction);
+    expect(firstState).toEqual(secondState);
+    expect(secondState.courses).toEqual([{ id: 1, title: 'Course 1' }]);
+    expect(secondState.isLoaded).toBe(true);
+  });
 
-    test('should handle an empty list of courses in RECEIVE_ACTIVE_COURSES', () => {
-        const initialState = {
-            courses: [{ id: 1, title: 'Existing Course' }],
-            isLoaded: true,
-            sort: { key: null, sortKey: null },
-        };
-        deepFreeze(initialState);
-        const mockedAction = {
-            type: RECEIVE_ACTIVE_COURSES,
-            data: { courses: [] },
-        };
-        const newState = active_courses(initialState, mockedAction);
-        expect(newState.courses).toEqual([]);
-        expect(newState.isLoaded).toBe(true);
-    });
+  test('should handle an empty list of courses in RECEIVE_ACTIVE_COURSES', () => {
+    const initialState = {
+      courses: [{ id: 1, title: 'Existing Course' }],
+      isLoaded: true,
+      sort: { key: null, sortKey: null },
+    };
+    deepFreeze(initialState);
+    const mockedAction = {
+      type: RECEIVE_ACTIVE_COURSES,
+      data: { courses: [] },
+    };
+    const newState = active_courses(initialState, mockedAction);
+    expect(newState.courses).toEqual([]);
+    expect(newState.isLoaded).toBe(true);
+  });
 
-    test('should return active course data  with RECEIVE_ACTIVE_COURSES and set isLoaded to true', () => {
-        const initialState = {};
-        deepFreeze(initialState);
-        const mockedAction = {
-            type: RECEIVE_ACTIVE_COURSES,
-            data: { courses: [{ title: 'title' }] },
-        };
-        const newState = active_courses(initialState, mockedAction);
-        const expectedState = { courses: [{ title: 'title' }], isLoaded: true };
-        expect(newState).toEqual(expectedState);
-    });
+  test('should return active course data  with RECEIVE_ACTIVE_COURSES and set isLoaded to true', () => {
+    const initialState = {};
+    deepFreeze(initialState);
+    const mockedAction = {
+      type: RECEIVE_ACTIVE_COURSES,
+      data: { courses: [{ title: 'title' }] },
+    };
+    const newState = active_courses(initialState, mockedAction);
+    const expectedState = { courses: [{ title: 'title' }], isLoaded: true };
+    expect(newState).toEqual(expectedState);
+  });
 
-    test('handles RECEIVE_CAMPAIGN_ACTIVE_COURSES by updating active courses with campaign data ', () => {
-        const initialState = { courses: [{ title: 'title' }] };
-        deepFreeze(initialState);
-        const mockedAction = {
-            type: RECEIVE_CAMPAIGN_ACTIVE_COURSES,
-            data: { courses: [{ title: 'new title', description: 'new text' }] }
-        };
-        const newState = active_courses(initialState, mockedAction);
-        expect(newState.isLoaded).toBe(true);
-        expect(newState.courses).toEqual([{ title: 'new title', description: 'new text' }]);
-    });
+  test('handles RECEIVE_CAMPAIGN_ACTIVE_COURSES by updating active courses with campaign data ', () => {
+    const initialState = { courses: [{ title: 'title' }] };
+    deepFreeze(initialState);
+    const mockedAction = {
+      type: RECEIVE_CAMPAIGN_ACTIVE_COURSES,
+      data: { courses: [{ title: 'new title', description: 'new text' }] }
+    };
+    const newState = active_courses(initialState, mockedAction);
+    expect(newState.isLoaded).toBe(true);
+    expect(newState.courses).toEqual([{ title: 'new title', description: 'new text' }]);
+  });
 
-    test('sort active courses via SORT_ACTIVE_COURSES ', () => {
-        const initialState = {
-            courses: [{ id: 2, title: 'title two' }, { id: 1, title: 'title one' }],
-            sort: { sorKey: null }
-        };
-        deepFreeze(initialState);
-        const mockedAction = {
-            type: SORT_ACTIVE_COURSES,
-            key: 'id'
-        };
-        const newState = active_courses(initialState, mockedAction);
-        expect(newState.sort.key).toBe('id');
-        expect(newState.courses[0].id).toBe(1);
-        expect(newState.courses[1].id).toBe(2);
-    });
+  test('sort active courses via SORT_ACTIVE_COURSES ', () => {
+    const initialState = {
+      courses: [{ id: 2, title: 'title two' }, { id: 1, title: 'title one' }],
+      sort: { sorKey: null }
+    };
+    deepFreeze(initialState);
+    const mockedAction = {
+      type: SORT_ACTIVE_COURSES,
+      key: 'id'
+    };
+    const newState = active_courses(initialState, mockedAction);
+    expect(newState.sort.key).toBe('id');
+    expect(newState.courses[0].id).toBe(1);
+    expect(newState.courses[1].id).toBe(2);
+  });
 
-    test('should not modify courses when SORT_ACTIVE_COURSES is dispatched with an invalid key', () => {
-        const initialState = {
-            courses: [{ id: 2, title: 'Course 2' }, { id: 1, title: 'Course 1' }],
-            sort: { sortKey: null, key: null },
-        };
-        deepFreeze(initialState);
-        const mockedAction = {
-            type: SORT_ACTIVE_COURSES,
-            key: 'nonExistentKey',
-        };
-        const newState = active_courses(initialState, mockedAction);
-        expect(newState.courses).toEqual(initialState.courses); // Should remain unchanged
-        expect(newState.sort.key).toBe('nonExistentKey');
-    });
+  test('should not modify courses when SORT_ACTIVE_COURSES is dispatched with an invalid key', () => {
+    const initialState = {
+      courses: [{ id: 2, title: 'Course 2' }, { id: 1, title: 'Course 1' }],
+      sort: { sortKey: null, key: null },
+    };
+    deepFreeze(initialState);
+    const mockedAction = {
+      type: SORT_ACTIVE_COURSES,
+      key: 'nonExistentKey',
+    };
+    const newState = active_courses(initialState, mockedAction);
+    expect(newState.courses).toEqual(initialState.courses); // Should remain unchanged
+    expect(newState.sort.key).toBe('nonExistentKey');
+  });
 });

--- a/test/reducers/confirm.spec.js
+++ b/test/reducers/confirm.spec.js
@@ -4,39 +4,39 @@ import { CONFIRMATION_INITIATED, ACTION_CONFIRMED, ACTION_CANCELLED } from '../.
 import '../testHelper';
 
 const initialState = {
-    explanation: null,
-    confirmationActive: false,
-    confirmMessage: null,
-    onConfirm: null,
-    showInput: false,
-    warningMessage: null,
-  };
+  explanation: null,
+  confirmationActive: false,
+  confirmMessage: null,
+  onConfirm: null,
+  showInput: false,
+  warningMessage: null,
+};
 
 describe('article_details reducer', () => {
-    test('should handle CONFIRMATION_INITIATED action by updating state', () => {
-          const action = {
-            type: CONFIRMATION_INITIATED,
-            explanation: 'Test explanation',
-            confirmationActive: true,
-            confirmMessage: 'Test confirm message',
-            onConfirm: jest.fn(),
-            showInput: true,
-            warningMessage: 'Test warning message',
-          };
+  test('should handle CONFIRMATION_INITIATED action by updating state', () => {
+    const action = {
+      type: CONFIRMATION_INITIATED,
+      explanation: 'Test explanation',
+      confirmationActive: true,
+      confirmMessage: 'Test confirm message',
+      onConfirm: jest.fn(),
+      showInput: true,
+      warningMessage: 'Test warning message',
+    };
 
-     const expectedState = {
-    explanation: 'Test explanation',
-    confirmationActive: true,
-    confirmMessage: 'Test confirm message',
-    onConfirm: expect.any(Function), // You can use expect.any(Function) for functions
-    showInput: true,
-    warningMessage: 'Test warning message',
-  };
-          deepFreeze(initialState);
-          const newState = ui(initialState, action);
+    const expectedState = {
+      explanation: 'Test explanation',
+      confirmationActive: true,
+      confirmMessage: 'Test confirm message',
+      onConfirm: expect.any(Function), // You can use expect.any(Function) for functions
+      showInput: true,
+      warningMessage: 'Test warning message',
+    };
+    deepFreeze(initialState);
+    const newState = ui(initialState, action);
 
-          expect(newState).toEqual(expectedState);
-    });
+    expect(newState).toEqual(expectedState);
+  });
 
   test('should handle ACTION_CONFIRMED action by resetting to initial state', () => {
     const action = {
@@ -47,9 +47,9 @@ describe('article_details reducer', () => {
     const expectedState = initialState;
     const newState = ui(initialState, action);
     expect(newState).toEqual(ui(undefined, expectedState));
-});
+  });
 
-test('should handle ACTION_CANCELLED action by resetting to initial state', () => {
+  test('should handle ACTION_CANCELLED action by resetting to initial state', () => {
     const action = {
       type: ACTION_CANCELLED,
     };
@@ -58,5 +58,5 @@ test('should handle ACTION_CANCELLED action by resetting to initial state', () =
     const expectedState = initialState;
     const newState = ui(initialState, action);
     expect(newState).toEqual(ui(undefined, expectedState));
-});
+  });
 });

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -20,64 +20,64 @@ describe('users reducer', () => {
   );
 
   test('returns the previous state and updates users array from action via RECEIVE_USERS, ADD_USER, and REMOVE_USER', () => {
-  const initialState = users(undefined, { type: null });
-  deepFreeze(initialState);
+    const initialState = users(undefined, { type: null });
+    deepFreeze(initialState);
 
-  const action = (type, users_array) => ({
-    type: type,
-    data: {
-      course: {
-        users: users_array
+    const action = (type, users_array) => ({
+      type: type,
+      data: {
+        course: {
+          users: users_array
+        }
       }
-    }
+    });
+
+    let users_array = [
+      { id: 1, real_name: 'John Doe', role: 'student' },
+      { id: 2, real_name: 'Jane Smith', role: 'admin' }
+    ];
+
+    users_array = users_array.map((user) => {
+      const [first_name, ...rest] = (user.real_name?.trim() || '').split(' ');
+      return { ...user, first_name, last_name: rest.join(' ') };
+    });
+
+    const mockedReceivedAction = action(RECEIVE_USERS, users_array);
+    const receiveUserState = users(initialState, mockedReceivedAction);
+    expect(receiveUserState.users).toEqual(users_array);
+    expect(receiveUserState.isLoaded).toBe(true);
+
+    users_array = [
+      { id: 3, real_name: 'Bob Johnson', role: 'student' },
+      { id: 4, real_name: 'Alice Williams', role: 'admin' },
+      { id: 5, real_name: 'Eve Brown', role: 'student' }
+    ];
+
+    users_array = users_array.map((user) => {
+      const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+      return { ...user, first_name, last_name: rest.join(' ') };
+    });
+
+    const mockedAddAction = action(ADD_USER, users_array);
+    const addUserState = users(receiveUserState, mockedAddAction);
+    expect(addUserState.users).toEqual(users_array);
+    expect(addUserState.isLoaded).toBe(true);
+
+    users_array = [
+      { id: 4, real_name: 'Alice Williams', role: 'admin' },
+      { id: 5, real_name: 'Eve Brown', role: 'student' }
+    ];
+
+    users_array = users_array.map((user) => {
+      const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
+      return { ...user, first_name, last_name: rest.join(' ') };
+    });
+
+    const mockedRemoveAction = action(REMOVE_USER, users_array);
+    const removeUserState = users(addUserState, mockedRemoveAction);
+    expect(removeUserState.users).toEqual(users_array);
+    expect(removeUserState.isLoaded).toBe(true);
   });
-
-  let users_array = [
-    { id: 1, real_name: 'John Doe', role: 'student' },
-    { id: 2, real_name: 'Jane Smith', role: 'admin' }
-  ];
-
-  users_array = users_array.map((user) => {
-    const [first_name, ...rest] = (user.real_name?.trim() || '').split(' ');
-    return { ...user, first_name, last_name: rest.join(' ') };
-  });
-
-  const mockedReceivedAction = action(RECEIVE_USERS, users_array);
-  const receiveUserState = users(initialState, mockedReceivedAction);
-  expect(receiveUserState.users).toEqual(users_array);
-  expect(receiveUserState.isLoaded).toBe(true);
-
-  users_array = [
-    { id: 3, real_name: 'Bob Johnson', role: 'student' },
-    { id: 4, real_name: 'Alice Williams', role: 'admin' },
-    { id: 5, real_name: 'Eve Brown', role: 'student' }
-  ];
-
-  users_array = users_array.map((user) => {
-    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
-    return { ...user, first_name, last_name: rest.join(' ') };
-  });
-
-  const mockedAddAction = action(ADD_USER, users_array);
-  const addUserState = users(receiveUserState, mockedAddAction);
-  expect(addUserState.users).toEqual(users_array);
-  expect(addUserState.isLoaded).toBe(true);
-
-  users_array = [
-    { id: 4, real_name: 'Alice Williams', role: 'admin' },
-    { id: 5, real_name: 'Eve Brown', role: 'student' }
-  ];
-
-  users_array = users_array.map((user) => {
-    const [first_name, ...rest] = (user.real_name?.trim().toLowerCase() || '').split(' ');
-    return { ...user, first_name, last_name: rest.join(' ') };
-  });
-
-  const mockedRemoveAction = action(REMOVE_USER, users_array);
-  const removeUserState = users(addUserState, mockedRemoveAction);
-  expect(removeUserState.users).toEqual(users_array);
-  expect(removeUserState.isLoaded).toBe(true);
-});
 
   test('sorts users given a key by action via SORT_USERS', () => {
     const initialState = {

--- a/test/utils/infer_default_campaign.spec.js
+++ b/test/utils/infer_default_campaign.spec.js
@@ -25,10 +25,10 @@ describe('Matching campaigns available', () => {
     });
 
     test('April 2022 - should return Spring 2022', () => {
-        start_date = new Date(2022, 3, 30);
-        const result = inferDefaultCampaign(campaigns, start_date);
-        expect(result).toStrictEqual({ id: 1, title: 'Spring 2022', slug: 'spring_2022' });
-      });
+      start_date = new Date(2022, 3, 30);
+      const result = inferDefaultCampaign(campaigns, start_date);
+      expect(result).toStrictEqual({ id: 1, title: 'Spring 2022', slug: 'spring_2022' });
+    });
   });
 
   describe('May to July', () => {
@@ -39,10 +39,10 @@ describe('Matching campaigns available', () => {
     });
 
     test('July 2022 - should return Summer 2022', () => {
-        start_date = new Date(2022, 6, 31);
-        const result = inferDefaultCampaign(campaigns, start_date);
-        expect(result).toStrictEqual({ id: 2, title: 'Summer 2022', slug: 'summer_2022' });
-      });
+      start_date = new Date(2022, 6, 31);
+      const result = inferDefaultCampaign(campaigns, start_date);
+      expect(result).toStrictEqual({ id: 2, title: 'Summer 2022', slug: 'summer_2022' });
+    });
   });
 
   describe('August to November', () => {
@@ -53,9 +53,9 @@ describe('Matching campaigns available', () => {
     });
 
     test('November 2022 - should return Fall 2022', () => {
-        start_date = new Date(2022, 10, 30);
-        const result = inferDefaultCampaign(campaigns, start_date);
-        expect(result).toStrictEqual({ id: 3, title: 'Fall 2022', slug: 'fall_2022' });
-      });
+      start_date = new Date(2022, 10, 30);
+      const result = inferDefaultCampaign(campaigns, start_date);
+      expect(result).toStrictEqual({ id: 3, title: 'Fall 2022', slug: 'fall_2022' });
+    });
   });
 });

--- a/test/utils/revision_utils.spec.js
+++ b/test/utils/revision_utils.spec.js
@@ -40,29 +40,29 @@ describe('gets references count for ', () => {
   test('first revision', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, enwikiRevisionParent);
     expect(referencesAdded).toBe(10);
-   });
+  });
   test('revision with parent', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, enwikiRevision);
     expect(referencesAdded).toBe(10);
-   });
+  });
   test('revision under wikidata', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, wikidataRevision);
     expect(referencesAdded).toBe(2);
-   });
+  });
   test('revision with no ORES data', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, enwikiRevisionNoORES);
     expect(referencesAdded).not.toBeDefined();
-   });
+  });
   test('revision with parent having no ORES data', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, wikidataRevisionParent);
     expect(referencesAdded).not.toBeDefined();
-   });
+  });
   test('first revision having no references', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, enwikiFirstRevisionNoReferences);
     expect(referencesAdded).toBe(0);
-   });
+  });
   test('revision which added 0 references', () => {
     const referencesAdded = getReferencesAdded(ORES_OBJECT, frwikiRevision);
     expect(referencesAdded).toBe(0);
-   });
+  });
 });

--- a/test/utils/statistic_update_info_utils.spec.js
+++ b/test/utils/statistic_update_info_utils.spec.js
@@ -157,26 +157,26 @@ describe('getFirstUpdateMessage', () => {
     'returns an array with the first update information',
     () => {
       const course = {
-            id: 1,
-            title: 'My Awesome Course',
-            flags: {
-              academic_system: null,
-              format: '',
-              first_update: {
-                enqueued_at: '2021-11-30T13:30:14.148Z',
-                queue_name: 'medium_update',
-                queue_latency: 0.3774135112762451
-              },
-            },
-            update_until: '2022-09-29T22:00:00.000Z',
-            updates: {
-              average_delay: null,
-              last_update: null
-            },
-            survey_notifications: [],
-            passcode_required: false,
-            passcode: 'omupyzac',
-            canUploadSyllabus: true,
+        id: 1,
+        title: 'My Awesome Course',
+        flags: {
+          academic_system: null,
+          format: '',
+          first_update: {
+            enqueued_at: '2021-11-30T13:30:14.148Z',
+            queue_name: 'medium_update',
+            queue_latency: 0.3774135112762451
+          },
+        },
+        update_until: '2022-09-29T22:00:00.000Z',
+        updates: {
+          average_delay: null,
+          last_update: null
+        },
+        survey_notifications: [],
+        passcode_required: false,
+        passcode: 'omupyzac',
+        canUploadSyllabus: true,
       };
 
       const result = getFirstUpdateMessage(course);
@@ -187,21 +187,21 @@ describe('getFirstUpdateMessage', () => {
     'if no first update data, still returns array with that information',
     () => {
       const course = {
-            id: 1,
-            title: 'My Awesome Course',
-            flags: {
-              academic_system: null,
-              format: ''
-            },
-            update_until: '2022-09-29T22:00:00.000Z',
-            updates: {
-              average_delay: null,
-              last_update: null
-            },
-            survey_notifications: [],
-            passcode_required: false,
-            passcode: 'omupyzac',
-            canUploadSyllabus: true,
+        id: 1,
+        title: 'My Awesome Course',
+        flags: {
+          academic_system: null,
+          format: ''
+        },
+        update_until: '2022-09-29T22:00:00.000Z',
+        updates: {
+          average_delay: null,
+          last_update: null
+        },
+        survey_notifications: [],
+        passcode_required: false,
+        passcode: 'omupyzac',
+        canUploadSyllabus: true,
       };
 
       const result = getFirstUpdateMessage(course);
@@ -514,7 +514,7 @@ describe('getUpdateLogs', () => {
       const result = getUpdateLogs(course);
       expect(result.length).toBe(4);
     }
-    );
+  );
   test(
     'if no last update data, returns an empty array',
     () => {

--- a/test/utils/wiki_utils.spec.js
+++ b/test/utils/wiki_utils.spec.js
@@ -65,8 +65,8 @@ describe('trackedWikisMaker', () => {
           project: 'wikipedia'
         }]
       };
-  const result = trackedWikisMaker(course);
-  expect(result).toStrictEqual([{ label: 'en.wikipedia.org', value: '{"language":"en","project":"wikipedia"}' }, { label: 'www.wikipedia.org', value: '{"language":"www","project":"wikipedia"}' }]);
+      const result = trackedWikisMaker(course);
+      expect(result).toStrictEqual([{ label: 'en.wikipedia.org', value: '{"language":"en","project":"wikipedia"}' }, { label: 'www.wikipedia.org', value: '{"language":"www","project":"wikipedia"}' }]);
     }
   );
   test(


### PR DESCRIPTION

## What this PR does
This pull request is enabling some of the javascript style linting rules. The ESlint rules enabled in this pr include Indent, 

Before:
All the ESlint  rules worked on in this pull request were not in use and commented out.

After:

The ESlint are  re-enabled  and all the violations have been fixed in the codebase.
