### PR TITLE
Fix campaigns list rendering above recent news section  issue on index page when navigating back via cancel button

### DIFF
--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -1,11 +1,5 @@
 - content_for :after_title, " - #{t("application.my_dashboard")}"
 
--# this is the react root when the route is /course_creator
-- if request.path.include?('/course_creator')
-  #react_root{data: {default_course_type: @pres.default_course_type,
-                   course_string_prefix: Features.default_course_string_prefix,
-                   course_creation_notice: Deadlines.course_creation_notice,
-                   use_start_and_end_times: @pres.default_use_start_and_end_times ? 'true' : 'false'}}
 .container.dashboard
   %header
     %h1= @pres.heading_message
@@ -89,3 +83,10 @@
   - if @pres.campaign_organizer? && !request.path.include?('/course_creator')
     -# this is the react root when at the root page
     #react_root
+    
+-# this is the react root when the route is /course_creator
+- if request.path.include?('/course_creator')
+  #react_root{data: {default_course_type: @pres.default_course_type,
+                   course_string_prefix: Features.default_course_string_prefix,
+                   course_creation_notice: Deadlines.course_creation_notice,
+                   use_start_and_end_times: @pres.default_use_start_and_end_times ? 'true' : 'false'}}


### PR DESCRIPTION
## What this PR does

This pull request fixes an issue where the campaigns list sometimes rendered incorrectly above the Recent News section when navigating back via the cancel button. The campaigns list now consistently appears below Recent News.

## Screenshots

Before:


https://github.com/user-attachments/assets/9900e65a-7b4b-40d5-b0d6-7d19f4a2487e



After:


https://github.com/user-attachments/assets/ce412455-3a45-4e0a-afaf-a949278eaff6



## Cause of Bug :

The issue occurred because, in the HAML file, the HTML for the campaigns list was placed above the HTML for the Recent News section. This behavior was observed when the request path included /course_creator.

