### PR TITLE
Add links to student articles in revision component

### DIFF
--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -4,16 +4,20 @@ import DiffViewer from './diff_viewer.jsx';
 import CourseUtils from '../../utils/course_utils.js';
 import { formatDateWithTime } from '../../utils/date_utils.js';
 import { trunc } from '../../utils/strings.js';
+import withRouter from '@components/util/withRouter.jsx';
 
-const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, lastIndex, selectedIndex, student }) => {
+const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, lastIndex, selectedIndex, student, router }) => {
   const ratingClass = `rating ${revision.rating}`;
   const ratingMobileClass = `${ratingClass} tablet-only`;
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
   const isWikipedia = revision.wiki.project === 'wikipedia';
   const showRealName = student.real_name;
-  const url = `/courses/${course.slug}/students/articles/${encodeURIComponent(student.username)}`;
 
+  const openStudentDetails = () => {
+    const url = `/courses/${course.slug}/students/articles/${encodeURIComponent(student.username)}`;
+    router.navigate(url);
+  };
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
@@ -33,14 +37,22 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
           <span>
             <strong>{trunc(student.real_name)}</strong>&nbsp;
             (
-            <a href={url}>
+            <a
+              onClick={openStudentDetails} style={{
+                cursor: 'pointer'
+              }}
+            >
               {revision.revisor}
             </a>
             )
           </span>
         ) : (
           <span>
-            <a href={url}>
+            <a
+              onClick={openStudentDetails} style={{
+                cursor: 'pointer'
+              }}
+            >
               {revision.revisor}
             </a>
           </span>
@@ -75,4 +87,4 @@ Revision.propTypes = {
   student: PropTypes.object
 };
 
-export default Revision;
+export default withRouter(Revision);

--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -12,6 +12,8 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
   const isWikipedia = revision.wiki.project === 'wikipedia';
   const showRealName = student.real_name;
+  const url = `/courses/${course.slug}/students/articles/${encodeURIComponent(student.username)}`;
+
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
@@ -31,14 +33,14 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
           <span>
             <strong>{trunc(student.real_name)}</strong>&nbsp;
             (
-            <a onClick={e => e.preventDefault()}>
+            <a href={url}>
               {revision.revisor}
             </a>
             )
           </span>
         ) : (
           <span>
-            <a onClick={e => e.preventDefault()}>
+            <a href={url}>
               {revision.revisor}
             </a>
           </span>


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This PR adds clickable username links to the activity pages on both the admin and user sides of the application.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:

https://github.com/user-attachments/assets/44de80a6-efb5-42ce-8fdd-6ae9ef926fad



#6034 
