### PR TITLE
Fix: Relax the validation on term (when) field on create a course form

### DIFF
--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -176,6 +176,7 @@ const CourseClonedModal = createReactClass({
 
     const dateProps = CourseDateUtils.dateProps(this.state.course);
     const saveDisabled = this.saveEnabled() ? '' : 'disabled';
+    const isRequiredTermField = this.props.course.type === 'ClassroomProgramCourse';
 
     // Form components that are conditional on course type
     let expectedStudents;
@@ -339,6 +340,7 @@ const CourseClonedModal = createReactClass({
           onChange={this.updateCourse}
           value={this.state.course.term}
           value_key="term"
+          required={isRequiredTermField}
           validation={CourseUtils.courseSlugRegex()}
           editable={true}
           label={CourseUtils.i18n('creator.course_term', i18nPrefix)}

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -339,7 +339,6 @@ const CourseClonedModal = createReactClass({
           onChange={this.updateCourse}
           value={this.state.course.term}
           value_key="term"
-          required={true}
           validation={CourseUtils.courseSlugRegex()}
           editable={true}
           label={CourseUtils.i18n('creator.course_term', i18nPrefix)}


### PR DESCRIPTION
## What this PR does
This PR addresses  issue #5837 where the "Term" field in the Wiki Education Dashboard's course creation form. Previously, the validation for this field was overly strict. This update relaxes the validation criteria
## Screenshots
Before:

https://github.com/user-attachments/assets/cc7c0157-3f74-4c01-9cd9-67ce361f6d4a



After:

https://github.com/user-attachments/assets/ab169d8e-8253-4aa0-af2e-d33a145ae8e8

