### PR TITLE
Add Dynamic Titles to Show Page for Courses by Wiki

### DIFF
--- a/app/views/courses_by_wiki/show.html.haml
+++ b/app/views/courses_by_wiki/show.html.haml
@@ -1,2 +1,10 @@
-.container
-  #react_root{"data-current_user" => current_user ? { admin: current_user.admin?, id: current_user.id }.to_json : '{ "admin": false, "id": null }'}
+- content_for :title, "Courses by Wiki - #{current_user.username} Settings"
+- user = current_user.to_json(only: [:real_name, :email, :permissions, :username]).to_str
+
+%html
+  %head
+    %title= yield(:title)
+  %body
+    .container
+      #react_root{"data-current_user" => current_user ? { admin: current_user.admin?, id: current_user.id }.to_json : '{ "admin": false, "id": null }'}
+


### PR DESCRIPTION



## What this PR does
This PR adds dynamic titles to the show page for the "courses by wiki" section to improve user experience and ensure consistency in page naming conventions.

## Page-by-Page Breakdown:

/courses/:id: ➡️ Courses by Wiki - {Course Name}

 ## Impact:

User Experience: Clearer, more descriptive page titles improve the user's ability to navigate the platform effectively.

## Notes:

This PR does not affect any functionality apart from the front-end display of titles in the browser tab and search engine metadata.

