### PR TITLE
[Data rearchitecture] Try to speed up pre-update process

### DIFF
--- a/app/services/update_timeslices_untracked_article.rb
+++ b/app/services/update_timeslices_untracked_article.rb
@@ -41,11 +41,17 @@ class UpdateTimeslicesUntrackedArticle
 
   def retrack(article_ids)
     return if article_ids.empty?
+
+    # Most of the time there are no untracked timeslices, so we can skip the retrack step
+    has_untracked_timeslices = @course.article_course_timeslices.exists?(tracked: false)
+    return unless has_untracked_timeslices
+
     @article_course_timeslices_to_retrack = ArticleCourseTimeslice
                                             .for_course_and_article(@course, article_ids)
                                             .where(tracked: false)
     # Only reprocess those non-empty timeslices
     non_empty = @article_course_timeslices_to_retrack.where.not(user_ids: nil)
+
     # Mark course wiki timeslices that needs to be re-proccesed
     wikis_and_starts = @timeslice_manager.get_wiki_and_start_dates_to_reprocess(non_empty)
     @timeslice_manager.update_course_wiki_timeslices_that_need_update(wikis_and_starts)

--- a/db/migrate/20241118190824_add_tracked_index_to_article_course_timeslices.rb
+++ b/db/migrate/20241118190824_add_tracked_index_to_article_course_timeslices.rb
@@ -1,0 +1,5 @@
+class AddTrackedIndexToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
+  def change
+    add_index :article_course_timeslices, [:course_id, :tracked], name: 'article_course_timeslice_by_tracked'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.boolean "new_article", default: false
     t.boolean "tracked", default: true
     t.index ["article_id", "course_id", "start", "end"], name: "article_course_timeslice_by_article_course_start_and_end", unique: true
+    t.index ["course_id", "tracked"], name: "article_course_timeslice_by_tracked"
     t.index ["course_id", "updated_at", "article_id"], name: "article_course_timeslice_by_updated_at"
   end
 


### PR DESCRIPTION
## What this PR does
This PR adds a new index to `article_course_timeslices` table to try to speed up the pre-update process.

I noticed that for some heavy courses like [Pharmacology at Bar Ilan University](https://outreachdashboard.wmflabs.org/courses/Bar_Ilan_University/Pharmacology_at_Bar_Ilan_University_-_2024/home) or [Denkmal-Cup](https://outreachdashboard.wmflabs.org/courses/WLM/Denkmal-Cup_(2024)/home) the pre-update process takes 4 minutes even though no course data changed (no new dates, no new wikis, no new users, no new untracked articles). The heaviest queries are those that involve `article_course_timeslices` table, so I added a new index to speed up this task.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
