### PR TITLE
Fix: Added rapid: false parameter to textarea set method 

### DIFF
--- a/spec/features/multiwiki_assignment_spec.rb
+++ b/spec/features/multiwiki_assignment_spec.rb
@@ -48,8 +48,6 @@ describe 'multiwiki assignments', type: :feature, js: true do
   end
 
   it 'creates valid assignments from multiple article titles' do
-    pending 'Fails in CI caused by Assign all button not found'
-
     VCR.use_cassette 'multiwiki_assignment' do
       visit "/courses/#{course.slug}/students/articles"
       first('.student-selection .student').click
@@ -60,7 +58,8 @@ describe 'multiwiki assignments', type: :feature, js: true do
 
       within('#users') do
         first('textarea').set(
-          "Terre\nhttps://fr.wikipedia.org/wiki/Anglais"
+          "Terre\nhttps://fr.wikipedia.org/wiki/Anglais",
+          rapid: false
         )
       end
       click_button 'Assign all'
@@ -76,8 +75,6 @@ describe 'multiwiki assignments', type: :feature, js: true do
       expect(page).to have_css('a[href="https://fr.wikipedia.org/wiki/Anglais"]')
       expect(page).to have_css('a[href="https://fr.wikipedia.org/wiki/Terre"]')
     end
-
-    pass_pending_spec
   end
 
   it 'creates a valid assignment from an article and a project and language from tracked Wikis' do
@@ -90,7 +87,7 @@ describe 'multiwiki assignments', type: :feature, js: true do
       button.click
 
       within('#users') do
-        find('textarea', visible: true).set('No le des prisa, dolor')
+        find('textarea', visible: true).set('No le des prisa, dolor', rapid: false)
         click_link 'Change'
         find('div.wiki-select').click
         within('.wiki-select') do
@@ -112,8 +109,6 @@ describe 'multiwiki assignments', type: :feature, js: true do
   end
 
   it 'will create a valid assignment for multilingual wikisource projects' do
-    pending 'Fails in CI caused by Heyder Cansa content not found'
-
     VCR.use_cassette 'multiwiki_assignment' do
       visit "/courses/#{course.slug}/students/articles"
       first('.student-selection .student').click
@@ -122,7 +117,7 @@ describe 'multiwiki assignments', type: :feature, js: true do
       expect(button).to have_content 'Assign/remove an article'
       button.click
       within('#users') do
-        first('textarea').set('https://wikisource.org/wiki/Heyder_Cansa')
+        first('textarea').set('https://wikisource.org/wiki/Heyder_Cansa', rapid: false)
       end
       click_button 'Assign'
       visit "/courses/#{course.slug}/students/articles"
@@ -134,13 +129,9 @@ describe 'multiwiki assignments', type: :feature, js: true do
         expect(link[:href]).to include('wikisource')
       end
     end
-
-    pass_pending_spec
   end
 
   it 'will create a valid assignment for multilingual wikimedia incubator projects' do
-    pending 'Fails in CI caused by Wp/kiu/Hey content not found'
-
     VCR.use_cassette 'multiwiki_assignment' do
       visit "/courses/#{course.slug}/students/articles"
       first('.student-selection .student').click
@@ -149,7 +140,8 @@ describe 'multiwiki assignments', type: :feature, js: true do
       expect(button).to have_content 'Assign/remove an article'
       button.click
       within('#users') do
-        first('textarea').set('https://incubator.wikimedia.org/wiki/Wp/kiu/Heyder_Cansa')
+        first('textarea').set('https://incubator.wikimedia.org/wiki/Wp/kiu/Heyder_Cansa',
+                              rapid: false)
       end
       click_button 'Assign'
       visit "/courses/#{course.slug}/students/articles"
@@ -161,7 +153,5 @@ describe 'multiwiki assignments', type: :feature, js: true do
         expect(link[:href]).to include('incubator.wikimedia')
       end
     end
-
-    pass_pending_spec
   end
 end


### PR DESCRIPTION

## What this PR does
This PR aims to solve the issue that occurs where the multiwiki-assignment-spec fails intermittently this is mostly due to from the observation from the screen shot that was gotten from the CI build

usually if fails with the following error

Assign All button not found this is because

The Capybara defaulut for the set parameter of an input fiels is set to true meaning is runs in a  faster "rapid" mode, which causes a race condition if the imput fiels has to process the input passed to generate the final test which is the case here as mentioned in this discussion , so from the screen shot we see the text passed to the input field is this `Terre\nhttps://fr.wikipedia.org/wiki/Anglais` but when the test was ran it had just this `Terrais` which is just a single word with no new line so the `Assign all ` text is not displayed cause it appreas just when a new line is added with another text, so the text fails because the typying speed for capybara is too fast since we have some Javascript interactions on form inputs


The other failure which had to do with the text `Heyder Cansa` and `Wp/kiu/Hey` not found, the same applies it to it as above simce the typing speed is fast the  interactions with the javascript is not complte to fully rendere the correct content hence these text cannot be found on the screen 

