### PR TITLE
Fix: Resolves 'revision_score_importer_spec' issues #5854

### DIFF
--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -9,7 +9,11 @@ class LiftWingApi
   include ApiErrorHandling
   include WeightedScoreCalculator
 
-  DELETED_REVISION_ERRORS = %w[TextDeleted RevisionNotFound].freeze
+  DELETED_REVISION_ERRORS = [
+    'TextDeleted',
+    'RevisionNotFound',
+    'The MW API does not have any info related to the rev-id'
+  ].freeze
 
   LIFT_WING_SERVER_URL = 'https://api.wikimedia.org'
 

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -12,7 +12,7 @@ class LiftWingApi
   DELETED_REVISION_ERRORS = [
     'TextDeleted',
     'RevisionNotFound',
-    'The MW API does not have any info related to the rev-id'
+    'MW API does not have any info'
   ].freeze
 
   LIFT_WING_SERVER_URL = 'https://api.wikimedia.org'

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -78,7 +78,7 @@ describe RevisionScoreImporter do
   end
 
   it 'marks RevisionNotFound revisions as deleted' do
-    VCR.use_cassette 'revision_scores/deleted_revision' do
+    VCR.use_cassette 'revision_scores/not_found_revision' do
       # Article and its revisions are deleted
       article = create(:article,
                        mw_page_id: 123456,


### PR DESCRIPTION
## What this PR does
Resolves Issue #5854 by:
- Adding the `MW API does not have any info` string as an additional item in the DELETED_REVISION_ERRORS  array to solve the issue of the `marks RevisionNotFound revisions as deleted` spec failing.

- Renaming the cassette to `revision_scores/not_found_revision` for the `marks RevisionNotFound revisions as deleted` spec to solve the missing LiftWing API response in the fixtures files.
