### PR TITLE
Reduce unnecessary polling for the News feature

### DIFF
--- a/app/assets/javascripts/components/nav/news/news_nav_icon.jsx
+++ b/app/assets/javascripts/components/nav/news/news_nav_icon.jsx
@@ -21,7 +21,7 @@ const NewsNavIcon = ({ setIsOpen }) => {
   };
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchNewsData = async () => {
       try {
         const newsContentList = await API.fetchNews(newsType);
 
@@ -41,12 +41,7 @@ const NewsNavIcon = ({ setIsOpen }) => {
       }
     };
 
-    // Fetch the data and set up a polling interval to fetch data periodically (every 60 seconds)
-    fetchData();
-    const pollInterval = setInterval(fetchData, 60000);
-
-    // Clean up the polling interval when the component unmounts
-    return () => clearInterval(pollInterval);
+    fetchNewsData();
   }, []);
 
   return (


### PR DESCRIPTION
## What this PR does

This PR addresses the issue of frequent polling by the handle_special_faq_query function, which was fetching data for the News feature in the navigation bar every minute. Since new updates to the News feature are infrequent, this behavior was unnecessary and could result in excessive network requests.

## Screenshots
Before:


https://github.com/user-attachments/assets/9648596d-0fa4-4756-b59c-b86b496f5ffe



After:


https://github.com/user-attachments/assets/b867e621-fb35-467d-bfdf-a05317cacc27


