### PR TITLE
Fix: Prevent state mutation in fetchRevisionsPromise function

### DIFF
--- a/app/assets/javascripts/actions/revisions_actions.js
+++ b/app/assets/javascripts/actions/revisions_actions.js
@@ -1,4 +1,3 @@
-
 import {
   RECEIVE_REVISIONS,
   REVISIONS_LOADING,
@@ -35,12 +34,19 @@ const fetchAllArticles = async (course) => {
 
 const fetchRevisionsPromise = async (course, users, last_date, dispatch) => {
   const { revisions, last_date: new_last_date } = await fetchRevisionsFromUsers(course, users, 7, last_date);
-  course.revisions = sortRevisionsByDate(revisions);
 
-  // we don't await this. When the assessments/references get laoded, the action is dispatched
+  // Create a new course object with updated revisions
+  const updatedCourse = {
+    ...course,
+    revisions: sortRevisionsByDate(revisions),
+  };
+
+  // we don't await this. When the assessments/references get loaded, the action is dispatched
   fetchRevisionsAndReferences(revisions, dispatch);
-  return { course, last_date: new_last_date };
+
+  return { course: updatedCourse, last_date: new_last_date };
 };
+
 const fetchRevisionsCourseSpecificPromise = async (course, users, last_date, dispatch, articles) => {
   const trackedArticles = new Set(
     articles.filter(article => article.tracked).map(article => article.title)


### PR DESCRIPTION
## What this PR does

- Fixes a state mutation issue in the `fetchRevisionsPromise` function that caused errors in Redux.
- Updates the logic to create a new `course` object with updated revisions instead of directly modifying the existing `course` object.
- Ensures Redux Toolkit's immutability rules are followed to prevent unexpected behavior.


## Cause of the Mutation:
- The `course.revisions` property was being directly modified within the `fetchRevisionsPromise` function.
- Direct state mutation violates Redux’s immutability principles, which led to a detected mutation error.

## Fix for the Mutation:
- Replaced the direct mutation of course.revisions with the creation of a new object:
```
const updatedCourse = {
  ...course,
  revisions: sortRevisionsByDate(revisions),
};
```
- This approach maintains immutability by ensuring the original course object remains unchanged.

## Note:

For testing please set `enableMutationChecks to true` in create_store.js


## Screenshots

Before:


https://github.com/user-attachments/assets/6b0d7494-92ba-428f-8e1a-9708b7e3c1bf



https://github.com/user-attachments/assets/119966b1-844b-4066-9af3-140c6594db1c



After:


https://github.com/user-attachments/assets/16872954-abeb-4985-87b6-eb5cbbc66657



https://github.com/user-attachments/assets/08e453ed-23e5-4b73-8177-c1d09f16e102

