### PR TITLE
Query Fix: remove dependency on depreciated revision table

### DIFF
--- a/app/assets/javascripts/components/user_profiles/student_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/student_stats.jsx
@@ -25,26 +25,10 @@ const StudentStats = ({ username, stats, maxProject }) => {
         </div>
         <div className= "stat-display__stat">
           <div className="stat-display__value">
-            {stats.individual_references_count}
-          </div>
-          <small>
-            {I18n.t('metrics.references_count')}
-          </small>
-        </div>
-        <div className= "stat-display__stat">
-          <div className="stat-display__value">
             {stats.individual_article_views}
           </div>
           <small>
             {I18n.t(`metrics.${ArticleUtils.projectSuffix(maxProject, 'view_count_description')}`)}
-          </small>
-        </div>
-        <div className= "stat-display__stat">
-          <div className="stat-display__value">
-            {stats.individual_article_count}
-          </div>
-          <small>
-            {I18n.t(`metrics.${ArticleUtils.projectSuffix(maxProject, 'articles_edited')}`)}
           </small>
         </div>
         <div className= "stat-display__stat">

--- a/app/presenters/individual_statistics_presenter.rb
+++ b/app/presenters/individual_statistics_presenter.rb
@@ -67,7 +67,7 @@ class IndividualStatisticsPresenter
   def set_articles_created
     @articles_created = {}
     individual_courses.each do |course|
-      course.articles_courses.each do |edit|
+      course.articles_courses.where(user: @user).each do |edit|
         articles = @articles_created[edit.article_id] || { new_article: true,
                                                                 views: 0,
                                                                 character_sum: 0,

--- a/app/presenters/individual_statistics_presenter.rb
+++ b/app/presenters/individual_statistics_presenter.rb
@@ -67,7 +67,7 @@ class IndividualStatisticsPresenter
   def set_articles_created
     @articles_created = {}
     individual_courses.each do |course|
-      course.articles_courses.where(new_article: true).each do |edit|
+      course.articles_courses.each do |edit|
         articles = @articles_created[edit.article_id] || { new_article: true,
                                                                 views: 0,
                                                                 character_sum: 0,

--- a/app/presenters/individual_statistics_presenter.rb
+++ b/app/presenters/individual_statistics_presenter.rb
@@ -72,9 +72,11 @@ class IndividualStatisticsPresenter
           articles = @articles_created[edit.article_id] || { new_article: false,
                                                                   views: 0,
                                                                   characters: {},
-                                                                  references: {} }
+                                                                  references: {},
+                                                                  earliest_revision: nil }
           articles[:characters][0] ||= edit.character_sum
           articles[:references][1] ||= edit.references_count
+          articles[:earliest_revision] = edit.updated_at if earliest_rev_yet?(edit, articles)
           articles[:average_views] ||= edit.article.average_views
           @articles_created[edit.article_id] = articles
         end
@@ -89,6 +91,11 @@ class IndividualStatisticsPresenter
       days = (Time.now.utc.to_date - articles[:earliest_revision].to_date).to_i
       articles[:views] = days * articles[:average_views]
     end
+  end
+
+  def earliest_rev_yet?(edit, article_edits)
+    return true if article_edits[:earliest_revision].nil?
+    edit.date < article_edits[:earliest_revision]
   end
 
   def set_upload_usage_counts


### PR DESCRIPTION
## What this PR Does

- This PR addresses issue #5995 by shifting the focus of student statistics from articles **edited** to articles **created**, aligning with the new impact factor.
  
### Notable Changes
- The key metric has changed from `articles_edited` to `articles_created`.
- Refactored logic: Replaced the `individual_mainspace_edits` query (which used the `revisions` table) with a new approach that uses the `articles_courses` table.

### Expected Data Output

#### Before 
![Old Dashboard View](https://github.com/user-attachments/assets/18556e87-30f0-4292-98db-f000e7b339e4)

  ##### (Prior Data Fields):
- `course_string_prefix`
- `individual_article_count`
- `individual_article_views`
- `individual_articles_created`
- `individual_courses_count`
- `individual_references_count`
- `individual_upload_count`
- `individual_upload_usage_count`
- `individual_word_count`

#### After 
![New Dashboard View](https://github.com/user-attachments/assets/28f56f4a-c540-42b6-accd-3e0c214b4e33)


  ##### (Updated Data Fields):
- `course_string_prefix`
- `individual_article_views` ![Views on user articles]
- `individual_articles_created`
- `individual_courses_count`
- `individual_upload_count` 
- `individual_word_count` ![Words added by the user via article created]

> **Note:** The `individual_references_count` field has been removed from the data output with the new stats depending on the users articles.
