### PR TITLE
Fix Conditional Question Display State Issues in Surveys

### DIFF
--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -698,50 +698,45 @@ const Survey = {
     }
   },
 
-  // FIXME: This is supposed to remove a conditional question from
-  // the flow if the condition that it depends on has changed.
-  // However, when this happens it leaves the survey in a state
-  // with no visible questions and no way to proceed.
-  // Disabling this feature means that, once inserted, a conditional
-  // question will not be removed, but that's better than a broken survey.
-  resetConditionalGroupChildren(/* conditionalGroup */) {
-    // const { children, currentAnswers } = conditionalGroup;
+  // To remove a conditional question from the flow if the condition that it depends on has changed.
+  resetConditionalGroupChildren(conditionalGroup) {
+    const { children, currentAnswers } = conditionalGroup;
 
-    // if ((typeof currentAnswers !== 'undefined' && currentAnswers !== null) && currentAnswers.length) {
-    //   const excludeFromReset = [];
-    //   currentAnswers.forEach((a) => { excludeFromReset.push(a); });
-    //   children.forEach((question) => {
-    //     const $question = $(question);
-    //     let string;
-    //     if ($question.data('conditional-question')) {
-    //       string = $question.data('conditional-question');
-    //     } else {
-    //       string = $question.find('[data-conditional-question]').data('conditional-question');
-    //     }
-    //     const { value } = Utils.parseConditionalString(string);
-    //     if (excludeFromReset.indexOf(value) === -1) {
-    //       this.resetConditionalQuestion($question);
-    //     } else {
-    //       $question.removeClass('hidden');
-    //     }
-    //   });
-    // } else {
-    //   children.forEach((question) => {
-    //     this.resetConditionalQuestion($(question));
-    //     if ($(question).hasClass('survey__question-row')) {
-    //       const $parentBlock = $(question).parents(BLOCK_CONTAINER_SELECTOR);
-    //       const blockIndex = $(question).data('block-index');
-    //       if (!($parentBlock.find('.survey__question-row:not([data-conditional-question])').length > 1)) {
-    //         this.resetConditionalQuestion($parentBlock);
-    //         if (this.detachedParentBlocks[blockIndex] === undefined) {
-    //           this.detachedParentBlocks[blockIndex] = $parentBlock;
-    //           this.removeSlide($parentBlock);
-    //           $parentBlock.detach();
-    //         }
-    //       }
-    //     }
-    //   });
-    // }
+    if ((typeof currentAnswers !== 'undefined' && currentAnswers !== null) && currentAnswers.length) {
+      const excludeFromReset = [];
+      currentAnswers.forEach((a) => { excludeFromReset.push(a); });
+      children.forEach((question) => {
+        const $question = $(question);
+        let string;
+        if ($question.data('conditional-question')) {
+          string = $question.data('conditional-question');
+        } else {
+          string = $question.find('[data-conditional-question]').data('conditional-question');
+        }
+        const { value } = Utils.parseConditionalString(string);
+        if (excludeFromReset.indexOf(value) === -1) {
+          this.resetConditionalQuestion($question);
+        } else {
+          $question.removeClass('hidden');
+        }
+      });
+    } else {
+      children.forEach((question) => {
+        this.resetConditionalQuestion($(question));
+        if ($(question).hasClass('survey__question-row')) {
+          const $parentBlock = $(question).parents(BLOCK_CONTAINER_SELECTOR);
+          const blockIndex = $(question).data('block-index');
+          if (!($parentBlock.find('.survey__question-row:not([data-conditional-question])').length > 1)) {
+            this.resetConditionalQuestion($parentBlock);
+            if (this.detachedParentBlocks[blockIndex] === undefined) {
+              this.detachedParentBlocks[blockIndex] = $parentBlock;
+              this.removeSlide($parentBlock);
+              $parentBlock.detach();
+            }
+          }
+        }
+      });
+    }
   },
 
   removeSlide($block) {
@@ -753,7 +748,29 @@ const Survey = {
     if ($question.hasClass('survey__question-row')) {
       $question.removeAttr('style').addClass('hidden not-seen disabled');
     } else {
+      // Find which question group/slider this question belongs to by climbing up the DOM tree
+      const $grandParents = $question.parents('[data-question-group-blocks]');
+
+      // Extract the group's index number so we know which specific slider we need to modify
+      const questionGroupIndex = $grandParents.data('question-group-blocks');
+
+      // Get the actual slider jQuery object that we need to remove the question from
+      const $slider = this.groupSliders[questionGroupIndex];
+
+      // Get the slide index before detaching
+      const slideIndex = $question.data('slick-index');
+
+      // Remove the slide from Slick first
+      $slider?.slick('slickRemove', slideIndex);
+
+      // Then detach the element
       $question.detach();
+
+      // Updates Progress Bar on Top Right of the UI.
+      this.indexBlocks();
+
+      // Update Slide Button to Determine whether to show Next or Submit button.
+      this.updateButtonText();
     }
     $question.find('input[type=text], textarea').val('');
     $question.find('input:checked').removeAttr('checked');

--- a/spec/features/survey_bugs_spec.rb
+++ b/spec/features/survey_bugs_spec.rb
@@ -128,14 +128,8 @@ describe 'Survey navigation and rendering', type: :feature, js: true do
         click_button('Next', visible: true) # Q2
       end
 
-      # Now this question ideally should be skipped
-      # but the code that did that breaks the survey
-      # by removing the question without sliding
-      # the next one into view.
-      find('.label', text: 'Maybe').click
-      within('div[data-progress-index="4"]') do
-        click_button('Next', visible: true) # Q3
-      end
+      sleep 2
+      expect(page).to have_content('Submit Survey')
 
       # Now we can actually submit the survey
       # and finish.


### PR DESCRIPTION
closed #2190

## What this PR does

This PR fixes an issue where conditional questions in a survey were being displayed incorrectly. Now, conditional questions are shown only if the preceding question is answered with an option that triggers the conditional question. If the triggering option is not selected, the conditional question will not be displayed.

## Cause of the Bug

When the answer to the trigger question was changed, the `resetConditionalQuestion function` [detached](https://api.jquery.com/detach/) the conditional question's DOM element but did not remove it from the `Slick slide` managed by the [Slick library](https://kenwheeler.github.io/slick/). This caused Slick to display a detached DOM element, leading to inconsistent behavior.

**Note (Not Related to the Bug)**
The DOM for the conditional question was being added to the `Slick slide` using the `activateConditionalQuestion function.


` $slider.slick('slickAdd', $question, parentIndex);`


## Fix

The fix ensures that when the answer to a trigger question changes, the conditional follow-up question is properly removed. This is done by updating the Slick slider's internal state before performing DOM manipulations (e.g., using [jQuery .detach()](https://api.jquery.com/detach/)). This restores the intended flow of the survey.

## Test

- Removed few lines of test code in survey_bugs_spec.rb  that was no longer required due to the current fix.
- Verified that the conditional question is skipped correctly without breaking the survey flow.

## Screenshot:

Before:


https://github.com/user-attachments/assets/f84bc42b-c48d-443a-8ed7-595a8c304dd8



After:


https://github.com/user-attachments/assets/0dfb5040-9ff1-4d3b-962c-0cb0267d3501

## Open questions and concerns

Additionally, when attempting to preview any of the question groups in the "Question Groups" tab, an empty page appears upon clicking the Preview Question Group button, as shown below.


https://github.com/user-attachments/assets/903b644c-b907-4978-b7f9-4b278f6787db


