### PR TITLE
 Fix Broken Conditionals When Cloning Survey Question Groups

### DIFF
--- a/app/assets/javascripts/surveys/modules/SurveyAdmin.js
+++ b/app/assets/javascripts/surveys/modules/SurveyAdmin.js
@@ -182,7 +182,7 @@ const SurveyAdmin = {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
-        'X-CSRF-Token': SurveyAdmin.$csrf_token.content
+        'X-CSRF-Token': SurveyAdmin.$csrf_token?.content
       },
     }).then(response => response.json())
       .then((data) => {

--- a/spec/features/survey_admin_spec.rb
+++ b/spec/features/survey_admin_spec.rb
@@ -223,7 +223,7 @@ describe 'Survey Administration', type: :feature, js: true do
       expect(page).not_to have_content instructor.username
     end
 
-    it 'correctly clones question groups with conditionals question', js: true do
+    it 'correctly clones question groups with conditional questions', js: true do
       # Create a base question group with conditional questions
 
       # Visit question groups page and create Question Group
@@ -232,7 +232,7 @@ describe 'Survey Administration', type: :feature, js: true do
       fill_in('question_group_name', with: 'Conditional Questions Group')
       page.find('input.button[value="Save Question Group"]').click
 
-      # Create first question
+      # Create the first question
       click_link 'Edit'
       omniclick(find('a.button', text: 'Add New Question'))
       first_question_text = 'Do you like ice cream?'
@@ -242,7 +242,7 @@ describe 'Survey Administration', type: :feature, js: true do
 
       # Create a conditional follow-up question
       omniclick(find('a.button', text: 'Add New Question'))
-      follow_up_question_text = 'What is your favorite flavour?'
+      follow_up_question_text = 'What is your favorite flavor?'
       find('textarea#question_text').set(follow_up_question_text)
       find('textarea#question_answer_options').set("Vanilla\nChocolate")
 
@@ -250,16 +250,16 @@ describe 'Survey Administration', type: :feature, js: true do
       page.find('label', text: 'Conditionally show this question').click
 
       # Wait and verify the conditional elements are present
-      first_question = Rapidfire::Question.find_by(question_text: first_question_text)
+      first_question_record = Rapidfire::Question.find_by(question_text: first_question_text)
 
-      # Use a way to interact with the conditional elements
+      # Interact with conditional elements
       within('.survey__question__conditional-row') do
         # Trigger the conditional select to populate options
         page.find('select[data-conditional-select="true"]').click
 
         # Wait for and select the first question
         option = page.find('select[data-conditional-select="true"] option',
-                           text: first_question.question_text)
+                           text: first_question_record.question_text)
         page.execute_script(
           "arguments[0].selected = true;
           arguments[0].parentNode.dispatchEvent(new Event('change'))", option.native
@@ -267,31 +267,31 @@ describe 'Survey Administration', type: :feature, js: true do
 
         # Select the condition value
         find('select[data-conditional-value-select=""]')
-          .select(first_question.answer_options[/^\s*Yes\b/])
+          .select(first_question_record.answer_options[/^\s*Yes\b/])
       end
 
       # Verify the hidden input has been populated correctly
       hidden_input = page.find('input[data-conditional-field-input="true"]', visible: false)
-      expect(hidden_input.value)
-        .to include("#{first_question.id}|=|#{first_question.answer_options[/^\s*Yes\b/]}|multi")
+      # rubocop:disable Layout/LineLength,Lint/MissingCopEnableDirective
+      expected_conditionals = "#{first_question_record.id}|=|#{first_question_record.answer_options[/^\s*Yes\b/]}|multi"
+      expect(hidden_input.value).to include(expected_conditionals)
 
       page.find('input.button').click
 
       # Visit the question groups page to clone the newly created question group
       visit 'surveys/rapidfire/question_groups'
 
-      # Find the clone link for the newly created question group and click it to clone it
+      # Find and click the clone link for the newly created question group
       within("li#question_group_#{Rapidfire::QuestionGroup.last.id}") do
         click_link 'Clone'
       end
 
-      # Find the Edit link for the cloned question group
+      # Edit the cloned question group
       within("li#question_group_#{Rapidfire::QuestionGroup.last.id}") do
         click_link 'Edit'
       end
 
-      # Find the conditional question of the cloned question group and click edit
-      # If successfully cloned then there should be no error
+      # Edit the conditional question of the cloned group
       within "tr[data-item-id=\"#{Rapidfire::Question.last.id}\"]" do
         click_link 'Edit'
       end
@@ -303,16 +303,16 @@ describe 'Survey Administration', type: :feature, js: true do
       # Verify questions were cloned
       expect(cloned_group.questions.count).to eq(2)
 
-      # Check conditional question
-      conditional_question = cloned_group.questions.detect { |q| q.question_text == follow_up_question_text } # rubocop:disable Layout/LineLength
+      # Check the conditional question
+      conditional_question = cloned_group.questions.detect { |q| q.question_text == follow_up_question_text }
       expect(conditional_question).not_to be_nil
 
       # Verify the conditional logic points to the cloned first question
       cloned_first_question = cloned_group.questions.detect do |q|
         q.question_text == first_question_text
       end
-      expect(conditional_question.conditionals)
-        .to eq("#{cloned_first_question.id}|=|#{cloned_first_question.answer_options[/^\s*Yes\b/]}|multi") # rubocop:disable Layout/LineLength
+      expected_cloned_conditionals = "#{cloned_first_question.id}|=|#{cloned_first_question.answer_options[/^\s*Yes\b/]}|multi"
+      expect(conditional_question.conditionals).to eq(expected_cloned_conditionals)
     end
   end
 end


### PR DESCRIPTION
closes #2418

## What this PR does

Fixes an issue where conditionals in cloned question groups pointed to non-existent questions from the original group by updating them to reference corresponding cloned questions and adding validations to ensure conditionals are valid.

## Cause of the Bug:

The root cause of the issue lies in the cloning process. When a question group is cloned:

- All questions within the group are duplicated, generating new records with new IDs.
- Conditionals are copied directly from the original questions without updating the referenced question IDs to match the new cloned group.
- As a result, conditionals in the cloned group refer to question IDs from the original group, causing broken or invalid behavior in `initConditionals() in SurveyAdmin.js` the line of code which lead to the error is mentioned below.

```
 return $row.find('select').val(`${question_id}`).trigger('change'); 
```


## Changes Implemented

**1.** **Conditional Mapping During Cloning:**

- When a question group is cloned, a mapping is created between the original questions and their cloned counterparts.
- Conditionals in the cloned questions are updated to refer to the corresponding cloned question IDs instead of the original IDs.

**2.** **Validation for Conditionals:**

- Added validation to ensure all conditionals within a question group point to questions that exist within the same group.
- This prevents broken or invalid conditionals from being saved.

**3.** **Fallback Handling:**

- If an original question referenced in a conditional cannot be matched to a cloned question, the conditional is cleared to prevent invalid references.

## Test Description

This test verifies that conditional question groups are correctly cloned, including their conditional logic.

#### Setup:
- Creates a new question group with a conditional follow-up question.
- Configures conditional logic to show the follow-up question only when a specific answer is selected for the first question.

#### Clone Operation:
- Clones the created question group using the "Clone" action.

#### Assertions:
- Ensures the cloned question group exists with the correct number of questions.
- Confirms the conditional logic in the cloned group correctly points to the corresponding cloned questions and values.

This ensures that the cloning functionality preserves all related conditional configurations.


## Screenshots
Before:


https://github.com/user-attachments/assets/0af8d059-22ad-4204-b0b0-cae15dfef81d





After:


https://github.com/user-attachments/assets/a18e45ab-a206-4698-b330-7bc2be7edace


## Open questions and concerns

- When a question group is deleted, the questions belonging to that group still exist in the database. Shouldn't these questions also be deleted ?


https://github.com/user-attachments/assets/6a369517-5c7e-49af-8eb1-e40bfc122d4a



- When a question used by a conditional question is deleted, the conditionals column of the conditional question is not updated. It still references the deleted question instead of being set to NULL. 


https://github.com/user-attachments/assets/10639cdb-aa24-41e6-bd83-82559124daae


