### PR TITLE
Solobarine/dynamic titles

### DIFF
--- a/app/views/copy_course/index.html.haml
+++ b/app/views/copy_course/index.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, "Copy Course"
 .container.dashboard
   %header
     %h1

--- a/app/views/faq/edit.html.haml
+++ b/app/views/faq/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, "Edit FAQ - #{@faq.title}"
 .container
   = simple_form_for @faq do |f|
     = f.input :title

--- a/app/views/faq/index.html.haml
+++ b/app/views/faq/index.html.haml
@@ -1,5 +1,5 @@
 = hot_javascript_tag 'accordian'
-
+- content_for :before_title, "Frequently Asked Questions(FAQs)"
 %header
   .container.faq-header
     %h1 Frequently Asked Questions

--- a/app/views/faq/new.html.haml
+++ b/app/views/faq/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, "New FAQ"
 .container
   %h1 Add new FAQ
   = simple_form_for @faq, url: '/faq' do |f|

--- a/app/views/faq/show.html.haml
+++ b/app/views/faq/show.html.haml
@@ -1,4 +1,5 @@
 = hot_javascript_tag 'accordian'
+- content_for :before_title, "FAQ - #{@faq.title}"
 .container
   .faq-list
     %a{href: '/faq'} FAQs

--- a/app/views/faq_topics/edit.html.haml
+++ b/app/views/faq_topics/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :before_title, "Edit FAQ Topic - #{@topic.title}"
+- content_for :before_title, "Edit FAQ Topic - #{@topic.slug}"
 .container
   %h2= "Editing topic: #{@topic.slug}"
   = form_with url: "/faq_topics/#{@topic.slug}", method: :update do

--- a/app/views/faq_topics/edit.html.haml
+++ b/app/views/faq_topics/edit.html.haml
@@ -1,5 +1,6 @@
+- content_for :before_title, "Edit FAQ Topic - #{@topic.title}"
 .container
-  %h2= "Editing topic: #{@topic.slug}" 
+  %h2= "Editing topic: #{@topic.slug}"
   = form_with url: "/faq_topics/#{@topic.slug}", method: :update do
     = label_tag :name, 'Name'
     = text_field_tag :name, @topic.name
@@ -12,7 +13,7 @@
       - @topic.faqs.each do |faq|
         %li
           %a{href: "/faq/#{faq.id}"}= faq.title
-          = "(#{faq.id})" 
+          = "(#{faq.id})"
 
   %hr
   = button_to 'delete', "/faq_topics/#{@topic.slug}", method: :delete, data: { confirm: "Are you sure you want to delete this?" }

--- a/app/views/faq_topics/index.html.haml
+++ b/app/views/faq_topics/index.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, 'FAQ Topics'
 .container
   %h1 FAQ Topics
   %a.button{href: '/faq_topics/new'} New Topic
@@ -15,4 +16,4 @@
           - topic.faqs.each do |faq|
             %li
               %a{href: "/faq/#{faq.id}"}= faq.title
-        
+

--- a/app/views/faq_topics/new.html.haml
+++ b/app/views/faq_topics/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, 'New FAQ Topic'
 .container
   = form_with url: '/faq_topics', method: :create do
     = label_tag :slug, 'Slug'

--- a/app/views/settings/index.html.haml
+++ b/app/views/settings/index.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, "#{current_user.username} Settings"
 -user =  current_user.to_json(only: [:real_name, :email, :permissions, :username]).to_str
 
 %div#react_root{"data-current_user" => user}

--- a/app/views/survey_assignments/edit.html.haml
+++ b/app/views/survey_assignments/edit.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, "Edit Survey Assignments"
 = render 'admin_header'
 .container.survey__admin
   .survey__questions-list

--- a/app/views/survey_assignments/new.html.haml
+++ b/app/views/survey_assignments/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :before_title, "New Survey Assignment"
 = render 'admin_header'
 .container.survey__admin
   = render 'form'

--- a/app/views/surveys/edit.html.haml
+++ b/app/views/surveys/edit.html.haml
@@ -1,1 +1,2 @@
+- content_for :before_title, "Edit Survey - #{@survey.name}"
 = render 'form'

--- a/app/views/surveys/results.html.haml
+++ b/app/views/surveys/results.html.haml
@@ -1,4 +1,4 @@
-- content_for :after_title, "#{@survey.name} Results"
+- content_for :before_title, "#{@survey.name} Results"
 
 - content_for :additional_javascripts do
   = javascript_include_tag '/assets/javascripts/jquery.min.js'


### PR DESCRIPTION
# Pull Request: Update Page Titles for Enhanced Clarity

## Summary
This PR updates the titles across various pages of the WikiEduDashboard to improve user experience and ensure consistency in page naming conventions.

## Changes Made:
- Standardized Page Titles: Updated titles for key pages to provide more informative and user-friendly text.
- Changed ambiguous or generic titles to more specific, descriptive versions.
- Added relevant keywords where applicable without keyword stuffing.

## Page-by-Page Breakdown:
### Copy Course
/copy_course: ➡️ Copy Course

### FAQ
/faq: ➡️ Frequently Asked Questions(FAQs)
/faq/:new ➡️ New FAQ
/faq/:id ➡️ FAQ - {Title}
/faq/:id/edit:  ➡️ Edit FAQ - {Title}

### FAQ Topics
/faq_topics  ➡️ FAQ Topics
/faq_topics/new ➡️ New FAQ Topic
/faq_topics/:slug/edit ➡️ Edit FAQ Topic - {name}

### Surveys
/surveys/results ➡️ {name} Results
/surveys/:id/edit ➡️ Edit Survey - {name}

### Survey Assignments
/surveys/assignments/new ➡️ New Survey Assignment
/surveys/assignments/:id/edit ➡️ Edit Survey Assignment

## Testing
- Manually reviewed the updated titles across all affected pages to ensure they display correctly and provide a better user experience.
- Verified that there are no regression issues (e.g., title truncation or unintended changes in the UI).

## Impact:
User Experience: Clearer, more descriptive page titles improve the user's ability to navigate the platform effectively.

## Notes:
This PR does not affect any functionality apart from the front-end display of titles in the browser tab and search engine metadata.
