### PR TITLE
Fix: Mock flaky tests

### DIFF
--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -20,6 +20,8 @@ class LiftWingApi
   # All the wikis with an articlequality model as of 2023-06-28
   # https://wikitech.wikimedia.org/wiki/Machine_Learning/LiftWingq
   AVAILABLE_WIKIPEDIAS = %w[en eu fa fr gl nl pt ru sv tr uk].freeze
+  # config/initializers/retry_config.rb
+  RETRY_COUNT = 5
 
   def self.valid_wiki?(wiki)
     return true if wiki.project == 'wikidata'
@@ -51,7 +53,6 @@ class LiftWingApi
     end
 
     log_error_batch(rev_ids)
-
     return results
   end
 
@@ -60,7 +61,7 @@ class LiftWingApi
   # Returns a hash with wp10, features, deleted, and prediction, or empty hash if
   # there is an error.
   def get_single_revision_parsed_data(rev_id)
-    tries ||= 5
+    tries ||= RETRY_COUNT
     body = { rev_id:, extended_output: true }.to_json
     response = lift_wing_server.post(quality_query_url, body)
     parsed_response = Oj.load(response.body)
@@ -69,7 +70,6 @@ class LiftWingApi
       return { 'wp10' => nil, 'features' => nil, 'deleted' => deleted?(parsed_response),
       'prediction' => nil }
     end
-
     build_successful_response(rev_id, parsed_response)
   rescue StandardError => e
     tries -= 1

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -25,9 +25,6 @@ describe LiftWingApi do
     # Get revision data for valid rev ids for English Wikipedia
     let(:subject0) { lift_wing_api_class_en_wiki.get_revision_data(rev_ids) }
 
-    # Get revision data for valid rev ids for Wikidata
-    let(:subject1) { described_class.new(wiki).get_revision_data(rev_ids) }
-
     # Get revision data for deleted rev ids for English Wikipedia
     let(:subject2) { lift_wing_api_class_en_wiki.get_revision_data([deleted_rev_id]) }
 
@@ -47,8 +44,16 @@ describe LiftWingApi do
       end
     end
 
-    it 'fetches json from api.wikimedia.org for wikidata' do
-      VCR.use_cassette 'liftwing_api/wikidata' do
+    context 'fetch json data from api.wikimedia.org' do
+      before do
+        stub_wiki_validation
+        stub_lift_wing_response
+      end
+
+      # Get revision data for valid rev ids for Wikidata
+      let(:subject1) { described_class.new(wiki).get_revision_data([829840084, 829840085]) }
+
+      it 'fetches data for wikidata' do
         expect(subject1).to be_a(Hash)
         expect(subject1.dig('829840084')).to have_key('wp10')
         expect(subject1.dig('829840084', 'wp10')).to eq(nil)

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -11,6 +11,7 @@ describe ReferenceCounterApi do
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
   let(:deleted_rev_ids) { [708326238] }
   let(:rev_ids) { [5006940, 5006942, 5006946] }
+  let(:response) { stub_reference_counter_response }
 
   it 'raises InvalidProjectError if using wikidata project' do
     expect do
@@ -18,12 +19,20 @@ describe ReferenceCounterApi do
     end.to raise_error(described_class::InvalidProjectError)
   end
 
-  it 'returns the number of references if response is 200 OK', vcr: true do
-    ref_counter_api = described_class.new(es_wiktionary)
-    response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
-    expect(response.dig('5006940', 'num_ref')).to eq(10)
-    expect(response.dig('5006942', 'num_ref')).to eq(4)
-    expect(response.dig('5006946', 'num_ref')).to eq(2)
+  context 'returns the number of references' do
+    before do
+      stub_wiki_validation
+      stub_reference_counter_response
+    end
+
+    # Get revision data for valid rev ids for Wikidata
+    it 'if response is 200 OK', vcr: true do
+      ref_counter_api = described_class.new(es_wiktionary)
+      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
+      expect(response.dig('5006940', 'num_ref')).to eq(10)
+      expect(response.dig('5006942', 'num_ref')).to eq(4)
+      expect(response.dig('5006946', 'num_ref')).to eq(2)
+    end
   end
 
   # it 'logs the message if response is not 200 OK', vcr: true do

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -9,7 +9,7 @@ describe RevisionScoreApiHandler do
     let(:subject) { handler.get_revision_data [829840090, 829840091] }
 
     describe '#get_revision_data' do
-      it 'returns completed scores if retrieves data without errors' do
+      it 'returns completed scores if data is retrieved without errors' do
         VCR.use_cassette 'revision_score_api_handler/en_wikipedia' do
           expect(subject).to be_a(Hash)
           expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.81)
@@ -28,15 +28,26 @@ describe RevisionScoreApiHandler do
         end
       end
 
-      it 'returns completed scores if there is an error hitting LiftWingApi' do
-        VCR.use_cassette 'revision_score_api_handler/en_wikipedia_liftwing_error' do
-          stub_request(:any, /.*api.wikimedia.org.*/)
-            .to_raise(Errno::ETIMEDOUT)
-          expect(subject).to be_a(Hash)
-          expect(subject.dig('829840090')).to eq({ 'wp10' => nil,
-          'features' => { 'num_ref' => 132 }, 'deleted' => false, 'prediction' => nil })
-          expect(subject.dig('829840091')).to eq({ 'wp10' => nil,
-          'features' => { 'num_ref' => 1 }, 'deleted' => false, 'prediction' => nil })
+      describe 'error hitting LiftWingApi' do
+        before do
+          stub_wiki_validation
+          stub_revision_score_reference_counter_reponse
+        end
+
+        let(:wiki) { create(:wiki, project: 'wikipedia', language: 'es') }
+        let(:handler) { described_class.new(wiki:) }
+        let(:subject) { handler.get_revision_data [829840090, 829840091] }
+
+        it 'returns completed scores if there is an error hitting LiftWingApi' do
+          VCR.use_cassette 'revision_score_api_handler/en_wikipedia_liftwing_error' do
+            stub_request(:any, /.*api.wikimedia.org.*/)
+              .to_raise(Errno::ETIMEDOUT)
+            expect(subject).to be_a(Hash)
+            expect(subject.dig('829840090')).to eq({ 'wp10' => nil,
+            'features' => { 'num_ref' => 132 }, 'deleted' => false, 'prediction' => nil })
+            expect(subject.dig('829840091')).to eq({ 'wp10' => nil,
+            'features' => { 'num_ref' => 1 }, 'deleted' => false, 'prediction' => nil })
+          end
         end
       end
 
@@ -76,34 +87,36 @@ describe RevisionScoreApiHandler do
   end
 
   context 'when the wiki is available only for LiftWing API' do
-    before { stub_wiki_validation }
-
     let(:wiki) { create(:wiki, project: 'wikidata', language: nil) }
     let(:handler) { described_class.new(wiki:) }
-    let(:subject) { handler.get_revision_data [144495297, 144495298] }
+
+    before do
+      stub_wiki_validation
+      stub_revision_score_lift_wing_reponse
+    end
 
     describe '#get_revision_data' do
-      it 'returns completed scores if retrieves data without errors' do
-        VCR.use_cassette 'revision_score_api_handler/wikidata' do
-          expect(subject).to be_a(Hash)
-          expect(subject.dig('144495297', 'wp10').to_f).to eq(0)
-          expect(subject.dig('144495297', 'features')).to be_a(Hash)
-          expect(subject.dig('144495297', 'features',
-                             'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(2)
-          # 'num_ref' key doesn't exist for wikidata features
-          expect(subject.dig('144495297', 'features').key?('num_ref')).to eq(false)
-          expect(subject.dig('144495297', 'deleted')).to eq(false)
-          expect(subject.dig('144495297', 'prediction')).to eq('D')
+      let(:subject) { handler.get_revision_data [144495297, 144495298] }
 
-          expect(subject.dig('144495298', 'wp10').to_f).to eq(0)
-          expect(subject.dig('144495298', 'features')).to be_a(Hash)
-          expect(subject.dig('144495298', 'features',
-                             'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(0)
-          # 'num_ref' key doesn't exist for wikidata features
-          expect(subject.dig('144495298', 'features').key?('num_ref')).to eq(false)
-          expect(subject.dig('144495298', 'deleted')).to eq(false)
-          expect(subject.dig('144495298', 'prediction')).to eq('E')
-        end
+      it 'returns completed scores if data is retrieved without errors' do
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('144495297', 'wp10').to_f).to eq(0)
+        expect(subject.dig('144495297', 'features')).to be_a(Hash)
+        expect(subject.dig('144495297', 'features',
+                           'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(2)
+        # 'num_ref' key doesn't exist for wikidata features
+        expect(subject.dig('144495297', 'features').key?('num_ref')).to eq(false)
+        expect(subject.dig('144495297', 'deleted')).to eq(false)
+        expect(subject.dig('144495297', 'prediction')).to eq('D')
+
+        expect(subject.dig('144495298', 'wp10').to_f).to eq(0)
+        expect(subject.dig('144495298', 'features')).to be_a(Hash)
+        expect(subject.dig('144495298', 'features',
+                           'feature.len(<datasource.wikidatawiki.revision.references>)')).to eq(0)
+        # 'num_ref' key doesn't exist for wikidata features
+        expect(subject.dig('144495298', 'features').key?('num_ref')).to eq(false)
+        expect(subject.dig('144495298', 'deleted')).to eq(false)
+        expect(subject.dig('144495298', 'prediction')).to eq('E')
       end
 
       it 'returns completed scores if there is an error hitting LiftWingApi' do
@@ -119,7 +132,10 @@ describe RevisionScoreApiHandler do
   end
 
   context 'when the wiki is available only for reference-counter API' do
-    before { stub_wiki_validation }
+    before do
+      stub_wiki_validation
+      stub_revision_score_reference_counter_reponse
+    end
 
     let(:wiki) { create(:wiki, project: 'wikipedia', language: 'es') }
     let(:handler) { described_class.new(wiki:) }
@@ -127,13 +143,11 @@ describe RevisionScoreApiHandler do
 
     describe '#get_revision_data' do
       it 'returns completed scores if retrieves data without errors' do
-        VCR.use_cassette 'revision_score_api_handler/es_wikipedia' do
-          expect(subject).to be_a(Hash)
-          expect(subject.dig('157412237')).to eq({ 'wp10' => nil,
-          'features' => { 'num_ref' => 111 }, 'deleted' => false, 'prediction' => nil })
-          expect(subject.dig('157417768')).to eq({ 'wp10' => nil,
-          'features' => { 'num_ref' => 42 }, 'deleted' => false, 'prediction' => nil })
-        end
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('157412237')).to eq({ 'wp10' => nil,
+        'features' => { 'num_ref' => 111 }, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('157417768')).to eq({ 'wp10' => nil,
+        'features' => { 'num_ref' => 42 }, 'deleted' => false, 'prediction' => nil })
       end
 
       it 'returns completed scores if there is an error hitting reference-counter api' do

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'json' # Ensure JSON is required for to_json
 
 #= Stubs for various requests
 module RequestHelpers
@@ -560,5 +561,160 @@ module RequestHelpers
     stub_training_modules
     stub_timeline
     stub_users
+  end
+
+  def stub_lift_wing_response
+    request_body = {
+      'wikidatawiki' => {
+        'models' => {
+          'itemquality' => {
+            'version' => '0.5.0'
+          }
+        },
+        'scores' => {
+          '829840084' => {
+            'itemquality' => {
+              'score' => {
+                'prediction' => 'D',
+                'probability' => { 'A' => 0.001863543366261331, 'B' => 0.001863543366261331 }
+              },
+              'features' => {
+                'feature.len(<datasource.wikibase.revision.claim>)' => 3.0,
+                'feature.len(<datasource.wikibase.revision.properties>)' => 3.0,
+                'feature.len(<datasource.wikibase.revision.aliases>)' => 0.0
+              }
+            }
+          },
+          '829840085' => {
+            'itemquality' => {
+              'score' => {
+                'prediction' => 'D',
+                'probability' => { 'A' => 0.005396336449201622, 'B' => 0.005396336449201622 }
+              },
+              'features' => {
+                'feature.len(<datasource.wikibase.revision.claim>)' => 10.0,
+                'feature.len(<datasource.wikibase.revision.properties>)' => 9.0,
+                'feature.len(<datasource.wikibase.revision.aliases>)' => 1.0
+              }
+            }
+          }
+        }
+      }
+    }
+    stub_request(:post, 'https://api.wikimedia.org/service/lw/inference/v1/models/wikidatawiki-itemquality:predict')
+      .with(
+        body: hash_including(extended_output: true),
+        headers: { 'Content-Type': 'application/json' }
+      ).to_return(
+        status: 200,
+        body: request_body.to_json
+      )
+  end
+
+  def stub_reference_counter_response
+    # Define the response body in a hash with revision IDs as keys
+    request_body = {
+      '5006940' => { 'num_ref' => 10, 'lang' => 'es', 'project' => 'wiktionary',
+      'revid' => 5006940 },
+      '5006942' => { 'num_ref' => 4, 'lang' => 'es', 'project' => 'wiktionary',
+      'revid' => 5006942 },
+      '5006946' => { 'num_ref' => 2, 'lang' => 'es', 'project' => 'wiktionary', 'revid' => 5006946 }
+    }
+
+    # Stub the request to match the revision ID in the URL
+    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wiktionary/es/\d+})
+      .to_return(
+        status: 200,
+        body: lambda do |request|
+          # Extract revision ID from the URL
+          rev_id = request.uri.path.split('/').last
+          # Return the appropriate response based on the revision ID
+          { 'num_ref' => request_body[rev_id.to_s]['num_ref'] }.to_json
+        end,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def stub_revision_score_lift_wing_reponse
+    request_body =
+      {
+          'wikidatawiki' => {
+            'models' => {
+              'itemquality' => {
+                'version' => '0.5.0'
+              }
+            },
+            'scores' => {
+              '144495297' => {
+                'itemquality' => {
+                  'score' => {
+                    'prediction' => 'D',
+                    'probability' => {
+                      'A' => 0.004943068308984735,
+                      'B' => 0.004943068308984735
+                    }
+                  },
+                  'features' => {
+                  'feature.len(<datasource.wikibase.revision.claim>)' => 3.0,
+                  'feature.len(<datasource.wikibase.revision.properties>)' => 3.0,
+                  'feature.len(<datasource.wikibase.revision.aliases>)' => 2.0,
+                  'feature.len(<datasource.wikidatawiki.revision.references>)' => 2.0
+                  }
+                }
+              },
+              '144495298' => {
+                'itemquality' => {
+                  'score' => {
+                    'prediction' => 'E',
+                    'probability' => {
+                      'A' => 0.0006501008909422321,
+                      'B' => 0.000887054617313177
+                    }
+                  },
+                  'features' => {
+                  'feature.len(<datasource.wikibase.revision.claim>)' => 1.0,
+                  'feature.len(<datasource.wikibase.revision.properties>)' => 1.0,
+                  'feature.len(<datasource.wikibase.revision.aliases>)' => 0.0,
+                  'feature.len(<datasource.wikidatawiki.revision.references>)' => 0.0
+                  }
+                }
+              }
+            }
+          }
+        }
+    stub_request(:post, 'https://api.wikimedia.org/service/lw/inference/v1/models/wikidatawiki-itemquality:predict')
+      .with(
+        body: hash_including(extended_output: true),
+        headers: { 'Content-Type': 'application/json' }
+      ).to_return(
+        status: 200,
+        body: request_body.to_json
+      )
+  end
+
+  def stub_revision_score_reference_counter_reponse
+    request_body = {
+      '157412237' => { 'num_ref' => 111, 'lang' => 'es', 'project' => 'wikipedia',
+      'revid' => 157412237 },
+      '157417768' => { 'num_ref' => 42, 'lang' => 'es', 'project' => 'wikipedia',
+      'revid' => 157417768 },
+      '829840090' => { 'num_ref' => 132, 'lang' => 'es', 'project' => 'wikipedia',
+      'revid' => 829840090 },
+      '829840091' => { 'num_ref' => 1, 'lang' => 'es', 'project' => 'wikipedia',
+      'revid' => 829840091 }
+    }
+
+    # Stub the request to match the revision ID in the URL
+    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/es/\d+})
+      .to_return(
+        status: 200,
+        body: lambda do |request|
+          # Extract revision ID from the URL
+          rev_id = request.uri.path.split('/').last
+          # Return the appropriate response based on the revision ID
+          { 'num_ref' => request_body[rev_id.to_s]['num_ref'] }.to_json
+        end,
+        headers: { 'Content-Type' => 'application/json' }
+      )
   end
 end


### PR DESCRIPTION
## What this PR does
This PR addresses flaky tests that are caused by interactions with external api's like LiftWing and the Reference Counter API 
#### Changes Made:
- Mocked API responses for LiftWingApi, referenceCounterApi, and revision_score_api by stubbing the request using WebMock and returning the expected data this helps to resolve flaky test failures caused by external dependencies.
- Explicitly verified actual error counts in the `update_course_stats` test to prevent reliance on static values and ensure accurate error reporting 
- Prevent retries during testing in the LiftWing class by using a RETRY-COUNT constant that is stub in the test using `stub_const` to prevent multiple retries in test mode

These changes ensure more stable and reliable test execution by isolating tests from external API calls and improving the validation logic.

