### PR TITLE
[WIP] : Extending workflow to save artifacts for debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         if: failure()
         with:
           name: dist-without-markdown
-          path: tmp/capybara/*.png
+          path: tmp/screenshots/*.png
           if-no-files-found: ignore
             
       - name: Ruby linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,14 @@ jobs:
           coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
           coverageLocations: |
             ${{github.workspace}}/public/js_coverage/lcov.info:lcov
+      
+      - name: Archive capybara failure screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: dist-without-markdown
+          path: tmp/capybara/*.png
+          if-no-files-found: ignore
             
       - name: Ruby linting
         run: bundle exec rubocop

--- a/spec/features/account_requests_spec.rb
+++ b/spec/features/account_requests_spec.rb
@@ -39,11 +39,4 @@ describe 'Account requests', type: :feature, js: true do
 
     pass_pending_spec
   end
-
-  it 'Testing Capybara screenshot on CI' do
-    login_as(instructor)
-    visit "/courses/#{course.slug}"
-    click_button 'Enable account'
-    expect(page).to have_content('Account request generation enabled')
-  end
 end

--- a/spec/features/account_requests_spec.rb
+++ b/spec/features/account_requests_spec.rb
@@ -39,4 +39,11 @@ describe 'Account requests', type: :feature, js: true do
 
     pass_pending_spec
   end
+
+  it 'Testing Capybara screenshot on CI' do
+    login_as(instructor)
+    visit "/courses/#{course.slug}"
+    click_button 'Enable account'
+    expect(page).to have_content('Account request generation enabled')
+  end
 end

--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -61,6 +61,8 @@ describe 'multiwiki assignments', type: :feature, js: true do
           "Terre\nhttps://fr.wikipedia.org/wiki/Anglais"
         )
       end
+
+      save_screenshot('first_textarea_filled.png')
       click_button 'Assign all'
 
       visit "/courses/#{course.slug}/students/articles"
@@ -118,6 +120,7 @@ describe 'multiwiki assignments', type: :feature, js: true do
       within('#users') do
         first('textarea').set('https://wikisource.org/wiki/Heyder_Cansa')
       end
+      save_screenshot('second_textarea_filled.png')
       click_button 'Assign'
       visit "/courses/#{course.slug}/students/articles"
       first('.student-selection .student').click
@@ -141,12 +144,13 @@ describe 'multiwiki assignments', type: :feature, js: true do
       within('#users') do
         first('textarea').set('https://incubator.wikimedia.org/wiki/Wp/kiu/Heyder_Cansa')
       end
+      save_screenshot('third_textarea_filled.png')
       click_button 'Assign'
       visit "/courses/#{course.slug}/students/articles"
       first('.student-selection .student').click
 
       within('#users') do
-        expect(page).to have_content 'Wp/kiu/Hey'
+        expect(page).to have_content 'Wp/kiu/Heyder Cansa'
         link = first('.assignment-links a')
         expect(link[:href]).to include('incubator.wikimedia')
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,9 @@ end
 
 Rails.cache.clear
 Capybara::Screenshot.prune_strategy = :keep_last_run
+Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|
+  "screenshot_#{example.description.tr(' ', '-').gsub(%r{^.*/spec/}, '')}"
+end
 Capybara.save_path = 'tmp/screenshots/'
 Capybara.server = :puma, { Silent: true }
 Capybara.default_max_wait_time = 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,7 +101,7 @@ RSpec.configure do |config|
     # them.
     # Instead, we clear and print any after-success error
     # logs in the `before` block above.
-    Capybara::Screenshot.screenshot_and_save_page if example.exception
+    # Capybara::Screenshot.screenshot_and_save_page if example.exception
     errors = page.driver.browser.logs.get(:browser)
 
     # pass `js_error_expected: true` to skip JS error checking


### PR DESCRIPTION

## What this PR does
This PR extends the CI workflow by adding functionality to save screenshots of failed Capybara tests as artifacts. When Capybara tests fail during execution, screenshots of the failed state are automatically captured. These screenshots will  be  archived and uploaded as artifacts in the CI pipeline, making it easier to debug and investigate test failures