### PR TITLE
Fix: integrated imagemagick into github workflow and resolved build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,32 @@ jobs:
         with:
           pandoc-version: '2.9.2.1'
       
+      - name: install ImageMagick
+        uses: mfinelli/setup-imagemagick@v6
+        with:
+          cache: true
+
+      # Cache ImageMagick binaries
+      - name: Cache Latest ImageMagick
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/bin/magick
+          key: ${{ runner.os }}-imagemagick-latest
+          restore-keys: |
+            ${{ runner.os }}-imagemagick-latest
+
+      # Update PATH for ImageMagick
+      - name: Update PATH for ImageMagick
+        run: echo "/home/runner/bin" >> $GITHUB_PATH
+
+      - name: Create symlink for identify and convert
+        run: |
+          for cmd in identify convert; do
+            if ! [ -x "$(command -v $cmd)" ]; then
+              sudo ln -s $(which magick) /usr/bin/$cmd
+            fi
+          done
+
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0
       

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,8 @@ Rails.application.configure do
   # Settings specified here will take
   # precedence over those in config/application.rb.
 
+  Paperclip.options[:command_path] = "/usr/bin"
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped


### PR DESCRIPTION
## What this PR does
This pull request resolves a compatibility issue with ImageMagick in the CI workflow, which caused the error: Paperclip::Errors::CommandNotFoundError: Could not run the 'identify' command. Please install ImageMagick.

#### Issue:
kt-paperclip expected separate binaries for identify and convert, but recent versions of ImageMagick consolidate these tools into the magick command. Additionally, the location of the magick binary was not where Paperclip expected.

### Changes Made
To address the issue and ensure that kt-paperclip works with the latest version of ImageMagick, I implemented the following changes:

- Installed ImageMagick: I installed the required version of ImageMagick on the system to ensure that Paperclip has access to the necessary tools.

-  Created Symlinks for identify and convert:
Since Paperclip calls identify and convert, I created symlinks for these commands that point to the magick binary. This allows Paperclip to use magick in place of the older separate identify and convert binaries
`for cmd in identify convert; do
  if ! [ -x "$(command -v $cmd)" ]; then
    sudo ln -s $(which magick) /usr/bin/$cmd
  fi
done
`

- Cached ImageMagick Binary:
To speed up subsequent builds and avoid re-downloading ImageMagick each time, I added caching for the ImageMagick binary:
`- name: Cache Latest ImageMagick
  uses: actions/cache@v3
  with:
    path: /home/runner/bin/magick
    key: ${{ runner.os }}-imagemagick-latest
    restore-keys: |
      ${{ runner.os }}-imagemagick-latest
`

- Updated Path for ImageMagick:
To ensure that the system recognizes the location of ImageMagick binaries, I updated the system path to include the directory where magick is located (/home/runner/bin).

`- name: Update PATH for ImageMagick
  run: echo "/home/runner/bin" >> $GITHUB_PATH
`

- Updated Paperclip’s Command Path:
I explicitly configured Paperclip to look for ImageMagick commands in /usr/bin, where the symlinks for identify and convert are located.

`Paperclip.options[:command_path] = "/usr/bin"`

These changes ensure Paperclip functions correctly with the latest ImageMagick version, using the consolidated magick binary, and improve build efficiency by caching the binary
