### PR TITLE
Feature: Add tooltip to Article Views metrics on relevant pages #6024

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign_stats.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_stats.jsx
@@ -49,6 +49,8 @@ const CampaignStats = ({ campaign }) => {
         stat={campaign.view_sum_human}
         statMsg={I18n.t('metrics.view_count_description')}
         renderZero={true}
+        info={I18n.t('metrics.view_count_doc')}
+        infoId="campaign-views-info"
       />
 
       <OverviewStat

--- a/app/assets/javascripts/components/overview/overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/overview_stats.jsx
@@ -136,6 +136,8 @@ const OverviewStats = ({ course }) => {
         stat={course.view_count}
         statMsg={I18n.t(`metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'view_count_description')}`)}
         renderZero={false}
+        info={I18n.t(`metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'view_count_doc')}`)}
+        infoId="view-count-info"
       />
       {uploadCount}
     </div>

--- a/app/assets/javascripts/components/tagged_courses/TaggedCoursesStats.jsx
+++ b/app/assets/javascripts/components/tagged_courses/TaggedCoursesStats.jsx
@@ -65,6 +65,8 @@ const TaggedCoursesStats = () => {
           stat={tagged_courses_stats.view_sum_human}
           statMsg={I18n.t('metrics.view_count_description')}
           renderZero={true}
+          info={I18n.t('metrics.view_count_doc')}
+          infoId="tagged-courses-article-views-info"
         />
         <OverviewStat
           id="articles-edited"

--- a/app/views/courses/_header_stats.html.haml
+++ b/app/views/courses/_header_stats.html.haml
@@ -23,8 +23,12 @@
     .tooltip.dark
       %p= t("metrics.references_doc")
   .stat-display__stat
-    .stat-display__value= number_to_human presenter.courses.sum(:view_sum)
+    .stat-display__value
+      = number_to_human presenter.courses.sum(:view_sum)
+      %img{:src => "/assets/images/info.svg", :alt => "tooltip default logo"}
     %small= t("metrics.view_count_description")
+    .tooltip.dark
+      %p= t("metrics.view_count_doc")
   .stat-display__stat
     .stat-display__value= number_to_human presenter.courses.sum(:article_count)
     %small= t("metrics.articles_edited")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1129,6 +1129,7 @@ en:
     view_count_description: Article Views
     view_count_description_wikidata: Item Views
     view_count_doc: This is the estimated number of views based on a 30-day average for each article, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
+    view_count_doc_wikidata: This is the estimated number of views based on a 30-day average for each item, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
     view_data_unavailable: No view data available
     view: Views
     wiki_ed_help: Use the 'Get Help' button to report a problem.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1128,6 +1128,7 @@ en:
       other: total usages across languages
     view_count_description: Article Views
     view_count_description_wikidata: Item Views
+    view_count_doc: This is the estimated number of views based on a 30-day average for each article, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
     view_data_unavailable: No view data available
     view: Views
     wiki_ed_help: Use the 'Get Help' button to report a problem.


### PR DESCRIPTION
## What this PR does
Resolves Issue #6024 by adding a tooltip for Article Views to provide users with context about how the numbers are calculated.

Note: I added the tooltip  only to pages where 'References Added' also has a tooltip and the `metrics.view_count_description` specifically is used

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/8024f393-0aa4-4e4a-bbee-53f8503e73c1)

For wikidata:
![image](https://github.com/user-attachments/assets/99bcf50b-66e8-40f9-8a18-e26522f1fa5f)




After:
![image](https://github.com/user-attachments/assets/0ebde880-2dd0-4d95-b69b-9cf4de9dd1d2)

For wikidata:

![image](https://github.com/user-attachments/assets/e79c8267-0c8b-497f-973f-a76ace0fbc20)


