### PR TITLE
Sync troubleshooting.md with setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,7 +24,7 @@ For Windows, the easiest way to get an environment set up is to [use Ubuntu with
 ## Prerequisite
 There are some basic requirements for the script to work:
 - git (to clone the repository)
-- node version 14 or 16
+- node version 14 or newer
 - python 3.5 or newer
 - ruby 3.1.2
 - apt (debian) or homebrew (MacOS)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,7 @@ Your system has cmdtest installed, which provides a different program as yarn. U
 
 - **To check if redis is running as a daemon in Linux** `ps aux | grep redis-server`
 
-- Use node v10 or lower to avoid any errors.
+- Use node v14 or newer to avoid any errors.
 - **For WSL users , if rspec tests are taking too long to run** make sure to fork the repo in the linux file system and not in the windows partition. Use command `pwd` to know the exact path of your repo. If the path starts with `/mnt/`, the repo is in windows partition. Follow the documentation available at link: https://learn.microsoft.com/en-us/windows/wsl/filesystems to know more about storing and moving files in the linux file system. 
 
 	If you have received error related to dependencies(`sudo apt-get install -y redis-server mariadb-server libmariadb-dev rvm nodejs npm pandoc`), try to install packages one by one and figure out which packages are creating problems.


### PR DESCRIPTION
Currently, the [prerequisites section](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/docs/setup.md#prerequisite) of `setup.md` says to use Node version 14 or 16. However, the [common setup issues section](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/docs/troubleshooting.md#other-common-setup-issues) of `troubleshooting.md` says to use Node 10 or below. After having run into issues with using Node 10, it seemed to me that that information was out of date.

In this PR, I change `troubleshooting.md` to state the same Node versions as `setup.md`.
