### PR TITLE
Fix: multiwiki_assignment_spec failure

### DIFF
--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -60,8 +60,9 @@ describe 'multiwiki assignments', type: :feature, js: true do
         first('textarea').set(
           "Terre\nhttps://fr.wikipedia.org/wiki/Anglais"
         )
+        expect(page).to have_button('Assign all')
+        click_button 'Assign all'
       end
-      click_button 'Assign all'
 
       visit "/courses/#{course.slug}/students/articles"
       first('.student-selection .student').click


### PR DESCRIPTION
## What this PR does
This PR addresses the recent failure in the multiwiki_assignment_spec where Capybara was unable to find the button "Assign all" because it possible was not available. The issue is resolved by utilizing Capybara's default wait mechanism, ensuring that the button is present and enabled before interacting with it.

#### Notes:
The other errors that occurred along with this issue, such as the missing content ("Heyder Cansa" and "Wp/kiu/Hey"), have not occurred recently.
This improvement is due to the increased Capybara wait time, which accounted for the longer period required for the element to become available, thus preventing interaction failures.

<img width="1416" alt="Screenshot 2025-01-04 at 05 21 09" src="https://github.com/user-attachments/assets/bd5cc0d9-d78d-48cd-bbaa-06813fa6d43f" />