### PR TITLE
chore: remove explicit devTools config, use default behavior

### DIFF
--- a/app/assets/javascripts/components/util/create_store.js
+++ b/app/assets/javascripts/components/util/create_store.js
@@ -43,8 +43,6 @@ export const getStore = () => {
       immutableCheck: enableMutationChecks,
       serializableCheck: enableMutationChecks,
     }),
-    // Enable Redux DevTools
-    devTools: true
   });
 
   return store;


### PR DESCRIPTION
## What this PR does

Removes the explicit devTools configuration from the Redux store, as [configureStore enables it by default.
](https://redux.js.org/tutorials/essentials/part-3-data-flow#creating-the-store)

![Screenshot from 2024-11-20 13-27-33](https://github.com/user-attachments/assets/698e7335-1236-4b30-a496-46c4b54fd418)

Before:



https://github.com/user-attachments/assets/4c3a2dc6-83f1-4380-8f37-209fbddadaa8



After:


https://github.com/user-attachments/assets/7c0044bb-b8c8-4543-b454-bd78ed34d0ee

