### PR TITLE
Automatically update user role to instructor upon completion of the "How to Teach with Wikipedia" orientation module. 

### DIFF
--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -64,6 +64,7 @@ class TrainingModulesUsersController < ApplicationController
   HOW_TO_TEACH_WITH_WIKIPEDIA_TRAINING_MODULE_ID = 3
 
   def instructor_orientation_module?
+    return false unless Features.wiki_ed?
     @training_module_user.completed_at.present? &&
       (HOW_TO_TEACH_WITH_WIKIPEDIA_TRAINING_MODULE_ID == @training_module.id)
   end

--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -4,9 +4,6 @@ class TrainingModulesUsersController < ApplicationController
   respond_to :json
   before_action :require_signed_in, only: [:create_or_update, :mark_exercise_complete]
 
-  # ID of the "How to teach with Wikipedia" training module
-  MODULE_ID = 3
-
   def index
     course = Course.find(params[:course_id])
     user = User.find_by(id: params[:user_id]) if params[:user_id]
@@ -20,7 +17,6 @@ class TrainingModulesUsersController < ApplicationController
     complete_slide if should_set_slide_completed?
     complete_module if last_slide?
     @completed = @training_module_user.completed_at.present?
-    make_training_module_user_instructor if @completed && (MODULE_ID == @training_module.id)
     render_slide
   end
 
@@ -62,6 +58,14 @@ class TrainingModulesUsersController < ApplicationController
 
   def complete_module
     @training_module_user.update(completed_at: Time.now.utc)
+    make_training_module_user_instructor if instructor_orientation_module?
+  end
+
+  HOW_TO_TEACH_WITH_WIKIPEDIA_TRAINING_MODULE_ID = 3
+
+  def instructor_orientation_module?
+    @training_module_user.completed_at.present? &&
+      (HOW_TO_TEACH_WITH_WIKIPEDIA_TRAINING_MODULE_ID == @training_module.id)
   end
 
   def last_slide?

--- a/spec/features/training_tool_spec.rb
+++ b/spec/features/training_tool_spec.rb
@@ -7,6 +7,9 @@ DESIRED_TRAINING_MODULES = [{ slug: 'evaluating-articles' }].freeze
 describe 'Training', type: :feature, js: true do
   let(:user) { create(:user, id: 1) }
   let(:module_2) { TrainingModule.find_by(slug: 'evaluating-articles') }
+  let(:new_instructor_orientation_module) do
+    TrainingModule.find_by(slug: 'new-instructor-orientation')
+  end
 
   before(:all) do
     TrainingModule.load_all
@@ -119,6 +122,20 @@ describe 'Training', type: :feature, js: true do
       visit "/training/students/#{module_2.slug}/#{module_2.slides.last.slug}"
       sleep 2
       expect(tmu.reload.completed_at).to be_between(1.minute.ago, 1.minute.from_now)
+    end
+
+    it 'sets the new_instructor_orientation completed on viewing the last slide and promotes the user to instructor if applicable' do # rubocop:disable Layout/LineLength
+      login_as(user, scope: :user)
+      sleep 1
+      visit "/training/students/#{new_instructor_orientation_module.slug}"
+      click_link 'Start'
+      tmu = TrainingModulesUsers.find_by(user_id: user.id,
+                                         training_module_id: new_instructor_orientation_module.id)
+      visit "/training/students/#{new_instructor_orientation_module.slug}
+                              /#{new_instructor_orientation_module.slides.last.slug}"
+      sleep 2
+      expect(tmu.reload.completed_at).to be_between(1.minute.ago, 1.minute.from_now)
+      expect(user.reload.permissions).to eq(User::Permissions::INSTRUCTOR)
     end
 
     it 'disables slides that have not been seen' do

--- a/spec/features/training_tool_spec.rb
+++ b/spec/features/training_tool_spec.rb
@@ -125,8 +125,6 @@ describe 'Training', type: :feature, js: true do
     end
 
     it 'sets the new_instructor_orientation completed on viewing the last slide and promotes the user to instructor if applicable' do # rubocop:disable Layout/LineLength
-      login_as(user, scope: :user)
-      sleep 1
       visit "/training/students/#{new_instructor_orientation_module.slug}"
       click_link 'Start'
       tmu = TrainingModulesUsers.find_by(user_id: user.id,


### PR DESCRIPTION
## What this PR does

Adds a feature to automatically update a user’s role to instructor upon completing the "[How to Teach with Wikipedia](https://dashboard.wikiedu.org/training/instructors/new-instructor-orientation)" orientation module.

## Screenshots
Before:


https://github.com/user-attachments/assets/06c770d4-1a12-43eb-b801-711710458c83



After:


https://github.com/user-attachments/assets/276c5af1-53e7-45d7-92de-aaae34532bc5



