### PR TITLE
Feature: Extended workflow to save screenshot of failed Capybara tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,14 @@ jobs:
           coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
           coverageLocations: |
             ${{github.workspace}}/public/js_coverage/lcov.info:lcov
+      
+      - name: Archive capybara failure screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: dist-without-markdown
+          path: tmp/capybara/*.png
+          if-no-files-found: ignore
             
       - name: Ruby linting
         run: bundle exec rubocop

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,11 @@ end
 
 Rails.cache.clear
 Capybara::Screenshot.prune_strategy = :keep_last_run
+Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|
+  file_name = example.file_path.split('/').last.gsub('.rb', '')
+  formatted_description = example.description.tr(' ', '-').gsub(%r{^.*/spec/}, '')
+  "screenshot_#{file_name}_description_#{formatted_description}"
+end
 Capybara.save_path = 'tmp/screenshots/'
 Capybara.server = :puma, { Silent: true }
 Capybara.default_max_wait_time = 10
@@ -98,7 +103,6 @@ RSpec.configure do |config|
     # them.
     # Instead, we clear and print any after-success error
     # logs in the `before` block above.
-    Capybara::Screenshot.screenshot_and_save_page if example.exception
     errors = page.driver.browser.logs.get(:browser)
 
     # pass `js_error_expected: true` to skip JS error checking


### PR DESCRIPTION

## What this PR does
This PR extends the Git workflow to save screenshots of failed Capybara tests as artifacts for debugging. It saves the screenshot with the file name of the test that failed, along with a description of the specific block that caused the failure 