### PR TITLE
[Data rearchitecture] Stop creating complete universe of article course timeslices

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -205,7 +205,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
       { article_id: id, course_id: course.id, first_revision: first_revisions[id] }
     end
 
-    maybe_insert_new_records(course, new_records)
+    maybe_insert_new_records(new_records)
   end
 
   # Given an array of revisions and an array of article ids,
@@ -223,7 +223,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     min_dates
   end
 
-  def self.maybe_insert_new_records(_course, new_records)
+  def self.maybe_insert_new_records(new_records)
     return if new_records.empty?
     # Do this in batches to avoid running the MySQL server out of memory
     new_records.each_slice(5000) do |new_record_slice|

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -223,7 +223,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     min_dates
   end
 
-  def self.maybe_insert_new_records(course, new_records)
+  def self.maybe_insert_new_records(_course, new_records)
     return if new_records.empty?
     # Do this in batches to avoid running the MySQL server out of memory
     new_records.each_slice(5000) do |new_record_slice|
@@ -231,8 +231,6 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
       insert_all new_record_slice
       # rubocop:enable Rails/SkipsModelValidations
     end
-
-    TimesliceManager.new(course).create_timeslices_for_new_article_course_records(new_records)
   end
 
   def self.destroy_invalid_records(course, valid_article_ids)

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -112,7 +112,6 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   def create_timeslices_for_new_course_start_date
     courses_wikis = @course.courses_wikis
     # order matters
-    create_empty_article_course_timeslices(start_dates_backward, @course.articles_courses)
     create_empty_course_user_wiki_timeslices(start_dates_backward)
     create_empty_course_wiki_timeslices(start_dates_backward, courses_wikis, needs_update: true)
   end
@@ -122,7 +121,6 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   def create_timeslices_up_to_new_course_end_date
     courses_wikis = @course.courses_wikis
     # order matters
-    create_empty_article_course_timeslices(start_dates_from_old_end, @course.articles_courses)
     create_empty_course_user_wiki_timeslices(start_dates_from_old_end)
     create_empty_course_wiki_timeslices(start_dates_from_old_end, courses_wikis, needs_update: true)
   end

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -85,13 +85,6 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # Creates article course timeslices records for new articles courses
-  # Takes an array like the following:
-  # [{:article_id=>115, :course_id=>72},..., {:article_id=>116, :course_id=>72}]
-  def create_timeslices_for_new_article_course_records(articles_courses)
-    create_empty_article_course_timeslices(start_dates, articles_courses)
-  end
-
   # Creates course user timeslices records for every course wiki for new course users
   # Takes an array of CoursesUsers records
   def create_timeslices_for_new_course_user_records(courses_users)

--- a/spec/lib/articles_courses_cleaner_timeslice_spec.rb
+++ b/spec/lib/articles_courses_cleaner_timeslice_spec.rb
@@ -6,7 +6,8 @@ require "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
 describe ArticlesCoursesCleanerTimeslice do
   let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
   let(:wikidata) { Wiki.get_or_create(project: 'wikidata', language: nil) }
-  let(:course) { create(:course, start: '2024-01-01', end: '2024-04-20') }
+  let(:start) { '2024-01-01'.to_datetime }
+  let(:course) { create(:course, start:, end: '2024-04-20') }
   let(:manager) { TimesliceManager.new(course) }
   let(:article1) { create(:article, wiki: enwiki) }
   let(:article2) { create(:article, wiki: wikidata) }
@@ -34,19 +35,17 @@ describe ArticlesCoursesCleanerTimeslice do
       create(:articles_course, course:, article: article1, user_ids: [1, 45])
       create(:articles_course, course:, article: article3, user_ids: [47, 45, 5])
       create(:articles_course, course:, article: article2, user_ids: [455])
-      manager.create_timeslices_for_new_article_course_records(
-        [{ article_id: article1.id, course_id: course.id },
-         { article_id: article2.id, course_id: course.id },
-         { article_id: article3.id, course_id: course.id }]
-      )
+      create(:article_course_timeslice, course:, article: article1)
+      create(:article_course_timeslice, course:, article: article2)
+      create(:article_course_timeslice, course:, article: article3)
     end
 
     it 'removes ArticlesCourses and their timeslices that were edited only by removed users' do
-      expect(course.article_course_timeslices.size).to eq(333)
+      expect(course.article_course_timeslices.size).to eq(3)
       expect(course.articles_courses.size).to eq(3)
       # User ids 5, 45 and 47 were deleted
       described_class.clean_articles_courses_for_user_ids(course, [5, 45, 47])
-      expect(course.article_course_timeslices.size).to eq(222)
+      expect(course.article_course_timeslices.size).to eq(2)
       expect(course.articles_courses.size).to eq(2)
       expect(course.articles_courses.first.user_ids).to eq([1, 45])
       expect(course.articles_courses.second.user_ids).to eq([455])
@@ -59,41 +58,27 @@ describe ArticlesCoursesCleanerTimeslice do
       create(:articles_course, course:, article: article1, user_ids: [1])
       create(:articles_course, course:, article: article2, user_ids: [47])
       create(:articles_course, course:, article: article3, user_ids: [455])
-      manager.create_timeslices_for_new_article_course_records(
-        [{ article_id: article1.id, course_id: course.id },
-         { article_id: article2.id, course_id: course.id },
-         { article_id: article3.id, course_id: course.id }]
-      )
-      # Course start date is updated
-      course.update(start: '2024-01-10')
 
       # Article 1 was only edited before the new start date
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article1.id)
-                                        .where(start: '2024-01-02'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [1])
+      create(:article_course_timeslice, course:, article: article1, start:,
+             end: start + 1.day, user_ids: [1])
+
       # Article 2 was edited before and after the new start date
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article2.id)
-                                        .where(start: '2024-01-02'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [47])
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article2.id)
-                                        .where(start: '2024-02-15'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [47])
+      create(:article_course_timeslice, course:, article: article2, start:,
+             end: start + 1.day, user_ids: [47])
+      create(:article_course_timeslice, course:, article: article2, start: start + 10.days,
+             end: start + 11.days, user_ids: [47])
+
       # Article 3 was only edited after the new start date
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article3.id)
-                                        .where(start: '2024-02-18'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [455])
+      create(:article_course_timeslice, course:, article: article3, start: start + 10.days,
+             end: start + 11.days, user_ids: [455])
+
+      # Course start date is updated
+      course.update(start: '2024-01-10')
     end
 
     it 'removes ArticlesCourses and timeslices that do not belong to the course anymore' do
-      expect(course.article_course_timeslices.size).to eq(333)
+      expect(course.article_course_timeslices.size).to eq(4)
       expect(course.articles_courses.size).to eq(3)
       # Clean articles courses
       described_class.clean_articles_courses_prior_to_course_start(course)
@@ -102,7 +87,7 @@ describe ArticlesCoursesCleanerTimeslice do
       expect(course.article_course_timeslices.where(article_id: article1.id).size).to eq(0)
       # Timeslices prior to the new course start date were deleted
       expect(course.article_course_timeslices.where('end <= ?', course.start).size).to eq(0)
-      expect(course.article_course_timeslices.size).to eq(204)
+      expect(course.article_course_timeslices.size).to eq(2)
       # Article 1 was deleted
       expect(course.articles_courses.size).to eq(2)
       expect(course.articles_courses.first.article_id).to eq(article2.id)
@@ -116,41 +101,27 @@ describe ArticlesCoursesCleanerTimeslice do
       create(:articles_course, course:, article: article1, user_ids: [1])
       create(:articles_course, course:, article: article2, user_ids: [47])
       create(:articles_course, course:, article: article3, user_ids: [455])
-      manager.create_timeslices_for_new_article_course_records(
-        [{ article_id: article1.id, course_id: course.id },
-         { article_id: article2.id, course_id: course.id },
-         { article_id: article3.id, course_id: course.id }]
-      )
-      # Course end date is updated
-      course.update(end: '2024-04-10')
 
       # Article 1 was only edited after the new end date
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article1.id)
-                                        .where(start: '2024-04-15'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [1])
+      create(:article_course_timeslice, course:, article: article1, start: '2024-04-11',
+             end: '2024-04-12', user_ids: [1])
+
       # Article 2 was edited before and after the new end date
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article2.id)
-                                        .where(start: '2024-01-02'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [47])
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article2.id)
-                                        .where(start: '2024-04-16'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [47])
-      # Article 3 was only edited after the new end date
-      timeslice = ArticleCourseTimeslice.where(course:)
-                                        .where(article_id: article3.id)
-                                        .where(start: '2024-02-18'.to_datetime)
-                                        .first
-      timeslice.update(user_ids: [455])
+      create(:article_course_timeslice, course:, article: article2, start:,
+             end: start + 1.day, user_ids: [47])
+      create(:article_course_timeslice, course:, article: article2, start: '2024-04-11',
+             end: '2024-04-12', user_ids: [47])
+
+      # Article 3 was only edited before the new end date
+      create(:article_course_timeslice, course:, article: article3, start:,
+             end: start + 1.day, user_ids: [455])
+
+      # Course end date is updated
+      course.update(end: '2024-04-10')
     end
 
     it 'removes ArticlesCourses and timeslices that do not belong to the course anymore' do
-      expect(course.article_course_timeslices.size).to eq(333)
+      expect(course.article_course_timeslices.size).to eq(4)
       expect(course.articles_courses.size).to eq(3)
       # Clean articles courses
       described_class.clean_articles_courses_after_course_end(course)
@@ -159,7 +130,7 @@ describe ArticlesCoursesCleanerTimeslice do
       expect(course.article_course_timeslices.where(article_id: article1.id).size).to eq(0)
       # Timeslices after the new course end date were deleted
       expect(course.article_course_timeslices.where('start > ?', course.end).size).to eq(0)
-      expect(course.article_course_timeslices.size).to eq(202)
+      expect(course.article_course_timeslices.size).to eq(2)
       # Article 1 was deleted
       expect(course.articles_courses.size).to eq(2)
       expect(course.articles_courses.first.article_id).to eq(article2.id)

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -82,8 +82,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
       course.update(start: '2023-12-20')
       course.reload
     end
@@ -107,8 +107,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
       course.update(end: '2024-04-30')
       course.reload
     end
@@ -146,8 +146,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
       create(:article_course_timeslice, course:, article: article1)
       create(:article_course_timeslice, course:, article: article2)
       create(:article_course_timeslice, course:, article: article3)
@@ -160,7 +160,7 @@ describe TimesliceManager do
       expect(course.article_course_timeslices.size).to eq(3)
 
       timeslice_manager.delete_timeslices_for_deleted_course_wikis([wikibooks.id,
-                                                                              wikidata.id])
+                                                                    wikidata.id])
       course.reload
       # Course wiki timeslices for wikibooks and wikidata were deleted
       expect(course.course_wiki_timeslices.where(wiki_id: wikibooks.id).size).to eq(0)
@@ -177,8 +177,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
       course.reload
     end
 
@@ -199,8 +199,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
       course.reload
     end
 
@@ -221,8 +221,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
       course.reload
     end
 
@@ -243,8 +243,8 @@ describe TimesliceManager do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                                 wikidata,
-                                                                                 enwiki])
+                                                                       wikidata,
+                                                                       enwiki])
     end
 
     it 'deletes course user wiki timeslices for dates after the end date properly' do

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -113,11 +113,10 @@ describe TimesliceManager do
 
         timeslice_manager.create_timeslices_for_new_course_start_date
         course.reload
-        # Create timeslices for the period between 2023-12-20 and 2024-01-01
+        # Create course and user timeslices for the period between 2023-12-20 and 2024-01-01
         expect(course.course_wiki_timeslices.size).to eq(369)
         expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(36)
         expect(course.course_user_wiki_timeslices.size).to eq(738)
-        expect(course.article_course_timeslices.size).to eq(369)
       end
     end
   end
@@ -142,11 +141,10 @@ describe TimesliceManager do
 
         timeslice_manager.create_timeslices_up_to_new_course_end_date
         course.reload
-        # Create timeslices for the period between 2024-04-20 and 2024-04-30
+        # Create course and user timeslices for the period between 2024-04-20 and 2024-04-30
         expect(course.course_wiki_timeslices.size).to eq(363)
         expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(30)
         expect(course.course_user_wiki_timeslices.size).to eq(726)
-        expect(course.article_course_timeslices.size).to eq(363)
       end
     end
   end

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -228,9 +228,6 @@ describe ArticlesCourses, type: :model do
       described_class.update_from_course_revisions(course, array_revisions)
       expect(described_class.count).to eq(2)
       expect(described_class.first.first_revision).to eq('2024-07-06 20:05:10')
-      # 62 days from course start up to course end x 2 articles courses
-      expect(described_class.first.article_course_timeslices.count).to eq(62)
-      expect(described_class.second.article_course_timeslices.count).to eq(62)
     end
   end
 end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -51,10 +51,9 @@ describe UpdateCourseWikiTimeslices do
       article_course = ArticlesCourses.find_by(article_id: article.id)
 
       # Article course timeslice record was created for mw_page_id 6901525
-      # timeslices from 2018-11-24 to 2018-11-30 were created
-      expect(article_course.article_course_timeslices.count).to eq(7)
+      # timeslices for 2018-11-24 was created
+      expect(article_course.article_course_timeslices.count).to eq(1)
       expect(article_course.article_course_timeslices.first.start).to eq('2018-11-24')
-      expect(article_course.article_course_timeslices.last.start).to eq('2018-11-30')
       # Article course timeslices caches were updated
       expect(article_course.article_course_timeslices.first.character_sum).to eq(427)
       expect(article_course.article_course_timeslices.first.references_count).to eq(-2)

--- a/spec/services/update_timeslices_course_date_spec.rb
+++ b/spec/services/update_timeslices_course_date_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe UpdateTimeslicesCourseDate do
+  let(:start) { '2021-01-24'.to_datetime }
   let(:course) { create(:course, start: '2021-01-24', end: '2021-01-30') }
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:updater) { described_class.new(course).run }
@@ -22,13 +23,11 @@ describe UpdateTimeslicesCourseDate do
     # Add articles courses and timeslices manually
     create(:articles_course, course:, article: article1, user_ids: [user1.id])
     create(:articles_course, course:, article: article2, user_ids: [user1.id, user2.id])
-    manager.create_timeslices_for_new_article_course_records(
-      [{ article_id: article1.id, course_id: course.id },
-       { article_id: article2.id, course_id: course.id }]
-    )
-    # Update articles courses timeslices
-    ArticleCourseTimeslice.where(course:, article: article1).first.update(user_ids: [user1.id])
-    ArticleCourseTimeslice.where(course:, article: article2).last.update(user_ids: [user1.id])
+
+    create(:article_course_timeslice, course:, article: article1, start:, end: start + 1.day,
+           user_ids: [user1.id])
+    create(:article_course_timeslice, course:, article: article2, start: start + 6.days,
+           end: start + 7.days, user_ids: [user1.id])
   end
 
   context 'when the start date changed to a previous date' do
@@ -41,14 +40,13 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
-      expect(course.article_course_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(2)
 
       described_class.new(course).run
-      # Timeslices from 2021-01-20 to 2021-01-24 were added
+      # Course wiki and course user timeslices from 2021-01-20 to 2021-01-24 were added
       expect(course.course_wiki_timeslices.count).to eq(11)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(4)
       expect(course.course_user_wiki_timeslices.count).to eq(22)
-      expect(course.article_course_timeslices.count).to eq(22)
     end
   end
 
@@ -63,7 +61,7 @@ describe UpdateTimeslicesCourseDate do
       # When updating the start date, the timeslice is marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
-      expect(course.article_course_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
       described_class.new(course).run
@@ -73,7 +71,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_user_wiki_timeslices.count).to eq(10)
       # Article course for article 1 was deleted
       expect(course.articles_courses.count).to eq(1)
-      expect(course.article_course_timeslices.count).to eq(5)
+      expect(course.article_course_timeslices.count).to eq(1)
     end
   end
 
@@ -87,14 +85,14 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
-      expect(course.article_course_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(2)
 
       described_class.new(course).run
       # Timeslices from 2021-01-30 to 2021-02-11 were added
       expect(course.course_wiki_timeslices.count).to eq(19)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(13)
       expect(course.course_user_wiki_timeslices.count).to eq(38)
-      expect(course.article_course_timeslices.count).to eq(38)
+      expect(course.article_course_timeslices.count).to eq(2)
     end
   end
 
@@ -109,7 +107,7 @@ describe UpdateTimeslicesCourseDate do
       # When updating the start date, the timeslice is marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
-      expect(course.article_course_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
       described_class.new(course).run
@@ -119,7 +117,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_user_wiki_timeslices.count).to eq(12)
       # Article course for article 2 was deleted
       expect(course.articles_courses.count).to eq(1)
-      expect(course.article_course_timeslices.count).to eq(6)
+      expect(course.article_course_timeslices.count).to eq(1)
     end
   end
 end

--- a/spec/services/update_timeslices_course_wiki_spec.rb
+++ b/spec/services/update_timeslices_course_wiki_spec.rb
@@ -22,10 +22,9 @@ describe UpdateTimeslicesCourseWiki do
       # Add articles courses and timeslices manually
       create(:articles_course, course:, article: wikidata_article)
       create(:articles_course, course:, article:)
-      manager.create_timeslices_for_new_article_course_records(
-        [{ article_id: wikidata_article.id, course_id: course.id },
-         { article_id: article.id, course_id: course.id }]
-      )
+      create(:article_course_timeslice, course:, article: wikidata_article)
+      create(:article_course_timeslice, course:, article:)
+
       # Create course wiki timeslices manually for wikidata
       course.wikis << wikidata
       manager.create_timeslices_for_new_course_wiki_records([wikidata])
@@ -36,7 +35,7 @@ describe UpdateTimeslicesCourseWiki do
       # There is one user, two articles and two wikis
       expect(course.course_wiki_timeslices.count).to eq(14)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
-      expect(course.article_course_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(2)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
@@ -44,7 +43,7 @@ describe UpdateTimeslicesCourseWiki do
       # There is one user, one article and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_user_wiki_timeslices.count).to eq(7)
-      expect(course.article_course_timeslices.count).to eq(7)
+      expect(course.article_course_timeslices.count).to eq(1)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end
@@ -59,16 +58,12 @@ describe UpdateTimeslicesCourseWiki do
       manager.create_timeslices_for_new_course_wiki_records([enwiki])
       # Add articles courses and timeslices manually
       create(:articles_course, course:, article:)
-      manager.create_timeslices_for_new_article_course_records(
-        [{ article_id: article.id, course_id: course.id }]
-      )
     end
 
     it 'adds wiki timeslices' do
       # There is one user, one article and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_user_wiki_timeslices.count).to eq(7)
-      expect(course.article_course_timeslices.count).to eq(7)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
 
@@ -77,7 +72,6 @@ describe UpdateTimeslicesCourseWiki do
       # There is one user, one article and two wikis
       expect(course.course_wiki_timeslices.count).to eq(14)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
-      expect(course.article_course_timeslices.count).to eq(7)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end


### PR DESCRIPTION
## What this PR does
This PR stops calling `create_timeslices_for_new_article_course_records` when new articles are ingested. Having the complete universe of article course timeslices for courses with a huge number of articles implies a lot of disk space that is not useful since most timeslices are empty. For this reason, this PR implements a new approach, in which article course timeslices are only created if they are non-empty (i.e. when there is a revision for that article and that date). This new approach should considerably decrease the disk space used in the data-rearchitecture instance.

## Open questions and concerns
This approach could be replicated for course user wiki timeslices in the future, although the `course_user_wiki_timeslices` table does not appear to take up considerable space.