### PR TITLE
Feature: Allows Programs to be Deleted before Removing Campaigns on Programs & Events Dashboard #6012

### DIFF
--- a/app/assets/javascripts/actions/course_actions.js
+++ b/app/assets/javascripts/actions/course_actions.js
@@ -141,6 +141,12 @@ export const deleteCourse = courseSlug => (dispatch) => {
     .catch(data => dispatch({ type: API_FAIL, data }));
 };
 
+export const removeAndDeleteCourse = (courseSlug, campaignTitle, campaignId, campaignSlug) => (dispatch) => {
+  return API.removeAndDeleteCourse(courseSlug, campaignTitle, campaignId, campaignSlug)
+    .then(data => dispatch({ type: 'DELETED_COURSE', data }))
+    .catch(data => dispatch({ type: API_FAIL, data }));
+};
+
 export const notifyOverdue = courseSlug => (dispatch) => {
   return API.notifyOverdue(courseSlug)
     .then(data => dispatch({ type: 'NOTIFIED_OVERDUE', data }))

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -58,8 +58,8 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
     const enteredTitle = prompt(I18n.t('courses.confirm_course_deletion', { title: course.title }));
     // Check if enteredTitle is not null before calling trim.
     if (enteredTitle !== null && enteredTitle.trim() === course.title.trim()) {
-      // If in Wiki Ed or course has no campaigns, delete the course directly; otherwise, remove from campaign first.
-      if (Features.wikiEd || !course.campaigns || course.campaigns.length === 0) {
+      // If course has no campaigns, delete the course directly; otherwise, remove from campaign first.
+      if (!course.campaigns || course.campaigns.length === 0) {
         return dispatch(deleteCourse(courseSlug));
       }
       const campaign = course.campaigns[0];

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -54,11 +54,6 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
   };
 
   const deleteCourseFunc = () => {
-    // The action is only available once a course has been removed from all campaigns.
-    if (course.published) {
-      return alert(I18n.t('courses.delete_course_instructions'));
-    }
-
     const enteredTitle = prompt(I18n.t('courses.confirm_course_deletion', { title: course.title }));
     // Check if enteredTitle is not null before calling trim.
     if (enteredTitle !== null && enteredTitle.trim() === course.title.trim()) {
@@ -112,7 +107,7 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
     // so that users can see the instructions for how to enable deletion.
     if ((user.isAdvancedRole || user.admin) && (!course.published || !Features.wikiEd)) {
       controls.push((
-        <div title={I18n.t('courses.delete_course_instructions')} key="delete" className="available-action">
+        <div title={Features.wikiEd ? I18n.t('courses.delete_course_instructions') : undefined} key="delete" className="available-action">
           <button className="button danger" onClick={deleteCourseFunc}>
             {CourseUtils.i18n('delete_course', course.string_prefix)}
           </button>

--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -11,7 +11,7 @@ import CourseStatsDownloadModal from './course_stats_download_modal.jsx';
 import EmbedStatsButton from './embed_stats_button.jsx';
 import CloneCourseButton from './clone_course_button.jsx';
 import { enableAccountRequests } from '../../actions/new_account_actions.js';
-import { needsUpdate, linkToSalesforce, updateSalesforceRecord, deleteCourse } from '../../actions/course_actions';
+import { needsUpdate, linkToSalesforce, updateSalesforceRecord, deleteCourse, removeAndDeleteCourse } from '../../actions/course_actions';
 import { STUDENT_ROLE, ONLINE_VOLUNTEER_ROLE } from '../../constants/user_roles';
 import { removeUser } from '../../actions/user_actions';
 import NotifyInstructorsButton from './notify_instructors_button.jsx';
@@ -54,10 +54,19 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
   };
 
   const deleteCourseFunc = () => {
+    const courseSlug = course.slug;
     const enteredTitle = prompt(I18n.t('courses.confirm_course_deletion', { title: course.title }));
     // Check if enteredTitle is not null before calling trim.
     if (enteredTitle !== null && enteredTitle.trim() === course.title.trim()) {
-      return dispatch(deleteCourse(course.slug));
+      // If in Wiki Ed or course has no campaigns, delete the course directly; otherwise, remove from campaign first.
+      if (Features.wikiEd || !course.campaigns || course.campaigns.length === 0) {
+        return dispatch(deleteCourse(courseSlug));
+      }
+      const campaign = course.campaigns[0];
+      const campaignTitle = campaign.title;
+      const campaignId = campaign.id;
+      const campaignSlug = campaign.slug;
+      return dispatch(removeAndDeleteCourse(courseSlug, campaignTitle, campaignId, campaignSlug));
     } else if (enteredTitle) {
       return alert(I18n.t('courses.confirm_course_deletion_failed', { title: enteredTitle }));
     }
@@ -103,8 +112,6 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
       controls.push((<div key="search" className="available-action"><a href={`/tickets/dashboard?search_by_course=${course.slug}`} className="button">{I18n.t('courses.search_all_tickets_for_this_course')}</a></div>));
     }
     // If course is not published, show the 'delete' button to instructors and admins.
-    // Show a disabled version of it on P&E Dashboard even if a course is published,
-    // so that users can see the instructions for how to enable deletion.
     if ((user.isAdvancedRole || user.admin) && (!course.published || !Features.wikiEd)) {
       controls.push((
         <div title={Features.wikiEd ? I18n.t('courses.delete_course_instructions') : undefined} key="delete" className="available-action">

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -391,8 +391,25 @@ const API = {
       response.responseText = data;
       throw response;
     }
+    const result = await response.json();
     window.location = '/';
-    return response.json();
+    return result;
+  },
+
+  async removeAndDeleteCourse(courseSlug, campaignTitle, campaignId, campaignSlug) {
+    const response = await request(`/courses/${courseSlug}.json/delete_from_campaign?campaign_title=${campaignTitle}&campaign_id=${campaignId}&campaign_slug=${campaignSlug}`, {
+      method: 'DELETE'
+    });
+
+    if (!response.ok) {
+      logErrorMessage(response);
+      const data = await response.text();
+      response.responseText = data;
+      throw response;
+    }
+    const result = await response.json();
+    window.location = '/';
+    return result;
   },
 
   async deleteBlock(block_id) {


### PR DESCRIPTION
## What this PR does
Solves Issue #6012 and https://phabricator.wikimedia.org/T378013 by removing the requirement to remove campaigns before deleting a program is the behavior on Programs & Events Dashboard.

## Changes Made:
1. When a user attempts to delete a program with the 'Delete Program' button:
-If in the Wiki Ed environment or if the program has no associated campaigns, it is deleted immediately using the normal `deleteCourse` actions.
-If in a non-Wiki Ed environment i.e on Program and Events Dashboard and the program is linked to campaigns, it removes the program from the associated campaign(s) before deletion, using new `removeAndDeleteCourse` actions.

This makes deleting courses more flexible by eliminating the previous need to first remove all campaign associations manually.
It however retains the requirement to remove campaigns before deleting a course if in wiki_education mode.

2. Alerts and hover-activated titles showing course delete instructions removed on the Program & Events Dashboard

## Screenshots:

Before:
Could not delete programs that were associated with campaigns, no `DeleteCourseWorker` jobs seen in sidekiq

![before alert, tooltip](https://github.com/user-attachments/assets/fa04952f-4fb5-4eab-95ee-b91618a6b0fe)

After:
Can now delete programs that are associated with campaigns, DeleteCourseWorker jobs seen in sidekiq and sentry

![after working now](https://github.com/user-attachments/assets/76838ba8-8223-4381-b257-d0628b363fe6)

Evidence of Deletion in Sidekiq:
![world reg cropped](https://github.com/user-attachments/assets/9feffe18-e9c3-4ecb-8bd0-f17b21da0fba)

Evidence of Deletion in Sentry:
![image](https://github.com/user-attachments/assets/678fd515-8eed-4be0-9917-320992f88b6f)

