### PR TITLE
Fix "Preview Question Group" button rendering an empty page when accessing through Question Groups tab

### DIFF
--- a/app/views/layouts/surveys.html.haml
+++ b/app/views/layouts/surveys.html.haml
@@ -20,6 +20,6 @@
     // survey.js sometimes interferes with the rendering of results.
     = javascript_include_tag '/assets/javascripts/jquery.min.js'
     = hot_javascript_tag("survey") unless page_class == 'surveys results'
-    - if can_administer?
+    - if can_administer? && !params.key?("preview")
       = hot_javascript_tag("survey_admin")
     = content_for :additional_javascripts


### PR DESCRIPTION
## What this PR does

This PR fixes the "Preview Question Group" button in the "Question Groups" tab, which was previously rendering an empty page.

## Root Cause

The issue occurred because `survey-admin.js` was being unnecessarily loaded during the preview mode. This file is irrelevant in preview mode and caused conflicts.

## Fix

Updated the condition in `surveys.html.haml` to check for the `preview` parameter in the request. The `survey_admin.js` script will now be excluded from the preview mode.

## Screenshots
Before:


https://github.com/user-attachments/assets/60962b18-4f37-4213-bdd4-43f0ccebd274



After:


https://github.com/user-attachments/assets/7e2068ff-32b7-4430-9ba3-f04c8fef5f9e


