### PR TITLE
FIX: Add guard statements to prevent `NoMethodError`s when `get_user_info's `user_data` is `nil` 

### DIFF
--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -114,7 +114,7 @@ class UserImporter
 
   def self.update_user_from_wiki(user, wiki)
     user_data = WikiApi.new(wiki).get_user_info(user.username)
-    return if user_data['missing']
+    return if user_data.nil? || user_data['missing']
     user.update!(username: user_data['name'],
                  registered_at: user_data['registration'],
                  global_id: user_data&.dig('centralids', 'CentralAuth'))

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -47,7 +47,7 @@ class WikiApi
                    ususers: username,
                    usprop: 'centralids|registration' }
     user_data = mediawiki('query', user_query)
-    return unless user_data.data['users'].any?
+    return unless user_data&.data&.dig('users')&.any?
     user_data.data['users'][0]
   end
 

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -169,6 +169,18 @@ describe WikiApi do
     end
   end
 
+  describe '#get_user_info' do
+    let(:wiki) { Wiki.new(language: 'en', project: 'wikipedia') }
+
+    context 'when mediawiki query returns nil' do
+      it 'returns early without raising an error' do
+        allow_any_instance_of(described_class).to receive(:mediawiki).and_return(nil)
+        expect { described_class.new.get_user_info('Ragesoss') }.not_to raise_error
+        expect(described_class.new.get_user_info('Ragesoss')).to be_nil
+      end
+    end
+  end
+
   describe '#redirect?' do
     let(:wiki) { Wiki.new(language: 'en', project: 'wikipedia') }
     let(:subject) { described_class.new(wiki).redirect?(title) }


### PR DESCRIPTION
## What this PR does
The `DailyUpdateWorker` triggers the `UpdateUsersWorker`, which calls [`UserImporter`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/ac19ee05d03ec8cd387506f82f06ec61870f8625/lib/importers/user_importer.rb#L7) and subsequently the [`get_user_info`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/ac19ee05d03ec8cd387506f82f06ec61870f8625/lib/wiki_api.rb#L45) method in `WikiApi`. A `NoMethodError` frequently occurs due to `user_data` being nil, specifically when trying to access `user_data.data['users']`:

```
undefined method `data' for nil:NilClass

    return unless user_data.data['users'].any?
                           ^^^^^
```

`UpdateUsersWorker` also encounters a `MediawikiApi::HttpError (429 - Too Many Requests)` error at the same time, and after further investigaton, I concluded that the `NoMethodError` happens because [`mediawiki('query', user_query)`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/ac19ee05d03ec8cd387506f82f06ec61870f8625/lib/wiki_api.rb#L100) returns `nil` after failing 3 times, causing `user_data` to be `nil`.

My solution was to update the [guard statement in `wiki_api`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/ac19ee05d03ec8cd387506f82f06ec61870f8625/lib/wiki_api.rb#L50) from:
```
 return unless user_data.data['users'].any?
```
to
```
 return unless user_data&.data&.dig('users')&.any?
```
The safe navigation operator (&.) ensures that the statement returns early if any of `user_data`, `user_data.data` or `user_data.data['users']` is nil or an empty array. This ensures that no `NoMethodError` will be raised.

This updated statement however also caused a `NoMethodError` in [`update_user_from_wiki`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/ac19ee05d03ec8cd387506f82f06ec61870f8625/lib/importers/user_importer.rb#L115) as the method was designed to only handle cases where `user_data['missing']`. The solution was to extend the return condition to 
```
return if user_data.nil? || user_data['missing']
````

Note that this fix prevents the `NoMethodError`s but does not resolve the `MediawikiApi::HttpError (429)` errors.


## Screenshots
I wrote tests to ensure the methods behaved as expected:

### `wiki_api_spec`
Before:
![b4](https://github.com/user-attachments/assets/f781e5f7-c99b-46f9-bb47-d6a5f2e1f078)

After:
![afta](https://github.com/user-attachments/assets/7ec87b42-2591-45e0-8837-dbf7f7b20612)

### `user_importer_spec`
Before:
![user b4](https://github.com/user-attachments/assets/94a99861-d335-4d64-a69c-d837a3da983e)

After:
![user afta](https://github.com/user-attachments/assets/da77b10d-392b-495c-9e10-3cf8f273df53)

