### PR TITLE
Minor: Fix commented-out tests and Poltergeist selector issues in SurveyAdmin.

### DIFF
--- a/spec/features/survey_admin_spec.rb
+++ b/spec/features/survey_admin_spec.rb
@@ -41,11 +41,13 @@ describe 'Survey Administration', type: :feature, js: true do
       click_link 'New Question Group'
       fill_in('question_group_name', with: 'New Question Group')
 
-      # FIXME: Fails to find the div with Poltergeist
-      # within('div#question_group_campaign_ids_chosen') do
-      #   find('input').set('Spring 2015')
-      #   find('input').native.send_keys(:return)
-      # end
+      within('#question_group_campaign_ids') do
+        option = find('option', text: 'Spring 2015')
+        page.execute_script(
+          "arguments[0].selected = true;
+          arguments[0].parentNode.dispatchEvent(new Event('change'))", option.native
+        )
+      end
       page.find('input.button[value="Save Question Group"]').click
 
       # Create a question
@@ -68,13 +70,13 @@ describe 'Survey Administration', type: :feature, js: true do
       expect(Rapidfire::Question.count).to eq(2)
 
       page.find('label', text: 'Conditionally show this question').click
-      # FIXME: fails to find the div with Poltergeist
-      # within 'div.survey__question__conditional-row' do
-      #   select('Who is awesome?')
-      # end
-      # within 'select[data-conditional-value-select=""]' do
-      #   select('Me!')
-      # end
+
+      within 'div.survey__question__conditional-row' do
+        select('Who is awesome?')
+      end
+      within 'select[data-conditional-value-select=""]' do
+        select('Me!')
+      end
       page.find('input.button').click
 
       # Create two more question groups, so that we can reorder them.
@@ -127,11 +129,14 @@ describe 'Survey Administration', type: :feature, js: true do
       visit '/surveys/assignments'
       click_link 'New Survey Assignment'
 
-      # FIXME: Fails to find the div with Poltergeist
-      # within('div#survey_assignment_campaign_ids_chosen') do
-      #   find('input').set('Spring 2015')
-      #   find('input').native.send_keys(:return)
-      # end
+      within('#survey_assignment_campaign_ids') do
+        option = find('option', text: 'Spring 2015')
+        page.execute_script(
+          "arguments[0].selected = true;
+          arguments[0].parentNode.dispatchEvent(new Event('change'))", option.native
+        )
+      end
+
       fill_in('survey_assignment_send_date_days', with: '7')
       check 'survey_assignment_published'
       fill_in('survey_assignment_custom_email_subject', with: 'My Custom Subject!')


### PR DESCRIPTION
## What this PR does

This PR fixes three commented-out minor test sections in the `survey_admin_spec.rb` file.

## Fixes:

**1. Issue:**

 ![Screenshot from 2024-12-22 14-03-21](https://github.com/user-attachments/assets/b18d63de-d8c3-4aef-8030-1dae0a6b4cb7)

- **Fix:**
This issue was resolved by using optional chaining (`?.`) in `SurveyAdmin.js` (#6064).  Optional chaining ensures safe access to nested properties without throwing an error if any property in the chain is null or undefined.

- For more details, please refer to the discussion here: [GitHub Pull Request #6064, comment](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6064#issuecomment-2553378416).

**2. Issue:**

![Screenshot from 2024-12-22 14-07-25](https://github.com/user-attachments/assets/6bd48f2b-850d-43cc-8f3e-96ca17fd5d01)

- **Explanation:**
The `within('div#question_group_campaign_ids_chosen')` selector attempts to find an ID that does not exist. Instead, the correct ID is `#question_group_campaign_ids`. This element represents the options to select multiple campaigns from the available list as shown below.

![surveys_rapidfire_question_groups_60_edit](https://github.com/user-attachments/assets/b9ca1581-962c-4f95-9eb1-0b3dcd96a51d)


- **Fix:**
Updated the code to use the correct selector `#question_group_campaign_ids`. Replaced the existing code with a `within` block that selects the option programmatically and triggers the `change` event using `page.execute_script`.

**3. Issue:**

![Screenshot from 2024-12-22 14-19-15](https://github.com/user-attachments/assets/16aa15f5-e3ad-49a3-91a8-3eaba26a0072)


- **Explanation:**
Similarly, the selector `within('div#survey_assignment_campaign_ids_choosen')` attempts to find a non-existent ID. The correct ID is `#survey_assignment_campaign_ids`, which represents the options to select multiple campaigns as shown below.

 
![survey_assignments_new](https://github.com/user-attachments/assets/8d7d790d-f5d9-4a8b-8471-b34a40fcbe64)

- **Fix:**
Adjusted the selector to use the correct ID.


## Screenshots

Before:

https://github.com/user-attachments/assets/35985a64-2037-4197-8ff3-25d2feb2a1c9



After:


https://github.com/user-attachments/assets/bf18ae75-fd01-4070-98ee-cce513b953b8

## Capybara screenshots for refrence

**1.**
 ![FIXME_TWO](https://github.com/user-attachments/assets/62a49242-90e4-4366-bc3e-4480d226dffe)
**2.**
 ![FIXME_ONE](https://github.com/user-attachments/assets/3f81d748-6bd2-484e-8793-b7c47da9159a)
**3.**
 ![FIXME_THREE](https://github.com/user-attachments/assets/ae9238d7-09d2-4f0d-b3ae-f550c9b9abcd)



## Open questions and concerns

While fixing these issues, I noticed that selecting multiple campaigns in Survey Assignments and Question Groups requires using `Ctrl + mouse click.`  Is this the intended behavior for selecting multiple options? Additionally, pressing Enter doesn't work either; only Ctrl + mouse click allows multiple selections.


https://github.com/user-attachments/assets/cfdab0b0-c77f-4158-a925-fe114eb7e1f9



