### PR TITLE
Bugfix: Remove Unused Dialog Link from Navigation

### DIFF
--- a/app/views/styleguide/_dialogs.html.haml
+++ b/app/views/styleguide/_dialogs.html.haml
@@ -1,2 +1,2 @@
 .sg-note
-  TODO: wizard, unsure of where else
+Dialogs are not implemented yet. This section will be updated once dialogs are added.

--- a/app/views/styleguide/_dialogs.html.haml
+++ b/app/views/styleguide/_dialogs.html.haml
@@ -1,2 +1,3 @@
 .sg-note
-Dialogs are not implemented yet. This section will be updated once dialogs are added.
+TODO: wizard, unsure of where else
+

--- a/app/views/styleguide/_nav.html.haml
+++ b/app/views/styleguide/_nav.html.haml
@@ -12,8 +12,6 @@
   %li
     %a{href: "#forms"}Forms
   %li
-    %a{href: "#dialogs"}Dialogs
-  %li
     %a{href: "#popovers"}Popovers
   %li
     %a{href: "#progressandloading"}Progress and loading


### PR DESCRIPTION
With refrence to #5713 
## What this PR does
This PR addresses the issue of the "Dialogs" link in the navigation sidebar of the Style Guide, which currently points to an incomplete or missing section.

## Screenshots
Before:

![Screenshot 2025-01-15 114705](https://github.com/user-attachments/assets/ee1e87af-d905-44a7-a108-a62f4bf339e2)


After:
![Screenshot 2025-01-15 110625](https://github.com/user-attachments/assets/a7804e76-e91c-4a5c-9de5-069d00c8d743)

## Open questions and concerns
Should the "Dialogs" section be completely removed until dialogs are implemented, or should we keep the placeholder content for future reference?

Are there any existing dialog components in the codebase that should be showcased in this section? If so, guidance on identifying them would be helpful.
