### PR TITLE
Add links to admin_guide.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ If you're a new developer and you're looking for an easy way to get involved, tr
 - [MediaWiki API Sandbox](https://en.wikipedia.org/wiki/Special%3aApiSandbox)
 - [Quarry](http://quarry.wmflabs.org/): Public querying interface for the Labs replica database. Very useful for testing SQL queries and for figuring out what data is available.
 - [Guide to the front end](docs/frontend.md)
+- [Admin Guide](docs/admin_guide.md): Overview of the Dashboard infrastructure, including servers, tools, dependencies, and troubleshooting resources.
 - [Vagrant](https://github.com/marxarelli/wikied-vagrant): a configuration to quickly get a development environment up and running using Vagrant. If you already have VirtualBox and/or Vagrant on your machine, this might be a simple way to set up a dev environment. However, it is not actively maintained. If you try it and run into problems, let us know!
 
 #### Code Style

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This project welcomes contributions, and we try to be as newbie-friendly as poss
 - [Interface strings & Internationalization](docs/i18n.md)
 - [OAuth setup](docs/oauth.md)
 - [Deployment](docs/deploy.md)
+- [Admin Guide](docs/admin_guide.md) - Overview of the Dashboard infrastructure, including servers, tools, dependencies, and troubleshooting resources.
 - [Tools & Integrations](docs/tools.md)
 - [Using Docker for development](docs/docker.md)
 - [Model diagram](erd.pdf)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - [Contributing](../CONTRIBUTING.md)
 - [Development Process outline](dev_process.md)
 - [Deployment](deploy.md)
+- [Admin Guide](docs/admin_guide.md)
 - [Upgrading dependencies](upgrade_dependencies.md)
 - [Tools & Integrations](tools.md)
 - [Model diagram](../erd.pdf)

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -1,4 +1,7 @@
-# Admin Guide for Program & Events Dashboard
+[Back to README](../README.md)
+
+## Admin Guide for Program & Events Dashboard
+
 The **Programs & Events Dashboard** ([outreachdashboard.wmflabs.org](https://outreachdashboard.wmflabs.org)) is a web application designed to support the global Wikimedia community in organizing various programs, including edit-a-thons, education initiatives, and other events. See the **[Source Code](https://github.com/WikiEducationFoundation/WikiEduDashboard/tree/wmflabs)** and **[Phabricator Project](https://phabricator.wikimedia.org/project/manage/1052/)** for more details.
 
 This guide provides an overview of the **Program & Events Dashboard** infrastructure, detailing the servers, tools, and third-party dependencies that power the system. It also provides resources for managing and troubleshooting the system.


### PR DESCRIPTION
## What this PR does
Adds links to the [admin_guide.md](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/docs/admin_guide.md) in the 2 READMEs and the CONTRIBUTING.md. Also adds link back to the main README in the guide 