### PR TITLE
Added real names to the activity tab

### DIFF
--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -3,13 +3,15 @@ import PropTypes from 'prop-types';
 import DiffViewer from './diff_viewer.jsx';
 import CourseUtils from '../../utils/course_utils.js';
 import { formatDateWithTime } from '../../utils/date_utils.js';
+import { trunc } from '../../utils/strings.js';
 
-const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, lastIndex, selectedIndex }) => {
+const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, lastIndex, selectedIndex, student }) => {
   const ratingClass = `rating ${revision.rating}`;
   const ratingMobileClass = `${ratingClass} tablet-only`;
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
   const isWikipedia = revision.wiki.project === 'wikipedia';
+  const showRealName = student.first_name && student.last_name;
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
@@ -24,7 +26,24 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
         {isWikipedia && <div className={ratingMobileClass}><p>{revision.pretty_rating || '-'}</p></div>}
         <a href={revision.article_url} target="_blank" className="inline"><p className="title">{formattedTitle}&nbsp;<small>{subtitle}</small></p></a>
       </td>
-      <td className="desktop-only-tc">{revision.revisor}</td>
+      <td className="desktop-only-tc">
+        {showRealName ? (
+          <span>
+            <strong>{trunc(student.real_name)}</strong>&nbsp;
+            (
+            <a onClick={e => e.preventDefault()}>
+              {revision.revisor}
+            </a>
+            )
+          </span>
+        ) : (
+          <span>
+            <a onClick={e => e.preventDefault()}>
+              {revision.revisor}
+            </a>
+          </span>
+        )}
+      </td>
       <td className="desktop-only-tc">{revision.characters}</td>
       <td className="desktop-only-tc">{revision.references_added}</td>
       <td className="desktop-only-tc date"><a href={revision.url}>{formatDateWithTime(revision.date)}</a></td>
@@ -50,7 +69,8 @@ Revision.propTypes = {
   course: PropTypes.object,
   setSelectedIndex: PropTypes.func,
   lastIndex: PropTypes.number,
-  selectedIndex: PropTypes.number
+  selectedIndex: PropTypes.number,
+  student: PropTypes.object
 };
 
 export default Revision;

--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -11,7 +11,7 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
   const isWikipedia = revision.wiki.project === 'wikipedia';
-  const showRealName = student.first_name && student.last_name;
+  const showRealName = student.real_name;
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">

--- a/app/assets/javascripts/components/revisions/revision_list.jsx
+++ b/app/assets/javascripts/components/revisions/revision_list.jsx
@@ -5,7 +5,7 @@ import Revision from './revision.jsx';
 import CourseUtils from '../../utils/course_utils.js';
 import ArticleUtils from '../../utils/article_utils.js';
 
-const RevisionList = ({ revisions, course, sortBy, wikidataLabels, sort, loaded }) => {
+const RevisionList = ({ revisions, course, sortBy, wikidataLabels, sort, loaded, students }) => {
   const [selectedIndex, setSelectedIndex] = useState(-1);
 
   const showDiff = (index) => {
@@ -22,6 +22,7 @@ const RevisionList = ({ revisions, course, sortBy, wikidataLabels, sort, loaded 
       setSelectedIndex={showDiff}
       lastIndex={revisions.length}
       selectedIndex={selectedIndex}
+      student={students.find(student => student.username === revision.revisor)}
     />
   ));
 
@@ -81,7 +82,8 @@ RevisionList.propTypes = {
   sortBy: PropTypes.func,
   wikidataLabels: PropTypes.object,
   sort: PropTypes.object,
-  loaded: PropTypes.bool
+  loaded: PropTypes.bool,
+  students: PropTypes.array
 };
 
 export default RevisionList;

--- a/app/assets/javascripts/components/revisions/revisions_handler.jsx
+++ b/app/assets/javascripts/components/revisions/revisions_handler.jsx
@@ -8,6 +8,7 @@ import ProgressIndicator from '../common/progress_indicator.jsx';
 import { ARTICLE_FETCH_LIMIT } from '../../constants/revisions.js';
 import Select from 'react-select';
 import sortSelectStyles from '../../styles/sort_select';
+import { getStudentUsers } from '../../selectors/index.js';
 
 const RevisionHandler = ({ course, courseScopedLimit }) => {
   const [isCourseScoped, setIsCourseScoped] = useState(false);
@@ -26,6 +27,7 @@ const RevisionHandler = ({ course, courseScopedLimit }) => {
   const referencesLoaded = useSelector(state => state.revisions.referencesLoaded);
   const assessmentsLoaded = useSelector(state => state.revisions.assessmentsLoaded);
   const courseSpecificReferencesLoaded = useSelector(state => state.revisions.courseSpecificReferencesLoaded);
+  const students = useSelector(state => getStudentUsers(state));
 
   useEffect(() => {
     // sets the title of this tab
@@ -126,7 +128,7 @@ const RevisionHandler = ({ course, courseScopedLimit }) => {
           />
         </div>
       </div>
-      <div className= "revision-list-container">
+      <div className="revision-list-container">
         <RevisionList
           revisions={isCourseScoped ? revisionsDisplayedCourseSpecific : revisionsDisplayed}
           loaded={loaded}
@@ -134,11 +136,12 @@ const RevisionHandler = ({ course, courseScopedLimit }) => {
           sortBy={sortRevisions}
           wikidataLabels={wikidataLabels}
           sort={sort}
+          students={students}
         />
       </div>
-      {!loaded && <Loading/>}
+      {!loaded && <Loading />}
       {loaded && showMoreButton}
-      {loaded && metaDataLoading && <ProgressIndicator message={getLoadingMessage()}/>}
+      {loaded && metaDataLoading && <ProgressIndicator message={getLoadingMessage()} />}
     </div>
   );
 };


### PR DESCRIPTION

**NOTE:** Please review the pull request process before opening your first PR: [WikiEduDashboard Contribution Guide](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process)

## Summary of Changes
This PR enhances the Activity tab by displaying users' real names alongside their usernames, similar to the existing layout in the Students tab.

## Screenshots
**Before:**
![image](https://github.com/user-attachments/assets/9cf3c54d-96d8-4b50-9285-dfa96f7816e4)

**After:**
- **User View:**  
    ![Screenshot from 2024-11-14 22-32-32](https://github.com/user-attachments/assets/2cbfcf5d-299d-4fb0-8f2b-fb5628f726a8)

- **Admin/Instructor View:**  
  ![Screenshot from 2024-11-14 22-32-41](https://github.com/user-attachments/assets/52a9badb-8dba-48c0-8c0f-20c39baaaf6b)

## Open Questions and Concerns
I apologize for the mistake on my end; I accidentally deleted my comment in the issue where I had mentioned my interest in working on it.

**Related Issue:** #6034