### PR TITLE
Chore: Refactor variable name for Redux safety checks

### DIFF
--- a/app/assets/javascripts/components/util/create_store.js
+++ b/app/assets/javascripts/components/util/create_store.js
@@ -29,8 +29,8 @@ export const getStore = () => {
     };
   }
 
-  // Determine if mutation checks should be enabled
-  const enableMutationChecks = false;
+  // Determine if Redux Toolkit's safety checks should be enabled
+  const enableReduxSafetyChecks = false;
 
   const store = configureStore({
     reducer,
@@ -39,9 +39,9 @@ export const getStore = () => {
     getDefaultMiddleware({
       // Temporarily disable mutation checks feature to facilitate Redux Toolkit migration.
       // TODO: Gradually resolve state mutations and re-enable these checks in the future.
-      // Enable mutation checks when resolving or detecting these issues by setting enableMutationChecks to true.
-      immutableCheck: enableMutationChecks,
-      serializableCheck: enableMutationChecks,
+      // Enable mutation checks when resolving or detecting these issues by setting enableReduxSafetyChecks to true.
+      immutableCheck: enableReduxSafetyChecks,
+      serializableCheck: enableReduxSafetyChecks,
     }),
   });
 


### PR DESCRIPTION
## What this PR does

- Renames the `enableMutationChecks` variable to `enableReduxSafetyChecks` to better reflect its dual purpose:
  - Controls both mutation checks (immutability violations).
  - Controls serializability checks (ensures actions and state are serializable).


