### PR TITLE
Fix: updated directory for saving  screenshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         if: failure()
         with:
           name: dist-without-markdown
-          path: tmp/capybara/*.png
+          path: tmp/screenshots/*.png
           if-no-files-found: ignore
             
       - name: Ruby linting


### PR DESCRIPTION

## What this PR does
This PR is a quick fix to using the appropriate location for storing the Capybara screenshot in the workflow artifacts, the actual location for storing this screenshot is at `tmp/screenshots/` as per the structure of the project not `tmp/capybara/`
reason why recent feature test failure do not store the appropriate screenshot
https://github.com/WikiEducationFoundation/WikiEduDashboard/actions/runs/12775327100/job/35611452008