### PR TITLE
Test: Add comprehensive tests for the persisted course reducer

### DIFF
--- a/test/reducers/persisted_course.spec.js
+++ b/test/reducers/persisted_course.spec.js
@@ -1,0 +1,41 @@
+import persistedCourse from '../../app/assets/javascripts/reducers/persisted_course';
+import { RECEIVE_COURSE, PERSISTED_COURSE } from '../../app/assets/javascripts/constants';
+
+describe('persistedCourse reducer', () => {
+  it('should return the initial state', () => {
+    expect(persistedCourse(undefined, {})).toEqual({});
+  });
+
+  it('should handle RECEIVE_COURSE', () => {
+    const initialState = {};
+    const courseData = { id: 1, title: 'Course Title' };
+
+    const action = {
+      type: RECEIVE_COURSE,
+      data: { course: courseData }
+    };
+
+    expect(persistedCourse(initialState, action)).toEqual(courseData);
+  });
+
+  it('should handle PERSISTED_COURSE', () => {
+    const initialState = {};
+    const courseData = { id: 1, title: 'Course Title' };
+
+    const action = {
+      type: PERSISTED_COURSE,
+      data: { course: courseData }
+    };
+
+    expect(persistedCourse(initialState, action)).toEqual(courseData);
+  });
+
+  it('should handle unknown action type', () => {
+    const initialState = { id: 1, title: 'Course Title' };
+    const action = {
+      type: 'UNKNOWN_ACTION'
+    };
+
+    expect(persistedCourse(initialState, action)).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
## What this PR does
This PR addresses #2082 by adding comprehensive tests for the persisted course reducer.

## File changed
Created a new file test/reducers/persisted_course.spec.js that covers all test cases for this reducer.

All tests were run with both npm test and yarn test, and they passed successfully.
Confirmed that npm run lint-non-build passes without errors.
Any feedback will be highly appreciated. Thank you.