### PR TITLE
[Data rearchitecture] Add dependent destroy to timeslices associations

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -130,9 +130,9 @@ class Course < ApplicationRecord
 
   has_many :course_wiki_namespaces, class_name: 'CourseWikiNamespaces', through: :courses_wikis
 
-  has_many :article_course_timeslices
-  has_many :course_user_wiki_timeslices
-  has_many :course_wiki_timeslices
+  has_many :article_course_timeslices, dependent: :destroy
+  has_many :course_user_wiki_timeslices, dependent: :destroy
+  has_many :course_wiki_timeslices, dependent: :destroy
 
   serialize :flags, Hash
 


### PR DESCRIPTION
## What this PR does
Add `dependent: :destroy` to the timeslices associations to ensure they are automatically destroyed when a course is deleted. This aligns with the current behavior in `DeleteCourseWorker` for removing courses (we call `course.destroy`).

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
