### PR TITLE
Enable object-short-hand linting rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,6 @@
     "import/no-named-as-default": 0,
     "no-underscore-dangle": 0,
     "no-empty-pattern": 0,
-    "object-shorthand": ["error", "always"],
     "no-useless-computed-key": 0,
     "newline-per-chained-call": 0,
     "class-methods-use-this": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,7 @@
     "import/no-named-as-default": 0,
     "no-underscore-dangle": 0,
     "no-empty-pattern": 0,
-    "object-shorthand": 2,
+    "object-shorthand": ["error", "properties"],
     "no-useless-computed-key": 0,
     "newline-per-chained-call": 0,
     "class-methods-use-this": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,7 @@
     "import/no-named-as-default": 0,
     "no-underscore-dangle": 0,
     "no-empty-pattern": 0,
-    "object-shorthand": ["error", "properties"],
+    "object-shorthand": ["error", "always"],
     "no-useless-computed-key": 0,
     "newline-per-chained-call": 0,
     "class-methods-use-this": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,7 @@
     "import/no-named-as-default": 0,
     "no-underscore-dangle": 0,
     "no-empty-pattern": 0,
-    "object-shorthand": 0,
+    "object-shorthand": 2,
     "no-useless-computed-key": 0,
     "newline-per-chained-call": 0,
     "class-methods-use-this": 0,

--- a/app/assets/javascripts/actions/admin_course_notes_action.js
+++ b/app/assets/javascripts/actions/admin_course_notes_action.js
@@ -59,7 +59,7 @@ export const saveUpdatedAdminCourseNote = adminCourseNoteDetails => async (dispa
         return note;
     });
 
-    dispatch({ type: UPDATE_NOTES_LIST, updatedNotesList: updatedNotesList });
+    dispatch({ type: UPDATE_NOTES_LIST, updatedNotesList });
   } else {
     sendNotification(dispatch, 'Error', 'notes.failure');
   }

--- a/app/assets/javascripts/actions/alert_actions.js
+++ b/app/assets/javascripts/actions/alert_actions.js
@@ -135,9 +135,9 @@ export const fetchCourseAlerts = courseSlug => (dispatch) => {
 };
 
 
-export const sortAlerts = key => ({ type: types.SORT_ALERTS, key: key });
+export const sortAlerts = key => ({ type: types.SORT_ALERTS, key });
 
-export const filterAlerts = selectedFilters => ({ type: types.FILTER_ALERTS, selectedFilters: selectedFilters });
+export const filterAlerts = selectedFilters => ({ type: types.FILTER_ALERTS, selectedFilters });
 
 export const createInstructorAlert = ({ courseTitle, courseId, subject, message }) => {
   return (dispatch) => {
@@ -153,7 +153,7 @@ export const createInstructorAlert = ({ courseTitle, courseId, subject, message 
         dispatch({
           type: types.ADD_NOTIFICATION,
           notification: {
-            message: I18n.t('course_instructor_notification.notification_sent_success', { courseTitle: courseTitle }),
+            message: I18n.t('course_instructor_notification.notification_sent_success', { courseTitle }),
             closable: true,
             type: 'success',
           },

--- a/app/assets/javascripts/actions/article_actions.js
+++ b/app/assets/javascripts/actions/article_actions.js
@@ -12,7 +12,7 @@ export function fetchArticleDetails(articleId, courseId) {
     return API.fetchArticleDetails(articleId, courseId)
       .then(response => (dispatch({
         type: types.RECEIVE_ARTICLE_DETAILS,
-        articleId: articleId,
+        articleId,
         data: response
       })))
       .catch(response => (dispatch({ type: types.API_FAIL, data: response })));
@@ -23,8 +23,8 @@ export function updateArticleTrackedStatus(articleId, courseId, tracked) {
   return function (dispatch) {
     return API.updateArticleTrackedStatus(articleId, courseId, tracked).then(response => (dispatch({
       type: types.UPDATE_ARTICLE_TRACKED_STATUS,
-      articleId: articleId,
-      tracked: tracked,
+      articleId,
+      tracked,
       data: response
     }))).catch(response => (dispatch({ type: types.API_FAIL, data: response })));
   };

--- a/app/assets/javascripts/actions/article_finder_action.js
+++ b/app/assets/javascripts/actions/article_finder_action.js
@@ -27,8 +27,8 @@ export const updateFields = (key, value) => (dispatch) => {
   dispatch({
     type: UPDATE_FINDER_FIELD,
     data: {
-      key: key,
-      value: value,
+      key,
+      value,
     },
   });
 };
@@ -36,7 +36,7 @@ export const updateFields = (key, value) => (dispatch) => {
 export const sortArticleFinder = (key) => {
   return {
     type: SORT_ARTICLE_FINDER,
-    key: key,
+    key,
   };
 };
 
@@ -67,7 +67,7 @@ const getDataForCategory = (category, wiki, cmcontinue, namespace = 0, dispatch,
     //   }
     dispatch({
       type: RECEIVE_CATEGORY_RESULTS,
-      data: data,
+      data,
     });
     return data.query.categorymembers;
   })
@@ -102,7 +102,7 @@ const fetchPageViews = (articlesList, wiki, dispatch, getState) => {
     .then((data) => {
       dispatch({
         type: RECEIVE_ARTICLE_PAGEVIEWS,
-        data: data
+        data
       });
     })
     .catch(response => (dispatch({ type: API_FAIL, data: response })));
@@ -120,7 +120,7 @@ const fetchPageViews = (articlesList, wiki, dispatch, getState) => {
       type: SORT_ARTICLE_FINDER,
       key: sort.key,
       initial: true,
-      desc: desc,
+      desc,
     });
   });
 };
@@ -135,7 +135,7 @@ const fetchPageAssessment = (articlesList, wiki, dispatch, getState) => {
       .then((data) => {
         dispatch({
           type: RECEIVE_ARTICLE_PAGEASSESSMENT,
-          data: data
+          data
         });
       })
       .catch(response => (dispatch({ type: API_FAIL, data: response })));
@@ -159,7 +159,7 @@ const fetchPageRevision = (articlesList, wiki, dispatch, getState) => {
       .then((data) => {
         dispatch({
           type: RECEIVE_ARTICLE_REVISION,
-          data: data
+          data
         });
         return data;
       })
@@ -209,7 +209,7 @@ const fetchPageRevisionScore = async (revids, wiki, dispatch) => {
     await dispatch({
       type: RECEIVE_ARTICLE_REVISIONSCORE,
       data: {
-        data: data,
+        data,
         language: wiki.language,
         project: wiki.project,
       },
@@ -239,7 +239,7 @@ export const fetchKeywordResults = (keyword, wiki, offset = 0, continueResults =
   .then((data) => {
     dispatch({
       type: RECEIVE_KEYWORD_RESULTS,
-      data: data,
+      data,
     });
     return data.query.search;
   })

--- a/app/assets/javascripts/actions/articles_actions.js
+++ b/app/assets/javascripts/actions/articles_actions.js
@@ -25,7 +25,7 @@ export const fetchArticles = (courseId, limit, refresh = false) => {
         dispatch({
           type: types.RECEIVE_ARTICLES,
           data: resp,
-          limit: limit,
+          limit,
         });
         dispatch({
           type: types.SORT_ARTICLES,
@@ -47,13 +47,13 @@ export const fetchArticles = (courseId, limit, refresh = false) => {
 
 export const sortArticles = (key, refresh) => ({
   type: types.SORT_ARTICLES,
-  key: key,
+  key,
   refresh,
 });
 
 export const filterArticles = wiki => ({
   type: types.SET_PROJECT_FILTER,
-  wiki: wiki,
+  wiki,
 });
 
 export const filterNewness = newness => ({

--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -103,7 +103,7 @@ const updateSandboxUrlPromise = (assignment, newUrl) => {
   const body = {
     id: assignment.id,
     user_id: assignment.user_id,
-    newUrl: newUrl
+    newUrl
   };
   return request(`/assignments/${assignment.id}/update_sandbox_url`, {
     body: JSON.stringify(body),

--- a/app/assets/javascripts/actions/campaign_actions.js
+++ b/app/assets/javascripts/actions/campaign_actions.js
@@ -27,7 +27,7 @@ export const fetchCampaigns = courseId => (dispatch) => {
   );
 };
 
-export const sortCampaigns = key => ({ type: SORT_CAMPAIGNS_WITH_STATS, key: key });
+export const sortCampaigns = key => ({ type: SORT_CAMPAIGNS_WITH_STATS, key });
 
 const removeCampaignsPromise = async (courseId, campaignId) => {
   const response = await request(`/courses/${courseId}/campaign.json`, {

--- a/app/assets/javascripts/actions/course_actions.js
+++ b/app/assets/javascripts/actions/course_actions.js
@@ -165,7 +165,7 @@ export const searchPrograms = searchQuery => async (dispatch) => {
   return dispatch({ type: RECEIVE_COURSE_SEARCH_RESULTS, data });
 };
 
-export const sortCourseSearchResults = key => ({ type: SORT_COURSE_SEARCH_RESULTS, key: key });
+export const sortCourseSearchResults = key => ({ type: SORT_COURSE_SEARCH_RESULTS, key });
 
 // this fetches the active courses of a particular campaign(which currently is just the default campaign)
 export const fetchActiveCampaignCourses = campaign_slug => async (dispatch) => {
@@ -178,7 +178,7 @@ export const fetchActiveCampaignCourses = campaign_slug => async (dispatch) => {
   return dispatch({ type: RECEIVE_CAMPAIGN_ACTIVE_COURSES, data });
 };
 
-export const sortActiveCourses = key => ({ type: SORT_ACTIVE_COURSES, key: key });
+export const sortActiveCourses = key => ({ type: SORT_ACTIVE_COURSES, key });
 
 // this fetches the active courses across all campaigns
 export const fetchActiveCourses = () => async (dispatch) => {
@@ -202,4 +202,4 @@ export const fetchCoursesFromWiki = wiki => async (dispatch) => {
   return dispatch({ type: RECEIVE_WIKI_COURSES, data });
 };
 
-export const sortWikiCourses = key => ({ type: SORT_WIKI_COURSES, key: key });
+export const sortWikiCourses = key => ({ type: SORT_WIKI_COURSES, key });

--- a/app/assets/javascripts/actions/did_you_know_actions.js
+++ b/app/assets/javascripts/actions/did_you_know_actions.js
@@ -15,4 +15,4 @@ export const fetchDYKArticles = (opts = {}) => (dispatch) => {
   );
 };
 
-export const sortDYKArticles = key => ({ type: SORT_DYK, key: key });
+export const sortDYKArticles = key => ({ type: SORT_DYK, key });

--- a/app/assets/javascripts/actions/feedback_action.js
+++ b/app/assets/javascripts/actions/feedback_action.js
@@ -11,7 +11,7 @@ export function fetchFeedback(articleTitle, assignmentId) {
   return function (dispatch) {
     return API.fetchFeedback(articleTitle, assignmentId)
       .then((resp) => {
-        dispatch({ type: types.RECEIVE_ARTICLE_FEEDBACK, data: resp, assignmentId: assignmentId });
+        dispatch({ type: types.RECEIVE_ARTICLE_FEEDBACK, data: resp, assignmentId });
       })
       .catch(response => (dispatch({ type: types.API_FAIL, data: response })));
   };
@@ -22,7 +22,7 @@ export function postUserFeedback(assignmentId, feedback, userId) {
     return API.createCustomFeedback(assignmentId, feedback, userId)
       .then((resp) => {
         dispatch({
-          type: types.POST_USER_FEEDBACK, data: resp, assignmentId: assignmentId, feedback: feedback, messageId: resp.id, userId: userId
+          type: types.POST_USER_FEEDBACK, data: resp, assignmentId, feedback, messageId: resp.id, userId
         });
       })
       .catch(response => (dispatch({ type: types.API_FAIL, data: response })));
@@ -34,7 +34,7 @@ export function deleteUserFeedback(assignmentId, messageId, arrayId) {
     return API.destroyCustomFeedback(assignmentId, messageId)
       .then((resp) => {
         dispatch({
-          type: types.DELETE_USER_FEEDBACK, data: resp, assignmentId: assignmentId, arrayId: arrayId
+          type: types.DELETE_USER_FEEDBACK, data: resp, assignmentId, arrayId
         });
       })
       .catch(response => (dispatch({ type: types.API_FAIL, data: response })));

--- a/app/assets/javascripts/actions/recent_edits_actions.js
+++ b/app/assets/javascripts/actions/recent_edits_actions.js
@@ -27,4 +27,4 @@ export const fetchRecentEdits = (opts = {}) => (dispatch) => {
   );
 };
 
-export const sortRecentEdits = key => ({ type: SORT_RECENT_EDITS, key: key });
+export const sortRecentEdits = key => ({ type: SORT_RECENT_EDITS, key });

--- a/app/assets/javascripts/actions/recent_uploads_actions.js
+++ b/app/assets/javascripts/actions/recent_uploads_actions.js
@@ -13,4 +13,4 @@ export const fetchRecentUploads = (opts = {}) => (dispatch) => {
   );
 };
 
-export const sortRecentUploads = key => ({ type: SORT_RECENT_UPLOADS, key: key });
+export const sortRecentUploads = key => ({ type: SORT_RECENT_UPLOADS, key });

--- a/app/assets/javascripts/actions/revisions_actions.js
+++ b/app/assets/javascripts/actions/revisions_actions.js
@@ -152,7 +152,7 @@ export const fetchCourseScopedRevisions = (course, limit) => async (dispatch, ge
         dispatch({
           type: RECEIVE_COURSE_SCOPED_REVISIONS,
           data: resp,
-          limit: limit
+          limit
         });
         // Now that we received the revisions data, query wikidata.org for the labels
         // of any Wikidata entries that are among the revisions.
@@ -161,4 +161,4 @@ export const fetchCourseScopedRevisions = (course, limit) => async (dispatch, ge
       .catch(response => (dispatch({ type: API_FAIL, data: response })))
   );
 };
-export const sortRevisions = key => ({ type: SORT_REVISIONS, key: key });
+export const sortRevisions = key => ({ type: SORT_REVISIONS, key });

--- a/app/assets/javascripts/actions/settings_actions.js
+++ b/app/assets/javascripts/actions/settings_actions.js
@@ -43,7 +43,7 @@ const grantAdminPromise = async (username, upgrade) => {
   const url = `/settings/${upgrade ? 'upgrade' : 'downgrade'}_admin`;
   const response = await request(url, {
     method: 'POST',
-    body: JSON.stringify({ user: { username: username } })
+    body: JSON.stringify({ user: { username } })
   });
   if (!response.ok) {
     logErrorMessage(response);
@@ -153,7 +153,7 @@ export const downgradeSpecialUser = (username, position) => (dispatch) => {
     data: {
       revoking: {
         status: true,
-        username: username,
+        username,
       },
     },
   });
@@ -179,7 +179,7 @@ export const downgradeSpecialUser = (username, position) => (dispatch) => {
             data: {
               revoking: {
                 status: false,
-                username: username,
+                username,
               },
             },
           });
@@ -262,7 +262,7 @@ export const downgradeAdmin = username => (dispatch) => {
     data: {
       revoking: {
         status: true,
-        username: username,
+        username,
       },
     },
   });
@@ -288,7 +288,7 @@ export const downgradeAdmin = username => (dispatch) => {
             data: {
               revoking: {
                 status: false,
-                username: username,
+                username,
               },
             },
           });
@@ -435,7 +435,7 @@ export const updateDefaultCampaign = campaignSlug => (dispatch) => {
 
 const updateImpactStatsPromise = async (impactStats) => {
   const body = {
-    impactStats: impactStats,
+    impactStats,
   };
   const response = await request('/settings/update_impact_stats', {
     method: 'POST',

--- a/app/assets/javascripts/actions/tickets_actions.js
+++ b/app/assets/javascripts/actions/tickets_actions.js
@@ -102,7 +102,7 @@ export const readAllMessages = ticket => async (dispatch) => {
 
 const fetchSomeTickets = async (dispatch, page, searchQuery, batchSize = 100) => {
   const offset = batchSize * page;
-  let paramsObj = { limit: batchSize, offset: offset };
+  let paramsObj = { limit: batchSize, offset };
   // Initial display => TicketDispenser
   let path = '/td/tickets';
   // if at least one search query value is not-empty => search in DB

--- a/app/assets/javascripts/actions/uploads_actions.js
+++ b/app/assets/javascripts/actions/uploads_actions.js
@@ -146,8 +146,8 @@ export const setUploadPageViews = articleList => (dispatch) => {
 
 export const resetUploadsViews = () => ({ type: RESET_UPLOAD_PAGEVIEWS });
 
-export const sortUploads = key => ({ type: SORT_UPLOADS, key: key });
+export const sortUploads = key => ({ type: SORT_UPLOADS, key });
 
-export const setView = view => ({ type: SET_VIEW, view: view });
+export const setView = view => ({ type: SET_VIEW, view });
 
-export const setUploadFilters = selectedFilters => ({ type: FILTER_UPLOADS, selectedFilters: selectedFilters });
+export const setUploadFilters = selectedFilters => ({ type: FILTER_UPLOADS, selectedFilters });

--- a/app/assets/javascripts/actions/wizard_actions.js
+++ b/app/assets/javascripts/actions/wizard_actions.js
@@ -55,7 +55,7 @@ export const fetchWizardPanels = wizardId => (dispatch, getState) => {
 
   return fetchWizardPanelsPromise(wizardId)
     .then((data) => {
-      dispatch({ type: RECEIVE_WIZARD_PANELS, extraPanels: data, course: course });
+      dispatch({ type: RECEIVE_WIZARD_PANELS, extraPanels: data, course });
       // Using a 0 timeout here gives the browser a chance
       // to re-render the new off-screen panels before the
       // advance to the next slide and helps ensure a smooth

--- a/app/assets/javascripts/components/article_finder/article_finder.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder.jsx
@@ -411,15 +411,15 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
-  fetchCategoryResults: fetchCategoryResults,
-  updateFields: updateFields,
-  addAssignment: addAssignment,
-  fetchAssignments: fetchAssignments,
-  sortArticleFinder: sortArticleFinder,
-  fetchKeywordResults: fetchKeywordResults,
-  deleteAssignment: deleteAssignment,
-  resetArticleFinder: resetArticleFinder,
-  clearResults: clearResults,
+  fetchCategoryResults,
+  updateFields,
+  addAssignment,
+  fetchAssignments,
+  sortArticleFinder,
+  fetchKeywordResults,
+  deleteAssignment,
+  resetArticleFinder,
+  clearResults,
 };
 
 export default compose(

--- a/app/assets/javascripts/components/articles/add_available_articles.jsx
+++ b/app/assets/javascripts/components/articles/add_available_articles.jsx
@@ -47,7 +47,7 @@ const AddAvailableArticles = ({
         project: proj,
         language: lang,
         course_slug: course_id,
-        role: role,
+        role,
       };
     });
 

--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -202,7 +202,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   // Function to check if contributions of unhighlighted editors exist in the wikitext metadata
   const usersContributionExists = (usersID) => {
     // Create a URL builder and API instance for fetching wikitext metadata
-    const builder = new URLBuilder({ article: article });
+    const builder = new URLBuilder({ article });
     const api = new ArticleViewerAPI({ builder });
 
     // Fetch wikitext metadata for the current article revision
@@ -234,7 +234,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   };
 
   const fetchParsedArticle = () => {
-    const builder = new URLBuilder({ article: article });
+    const builder = new URLBuilder({ article });
     const api = new ArticleViewerAPI({ builder });
     setPendingRequest(true);
     api.fetchParsedArticle(revisionId)
@@ -249,7 +249,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
   };
 
   const fetchWhocolorHtml = () => {
-    const builder = new URLBuilder({ article: article });
+    const builder = new URLBuilder({ article });
     const api = new ArticleViewerAPI({ builder });
     api.fetchWhocolorHtml(revisionId)
       .then((response) => {
@@ -271,7 +271,7 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
       In this case, the users prop will be combined with an empty array.
      */
     const allUsers = union(assignedUsers || [], users);
-    const builder = new URLBuilder({ article: article, users: allUsers });
+    const builder = new URLBuilder({ article, users: allUsers });
     const api = new ArticleViewerAPI({ builder });
     api.fetchUserIds()
       .then((response) => {

--- a/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleScroll.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/ArticleScroll.js
@@ -27,7 +27,7 @@ export class ArticleScroll {
                 }
                 if (paragraph.querySelector(`span.token-editor-${user.userid}`) !== null) {
                     const resObj = {
-                        paragraph: paragraph,
+                        paragraph,
                         position: index,
                         coordinates: paragraph.getBoundingClientRect()
                     };

--- a/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
+++ b/app/assets/javascripts/components/common/AssignCell/AssignButton.jsx
@@ -311,10 +311,10 @@ const AssignButton = ({ course, role, course_id, wikidataLabels = {}, hideAssign
     title.split('\n').filter(Boolean).forEach((assignment_title) => {
       const assignment = {
         title: decodeURIComponent(assignment_title).trim(),
-        project: project,
-        language: language,
+        project,
+        language,
         course_slug: course.slug,
-        role: role
+        role
       };
 
       if (!assignment.title || assignment.title === 'undefined') return;
@@ -353,7 +353,7 @@ const AssignButton = ({ course, role, course_id, wikidataLabels = {}, hideAssign
       action: claimAssignment,
       assignment: {
         id: assignment.id,
-        role: role
+        role
       },
       title: assignment.article_title
     });

--- a/app/assets/javascripts/components/common/enroll_button.jsx
+++ b/app/assets/javascripts/components/common/enroll_button.jsx
@@ -26,7 +26,7 @@ const EnrollButton = ({ users, role, course, current_user, allowed, inline }) =>
   useEffect(() => {
     if (!usernameRef.current || !usernameRef.current.value) { return; }
     const username = usernameRef.current.value;
-    if (getFiltered(users, { username, role: role }).length > 0) {
+    if (getFiltered(users, { username, role }).length > 0) {
       dispatch(addNotification({
         message: I18n.t('users.enrolled_success', { username }),
         closable: true,
@@ -57,7 +57,7 @@ const EnrollButton = ({ users, role, course, current_user, allowed, inline }) =>
 
     const userObject = {
       username,
-      role: role,
+      role,
       role_description: roleDescription,
       real_name: realName
     };
@@ -69,7 +69,7 @@ const EnrollButton = ({ users, role, course, current_user, allowed, inline }) =>
     const confirmMessage = I18n.t('users.enroll_confirmation', { username });
 
     // If the user is not already enrolled
-    if (getFiltered(users, { username, role: role }).length === 0) {
+    if (getFiltered(users, { username, role }).length === 0) {
       return dispatch(initiateConfirm({ confirmMessage, onConfirm }));
     }
     // If the user us already enrolled
@@ -81,9 +81,9 @@ const EnrollButton = ({ users, role, course, current_user, allowed, inline }) =>
   };
 
   const unenroll = (userId) => {
-    const user = getFiltered(users, { id: userId, role: role })[0];
+    const user = getFiltered(users, { id: userId, role })[0];
     const courseId = course.slug;
-    const userObject = { user_id: userId, role: role };
+    const userObject = { user_id: userId, role };
 
     const onConfirm = () => {
       // Post the user deletion request to the server

--- a/app/assets/javascripts/components/common/weekday_picker.jsx
+++ b/app/assets/javascripts/components/common/weekday_picker.jsx
@@ -5,9 +5,11 @@ const WEEKDAYS_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', '
 const WEEKDAYS_SHORT = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 
 const localeUtils = {
+  // eslint-disable-next-line object-shorthand
   formatWeekdayLong: function (weekday) {
     return WEEKDAYS_LONG[weekday];
   },
+  // eslint-disable-next-line object-shorthand
   formatWeekdayShort: function (weekday) {
     return WEEKDAYS_SHORT[weekday];
   }

--- a/app/assets/javascripts/components/common/weekday_picker.jsx
+++ b/app/assets/javascripts/components/common/weekday_picker.jsx
@@ -5,12 +5,10 @@ const WEEKDAYS_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', '
 const WEEKDAYS_SHORT = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 
 const localeUtils = {
-  // eslint-disable-next-line object-shorthand
-  formatWeekdayLong: function (weekday) {
+  formatWeekdayLong(weekday) {
     return WEEKDAYS_LONG[weekday];
   },
-  // eslint-disable-next-line object-shorthand
-  formatWeekdayShort: function (weekday) {
+  formatWeekdayShort(weekday) {
     return WEEKDAYS_SHORT[weekday];
   }
 };

--- a/app/assets/javascripts/components/nav/news/news_nav_icon.jsx
+++ b/app/assets/javascripts/components/nav/news/news_nav_icon.jsx
@@ -17,7 +17,7 @@ const NewsNavIcon = ({ setIsOpen }) => {
     const expires = new Date();
     expires.setFullYear(expires.getFullYear() + 10);
 
-    Cookies.set(`lastFetchTimestamp_${newsType}`, currentTimestamp, { expires: expires });
+    Cookies.set(`lastFetchTimestamp_${newsType}`, currentTimestamp, { expires });
   };
 
   useEffect(() => {

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -47,7 +47,7 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
   const leave = () => {
     const courseSlug = course.slug;
     const role = current_user.isOnlineVolunteer ? ONLINE_VOLUNTEER_ROLE : STUDENT_ROLE;
-    const userRecord = { user: { user_id: current_user.id, role: role } };
+    const userRecord = { user: { user_id: current_user.id, role } };
     const onConfirm = () => dispatch(removeUser(courseSlug, userRecord));
     const confirmMessage = I18n.t('courses.leave_confirmation');
     dispatch(initiateConfirm({ confirmMessage, onConfirm }));

--- a/app/assets/javascripts/components/revisions/diff_viewer.jsx
+++ b/app/assets/javascripts/components/revisions/diff_viewer.jsx
@@ -197,7 +197,7 @@ const DiffViewer = createReactClass({
       }
 
       this.setState({
-        diff: diff,
+        diff,
         comment: firstRevisionData.comment,
         fetched: true,
         firstRevDateTime: firstRevisionData.timestamp,

--- a/app/assets/javascripts/components/settings/views/admin_user.jsx
+++ b/app/assets/javascripts/components/settings/views/admin_user.jsx
@@ -13,8 +13,7 @@ const AdminUser = createReactClass({
     }),
   },
 
-  // eslint-disable-next-line object-shorthand
-  getInitialState: function () {
+  getInitialState() {
     return { confirming: false };
   },
 

--- a/app/assets/javascripts/components/settings/views/admin_user.jsx
+++ b/app/assets/javascripts/components/settings/views/admin_user.jsx
@@ -13,6 +13,7 @@ const AdminUser = createReactClass({
     }),
   },
 
+  // eslint-disable-next-line object-shorthand
   getInitialState: function () {
     return { confirming: false };
   },

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/AssignmentsList/Assignment/Assignment.jsx
@@ -78,5 +78,5 @@ Assignment.propTypes = {
   user: PropTypes.object.isRequired
 };
 
-const mapStateToProps = ({ articleDetails }) => ({ articleDetails: articleDetails });
+const mapStateToProps = ({ articleDetails }) => ({ articleDetails });
 export default connect(mapStateToProps)(Assignment);

--- a/app/assets/javascripts/components/tickets/new_reply_form.jsx
+++ b/app/assets/javascripts/components/tickets/new_reply_form.jsx
@@ -38,7 +38,7 @@ const NewReplyForm = ({ ticket, currentUser }) => {
 
   const onTextAreaChange = (_key, content, _e) => {
     setReplyDetails(prevState => ({
-      ...prevState, content: content, plainText: content
+      ...prevState, content, plainText: content
     }));
   };
 

--- a/app/assets/javascripts/components/user_profiles/by_students_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/by_students_stats.jsx
@@ -8,7 +8,7 @@ const ByStudentsStats = ({ username, stats, maxProject }) => {
   return (
     <div className = "user_stats">
       <h5>
-        {I18n.t('user_profiles.instructors_student_impact', { username: username })}
+        {I18n.t('user_profiles.instructors_student_impact', { username })}
       </h5>
       <div className= "stat-display">
         <div className= "stat-display__stat">

--- a/app/assets/javascripts/components/user_profiles/instructor_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/instructor_stats.jsx
@@ -65,7 +65,7 @@ const InstructorStats = ({ username, stats, maxProject, statsGraphsData, graphWi
     <div className="user_stats">
       <div id="instructor-profile-stats">
         <h5>
-          {I18n.t('user_profiles.instructor_impact', { username: username })}
+          {I18n.t('user_profiles.instructor_impact', { username })}
         </h5>
         <div className="stat-display">
           <div onClick={setCoursesCountGraph} className={`stat-display__stat button${coursesGraph ? ' active-button' : ''}`}>

--- a/app/assets/javascripts/components/user_profiles/student_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/student_stats.jsx
@@ -5,7 +5,7 @@ import ArticleUtils from '../../utils/article_utils';
 const StudentStats = ({ username, stats, maxProject }) => {
   return (
     <div className= "user_stats">
-      <h5> {I18n.t('user_profiles.student_impact', { username: username })} </h5>
+      <h5> {I18n.t('user_profiles.student_impact', { username })} </h5>
       <div className= "stat-display">
         <div className= "stat-display__stat">
           <div className="stat-display__value">

--- a/app/assets/javascripts/reducers/article_finder.js
+++ b/app/assets/javascripts/reducers/article_finder.js
@@ -103,9 +103,9 @@ export default function articleFinder(state = initialState, action) {
         ...state,
         articles: newStateArticles,
         continue_results: continueResults,
-        cmcontinue: cmcontinue,
+        cmcontinue,
         loading: false,
-        fetchState: fetchState,
+        fetchState,
         lastRelevanceIndex: state.lastRelevanceIndex + 50,
       };
     }
@@ -134,9 +134,9 @@ export default function articleFinder(state = initialState, action) {
         ...state,
         articles: newStateArticles,
         continue_results: continueResults,
-        offset: offset,
+        offset,
         loading: false,
-        fetchState: fetchState,
+        fetchState,
         lastRelevanceIndex: state.lastRelevanceIndex + 50,
       };
     }

--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -1,3 +1,4 @@
+/* eslint-disable object-shorthand */
 //--------------------------------------------------------
 // Vendor Requirements [imports]
 //--------------------------------------------------------
@@ -256,7 +257,7 @@ const Survey = {
       e.preventDefault();
       const data = _context.processQuestionGroupData($(this).serializeArray());
       return fetch(url, {
-        method: method,
+        method,
         body: JSON.stringify(data),
         credentials: 'include',
         headers: {

--- a/app/assets/javascripts/utils/article_finder_utils.js
+++ b/app/assets/javascripts/utils/article_finder_utils.js
@@ -27,7 +27,7 @@ export const categoryQueryGenerator = (category, cmcontinue, namespace) => {
     cmtitle: category,
     cmlimit: 50,
     cmnamespace: namespace,
-    cmcontinue: cmcontinue
+    cmcontinue
   };
 };
 

--- a/app/assets/javascripts/utils/course_utils.js
+++ b/app/assets/javascripts/utils/course_utils.js
@@ -98,9 +98,9 @@ export default class CourseUtils {
         const project = indexphpFormatUrlParts[2];
         const language = indexphpFormatUrlParts[1];
         return {
-          title: title,
-          project: project,
-          language: language,
+          title,
+          project,
+          language,
            article_url: articleTitle,
         };
       }

--- a/app/assets/javascripts/utils/model_utils.js
+++ b/app/assets/javascripts/utils/model_utils.js
@@ -76,8 +76,8 @@ export const transformUsers = (users) => {
       const last_name = middle_last_name.pop(); // Get the last name from the split
       usersWithRealName.push({
         ...user,
-        first_name: first_name,
-        ...(last_name && { last_name: last_name }),
+        first_name,
+        ...(last_name && { last_name }),
       });
     } else {
       usersWithoutRealName.push(user);

--- a/test/actions/settings_actions.spec.js
+++ b/test/actions/settings_actions.spec.js
@@ -114,7 +114,7 @@ describe('downgradeAdmin', () => {
         data: {
           revoking: {
             status: true,
-            username: username,
+            username,
           },
         },
       },
@@ -135,7 +135,7 @@ describe('downgradeAdmin', () => {
         data: {
           revoking: {
             status: false,
-            username: username,
+            username,
           },
         },
       }

--- a/test/reducers/admin_course_notes.spec.js
+++ b/test/reducers/admin_course_notes.spec.js
@@ -22,7 +22,7 @@ describe('courseNotes reducer', () => {
 
   it('should handle ADD_NEW_NOTE_TO_LIST', () => {
     const newNote = { id: 2, title: 'Note 2' };
-    const action = { type: types.ADD_NEW_NOTE_TO_LIST, newNote: newNote };
+    const action = { type: types.ADD_NEW_NOTE_TO_LIST, newNote };
 
     expect(courseNotesReducer(initialState, action)).toEqual({
       ...initialState,

--- a/test/reducers/course.spec.js
+++ b/test/reducers/course.spec.js
@@ -148,7 +148,7 @@ describe('course reducer', () => {
       };
       const mockedAction = {
         type: RECEIVE_INITIAL_CAMPAIGN,
-        data: { campaign: campaign }
+        data: { campaign }
       };
 
       const newState = course(initialState, mockedAction);

--- a/test/reducers/users.spec.js
+++ b/test/reducers/users.spec.js
@@ -24,7 +24,7 @@ describe('users reducer', () => {
   deepFreeze(initialState);
 
   const action = (type, users_array) => ({
-    type: type,
+    type,
     data: {
       course: {
         users: users_array


### PR DESCRIPTION
issue - https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1408#issue-259228085


## What this PR does
This PR is enabling the  Object-Short-hand JavaScript linting rule. 
Object-Short-hand require or disallow method and property shorthand syntax for object literals. In this PR i'm only enforcing the use of shorthand syntax on only 'properties' defined where the key name matches name of the assigned variable. 

The default rule (always), would apply to all 'methods' (including generators) defined in object literals and any 'properties'

PROPERTIES
Example ;
    
 *before:
              var foo = {
                    x: x,
                    y: y,
                    z: z,
                };
 
 *after
             var foo = {x, y, z};    

METHODS       
Example ;
    
 *before:
              var foo = {
                    a: function() {},
                    b: function() {}
                    };

 *after
     var foo = {
              a() {},
              b() {}
             };          
      
#Why
I did not enable the default rule (leaving out the methods), because i felt it would bring violations that may be confusing to some people, so i felt it was not necessary.

