### PR TITLE
Fix: `uploads.json` endpoint returns `500 internal server error` for some courses#6046

### DIFF
--- a/app/assets/javascripts/actions/uploads_actions.js
+++ b/app/assets/javascripts/actions/uploads_actions.js
@@ -10,7 +10,7 @@ const fetchUploads = (courseId) => {
       if (res.ok && res.status === 200) {
         return res.json();
       }
-      return Promise.reject({ error: 'Failed to fetch uploads', status: res.status });
+      return Promise.reject(new Error(`Failed to fetch uploads. Status: ${res.status}`));
     })
     .catch((error) => {
       logErrorMessage(error);

--- a/app/assets/javascripts/actions/uploads_actions.js
+++ b/app/assets/javascripts/actions/uploads_actions.js
@@ -10,25 +10,34 @@ const fetchUploads = (courseId) => {
       if (res.ok && res.status === 200) {
         return res.json();
       }
-        return Promise.reject(res);
+      return Promise.reject({ error: 'Failed to fetch uploads', status: res.status });
     })
     .catch((error) => {
       logErrorMessage(error);
+      return { error: 'Failed to fetch uploads', status: error.status || 500 };
     });
 };
 
 export const receiveUploads = courseId => (dispatch) => {
-  return (
-    fetchUploads(courseId)
-      .then(resp => dispatch({
+  return fetchUploads(courseId)
+    .then((resp) => {
+      if (!resp) {
+        return dispatch({
+          type: API_FAIL,
+          data: { error: 'No response received' },
+        });
+      }
+      return dispatch({
         type: RECEIVE_UPLOADS,
         data: resp,
-      }))
-      .catch(resp => dispatch({
+      });
+    })
+    .catch((resp) => {
+      dispatch({
         type: API_FAIL,
-        data: resp
-      }))
-  );
+        data: resp,
+      });
+    });
 };
 
 const fetchUploadMetadata = (uploads) => {

--- a/app/assets/javascripts/reducers/uploads.js
+++ b/app/assets/javascripts/reducers/uploads.js
@@ -30,7 +30,7 @@ const SORT_DESCENDING = {
 export default function uploads(state = initialState, action) {
   switch (action.type) {
     case RECEIVE_UPLOADS: {
-      const dataUploads = action.data.course.uploads;
+      const dataUploads = action.data?.course?.uploads || [];
       // Intial sorting by upload date
       const sortedModel = sortByKey(dataUploads, 'uploaded_at', state.sortKey, SORT_DESCENDING.uploaded_at);
 

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -3,7 +3,7 @@
 #= Helpers for course views
 module UploadsHelper
   def pretty_filename(upload)
-    pretty = upload.file_name
+    pretty = CGI.unescape(upload.file_name)
     pretty['File:'] = ''
     pretty
   end

--- a/spec/helpers/uploads_helper_spec.rb
+++ b/spec/helpers/uploads_helper_spec.rb
@@ -10,5 +10,14 @@ describe UploadsHelper do
       result = pretty_filename(upload)
       expect(result).to eq('My file.jpg')
     end
+
+    it 'formats a complex filename with encoded characters nicely for display' do
+      upload = build(:commons_upload,
+                     # rubocop:disable Layout/LineLength
+                     file_name: 'File%3AA+sunflower+%F0%9F%8C%BB%F0%9F%8C%BB+in+Kaduna+Polytechnic%2CSabo+Campus.jpg')
+      # rubocop:enable Layout/LineLength
+      result = pretty_filename(upload)
+      expect(result).to eq('A sunflower 🌻🌻 in Kaduna Polytechnic,Sabo Campus.jpg')
+    end
   end
 end


### PR DESCRIPTION
## What this PR does

Fixes the apparent cause of the 500 Internal server error in Issue #6046 and the subsequent `TypeError` it causes.

Note: I could not replicate the error on my dev as only 138 uploads were imported out of the around 7000 after running updates multiple times. The 138 uploads loaded without error for me which I assume is because the problematic upload / file name `File%3AA+sunflower+%F0%9F%8C%BB%F0%9F%8C%BB+in+Kaduna+Polytechnic%2CSabo+Campus.jpg` was not imported. 

The commons link is [here](https://commons.wikimedia.org/wiki/File:A_sunflower_%F0%9F%8C%BB%F0%9F%8C%BB_in_Kaduna_Polytechnic,Sabo_Campus.jpg). It was uploaded by a user ‘Bambi Cia’ who has apparently deleted their user page / account. Trying to view their profile with this link, just shows loading: [https://outreachdashboard.wmflabs.org/users/Bambi Cia](https://outreachdashboard.wmflabs.org/users/Bambi%20Cia) because this request throws a 500 internal server error too: [https://outreachdashboard.wmflabs.org/user_stats.json?username=Bambi Cia](https://outreachdashboard.wmflabs.org/user_stats.json?username=Bambi%20Cia) {"message":"Internal server error"}.

I used the test to verify this fix, and ran the updated code locally + used chrome dev tools to verify the TypeError fix works and doesn't break anything.

## Fixing the 500 Error by allowing decoding of encoded strings

To fix this, I added `CGI.unescape` to decode such url encoded strings to their original formats:

`pretty = CGI.unescape(upload.file_name)`

I then added another test in the `uploads_helper_spec.rb` to confirm it works.

Before:
![b4](https://github.com/user-attachments/assets/aac52b97-3d2e-4511-b345-593af9972fd8)

After:
![afta](https://github.com/user-attachments/assets/123f17ea-cbe7-44d9-96e2-e0b5c1a30dc2)



## Fixing the resulting TypeError

![image](https://github.com/user-attachments/assets/19575798-aafd-401e-b1ee-ea2d0b2a2d3a)

When a 500 error occurs, the flow goes through the `.catch()` block inside the [`fetchUploads`](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/35ecd9ab18230cdd249e337fceb9dbddfab7b117/app/assets/javascripts/actions/uploads_actions.js#L7) function, and `resp` is logged there. However, when the control goes back to the `.then()` block, `resp` is undefined because the promise is rejected and there is no valid response object passed.

Then when the case `RECEIVE_UPLOADS` is reached in the [`uploads.js` reducer](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/35ecd9ab18230cdd249e337fceb9dbddfab7b117/app/assets/javascripts/reducers/uploads.js#L32), the `action.data` will be undefined, and trying to access `action.data.course.uploads` throws the `TypeError: Cannot read properties of undefined('reading course'`.

To prevent this, I:
- Added the optional chaining operator `?.` with a fallback to `[]` so instead of throwing a TypeError when trying to access `.course` on undefined or `.uploads` on undefined, it evaluates to undefined. So if  `action.data?.course?.uploads` evaluates to undefined (because any part of the chain is missing), `[]` is assigned to `dataUploads`:
`const dataUploads = action.data?.course?.uploads || [];`

So when  `dataUploads` is [], `sortByKey` will return an empty array for `newModels`, and the reducer will update the state with an empty uploads array.

I also:
- Expanded the error handling in fetchUploads as when the 500 error occurs, `res` does not hold any relevant info other than the status being 500, (the status.text is an empty string) and `Error: undefined` is what is logged in the console. 

- Added an explicit check for if `resp` is undefined, to explicitly state 'No response received.'