### PR TITLE
Fix Redux state mutation in BlockList by immutably updating block order

### DIFF
--- a/app/assets/javascripts/components/timeline/BlockList.jsx
+++ b/app/assets/javascripts/components/timeline/BlockList.jsx
@@ -5,8 +5,8 @@ import { Flipper } from 'react-flip-toolkit';
 
 const BlockList = ({ blocks, moveBlock, week_id, ...props }) => {
   const springBlocks = blocks.map((block, i) => {
-    block.order = i;
-    return <SpringBlock block={block} i={i} key={block.id} {...props} />;
+    const updatedBlock = { ...block, order: i };
+    return <SpringBlock block={updatedBlock} i={i} key={block.id} {...props} />;
   });
   return (
     <Flipper flipKey={blocks.map(block => block.id).join('')} spring="stiff">


### PR DESCRIPTION
## What this PR does

This PR resolves a bug in the `BlockList` component where the `blocks` array was being mutated during rendering, causing Redux state mutation warnings and potential incorrect behavior. The issue was fixed by updating `block.order` immutably without modifying the original blocks array.

## Bug cause:

The issue originated from a state mutation in the `BlockList` component. The `blocks` array was sourced from the `getAllWeeksArray` selector, which was stored in `allWeeks` during the mapStateToProps mapping in `timlineHandler`. Since the `blocks` array is part of the Redux state of the `timeline slice`, directly modifying its properties (like `block.order`) in the `BlockList` component violated Redux's immutability principles.

The mutation occurred as the flow progressed through the following components: `timelineHandler` -> `timeline` -> `week` -> `BlockList`. And, finally the `BlockList` component was directly updating the `order` property of blocks during the `map` operation.


## Fix:
Replaced direct mutation with the creation of a new object for each block using the spread operator `{ ...block, order: i }`.

## Screenshots
Before:

https://github.com/user-attachments/assets/50d2710a-4738-4395-8c02-3e60451fe02c



After:


https://github.com/user-attachments/assets/de2e5253-92ee-4e8c-a938-257322ef0843
