### PR TITLE
[Data rearchitecture] ArticleScopedProgram/VisitingScholarship: Handle changes in categories and assignments 

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -182,7 +182,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.update_from_course_revisions(course, revisions)
-    revisions = revisions.reject { |r| r.views.zero? }
+    revisions = revisions.select(&:scoped_revision)
     course_article_ids = course.articles.where(wiki: course.wikis).pluck(:id)
     revision_article_ids = article_ids_by_namespaces_from_revisions(course, revisions)
 

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -182,6 +182,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.update_from_course_revisions(course, revisions)
+    revisions = revisions.reject { |r| r.views.zero? }
     course_article_ids = course.articles.where(wiki: course.wikis).pluck(:id)
     revision_article_ids = article_ids_by_namespaces_from_revisions(course, revisions)
 

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -89,4 +89,8 @@ class VisitingScholarship < Course
   def scoped_article_titles
     assignments.pluck(:article_title)
   end
+
+  def scoped_article_ids
+    assignments.pluck(:article_id)
+  end
 end

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -45,7 +45,6 @@ class CourseUserWikiTimeslice < ApplicationRecord
   # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
   # updates the article course timeslices based on the revisions.
   def self.update_course_user_wiki_timeslices(course, user_id, wiki, revisions)
-    revisions[:revisions] = revisions[:revisions].reject { |r| r.views.zero? }
     rev_start = revisions[:start]
     rev_end = revisions[:end]
     # Timeslice dates to update are determined based on course wiki timeslices
@@ -53,7 +52,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
                        .for_revisions_between(rev_start, rev_end)
     timeslices.each do |timeslice|
       # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select do |revision|
+      revisions_in_timeslice = revisions[:revisions].select(&:scoped_revision).select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
       # Get or create article course timeslice based on course, article_id,

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -45,6 +45,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
   # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
   # updates the article course timeslices based on the revisions.
   def self.update_course_user_wiki_timeslices(course, user_id, wiki, revisions)
+    revisions[:revisions] = revisions[:revisions].reject { |r| r.views.zero? }
     rev_start = revisions[:start]
     rev_end = revisions[:end]
     # Timeslice dates to update are determined based on course wiki timeslices

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -48,6 +48,7 @@ class CourseWikiTimeslice < ApplicationRecord
   # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
   # updates the course wiki timeslices based on the revisions.
   def self.update_course_wiki_timeslices(course, wiki, revisions)
+    revisions[:revisions] = revisions[:revisions].reject { |r| r.views.zero? }
     rev_start = revisions[:start]
     rev_end = revisions[:end]
     # Course wiki timeslices to update

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -48,7 +48,6 @@ class CourseWikiTimeslice < ApplicationRecord
   # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
   # updates the course wiki timeslices based on the revisions.
   def self.update_course_wiki_timeslices(course, wiki, revisions)
-    revisions[:revisions] = revisions[:revisions].reject { |r| r.views.zero? }
     rev_start = revisions[:start]
     rev_end = revisions[:end]
     # Course wiki timeslices to update
@@ -57,7 +56,7 @@ class CourseWikiTimeslice < ApplicationRecord
                                                 .for_revisions_between(rev_start, rev_end)
     course_wiki_timeslices.each do |timeslice|
       # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select do |revision|
+      revisions_in_timeslice = revisions[:revisions].select(&:scoped_revision).select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
       # Update cache for CourseWikiTimeslice

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -107,4 +107,8 @@ class Revision < ApplicationRecord
   rescue JSON::ParserError
     nil # Return nil if parsing fails (i.e., not diff_stats)
   end
+
+  def scoped_revision
+    !views.zero?
+  end
 end

--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -35,6 +35,7 @@ class PrepareTimeslices
     UpdateTimeslicesCourseUser.new(@course).run
     UpdateTimeslicesUntrackedArticle.new(@course).run
     UpdateTimeslicesCourseDate.new(@course).run
+    UpdateTimeslicesScopedArticle.new(@course).run
     @debugger.log_update_progress :adjust_timeslices_end
   end
 end

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/revision_data_manager"
+
+# Set as 'needs_update' timeslices associated to new scoped articles
+# or to articles that are not scoped anymore due to changes in assignments
+# and categories.
+# Only for ArticleScopedProgram and VisitingScholarship courses
+class UpdateTimeslicesScopedArticle
+  def initialize(course)
+    @course = course
+    @timeslice_manager = TimesliceManager.new(course)
+    @scoped_article_ids = course.scoped_article_ids
+  end
+
+  def run
+    return unless %w[ArticleScopedProgram VisitingScholarship].include? @course.type
+    # Get the scoped articles that don't have articles courses but do have ac timeslices
+    articles_with_timeslices = @course.article_course_timeslices
+                                      .where(article_id: @scoped_article_ids)
+                                      .pluck(:article_id)
+
+    tracked_articles = @course.articles_courses
+                              .where(article_id: @scoped_article_ids)
+                              .pluck(:article_id)
+
+    new_articles = articles_with_timeslices - tracked_articles
+    reset(new_articles)
+
+    # Get not-scoped articles with article course records
+    old_articles = @course.articles_courses
+                          .where.not(article_id: @scoped_article_ids)
+                          .pluck(:article_id)
+
+    reset(old_articles)
+  end
+
+  private
+
+  def reset(article_ids)
+    return if article_ids.empty?
+
+    # Mark course wiki timeslices to be re-proccesed
+    articles = Article.where(id: article_ids)
+    ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, articles)
+  end
+end

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -157,8 +157,8 @@ class TimesliceManager # rubocop:disable Metrics/ClassLength
 
   # Resets course wiki timeslices. This involves:
   # - Marking timeslices as needs_update for dates with associated article course timeslices
-  # - Deleting given article course timeslices
-  # - Deleting course wiki timeslcies for those dates and wikis
+  # - Deleting given article course timeslices if no soft
+  # - Deleting course user wiki timeslices for those dates and wikis
   # Takes a collection of article course timeslices
   def reset_timeslices_that_need_update_from_article_timeslices(timeslices,
                                                                 wiki: nil,

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -23,9 +23,13 @@ describe RevisionDataManager do
       [{ 'mw_page_id' => '777',
       'wiki_id' => 1,
       'title' => 'Ragesoss/citing_sources',
-      'namespace' => '4' }]
+      'namespace' => '4' },
+       { 'mw_page_id' => '123',
+       'wiki_id' => 1,
+       'title' => 'Draft article',
+       'namespace' => '118' }]
     end
-    let(:sub_data) { [data1] }
+    let(:sub_data) { [data1, data2] }
     let(:data1) do
       [
         '112',
@@ -62,7 +66,7 @@ describe RevisionDataManager do
         }
       ]
     end
-    let(:filtered_sub_data) { [] }
+    let(:filtered_sub_data) { [data1] }
 
     before do
       create(:courses_user, course:, user:)

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -208,15 +208,15 @@ describe ArticlesCourses, type: :model do
       create(:courses_user, user:, course:,
                             role: CoursesUsers::Roles::STUDENT_ROLE)
       array_revisions << build(:revision, article:, user:, date: '2024-07-07',
-                        system: true, new_article: true)
+                        system: true, new_article: true, views: true)
       array_revisions << build(:revision, article:, user:, date: '2024-07-06 20:05:10',
-                        system: true, new_article: true)
+                        system: true, new_article: true, views: true)
       array_revisions << build(:revision, article:, user:, date: '2024-07-06 20:06:11',
-                        system: true, new_article: true)
+                        system: true, new_article: true, views: true)
       array_revisions << build(:revision, article:, user:, date: '2024-07-08 20:03:01',
-                        system: true, new_article: true)
+                        system: true, new_article: true, views: true)
       array_revisions << build(:revision, article: article3, user:, date: '2024-07-07',
-                        system: true, new_article: true)
+                        system: true, new_article: true, views: true)
       # revision for a non-tracked wiki
       array_revisions << build(:revision, article: article2, user:, date: '2024-07-06')
       # revision for a non-tracked namespace

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -55,28 +55,32 @@ describe CourseUserWikiTimeslice, type: :model do
            characters: 123,
            features: { 'num_ref' => 8 },
            features_previous: { 'num_ref' => 1 },
-           user_id: user.id)
+           user_id: user.id,
+           views: true)
   end
   let(:revision1) do
     build(:revision, article: talk_page, date: start,
            characters: 200,
            features: { 'num_ref' => 12 },
            features_previous: { 'num_ref' => 10 },
-           user_id: user.id)
+           user_id: user.id,
+           views: true)
   end
   let(:revision2) do
     build(:revision, article: sandbox, date: start,
            characters: -65,
            features: { 'num_ref' => 1 },
            features_previous: { 'num_ref' => 2 },
-           user_id: user.id)
+           user_id: user.id,
+           views: true)
   end
   let(:revision3) do
     build(:revision, article: draft, date: start,
            characters: 225,
            features: { 'num_ref' => 3 },
            features_previous: { 'num_ref' => 3 },
-           user_id: user.id)
+           user_id: user.id,
+           views: true)
   end
   let(:revision4) do
     build(:revision, article:, date: start,
@@ -84,7 +88,8 @@ describe CourseUserWikiTimeslice, type: :model do
             deleted: true, # deleted revision
             features: { 'num_ref' => 2 },
             features_previous: { 'num_ref' => 0 },
-            user_id: user.id)
+            user_id: user.id,
+            views: true)
   end
   let(:revision5) do
     build(:revision, article_id: -1, # revision for a non-existing article
@@ -93,7 +98,8 @@ describe CourseUserWikiTimeslice, type: :model do
             deleted: false,
             features: { 'num_ref' => 2 },
             features_previous: { 'num_ref' => 0 },
-            user_id: user.id)
+            user_id: user.id,
+            views: true)
   end
   let(:revision6) do
     build(:revision, article: draft, date: start,
@@ -101,7 +107,8 @@ describe CourseUserWikiTimeslice, type: :model do
            features: { 'num_ref' => 1 },
            features_previous: { 'num_ref' => 0 },
            user_id: user.id,
-           system: true) # revision made by the system
+           system: true, # revision made by the system
+           views: true)
   end
   let(:revisions) { [revision0, revision1, revision2, revision3, revision4, revision5, revision6] }
   let(:subject) { course_user_wiki_timeslice.update_cache_from_revisions revisions }
@@ -109,9 +116,9 @@ describe CourseUserWikiTimeslice, type: :model do
   describe '.update_course_user_wiki_timeslices' do
     before do
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
-      revisions << build(:revision, article:, user_id: user.id, date: start + 26.hours)
-      revisions << build(:revision, article:, user_id: user.id, date: start + 50.hours)
-      revisions << build(:revision, article:, user_id: user.id, date: start + 51.hours)
+      revisions << build(:revision, article:, user_id: user.id, date: start + 26.hours, views: true)
+      revisions << build(:revision, article:, user_id: user.id, date: start + 50.hours, views: true)
+      revisions << build(:revision, article:, user_id: user.id, date: start + 51.hours, views: true)
     end
 
     it 'creates the right article timeslices based on the revisions' do

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -86,19 +86,21 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
            references_count: 4,
            revision_count: 4)
 
-    array_revisions << build(:revision, article:, user_id: 1, date: start)
-    array_revisions << build(:revision, article:, user_id: 1, date: start + 2.hours)
-    array_revisions << build(:revision, article:, user_id: 2, date: start + 3.hours)
-    array_revisions << build(:revision, article:, user_id: 2, date: start + 3.hours, system: true)
-    array_revisions << build(:revision, article:, deleted: true, user_id: 1, date: start + 8.hours)
+    array_revisions << build(:revision, article:, user_id: 1, date: start, views: true)
+    array_revisions << build(:revision, article:, user_id: 1, date: start + 2.hours, views: true)
+    array_revisions << build(:revision, article:, user_id: 2, date: start + 3.hours, views: true)
+    array_revisions << build(:revision, article:, user_id: 2, date: start + 3.hours, system: true,
+                             views: true)
+    array_revisions << build(:revision, article:, deleted: true, user_id: 1, date: start + 8.hours,
+                             views: true)
   end
 
   describe '.update_course_wiki_timeslices' do
     before do
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wiki])
-      array_revisions << build(:revision, article:, user_id: 1, date: start + 26.hours)
-      array_revisions << build(:revision, article:, user_id: 1, date: start + 50.hours)
-      array_revisions << build(:revision, article:, user_id: 1, date: start + 51.hours)
+      array_revisions << build(:revision, article:, user_id: 1, date: start + 26.hours, views: true)
+      array_revisions << build(:revision, article:, user_id: 1, date: start + 50.hours, views: true)
+      array_revisions << build(:revision, article:, user_id: 1, date: start + 51.hours, views: true)
     end
 
     it 'updates the right course wiki timeslices based on the revisions' do

--- a/spec/services/update_timeslices_scoped_article_spec.rb
+++ b/spec/services/update_timeslices_scoped_article_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdateTimeslicesScopedArticle do
+  let(:course) { create(:article_scoped_program) }
+  let(:basic_course) { create(:course) }
+  let(:assigned_article) { create(:article, title: 'Assigned', id: 2, namespace: 0) }
+  let(:random_article) { create(:article, title: 'Random', id: 1, namespace: 0) }
+
+  context 'for ArticleScopedProgram' do
+    before do
+      enwiki = Wiki.get_or_create(language: 'en', project: 'wikipedia')
+      user = create(:user, username: 'Ragesoss')
+      create(:assignment, user_id: user.id, course_id: course.id, article_id: 2,
+            article_title: 'Assigned')
+      manager = TimesliceManager.new(course)
+      manager.create_timeslices_for_new_course_wiki_records([enwiki])
+
+      create(:article_course_timeslice, course:, article: random_article,
+            start: course.start + 1.day)
+      create(:article_course_timeslice, course:, article: assigned_article,
+            start: course.start)
+    end
+
+    it 'sets timeslices as needs_update for new scoped articles' do
+      described_class.new(course).run
+
+      expect(course.course_wiki_timeslices.where(needs_update: true).count).to eq(1)
+      expect(course.course_wiki_timeslices.find_by(needs_update: true).start).to eq(course.start)
+      expect(course.article_course_timeslices.where(article_id: assigned_article.id).count).to eq(0)
+    end
+
+    it 'sets timeslices as needs_update for old scoped articles' do
+      create(:articles_course, course:, article: assigned_article)
+      create(:articles_course, course:, article: random_article)
+      described_class.new(course).run
+
+      expect(course.course_wiki_timeslices.where(needs_update: true).count).to eq(1)
+      expect(course.course_wiki_timeslices.find_by(needs_update: true).start)
+        .to eq(course.start + 1.day)
+      expect(course.article_course_timeslices.where(article_id: random_article.id).count).to eq(0)
+      expect(course.articles_courses.count).to eq(1)
+      expect(course.articles_courses.where(article_id: random_article).count).to eq(0)
+    end
+  end
+
+  context 'for basic course' do
+    before do
+      enwiki = Wiki.get_or_create(language: 'en', project: 'wikipedia')
+      user = create(:user, username: 'Ragesoss')
+      create(:assignment, user_id: user.id, course_id: basic_course.id, article_id: 2,
+            article_title: 'Assigned')
+      manager = TimesliceManager.new(basic_course)
+      manager.create_timeslices_for_new_course_wiki_records([enwiki])
+
+      create(:article_course_timeslice, course: basic_course, article: random_article,
+            start: basic_course.start + 1.day)
+      create(:article_course_timeslice, course: basic_course, article: assigned_article,
+            start: basic_course.start)
+    end
+
+    it 'returns prematurely' do
+      create(:articles_course, course: basic_course, article: assigned_article)
+      create(:articles_course, course: basic_course, article: random_article)
+      described_class.new(basic_course).run
+
+      expect(basic_course.course_wiki_timeslices.where(needs_update: true).count).to eq(0)
+      expect(basic_course.article_course_timeslices.count).to eq(2)
+      expect(basic_course.articles_courses.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR addresses several changes in order to deal with updates in categories and assignments for `ArticleScopedProgram` and `VisitingScholarship` course types.

1.  **Create article records for every revision**
On one hand, the `ConstantUpdate` class invokes `AssignmentUpdater.update_assignment_article_ids_and_titles` with the following description:
```
  # Update article ids for Assignments that lack them, if an Article with the
  # same title exists in mainspace.
  # This does a case-insensitive match, so it will find cases where no article
  # with the exact title was found when the assignment was first created, but
  # the user edited the actual intended article and so it got imported later.
```
This means we need article records for every article, not just the scoped ones. As a result, this PR modifies how revisions are filtered (through `course.filter_revisions`) and ensures that article records are always created, even for non-scoped articles.
 
2. **Create article course timeslice records for every revision**
Assignments can be added or removed at any point in the course. In addition, categories may change even without any user action, as one article may be added or removed from a category independently. To handle this changes in an easier way, article course timeslices are created for every revision (even for those not associated to a scoped article).

3. **Implement `UpdateTimeslicesScopedArticle` class**
This new class handles changes in assignments and categories, and put some timeslices to re-process. Only for article scoped program or visiting scholarship courses.

## Open questions and concerns
TODO: this PR users the (not used) `views` Revision field to specify if a given revision is scoped or not. We should change this to something more meaningful when deleting Revision code.
