### PR TITLE
[Data rearchitecture] Add debug messages when scheduling course updates

### DIFF
--- a/app/workers/course_data_update_worker.rb
+++ b/app/workers/course_data_update_worker.rb
@@ -14,6 +14,7 @@ class CourseDataUpdateWorker
 
   def perform(course_id)
     course = Course.find(course_id)
+    logger.info "Ignoring #{course.slug} update" if course.very_long_update?
     return if course.very_long_update?
 
     logger.info "Updating course timeslice version: #{course.slug}"

--- a/lib/data_cycle/schedule_course_updates.rb
+++ b/lib/data_cycle/schedule_course_updates.rb
@@ -42,8 +42,12 @@ class ScheduleCourseUpdates
 
     courses_to_update = Course.ready_for_update
 
+    log_message "Courses to update #{courses_to_update.map(&:slug).join(', ')}"
+
     courses_to_update.each do |course|
-      CourseDataUpdateWorker.update_course(course_id: course.id, queue: queue_for(course))
+      queue = queue_for(course)
+      log_message "Set course #{course.slug} to queue #{queue}"
+      CourseDataUpdateWorker.update_course(course_id: course.id, queue:)
 
       # if course isn't updated before, add first update flags
       next if course.flags[:first_update] || course.flags['update_logs']


### PR DESCRIPTION
## What this PR does
This PR adds some logs to debug the queuing process. Course [Denkmal-Cup for Timeslices 1.day](https://data-rearchitecture-test.wmcloud.org/courses/WLM/Denkmal-Cup_for_Timeslices_1.day_(November_2024)#) stops being updated in the data-rearchitecture instance. It looks like at some point the course stops being queued (I don't see its course id in the sidekiq queues) but I don't understand why. 

The course flags are the following. It seems that the updates were working fine until they stopped working. There are not errors in Sentry. If I copy and past the flags from another course, the course starts being updated again, so it looks like it's a problem with its flags?.

```
---
:timeline_enabled: true
:wiki_edits_enabled: false
:online_volunteers_enabled: false
:disable_student_emails: false
:stay_in_sandbox: false
:retain_available_articles: false
edit_settings:
  wiki_course_page_enabled: false
  assignment_edits_enabled: false
  enrollment_edits_enabled: false
academic_system:
format:
:longest_update: 32143
:first_update:
  :enqueued_at: !ruby/object:ActiveSupport::TimeWithZone
    utc: 2024-11-08 15:30:02.531367355 Z
    zone: !ruby/object:ActiveSupport::TimeZone
      name: Etc/UTC
    time: 2024-11-08 15:30:02.531367355 Z
  :queue_name: medium_update
  :queue_latency: 0.0442044734954834
update_logs:
  1160:
    start_time: !ruby/object:DateTime 2024-12-03 04:02:31.831203842 Z
    end_time: !ruby/object:DateTime 2024-12-03 04:05:01.207412641 Z
    sentry_tag_uuid: 491ac272-246a-43e2-8f6d-6b8f22933ac4
    error_count: 0
  1161:
    start_time: !ruby/object:DateTime 2024-12-03 04:15:38.757710257 Z
    end_time: !ruby/object:DateTime 2024-12-03 04:18:07.784323682 Z
    sentry_tag_uuid: 37c2ab77-0edb-4082-833d-7a10a283e9de
    error_count: 0
  1162:
    start_time: !ruby/object:DateTime 2024-12-03 04:34:05.722099863 Z
    end_time: !ruby/object:DateTime 2024-12-03 04:36:38.202288084 Z
    sentry_tag_uuid: b14f8dc2-a028-4ce1-b7f6-8cda2e2eb145
    error_count: 0
  1163:
    start_time: !ruby/object:DateTime 2024-12-03 04:52:34.500014463 Z
    end_time: !ruby/object:DateTime 2024-12-03 04:55:02.522387451 Z
    sentry_tag_uuid: 9351673b-f889-4bcf-983f-9f3b509692c2
    error_count: 0
  1164:
    start_time: !ruby/object:DateTime 2024-12-03 05:10:39.024958401 Z
    end_time: !ruby/object:DateTime 2024-12-03 05:13:13.646999306 Z
    sentry_tag_uuid: d0fda4a8-b726-4f5b-9a58-981a45f464be
    error_count: 0
  1165:
    start_time: !ruby/object:DateTime 2024-12-03 05:29:21.213150678 Z
    end_time: !ruby/object:DateTime 2024-12-03 05:31:59.022351604 Z
    sentry_tag_uuid: c9c48d43-78f8-4bdb-985e-ee64a8fc9bf7
    error_count: 0
  1166:
    start_time: !ruby/object:DateTime 2024-12-03 05:48:08.010244361 Z
    end_time: !ruby/object:DateTime 2024-12-03 05:50:41.286233113 Z
    sentry_tag_uuid: c4933498-145f-476a-a206-8f9261691658
    error_count: 0
  1167:
    start_time: !ruby/object:DateTime 2024-12-03 06:07:12.608655980 Z
    end_time: !ruby/object:DateTime 2024-12-03 06:09:40.390402951 Z
    sentry_tag_uuid: 84bfcd7d-7bc1-459b-b647-2fe603a7e935
    error_count: 0
  1168:
    start_time: !ruby/object:DateTime 2024-12-03 06:26:09.792092168 Z
    end_time: !ruby/object:DateTime 2024-12-03 06:28:43.624442771 Z
    sentry_tag_uuid: d9feaa74-0761-4697-a946-8afa59cca9c5
    error_count: 0
  1169:
    start_time: !ruby/object:DateTime 2024-12-03 06:46:42.047331164 Z
    end_time: !ruby/object:DateTime 2024-12-03 06:49:14.134712702 Z
    sentry_tag_uuid: 3b9c9b98-be63-4c1c-9622-1a9edbf0ab10
    error_count: 0
average_update_delay: 1094
```


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
