### PR TITLE
Add ?teach parameter to see instructor version of homepage regardless of user role (#5812)

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -14,7 +14,8 @@ class DashboardController < ApplicationController
     set_blog_posts if Features.wiki_ed?
     set_admin_courses_if_admin
     @pres = DashboardPresenter.new(current_courses, past_courses,
-                                   @submitted, @strictly_current, current_user)
+                                   @submitted, @strictly_current,
+                                   current_user, params.key?(:teach))
   end
 
   def my_account

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -8,16 +8,17 @@ class DashboardPresenter
 
   ORIENTATION_ID = 3
 
-  def initialize(current, past, submitted, strictly_current, current_user)
+  def initialize(current, past, submitted, strictly_current, current_user, force_instructor_view) # rubocop:disable Metrics/ParameterLists
     @current = current
     @past = past
     @submitted = submitted
     @strictly_current = strictly_current
     @current_user = current_user
+    @force_instructor_view = force_instructor_view
   end
 
   def instructor?
-    current_user.instructor_permissions?
+    @force_instructor_view || current_user.instructor_permissions?
   end
 
   def admin?
@@ -80,7 +81,7 @@ class DashboardPresenter
 
   # Show explore button for non instructors/admins
   def show_explore_button?
-    current_user.permissions == User::Permissions::NONE
+    !instructor? && current_user.permissions == User::Permissions::NONE
   end
 
   # Get the url path for orientation


### PR DESCRIPTION
#5812

## What this PR does

Introduces a new feature to force the instructor view of the homepage for users using ?teach param, regardless of their role


## Screenshots
Before:


https://github.com/user-attachments/assets/e4e279d3-b8f6-4d2a-910a-96265a83d3f4




After:




https://github.com/user-attachments/assets/da3cd9fc-cf06-4252-b2eb-91d2dbfd5e67



