### PR TITLE
[Data rearchitecture] Improve logs to debug updates

### DIFF
--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -1,25 +1,30 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 # Ensures that the necessary timeslices are created prior to a new update
 # of the course statistics.
 class PrepareTimeslices
   def initialize(course)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
+    @debugger = UpdateDebugger.new(@course)
   end
 
   # Deletes all existing timeslices and recreates them from scratch.
   def recreate_timeslices
+    @debugger.log_update_progress :recreate_timeslices_start
     @timeslice_manager.delete_timeslices_for_deleted_course_wikis(@course.wikis.pluck(:wiki_id))
     # Destroy articles courses records to re-create article courses timeslices, except for
     # untracked articles courses so that we don't miss they're untracked.
     @course.articles_courses.tracked.destroy_all
     @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
+    @debugger.log_update_progress :recreate_timeslices_end
   end
 
   # Updates timeslices, making changes based on modifications to course data,
   # such as some wiki/users were added or removed, the start/end course dates changed.
   def adjust_timeslices
+    @debugger.log_update_progress :adjust_timeslices_start
     # Ensure initial timeslices are created if this is the first course update
     unless @course.was_course_ever_updated?
       @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
@@ -29,5 +34,6 @@ class PrepareTimeslices
     UpdateTimeslicesUntrackedArticle.new(@course).run
     UpdateTimeslicesCourseWiki.new(@course).run
     UpdateTimeslicesCourseDate.new(@course).run
+    @debugger.log_update_progress :adjust_timeslices_end
   end
 end

--- a/lib/data_cycle/update_debugger.rb
+++ b/lib/data_cycle/update_debugger.rb
@@ -7,7 +7,6 @@ class UpdateDebugger
 
   def log_update_progress(step)
     return unless debug?
-    # puts "#{@course.title} update: #{step}"
     @sentry_logs ||= {}
     @sentry_logs[step] = Time.zone.now
     Sentry.capture_message "#{@course.title} update: #{step}",

--- a/lib/data_cycle/update_debugger.rb
+++ b/lib/data_cycle/update_debugger.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UpdateDebugger
+  def initialize(course)
+    @course = course
+  end
+
+  def log_update_progress(step)
+    return unless debug?
+    # puts "#{@course.title} update: #{step}"
+    @sentry_logs ||= {}
+    @sentry_logs[step] = Time.zone.now
+    Sentry.capture_message "#{@course.title} update: #{step}",
+                           level: 'warning',
+                           extra: { logs: @sentry_logs }
+  end
+
+  def debug?
+    @course.flags[:debug_updates]
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR improves the way of logging update steps for timeslices updates.

## Open questions and concerns
This is for early debugging purposes only. We may implement a better logger in the future.