### PR TITLE
Fix: Improved slug validation and error handling for courses 

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -60,6 +60,9 @@ class Course < ApplicationRecord
   ######################
   # Users for a course #
   ######################
+  # Validations
+  validates :slug, presence: true, uniqueness: { message: "Slug must be unique. Another course with this slug already exists." }
+
   has_many :courses_users, class_name: 'CoursesUsers', dependent: :destroy
   has_many :users, -> { distinct }, through: :courses_users
   has_many :students, -> { where('courses_users.role = 0') },


### PR DESCRIPTION
#6087  This PR fixes an issue where updating a course slug to a duplicate value caused a generic "Internal Server Error." The changes include:

1. **Added Slug Validation in `Course` Model**:
   - Ensures `slug` is unique with a clear error message: 
     `"Slug must be unique. Another course with this slug already exists."`

2. **Improved Error Handling in `update` Method**:
   - The `courses_controller.rb` now validates updates and provides meaningful error messages to users when a slug conflict occurs.
   - Returns a `422 Unprocessable Entity` status with detailed validation messages.
