### PR TITLE
[Data rearchitecture] Handle changes in timeslice durations

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -360,7 +360,7 @@ class CoursesController < ApplicationController
 
   def update_timeslice_duration
     # Set the timeslice_duration to the default value
-    @course.flags['timeslice_duration'] = TimesliceManager::TIMESLICE_DURATION
+    @course.flags[:timeslice_duration] = TimesliceManager::TIMESLICE_DURATION
     @course.save
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -359,8 +359,8 @@ class CoursesController < ApplicationController
   end
 
   def update_timeslice_duration
-    # Set the timeslice_duration to the default value
-    @course.flags[:timeslice_duration] = TimesliceManager::TIMESLICE_DURATION
+    # Set the default timeslice_duration to the default value
+    @course.flags[:timeslice_duration] = { default: TimesliceManager::TIMESLICE_DURATION }
     @course.save
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -358,6 +358,12 @@ class CoursesController < ApplicationController
     @course.save
   end
 
+  def update_timeslice_duration
+    # Set the timeslice_duration to the default value
+    @course.flags['timeslice_duration'] = TimesliceManager::TIMESLICE_DURATION
+    @course.save
+  end
+
   def update_last_reviewed
     username = params.dig(:course, 'last_reviewed', 'username')
     timestamp = params.dig(:course, 'last_reviewed', 'timestamp')
@@ -375,6 +381,7 @@ class CoursesController < ApplicationController
     update_course_wiki_namespaces
     update_academic_system
     update_course_format
+    update_timeslice_duration
   end
 
   def course_params

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -519,6 +519,10 @@ class Course < ApplicationRecord
     flags[:no_sandboxes].present?
   end
 
+  def timeslice_duration
+    flags[:timeslice_duration]
+  end
+
   #################
   # Cache methods #
   #################

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -520,7 +520,7 @@ class Course < ApplicationRecord
   end
 
   def timeslice_duration
-    flags[:timeslice_duration]
+    (flags[:timeslice_duration] || TimesliceManager::TIMESLICE_DURATION).seconds
   end
 
   #################

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -519,10 +519,6 @@ class Course < ApplicationRecord
     flags[:no_sandboxes].present?
   end
 
-  def timeslice_duration
-    (flags[:timeslice_duration] || TimesliceManager::TIMESLICE_DURATION).seconds
-  end
-
   #################
   # Cache methods #
   #################

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -472,7 +472,7 @@ class Course < ApplicationRecord
 
   # TODO: find a better way to check if the course was already updated
   def was_course_ever_updated?
-    flags[:first_update].present? || flags['update_logs'].present?
+    flags['update_logs'].present?
   end
 
   # Overridden for ClassroomProgramCourse

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -72,12 +72,6 @@ class CourseWikiTimeslice < ApplicationRecord
     end.max
   end
 
-  def self.min_max_course_start(course)
-    course.wikis.filter_map do |wiki|
-      CourseWikiTimeslice.for_course_and_wiki(course, wiki).maximum(:start)
-    end.min
-  end
-
   def self.min_max_course_end(course)
     course.wikis.filter_map do |wiki|
       CourseWikiTimeslice.for_course_and_wiki(course, wiki).maximum(:end)

--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -30,9 +30,9 @@ class PrepareTimeslices
       @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
     end
     # Execute update tasks in a specific order
+    UpdateTimeslicesCourseWiki.new(@course).run
     UpdateTimeslicesCourseUser.new(@course).run
     UpdateTimeslicesUntrackedArticle.new(@course).run
-    UpdateTimeslicesCourseWiki.new(@course).run
     UpdateTimeslicesCourseDate.new(@course).run
     @debugger.log_update_progress :adjust_timeslices_end
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -61,10 +61,11 @@ class UpdateCourseWikiTimeslices
     current_start = first_start
     while current_start <= latest_start
       start_date = [current_start, @course.start].max
-      end_date = [current_start + @course.timeslice_duration - 1.second, @course.end].min
+      end_date = [current_start + @timeslice_manager.timeslice_duration(wiki) - 1.second,
+                  @course.end].min
       fetch_data(wiki, start_date, end_date)
       process_timeslices(wiki)
-      current_start += @course.timeslice_duration
+      current_start += @timeslice_manager.timeslice_duration(wiki)
     end
     @debugger.log_update_progress :fetch_and_process_timeslices_finish
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -61,10 +61,10 @@ class UpdateCourseWikiTimeslices
     current_start = first_start
     while current_start <= latest_start
       start_date = [current_start, @course.start].max
-      end_date = [current_start + TimesliceManager::TIMESLICE_DURATION - 1.second, @course.end].min
+      end_date = [current_start + @course.timeslice_duration - 1.second, @course.end].min
       fetch_data(wiki, start_date, end_date)
       process_timeslices(wiki)
-      current_start += TimesliceManager::TIMESLICE_DURATION
+      current_start += @course.timeslice_duration
     end
     @debugger.log_update_progress :fetch_and_process_timeslices_finish
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -37,6 +37,10 @@ class UpdateCourseWikiTimeslices
 
   def fetch_data_and_process_timeslices_for_every_wiki(all_time)
     @course.wikis.each do |wiki|
+      # Sometimes we need to reprocess timeslices due to changes such as
+      # users removed from a course.
+      fetch_data_and_reprocess_timeslices(wiki)
+
       # Get start time from first timeslice to update
       first_start = if all_time
                       CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
@@ -46,10 +50,6 @@ class UpdateCourseWikiTimeslices
                     end
       # Get start time from latest timeslice to update
       latest_start = @timeslice_manager.get_latest_start_time_for_wiki(wiki)
-
-      # Sometimes we need to reprocess timeslices due to changes such as
-      # users removed from a course.
-      fetch_data_and_reprocess_timeslices(wiki)
 
       fetch_data_and_process_timeslices(wiki, first_start, latest_start)
     end

--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -90,8 +90,8 @@ class UpdateTimeslicesCourseDate
   def mark_new_wiki_first_timeslce_as_needs_update(wiki)
     # If the start date changed, mark the new first timeslices as 'needs_update'
     timeslice = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
-                                    .for_datetime(@course.start)
-                                    .first
+                                   .for_datetime(@course.start)
+                                   .first
     return unless timeslice
     timeslice.update(needs_update: true)
   end
@@ -106,7 +106,7 @@ class UpdateTimeslicesCourseDate
   def mark_old_last_wiki_timeslce_as_needs_update(wiki)
     # If the end date changed, mark the previous last timeslices as 'needs_update'
     timeslice = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
-                                    .last
+                                   .last
     return unless timeslice
     timeslice.update(needs_update: true)
   end

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -35,10 +35,6 @@ class UpdateTimeslicesCourseUser
 
   def add_user_ids(user_ids)
     return if user_ids.empty?
-    course_user_ids = @course.courses_users.where(user: user_ids)
-    # Create course user wiki timeslices
-    @timeslice_manager.create_timeslices_for_new_course_user_records course_user_ids
-    return unless @course.was_course_ever_updated?
 
     @course.wikis.each do |wiki|
       fetch_users_revisions_for_wiki(wiki, user_ids, @course.start, @course.end)

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -43,7 +43,7 @@ class UpdateTimeslicesCourseUser
     users = User.find(user_ids)
 
     manager = RevisionDataManager.new(wiki, @course)
-    current_end = latest_start + TimesliceManager::TIMESLICE_DURATION
+    current_end = latest_start + @course.timeslice_duration
     # Fetch the revisions for users for the complete period
     revisions = manager.fetch_revision_data_for_users(users,
                                                       current_start.strftime('%Y%m%d%H%M%S'),
@@ -88,7 +88,7 @@ class UpdateTimeslicesCourseUser
     tuples = []
     current_start = first_start
     while current_start <= latest_start
-      current_end = current_start + TimesliceManager::TIMESLICE_DURATION
+      current_end = current_start + @course.timeslice_duration
       revisions_per_timeslice = revisions.select do |r|
         current_start <= r.date && r.date < current_end
       end
@@ -96,7 +96,7 @@ class UpdateTimeslicesCourseUser
         tuples += [[wiki_id,
                     current_start.strftime('%Y%m%d%H%M%S')]]
       end
-      current_start += TimesliceManager::TIMESLICE_DURATION
+      current_start += @course.timeslice_duration
     end
     tuples
   end

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -46,13 +46,13 @@ class UpdateTimeslicesCourseUser
     users = User.find(user_ids)
 
     manager = RevisionDataManager.new(wiki, @course)
-    current_end = latest_start + @course.timeslice_duration
+    current_end = latest_start + @timeslice_manager.timeslice_duration(wiki)
     # Fetch the revisions for users for the complete period
     revisions = manager.fetch_revision_data_for_users(users,
                                                       current_start.strftime('%Y%m%d%H%M%S'),
                                                       current_end.strftime('%Y%m%d%H%M%S'))
     wikis_and_starts = revisions_to_wiki_and_start_dates(revisions,
-                                                         wiki.id,
+                                                         wiki,
                                                          first_start,
                                                          latest_start)
 
@@ -87,19 +87,19 @@ class UpdateTimeslicesCourseUser
     timeslices.flatten
   end
 
-  def revisions_to_wiki_and_start_dates(revisions, wiki_id, first_start, latest_start)
+  def revisions_to_wiki_and_start_dates(revisions, wiki, first_start, latest_start)
     tuples = []
     current_start = first_start
     while current_start <= latest_start
-      current_end = current_start + @course.timeslice_duration
+      current_end = current_start + @timeslice_manager.timeslice_duration(wiki)
       revisions_per_timeslice = revisions.select do |r|
         current_start <= r.date && r.date < current_end
       end
       unless revisions_per_timeslice.empty?
-        tuples += [[wiki_id,
+        tuples += [[wiki.id,
                     current_start.strftime('%Y%m%d%H%M%S')]]
       end
-      current_start += @course.timeslice_duration
+      current_start += @timeslice_manager.timeslice_duration(wiki)
     end
     tuples
   end

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -27,7 +27,7 @@ class UpdateTimeslicesCourseUser
     # It's not safe to rely on new_user_ids = current_user_ids - processed_users
     course_update_start = @course.flags['update_logs'].values.last['start_time']
     new_user_ids = @course.students.where('courses_users.created_at >= ?',
-                                                  course_update_start).pluck(:id)
+                                          course_update_start).pluck(:id)
     add_user_ids(new_user_ids)
   end
 

--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -37,8 +37,9 @@ class UpdateTimeslicesCourseWiki
   end
 
   def add_courses_wikis(wiki_ids)
+    wikis = Wiki.where(wiki_id: wiki_ids)
     # Create course wiki timeslice records for new wikis
-    @timeslice_manager.create_timeslices_for_new_course_wiki_records wiki_ids
+    @timeslice_manager.create_timeslices_for_new_course_wiki_records(wikis)
   end
 
   def update_timeslices_durations
@@ -46,7 +47,7 @@ class UpdateTimeslicesCourseWiki
       start = @timeslice_manager.get_ingestion_start_time_for_wiki wiki
       timeslice = @course.course_wiki_timeslices.where(wiki:, start:).first
       effective_timeslice_duration = timeslice.end - timeslice.start
-      real_timeslice_duration = @course.timeslice_duration
+      real_timeslice_duration = @timeslice_manager.timeslice_duration(wiki)
       # Continue if timeslice duration didn't change for the wiki
       next unless effective_timeslice_duration != real_timeslice_duration
       @timeslice_manager.delete_course_wiki_timeslices_after_date([wiki], start - 1.second)

--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -37,7 +37,7 @@ class UpdateTimeslicesCourseWiki
   end
 
   def add_courses_wikis(wiki_ids)
-    wikis = Wiki.where(wiki_id: wiki_ids)
+    wikis = Wiki.where(id: wiki_ids)
     # Create course wiki timeslice records for new wikis
     @timeslice_manager.create_timeslices_for_new_course_wiki_records(wikis)
   end

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -129,3 +129,6 @@
 # Secret for authentication with Wikimedia Event Center
 # Generate one for production or staging via `rails secret`
 # WikimediaCampaignsPlatformSecret: 
+
+# Default timeslice duration (in seconds) used for processing course updates
+  TIMESLICE_DURATION: '86400'

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -152,7 +152,8 @@ class CourseCloneManager
     :peer_review_count,
     :retain_available_articles,
     :stay_in_sandbox,
-    :no_sandboxes
+    :no_sandboxes,
+    :timeslice_duration
   ].freeze
   def add_flags
     FLAGS_TO_CARRY_OVER.each do |flag_key|

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -199,7 +199,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     course_wiki_timeslices.update_all(needs_update: true) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  TIMESLICE_DURATION = ENV['TIMESLICE_DURATION'].to_i.seconds
+  TIMESLICE_DURATION = ENV['TIMESLICE_DURATION'].to_i
 
   private
 

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -212,8 +212,8 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   # Creates empty course wiki timeslices
   def create_empty_course_wiki_timeslices(starts, wiki, needs_update: false)
     new_records = starts.map do |start|
-        { course_id: @course.id, wiki_id: wiki.id, start:,
-          end: start + timeslice_duration(wiki), needs_update: }
+      { course_id: @course.id, wiki_id: wiki.id, start:,
+        end: start + timeslice_duration(wiki), needs_update: }
     end
 
     return if new_records.empty?

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -199,7 +199,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     course_wiki_timeslices.update_all(needs_update: true) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  TIMESLICE_DURATION = 1.day
+  TIMESLICE_DURATION = ENV['TIMESLICE_DURATION'].to_i.seconds
 
   private
 

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -211,7 +211,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
       articles_courses.map do |a_c|
         tracked = a_c[:tracked].nil? || a_c[:tracked]
         { article_id: a_c[:article_id], course_id: a_c[:course_id], start:,
-          end: start + TIMESLICE_DURATION, tracked: }
+          end: start + @course.timeslice_duration, tracked: }
       end
     end.flatten
 
@@ -231,7 +231,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
       courses_users.map do |c_u|
         courses_wikis.map do |c_w|
           { course_id: c_u.course_id, user_id: c_u.user_id, wiki_id: c_w.wiki_id, start:,
-            end: start + TIMESLICE_DURATION }
+            end: start + @course.timeslice_duration }
         end
       end
     end.flatten
@@ -251,8 +251,8 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   def create_empty_course_wiki_timeslices(starts, courses_wikis, needs_update: false)
     new_records = starts.map do |start|
       courses_wikis.map do |c_w|
-        { course_id: @course.id, wiki_id: c_w.wiki_id, start:, end: start + TIMESLICE_DURATION,
-          needs_update: }
+        { course_id: @course.id, wiki_id: c_w.wiki_id, start:,
+          end: start + @course.timeslice_duration, needs_update: }
       end
     end.flatten
 
@@ -314,7 +314,7 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     current_start = @course.start
     while current_start <= @course.end
       start_dates << current_start
-      current_start += TIMESLICE_DURATION
+      current_start += @course.timeslice_duration
     end
 
     start_dates
@@ -326,10 +326,10 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     start_dates = []
     # There is no guarantee that all wikis are in the same state.
     last_start = CourseWikiTimeslice.max_min_course_start(@course)
-    current_start = last_start - TIMESLICE_DURATION
+    current_start = last_start - @course.timeslice_duration
     while current_start >= @course.start
       start_dates << current_start
-      current_start -= TIMESLICE_DURATION
+      current_start -= @course.timeslice_duration
     end
 
     start_dates
@@ -341,10 +341,10 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
     start_dates = []
     # There is no guarantee that all wikis are in the same state.
     last_start = CourseWikiTimeslice.min_max_course_start(@course)
-    current_start = last_start + TIMESLICE_DURATION
+    current_start = last_start + @course.timeslice_duration
     while current_start <= @course.end
       start_dates << current_start
-      current_start += TIMESLICE_DURATION
+      current_start += @course.timeslice_duration
     end
 
     start_dates

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -91,15 +91,12 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   def create_timeslices_for_new_course_wiki_records(wikis)
     courses_wikis = @course.courses_wikis.where(wiki: wikis)
     create_empty_course_wiki_timeslices(start_dates, courses_wikis)
-    # create_empty_course_user_wiki_timeslices(start_dates, courses_wikis:)
   end
 
   # Creates course wiki timeslices records for missing timeslices due to a change in the start date
   # Creates course user wiki timeslices records for missing timeslices
   def create_timeslices_for_new_course_start_date
     courses_wikis = @course.courses_wikis
-    # order matters
-    # create_empty_course_user_wiki_timeslices(start_dates_backward)
     create_empty_course_wiki_timeslices(start_dates_backward, courses_wikis, needs_update: true)
   end
 
@@ -107,8 +104,6 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
   # Creates course user wiki timeslices records for missing timeslices
   def create_timeslices_up_to_new_course_end_date
     courses_wikis = @course.courses_wikis
-    # order matters
-    # create_empty_course_user_wiki_timeslices(start_dates_from_old_end)
     create_empty_course_wiki_timeslices(start_dates_from_old_end, courses_wikis, needs_update: true)
   end
 

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -95,15 +95,17 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
 
   # Creates course wiki timeslices records for missing timeslices due to a change in the start date
   # Creates course user wiki timeslices records for missing timeslices
-  def create_timeslices_for_new_course_start_date
-    courses_wikis = @course.courses_wikis
+  def create_wiki_timeslices_for_new_course_start_date(wiki)
+    courses_wikis = @course.courses_wikis.where(wiki:)
+    # Notice that start_dates_backward should use the timeslice duration for the specific wiki
     create_empty_course_wiki_timeslices(start_dates_backward, courses_wikis, needs_update: true)
   end
 
   # Creates course wiki timeslices records for missing timeslices due to a change in the end date
   # Creates course user wiki timeslices records for missing timeslices
-  def create_timeslices_up_to_new_course_end_date
-    courses_wikis = @course.courses_wikis
+  def create_wiki_timeslices_up_to_new_course_end_date(wiki)
+    courses_wikis = @course.courses_wikis.where(wiki:)
+    # Notice that start_dates_from_old_end should use the timeslice duration for the specific wiki
     create_empty_course_wiki_timeslices(start_dates_from_old_end, courses_wikis, needs_update: true)
   end
 

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -58,48 +58,44 @@ describe TimesliceManager do
     end
   end
 
-  describe '#create_timeslices_for_new_course_start_date' do
+  describe '#create_wiki_timeslices_for_new_course_start_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
-      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                       wikidata,
-                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_course_wiki_records(wikibooks)
       course.update(start: '2023-12-20')
       course.reload
     end
 
     context 'when the start date changed to a previous date' do
       it 'creates timeslices for the missing period that needs_update' do
-        expect(course.course_wiki_timeslices.size).to eq(333)
+        expect(course.course_wiki_timeslices.size).to eq(111)
 
-        timeslice_manager.create_timeslices_for_new_course_start_date
+        timeslice_manager.create_wiki_timeslices_for_new_course_start_date(wikibooks)
         course.reload
         # Create course and user timeslices for the period between 2023-12-20 and 2024-01-01
-        expect(course.course_wiki_timeslices.size).to eq(369)
-        expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(36)
+        expect(course.course_wiki_timeslices.size).to eq(123)
+        expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(12)
       end
     end
   end
 
-  describe '#create_timeslices_up_to_new_course_end_date' do
+  describe '#create_wiki_timeslices_up_to_new_course_end_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
-      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                       wikidata,
-                                                                       enwiki])
+      timeslice_manager.create_timeslices_for_new_course_wiki_records(wikibooks)
       course.update(end: '2024-04-30')
       course.reload
     end
 
     context 'when the end date changed to a later date' do
       it 'creates timeslices for the missing period that needs_update' do
-        expect(course.course_wiki_timeslices.size).to eq(333)
+        expect(course.course_wiki_timeslices.size).to eq(111)
 
-        timeslice_manager.create_timeslices_up_to_new_course_end_date
+        timeslice_manager.create_wiki_timeslices_up_to_new_course_end_date(wikibooks)
         course.reload
         # Create course and user timeslices for the period between 2024-04-20 and 2024-04-30
-        expect(course.course_wiki_timeslices.size).to eq(363)
-        expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(30)
+        expect(course.course_wiki_timeslices.size).to eq(121)
+        expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(10)
       end
     end
   end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -61,7 +61,7 @@ describe TimesliceManager do
   describe '#create_wiki_timeslices_for_new_course_start_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
-      timeslice_manager.create_timeslices_for_new_course_wiki_records(wikibooks)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks])
       course.update(start: '2023-12-20')
       course.reload
     end
@@ -82,7 +82,7 @@ describe TimesliceManager do
   describe '#create_wiki_timeslices_up_to_new_course_end_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
-      timeslice_manager.create_timeslices_for_new_course_wiki_records(wikibooks)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks])
       course.update(end: '2024-04-30')
       course.reload
     end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -35,23 +35,6 @@ describe TimesliceManager do
     course.reload
   end
 
-  describe '#create_timeslices_for_new_course_user_records' do
-    context 'when there are new courses users' do
-      it 'creates course user wiki timeslices for every wiki for the entire course' do
-        expect(course.course_user_wiki_timeslices.size).to eq(0)
-        timeslice_manager.create_timeslices_for_new_course_user_records(
-          new_course_users
-        )
-        course.reload
-        expect(course.course_user_wiki_timeslices.size).to eq(666)
-        expect(course.course_user_wiki_timeslices.min_by(&:start).start.to_date)
-          .to eq(Date.new(2024, 1, 1))
-        expect(course.course_user_wiki_timeslices.max_by(&:start).start.to_date)
-          .to eq(Date.new(2024, 4, 20))
-      end
-    end
-  end
-
   describe '#create_course_wiki_timeslices_for_new_records' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
@@ -59,7 +42,7 @@ describe TimesliceManager do
     end
 
     context 'when there are new courses wikis' do
-      it 'creates course wiki and course user wiki timeslices for the entire course' do
+      it 'creates course wiki timeslices for the entire course' do
         # No course wiki timeslices exist previously
         expect(course.course_wiki_timeslices.size).to eq(0)
         timeslice_manager.create_timeslices_for_new_course_wiki_records([enwiki,
@@ -69,11 +52,8 @@ describe TimesliceManager do
         expect(course.course_wiki_timeslices.first.wiki).to eq(enwiki)
         expect(course.course_wiki_timeslices.last.wiki).to eq(wikibooks)
         expect(course.course_wiki_timeslices.size).to eq(222)
-        # Create all the course user wiki timeslices for the existing course users with student role
-        # for the new wiki
-        expect(course.course_user_wiki_timeslices.first.wiki).to eq(enwiki)
-        expect(course.course_user_wiki_timeslices.last.wiki).to eq(wikibooks)
-        expect(course.course_user_wiki_timeslices.size).to eq(444)
+
+        expect(course.course_user_wiki_timeslices.size).to eq(0)
       end
     end
   end
@@ -91,14 +71,12 @@ describe TimesliceManager do
     context 'when the start date changed to a previous date' do
       it 'creates timeslices for the missing period that needs_update' do
         expect(course.course_wiki_timeslices.size).to eq(333)
-        expect(course.course_user_wiki_timeslices.size).to eq(666)
 
         timeslice_manager.create_timeslices_for_new_course_start_date
         course.reload
         # Create course and user timeslices for the period between 2023-12-20 and 2024-01-01
         expect(course.course_wiki_timeslices.size).to eq(369)
         expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(36)
-        expect(course.course_user_wiki_timeslices.size).to eq(738)
       end
     end
   end
@@ -116,29 +94,28 @@ describe TimesliceManager do
     context 'when the end date changed to a later date' do
       it 'creates timeslices for the missing period that needs_update' do
         expect(course.course_wiki_timeslices.size).to eq(333)
-        expect(course.course_user_wiki_timeslices.size).to eq(666)
 
         timeslice_manager.create_timeslices_up_to_new_course_end_date
         course.reload
         # Create course and user timeslices for the period between 2024-04-20 and 2024-04-30
         expect(course.course_wiki_timeslices.size).to eq(363)
         expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(30)
-        expect(course.course_user_wiki_timeslices.size).to eq(726)
       end
     end
   end
 
   describe '#delete_course_user_timeslices_for_deleted_course_users' do
     before do
-      timeslice_manager.create_timeslices_for_new_course_user_records(new_course_users)
-      course.reload
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki)
+      create(:course_user_wiki_timeslice, course:, user_id: 2, wiki: enwiki)
+      create(:course_user_wiki_timeslice, course:, user_id: 3, wiki: enwiki)
     end
 
     it 'deletes course user wiki timeslices for the given users properly' do
-      expect(course.course_user_wiki_timeslices.size).to eq(666)
+      expect(course.course_user_wiki_timeslices.size).to eq(3)
 
       timeslice_manager.delete_course_user_timeslices_for_deleted_course_users([1, 2])
-      expect(course.course_user_wiki_timeslices.size).to eq(222)
+      expect(course.course_user_wiki_timeslices.size).to eq(1)
     end
   end
 
@@ -148,6 +125,9 @@ describe TimesliceManager do
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
                                                                        wikidata,
                                                                        enwiki])
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: wikibooks)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: wikidata)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki)
       create(:article_course_timeslice, course:, article: article1)
       create(:article_course_timeslice, course:, article: article2)
       create(:article_course_timeslice, course:, article: article3)
@@ -156,12 +136,13 @@ describe TimesliceManager do
 
     it 'deletes wiki timeslices for the entire course properly' do
       expect(course.course_wiki_timeslices.size).to eq(333)
-      expect(course.course_user_wiki_timeslices.size).to eq(666)
+      expect(course.course_user_wiki_timeslices.size).to eq(3)
       expect(course.article_course_timeslices.size).to eq(3)
 
       timeslice_manager.delete_timeslices_for_deleted_course_wikis([wikibooks.id,
                                                                     wikidata.id])
       course.reload
+      expect(course.course_user_wiki_timeslices.size).to eq(1)
       # Course wiki timeslices for wikibooks and wikidata were deleted
       expect(course.course_wiki_timeslices.where(wiki_id: wikibooks.id).size).to eq(0)
       expect(course.course_wiki_timeslices.where(wiki_id: wikidata.id).size).to eq(0)
@@ -223,11 +204,17 @@ describe TimesliceManager do
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
                                                                        wikidata,
                                                                        enwiki])
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+             start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+             start: '2024-01-10'.to_datetime, end: '2024-01-11'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+             start: '2024-01-11'.to_datetime, end: '2024-01-12'.to_datetime)
       course.reload
     end
 
     it 'deletes course user wiki timeslices for dates prior to start date properly' do
-      expect(course.course_user_wiki_timeslices.size).to eq(666)
+      expect(course.course_user_wiki_timeslices.size).to eq(3)
 
       # Update course start date
       course.update(start: '2024-01-10'.to_datetime)
@@ -235,7 +222,7 @@ describe TimesliceManager do
       course.reload
 
       # Course user wiki timeslices prior to the new start date were deleted
-      expect(course.course_user_wiki_timeslices.size).to eq(612)
+      expect(course.course_user_wiki_timeslices.size).to eq(2)
     end
   end
 
@@ -245,10 +232,16 @@ describe TimesliceManager do
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
                                                                        wikidata,
                                                                        enwiki])
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+              start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+              start: '2024-04-10'.to_datetime, end: '2024-04-11'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+              start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
     end
 
     it 'deletes course user wiki timeslices for dates after the end date properly' do
-      expect(course.course_user_wiki_timeslices.size).to eq(666)
+      expect(course.course_user_wiki_timeslices.size).to eq(3)
 
       # Update course start date
       course.update(end: '2024-04-10'.to_datetime)
@@ -256,7 +249,7 @@ describe TimesliceManager do
       course.reload
 
       # Course user wiki timeslices prior to the new start date were deleted
-      expect(course.course_user_wiki_timeslices.size).to eq(606)
+      expect(course.course_user_wiki_timeslices.size).to eq(2)
     end
   end
 

--- a/spec/services/update_timeslices_course_date_spec.rb
+++ b/spec/services/update_timeslices_course_date_spec.rb
@@ -28,6 +28,12 @@ describe UpdateTimeslicesCourseDate do
            user_ids: [user1.id])
     create(:article_course_timeslice, course:, article: article2, start: start + 6.days,
            end: start + 7.days, user_ids: [user1.id])
+    create(:course_user_wiki_timeslice, course:, user: user1, wiki: enwiki,
+           start:, end: start + 1.day)
+    create(:course_user_wiki_timeslice, course:, user: user1, wiki: enwiki,
+           start: start + 3.days, end: start + 4.days)
+    create(:course_user_wiki_timeslice, course:, user: user1, wiki: enwiki,
+           start: start + 6.days, end: start + 7.days)
   end
 
   context 'when the start date changed to a previous date' do
@@ -39,14 +45,15 @@ describe UpdateTimeslicesCourseDate do
       # There are two users, two articles and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(3)
       expect(course.article_course_timeslices.count).to eq(2)
 
       described_class.new(course).run
-      # Course wiki and course user timeslices from 2021-01-20 to 2021-01-24 were added
+      # Course wiki timeslices from 2021-01-20 to 2021-01-24 were added
       expect(course.course_wiki_timeslices.count).to eq(11)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(4)
-      expect(course.course_user_wiki_timeslices.count).to eq(22)
+      expect(course.course_user_wiki_timeslices.count).to eq(3)
+      expect(course.article_course_timeslices.count).to eq(2)
     end
   end
 
@@ -60,7 +67,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.count).to eq(7)
       # When updating the start date, the timeslice is marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(3)
       expect(course.article_course_timeslices.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
@@ -68,7 +75,7 @@ describe UpdateTimeslicesCourseDate do
       # Timeslices from 2021-01-24 to 2021-01-26 were deleted
       expect(course.course_wiki_timeslices.count).to eq(5)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
-      expect(course.course_user_wiki_timeslices.count).to eq(10)
+      expect(course.course_user_wiki_timeslices.count).to eq(2)
       # Article course for article 1 was deleted
       expect(course.articles_courses.count).to eq(1)
       expect(course.article_course_timeslices.count).to eq(1)
@@ -84,14 +91,14 @@ describe UpdateTimeslicesCourseDate do
       # There are two users, two articles and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(3)
       expect(course.article_course_timeslices.count).to eq(2)
 
       described_class.new(course).run
       # Timeslices from 2021-01-30 to 2021-02-11 were added
       expect(course.course_wiki_timeslices.count).to eq(19)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(13)
-      expect(course.course_user_wiki_timeslices.count).to eq(38)
+      expect(course.course_user_wiki_timeslices.count).to eq(3)
       expect(course.article_course_timeslices.count).to eq(2)
     end
   end
@@ -106,7 +113,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.count).to eq(7)
       # When updating the start date, the timeslice is marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(3)
       expect(course.article_course_timeslices.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
 
@@ -114,7 +121,7 @@ describe UpdateTimeslicesCourseDate do
       # Timeslices for 2021-01-30 were deleted
       expect(course.course_wiki_timeslices.count).to eq(6)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
-      expect(course.course_user_wiki_timeslices.count).to eq(12)
+      expect(course.course_user_wiki_timeslices.count).to eq(2)
       # Article course for article 2 was deleted
       expect(course.articles_courses.count).to eq(1)
       expect(course.article_course_timeslices.count).to eq(1)

--- a/spec/services/update_timeslices_course_user_spec.rb
+++ b/spec/services/update_timeslices_course_user_spec.rb
@@ -31,6 +31,9 @@ describe UpdateTimeslicesCourseUser do
       create(:articles_course, course:, article: article1, user_ids: [user1.id])
       create(:articles_course, course:, article: article2, user_ids: [user1.id, user2.id])
 
+      create(:course_user_wiki_timeslice, course:, user: user1, wiki: enwiki)
+      create(:course_user_wiki_timeslice, course:, user: user2, wiki: enwiki)
+
       create(:article_course_timeslice, course:, article: article1, start:, user_ids: [user1.id])
       create(:article_course_timeslice, course:, article: article2, start:,
       user_ids: [user1.id, user2.id])
@@ -46,7 +49,7 @@ describe UpdateTimeslicesCourseUser do
       # TODO: improve this spec because it doesn't make a lot of sense
       # There are two users, two articles and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(2)
       expect(course.article_course_timeslices.count).to eq(4)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
@@ -55,7 +58,7 @@ describe UpdateTimeslicesCourseUser do
 
       # Nothing changed
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(2)
       expect(course.article_course_timeslices.count).to eq(4)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
@@ -68,7 +71,7 @@ describe UpdateTimeslicesCourseUser do
 
       # There are two users, two articles and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(2)
       expect(course.article_course_timeslices.count).to eq(4)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
@@ -77,7 +80,7 @@ describe UpdateTimeslicesCourseUser do
       # There is one user, one article and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(2)
-      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end
@@ -93,6 +96,7 @@ describe UpdateTimeslicesCourseUser do
       course_user.update(created_at: 2.hours.ago)
 
       manager.create_timeslices_for_new_course_wiki_records([enwiki])
+      create(:course_user_wiki_timeslice, course:, user: user1, wiki: enwiki)
 
       # add the new user
       JoinCourse.new(course:, user: user2, role: CoursesUsers::Roles::STUDENT_ROLE)
@@ -102,7 +106,7 @@ describe UpdateTimeslicesCourseUser do
     it 'returns immediately if no previous update' do
       # There is one user and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
 
       VCR.use_cassette 'course_user_updater' do
         described_class.new(course).run
@@ -112,7 +116,7 @@ describe UpdateTimeslicesCourseUser do
       expect(course.course_wiki_timeslices.count).to eq(7)
       # No timeslice was marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
-      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
     end
 
     it 'updates course wiki timeslices if previous update' do
@@ -120,7 +124,7 @@ describe UpdateTimeslicesCourseUser do
       course.save
       # There is one user and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
 
       VCR.use_cassette 'course_user_updater' do
         described_class.new(course).run
@@ -129,7 +133,7 @@ describe UpdateTimeslicesCourseUser do
       # There are two student users and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(6)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
     end
   end
 end

--- a/spec/services/update_timeslices_course_user_spec.rb
+++ b/spec/services/update_timeslices_course_user_spec.rb
@@ -14,6 +14,10 @@ describe UpdateTimeslicesCourseUser do
   let(:wikidata_article) { create(:article, wiki: wikidata) }
   let(:article1) { create(:article, wiki: enwiki) }
   let(:article2) { create(:article, wiki: enwiki) }
+  let(:update_logs) do
+    { 'update_logs' => { 1 => { 'start_time' => 3.minutes.ago,
+      'end_time' => 2.minutes.ago } } }
+  end
 
   context 'when some course user was removed' do
     before do
@@ -38,7 +42,30 @@ describe UpdateTimeslicesCourseUser do
       CoursesUsers.find_by(course:, user: user1).delete
     end
 
+    it 'returns immediately if no previous update' do
+      # TODO: improve this spec because it doesn't make a lot of sense
+      # There are two users, two articles and one wiki
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(4)
+      expect(course.articles.count).to eq(2)
+      expect(course.articles_courses.count).to eq(2)
+
+      described_class.new(course).run
+
+      # Nothing changed
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.article_course_timeslices.count).to eq(4)
+      expect(course.articles.count).to eq(2)
+      expect(course.articles_courses.count).to eq(2)
+    end
+
     it 'removes course user wiki timeslices and updates course wiki timeslices' do
+      # Set previous update
+      course.flags = update_logs
+      course.save
+
       # There are two users, two articles and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_user_wiki_timeslices.count).to eq(14)
@@ -61,7 +88,10 @@ describe UpdateTimeslicesCourseUser do
       stub_wiki_validation
       # Add one user and create timeslices
       course.campaigns << Campaign.first
-      JoinCourse.new(course:, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)
+      course_user = CoursesUsers.create(user: user1, course:,
+                                        role: CoursesUsers::Roles::STUDENT_ROLE)
+      course_user.update(created_at: 2.hours.ago)
+
       manager.create_timeslices_for_new_course_wiki_records([enwiki])
 
       # add the new user
@@ -69,7 +99,7 @@ describe UpdateTimeslicesCourseUser do
       JoinCourse.new(course:, user: user3, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     end
 
-    it 'only adds course user wiki timeslices if no previous update' do
+    it 'returns immediately if no previous update' do
       # There is one user and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       expect(course.course_user_wiki_timeslices.count).to eq(7)
@@ -78,15 +108,15 @@ describe UpdateTimeslicesCourseUser do
         described_class.new(course).run
       end
 
-      # There are two users and one wiki
+      # There is one user and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
       # No timeslice was marked as needs_update
       expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(7)
     end
 
-    it 'adds course user wiki timeslices and updates course wiki timeslices if previous update' do
-      course.flags[:first_update] = true
+    it 'updates course wiki timeslices if previous update' do
+      course.flags = update_logs
       course.save
       # There is one user and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)

--- a/spec/services/update_timeslices_course_wiki_spec.rb
+++ b/spec/services/update_timeslices_course_wiki_spec.rb
@@ -98,7 +98,7 @@ describe UpdateTimeslicesCourseWiki do
 
     it 'updates current and future timeslices if new timeslice duration is smaller' do
       # Update timeslice duration to 12 hours
-      course.flags = { timeslice_duration: 43200 }
+      course.flags = { timeslice_duration: { default: 43200 } }
       course.save
 
       described_class.new(course).run
@@ -112,7 +112,7 @@ describe UpdateTimeslicesCourseWiki do
 
     it 'updates current and future timeslices if new timeslice duration is greater' do
       # Update timeslice duration to 2 days
-      course.flags = { timeslice_duration: 172800 }
+      course.flags = { timeslice_duration: { default: 172800 } }
       course.save
 
       described_class.new(course).run

--- a/spec/services/update_timeslices_course_wiki_spec.rb
+++ b/spec/services/update_timeslices_course_wiki_spec.rb
@@ -25,6 +25,10 @@ describe UpdateTimeslicesCourseWiki do
       create(:article_course_timeslice, course:, article: wikidata_article)
       create(:article_course_timeslice, course:, article:)
 
+      # Add course user wiki timeslices manually
+      create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki)
+      create(:course_user_wiki_timeslice, course:, user:, wiki: wikidata)
+
       # Create course wiki timeslices manually for wikidata
       course.wikis << wikidata
       manager.create_timeslices_for_new_course_wiki_records([wikidata])
@@ -34,7 +38,7 @@ describe UpdateTimeslicesCourseWiki do
     it 'removes existing wiki timeslices' do
       # There is one user, two articles and two wikis
       expect(course.course_wiki_timeslices.count).to eq(14)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(2)
       expect(course.article_course_timeslices.count).to eq(2)
       expect(course.articles.count).to eq(2)
       expect(course.articles_courses.count).to eq(2)
@@ -42,7 +46,7 @@ describe UpdateTimeslicesCourseWiki do
       described_class.new(course).run
       # There is one user, one article and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
       expect(course.article_course_timeslices.count).to eq(1)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
@@ -63,7 +67,7 @@ describe UpdateTimeslicesCourseWiki do
     it 'adds wiki timeslices' do
       # There is one user, one article and one wiki
       expect(course.course_wiki_timeslices.count).to eq(7)
-      expect(course.course_user_wiki_timeslices.count).to eq(7)
+      expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
 
@@ -71,7 +75,7 @@ describe UpdateTimeslicesCourseWiki do
       described_class.new(course).run
       # There is one user, one article and two wikis
       expect(course.course_wiki_timeslices.count).to eq(14)
-      expect(course.course_user_wiki_timeslices.count).to eq(14)
+      expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.articles.count).to eq(1)
       expect(course.articles_courses.count).to eq(1)
     end


### PR DESCRIPTION
## What this PR does
This PR adds functionality to change the timeslice duration for a given course. The timeslice duration works at course wiki level as we may want to set different timeslice durations for different wikis within the same course.

There is a new `TIMESLICE_DURATION` env variable to set the default timeslice duration. In addition, a course may have a `timeslice_duration` flag to specify timeslice durations for wikis. The flag looks as follows:
```
:timeslice_duration:
    :default: 86400
    :en.wikipedia.org: 43200
    :es.wikipedia.org: 864000
```
Lengths are measured in seconds (e.g., 86400 seconds = 1 day, 43200 seconds = 12 hours, 864000 seconds = 10 days).
- If a specific value is defined for a wiki domain (`wiki.domain`), that value is used for the corresponding wiki.
- Otherwise, the `default` value is applied.
- If the `timeslice_duration` flag is not provided for the course, the `TIMESLICE_DURATION` environment variable is used.

As part of the changes, this PR also stops creating the complete universe of timeslices for course user wiki. That means that we only create a course user wiki timeslice when we found some revisions for that course user wiki in the given period of time. Note that the timeslice could still be empty (`revision_count` set to 0) because we only consider _live revisions_ (revisions for tracked article courses for which already exists an article record). See `CourseUserWikiTimeslice.update_cache_from_revisions`. This refactor was addressed in this PR for simplicity reasons.

## Open questions and concerns
An admin view to easily get and update the timeslice duration for a course will be created in the future. For now, only manual updates are supported (in the `flag` field).