### PR TITLE
Fix: removed check for loading  feedback text in  assigned article spec

### DIFF
--- a/spec/features/assigned_articles_spec.rb
+++ b/spec/features/assigned_articles_spec.rb
@@ -23,7 +23,6 @@ describe 'Assigned Articles view', type: :feature, js: true do
       visit "/courses/#{course.slug}/articles/assigned"
       expect(page).to have_content('Nancy Tuana')
       find('a', text: 'Feedback').click
-      expect(page).to have_no_content(I18n.t('courses.feedback_loading'), wait: 10)
       expect(page).to have_selector('textarea.feedback-form')
       find('textarea.feedback-form').fill_in with: 'This is a great article!'
       click_button 'Add Suggestion'


### PR DESCRIPTION
## What this PR does
This PR addresses a test failure caused by an update to the assigned_article feedback loading behavior. The failure was introduced when a check was added to ensure that the loading text for feedback disappeared before accessing the textarea on the form to ensure all the content was loaded before interacting with it.

### Possible Fixes:
- Check for Text Availability and Then Disappearance
This approach worked when content took time to load during the first run. However, in subsequent runs, the content is already loaded, and the loader doesn't appear. This causes the test to fail, as the loader's disappearance is no longer observed.

- Remove the Check for Loaders Entirely
Given the increased default wait time, the system now waits long enough for the content to appear, including the loader. Since the content is guaranteed to be available after this time, there’s no need to check for the loader anymore, simplifying the test.

Currently I am using the second approach.

