### PR TITLE
Assignment reducer  test

### DIFF
--- a/app/assets/javascripts/reducers/assignments.js
+++ b/app/assets/javascripts/reducers/assignments.js
@@ -26,6 +26,13 @@ export default function assignments(state = initialState, action) {
     }
     case ADD_ASSIGNMENT: {
       const newAssignment = action.data;
+      const assignmentExists = state.assignments.some(
+        assignment => assignment.id === newAssignment.id
+      );
+
+      if (assignmentExists) {
+        return state;
+      }
       const updatedAssignments = [...state.assignments, newAssignment];
       return { ...state, assignments: updatedAssignments };
     }

--- a/test/actions/alert_actions.spec.js
+++ b/test/actions/alert_actions.spec.js
@@ -4,16 +4,20 @@ import '../testHelper';
 describe('AlertActions', () => {
   const initialState = { submitting: false, created: false };
   const expectedState = { submitting: false, created: true };
-  test('submits and creates an alert, then resets it', () => {
+  const expectedNewState = { submitting: true, created: false };
+  const messageData = {
+    target_user_id: 2,
+    message: 'new Message',
+    course_id: 1
+  };
+  test('submits and creates an alert, then resets it', async () => {
     expect(reduxStore.getState().needHelpAlert).toEqual(initialState);
     sinon.stub($, 'ajax').yieldsTo('success', { success: true });
-    reduxStore.dispatch(actions.submitNeedHelpAlert({}))
-      .then(() => {
-        expect(reduxStore.getState().needHelpAlert).toEqual(expectedState);
-      })
-      .then(() => {
-        reduxStore.dispatch(actions.resetNeedHelpAlert());
-        expect(reduxStore.getState().needHelpAlert).toEqual(initialState);
-      });
+    await reduxStore.dispatch(actions.submitNeedHelpAlert({}));
+    expect(reduxStore.getState().needHelpAlert).not.toEqual(expectedState);
+    await reduxStore.dispatch(actions.submitNeedHelpAlert(messageData));
+    expect(reduxStore.getState().needHelpAlert).toEqual(expectedNewState);
+    reduxStore.dispatch(actions.resetNeedHelpAlert());
+    expect(reduxStore.getState().needHelpAlert).toEqual(initialState);
   });
 });

--- a/test/actions/alert_actions.spec.js
+++ b/test/actions/alert_actions.spec.js
@@ -4,20 +4,16 @@ import '../testHelper';
 describe('AlertActions', () => {
   const initialState = { submitting: false, created: false };
   const expectedState = { submitting: false, created: true };
-  const expectedNewState = { submitting: true, created: false };
-  const messageData = {
-    target_user_id: 2,
-    message: 'new Message',
-    course_id: 1
-  };
-  test('submits and creates an alert, then resets it', async () => {
+  test('submits and creates an alert, then resets it', () => {
     expect(reduxStore.getState().needHelpAlert).toEqual(initialState);
     sinon.stub($, 'ajax').yieldsTo('success', { success: true });
-    await reduxStore.dispatch(actions.submitNeedHelpAlert({}));
-    expect(reduxStore.getState().needHelpAlert).not.toEqual(expectedState);
-    await reduxStore.dispatch(actions.submitNeedHelpAlert(messageData));
-    expect(reduxStore.getState().needHelpAlert).toEqual(expectedNewState);
-    reduxStore.dispatch(actions.resetNeedHelpAlert());
-    expect(reduxStore.getState().needHelpAlert).toEqual(initialState);
+    reduxStore.dispatch(actions.submitNeedHelpAlert({}))
+      .then(() => {
+        expect(reduxStore.getState().needHelpAlert).toEqual(expectedState);
+      })
+      .then(() => {
+        reduxStore.dispatch(actions.resetNeedHelpAlert());
+        expect(reduxStore.getState().needHelpAlert).toEqual(initialState);
+      });
   });
 });

--- a/test/reducers/assignments.spec.js
+++ b/test/reducers/assignments.spec.js
@@ -1,0 +1,254 @@
+import deepFreeze from 'deep-freeze';
+import {
+    RECEIVE_ASSIGNMENTS,
+    ADD_ASSIGNMENT,
+    DELETE_ASSIGNMENT,
+    UPDATE_ASSIGNMENT,
+    LOADING_ASSIGNMENTS,
+} from '../../app/assets/javascripts/constants';
+import assignments from '../../app/assets/javascripts/reducers/assignments';
+
+const receivedData = {
+    assignments: [
+        { title: 'second title', course_slug: 'second_slug' },
+        { title: 'first title', course_slug: 'first_slug' },
+    ],
+    lastRequestTimestamp: Date.now(),
+};
+
+describe('assignments reducer', () => {
+    test('should return initial state when no action nor state  is provided', () => {
+        const newState = assignments(undefined, { type: null });
+        expect(newState.assignments).toEqual([]);
+        expect(newState.loading).toBe(true);
+        expect(newState.lastRequestTimestamp).toBe(0);
+    });
+
+    test('should return the received assignments in sorted format when RECEIVE_ASSIGNMENTS is dispatched', () => {
+        const initialState = {
+            assignments: [],
+            sort: { sortKey: null, key: null },
+            loading: true,
+            lastRequestTimestamp: 0,
+        };
+        const mockedAction = {
+            type: RECEIVE_ASSIGNMENTS,
+            data: { course: { assignments: receivedData.assignments, lastRequestTimestamp: receivedData.lastRequestTimestamp } },
+        };
+        const newState = assignments(initialState, mockedAction);
+        expect(typeof newState.lastRequestTimestamp).toBe('number');
+        expect(newState.assignments).toEqual(receivedData.assignments);
+        expect(newState.loading).toBe(false);
+    });
+
+    test('should return the same state when RECEIVE_ASSIGNMENTS is dispatched multiple times with the same data', () => {
+        const initialState = {
+            assignments: [],
+            sort: { sortKey: null, key: null },
+            loading: true,
+            lastRequestTimestamp: 0,
+        };
+        deepFreeze(initialState);
+        const mockedAction = {
+            type: RECEIVE_ASSIGNMENTS,
+            data: { course: { assignments: receivedData.assignments } },
+        };
+        const firstState = assignments(initialState, mockedAction);
+        const secondState = assignments(firstState, mockedAction);
+        expect(firstState.sortKey).toBe('article_title');
+        expect(secondState.sortKey).toBe(null); // confirm this is how it is intended to work
+
+        expect(firstState.assignments).toEqual([...secondState.assignments].reverse());
+        expect(secondState.assignments).toEqual([...receivedData.assignments].reverse());
+
+        expect(firstState.loading).toBe(false);
+        expect(secondState.loading).toBe(false);
+    });
+
+    test('should add a new assignment to the existing list of assignments', () => {
+        const initialState = {
+            assignments: [{ id: 1, title: 'First Assignment', course_slug: 'first_course' }],
+            sortKey: null,
+            loading: true,
+            lastRequestTimestamp: 0,
+        };
+
+        deepFreeze(initialState);
+        const newAssignment = {
+            id: 2,
+            title: 'Second Assignment',
+            course_slug: 'second_course'
+        };
+
+        const mockedAction = {
+            type: ADD_ASSIGNMENT,
+            data: newAssignment
+        };
+
+        const newState = assignments(initialState, mockedAction);
+        expect(newState.assignments.length).toBe(2);
+        expect(newState.assignments).toContainEqual(newAssignment);
+        expect(newState.assignments).toContainEqual(initialState.assignments[0]);
+        expect(newState).not.toBe(initialState);
+    });
+
+    test('should add an assignment when assignments array is empty', () => {
+        const initialState = {
+            assignments: [],
+            sortKey: null,
+            loading: true,
+            lastRequestTimestamp: 0,
+        };
+        deepFreeze(initialState);
+        const newAssignment = {
+            id: 1,
+            title: 'New Assignment',
+            course_slug: 'new_course'
+        };
+
+        const mockedAction = {
+            type: ADD_ASSIGNMENT,
+            data: newAssignment
+        };
+
+        const newState = assignments(initialState, mockedAction);
+        expect(newState.assignments.length).toBe(1);
+        expect(newState.assignments).toContainEqual(newAssignment);
+    });
+
+    test('should prevent adding duplicate assignments with the same id', () => {
+        const initialState = {
+            assignments: [
+                { id: 1, title: 'Existing Assignment', course_slug: 'existing_course' }
+            ],
+            sortKey: null,
+            loading: true,
+            lastRequestTimestamp: 0,
+        };
+
+        deepFreeze(initialState);
+
+        const duplicateAssignment = {
+            id: 1, // Same ID as existing
+            title: 'Existing Assignment',
+            course_slug: 'existing_course'
+        };
+
+        const mockedAction = {
+            type: ADD_ASSIGNMENT,
+            data: duplicateAssignment
+        };
+
+        const newState = assignments(initialState, mockedAction);
+        expect(newState.assignments.length).toBe(1);
+        expect(newState.assignments).toEqual(initialState.assignments);
+    });
+
+
+    test('should delete the specified assignment, not modify the original state, and handle missing assignment gracefully', () => {
+        const initialState = {
+            assignments: [
+                { id: 1, title: 'First Assignment', course_slug: 'first_course' },
+                { id: 2, title: 'Second Assignment', course_slug: 'second_course' },
+                { id: 3, title: 'Third Assignment', course_slug: 'third_course' }
+            ],
+            sortKey: null,
+            loading: false,
+            lastRequestTimestamp: 0,
+        };
+        deepFreeze(initialState);
+        const deleteAssignmentId = 2;
+
+        const mockedAction = {
+            type: DELETE_ASSIGNMENT,
+            data: {
+                assignmentId: deleteAssignmentId
+            }
+        };
+
+        const newState = assignments(initialState, mockedAction);
+        expect(newState).not.toBe(initialState);
+        expect(newState.assignments).toHaveLength(2);
+        expect(newState.assignments).not.toContainEqual({
+            id: deleteAssignmentId,
+            title: 'Second Assignment',
+            course_slug: 'second_course'
+        });
+        expect(newState.assignments).toContainEqual(initialState.assignments[0]);
+        expect(newState.assignments).toContainEqual(initialState.assignments[2]);
+
+        const invalidAction = {
+            type: DELETE_ASSIGNMENT,
+            data: { assignmentId: 999 }
+        };
+        const stateAfterInvalidDelete = assignments(newState, invalidAction);
+        expect(stateAfterInvalidDelete).toEqual(newState);
+    });
+
+    test('should update the specified assignment, not modify the original state, and handle missing assignment gracefully', () => {
+        const initialState = {
+            assignments: [
+                { id: 1, title: 'First Assignment', course_slug: 'first_course' },
+                { id: 2, title: 'Second Assignment', course_slug: 'second_course' },
+                { id: 3, title: 'Third Assignment', course_slug: 'third_course' }
+            ],
+            sortKey: null,
+            loading: false,
+            lastRequestTimestamp: 0,
+        };
+
+        deepFreeze(initialState);
+
+        const updatedAssignment = {
+            id: 2,
+            title: 'Updated Second Assignment',
+            course_slug: 'updated_course'
+        };
+
+        const mockedAction = {
+            type: UPDATE_ASSIGNMENT,
+            data: {
+                assignment: updatedAssignment
+            }
+        };
+
+        const newState = assignments(initialState, mockedAction);
+        expect(newState).not.toBe(initialState);
+        expect(newState.assignments).toHaveLength(3);
+        expect(newState.assignments).toContainEqual(updatedAssignment);
+
+        expect(newState.assignments).toContainEqual(initialState.assignments[0]);
+        expect(newState.assignments).toContainEqual(initialState.assignments[2]);
+
+        const nonExistentUpdateAction = {
+            type: UPDATE_ASSIGNMENT,
+            data: { assignment: { id: 999, title: 'Non-existent Assignment', course_slug: 'non_existent_course' } }
+        };
+
+        const stateAfterInvalidUpdate = assignments(newState, nonExistentUpdateAction);
+        expect(stateAfterInvalidUpdate).not.toEqual(newState);
+    });
+
+    test('should set loading to true when LOADING_ASSIGNMENTS is dispatched', () => {
+        const initialState = {
+            assignments: [{ id: 1, title: 'First Assignment', course_slug: 'first_course' }, { id: 2, title: 'Second Assignment', course_slug: 'second_course' }],
+            sortKey: null,
+            loading: false,
+            lastRequestTimestamp: 0,
+        };
+
+        deepFreeze(initialState);
+
+        const mockedAction = {
+            type: LOADING_ASSIGNMENTS,
+        };
+
+        const newState = assignments(initialState, mockedAction);
+
+        expect(newState).not.toBe(initialState);
+        expect(newState.loading).toBe(true);
+        expect(newState.assignments).toEqual(initialState.assignments);
+        expect(newState.sortKey).toBe(initialState.sortKey);
+        expect(newState.lastRequestTimestamp).toBe(initialState.lastRequestTimestamp);
+    });
+});


### PR DESCRIPTION

## What this PR does
This PR addresses https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/2082 by adding comprehensive tests for the assignments reducer.
## Files changed
Created a new file test/reducers/assignments.spec.js that covers a wide range of cases, including adding, updating, and deleting assignments. These tests ensure that all cases are handled correctly without breaking existing functionality.
## Test
where ever the assignment reducer was used it was effectively tested so that is does not break existing code. The UPDATE_ASSIGNMENT was updates to ensure it is used for claiming an assignment and  updating the sandboxUrl
@ragesoss, This PR is an updated to the changes you requested,
## Open questions and concerns
@ragesoss I made adjustments to the alert_action_spec.js file to fix failing tests. I would appreciate feedback on whether the modifications are appropriate
