### PR TITLE
User#can_edit? fix

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -49,7 +49,7 @@ class AssignmentsController < ApplicationController
 
   # Select an Available Article as a new Assignment for a user
   def claim
-    @claimed_assignment = Assignment.find(params[:id])
+    @claimed_assignment = Assignment.find(params[:assignment_id])
     @course = @claimed_assignment.course
     check_permissions(assignment_params[:user_id].to_i)
     check_participation # prevents a user from a different course claiming an assignment

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -49,7 +49,7 @@ class AssignmentsController < ApplicationController
 
   # Select an Available Article as a new Assignment for a user
   def claim
-    @claimed_assignment = Assignment.find(params[:assignment_id])
+    @claimed_assignment = Assignment.find(params[:id])
     @course = @claimed_assignment.course
     check_permissions(assignment_params[:user_id].to_i)
     check_participation # prevents a user from a different course claiming an assignment
@@ -67,8 +67,9 @@ class AssignmentsController < ApplicationController
   end
 
   def update_status
-    check_permissions(assignment_params[:user_id].to_i)
     @assignment = Assignment.find(assignment_params[:id])
+    @course = @assignment.course
+    check_permissions(assignment_params[:user_id].to_i)
 
     if assignment_params[:status]
       @assignment.update_status(assignment_params[:status])

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -421,7 +421,7 @@ class CoursesController < ApplicationController
   def protect_privacy
     return unless @course.private
     # Admins and enrolled users have non-visitor roles
-    return if current_user&.can_view?(@course)
+    return if current_user&.nonvisitor?(@course)
     raise ActionController::RoutingError, 'not found'
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -421,7 +421,7 @@ class CoursesController < ApplicationController
   def protect_privacy
     return unless @course.private
     # Admins and enrolled users have non-visitor roles
-    return if current_user && current_user.role(@course) != CoursesUsers::Roles::VISITOR_ROLE
+    return if current_user&.can_view?(@course)
     raise ActionController::RoutingError, 'not found'
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -180,6 +180,8 @@ class User < ApplicationRecord
       if course_user.any? { |cu| EDITING_ROLES.include?(cu.role) }
         # return the editing role
         return course_user.find { |cu| EDITING_ROLES.include?(cu.role) }.role
+      else
+        return course_user.order('role DESC').first.role
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,9 +173,10 @@ class User < ApplicationRecord
   end
 
   def highest_role(course)
+    return CoursesUsers::Roles::INSTRUCTOR_ROLE if admin?
+
     roles = course_roles(course)
 
-    return CoursesUsers::Roles::INSTRUCTOR_ROLE if admin?
     return CoursesUsers::Roles::VISITOR_ROLE if roles.empty?
 
     roles.first
@@ -188,10 +189,6 @@ class User < ApplicationRecord
     return true if course_roles(course).any? { |role| EDITING_ROLES.include?(role) }
     return true if campaign_organizer?(course)
     false
-  end
-
-  def can_view?(course)
-    nonvisitor?(course)
   end
 
   def campaign_organizer?(course)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,8 +170,16 @@ class User < ApplicationRecord
 
   # returns an array of roles a user has in a given course
   def course_roles(course)
-    user_course_roles = course.courses_users.where(user_id: id).pluck(:role)
+    user_course_roles = course.courses_users.where(user_id: id).order('role DESC').pluck(:role)
     return user_course_roles
+  end
+
+  def highest_role(course)
+    roles = course_roles(course)
+
+    return CoursesUsers::Roles::VISITOR_ROLE if roles.empty?
+
+    roles.first
   end
 
   def editing_role?(course)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,8 +172,16 @@ class User < ApplicationRecord
     # Give admins the instructor permissions.
     return CoursesUsers::Roles::INSTRUCTOR_ROLE if admin?
 
-    course_user = course.courses_users.where(user_id: id).order('role DESC').first
-    return course_user.role unless course_user.nil?
+    # Get the courses_users record for the user in the course
+    course_user = course.courses_users.where(user_id: id)
+
+    if course_user.exists?
+      # check if the user has any editing role
+      if course_user.any? { |cu| EDITING_ROLES.include?(cu.role) }
+        # return the editing role
+        return course_user.find { |cu| EDITING_ROLES.include?(cu.role) }.role
+      end
+    end
 
     # User is in visitor role, if no other role found.
     CoursesUsers::Roles::VISITOR_ROLE

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,6 +175,7 @@ class User < ApplicationRecord
   def highest_role(course)
     roles = course_roles(course)
 
+    return CoursesUsers::Roles::INSTRUCTOR_ROLE if admin?
     return CoursesUsers::Roles::VISITOR_ROLE if roles.empty?
 
     roles.first

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.course do
-  user_role = current_user&.course_roles(@course) || CoursesUsers::Roles::VISITOR_ROLE
+  user_role = current_user&.highest_role(@course) || CoursesUsers::Roles::VISITOR_ROLE
 
   json.call(@course, :id, :title, :description, :start, :end, :school,
             :subject, :slug, :url, :submitted, :expected_students, :timeline_start,

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.course do
-  user_role = current_user&.role(@course) || CoursesUsers::Roles::VISITOR_ROLE
+  user_role = current_user&.course_roles(@course) || CoursesUsers::Roles::VISITOR_ROLE
 
   json.call(@course, :id, :title, :description, :start, :end, :school,
             :subject, :slug, :url, :submitted, :expected_students, :timeline_start,

--- a/config/initializers/ticket_dispenser.rb
+++ b/config/initializers/ticket_dispenser.rb
@@ -15,7 +15,7 @@ Rails.application.config.to_prepare do
         username: user.username,
         real_name: user.real_name,
         email: user.email,
-        role: user.role(project)
+        role: user.highest_role(project)
       }
     end
   end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -446,7 +446,8 @@ describe AssignmentsController, type: :request do
     context 'updating sandbox url with valid urls' do
       let(:preferred_sandbox_url) { "#{base_url}/User:#{new_username}/testingArticle" }
       let!(:request_params) do
-        { id: assignment.id, user_id: user.id, newUrl: preferred_sandbox_url, format: :json }
+        { id: assignment.id, user_id: user.id, newUrl: preferred_sandbox_url, format: :json,
+course_slug: course.slug }
       end
 
       it 'update sandbox url successfully with example 1' do
@@ -469,7 +470,8 @@ describe AssignmentsController, type: :request do
     context 'updating sandbox url with valid format but belongs to different wiki' do
       let(:preferred_sandbox_url) { "https://www.wikipedia.org/wiki/User:#{new_username}/testingArticle" }
       let!(:request_params) do
-        { id: assignment.id, user_id: user.id, newUrl: preferred_sandbox_url, format: :json }
+        { id: assignment.id, user_id: user.id, newUrl: preferred_sandbox_url, format: :json,
+course_slug: course.slug }
       end
 
       it 'does not update url and send response with status: unprocessable entity' do
@@ -484,7 +486,8 @@ describe AssignmentsController, type: :request do
     context 'updating sandbox url with invalid url format' do
       let(:preferred_sandbox_url) { 'anyGebberishURL' }
       let!(:request_params) do
-        { id: assignment.id, user_id: user.id, newUrl: preferred_sandbox_url, format: :json }
+        { id: assignment.id, user_id: user.id, newUrl: preferred_sandbox_url, format: :json,
+course_slug: course.slug }
       end
 
       it 'does not update url and send response with status: bad request example 1' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -136,6 +136,55 @@ describe User do
     end
   end
 
+  describe '#can_view?' do
+    it 'returns false when the user has only visitor role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: -1) # visitor
+      permission = user.can_view?(course)
+      expect(permission).to be false
+    end
+
+    it 'returns true when the user has one non-visitor role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      create(:courses_user,
+             course_id: 1,
+               user_id: 1,
+               role: 0) # student
+      permission = user.can_view?(course)
+      expect(permission).to be true
+    end
+
+    it 'returns true for users with multiple roles, including a visitor role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      # User is a visitor
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: -1) # visitor
+
+      # User is also a campus volunteer
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: 2) # campus volunteer
+
+      permission = user.can_view?(course)
+      expect(permission).to be true
+    end
+  end
+
   describe 'email validation' do
     context 'when email is valid' do
       it 'saves the email' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -167,10 +167,6 @@ describe User do
     it 'returns false when the user has only visitor role' do
       course = create(:course)
       user = create(:user)
-      create(:courses_user,
-             course_id: course.id,
-             user_id: user.id,
-             role: CoursesUsers::Roles::VISITOR_ROLE)
       permission = user.can_view?(course)
       expect(permission).to be false
     end
@@ -187,13 +183,9 @@ describe User do
     end
 
     it 'returns true for users with multiple roles, including a visitor role' do
+      # User is a visitor
       course = create(:course)
       user = create(:user)
-      # User is a visitor
-      create(:courses_user,
-             course_id: course.id,
-             user_id: user.id,
-             role: CoursesUsers::Roles::VISITOR_ROLE)
 
       # User is also a campus volunteer
       create(:courses_user,
@@ -230,15 +222,13 @@ describe User do
     end
 
     it 'returns true for users with multiple roles, including a real name role' do
+      # User is a visitor
       course = create(:course)
       user = create(:user)
-      # User is a visitor
-      create(:courses_user,
-             course_id: course.id,
-             user_id: user.id,
-             role: CoursesUsers::Roles::VISITOR_ROLE)
+      permission = user.can_see_real_names?(course)
+      expect(permission).to be false
 
-      # User is also an instructor
+      # Now user is an instructor
       create(:courses_user,
              course_id: course.id,
              user_id: user.id,
@@ -254,7 +244,7 @@ describe User do
       create(:courses_user,
              course_id: course.id,
               user_id: user.id,
-              role: CoursesUsers::Roles::VISITOR_ROLE)
+              role: CoursesUsers::Roles::STUDENT_ROLE)
       permission = user.can_see_real_names?(course)
       expect(permission).to be false
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -185,6 +185,86 @@ describe User do
     end
   end
 
+  describe '#can_see_real_names?' do
+    it 'returns true when the user has an instructor role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: 1) # Instructor
+      permission = user.can_see_real_names?(course)
+      expect(permission).to be true
+    end
+
+    it 'returns true when the user has a staff role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      create(:courses_user,
+             course_id: 1,
+              user_id: 1,
+              role: 4) # Wiki education staff
+      permission = user.can_see_real_names?(course)
+      expect(permission).to be true
+    end
+
+    it 'returns true for users with multiple roles, including a real name role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      # User is a visitor
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: -1) # visitor
+
+      # User is also an instructor
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: 1) # Instructor
+
+      permission = user.can_see_real_names?(course)
+      expect(permission).to be true
+    end
+
+    it 'returns false when the user has no real name role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      create(:courses_user,
+             course_id: 1,
+              user_id: 1,
+              role: -1) # visitor
+      permission = user.can_see_real_names?(course)
+      expect(permission).to be false
+    end
+
+    it 'returns false when the user has multiple roles and no real name role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      create(:courses_user,
+             course_id: 1,
+              user_id: 1,
+              role: 0) # student
+
+      create(:courses_user,
+             course_id: 1,
+               user_id: 1,
+               role: 2) # campus volunteer
+      permission = user.can_see_real_names?(course)
+      expect(permission).to be false
+    end
+  end
+
   describe 'email validation' do
     context 'when email is valid' do
       it 'saves the email' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,6 +140,27 @@ describe User do
       permission = user.can_edit?(course)
       expect(permission).to be false
     end
+
+    it 'returns true for users with multiple roles, including an editing role' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      # User is an instructor
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: 1) # instructor
+
+      # User is also a campus volunteer
+      create(:courses_user,
+             course_id: 1,
+             user_id: 1,
+             role: 2) # campus volunteer
+
+      permission = user.can_edit?(course)
+      expect(permission).to be true
+    end
   end
 
   describe 'email validation' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -163,11 +163,11 @@ describe User do
     end
   end
 
-  describe '#can_view?' do
+  describe '#nonvisitor' do
     it 'returns false when the user has only visitor role' do
       course = create(:course)
       user = create(:user)
-      permission = user.can_view?(course)
+      permission = user.nonvisitor?(course)
       expect(permission).to be false
     end
 
@@ -178,7 +178,7 @@ describe User do
              course_id: course.id,
                user_id: user.id,
                role: CoursesUsers::Roles::STUDENT_ROLE)
-      permission = user.can_view?(course)
+      permission = user.nonvisitor?(course)
       expect(permission).to be true
     end
 
@@ -193,7 +193,7 @@ describe User do
              user_id: user.id,
              role: CoursesUsers::Roles::CAMPUS_VOLUNTEER_ROLE)
 
-      permission = user.can_view?(course)
+      permission = user.nonvisitor?(course)
       expect(permission).to be true
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,22 +52,8 @@ describe User do
     end
   end
 
-  describe '#role' do
-    it 'grants instructor permission for a user creating a new course' do
-      course = nil
-      user = create(:user)
-      role = user.role(course)
-      expect(role).to eq(1)
-    end
-
-    it 'treats an admin like the instructor' do
-      course = create(:course)
-      admin = create(:admin)
-      role = admin.role(course)
-      expect(role).to eq(1)
-    end
-
-    it 'returns the assigned role for a non-admin' do
+  describe '#course_roles' do
+    it 'returns an array of roles a user has in a course' do
       course = create(:course,
                       id: 1)
       user = create(:user,
@@ -76,36 +62,23 @@ describe User do
              course_id: 1,
              user_id: 1,
              role: 0) # student
-      role = user.role(course)
-      expect(role).to eq(0)
-      expect(user.student?(course)).to eq(true)
-      expect(user.course_student?).to eq(true)
-      expect(user.instructor?(course)).to eq(false)
 
-      # Now let's make this user also an instructor.
       create(:courses_user,
              course_id: 1,
              user_id: 1,
              role: 1) # instructor
-      expect(user.instructor?(course)).to eq(true)
-      expect(user.course_instructor?).to eq(true)
 
-      # User is only an instructor, not an admin.
-      adminship = user.roles(course)[:admin]
-      expect(adminship).to eq(false)
-      # role = user.role(course)
-      # FIXME: User#role does not account for users with multiple roles.
-      # We can probably disable the option of multiple roles when we disconnect
-      # the MediaWiki EP extension. For the sake of permissions, though, #role
-      # probably ought to return the most permissive role for a user.
-      # expect(role).to eq(1)
+      roles = user.course_roles(course)
+      expect(roles).to contain_exactly(0, 1)
     end
 
-    it 'returns -1 for a user who is not part of the course' do
-      course = create(:course)
-      user = create(:user)
-      role = user.role(course)
-      expect(role).to eq(-1)
+    it 'returns an empty array when the user has no roles in the course' do
+      course = create(:course,
+                      id: 1)
+      user = create(:user,
+                    id: 1)
+      roles = user.course_roles(course)
+      expect(roles).to be_empty
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR addresses #5948 by ensuring users with multiple roles are correctly assigned editing permissions.

## More details on what was done

- Updated User#role method to properly handle cases where a user has multiple roles in a course.
- The method now checks if the user has any editing role and returns the appropriate role.
- Added unit test to verify that users with both campus volunteer (non-editing role) and instructor roles are correctly recognized as having editing privileges.
