### PR TITLE
Removed unneeded fields from new endpoint

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -142,10 +142,10 @@ class CoursesController < ApplicationController
   def classroom_program_students_json
     courses = Course.classroom_program_students
     render json: courses.as_json(
-      only: %i[title created_at updated_at start end school term slug],
+      only: %i[title school slug],
       include: {
         students: {
-          only: %i[username created_at updated_at permissions]
+          only: %i[username]
         }
       }
     )
@@ -154,13 +154,13 @@ class CoursesController < ApplicationController
   def classroom_program_students_and_instructors_json
     courses = Course.classroom_program_students_and_instructors
     render json: courses.as_json(
-      only: %i[title created_at updated_at start end school term slug],
+      only: %i[title school slug],
       include: {
         students: {
-          only: %i[username created_at updated_at permissions]
+          only: %i[username]
         },
         instructors: {
-          only: %i[username created_at updated_at permissions]
+          only: %i[username]
         }
       }
     )
@@ -169,10 +169,10 @@ class CoursesController < ApplicationController
   def fellows_cohort_students_json
     courses = Course.fellows_cohort_students
     render json: courses.as_json(
-      only: %i[title created_at updated_at start end school term slug],
+      only: %i[title school slug],
       include: {
         students: {
-          only: %i[username created_at updated_at permissions]
+          only: %i[username]
         }
       }
     )
@@ -181,13 +181,13 @@ class CoursesController < ApplicationController
   def fellows_cohort_students_and_instructors_json
     courses = Course.fellows_cohort_students_and_instructors
     render json: courses.as_json(
-      only: %i[title created_at updated_at start end school term slug],
+      only: %i[title school slug],
       include: {
         students: {
-          only: %i[username created_at updated_at permissions]
+          only: %i[username]
         },
         instructors: {
-          only: %i[username created_at updated_at permissions]
+          only: %i[username]
         }
       }
     )


### PR DESCRIPTION

## What this PR does
This is a small PR that removes some unnecessary fields that were returned from the new course students endpoint, this will help speed up the query time for some of the bigger queries that are made to that endpoint

Now the endpoint only returns title, school and slug for the course, and username for the student/instructor
