### PR TITLE
Improve/Fix Accessibility for WeekdayPicker Component for Screen reader

### DIFF
--- a/app/assets/javascripts/components/common/weekday_picker.jsx
+++ b/app/assets/javascripts/components/common/weekday_picker.jsx
@@ -25,7 +25,6 @@ const WeekdayPicker = ({
   style,
   tabIndex,
 
-  ariaModifier,
   modifiers,
 
   locale,
@@ -145,7 +144,7 @@ const WeekdayPicker = ({
 
     dayClassName += customModifiers.map(modifier => ` ${dayClassName}--${modifier}`).join('');
 
-    const ariaSelected = customModifiers.indexOf(ariaModifier) > -1;
+    const ariaSelected = customModifiers.indexOf('selected') > -1;
 
     let tabIndexValue = null;
     if (onWeekdayClick) {
@@ -159,10 +158,20 @@ const WeekdayPicker = ({
     const onMouseEnterHandler = onWeekdayMouseEnter ? e => handleWeekdayMouseEnter(e, weekday, customModifiers) : null;
     const onMouseLeaveHandler = onWeekdayMouseLeave ? e => handleWeekdayMouseLeave(e, weekday, customModifiers) : null;
 
+    const ariaLabelMessage = ariaSelected
+      ? I18n.t('weekday_picker.aria.weekday_selected', { weekday: localeUtils.formatWeekdayLong(weekday), })
+      : I18n.t('weekday_picker.aria.weekday_select', { weekday: localeUtils.formatWeekdayLong(weekday), });
+
+    const ariaLiveMessage = ariaSelected
+      ? I18n.t('weekday_picker.aria.weekday_selected', { weekday: localeUtils.formatWeekdayLong(weekday), })
+      : I18n.t('weekday_picker.aria.weekday_unselected', { weekday: localeUtils.formatWeekdayLong(weekday), });
+
     return (
       <button
-        key={weekday} className={dayClassName} tabIndex={tabIndexValue}
-        aria-pressed={ariaSelected}
+        key={weekday}
+        className={dayClassName}
+        tabIndex={tabIndexValue}
+        aria-label= {ariaLabelMessage}
         onClick={onClickHandler}
         onKeyDown={e => handleDayKeyDown(e, weekday, customModifiers)}
         onMouseEnter={onMouseEnterHandler}
@@ -171,6 +180,10 @@ const WeekdayPicker = ({
         <span title={localeUtils.formatWeekdayLong(weekday)}>
           {localeUtils.formatWeekdayShort(weekday)}
         </span>
+        {/* Aria-live region for screen reader announcements for confirmation of when a week day is selected or unselected */}
+        <div aria-live="assertive" aria-atomic="true" className="sr-WeekdayPicker-aria-live">
+          {ariaLiveMessage}
+        </div>
       </button>
     );
   };
@@ -201,7 +214,6 @@ WeekdayPicker.propTypes = {
   style: PropTypes.object,
   tabIndex: PropTypes.number,
 
-  ariaModifier: PropTypes.string,
   modifiers: PropTypes.object,
 
   locale: PropTypes.string,

--- a/app/assets/stylesheets/modules/_calendar.styl
+++ b/app/assets/stylesheets/modules/_calendar.styl
@@ -172,3 +172,15 @@
 
 .DayPicker--ar
   direction rtl
+
+// CSS for screen reader support for weekday picker
+.sr-WeekdayPicker-aria-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1870,9 +1870,16 @@ en:
         note_edit_cancel_button_focused: "Cancel note edit {{title}}"
         note_delete_button_focused: "Delete the note {{title}}"
         note_edit_mode: "Entered Edit mode for note titled: {{title}}. You can now edit the title and content."
-
+  
   customize_error_message:
     JSONP_request_failed: "The request to fetch data from Wikipedia has timed out. This may be due to a slow internet connection or temporary server issues. Please try again later."
 
   tagged_courses:
     download_csv: 'Download CSV'
+
+  weekday_picker:
+    aria:
+      weekday_select: "{{weekday}} Press Return key to select"
+      weekday_selected: "{{weekday}} Selected Press Return Key to unselect"
+      weekday_unselected: "{{weekday}} Unselected"
+      


### PR DESCRIPTION
closes #6051

## What this PR does

This PR fixes the accessibility of the Calendar and WeekdayPicker components by introducing the `aria-label` and removing `aria-pressed`. And prop `ariaModifier` which was not being used was replaced by  a simple hardcoded string which is used to detect if a "weekday" is selected.


<hr/>

## Cause of the Bug:

The `ariaModifier` prop (of type `PropTypes.string`) required by the WeekdayPicker component was not being passed from the Calendar component or any of its parent components. This prop is essential for determining whether a button has been pressed and updating the `aria-pressed` attribute accordingly. As a result, the `aria-pressed` attribute remained `false` even when the button was pressed because it depended on the correct value of `ariaModifier.` Which was not passed in the first place itself.

<hr/>



## Screenshots

Before:


https://github.com/user-attachments/assets/624f4bbf-298b-4b27-9c6c-64f7376e69fd



After:


https://github.com/user-attachments/assets/1068fde8-25a6-4252-8a63-fb5120ddec8a





## Open questions and concerns

I applied CSS to hide the `aria-live` div (weekday_picker.jsx), using a style similar to that already used for hiding admin notes. Although the two elements use different class names, the CSS properties are the same. I considered using a single shared CSS class for both cases but was uncertain about the best file to place this shared CSS in.