### PR TITLE
Bugfix: Remove Unused Dialog Link from Navigation

### DIFF
--- a/app/views/styleguide/_dialogs.html.haml
+++ b/app/views/styleguide/_dialogs.html.haml
@@ -1,2 +1,2 @@
 .sg-note
-  TODO: wizard, unsure of where else
+  Dialogs are not implemented yet. This section will be updated once dialogs are added.

--- a/app/views/styleguide/_nav.html.haml
+++ b/app/views/styleguide/_nav.html.haml
@@ -9,8 +9,7 @@
     %a{href: "#buttons"}Buttons
   %li
     %a{href: "#formcontrols"}Form Controls
-  %li
-    %a{href: "#forms"}Forms
+ 
   %li
     %a{href: "#dialogs"}Dialogs
   %li


### PR DESCRIPTION
With reference to #5713 

## What this PR does
This PR addresses the issue of the "Dialogs" link in the navigation sidebar of the Style Guide, which currently points to an incomplete or missing section.

## Screenshots

Before:
![Screenshot 2025-01-15 114705](https://github.com/user-attachments/assets/252acad8-3226-4241-96e5-98a0fdf96fee)
After:
![Screenshot 2025-01-15 110625](https://github.com/user-attachments/assets/54966d2b-7aa5-44b6-a64c-474d949c1bc9)

## Open questions and concerns
Should the "Dialogs" section be completely removed until dialogs are implemented, or should we keep the placeholder content for future reference?

Are there any existing dialog components in the codebase that should be showcased in this section? If so, guidance on identifying them would be helpful.