### PR TITLE
Fix: integrated imagemagick into github workflow and resolved the cou…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
             sudo ln -s $(which magick) /usr/bin/identify
           fi
 
+          if ! [ -x "$(command -v convert)" ]; then
+            sudo ln -s $(which magick) /usr/bin/convert
+          fi
 
       # Debug steps to check for magick and identify
       - name: Debug magick command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,39 @@ jobs:
         with:
           pandoc-version: '2.9.2.1'
       
-      - name: install imagemagick
+            # Install the latest version of ImageMagick
+      - name: Setup ImageMagick
         uses: mfinelli/setup-imagemagick@v6
         with:
-          cache: true
+          version: latest # Use '6.x.x' or '7.x.x' if you want a specific version
+          cache: true 
 
-      - name: Check identify path
-        run: which identify
+      # Cache ImageMagick binaries
+      - name: Cache Latest ImageMagick
+        uses: actions/cache@v3
+        with:
+          path: /usr/bin/magick
+          key: ${{ runner.os }}-imagemagick-latest
+          restore-keys: |
+            ${{ runner.os }}-imagemagick-latest
+
+      # Create symlink for identify
+      - name: Create Symlink for identify
+        run: |
+          if ! [ -x "$(command -v identify)" ]; then
+            sudo ln -s $(which magick) /usr/bin/identify
+          fi
+
+      # Debug steps
+      - name: Check ImageMagick Version
+        run: magick -version
+
+      - name: Verify identify Command
+        run: identify -version
+
+      - name: Testing which imagemagick
+        run: magick convert
+      
 
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Setup ImageMagick
         uses: mfinelli/setup-imagemagick@v6
         with:
-          version: latest # Use '6.x.x' or '7.x.x' if you want a specific version
           cache: true 
 
       # Cache ImageMagick binaries
@@ -42,15 +41,26 @@ jobs:
           fi
 
       # Debug steps
+
+      - name: Debug magick command
+        run: |
+          echo "Magick location: $(which magick)"
+          echo "Magick version: $(magick -version)"
+      - name: Check if identify exists
+        run: |
+          echo "Identify location: $(which identify)"
+
+      - name: Check ImageMagick 
+        run: which magick
+        
       - name: Check ImageMagick Version
         run: magick -version
 
-      - name: Verify identify Command
-        run: identify -version
-
       - name: Testing which imagemagick
         run: magick convert
-      
+
+      - name: Verify identify Command
+        run: identify -version
 
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           pandoc-version: '2.9.2.1'
       
+      - name: install imagemagick
+        uses: mfinelli/setup-imagemagick@v6
+        with:
+          cache: true
+
+      - name: Check identify path
+        run: which identify
+
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,46 +18,44 @@ jobs:
         with:
           pandoc-version: '2.9.2.1'
       
-            # Install the latest version of ImageMagick
       - name: Setup ImageMagick
         uses: mfinelli/setup-imagemagick@v6
         with:
-          cache: true 
+          cache: true
 
       # Cache ImageMagick binaries
       - name: Cache Latest ImageMagick
         uses: actions/cache@v3
         with:
-          path: /usr/bin/magick
+          path: /home/runner/bin/magick
           key: ${{ runner.os }}-imagemagick-latest
           restore-keys: |
             ${{ runner.os }}-imagemagick-latest
 
-      # Create symlink for identify
-      - name: Create Symlink for identify
+      # Update PATH for ImageMagick
+      - name: Update PATH for ImageMagick
+        run: echo "/home/runner/bin" >> $GITHUB_PATH
+
+      - name: Create symlink for identify
         run: |
           if ! [ -x "$(command -v identify)" ]; then
             sudo ln -s $(which magick) /usr/bin/identify
           fi
 
-      # Debug steps
 
+      # Debug steps to check for magick and identify
       - name: Debug magick command
         run: |
           echo "Magick location: $(which magick)"
           echo "Magick version: $(magick -version)"
+
       - name: Check if identify exists
         run: |
           echo "Identify location: $(which identify)"
 
-      - name: Check ImageMagick 
-        run: which magick
-        
+      # Check versions again for debugging
       - name: Check ImageMagick Version
         run: magick -version
-
-      - name: Testing which imagemagick
-        run: magick convert
 
       - name: Verify identify Command
         run: identify -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,6 @@ jobs:
         run: |
           echo "Identify location: $(which identify)"
 
-      # Check versions again for debugging
-      - name: Check ImageMagick Version
-        run: magick -version
-
-      - name: Verify identify Command
-        run: identify -version
-
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0
       

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  Paperclip.options[:command_path] = "/usr/bin"
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  Paperclip.options[:command_path] = "/usr/bin"
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ end
 Rails.application.configure do
   # Settings specified here will take
   # precedence over those in config/application.rb.
-
+  Paperclip.options[:command_path] = "/usr/bin"
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
@@ -94,4 +94,5 @@ Rails.application.configure do
   config.allow_concurrency = false
 
   config.log_level = :warn
+  
 end


### PR DESCRIPTION
## What this PR does
This pull request resolves a compatibility issue with ImageMagick in the CI workflow, which caused the error: Paperclip::Errors::CommandNotFoundError: Could not run the 'identify' command. Please install ImageMagick.

#### Issue:
kt-paperclip expected separate binaries for identify and convert, but recent versions of ImageMagick consolidate these tools into the magick command. Additionally, the location of the magick binary was not where Paperclip expected.

### Changes Made
To address the issue and ensure that kt-paperclip works with the latest version of ImageMagick, I implemented the following changes:

- Installed ImageMagick: I installed the required version of ImageMagick on the system to ensure that Paperclip has access to the necessary tools.

-  Created Symlinks for identify and convert:
Since Paperclip calls identify and convert, I created symlinks for these commands that point to the magick binary. This allows Paperclip to use magick in place of the older separate identify and convert binaries
`for cmd in identify convert; do
  if ! [ -x "$(command -v $cmd)" ]; then
    sudo ln -s $(which magick) /usr/bin/$cmd
  fi
done
`

- Cached ImageMagick Binary:
To speed up subsequent builds and avoid re-downloading ImageMagick each time, I added caching for the ImageMagick binary:
`- name: Cache Latest ImageMagick
  uses: actions/cache@v3
  with:
    path: /home/runner/bin/magick
    key: ${{ runner.os }}-imagemagick-latest
    restore-keys: |
      ${{ runner.os }}-imagemagick-latest
`

- Updated Path for ImageMagick:
To ensure that the system recognizes the location of ImageMagick binaries, I updated the system path to include the directory where magick is located (/home/runner/bin).

`- name: Update PATH for ImageMagick
  run: echo "/home/runner/bin" >> $GITHUB_PATH
`

- Updated Paperclip’s Command Path:
I explicitly configured Paperclip to look for ImageMagick commands in /usr/bin, where the symlinks for identify and convert are located.

`Paperclip.options[:command_path] = "/usr/bin"`

These changes ensure Paperclip functions correctly with the latest ImageMagick version, using the consolidated magick binary, and improve build efficiency by caching the binary