### PR TITLE
 [FIX]: Database Connection Issue by Hostname Resolution During Setup Using Docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -58,3 +58,10 @@ If you are using Linux you may encounter permission error when trying to change 
 $ sudo chown $USER:$GROUPS -R ./
 ```
 The command will change the owner of all file inside project directory to the `$USER:$GROUPS`
+
+If you encounter the following error when connecting to the database: _"There is an issue connecting with your hostname mysql"_, please run the following command:
+```sh
+bash ./update_hosts.sh
+```
+This script automatically resolves the issue by ensuring proper network mapping in your system's ```/etc/hosts``` file, facilitating seamless database connections. It retrieves the IP address of the MySQL Docker container, checks for any existing hostname entries, and updates or removes outdated ones. This process ensures that the hostname ```mysql``` is correctly mapped to the container’s IP address.
+This bash script is designed for Linux distributions like Fedora.

--- a/update_hosts.sh
+++ b/update_hosts.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Get the MySQL container ID
+MYSQL_CONTAINER_ID=$(docker ps --format '{{.ID}} {{.Names}}' | grep 'wikiedudashboard-mysql-1' | awk '{print $1}')
+
+echo $MYSQL_CONTAINER_ID
+
+# Fetch the IP address of the MySQL container
+MYSQL_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$MYSQL_CONTAINER_ID")
+
+# Check if we successfully fetched the IP address
+if [ -z "$MYSQL_IP" ]; then
+    echo "Failed to retrieve the MySQL container IP address. Please ensure the Docker containers are running by executing 'docker compose up -d'."
+    if grep -q "$MYSQL_IP mysql" /etc/hosts; then
+    sudo sed -i '/[[:space:]]mysql$/d' /etc/hosts
+    echo "MySQL entry removed from /etc/hosts."
+    fi
+    
+    exit 1
+fi
+
+# Print the IP address
+echo "MySQL IP address: $MYSQL_IP"
+
+# Backup /etc/hosts file
+sudo cp /etc/hosts /etc/hosts.bak
+
+# Add MySQL container IP to /etc/hosts
+if grep -q "$MYSQL_IP mysql" /etc/hosts; then
+    echo "MySQL entry already exists in /etc/hosts."
+    # Remove existing MySQL entry from /etc/hosts (if it exists)
+    sudo sed -i '/[[:space:]]mysql$/d' /etc/hosts
+    echo "Removed old MySQL entry from /etc/hosts."
+fi
+
+# Add new MySQL container IP address to /etc/hosts
+echo "Adding MySQL container IP address to /etc/hosts"
+echo "$MYSQL_IP mysql" | sudo tee -a /etc/hosts > /dev/null
+
+# Print success message
+echo "MySQL IP address has been added to /etc/hosts."


### PR DESCRIPTION
## What this PR does
This pull request addresses an issue encountered during the setup process on Fedora using Docker, where the database connection fails due to hostname resolution issues. The error occurs when the system is unable to resolve the required hostname, leading to the failure of the setup process.

Fixes #6074

### Changes Introduced:

Added a script that automatically resolves the hostname by ensuring proper network mapping, allowing the database connection to be established successfully.
This script ensures that the system can correctly resolve the hostname and connect to the database without errors.
Can be invoked by ```bash ./update_hosts.sh```

### Explanation:
The issue arises because the necessary host entries are not present in the ```/etc/hosts``` file
When the system attempts to resolve an address, it fails to locate the corresponding hostname in the local resolution file and subsequently defaults to querying the network gateway to determine if the address exists.
To address this, I have implemented a script to automate the addition of host entries to the ```/etc/hosts file```. This ensures that the hostname resolution process can efficiently locate and map the desired addresses locally without needing to fallback to external network queries.
The current Docker Compose file lacks the necessary configurations to locate the mappings effectively.

### Key Cases Handled:

- **Container Running:**  
  If the Docker container is up, the script updates the `/etc/hosts` file with the new IP address, ensuring correct hostname resolution.

- **Container Restarted:**  
  If the Docker container is restarted and the IP address changes, the script checks for the old address and updates it with the new IP address in `/etc/hosts`.

- **Container Down:**  
  If the Docker container is down, the `update_hosts.sh` script removes the corresponding address from the `/etc/hosts` file to prevent stale entries.

- **No Duplicate Entries:**  
  The script ensures that there are no duplicate IP addresses for the same hostname in the `/etc/hosts` file, maintaining clean mappings.


### Testing:

Verified that running the script ensures successful hostname resolution.
Confirmed that the database connection is now established properly, and the setup process completes without errors.

### Remark
This PR solves the database connection issue for Fedora

