### PR TITLE
Add student program endpoint

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -139,10 +139,28 @@ class CoursesController < ApplicationController
     @alerts = current_user&.admin? ? @course.alerts : @course.public_alerts
   end
 
-  def approved_classroom_courses_json
-    courses = Course.approved_classroom_courses_with_users
+  def classroom_program_students_json
+    courses = Course.classroom_program_students
 
-    render json: courses, include: :users
+    render json: courses, include: :students
+  end
+
+  def classroom_program_students_and_instructors_json
+    courses = Course.classroom_program_students_and_instructors
+
+    render json: courses, include: [:students, :instructors]
+  end
+
+  def fellows_cohort_students_json
+    courses = Course.fellows_cohort_students
+
+    render json: courses, include: :students
+  end
+
+  def fellows_cohort_students_and_instructors_json
+    courses = Course.fellows_cohort_students_and_instructors
+
+    render json: courses, include: [:students, :instructors]
   end
 
   ##########################

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -139,6 +139,12 @@ class CoursesController < ApplicationController
     @alerts = current_user&.admin? ? @course.alerts : @course.public_alerts
   end
 
+  def approved_classroom_courses_json
+    courses = Course.approved_classroom_courses_with_users
+
+    render json: courses, include: :users
+  end
+
   ##########################
   # User-initiated actions #
   ##########################

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -141,26 +141,56 @@ class CoursesController < ApplicationController
 
   def classroom_program_students_json
     courses = Course.classroom_program_students
-
-    render json: courses, include: :students
+    render json: courses.as_json(
+      only: %i[title created_at updated_at start end school term slug],
+      include: {
+        students: {
+          only: %i[username created_at updated_at permissions]
+        }
+      }
+    )
   end
 
   def classroom_program_students_and_instructors_json
     courses = Course.classroom_program_students_and_instructors
-
-    render json: courses, include: [:students, :instructors]
+    render json: courses.as_json(
+      only: %i[title created_at updated_at start end school term slug],
+      include: {
+        students: {
+          only: %i[username created_at updated_at permissions]
+        },
+        instructors: {
+          only: %i[username created_at updated_at permissions]
+        }
+      }
+    )
   end
 
   def fellows_cohort_students_json
     courses = Course.fellows_cohort_students
-
-    render json: courses, include: :students
+    render json: courses.as_json(
+      only: %i[title created_at updated_at start end school term slug],
+      include: {
+        students: {
+          only: %i[username created_at updated_at permissions]
+        }
+      }
+    )
   end
 
   def fellows_cohort_students_and_instructors_json
     courses = Course.fellows_cohort_students_and_instructors
-
-    render json: courses, include: [:students, :instructors]
+    render json: courses.as_json(
+      only: %i[title created_at updated_at start end school term slug],
+      include: {
+        students: {
+          only: %i[username created_at updated_at permissions]
+        },
+        instructors: {
+          only: %i[username created_at updated_at permissions]
+        }
+      }
+    )
   end
 
   ##########################

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -160,12 +160,36 @@ class Course < ApplicationRecord
           .where(submitted: false).references(:campaigns)
   end
 
-  def self.approved_classroom_courses_with_users
+  def self.classroom_program_students
     nonprivate
       .where(type: 'ClassroomProgramCourse', withdrawn: false)
       .joins(:campaigns)
       .distinct
-      .includes(:users)
+      .includes(:students)
+  end
+
+  def self.classroom_program_students_and_instructors
+    nonprivate
+      .where(type: 'ClassroomProgramCourse', withdrawn: false)
+      .joins(:campaigns)
+      .distinct
+      .includes(:students, :instructors)
+  end
+
+  def self.fellows_cohort_students
+    nonprivate
+      .where(type: 'FellowsCohort', withdrawn: false)
+      .joins(:campaigns)
+      .distinct
+      .includes(:students)
+  end
+
+  def self.fellows_cohort_students_and_instructors
+    nonprivate
+      .where(type: 'FellowsCohort', withdrawn: false)
+      .joins(:campaigns)
+      .distinct
+      .includes(:students, :instructors)
   end
 
   scope :strictly_current, -> { where('? BETWEEN start AND end', Time.zone.now) }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -160,6 +160,14 @@ class Course < ApplicationRecord
           .where(submitted: false).references(:campaigns)
   end
 
+  def self.approved_classroom_courses_with_users
+    nonprivate
+      .where(type: 'ClassroomProgramCourse', withdrawn: false)
+      .joins(:campaigns)
+      .distinct
+      .includes(:users)
+  end
+
   scope :strictly_current, -> { where('? BETWEEN start AND end', Time.zone.now) }
   scope :current, -> { current_and_future.where('start < ?', Time.zone.now) }
   scope :ended, -> { where('end < ?', Time.zone.now) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,9 +168,20 @@ Rails.application.routes.draw do
           titleterm: /[^\/]*/,
           _subsubsubpage: /.*/
         }
-    get '/courses/approved_classroom_courses.json',
-        to: 'courses#approved_classroom_courses_json',
-        as: :approved_classroom_courses
+
+    get '/courses/classroom_program_students.json',
+        to: 'courses#classroom_program_students_json',
+        as: :classroom_program_students
+    get '/courses/classroom_program_students_and_instructors.json',
+        to: 'courses#classroom_program_students_and_instructors_json',
+        as: :classroom_program_students_and_instructors
+    get '/courses/fellows_cohort_students.json',
+        to: 'courses#fellows_cohort_students_json',
+        as: :fellows_cohort_students
+    get '/courses/fellows_cohort_students_and_instructors.json',
+        to: 'courses#fellows_cohort_students_and_instructors_json',
+        as: :fellows_cohort_students_and_instructors
+
     post '/courses/:slug/students/add_to_watchlist', to: 'courses/watchlist#add_to_watchlist', as: 'add_to_watchlist',
         constraints: { slug: /.*/ }
     delete 'courses/:slug/delete_from_campaign' => 'courses/delete_from_campaign#delete_course_from_campaign', as: 'delete_from_campaign', 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,7 +168,9 @@ Rails.application.routes.draw do
           titleterm: /[^\/]*/,
           _subsubsubpage: /.*/
         }
-
+    get '/courses/approved_classroom_courses.json',
+        to: 'courses#approved_classroom_courses_json',
+        as: :approved_classroom_courses
     post '/courses/:slug/students/add_to_watchlist', to: 'courses/watchlist#add_to_watchlist', as: 'add_to_watchlist',
         constraints: { slug: /.*/ }
     delete 'courses/:slug/delete_from_campaign' => 'courses/delete_from_campaign#delete_course_from_campaign', as: 'delete_from_campaign', 


### PR DESCRIPTION

## What this PR does
This PR adds new JSON endpoints for the dashboard. These endpoints are needed to add new functionality to the impact-visualizer project.

**The added endpoints:**
`/courses/classroom_program_students.json` (returns all students and the courses they belong to from the Wikipedia Student Program)
`/courses/classroom_program_students_and_instructors.json`  (returns all students, instructors and the courses they belong to from the Wikipedia Student Program)
`/courses/fellows_cohort_students.json` (returns all students and the courses they belong to from the Scholars and Scientists Program)
`/courses/fellows_cohort_students_and_instructors.json`  (returns all students, instructors and the courses they belong to from the Scholars and Scientists Program)
