### PR TITLE
Incorporate new wikidatadiffanalyzer version 2.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'chartkick' # Used for plots in Rails views
 gem 'rack-cors', require: 'rack/cors' # Used for allowing cross-domain requests
 ### System utilities
 gem 'pandoc-ruby' # Text converter, for markdown<->html<->wikitext conversions
-gem 'wikidata-diff-analyzer' # Used for analyzing Wikidata edits
+gem 'wikidata-diff-analyzer', git: 'https://github.com/WikiEducationFoundation/wikidata-diff-analyzer'# Used for analyzing Wikidata edits
 
 ### Platform-specific fixes
 # You might need to uncomment these on Windows if you aren't using WSL.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,17 @@ GIT
       rails (>= 3.2.13)
 
 GIT
+  remote: https://github.com/WikiEducationFoundation/wikidata-diff-analyzer
+  revision: 22e5dbe0de3584ec8858ce2058e6f97cfc9d2f77
+  specs:
+    wikidata-diff-analyzer (2.0.3)
+      json (~> 2.1)
+      mediawiki_api (~> 0.7.0)
+      rake (~> 13.0)
+      rspec (~> 3.0)
+      rubocop (~> 1.21)
+
+GIT
   remote: https://github.com/ragesoss/mediawiki-ruby-api
   revision: f91ca9e7940a5ad22282d5fe714fbf2160815be2
   branch: master
@@ -589,12 +600,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wikidata-diff-analyzer (2.0.2)
-      json (~> 2.1)
-      mediawiki_api (~> 0.7.0)
-      rake (~> 13.0)
-      rspec (~> 3.0)
-      rubocop (~> 1.21)
     will_paginate (3.3.1)
     x25519 (1.0.10)
     xpath (3.2.0)
@@ -693,7 +698,7 @@ DEPENDENCIES
   validates_email_format_of
   vcr
   webmock
-  wikidata-diff-analyzer
+  wikidata-diff-analyzer!
   will_paginate
   x25519
 


### PR DESCRIPTION
## What this PR does
Updates the wikidata-diff-analyzer gem

## Screenshots
Before:
![before change](https://github.com/user-attachments/assets/38c3c58f-c25c-4e9d-b514-1f830187155f)


After:
![after change](https://github.com/user-attachments/assets/c29c8ead-e108-47e1-a3ba-cde8e85ec441)

where test.rb:
```
require 'wikidata-diff-analyzer'

revision_ids = [2266123021, 2266341034, 2266123060, 2266123123, 2266123148,
2266123175, 2266123210, 2266123270, 2266123325, 2266123373,
2266123418, 2266341148, 2266123442, 2266123459, 2266123479,
2266123502, 2266123529, 2266123536, 2266123548, 2266123562,
2266123568, 2266341782, 2266123581, 2266123596, 2266123602] # Replace with your actual revision IDs

analyzed_revisions = WikidataDiffAnalyzer.analyze(revision_ids)[:diffs]
```
