### PR TITLE
[Data rearchitecture] Add support for course start and end date updates

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -233,7 +233,7 @@ class Course < ApplicationRecord
   before_save :reorder_weeks
   before_save :set_default_times
   before_save :check_course_times
-  before_save :set_needs_update
+  before_save :set_needs_update_for_timeslice
   after_create :ensure_home_wiki_in_courses_wikis
 
   ####################
@@ -575,10 +575,16 @@ class Course < ApplicationRecord
     self.end = start if start > self.end
   end
 
-  # If the start date changed, set needs_update to `true` so that
-  # the stats will be updated to reflect the new start date
-  # and the earlier revisions will be fetched.
-  def set_needs_update
-    self.needs_update = true if start_changed?
+  # If the start date changed, set needs_update to `true` for the (maybe new)
+  # first course timeslice for every wiki. We need to do this now because we
+  # might not be able to identify a change in the start date after.
+  def set_needs_update_for_timeslice
+    if start_changed?
+      wikis.each do |wiki|
+        timeslice = CourseWikiTimeslice.for_course_and_wiki(self, wiki).for_datetime(start).first
+        break unless timeslice
+        timeslice.update(needs_update: true)
+      end
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -459,6 +459,11 @@ class Course < ApplicationRecord
     flags[:very_long_update].present?
   end
 
+  # TODO: find a better way to check if the course was already updated
+  def was_course_ever_updated?
+    flags[:first_update].present? || flags['update_logs'].present?
+  end
+
   # Overridden for ClassroomProgramCourse
   def progress_tracker_enabled?
     false

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -13,7 +13,6 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
     @cat_data = retrieve_categories_data
     copy_tracked_categories_data
     maybe_copy_user_data
-    create_timeslices
     @training_modules = retrieve_all_training_modules
     @timeline_data = retrieve_timeline_data
     # This only works if the wiki_education envvar is set differently from the
@@ -199,11 +198,5 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
       <i class=\"icon icon-rt_arrow_purple_training_module\"></i></a>"
 
     return html_block, matching_module['kind']
-  end
-
-  def create_timeslices
-    @course.reload
-    # Create course user wiki and course user timeslices
-    TimesliceManager.new(@course).create_timeslices_for_new_course_wiki_records(@course.wikis)
   end
 end

--- a/app/services/course_date_updater.rb
+++ b/app/services/course_date_updater.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+
+class CourseDateUpdater
+  def initialize(course)
+    @course = course
+    @timeslice_manager = TimesliceManager.new(course)
+  end
+
+  def run
+    # Get the min course wiki timeslice end date
+    min_course_end = CourseWikiTimeslice.where(course: @course)
+                                        .minimum(:end)
+
+    # Remove timeslices if there are timesmlices prior to the current start date
+    remove_timeslices_prior_to_start_date unless min_course_end > @course.start
+
+    # Get the min course wiki timeslice end start
+    min_course_start = CourseWikiTimeslice.where(course: @course)
+                                          .minimum(:start)
+
+    add_timeslices_from_new_start_date unless min_course_start <= @course.start
+  end
+
+  private
+
+  def remove_timeslices_prior_to_start_date
+    mark_new_first_timeslces_as_needs_update
+
+    # Delete course and course user timeslices
+    @timeslice_manager.delete_course_wiki_timeslices_prior_to_start_date
+    @timeslice_manager.delete_course_user_wiki_timeslices_prior_to_start_date
+
+    # Delete articles courses
+    ArticlesCoursesCleanerTimeslice.clean_articles_courses_prior_to_course_start(@course)
+  end
+
+  def add_timeslices_from_new_start_date
+    mark_new_first_timeslces_as_needs_update
+
+    @timeslice_manager.create_timeslices_for_new_course_start_date
+  end
+
+  def mark_new_first_timeslces_as_needs_update
+    # If the start date changed, mark the new first timeslices as 'needs_update'
+    @course.wikis.each do |wiki|
+      timeslice = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
+                                     .for_datetime(@course.start)
+                                     .first
+      break unless timeslice
+      timeslice.update(needs_update: true)
+    end
+  end
+end

--- a/app/services/course_user_updater.rb
+++ b/app/services/course_user_updater.rb
@@ -31,7 +31,7 @@ class CourseUserUpdater
     course_user_ids = @course.courses_users.where(user: user_ids)
     # Create course user wiki timeslices
     @timeslice_manager.create_timeslices_for_new_course_user_records course_user_ids
-    return unless was_course_ever_updated?
+    return unless @course.was_course_ever_updated?
 
     @course.wikis.each do |wiki|
       # Get start time from first timeslice to update
@@ -74,11 +74,6 @@ class CourseUserUpdater
     clean_article_course_timeslices
     # Delete articles courses that were updated only for removed users
     ArticlesCoursesCleanerTimeslice.clean_articles_courses_for_user_ids(@course, user_ids)
-  end
-
-  # TODO: find a better way to check if the course was already updated
-  def was_course_ever_updated?
-    @course.flags[:first_update].present? || @course.flags['update_logs'].present?
   end
 
   # Returns ArticleCourseTimeslice records that have edits from users

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -17,6 +17,7 @@ class UpdateCourseWikiTimeslices
     @timeslice_manager = TimesliceManager.new(@course)
     @course_wiki_updater = CourseWikiUpdater.new(@course)
     @course_user_updater = CourseUserUpdater.new(@course)
+    @course_date_updater = CourseDateUpdater.new(@course)
   end
 
   def run(all_time:)
@@ -38,7 +39,8 @@ class UpdateCourseWikiTimeslices
     )
   end
 
-  # Make changes if some wiki/users were added or removed.
+  # Make changes if some wiki/users were added or removed, or the start/end
+  # course dates changed.
   def pre_update
     # order matters
     unless @course.was_course_ever_updated?
@@ -46,6 +48,7 @@ class UpdateCourseWikiTimeslices
     end
     @course_user_updater.run
     @course_wiki_updater.run
+    @course_date_updater.run
   end
 
   def fetch_data_and_process_timeslices_for_every_wiki(all_time)

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -41,6 +41,9 @@ class UpdateCourseWikiTimeslices
   # Make changes if some wiki/users were added or removed.
   def pre_update
     # order matters
+    unless @course.was_course_ever_updated?
+      @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
+    end
     @course_user_updater.run
     @course_wiki_updater.run
   end

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -46,11 +46,37 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # Deletes course wiki timeslices records with a start date later than the current end date
+  def delete_course_wiki_timeslices_after_end_date
+    # Delete course wiki timeslices
+    timeslice_ids = CourseWikiTimeslice.where(course: @course)
+                                       .where('start > ?', @course.end)
+                                       .pluck(:id)
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      CourseWikiTimeslice.where(id: timeslice_id_slice).delete_all
+    end
+  end
+
   # Deletes course user wiki timeslices records with a date prior to the current start date
   def delete_course_user_wiki_timeslices_prior_to_start_date
     # Delete course user wiki timeslices
     timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
                                            .where('end <= ?', @course.start)
+                                           .pluck(:id)
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      CourseUserWikiTimeslice.where(id: timeslice_id_slice).delete_all
+    end
+  end
+
+  # Deletes course user wiki timeslices records with a start date later than the current end date
+  def delete_course_user_wiki_timeslices_after_end_date
+    # Delete course user wiki timeslices
+    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
+                                           .where('start > ?', @course.end)
                                            .pluck(:id)
 
     # Do this in batches to avoid running the MySQL server out of memory

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -204,8 +204,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
 
   def start_dates
     start_dates = []
-    # Create timeslices for 3 days before the course start day.
-    current_start = @course.start - 3.days
+    current_start = @course.start
     while current_start <= @course.end
       start_dates << current_start
       current_start += TIMESLICE_DURATION

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -33,6 +33,32 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     delete_existing_article_course_timeslices(wiki_ids)
   end
 
+  # Deletes course wiki timeslices records with a date prior to the current start date
+  def delete_course_wiki_timeslices_prior_to_start_date
+    # Delete course wiki timeslices
+    timeslice_ids = CourseWikiTimeslice.where(course: @course)
+                                       .where('end <= ?', @course.start)
+                                       .pluck(:id)
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      CourseWikiTimeslice.where(id: timeslice_id_slice).delete_all
+    end
+  end
+
+  # Deletes course user wiki timeslices records with a date prior to the current start date
+  def delete_course_user_wiki_timeslices_prior_to_start_date
+    # Delete course user wiki timeslices
+    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
+                                           .where('end <= ?', @course.start)
+                                           .pluck(:id)
+
+    # Do this in batches to avoid running the MySQL server out of memory
+    timeslice_ids.each_slice(5000) do |timeslice_id_slice|
+      CourseUserWikiTimeslice.where(id: timeslice_id_slice).delete_all
+    end
+  end
+
   # Creates article course timeslices records for new articles courses
   # Takes an array like the following:
   # [{:article_id=>115, :course_id=>72},..., {:article_id=>116, :course_id=>72}]

--- a/setup/populate_dashboard.rb
+++ b/setup/populate_dashboard.rb
@@ -41,10 +41,6 @@ def make_copy_of(url)
     CoursesUsers.create!(user_id: user.id, role: user_hash['role'], course_id: course.id)
   end
 
-  course.reload
-  # Create course user wiki and course user timeslices
-  TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
-
   # Get assignments
   assignments_data = JSON.parse(Net::HTTP.get URI(url + '/assignments.json'))['course']['assignments']
   # Replicate the assignments as available articles

--- a/spec/lib/articles_courses_cleaner_timeslice_spec.rb
+++ b/spec/lib/articles_courses_cleaner_timeslice_spec.rb
@@ -42,11 +42,11 @@ describe ArticlesCoursesCleanerTimeslice do
     end
 
     it 'removes ArticlesCourses and their timeslices that were edited only by removed users' do
-      expect(course.article_course_timeslices.size).to eq(342)
+      expect(course.article_course_timeslices.size).to eq(333)
       expect(course.articles_courses.size).to eq(3)
       # User ids 5, 45 and 47 were deleted
       described_class.clean_articles_courses_for_user_ids(course, [5, 45, 47])
-      expect(course.article_course_timeslices.size).to eq(228)
+      expect(course.article_course_timeslices.size).to eq(222)
       expect(course.articles_courses.size).to eq(2)
       expect(course.articles_courses.first.user_ids).to eq([1, 45])
       expect(course.articles_courses.second.user_ids).to eq([455])
@@ -93,7 +93,7 @@ describe ArticlesCoursesCleanerTimeslice do
     end
 
     it 'removes ArticlesCourses and timeslices that do not belong to the course anymore' do
-      expect(course.article_course_timeslices.size).to eq(342)
+      expect(course.article_course_timeslices.size).to eq(333)
       expect(course.articles_courses.size).to eq(3)
       # Clean articles courses
       described_class.clean_articles_courses_prior_to_course_start(course)

--- a/spec/lib/articles_courses_cleaner_timeslice_spec.rb
+++ b/spec/lib/articles_courses_cleaner_timeslice_spec.rb
@@ -52,4 +52,61 @@ describe ArticlesCoursesCleanerTimeslice do
       expect(course.articles_courses.second.user_ids).to eq([455])
     end
   end
+
+  describe '.clean_articles_courses_prior_to_course_start' do
+    before do
+      stub_wiki_validation
+      create(:articles_course, course:, article: article1, user_ids: [1])
+      create(:articles_course, course:, article: article2, user_ids: [47])
+      create(:articles_course, course:, article: article3, user_ids: [455])
+      manager.create_timeslices_for_new_article_course_records(
+        [{ article_id: article1.id, course_id: course.id },
+         { article_id: article2.id, course_id: course.id },
+         { article_id: article3.id, course_id: course.id }]
+      )
+      # Course start date is updated
+      course.update(start: '2024-01-10')
+
+      # Article 1 was only edited before the new start date
+      timeslice = ArticleCourseTimeslice.where(course:)
+                                        .where(article_id: article1.id)
+                                        .where(start: '2024-01-02'.to_datetime)
+                                        .first
+      timeslice.update(user_ids: [1])
+      # Article 2 was edited before and after the new start date
+      timeslice = ArticleCourseTimeslice.where(course:)
+                                        .where(article_id: article2.id)
+                                        .where(start: '2024-01-02'.to_datetime)
+                                        .first
+      timeslice.update(user_ids: [47])
+      timeslice = ArticleCourseTimeslice.where(course:)
+                                        .where(article_id: article2.id)
+                                        .where(start: '2024-02-15'.to_datetime)
+                                        .first
+      timeslice.update(user_ids: [47])
+      # Article 3 was only edited after the new start date
+      timeslice = ArticleCourseTimeslice.where(course:)
+                                        .where(article_id: article3.id)
+                                        .where(start: '2024-02-18'.to_datetime)
+                                        .first
+      timeslice.update(user_ids: [455])
+    end
+
+    it 'removes ArticlesCourses and timeslices that do not belong to the course anymore' do
+      expect(course.article_course_timeslices.size).to eq(342)
+      expect(course.articles_courses.size).to eq(3)
+      # Clean articles courses
+      described_class.clean_articles_courses_prior_to_course_start(course)
+
+      # Timeslices for article 1 were deleted
+      expect(course.article_course_timeslices.where(article_id: article1.id).size).to eq(0)
+      # Timeslices prior to the new course start date were deleted
+      expect(course.article_course_timeslices.where('end <= ?', course.start).size).to eq(0)
+      expect(course.article_course_timeslices.size).to eq(204)
+      # Article 1 was deleted
+      expect(course.articles_courses.size).to eq(2)
+      expect(course.articles_courses.first.article_id).to eq(article2.id)
+      expect(course.articles_courses.second.article_id).to eq(article3.id)
+    end
+  end
 end

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -30,10 +30,14 @@ describe ScheduleCourseUpdates do
                       slug: 'Medium/Course', needs_update: true)
       create(:course, start: 1.day.ago, end: 1.year.from_now,
                       slug: 'Long/Program')
-      create(:course, slug: 'Fast/Updates', flags: fast_update_logs)
-      create(:course, slug: 'Medium/Updates', flags: medium_update_logs)
-      create(:course, slug: 'Slow/Updates', flags: slow_update_logs)
-      create(:course, slug: 'VeryLong/Updates', flags: { very_long_updates: true })
+      create(:course, start: 1.day.ago, end: 2.months.from_now,
+                      slug: 'Fast/Updates', flags: fast_update_logs)
+      create(:course, start: 1.day.ago, end: 2.months.from_now,
+                      slug: 'Medium/Updates', flags: medium_update_logs)
+      create(:course, start: 1.day.ago, end: 2.months.from_now,
+                      slug: 'Slow/Updates', flags: slow_update_logs)
+      create(:course, start: 1.day.ago, end: 2.months.from_now,
+                      slug: 'VeryLong/Updates', flags: { very_long_updates: true })
     end
 
     it 'calls the revisions and articles updates on courses currently taking place' do

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -122,6 +122,35 @@ describe TimesliceManager do
     end
   end
 
+  describe '#create_timeslices_up_to_new_course_end_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
+                                                                       wikidata,
+                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_article_course_records(
+        new_article_courses
+      )
+      course.update(end: '2024-04-30')
+    end
+
+    context 'when the end date changed to a later date' do
+      it 'creates timeslices for the missing period that needs_update' do
+        expect(course.course_wiki_timeslices.size).to eq(333)
+        expect(course.course_user_wiki_timeslices.size).to eq(666)
+        expect(course.article_course_timeslices.size).to eq(333)
+
+        timeslice_manager.create_timeslices_up_to_new_course_end_date
+        course.reload
+        # Create timeslices for the period between 2024-04-20 and 2024-04-30
+        expect(course.course_wiki_timeslices.size).to eq(363)
+        expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(30)
+        expect(course.course_user_wiki_timeslices.size).to eq(726)
+        expect(course.article_course_timeslices.size).to eq(363)
+      end
+    end
+  end
+
   describe '#delete_course_user_timeslices_for_deleted_course_users' do
     before do
       timeslice_manager.create_timeslices_for_new_course_user_records(new_course_users)

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -217,6 +217,30 @@ describe TimesliceManager do
     end
   end
 
+  describe '#delete_course_wiki_timeslices_after_end_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
+                                                                       wikidata,
+                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_article_course_records(
+        new_article_courses
+      )
+    end
+
+    it 'deletes course wiki timeslices for dates after the end date properly' do
+      expect(course.course_wiki_timeslices.size).to eq(333)
+
+      # Update course start date
+      course.update(end: '2024-04-10'.to_datetime)
+      timeslice_manager.delete_course_wiki_timeslices_after_end_date
+      course.reload
+
+      # Course wiki timeslices prior to the new start date were deleted
+      expect(course.course_wiki_timeslices.size).to eq(303)
+    end
+  end
+
   describe '#delete_course_user_wiki_timeslices_prior_to_start_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
@@ -238,6 +262,30 @@ describe TimesliceManager do
 
       # Course user wiki timeslices prior to the new start date were deleted
       expect(course.course_user_wiki_timeslices.size).to eq(612)
+    end
+  end
+
+  describe '#delete_course_user_wiki_timeslices_after_end_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
+                                                                       wikidata,
+                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_article_course_records(
+        new_article_courses
+      )
+    end
+
+    it 'deletes course user wiki timeslices for dates after the end date properly' do
+      expect(course.course_user_wiki_timeslices.size).to eq(666)
+
+      # Update course start date
+      course.update(end: '2024-04-10'.to_datetime)
+      timeslice_manager.delete_course_user_wiki_timeslices_after_end_date
+      course.reload
+
+      # Course user wiki timeslices prior to the new start date were deleted
+      expect(course.course_user_wiki_timeslices.size).to eq(606)
     end
   end
 

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -135,6 +135,54 @@ describe TimesliceManager do
     end
   end
 
+  describe '#delete_course_wiki_timeslices_prior_to_start_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
+                                                                       wikidata,
+                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_article_course_records(
+        new_article_courses
+      )
+    end
+
+    it 'deletes course wiki timeslices for dates prior to start date properly' do
+      expect(course.course_wiki_timeslices.size).to eq(333)
+
+      # Update course start date
+      course.update(start: '2024-01-10'.to_datetime)
+      timeslice_manager.delete_course_wiki_timeslices_prior_to_start_date
+      course.reload
+
+      # Course wiki timeslices prior to the new start date were deleted
+      expect(course.course_wiki_timeslices.size).to eq(306)
+    end
+  end
+
+  describe '#delete_course_user_wiki_timeslices_prior_to_start_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
+                                                                       wikidata,
+                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_article_course_records(
+        new_article_courses
+      )
+    end
+
+    it 'deletes course user wiki timeslices for dates prior to start date properly' do
+      expect(course.course_user_wiki_timeslices.size).to eq(666)
+
+      # Update course start date
+      course.update(start: '2024-01-10'.to_datetime)
+      timeslice_manager.delete_course_user_wiki_timeslices_prior_to_start_date
+      course.reload
+
+      # Course user wiki timeslices prior to the new start date were deleted
+      expect(course.course_user_wiki_timeslices.size).to eq(612)
+    end
+  end
+
   describe '#get_ingestion_start_time_for_wiki' do
     context 'when no course wiki timeslices' do
       it 'returns course start date' do

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -43,9 +43,9 @@ describe TimesliceManager do
           new_article_courses
         )
         course.reload
-        expect(course.article_course_timeslices.size).to eq(342)
+        expect(course.article_course_timeslices.size).to eq(333)
         expect(course.article_course_timeslices.min_by(&:start).start.to_date)
-          .to eq(Date.new(2023, 12, 29))
+          .to eq(Date.new(2024, 1, 1))
         expect(course.article_course_timeslices.max_by(&:start).start.to_date)
           .to eq(Date.new(2024, 4, 20))
       end
@@ -60,9 +60,9 @@ describe TimesliceManager do
           new_course_users
         )
         course.reload
-        expect(course.course_user_wiki_timeslices.size).to eq(684)
+        expect(course.course_user_wiki_timeslices.size).to eq(666)
         expect(course.course_user_wiki_timeslices.min_by(&:start).start.to_date)
-          .to eq(Date.new(2023, 12, 29))
+          .to eq(Date.new(2024, 1, 1))
         expect(course.course_user_wiki_timeslices.max_by(&:start).start.to_date)
           .to eq(Date.new(2024, 4, 20))
       end
@@ -83,12 +83,12 @@ describe TimesliceManager do
         # Create enwiki and wikibooks course wiki timeslices for the entire course
         expect(course.course_wiki_timeslices.first.wiki).to eq(enwiki)
         expect(course.course_wiki_timeslices.last.wiki).to eq(wikibooks)
-        expect(course.course_wiki_timeslices.size).to eq(228)
+        expect(course.course_wiki_timeslices.size).to eq(222)
         # Create all the course user wiki timeslices for the existing course users with student role
         # for the new wiki
         expect(course.course_user_wiki_timeslices.first.wiki).to eq(enwiki)
         expect(course.course_user_wiki_timeslices.last.wiki).to eq(wikibooks)
-        expect(course.course_user_wiki_timeslices.size).to eq(456)
+        expect(course.course_user_wiki_timeslices.size).to eq(444)
       end
     end
   end
@@ -99,10 +99,10 @@ describe TimesliceManager do
     end
 
     it 'deletes course user wiki timeslices for the given users properly' do
-      expect(course.course_user_wiki_timeslices.size).to eq(684)
+      expect(course.course_user_wiki_timeslices.size).to eq(666)
 
       timeslice_manager.delete_course_user_timeslices_for_deleted_course_users([1, 2])
-      expect(course.course_user_wiki_timeslices.size).to eq(228)
+      expect(course.course_user_wiki_timeslices.size).to eq(222)
     end
   end
 
@@ -118,9 +118,9 @@ describe TimesliceManager do
     end
 
     it 'deletes wiki timeslices for the entire course properly' do
-      expect(course.course_wiki_timeslices.size).to eq(342)
-      expect(course.course_user_wiki_timeslices.size).to eq(684)
-      expect(course.article_course_timeslices.size).to eq(342)
+      expect(course.course_wiki_timeslices.size).to eq(333)
+      expect(course.course_user_wiki_timeslices.size).to eq(666)
+      expect(course.article_course_timeslices.size).to eq(333)
 
       timeslice_manager.delete_timeslices_for_deleted_course_wikis([wikibooks.id, wikidata.id])
       course.reload
@@ -131,7 +131,7 @@ describe TimesliceManager do
       expect(course.course_user_wiki_timeslices.where(wiki_id: wikibooks.id).size).to eq(0)
       expect(course.course_user_wiki_timeslices.where(wiki_id: wikidata.id).size).to eq(0)
       # Article course timeslices for wikibooks and wikidata were deleted
-      expect(course.article_course_timeslices.size).to eq(114)
+      expect(course.article_course_timeslices.size).to eq(111)
     end
   end
 
@@ -148,7 +148,7 @@ describe TimesliceManager do
     context 'when empty course wiki timeslices' do
       it 'returns course start date' do
         timeslice_manager.create_timeslices_for_new_course_wiki_records([enwiki])
-        expect(course.course_wiki_timeslices.where(wiki_id: enwiki.id).size).to eq(114)
+        expect(course.course_wiki_timeslices.where(wiki_id: enwiki.id).size).to eq(111)
         expect(timeslice_manager.get_ingestion_start_time_for_wiki(enwiki))
           .to eq('20240101000000'.to_datetime)
       end
@@ -174,7 +174,7 @@ describe TimesliceManager do
         fourth_timeslice.save
 
         expect(timeslice_manager.get_ingestion_start_time_for_wiki(enwiki))
-          .to eq('20240104000000'.to_datetime)
+          .to eq('20240107000000'.to_datetime)
       end
     end
   end
@@ -193,13 +193,12 @@ describe TimesliceManager do
       it 'updates last_mw_rev_datetime for every course wiki' do
         timeslice_manager.create_timeslices_for_new_course_wiki_records([enwiki])
         course_wiki_timeslices = course.course_wiki_timeslices.where(wiki_id: enwiki.id)
-        expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(114)
+        expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(111)
         timeslice_manager.update_last_mw_rev_datetime(new_fetched_data)
         # two course wiki timeslices were updated
-        expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(112)
-        # first, second and third timeslices are empty
-        expect(course_wiki_timeslices.fourth.last_mw_rev_datetime).to eq('20240101194045')
-        expect(course_wiki_timeslices[5].last_mw_rev_datetime).to eq('20240103030910')
+        expect(course_wiki_timeslices.where(last_mw_rev_datetime: nil).size).to eq(109)
+        expect(course_wiki_timeslices.first.last_mw_rev_datetime).to eq('20240101194045')
+        expect(course_wiki_timeslices.third.last_mw_rev_datetime).to eq('20240103030910')
       end
     end
   end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -93,6 +93,35 @@ describe TimesliceManager do
     end
   end
 
+  describe '#create_timeslices_for_new_course_start_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
+                                                                       wikidata,
+                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_article_course_records(
+        new_article_courses
+      )
+      course.update(start: '2023-12-20')
+    end
+
+    context 'when the start date changed to a previous date' do
+      it 'creates timeslices for the missing period that needs_update' do
+        expect(course.course_wiki_timeslices.size).to eq(333)
+        expect(course.course_user_wiki_timeslices.size).to eq(666)
+        expect(course.article_course_timeslices.size).to eq(333)
+
+        timeslice_manager.create_timeslices_for_new_course_start_date
+        course.reload
+        # Create timeslices for the period between 2023-12-20 and 2024-01-01
+        expect(course.course_wiki_timeslices.size).to eq(369)
+        expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(36)
+        expect(course.course_user_wiki_timeslices.size).to eq(738)
+        expect(course.article_course_timeslices.size).to eq(369)
+      end
+    end
+  end
+
   describe '#delete_course_user_timeslices_for_deleted_course_users' do
     before do
       timeslice_manager.create_timeslices_for_new_course_user_records(new_course_users)

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -215,8 +215,8 @@ describe ArticlesCourses, type: :model do
       described_class.update_from_course_revisions(course, array_revisions)
       expect(described_class.count).to eq(2)
       # 62 days from course start up to course end x 2 articles courses
-      expect(described_class.first.article_course_timeslices.count).to eq(65)
-      expect(described_class.second.article_course_timeslices.count).to eq(65)
+      expect(described_class.first.article_course_timeslices.count).to eq(62)
+      expect(described_class.second.article_course_timeslices.count).to eq(62)
     end
   end
 end

--- a/spec/services/course_date_updater_spec.rb
+++ b/spec/services/course_date_updater_spec.rb
@@ -80,4 +80,25 @@ describe CourseDateUpdater do
       expect(course.article_course_timeslices.count).to eq(5)
     end
   end
+
+  context 'when the end date changed to a later date' do
+    before do
+      course.update(end: '2021-02-11')
+    end
+
+    it 'adds new timeslices that needs_update' do
+      # There are two users, two articles and one wiki
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(14)
+
+      described_class.new(course).run
+      # Timeslices from 2021-01-30 to 2021-02-11 were added
+      expect(course.course_wiki_timeslices.count).to eq(19)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(13)
+      expect(course.course_user_wiki_timeslices.count).to eq(38)
+      expect(course.article_course_timeslices.count).to eq(38)
+    end
+  end
 end

--- a/spec/services/course_date_updater_spec.rb
+++ b/spec/services/course_date_updater_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CourseDateUpdater do
+  let(:course) { create(:course, start: '2021-01-24', end: '2021-01-30') }
+  let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:updater) { described_class.new(course).run }
+  let(:user1) { create(:user, username: 'Ragesoss') }
+  let(:user2) { create(:user, username: 'Oleryhlolsson') }
+  let(:manager) { TimesliceManager.new(course) }
+  let(:article1) { create(:article, wiki: enwiki) }
+  let(:article2) { create(:article, wiki: enwiki) }
+
+  before do
+    stub_wiki_validation
+    # Add two users
+    course.campaigns << Campaign.first
+    JoinCourse.new(course:, user: user1, role: 0)
+    JoinCourse.new(course:, user: user2, role: 0)
+    manager.create_timeslices_for_new_course_wiki_records([enwiki])
+    # Add articles courses and timeslices manually
+    create(:articles_course, course:, article: article1, user_ids: [user1.id])
+    create(:articles_course, course:, article: article2, user_ids: [user1.id, user2.id])
+    manager.create_timeslices_for_new_article_course_records(
+      [{ article_id: article1.id, course_id: course.id },
+       { article_id: article2.id, course_id: course.id }]
+    )
+    # Update articles courses timeslices
+    ArticleCourseTimeslice.where(course:,
+                                 article: article1).first.update(user_ids: [user1.id])
+    timeslices = ArticleCourseTimeslice.where(course:, article: article2)
+    timeslices.first.update(user_ids: [user1.id])
+    timeslices.second.update(user_ids: [user2.id])
+    timeslices.third.update(user_ids: [user1.id])
+  end
+
+  context 'when the start date changed to a previous date' do
+    before do
+      course.update(start: '2021-01-20')
+    end
+
+    it 'adds new timeslices that needs_update' do
+      # There are two users, two articles and one wiki
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(14)
+
+      described_class.new(course).run
+      # Timeslices from 2021-01-20 to 2021-01-24 were added
+      expect(course.course_wiki_timeslices.count).to eq(11)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(4)
+      expect(course.course_user_wiki_timeslices.count).to eq(22)
+      expect(course.article_course_timeslices.count).to eq(22)
+    end
+  end
+
+  context 'when the start date changed to a later date' do
+    before do
+      course.update(start: '2021-01-26')
+    end
+
+    it 'deletes timeslices and article courses' do
+      # There are two users, two articles and one wiki
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      # When updating the start date, the timeslice is marked as needs_update
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(14)
+      expect(course.articles_courses.count).to eq(2)
+
+      described_class.new(course).run
+      # Timeslices from 2021-01-24 to 2021-01-26 were deleted
+      expect(course.course_wiki_timeslices.count).to eq(5)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
+      expect(course.course_user_wiki_timeslices.count).to eq(10)
+      # Article course for article 1 was deleted
+      expect(course.articles_courses.count).to eq(1)
+      expect(course.article_course_timeslices.count).to eq(5)
+    end
+  end
+end

--- a/spec/services/course_user_updater_spec.rb
+++ b/spec/services/course_user_updater_spec.rb
@@ -40,17 +40,17 @@ describe CourseUserUpdater do
 
     it 'removes course user wiki timeslices and updates course wiki timeslices' do
       # There are two users, two articles and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
-      expect(course.course_user_wiki_timeslices.count).to eq(20)
-      expect(course.article_course_timeslices.count).to eq(20)
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(14)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
       described_class.new(course).run
       # There is one user, one article and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(2)
-      expect(course.course_user_wiki_timeslices.count).to eq(10)
+      expect(course.course_user_wiki_timeslices.count).to eq(7)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end
@@ -70,35 +70,35 @@ describe CourseUserUpdater do
 
     it 'only adds course user wiki timeslices if no previous update' do
       # There is one user and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
-      expect(course.course_user_wiki_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(7)
 
       VCR.use_cassette 'course_user_updater' do
         described_class.new(course).run
       end
 
       # There are two users and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
       # No timeslice was marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
-      expect(course.course_user_wiki_timeslices.count).to eq(20)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
     end
 
     it 'adds course user wiki timeslices and updates course wiki timeslices if previous update' do
       course.flags[:first_update] = true
       course.save
       # There is one user and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
-      expect(course.course_user_wiki_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(7)
 
       VCR.use_cassette 'course_user_updater' do
         described_class.new(course).run
       end
 
       # There are two users and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(6)
-      expect(course.course_user_wiki_timeslices.count).to eq(20)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
     end
   end
 end

--- a/spec/services/course_wiki_updater_spec.rb
+++ b/spec/services/course_wiki_updater_spec.rb
@@ -34,17 +34,17 @@ describe CourseWikiUpdater do
 
     it 'removes existing wiki timeslices' do
       # There is one user, two articles and two wikis
-      expect(course.course_wiki_timeslices.count).to eq(20)
-      expect(course.course_user_wiki_timeslices.count).to eq(20)
-      expect(course.article_course_timeslices.count).to eq(20)
+      expect(course.course_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(14)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
       described_class.new(course).run
       # There is one user, one article and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
-      expect(course.course_user_wiki_timeslices.count).to eq(10)
-      expect(course.article_course_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.article_course_timeslices.count).to eq(7)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end
@@ -66,18 +66,18 @@ describe CourseWikiUpdater do
 
     it 'adds wiki timeslices' do
       # There is one user, one article and one wiki
-      expect(course.course_wiki_timeslices.count).to eq(10)
-      expect(course.course_user_wiki_timeslices.count).to eq(10)
-      expect(course.article_course_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.article_course_timeslices.count).to eq(7)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
 
       course.wikis << wikidata
       described_class.new(course).run
       # There is one user, one article and two wikis
-      expect(course.course_wiki_timeslices.count).to eq(20)
-      expect(course.course_user_wiki_timeslices.count).to eq(20)
-      expect(course.article_course_timeslices.count).to eq(10)
+      expect(course.course_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(7)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -34,7 +34,6 @@ describe UpdateCourseStatsTimeslice do
       JoinCourse.new(course:, user:, role: 0)
       # Create course wiki timeslices manually for wikidata
       course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
-      TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wikidata])
     end
 
     it 'imports average views of edited articles' do

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -3,7 +3,10 @@
 require 'rails_helper'
 
 describe UpdateCourseWikiTimeslices do
-  let(:course) { create(:course, start: '2018-11-24', end: '2018-11-30', flags:) }
+  # Use basic_course to not override the end datetime with end_of_day
+  let(:course) do
+    create(:basic_course, start: '2018-11-24 00:00:00', end: '2018-11-30 23:55:00', flags:)
+  end
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
   let(:updater) { described_class.new(course) }
@@ -138,6 +141,32 @@ describe UpdateCourseWikiTimeslices do
       timeslice = course.course_wiki_timeslices.where(wiki: enwiki, start: '2018-11-29').first
 
       expect(timeslice.last_mw_rev_datetime).to be_nil
+    end
+
+    it 'fetches revisions up to end date' do
+      expected_dates = [
+        %w[20181124000000 20181124235959],
+        %w[20181125000000 20181125235959],
+        %w[20181126000000 20181126235959],
+        %w[20181127000000 20181127235959],
+        %w[20181128000000 20181128235959],
+        %w[20181129000000 20181129235959],
+        %w[20181130000000 20181130235500]
+      ]
+
+      expected_wikis = [enwiki, wikidata]
+
+      expected_dates.each do |start_time, end_time|
+        expected_wikis.each do |wiki|
+          expect(CourseRevisionUpdater).to receive(:fetch_revisions_and_scores_for_wiki)
+            .with(course, wiki, start_time, end_time, update_service: updater)
+            .once
+        end
+      end
+
+      VCR.use_cassette 'course_update' do
+        subject
+      end
     end
   end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -38,7 +38,6 @@ describe UpdateCourseWikiTimeslices do
       # Create course wiki timeslices manually for wikidata
       course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
       JoinCourse.new(course:, user:, role: 0)
-      TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([enwiki, wikidata])
     end
 
     it 'updates article course timeslices caches' do
@@ -53,13 +52,13 @@ describe UpdateCourseWikiTimeslices do
 
       # Article course timeslice record was created for mw_page_id 6901525
       # timeslices from 2018-11-24 to 2018-11-30 were created
-      expect(article_course.article_course_timeslices.count).to eq(10)
-      expect(article_course.article_course_timeslices.fourth.start).to eq('2018-11-24')
+      expect(article_course.article_course_timeslices.count).to eq(7)
+      expect(article_course.article_course_timeslices.first.start).to eq('2018-11-24')
       expect(article_course.article_course_timeslices.last.start).to eq('2018-11-30')
       # Article course timeslices caches were updated
-      expect(article_course.article_course_timeslices.fourth.character_sum).to eq(427)
-      expect(article_course.article_course_timeslices.fourth.references_count).to eq(-2)
-      expect(article_course.article_course_timeslices.fourth.user_ids).to eq([user.id])
+      expect(article_course.article_course_timeslices.first.character_sum).to eq(427)
+      expect(article_course.article_course_timeslices.first.references_count).to eq(-2)
+      expect(article_course.article_course_timeslices.first.user_ids).to eq([user.id])
     end
 
     it 'updates course user wiki timeslices caches' do
@@ -99,7 +98,7 @@ describe UpdateCourseWikiTimeslices do
         subject
       end
       # 14 course wiki timeslices records were created: 7 for enwiki and 7 for wikidata
-      expect(course.course_wiki_timeslices.count).to eq(20)
+      expect(course.course_wiki_timeslices.count).to eq(14)
 
       # Course user timeslices caches were updated
       # For enwiki


### PR DESCRIPTION
## What this PR does
This PR adds support for updating course start and end dates. There are 4 main cases to take into account:
1. The `start` date changes to a later date. In that case, we need to remove course wiki, course user wiki and articles courses timeslices from the previous start date up until the new one. Additionally, if any articles were only edited during that period, we may need to remove their associated article courses, along with the timeslices for those articles throughout the entire course.
2. The `start` date changes to a previous date. In that case, we only need to create new course wiki and course user wiki timeslices from the new start date up until the previous start date. Timeslices for that period needs to be created as needs_update, so that the timeslices will be processed in the next update.
3. The `end` date changes to a later date. Similar to 2.
4. The `end` date changes to a previous date. Similar to 1.

**Important behavior changes**: 
Before this PR, whenever the start date for a course gets updated, we set the course as 'needs_update' (see the course callback `set_needs_update`) . In the timeslice world, we want to do something less drastic. If the start date changes, we don't need to re-calculate the stats for the entire course, but we only need to mark the new first course timeslice as `needs_update` and add new timeslices (if the new start date is previous to the old one) or remove existing timeslices (if the new start date is later than the old one). Because of this, this PR replaces the `set_needs_update` course callback with a new `set_needs_update_timeslice` callback. This change broke the `schedule_course_updates` specs, which gets fixed in commit ae28c7d89b966935915e277e664f851a17a69b9e.

Prior to this PR, timeslices were created starting 3 days before the course start date to mitigate a previous issue where no timeslices were found for certain dates. This is not really necessary, so we reverted that behavior in this PR, and timeslices are now created right from the course start date.

## Open questions and concerns
- Changes are based on the `start` and `end` course fields. We don't take into account the `timeline_start` and `timeline_end` fields. Notice that if using the web-app to change the dates, we might need to update the timeline dates to make the start/end dates changes effective.
- TODO in another PR: course scope `ready_for_update` should be updated to include courses that have at least one single timeslice with `needs_update` set to true.
- TODO in another PR: we may need to analyse edge cases in pre-update where all start/end dates, wikis and users gets updated.