### PR TITLE
Fixed : On-wiki training_slide with quiz doesn't include complete question prompt

### DIFF
--- a/app/assets/javascripts/training/components/quiz.jsx
+++ b/app/assets/javascripts/training/components/quiz.jsx
@@ -64,9 +64,11 @@ const Quiz = (props) => {
       );
     });
 
+    const rawQuestionHtml = md.render(props.question);
+
     return (
       <form className="training__slide__quiz">
-        <h3>{props.question}</h3>
+        <h3 dangerouslySetInnerHTML={{ __html: rawQuestionHtml }} />
         <fieldset>
           <ul>
             {answers}

--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -216,9 +216,13 @@ class WikiSlideParser
   end
 
   def template_parameter_value(template, parameter)
-    # Extract value from something like:
-    # | parameter_name = value
-    match = template.match(/\|\s*#{parameter}\s*=\s*(?<value>.*)/)
-    match && match['value']
+    # Extract value from the template
+    match = template.match(/\|\s*#{parameter}\s*=\s*(?<value>.*?)(?=\||\Z)/m)
+
+    # Check if match is present and value is not nil
+    value = match && match['value']
+
+    # Remove undesired formatting and whitespace, only if value is not nil
+    value ? value.gsub(/(^:|''')/, '').strip : nil
   end
 end

--- a/lib/training/wiki_slide_parser.rb
+++ b/lib/training/wiki_slide_parser.rb
@@ -217,12 +217,22 @@ class WikiSlideParser
 
   def template_parameter_value(template, parameter)
     # Extract value from the template
+    # The expected format is: | parameter_name = value
+    # The regex breakdown:
+    # - \|:            Matches the pipe character at the start of the parameter line.
+    # - \s*:           Matches any whitespace characters (spaces or tabs) after the pipe.
+    # - #{parameter}:  Inserts the parameter name to match.
+    # - \s*=\s*:       Matches the equals sign with optional whitespace around it.
+    # - (?<value>.*?): Captures the value after the equals sign into a named group 'value'.
+    # - (?=\||\Z):     Positive lookahead to ensure the match ends at the next pipe
+    #                   or the end of the string.
     match = template.match(/\|\s*#{parameter}\s*=\s*(?<value>.*?)(?=\||\Z)/m)
 
     # Check if match is present and value is not nil
     value = match && match['value']
 
     # Remove undesired formatting and whitespace, only if value is not nil
+    # The gsub removes leading colons and triple quotes, and strip removes surrounding whitespace.
     value ? value.gsub(/(^:|''')/, '').strip : nil
   end
 end

--- a/spec/lib/training/wiki_slide_parser_spec.rb
+++ b/spec/lib/training/wiki_slide_parser_spec.rb
@@ -230,6 +230,24 @@ describe WikiSlideParser do
     WIKITEXT
   end
 
+  let(:multiline_quiz_wikitext) do
+    <<~WIKISLIDE
+      {{Training module quiz
+      | question = <translate>
+      Take a look at this original (fictional) passage. Then, look at the options below. Choose the one you think is an acceptable way to present that information on Wikipedia.
+
+      Passage:
+
+      :"In 1967, only 25% of eligible Boston voters supported a measure to limit the space afforded to keeping cattle in the city. Dr. Bickford's research suggests that this was on account of the confusing language on the ballot measure, and that support for the measure would have been higher had the memorandum been more clearly stated on the ballot."
+
+      '''How would you share this information in a Wikipedia article? '''</translate>
+      | correct_answer_id = 3
+      | answer_1 = <translate>Some answer text</translate>
+      | explanation_1 = <translate>Some explanation</translate>
+      }}
+    WIKISLIDE
+  end
+
   describe '#title' do
     it 'extracts title from translation-enabled source wikitext' do
       output = described_class.new(source_wikitext.dup).title
@@ -320,6 +338,19 @@ describe WikiSlideParser do
       output = described_class.new(quiz_wikitext.dup).quiz
       expect(output[:correct_answer_id]).to eq(1)
       expect(output[:answers].count).to eq(2)
+    end
+
+    it 'correctly parses multi-line quiz question with formatting' do
+      quiz = described_class.new(multiline_quiz_wikitext.dup).quiz
+
+      expect(quiz).to be_present
+      expect(quiz[:question]).to include('Take a look at this original (fictional) passage')
+      expect(quiz[:question]).to include('Passage:')
+      expect(quiz[:question]).to include(
+        'How would you share this information in a Wikipedia article?'
+      )
+      expect(quiz[:question]).not_to include(':"')
+      expect(quiz[:question]).not_to include("'''")
     end
   end
 


### PR DESCRIPTION
## What this PR does
Fixes #5823

This PR improves quiz question formatting by:
- Adding multi-line support for quiz content parsing
- Removing unwanted wiki markup (colons and triple quotes) from rendered content
- Preserving proper line breaks and paragraph formatting

## Technical Changes
- Updated `template_parameter_value` in `WikiSlideParser` to handle multi-line content
- Modified regex pattern to safely remove wiki formatting characters
- Added markdown processing for quiz questions in the frontend Quiz component

## Screenshots
Before:
![Before](https://github.com/user-attachments/assets/bfda6fcf-ab04-49b7-82a1-3c17a6459f06)

After:
![After](https://github.com/user-attachments/assets/623b08ed-946a-46dd-a6a2-ce562a7a1131)
