### PR TITLE
Add Comprehensive Tests for Campaigns Reducer

### DIFF
--- a/app/assets/javascripts/reducers/campaigns.js
+++ b/app/assets/javascripts/reducers/campaigns.js
@@ -33,11 +33,7 @@ const initialState = {
 
 export default function campaigns(state = initialState, action) {
   switch (action.type) {
-    case ADD_CAMPAIGN: {
-      const newCampaign = action.data.course.campaigns;
-      const updatedCampaign = [...state.campaigns, newCampaign];
-      return { ...state, campaigns: updatedCampaign, isLoaded: true };
-    }
+    case ADD_CAMPAIGN:
     case DELETE_CAMPAIGN:
     case RECEIVE_COURSE_CAMPAIGNS: {
       const newState = {

--- a/app/assets/javascripts/reducers/campaigns.js
+++ b/app/assets/javascripts/reducers/campaigns.js
@@ -33,7 +33,11 @@ const initialState = {
 
 export default function campaigns(state = initialState, action) {
   switch (action.type) {
-    case ADD_CAMPAIGN:
+    case ADD_CAMPAIGN: {
+      const newCampaign = action.data.course.campaigns;
+      const updatedCampaign = [...state.campaigns, newCampaign];
+      return { ...state, campaigns: updatedCampaign, isLoaded: true };
+    }
     case DELETE_CAMPAIGN:
     case RECEIVE_COURSE_CAMPAIGNS: {
       const newState = {

--- a/test/reducers/campaigns.spec.js
+++ b/test/reducers/campaigns.spec.js
@@ -1,0 +1,95 @@
+import deepFreeze from 'deep-freeze';
+import campaigns from '../../app/assets/javascripts/reducers/campaigns';
+import {
+    RECEIVE_COURSE_CAMPAIGNS,
+    RECEIVE_ALL_CAMPAIGNS,
+    ADD_CAMPAIGN,
+    SORT_CAMPAIGNS_WITH_STATS,
+    SORT_ALL_CAMPAIGNS } from '../../app/assets/javascripts/constants';
+
+const campaignsArray = [
+      { id: 2, slug: 'second_campaign', description: 'second description' },
+        { id: 1, slug: 'first_campaign', description: 'first description' }
+      ];
+ const sortedcampaignsArray = [
+      { id: 1, slug: 'first_campaign', description: 'first description' },
+      { id: 2, slug: 'second_campaign', description: 'second description' },
+      ];
+
+describe('campaigns reducer', () => {
+    test('should return initial state when no action nor state is provided', () => {
+        const newState = campaigns(undefined, { type: null });
+        expect(newState.campaigns).toEqual([]);
+        expect(newState.all_campaigns).toEqual([]);
+        expect(newState.isLoaded).toBe(false);
+    });
+
+    test('should add and return campaigns data with ADD_CAMPAIGN and set isLoaded to true', () => {
+        const initialState = { campaigns: [], all_campaigns: [], isLoaded: false };
+        deepFreeze(initialState);
+
+        const mockedAction = {
+          type: ADD_CAMPAIGN,
+          data: { course: { campaigns: campaignsArray[0] } }
+        };
+
+        const newState = campaigns(initialState, mockedAction);
+        expect(newState.campaigns).toContainEqual(campaignsArray[0]);
+        expect(newState.isLoaded).toBe(true);
+        expect(Array.isArray(newState.campaigns)).toBe(true);
+      });
+
+      test('should receives and return  course campaigns and update initial course campaigns with RECEIVE_COURSE_CAMPAIGNS', () => {
+        const initialState = { campaigns: [{ id: 3, slug: 'third_campaign', description: 'first description' }],
+                            all_campaigns: [],
+                            isLoaded: false };
+        deepFreeze(initialState);
+        const mockedAction = {
+          type: RECEIVE_COURSE_CAMPAIGNS,
+          data: { course: { campaigns: campaignsArray } }
+        };
+
+        const newState = campaigns(initialState, mockedAction);
+        expect(newState.campaigns).toEqual(campaignsArray);
+        expect(newState.isLoaded).toBe(true);
+      });
+
+      test('should receives all campaigns with RECEIVE_ALL_CAMPAIGNS and set all_campaigns_loaded to true', () => {
+        const initialState = { campaigns: [], all_campaigns: [], all_campaigns_loaded: false };
+        deepFreeze(initialState);
+
+        const mockedAction = {
+          type: RECEIVE_ALL_CAMPAIGNS,
+          data: { campaigns: campaignsArray }
+        };
+
+        const newState = campaigns(initialState, mockedAction);
+        expect(newState.all_campaigns).toEqual(campaignsArray);
+        expect(newState.all_campaigns_loaded).toBe(true);
+      });
+
+      test('sort active courses via SORT_ACTIVE_CAMPAIGN', () => {
+        const initialState = { campaigns: [], all_campaigns: campaignsArray, isLoaded: false, sort: { sortKey: null } };
+        deepFreeze(initialState);
+        const mockedAction = {
+            type: SORT_ALL_CAMPAIGNS,
+            key: 'id'
+        };
+
+        const newState = campaigns(initialState, mockedAction);
+        expect(newState.sort.key).toBe('id');
+        expect(newState.all_campaigns).toEqual(sortedcampaignsArray);
+    });
+
+    test('should not modify courses when SORT_ACTIVE_COURSES or SORT_CAMPAIGNS_WITH_STATS is dispatched with an invalid key', () => {
+        const initialState = { all_campaigns: campaignsArray, sort: { sortKey: null, key: null } };
+        deepFreeze(initialState);
+        const mockedAction = {
+            type: SORT_CAMPAIGNS_WITH_STATS,
+            key: 'nonExistentKey',
+        };
+        const newState = campaigns(initialState, mockedAction);
+        expect(newState.all_campaigns).toEqual(initialState.all_campaigns);
+        expect(newState.sort.key).toBe('nonExistentKey');
+    });
+});

--- a/test/reducers/campaigns.spec.js
+++ b/test/reducers/campaigns.spec.js
@@ -29,17 +29,13 @@ describe('campaigns reducer', () => {
     const initialState = { campaigns: [], all_campaigns: [], isLoaded: false };
     deepFreeze(initialState);
 
-
-    // Review needed: The implementation of the ADD_CAMPAIGN case in the reducer
-    // is unclear regarding whether it should replace the existing campaigns or
-    // append to them. The expected behavior of the state update should be clarified.
     const mockedAction = {
       type: ADD_CAMPAIGN,
       data: { course: { campaigns: campaignsArray[0] } }
     };
 
     const newState = campaigns(initialState, mockedAction);
-    expect(newState.campaigns).toEqual(campaignsArray[0]); // Adjust based on expected behavior
+    expect(newState.campaigns).toEqual(campaignsArray[0]);
     expect(newState.isLoaded).toBe(true);
   });
 

--- a/test/reducers/campaigns.spec.js
+++ b/test/reducers/campaigns.spec.js
@@ -1,98 +1,104 @@
 import deepFreeze from 'deep-freeze';
 import campaigns from '../../app/assets/javascripts/reducers/campaigns';
 import {
-    RECEIVE_COURSE_CAMPAIGNS,
-    RECEIVE_ALL_CAMPAIGNS,
-    ADD_CAMPAIGN,
-    SORT_CAMPAIGNS_WITH_STATS,
-    SORT_ALL_CAMPAIGNS } from '../../app/assets/javascripts/constants';
+  RECEIVE_COURSE_CAMPAIGNS,
+  RECEIVE_ALL_CAMPAIGNS,
+  ADD_CAMPAIGN,
+  SORT_CAMPAIGNS_WITH_STATS,
+  SORT_ALL_CAMPAIGNS
+} from '../../app/assets/javascripts/constants';
 
 const campaignsArray = [
-      { id: 2, slug: 'second_campaign', description: 'second description' },
-        { id: 1, slug: 'first_campaign', description: 'first description' }
-      ];
- const sortedcampaignsArray = [
-      { id: 1, slug: 'first_campaign', description: 'first description' },
-      { id: 2, slug: 'second_campaign', description: 'second description' },
-      ];
+  { id: 2, slug: 'second_campaign', description: 'second description' },
+  { id: 1, slug: 'first_campaign', description: 'first description' }
+];
+const sortedcampaignsArray = [
+  { id: 1, slug: 'first_campaign', description: 'first description' },
+  { id: 2, slug: 'second_campaign', description: 'second description' },
+];
 
 describe('campaigns reducer', () => {
-    test('should return initial state when no action nor state is provided', () => {
-        const newState = campaigns(undefined, { type: null });
-        expect(newState.campaigns).toEqual([]);
-        expect(newState.all_campaigns).toEqual([]);
-        expect(newState.isLoaded).toBe(false);
-    });
+  test('should return initial state when no action nor state is provided', () => {
+    const newState = campaigns(undefined, { type: null });
+    expect(newState.campaigns).toEqual([]);
+    expect(newState.all_campaigns).toEqual([]);
+    expect(newState.isLoaded).toBe(false);
+  });
 
-    test('should add and return campaigns data with ADD_CAMPAIGN and set isLoaded to true', () => {
-        const initialState = { campaigns: [], all_campaigns: [], isLoaded: false };
-        deepFreeze(initialState);
+  test('should add and return campaigns data with ADD_CAMPAIGN and set isLoaded to true', () => {
+    const initialState = { campaigns: [], all_campaigns: [], isLoaded: false };
+    deepFreeze(initialState);
 
-        const mockedAction = {
-          type: ADD_CAMPAIGN,
-          data: { course: { campaigns: campaignsArray[0] } }
-        };
 
-        const newState = campaigns(initialState, mockedAction);
-        expect(newState.campaigns).toContainEqual(campaignsArray[0]);
-        expect(newState.isLoaded).toBe(true);
-        expect(Array.isArray(newState.campaigns)).toBe(true);
-      });
+    // Review needed: The implementation of the ADD_CAMPAIGN case in the reducer
+    // is unclear regarding whether it should replace the existing campaigns or
+    // append to them. The expected behavior of the state update should be clarified.
+    const mockedAction = {
+      type: ADD_CAMPAIGN,
+      data: { course: { campaigns: campaignsArray[0] } }
+    };
 
-      test('should receives and return  course campaigns and update initial course campaigns with RECEIVE_COURSE_CAMPAIGNS', () => {
-        const initialState = { campaigns: [{ id: 3, slug: 'third_campaign', description: 'first description' }],
-                            all_campaigns: [],
-                            isLoaded: false };
-        deepFreeze(initialState);
+    const newState = campaigns(initialState, mockedAction);
+    expect(newState.campaigns).toEqual(campaignsArray[0]); // Adjust based on expected behavior
+    expect(newState.isLoaded).toBe(true);
+  });
 
-        const mockedAction = {
-          type: RECEIVE_COURSE_CAMPAIGNS,
-          data: { course: { campaigns: campaignsArray } }
-        };
+  test('should receives and return  course campaigns and update initial course campaigns with RECEIVE_COURSE_CAMPAIGNS', () => {
+    const initialState = {
+      campaigns: [{ id: 3, slug: 'third_campaign', description: 'first description' }],
+      all_campaigns: [],
+      isLoaded: false
+    };
+    deepFreeze(initialState);
 
-        const newState = campaigns(initialState, mockedAction);
-        expect(newState.campaigns).toEqual(campaignsArray);
-        expect(newState.isLoaded).toBe(true);
-      });
+    const mockedAction = {
+      type: RECEIVE_COURSE_CAMPAIGNS,
+      data: { course: { campaigns: campaignsArray } }
+    };
 
-      test('should receives all campaigns with RECEIVE_ALL_CAMPAIGNS and set all_campaigns_loaded to true', () => {
-        const initialState = { campaigns: [], all_campaigns: [], all_campaigns_loaded: false };
-        deepFreeze(initialState);
+    const newState = campaigns(initialState, mockedAction);
+    expect(newState.campaigns).toEqual(campaignsArray);
+    expect(newState.isLoaded).toBe(true);
+  });
 
-        const mockedAction = {
-          type: RECEIVE_ALL_CAMPAIGNS,
-          data: { campaigns: campaignsArray }
-        };
+  test('should receives all campaigns with RECEIVE_ALL_CAMPAIGNS and set all_campaigns_loaded to true', () => {
+    const initialState = { campaigns: [], all_campaigns: [], all_campaigns_loaded: false };
+    deepFreeze(initialState);
 
-        const newState = campaigns(initialState, mockedAction);
-        expect(newState.all_campaigns).toEqual(campaignsArray);
-        expect(newState.all_campaigns_loaded).toBe(true);
-      });
+    const mockedAction = {
+      type: RECEIVE_ALL_CAMPAIGNS,
+      data: { campaigns: campaignsArray }
+    };
 
-      test('sort active courses via SORT_ACTIVE_CAMPAIGN', () => {
-        const initialState = { campaigns: [], all_campaigns: campaignsArray, isLoaded: false, sort: { sortKey: null } };
-        deepFreeze(initialState);
+    const newState = campaigns(initialState, mockedAction);
+    expect(newState.all_campaigns).toEqual(campaignsArray);
+    expect(newState.all_campaigns_loaded).toBe(true);
+  });
 
-        const mockedAction = {
-            type: SORT_ALL_CAMPAIGNS,
-            key: 'id'
-        };
+  test('sort active courses via SORT_ACTIVE_CAMPAIGN', () => {
+    const initialState = { campaigns: [], all_campaigns: campaignsArray, isLoaded: false, sort: { sortKey: null } };
+    deepFreeze(initialState);
 
-        const newState = campaigns(initialState, mockedAction);
-        expect(newState.sort.key).toBe('id');
-        expect(newState.all_campaigns).toEqual(sortedcampaignsArray);
-    });
+    const mockedAction = {
+      type: SORT_ALL_CAMPAIGNS,
+      key: 'id'
+    };
 
-    test('should not modify courses when SORT_ACTIVE_COURSES or SORT_CAMPAIGNS_WITH_STATS is dispatched with an invalid key', () => {
-        const initialState = { all_campaigns: campaignsArray, sort: { sortKey: null, key: null } };
-        deepFreeze(initialState);
+    const newState = campaigns(initialState, mockedAction);
+    expect(newState.sort.key).toBe('id');
+    expect(newState.all_campaigns).toEqual(sortedcampaignsArray);
+  });
 
-        const mockedAction = {
-            type: SORT_CAMPAIGNS_WITH_STATS,
-            key: 'nonExistentKey',
-        };
-        const newState = campaigns(initialState, mockedAction);
-        expect(newState.all_campaigns).toEqual(initialState.all_campaigns);
-        expect(newState.sort.key).toBe('nonExistentKey');
-    });
+  test('should not modify courses when SORT_ACTIVE_COURSES or SORT_CAMPAIGNS_WITH_STATS is dispatched with an invalid key', () => {
+    const initialState = { all_campaigns: campaignsArray, sort: { sortKey: null, key: null } };
+    deepFreeze(initialState);
+
+    const mockedAction = {
+      type: SORT_CAMPAIGNS_WITH_STATS,
+      key: 'nonExistentKey',
+    };
+    const newState = campaigns(initialState, mockedAction);
+    expect(newState.all_campaigns).toEqual(initialState.all_campaigns);
+    expect(newState.sort.key).toBe('nonExistentKey');
+  });
 });

--- a/test/reducers/campaigns.spec.js
+++ b/test/reducers/campaigns.spec.js
@@ -44,6 +44,7 @@ describe('campaigns reducer', () => {
                             all_campaigns: [],
                             isLoaded: false };
         deepFreeze(initialState);
+
         const mockedAction = {
           type: RECEIVE_COURSE_CAMPAIGNS,
           data: { course: { campaigns: campaignsArray } }
@@ -71,6 +72,7 @@ describe('campaigns reducer', () => {
       test('sort active courses via SORT_ACTIVE_CAMPAIGN', () => {
         const initialState = { campaigns: [], all_campaigns: campaignsArray, isLoaded: false, sort: { sortKey: null } };
         deepFreeze(initialState);
+
         const mockedAction = {
             type: SORT_ALL_CAMPAIGNS,
             key: 'id'
@@ -84,6 +86,7 @@ describe('campaigns reducer', () => {
     test('should not modify courses when SORT_ACTIVE_COURSES or SORT_CAMPAIGNS_WITH_STATS is dispatched with an invalid key', () => {
         const initialState = { all_campaigns: campaignsArray, sort: { sortKey: null, key: null } };
         deepFreeze(initialState);
+
         const mockedAction = {
             type: SORT_CAMPAIGNS_WITH_STATS,
             key: 'nonExistentKey',


### PR DESCRIPTION
## What this PR does
This PR addresses https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/2082 by adding comprehensive tests for the campaigns reducer to ensure its functionality and correctness. The tests cover various scenarios, including adding campaigns, receiving course campaigns, receiving all campaigns, and sorting campaigns. This enhances the test coverage and verifies that the reducer behaves as expected
## Files changed
Created a new file test/reducers/campaigns.spec.js that includes tests for all relevant action types and edge cases related to the campaigns reducer

## Open Questions
@ragesoss I'm unclear about the DELETE_CAMPAIGN action in the reducer. Since it shares case handling with ADD_CAMPAIGN and RECEIVE_COURSE_CAMPAIGNS, does it imply that deletion requires providing an updated list of campaigns, or is there a mechanism for marking a campaign as deleted, like setting its published status to false?
