### PR TITLE
Fix: Improve error handling when `get_page_content` returns `nil` when called by `WikiCourseEdits`

### DIFF
--- a/app/services/add_sandbox_template.rb
+++ b/app/services/add_sandbox_template.rb
@@ -10,12 +10,19 @@ class AddSandboxTemplate
     @sandbox = sandbox
     @sandbox_template = sandbox_template
     @wiki_editor = WikiEdits.new(home_wiki)
-    wiki_api = WikiApi.new(home_wiki)
-    @initial_page_content = wiki_api.get_page_content(@sandbox)
+    @wiki_api = WikiApi.new(home_wiki)
+    initial_page_content
     add_template
   end
 
   private
+
+  def initial_page_content
+    @initial_page_content = @wiki_api.get_page_content(@sandbox)
+    exception = Errors::PageContentErrors::NilPageContentError.new(@sandbox)
+    raise exception if @initial_page_content.nil?
+    @initial_page_content
+  end
 
   def add_template
     # Never double-post the sandbox template

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,9 @@
+# frozen_string_literal: true
+
 Sentry.init do |config|
   config.dsn = ENV['sentry_dsn']
   config.enabled_environments = %w[development staging production test]
+
+  # Appends to IGNORE_DEFAULT array of exception classes that should never be sent to Sentry
+  config.excluded_exceptions += ['Errors::PageContentErrors::NilPageContentError']
 end

--- a/lib/errors/page_content_errors.rb
+++ b/lib/errors/page_content_errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Errors
+  module PageContentErrors
+    class NilPageContentError < StandardError
+      def initialize(page)
+        msg = "Failed to fetch content for #{page}. Initial page content is nil."
+        super(msg)
+      end
+    end
+  end
+end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -154,6 +154,10 @@ class WikiCourseEdits
 
     # Never double-post the enrollment template
     initial_page_content = @wiki_api.get_page_content(user_page)
+
+    exception = Errors::PageContentErrors::NilPageContentError.new(user_page)
+    raise exception if initial_page_content.nil?
+
     return if initial_page_content.include?(template)
 
     summary = @generator.enrollment_summary
@@ -167,6 +171,10 @@ class WikiCourseEdits
 
     # Never double-post the talk template
     initial_page_content = @wiki_api.get_page_content(talk_page)
+
+    exception = Errors::PageContentErrors::NilPageContentError.new(talk_page)
+    raise exception if initial_page_content.nil?
+
     return if initial_page_content.include?(talk_template)
 
     talk_summary = "adding {{#{template_name(@templates, 'user_talk')}}}"

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require "#{Rails.root}/lib/wiki_course_edits"
+require "#{Rails.root}/lib/errors/page_content_errors"
 
 describe WikiCourseEdits do
   let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
@@ -181,6 +182,19 @@ describe WikiCourseEdits do
                           course:,
                           current_user: user,
                           enrolling_user:)
+    end
+
+    context 'when get_page_content returns nil' do
+      it 'raises a NilPageContentError' do
+        allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return(nil)
+        expect_any_instance_of(WikiEdits).not_to receive(:add_to_page_top)
+        expect do
+          described_class.new(action: :enroll_in_course,
+                              course:,
+                              current_user: user,
+                              enrolling_user:)
+        end.to raise_error(Errors::PageContentErrors::NilPageContentError)
+      end
     end
 
     context 'makes correct edits on P&E Outreach Dashboard' do

--- a/spec/services/add_sandbox_template_spec.rb
+++ b/spec/services/add_sandbox_template_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/errors/page_content_errors"
 
 describe AddSandboxTemplate do
   let(:course) { create(:course, home_wiki_id: 1) }
@@ -33,5 +34,21 @@ describe AddSandboxTemplate do
     expect_any_instance_of(WikiEdits).not_to receive(:post_whole_page)
     described_class.new(home_wiki: course.home_wiki, sandbox:,
                         sandbox_template:, current_user: user)
+  end
+
+  context 'when get_page_content returns nil' do
+    it 'raises a NilPageContentError' do
+      allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return(nil)
+      expect_any_instance_of(WikiEdits).not_to receive(:post_whole_page)
+      expect_any_instance_of(WikiEdits).not_to receive(:add_to_page_top)
+      expect do
+        described_class.new(
+          home_wiki: course.home_wiki,
+          sandbox:,
+          sandbox_template:,
+          current_user: user
+        )
+      end.to raise_error(Errors::PageContentErrors::NilPageContentError)
+    end
   end
 end


### PR DESCRIPTION
## What this PR does
Improves error handling when `get_page_content` returns `nil` when called by `WikiCourseEdits`:
- Creates a custom `NilPageContentError` with a (more) descriptive error message
for example, "Failed to fetch content for User:Belajane41/sandbox. Initial page content is nil."

- Refactors `initialize` method of `AddSandboxTemplate`, `WikiCourseEdits`'s `add_template_to_user_page`, and `add_template_to_user_talk_page` methods to guard for and raise a `NilPageContentError` if `initial_page_content` is `nil`:

```
exception = Errors::PageContentErrors::NilPageContentError.new(user_page / talk_page / @sandbox)
raise exception if initial_page_content.nil?
```

- Adds test to ensure this expected behaviour is enforced in both classes
#### Before:
`add_sandbox_template_spec.rb`:
![image](https://github.com/user-attachments/assets/7cdf51ff-829c-4450-9a93-ea9e1363ba1f)

`wiki_course_edits_spec.rb`:
![image](https://github.com/user-attachments/assets/abfaae9b-5a29-47d5-85a4-fc65c3101ed6)

#### After:
`add_sandbox_template_spec.rb`:
![image](https://github.com/user-attachments/assets/69904278-ec0a-4623-bb18-7bba8b830dbb)

`wiki_course_edits_spec.rb`:
![image](https://github.com/user-attachments/assets/4e57d13e-61a7-472e-91bf-225c36bdd0dc)


- Adds `NilPageContentError` error type to sentry config's `excluded_exceptions` so occurences of it are not sent to Sentry since we know that retry via Sidekiq will take care of it. See [Sentry docs](https://docs.sentry.io/platforms/ruby/configuration/options/#excluded-exceptions) and [code implementation](https://github.com/getsentry/sentry-ruby/blob/a1d294128e3d0fa3f5ca80d53285ebf0a59bec8b/sentry-rails/lib/sentry/rails/configuration.rb#L15).

---

Note: The error is referenced with its full namespace path `Errors::PageContentErrors::NilPageContentError`  when used/called because the other option of:
```
require_dependency "#{Rails.root}/lib/errors/page_content_errors"
include Errors::PageContentErrors

#then calling it like
exception = NilPageContentError.new(talk_page)
raise exception if initial_page_content.nil?

```
results in NameErrors like:
```
 NameError:
       uninitialized constant WikiCourseEdits::PageContentErrors

           exception = PageContentErrors::NilPageContentError.new(user_page)
                       ^^^^^^^^^^^^^^^^^
```
due to the concerned classes being in `/services` and `/libs` + auto loading / eager loading / Zeitwerk configs. Alternatively could just be a skill issue on my part :-