### PR TITLE
Fix: failing test for assigned_article_spec

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,6 +481,7 @@ en:
     active_courses: Active Courses
     add_trainings: Please add student trainings to your assignment timeline. Assigning training modules is an essential part of Wiki Ed's best practices.
     alerts: Alerts
+    does_not_exist: The Item doesn't exist. Create a Sandbox page and assign yourself to that to receive suggestions.
     all_courses: All Courses
     already_enrolled: You are already a part of '%{title}'!
     already_exists: That already exists for this course!

--- a/spec/features/assigned_articles_spec.rb
+++ b/spec/features/assigned_articles_spec.rb
@@ -23,6 +23,8 @@ describe 'Assigned Articles view', type: :feature, js: true do
       visit "/courses/#{course.slug}/articles/assigned"
       expect(page).to have_content('Nancy Tuana')
       find('a', text: 'Feedback').click
+      expect(page).to have_no_content(I18n.t('courses.feedback_loading'))
+      expect(page).to have_selector('textarea.feedback-form')
       find('textarea.feedback-form').fill_in with: 'This is a great article!'
       click_button 'Add Suggestion'
       find('a', text: 'Delete').click


### PR DESCRIPTION
## What this PR does
This PR is a fix to one of the intermittent failing spec ./spec/features/assigned_articles_spec.rb, 
- To ensure this fixed the existing issue, the pages waits for the loading state that manages fetching the users suggestions, to leave the page, for the text area field to be displayed and accessed.
-  Add missing interface message does_not_exist, used in the  feedback modal when a course has no rating

**Files Changed:**
- assigned_article_spec.rb
- en.yml

**ScreenShot**

**Before**
<img width="1668" alt="Screenshot 2024-12-17 at 06 57 11" src="https://github.com/user-attachments/assets/83511dd3-aa23-4abd-82ab-e8f9e602b51a" />

**After:**
<img width="1352" alt="Screenshot 2024-12-17 at 06 58 49" src="https://github.com/user-attachments/assets/d16425db-906a-4630-a5ff-1162438b3f81" />



