### PR TITLE
[Data rearchitecture] Revisit `ready_for_update` course definition

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -32,7 +32,6 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :live, -> { joins(:article).where(articles: { deleted: false }).distinct }
   scope :new_article, -> { where(new_article: true) }
   scope :current, -> { joins(:course).merge(Course.current).distinct }
-  scope :ready_for_update, -> { joins(:course).merge(Course.ready_for_update).distinct }
   scope :tracked, -> { where(tracked: true).distinct }
   scope :not_tracked, -> { where(tracked: false).distinct }
 

--- a/app/models/course_data/courses_users.rb
+++ b/app/models/course_data/courses_users.rb
@@ -41,7 +41,9 @@ class CoursesUsers < ApplicationRecord
   validates :course_id, uniqueness: { scope: %i[user_id role] }
 
   scope :current, -> { joins(:course).merge(Course.current).distinct }
-  scope :ready_for_update, -> { joins(:course).merge(Course.ready_for_update).distinct }
+  scope :ready_for_update, lambda {
+                             joins(:course).where(course: Course.ready_for_update).distinct
+                           }
   scope :with_instructor_role, -> { where(role: Roles::INSTRUCTOR_ROLE) }
   scope :with_student_role, -> { where(role: Roles::STUDENT_ROLE) }
 

--- a/app/models/wiki_content/article.rb
+++ b/app/models/wiki_content/article.rb
@@ -36,7 +36,6 @@ class Article < ApplicationRecord
 
   scope :live, -> { where(deleted: false) }
   scope :current, -> { joins(:courses).merge(Course.current).distinct }
-  scope :ready_for_update, -> { joins(:courses).merge(Course.ready_for_update).distinct }
   scope :namespace, ->(ns) { where(namespace: ns) }
   scope :sandbox, -> { where(namespace: Namespaces::USER) }
   scope :assigned, -> { joins(:assignments).distinct }

--- a/docs/debugging_scripts/prioritize_updates.rb
+++ b/docs/debugging_scripts/prioritize_updates.rb
@@ -4,13 +4,13 @@
 # First, pause the updates and clear the queues.
 
 # See the breakdown of edit counts and decide some break points for dividing between queues
-Course.ready_for_update.order(:revision_count).map(&:revision_count)
+Course.ready_for_update.sort_by(&:revision_count).map(&:revision_count)
 
 # I'm going to try putting courses with fewer than 1000 revions in the short queue,
 # fewer than 10k in the medium queue, and the rest in the long queue.
 
 
-Course.ready_for_update.order(:revision_count).each do |course|
+Course.ready_for_update.sort_by(&:revision_count).each do |course|
   queue = case course.revision_count
           when 0..999
             'short_update'

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -22,6 +22,8 @@ describe ScheduleCourseUpdates do
     }
   end
 
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+
   describe 'on initialization' do
     before do
       create(:editathon, start: 1.day.ago, end: 2.hours.from_now,
@@ -36,8 +38,12 @@ describe ScheduleCourseUpdates do
                       slug: 'Medium/Updates', flags: medium_update_logs)
       create(:course, start: 1.day.ago, end: 2.months.from_now,
                       slug: 'Slow/Updates', flags: slow_update_logs)
-      create(:course, start: 1.day.ago, end: 2.months.from_now,
+      create(:course, start: 1.year.ago, end: 6.months.ago,
                       slug: 'VeryLong/Updates', flags: { very_long_updates: true })
+      course = Course.find_by(slug: 'VeryLong/Updates')
+      manager = TimesliceManager.new(course)
+      manager.create_timeslices_for_new_course_wiki_records([wiki])
+      course.course_wiki_timeslices.first.update(needs_update: true)
     end
 
     it 'calls the revisions and articles updates on courses currently taking place' do


### PR DESCRIPTION
## What this PR does
This PR changes the definition for `Course.ready_for_update`. Previous to this PR, `ready_for_update` returned current courses + courses that need a full update (`needs_update` field is set to true). Now, it also includes courses that need a partial update (courses with at lest one course wiki timeslice with `needs_update` field set to true).

Additionally, this PR updates the `CoursesUsers.ready_for_update` scope (that uses the `Course.ready_for_update` scope), and deletes unused `ArticlesCourses.ready_for_update` and `Article.ready_for_update` scopes.

`docs/debugging_scripts/prioritize_updates.rb` script is also updated because now `Course.ready_for_update` returns an array (not an `ActiveRecord` relation).
