### PR TITLE
[Data rearchitecture] Implement recent revisions for timeslices

### DIFF
--- a/app/models/course_data/courses_users.rb
+++ b/app/models/course_data/courses_users.rb
@@ -144,7 +144,8 @@ class CoursesUsers < ApplicationRecord
     update_values_from_timeslices
 
     # recent_revisions field doesn't belong to timeslices
-    self.recent_revisions = RevisionStat.recent_revisions_for_courses_user(self).count
+    self.recent_revisions = RevisionStatTimeslice.new(course)
+                                                 .recent_revisions_for_courses_user(self)
     # assigned_article_title field doesn't belong to timeslices
     assignments = user.assignments.where(course_id:)
     self.assigned_article_title = assignments.empty? ? '' : assignments.first.article_title

--- a/app/views/campaigns/programs.html.haml
+++ b/app/views/campaigns/programs.html.haml
@@ -50,7 +50,7 @@
               %span.sortable-indicator
               %span.tooltip-indicator
               .tooltip.dark
-                %p= t('courses.revisions_doc', timeframe: RevisionStat::REVISION_TIMEFRAME)
+                %p= t('courses.revisions_doc', timeframe: RevisionStatTimeslice::REVISION_TIMEFRAME)
           %th.sort.sortable{style: 'width: 172px;', 'data-default-order' => 'desc', 'data-sort' => 'characters'}
             .tooltip-trigger
               = t('metrics.word_count')

--- a/app/views/dashboard/_admin_courses.html.haml
+++ b/app/views/dashboard/_admin_courses.html.haml
@@ -10,7 +10,7 @@
             = t("metrics.revisions")
             %span.sortable-indicator
             .tooltip.dark
-              %p= t("courses.revisions_doc", timeframe: RevisionStat::REVISION_TIMEFRAME)
+              %p= t("courses.revisions_doc", timeframe: RevisionStatTimeslice::REVISION_TIMEFRAME)
         %th.sort.sortable{"data-sort" => "characters", :style => "width: 172px;"}
           .tooltip-trigger
             = t("metrics.word_count")

--- a/app/views/tagged_courses/programs.html.haml
+++ b/app/views/tagged_courses/programs.html.haml
@@ -55,7 +55,7 @@
               %span.sortable-indicator
               %span.tooltip-indicator
               .tooltip.dark
-                %p= t('courses.revisions_doc', timeframe: RevisionStat::REVISION_TIMEFRAME)
+                %p= t('courses.revisions_doc', timeframe: RevisionStatTimeslice::REVISION_TIMEFRAME)
           %th.sort.sortable{style: 'width: 172px;', 'data-default-order' => 'desc', 'data-sort' => 'characters'}
             .tooltip-trigger
               = t('metrics.word_count')

--- a/lib/course_cache_manager.rb
+++ b/lib/course_cache_manager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/revision_stat"
+require_dependency "#{Rails.root}/lib/revision_stat_timeslice"
 require_dependency "#{Rails.root}/lib/course_training_progress_manager"
 
 #= Service for updating the counts that are cached on Course objects
@@ -34,8 +35,7 @@ class CourseCacheManager
     update_view_sum_based_on_first_revision
     update_user_count
     update_trained_count
-    # TODO: count recent revisions based on revision_count field from last timeslices
-    # update_recent_revision_count
+    update_recent_revision_count_from_timeslices
     update_article_count
     update_new_article_count
     update_upload_count
@@ -109,6 +109,10 @@ class CourseCacheManager
 
   def update_recent_revision_count
     @course.recent_revision_count = RevisionStat.get_records(course: @course)
+  end
+
+  def update_recent_revision_count_from_timeslices
+    @course.recent_revision_count = RevisionStatTimeslice.new(@course).recent_revisions_for_course
   end
 
   def update_article_count

--- a/lib/revision_stat_timeslice.rb
+++ b/lib/revision_stat_timeslice.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#= Provides a count of recent revisions by a user(s)
+class RevisionStatTimeslice
+  REVISION_TIMEFRAME = 7
+
+  def initialize(course, end_period = Time.zone.now)
+    @course = course
+    @end_period = end_period
+    @start_period = REVISION_TIMEFRAME.days.ago
+  end
+
+  def recent_revisions_for_course
+    revisions = 0
+    @course.wikis.each do |wiki|
+      timeslices = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
+                                      .for_revisions_between(@start_period, @end_period)
+      next if timeslices.empty?
+      start = timeslices.minimum(:start)
+      revisions += calculate_revisions_in_timeframe(timeslices, start, @end_period)
+    end
+    revisions.ceil
+  end
+
+  def recent_revisions_for_courses_user(courses_user)
+    revisions = 0
+    @course.wikis.each do |wiki|
+      timeslices = CourseUserWikiTimeslice.for_course_user_and_wiki(
+        @course,
+        courses_user.user,
+        wiki
+      )
+                                          .for_revisions_between(@start_period, @end_period)
+      next if timeslices.empty?
+      start = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
+                                 .for_datetime(@start_period)
+                                 .first
+                                 .start
+      revisions += calculate_revisions_in_timeframe(timeslices, start, @end_period)
+    end
+    revisions.ceil
+  end
+
+  private
+
+  def calculate_revisions_in_timeframe(timeslices, start, end_period)
+    rev_count = timeslices.sum(&:revision_count)
+    seconds = (end_period - start).seconds
+    revisions_per_day = rev_count * 1.day.seconds / seconds
+    revisions_per_day * REVISION_TIMEFRAME
+  end
+end

--- a/spec/lib/revision_stat_timeslice_spec.rb
+++ b/spec/lib/revision_stat_timeslice_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/revision_stat_timeslice"
+
+describe RevisionStatTimeslice do
+  let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
+  let(:wikidata) { Wiki.get_or_create(project: 'wikidata', language: nil) }
+  let(:daily_timeslice) { 1.day }
+  let(:ten_timeslice) { 10.days }
+  let!(:course) { create(:course, start: 2.months.ago, end: 2.days.from_now) }
+
+  let(:date) { 7.days.ago.to_date }
+
+  describe '#recent_revisions_for_course' do
+    subject { described_class.new(course).recent_revisions_for_course }
+
+    before do
+      travel_to Time.zone.today
+      stub_wiki_validation
+      course.wikis << wikidata
+    end
+
+    context 'when daily timeslices' do
+      before do
+        start_timeframe = 7.days.ago.to_date
+
+        # Create first course wiki timeslice for wikis
+        create(:course_wiki_timeslice, course:, wiki: enwiki, start: start_timeframe,
+          end: start_timeframe + daily_timeslice, revision_count: 0)
+        create(:course_wiki_timeslice, course:, wiki: wikidata, start: start_timeframe,
+          end: start_timeframe + daily_timeslice, revision_count: 0)
+
+        # Create extra timeslices
+        create(:course_wiki_timeslice, course:, wiki: enwiki, start: start_date,
+         end: start_date + daily_timeslice, revision_count: 13)
+
+        create(:course_wiki_timeslice, course:, wiki: wikidata, start: start_date,
+       end: start_date + daily_timeslice, revision_count: 5)
+        create(:course_wiki_timeslice, course:, wiki: wikidata,
+          start: start_date - daily_timeslice, end: start_date, revision_count: 1)
+      end
+
+      context 'when no revisions' do
+        let(:start_date) { 1.month.ago.to_date }
+
+        it 'does not include in scope' do
+          expect(subject).to eq(0)
+        end
+      end
+
+      context 'when revisions in timeframe' do
+        let(:start_date) { 2.days.ago.to_date }
+
+        it 'does include in scope' do
+          expect(subject).to eq(19)
+        end
+      end
+    end
+
+    context 'when 10-days timeslices' do
+      before do
+        start_timeframe = 12.days.ago.to_date
+
+        # Create first course wiki timeslice for wikis
+        create(:course_wiki_timeslice, course:, wiki: enwiki, start: start_timeframe,
+          end: start_timeframe + ten_timeslice, revision_count: 0)
+        create(:course_wiki_timeslice, course:, wiki: wikidata, start: start_timeframe,
+          end: start_timeframe + ten_timeslice, revision_count: 0)
+
+        # Create extra timeslices
+        create(:course_wiki_timeslice, course:, wiki: enwiki, start: start_date,
+         end: start_date + ten_timeslice, revision_count: 13)
+
+        create(:course_wiki_timeslice, course:, wiki: wikidata, start: start_date,
+       end: start_date + ten_timeslice, revision_count: 5)
+      end
+
+      context 'when no revisions' do
+        let(:start_date) { 1.month.ago.to_date }
+
+        it 'does not include in scope' do
+          expect(subject).to eq(0)
+        end
+      end
+
+      context 'when revisions in timeframe' do
+        let(:start_date) { 2.days.ago.to_date }
+
+        it 'does include in scope' do
+          expect(subject).to eq(11)
+        end
+      end
+    end
+  end
+
+  describe '#recent_revisions_for_courses_user' do
+    subject { described_class.new(course).recent_revisions_for_courses_user(courses_user) }
+
+    let(:user) { create(:user) }
+    let(:courses_user) { create(:courses_user, course_id: course.id, user_id: user.id) }
+
+    let(:user2) { create(:user, username: 'username') }
+
+    before do
+      travel_to Time.zone.today
+      stub_wiki_validation
+      course.wikis << wikidata
+    end
+
+    context 'when daily timeslices' do
+      before do
+        start_timeframe = 7.days.ago.to_date
+
+        # Create first course wiki timeslice for wikis
+        create(:course_wiki_timeslice, course:, wiki: enwiki, start: start_timeframe,
+          end: start_timeframe + daily_timeslice, revision_count: 0)
+        create(:course_wiki_timeslice, course:, wiki: wikidata, start: start_timeframe,
+          end: start_timeframe + daily_timeslice, revision_count: 0)
+
+        create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki, start: start_timeframe,
+          end: start_timeframe + daily_timeslice, revision_count: 0)
+        create(:course_user_wiki_timeslice, course:, user:, wiki: wikidata, start: start_timeframe,
+          end: start_timeframe + daily_timeslice, revision_count: 0)
+
+        # Create extra timeslices
+        create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki, start: start_date,
+         end: start_date + daily_timeslice, revision_count: 13)
+        create(:course_user_wiki_timeslice, course:, user:, wiki: wikidata, start: start_date,
+       end: start_date + daily_timeslice, revision_count: 5)
+        create(:course_user_wiki_timeslice, course:, user:, wiki: wikidata,
+          start: start_date - daily_timeslice, end: start_date, revision_count: 1)
+
+        # Create timeslices for another user
+        create(:course_user_wiki_timeslice, course:, user: user2, wiki: enwiki, start: start_date,
+        end: start_date + daily_timeslice, revision_count: 13)
+      end
+
+      context 'when no revisions' do
+        let(:start_date) { 1.month.ago.to_date }
+
+        it 'does not include in scope' do
+          expect(subject).to eq(0)
+        end
+      end
+
+      context 'when revisions in timeframe' do
+        let(:start_date) { 2.days.ago.to_date }
+
+        it 'does include in scope' do
+          expect(subject).to eq(19)
+        end
+      end
+    end
+
+    context 'when 10-days timeslices' do
+      before do
+        start_timeframe = 12.days.ago.to_date
+
+        # Create first course wiki timeslice for wikis
+        create(:course_wiki_timeslice, course:, wiki: enwiki, start: start_timeframe,
+          end: start_timeframe + ten_timeslice, revision_count: 0)
+        create(:course_wiki_timeslice, course:, wiki: wikidata, start: start_timeframe,
+          end: start_timeframe + ten_timeslice, revision_count: 0)
+        create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki, start: start_timeframe,
+          end: start_timeframe + ten_timeslice, revision_count: 0)
+        create(:course_user_wiki_timeslice, course:, user:, wiki: wikidata, start: start_timeframe,
+          end: start_timeframe + ten_timeslice, revision_count: 0)
+
+        # Create extra timeslices
+        create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki, start: start_date,
+         end: start_date + ten_timeslice, revision_count: 13)
+        create(:course_user_wiki_timeslice, course:, user:, wiki: wikidata, start: start_date,
+       end: start_date + ten_timeslice, revision_count: 5)
+
+        # Create timeslices for another user
+        create(:course_user_wiki_timeslice, course:, user: user2, wiki: wikidata, start: start_date,
+          end: start_date + ten_timeslice, revision_count: 5)
+      end
+
+      context 'when no revisions' do
+        let(:start_date) { 1.month.ago.to_date }
+
+        it 'does not include in scope' do
+          expect(subject).to eq(0)
+        end
+      end
+
+      context 'when revisions in timeframe' do
+        let(:start_date) { 2.days.ago.to_date }
+
+        it 'does include in scope' do
+          expect(subject).to eq(11)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -78,9 +78,9 @@ describe UpdateCourseStatsTimeslice do
       expect(course_user.character_sum_ms).to eq(7991)
       expect(course_user.character_sum_us).to eq(0)
       expect(course_user.character_sum_draft).to eq(0)
-      # expect(course_user.references_count).to eq(-2)
+      expect(course_user.references_count).to eq(-2)
       expect(course_user.revision_count).to eq(29)
-      expect(course_user.recent_revisions).to eq(0)
+      expect(course_user.recent_revisions).to eq(29)
       expect(course_user.total_uploads).to eq(0)
     end
 
@@ -100,8 +100,7 @@ describe UpdateCourseStatsTimeslice do
       expect(course.view_sum).to be > 905580
       expect(course.user_count).to eq(1)
       expect(course.trained_count).to eq(1)
-      # TODO: update recent_revision_count
-      expect(course.recent_revision_count).to eq(0)
+      expect(course.recent_revision_count).to eq(29)
       expect(course.article_count).to eq(14)
       expect(course.new_article_count).to eq(3)
       expect(course.upload_count).to eq(0)


### PR DESCRIPTION
## What this PR does
This PR implements a new `RevisionStatTimeslice` class to replace the existing `RevisionStat` timeslice. Since raw revisions are no longer available, we calculate recent revisions based on the latest timeslices.

- For course-level recent revisions, we use the most recent `CourseWikiTimeslices` for the course. As we cannot assume a fixed timeslice duration, we compute a daily ratio of revisions (revisions per day) and multiply it by the `REVISION_TIMEFRAME` to determine the total count.
- For user-level recent revisions, we rely on the latest `CourseUserWikiTimeslices` for the course and user. This approach differs from the original implementation as it only considers revisions relevant to the course. In contrast, the previous method included all user edits, even those from namespaces like user talk, which are not directly pertinent to the course.

## Screenshots
Before:
Recent revisions was 0

After:
Recent revisions for course
![image](https://github.com/user-attachments/assets/3dee31eb-a38d-45f1-8b7f-5f6a036afc8b)

Recent revision for editors
![image](https://github.com/user-attachments/assets/1396e282-7676-4951-b0ac-f83612add99f)

## Open questions and concerns
As noted, the recent revision counts generated by the timeslice-based approach are not identical to the previous implementation. In particular, the user-level recent revision counts differ, leading to some discrepancies in the web application. For example:
![image](https://github.com/user-attachments/assets/f49704b3-7929-491c-804e-02608e6a823c)

To address this, we may want to consider updating the tooltip to provide additional clarity regarding the changes in how revisions are calculated.