### PR TITLE
Fix: failing test in account_requests_spec 

### DIFF
--- a/spec/features/account_requests_spec.rb
+++ b/spec/features/account_requests_spec.rb
@@ -18,7 +18,10 @@ describe 'Account requests', type: :feature, js: true do
     login_as(instructor)
     visit "/courses/#{course.slug}"
     click_button 'Enable account requests'
-    click_button 'OK'
+    expect(page).to have_selector('.confirm-modal-overlay')
+    within('.confirm-modal') do
+      click_button 'OK'
+    end
     expect(page).to have_content('Account request generation enabled')
   end
 


### PR DESCRIPTION
## What this PR does
This PR fixes the failing test in account_requests_spec by ensuring that the confirmation modal is visible and the "OK" button is rendered before interacting with it.

#### Key Changes:
- Added checks to ensure the modal is visible.
- Confirmed the "OK" button is available before the test interacts with it.

The initial failure could not be reproduced locally. However, a thorough analysis of the modal's implementation and the associated test suggests that the error is likely caused by the "OK" button not being available at the time the test is executed.

#### Files Changed:
-  account_request_spec.rb
## Screenshots
Before:(Failure on the CI log)
<img width="1373" alt="Screenshot 2024-12-17 at 12 13 15" src="https://github.com/user-attachments/assets/289ce1e8-b577-4a67-b3bb-d8bccb009be1" />
After:
<img width="1677" alt="Screenshot 2024-12-17 at 12 12 44" src="https://github.com/user-attachments/assets/7da1b240-8b2a-4777-b8f4-e12530cbb708" />
