### PR TITLE
[Data rearchitecture] Try to speed up article course cache updates

### DIFF
--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -77,7 +77,8 @@ class UpdateCourseStatsTimeslice
 
   def update_caches
     ActiveRecord::Base.transaction do
-      ArticlesCourses.update_all_caches_from_timeslices(@course.articles_courses)
+      ArticlesCourses.update_required_caches_from_timeslices(@course)
+      # ArticlesCourses.update_all_caches_from_timeslices(@course.articles_courses)
       @debugger.log_update_progress :articles_courses_updated
       CoursesUsers.update_all_caches_from_timeslices(@course.courses_users)
       @debugger.log_update_progress :courses_users_updated

--- a/db/migrate/20241115161634_add_updated_at_index_to_article_course_wiki_timeslices.rb
+++ b/db/migrate/20241115161634_add_updated_at_index_to_article_course_wiki_timeslices.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAtIndexToArticleCourseWikiTimeslices < ActiveRecord::Migration[7.0]
+  def change
+    add_index :article_course_timeslices, [:course_id, :updated_at, :article_id], name: 'article_course_timeslice_by_updated_at'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.boolean "new_article", default: false
     t.boolean "tracked", default: true
     t.index ["article_id", "course_id", "start", "end"], name: "article_course_timeslice_by_article_course_start_and_end", unique: true
+    t.index ["course_id", "updated_at", "article_id"], name: "article_course_timeslice_by_updated_at"
   end
 
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -148,7 +148,7 @@ describe ArticlesCourses, type: :model do
       expect(article_course.character_sum).to eq(9012)
       expect(article_course.references_count).to eq(9)
       expect(article_course.user_ids).to eq([2, 3, user.id])
-      expect(article_course.view_count).to eq(12340)
+      # expect(article_course.view_count).to eq(12340)
       expect(article_course.new_article).to be true
     end
   end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -61,7 +61,7 @@ describe UpdateCourseStatsTimeslice do
       expect(article_course.character_sum).to eq(427)
       expect(article_course.references_count).to eq(-2)
       expect(article_course.user_ids).to eq([user.id])
-      expect(article_course.view_count).to eq(3)
+      # expect(article_course.view_count).to eq(3)
     end
 
     it 'updates course user caches' do
@@ -94,7 +94,7 @@ describe UpdateCourseStatsTimeslice do
       expect(course.references_count).to eq(-2)
       expect(course.revision_count).to eq(29)
       # TODO: view_sum should be 918. See issue #5911
-      expect(course.view_sum).to eq(912)
+      # expect(course.view_sum).to eq(912)
       expect(course.user_count).to eq(1)
       expect(course.trained_count).to eq(1)
       # TODO: update recent_revision_count


### PR DESCRIPTION
## What this PR does
After running some course updates on the data-rearchitecture instance for a heavy course (Pharmacology_at_Bar_Ilan_University_-_2024), I noticed that updating the caches for every article course takes ~ 40 minutes. According to [production](https://outreachdashboard.wmflabs.org/courses/Bar_Ilan_University/Pharmacology_at_Bar_Ilan_University_-_2024/home), Pharmacology at Bar Ilan University - 2024 course has 63.4K articles courses. With that number of articles courses, I think it’s reasonable for the `ArticlesCourses.update_all_caches_from_timeslices(@course.articles_courses)` step to take a lot of time. While updating caches for a specific article course is not a heavy task, we need to retrieve all its timeslices, and with 63.4K articles courses, this means (at least) 63.4k queries.

In order to try to speed up the cache update for articles courses I'm trying the following strategy:
- Instead of updating every article course cache at any single course update, I retrieve the articles that have at least one timeslice that was updated after the last course update. That means, we only update caches for articles courses that have any new revision. If no timeslice for that article was updated after the last course update, that means that there were no new revisions in the last revision ingestion, so we don't need to re-calculate the cache for that article. For heavy courses with thousands of articles, this should reduce the amount of updated caches considerably. Notice that while the course has many articles, most of the articles have nothing more than a handful of revisions associated with it, so most of the time there is no point in updating its cache.
- A new index is added to the article_course_timeslices table to retrieve the articles that require a cache update quickly.
- `view_count` is no longer calculated for articles courses when updating its caches. If this strategy speeds up the update process, then we can revisit how to calculate `view_count`. 

## Open questions and concerns
As I'm not entirely sure this is going to work, I commented some lines of code (didn't remove anything). After testing this in my instance with heavy courses, I'll clean the code.