### PR TITLE
Refactor components to use navigation utility hook for student details view

### DIFF
--- a/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
@@ -59,9 +59,9 @@ const AssignmentLinks = ({ assignment, courseType, user, course, project, editMo
   let groupMembers;
   if (editors) {
     if (role === ASSIGNED_ROLE) {
-      groupMembers = <GroupMembersLink members={editors} />;
+      groupMembers = <GroupMembersLink members={editors} course={course} />;
     } else {
-      groupMembers = <EditorLink key={`editor-${id}`} editors={editors} />;
+      groupMembers = <EditorLink key={`editor-${id}`} editors={editors} course={course} />;
     }
   }
 

--- a/app/assets/javascripts/components/common/AssignmentLinks/EditorLink.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/EditorLink.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import AssignedToLink from '@components/overview/my_articles/common/AssignedToLink.jsx';
 
-export const EditorLink = ({ editors }) => {
-  return <AssignedToLink members={editors} name="editors" />;
+export const EditorLink = ({ editors, course }) => {
+  return <AssignedToLink members={editors} course={course} name="editors" />;
 };
 
 EditorLink.propTypes = {

--- a/app/assets/javascripts/components/common/AssignmentLinks/GroupMembersLink.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/GroupMembersLink.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import AssignedToLink from '@components/overview/my_articles/common/AssignedToLink.jsx';
 
-export const GroupMembersLink = ({ members }) => {
-  return <AssignedToLink members={members} name="group_members" />;
+export const GroupMembersLink = ({ members, course }) => {
+  return <AssignedToLink members={members} course={course} name="group_members" />;
 };
 
 GroupMembersLink.propTypes = {

--- a/app/assets/javascripts/components/overview/my_articles/common/AssignedToLink.jsx
+++ b/app/assets/javascripts/components/overview/my_articles/common/AssignedToLink.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import useNavigationsUtils from '../../../../hooks/useNavigationUtils';
 
-export const AssignedToLink = ({ name, members }) => {
+export const AssignedToLink = ({ name, members, course }) => {
   if (!members) return null;
 
   const label = <span key="label">{I18n.t(`assignments.${name}`)}: </span>;
   const list = [...members].sort((a, b) => a > b);
+  const { openStudentDetailsView } = useNavigationsUtils();
+
   const links = list.map((username, index, collection) => {
     return (
       <span key={username}>
-        <a href={`/users/${username}`}>
+        <a onClick={() => openStudentDetailsView(course.slug, username)} style={{ cursor: 'pointer' }}>
           {username}
         </a>
         {index < collection.length - 1 ? ', ' : null}

--- a/app/assets/javascripts/components/revisions/revision.jsx
+++ b/app/assets/javascripts/components/revisions/revision.jsx
@@ -5,19 +5,17 @@ import CourseUtils from '../../utils/course_utils.js';
 import { formatDateWithTime } from '../../utils/date_utils.js';
 import { trunc } from '../../utils/strings.js';
 import withRouter from '@components/util/withRouter.jsx';
+import useNavigationsUtils from '../../hooks/useNavigationUtils.js';
 
-const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, lastIndex, selectedIndex, student, router }) => {
+const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, lastIndex, selectedIndex, student }) => {
   const ratingClass = `rating ${revision.rating}`;
   const ratingMobileClass = `${ratingClass} tablet-only`;
   const formattedTitle = CourseUtils.formattedArticleTitle({ title: revision.title, project: revision.wiki.project, language: revision.wiki.language }, course.home_wiki, wikidataLabel);
   const subtitle = wikidataLabel ? `(${CourseUtils.removeNamespace(revision.title)})` : '';
   const isWikipedia = revision.wiki.project === 'wikipedia';
   const showRealName = student.real_name;
+  const { openStudentDetailsView } = useNavigationsUtils();
 
-  const openStudentDetails = () => {
-    const url = `/courses/${course.slug}/students/articles/${encodeURIComponent(student.username)}`;
-    router.navigate(url);
-  };
   return (
     <tr className="revision">
       <td className="tooltip-trigger desktop-only-tc">
@@ -38,7 +36,7 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
             <strong>{trunc(student.real_name)}</strong>&nbsp;
             (
             <a
-              onClick={openStudentDetails} style={{
+              onClick={() => openStudentDetailsView(course.slug, student.username)} style={{
                 cursor: 'pointer'
               }}
             >
@@ -49,7 +47,7 @@ const Revision = ({ revision, index, wikidataLabel, course, setSelectedIndex, la
         ) : (
           <span>
             <a
-              onClick={openStudentDetails} style={{
+              onClick={() => openStudentDetailsView(course.slug, student.username)} style={{
                 cursor: 'pointer'
               }}
             >

--- a/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
@@ -34,6 +34,7 @@ const Student = createReactClass({
     fetchTrainingStatus: PropTypes.func.isRequired,
     minimalView: PropTypes.bool,
     student: PropTypes.object.isRequired,
+    openStudentDetailsView: PropTypes.func.isRequired
   },
 
   setUploadFilters(selectedFilters) {
@@ -44,10 +45,9 @@ const Student = createReactClass({
     return e.stopPropagation();
   },
 
-  openStudentDetails() {
-    const { course, router, student } = this.props;
-    const url = `/courses/${course.slug}/students/articles/${encodeURIComponent(student.username)}`;
-    return router.navigate(url);
+  openStudentDetailsView() {
+    const { course, student, openStudentDetailsView } = this.props;
+    openStudentDetailsView(course.slug, student.username);
   },
 
   _shouldShowRealName() {
@@ -64,7 +64,7 @@ const Student = createReactClass({
     let recentRevisions;
     if (showRecent) {
       recentRevisions = (
-        <td className="desktop-only-tc" onClick={this.openStudentDetails} >
+        <td className="desktop-only-tc" onClick={this.openStudentDetailsView} >
           {student.recent_revisions}
         </td>
       );
@@ -111,7 +111,7 @@ const Student = createReactClass({
 
     return (
       <tr className="students">
-        <td onClick={this.openStudentDetails} style={{ minWidth: '250px' }}>
+        <td onClick={this.openStudentDetailsView} style={{ minWidth: '250px' }}>
           <div className="name">
             <StudentUsername current_user={current_user} student={student} />
           </div>
@@ -123,17 +123,17 @@ const Student = createReactClass({
           <ExerciseProgressDescription student={student} />
           <TrainingProgressDescription student={student} />
         </td>
-        <td className="desktop-only-tc" onClick={this.openStudentDetails}>
+        <td className="desktop-only-tc" onClick={this.openStudentDetailsView}>
           {assignButton}
         </td>
-        <td className="desktop-only-tc" onClick={this.openStudentDetails}>
+        <td className="desktop-only-tc" onClick={this.openStudentDetailsView}>
           {reviewButton}
         </td>
         {recentRevisions}
-        <td className="desktop-only-tc" onClick={this.openStudentDetails}>
+        <td className="desktop-only-tc" onClick={this.openStudentDetailsView}>
           <ContentAdded course={course} student={student} />
         </td>
-        <td className="desktop-only-tc" onClick={this.openStudentDetails}>
+        <td className="desktop-only-tc" onClick={this.openStudentDetailsView}>
           {student.references_count}
         </td>
         <td className="desktop-only-tc">

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentRow.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentRow.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Student from './Student/Student.jsx';
+import useNavigationsUtils from '../../../../hooks/useNavigationUtils.js';
 
 export const StudentRow = ({
   assignments, course, current_user, editAssignments, showRecent, student, wikidataLabels
 }) => {
+  const { openStudentDetailsView } = useNavigationsUtils();
   return (
     <Student
       assignments={assignments}
@@ -15,6 +17,7 @@ export const StudentRow = ({
       showRecent={showRecent}
       student={student}
       wikidataLabels={wikidataLabels}
+      openStudentDetailsView={openStudentDetailsView}
     />
   );
 };

--- a/app/assets/javascripts/hooks/useNavigationUtils.js
+++ b/app/assets/javascripts/hooks/useNavigationUtils.js
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom';
+
+const useNavigationsUtils = () => {
+  const navigate = useNavigate();
+
+  const openStudentDetailsView = (courseSlug, studentUsername) => {
+    const url = `/courses/${courseSlug}/students/articles/${encodeURIComponent(studentUsername)}`;
+    navigate(url);
+  };
+
+  return {
+    openStudentDetailsView,
+  };
+};
+
+export default useNavigationsUtils;


### PR DESCRIPTION
closes #6045

## What this PR does

This pull request introduces the usage of the `useNavigationsUtils hook` in multiple components to enable navigation to the student details view. The hook provides the `openStudentDetailsView function`, which constructs the URL for the single student view page within a course page and navigates to it.

## Screenshots
Before:


https://github.com/user-attachments/assets/bb774d48-39df-45e0-8916-ef4939abdb61



After:

https://github.com/user-attachments/assets/69577c08-3314-4cf3-a962-d0af3f197528

## Open questions and concerns

Additionally, the `ReviewerLink` component, which is supposed to navigate to user profile pages `(/users/USERNAME)`, does not seem to be used anywhere in the codebase (though I’m not 100% sure). However, based on a search through the code, the only place it's mentioned is within the `AssignmentsLinks` component, where it is currently commented out, as shown below:

`// const reviewers = <ReviewerLink key={`reviewers-${id}`} reviewers={assignment.reviewers} />;`



