### PR TITLE
Update ubuntu WSL setup documentation

### DIFF
--- a/docs/ubuntu_wsl_setup.md
+++ b/docs/ubuntu_wsl_setup.md
@@ -5,7 +5,7 @@
 2. Install "Ubuntu" app
    1. Open "Microsoft Store", search for and install the app "Ubuntu"
    2. Optional: install Windows Terminal from the Microsoft Store as well
-   3. Check whether you are on WSL 2: open a Windows terminal and enter ``. If your system is on WSL 1, try the upgrade command `wsl --set-version Ubuntu 2`. You may need to take additional steps to enable WSL 2, such as installing a kernel upgrade and enabling virtualization in your BIOS. See https://learn.microsoft.com/en-us/windows/wsl/install
+   3. Check whether you are on WSL 2: open a Windows PowerShell or Terminal as Admin and enter `wsl --list --verbose`. If your system is on WSL 1, try the upgrade 
 3. Launch the Ubuntu app, which opens an Ubuntu terminal, and then:
    1. Create your Ubuntu username and password (if this is the first time using the Ubuntu system)
    2. Add the RVM repo so you can install Ruby: `sudo apt-add-repository -y ppa:rael-gc/rvm`

--- a/docs/ubuntu_wsl_setup.md
+++ b/docs/ubuntu_wsl_setup.md
@@ -16,10 +16,10 @@
    1. If you haven't done so already, fork this repo, see [GitHub Forking Documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
    2. From Ubuntu terminal, clone your forked repo by replacing the URL in this command: `git clone https://github.com/{your-github-username}/WikiEducationFoundation/WikiEduDashboard.git`. For performance, it's important to install this in the WSL filesystem (`cd ~`).
    3. Enter the Dashboard directory, then attempt to install the Dashboard's current Ruby version (updating the version number in this command if necessary): `rvm install 3.1.2`.
-   5. `sudo apt-get update`
-   6. `sudo apt-get install -y mariadb-server libmariadb-dev`
+   5. Update system packages: `sudo apt-get update`
+   6. Install MariaDB: `sudo apt-get install -y mariadb-server libmariadb-dev`
    7. Start the database: `sudo /etc/init.d/mariadb start`
-5. The rest of the installation process should work the same way as a normal Linux installation, and the setup script can automate most of it: `python3 setup.py`. If the setup script fails, refer to the manual setup procedures in `setup.md` to continue.
+5. The rest of the installation process should work the same way as a normal Linux installation, and the setup script can automate most of it. Run setup script: `python3 setup.py`. If it fails, refer to the manual setup procedures in [`setup.md`](./setup.md) to continue.
 6. Build the assets: `yarn build`
 7. Run `rails s`. Now you should have a development running and accessible via web browser at localhost:3000.
 

--- a/docs/ubuntu_wsl_setup.md
+++ b/docs/ubuntu_wsl_setup.md
@@ -13,8 +13,8 @@
    4. Add your user to the rvm group: `sudo usermod -a -G rvm [your username]`
    5. Close and reopen the Ubuntu terminal to activate RVM
 4. Get the Dashboard code and install Ruby and other prerequisites.
-   1. If you haven't done so already, fork this repo on Github
-   2. From Ubuntu terminal, clone your forked repo by replacing the URL in this command: `git clone https://WikiEducationFoundation/WikiEduDashboard.git`. For performance, it's important to install this in the WSL filesystem.
+   1. If you haven't done so already, fork this repo, see [GitHub Forking Documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+   2. From Ubuntu terminal, clone your forked repo by replacing the URL in this command: `git clone https://github.com/{your-github-username}/WikiEducationFoundation/WikiEduDashboard.git`. For performance, it's important to install this in the WSL filesystem (`cd ~`).
    3. Enter the Dashboard directory, then attempt to install the Dashboard's current Ruby version (updating the version number in this command if necessary): `rvm install 3.1.2`.
    5. `sudo apt-get update`
    6. `sudo apt-get install -y mariadb-server libmariadb-dev`


### PR DESCRIPTION
## What this PR does
Edit on ubunt_wsl_setup.md

- Included the omitted command for checking WSL version to `wsl --list --verbose`.
- Corrected the cloning repo URL example to  `https://github.com/{your-github-username}/WikiEducationFoundation/WikiEduDashboard.git`.
- Highlighted for (`cd ~`) installing in the WSL filesystem.
- Other grammar corrections, instruction clarification and Readme text adjustment

## Screenshots
Before:
- ![image](https://github.com/user-attachments/assets/24590905-7216-4174-8d86-66620519f4bd)
- ![image](https://github.com/user-attachments/assets/c080196d-f961-4ef4-92ad-421d9235aa6a)
- ![image](https://github.com/user-attachments/assets/3964540a-988f-4a8a-ac43-f3a07072d99b)
- ![image](https://github.com/user-attachments/assets/d6d7c7ab-34c4-4c39-9d8e-4756ba97f177)

After:
- ![image](https://github.com/user-attachments/assets/bf8dafac-ee01-408c-8517-7d5a58be475c)
- ![image](https://github.com/user-attachments/assets/57b3d0c0-ae6e-418c-af52-01b7152d7af0)
- ![image](https://github.com/user-attachments/assets/68d3023e-a723-4765-a971-83989a309cb0)
- ![image](https://github.com/user-attachments/assets/613b65dd-5e48-44c7-81c6-1d6ed55011c6)

