### PR TITLE
Fix state immutability issues in the weeks property of the timeline slice by getWeeks selector.

### DIFF
--- a/app/assets/javascripts/components/timeline/timeline_handler.jsx
+++ b/app/assets/javascripts/components/timeline/timeline_handler.jsx
@@ -1,5 +1,5 @@
 // Import necessary hooks (useState, useEffect) and useNavigate from react-router-dom
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import TransitionGroup from '../common/css_transition_group';
@@ -25,11 +25,20 @@ const TimelineHandler = (props) => {
   const [reorderable, setReorderable] = useState(false);
   const [editableTitles, setEditableTitles] = useState(false);
 
-// Replace componentDidMount with useEffect hook
+  const resetWeekTitles = useRef(false);
+
+  // Replace componentDidMount with useEffect hook
   useEffect(() => {
     document.title = `${props.course.title} - ${I18n.t('courses.timeline_link')}`;
     props.fetchAllTrainingModules();
   }, [props.course.title, props.fetchAllTrainingModules]);
+
+  useEffect(() => {
+    if (resetWeekTitles.current) {
+      saveTimeline();
+      resetWeekTitles.current = false;
+    }
+  }, [props.weeks]);
 
 // Convert class methods to regular functions within the component
   const _cancelBlockEditable = (blockId) => {
@@ -54,7 +63,7 @@ const TimelineHandler = (props) => {
   const _resetTitles = () => {
     if (confirm(I18n.t('timeline.reset_titles_confirmation'))) {
       props.resetTitles();
-      saveTimeline();
+      resetWeekTitles.current = true;
     }
   };
 

--- a/app/assets/javascripts/reducers/timeline.js
+++ b/app/assets/javascripts/reducers/timeline.js
@@ -14,6 +14,7 @@ import {
   RESTORE_TIMELINE,
   EXERCISE_COMPLETION_UPDATE
 } from '../constants';
+import { cloneDeep } from 'lodash';
 
 const initialState = {
   blocks: {},
@@ -207,14 +208,14 @@ export default function timeline(state = initialState, action) {
       return { ...state, blocks };
     }
     case UPDATE_TITLE: {
-      const weeks = { ...state.weeks };
+      const weeks = cloneDeep(state.weeks);
       if (validateTitle(action.title)) {
         weeks[action.weekId].title = action.title;
       }
       return { ...state, weeks };
     }
     case RESET_TITLES: {
-      const weeks = { ...state.weeks };
+      const weeks = cloneDeep(state.weeks);
       Object.keys(weeks).forEach((weekId) => {
         weeks[weekId].title = '';
       });

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { sortBy, difference, uniq, filter, includes, pickBy, find } from 'lodash-es';
+import { sortBy, difference, uniq, filter, includes, pickBy, find, cloneDeep } from 'lodash-es';
 import { getFiltered } from '../utils/model_utils';
 import { STUDENT_ROLE, INSTRUCTOR_ROLE, ONLINE_VOLUNTEER_ROLE, CAMPUS_VOLUNTEER_ROLE, STAFF_ROLE, fetchStates, ARTICLES_PER_PAGE, REVIEWING_ROLE } from '../constants';
 import UserUtils from '../utils/user_utils.js';
@@ -254,7 +254,7 @@ export const getWeeksArray = createSelector(
     });
 
     weekIds.forEach((weekId) => {
-      const newWeek = weeks[weekId];
+      const newWeek = cloneDeep(weeks[weekId]);
       newWeek.blocks = blocksByWeek[weekId] || [];
       weeksArray.push(newWeek);
     });


### PR DESCRIPTION
## What this PR does

Fixes state immutability issues in the weeks property of the timeline slice done by getWeeksArray selector.

## Cause of Bug
- The bug  lies in the direct modification of the `newWeek object`, which is  a reference to the `weeks` property of the Redux state.

## Fix
- Resolved by using lodash [cloneDeep](https://lodash.com/docs/4.17.15#cloneDeep)

## Screenshots
Before:


https://github.com/user-attachments/assets/858f8265-6c71-41e0-9ebf-b61125271092



After:


https://github.com/user-attachments/assets/23b4bc39-b2d6-438d-a02e-354f8c9d1d34


