### PR TITLE
Fix: failure in Student_role_spec

### DIFF
--- a/spec/features/student_role_spec.rb
+++ b/spec/features/student_role_spec.rb
@@ -15,8 +15,8 @@ describe 'Student users', type: :feature, js: true do
            slug: 'University/An_Example_Course_(Term)',
            submitted: true,
            passcode: 'passcode',
-           start: '2015-01-01'.to_date,
-           end: '2025-01-01'.to_date)
+           start: '2025-01-01'.to_date,
+           end: 1.month.from_now)
   end
   let!(:editathon) do
     create(:editathon,
@@ -26,8 +26,8 @@ describe 'Student users', type: :feature, js: true do
            slug: 'University/An_Example_Editathon_(Term)',
            submitted: true,
            passcode: '',
-           start: '2015-01-01'.to_date,
-           end: '2025-01-01'.to_date)
+           start: '2025-01-01'.to_date,
+           end: 1.month.from_now)
   end
 
   before do


### PR DESCRIPTION

## What this PR does
This PR resolves the recent failure in the  multiwiki_assignment_spec and student_role_spec failure by fixing useNavigationUtils access and updating course creation date
## Screenshots
Before:
<img width="874" alt="Screenshot 2025-01-03 at 17 06 32" src="https://github.com/user-attachments/assets/83a2a2c2-4a10-4130-94eb-4fb356973616" />


<img width="1236" alt="Screenshot 2025-01-03 at 17 05 28" src="https://github.com/user-attachments/assets/84abd89a-6464-4716-ba9f-17ffcba4cb74" />

<img width="1092" alt="Screenshot 2025-01-03 at 17 06 53" src="https://github.com/user-attachments/assets/902b1490-8a8c-4279-a3fe-35d6cc4f180d" />

