### PR TITLE
Implement error logging in update_average_pageviews method in UpdateCourseStats

### DIFF
--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -66,7 +66,7 @@ class UpdateCourseStats
   end
 
   def update_average_pageviews
-    AverageViewsImporter.update_outdated_average_views(@course.articles)
+    AverageViewsImporter.update_outdated_average_views(@course.articles, update_service: self)
     log_update_progress :average_pageviews_updated
   end
 

--- a/lib/importers/average_views_importer.rb
+++ b/lib/importers/average_views_importer.rb
@@ -4,7 +4,7 @@ require_dependency "#{Rails.root}/lib/wiki_pageviews"
 
 class AverageViewsImporter
   DAYS_UNTIL_OUTDATED = 14
-  def self.update_outdated_average_views(articles)
+  def self.update_outdated_average_views(articles, update_service: nil)
     articles.where(average_views_updated_at: nil).or(
       articles.where('average_views_updated_at < ?', DAYS_UNTIL_OUTDATED.days.ago)
     ).includes(:wiki).find_in_batches(batch_size: 200) do |article_group|

--- a/lib/importers/average_views_importer.rb
+++ b/lib/importers/average_views_importer.rb
@@ -5,6 +5,7 @@ require_dependency "#{Rails.root}/lib/wiki_pageviews"
 class AverageViewsImporter
   DAYS_UNTIL_OUTDATED = 14
   def self.update_outdated_average_views(articles, update_service: nil)
+    Rails.logger.info("Updating average views for articles with update_service: #{update_service}")
     articles.where(average_views_updated_at: nil).or(
       articles.where('average_views_updated_at < ?', DAYS_UNTIL_OUTDATED.days.ago)
     ).includes(:wiki).find_in_batches(batch_size: 200) do |article_group|

--- a/spec/features/update_course_stats_average_views_importer_spec.rb
+++ b/spec/features/update_course_stats_average_views_importer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe UpdateCourseStats do
-  let(:course) { create(:course) } 
+  let(:course) { create(:course) }
   let!(:article1) { create(:article) }
   let!(:article2) { create(:article) }
   let(:update_service) { described_class.new(course) }
@@ -15,7 +15,7 @@ RSpec.describe UpdateCourseStats do
   describe '#update_average_pageviews' do
     it 'updates outdated average views for the course articles' do
       expect(AverageViewsImporter).to receive(:update_outdated_average_views)
-        .with(course.articles, update_service: update_service)
+        .with(course.articles, update_service:)
 
       # Call the update_average_pageviews method directly
       update_service.send(:update_average_pageviews)

--- a/spec/features/update_course_stats_average_views_importer_spec.rb
+++ b/spec/features/update_course_stats_average_views_importer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UpdateCourseStats do
+  let(:course) { create(:course) } 
+  let!(:article1) { create(:article) }
+  let!(:article2) { create(:article) }
+  let(:update_service) { described_class.new(course) }
+
+  before do
+    course.articles << [article1, article2]
+  end
+
+  describe '#update_average_pageviews' do
+    it 'updates outdated average views for the course articles' do
+      expect(AverageViewsImporter).to receive(:update_outdated_average_views)
+        .with(course.articles, update_service: update_service)
+
+      # Call the update_average_pageviews method directly
+      update_service.send(:update_average_pageviews)
+    end
+
+    it 'logs the progress of average pageviews updates' do
+      # Set up a spy on log_update_progress
+      expect(update_service).to receive(:log_update_progress).with(:average_pageviews_updated)
+
+      update_service.send(:update_average_pageviews)
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses issue #4340 by extending error logging during the average pageviews update process in the `UpdateCourseStats service`. The method `update_average_pageviews` now includes the `update_service` parameter when calling `AverageViewsImporter.update_outdated_average_views`, allowing for improved tracking of errors and Sentry IDs during the course data update process.

I have implemented an isolated test (`update_course_stats_average_views_importer_spec.rb`) for the `update_average_pageviews` method within the UpdateCourseStats class. The test validates two main functionalities:

-Updating Outdated Average Views: The test ensures that the `AverageViewsImporter.update_outdated_average_views` method is called with the correct parameters, specifically checking that it receives the list of articles associated with the course and the `update_service` instance.

-Logging Progress: The test verifies that the progress of updating average pageviews is logged correctly. This includes checking that the `log_update_progress` method is invoked with the expected symbol` :average_pageviews_updated`.


![image](https://github.com/user-attachments/assets/5b3bbc49-27d3-49c0-b264-bec820e8e31a)
