### PR TITLE
Fix mutation in timeline reducer

### DIFF
--- a/app/assets/javascripts/components/timeline/timeline_handler.jsx
+++ b/app/assets/javascripts/components/timeline/timeline_handler.jsx
@@ -1,11 +1,9 @@
-// Import necessary hooks (useState, useEffect) and useNavigate from react-router-dom
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import TransitionGroup from '../common/css_transition_group';
 import { Route, Routes } from 'react-router-dom';
 import Timeline from './timeline.jsx';
-// import Grading from './grading.jsx';
 import CourseDateUtils from '../../utils/course_date_utils.js';
 import Wizard from '../wizard/wizard.jsx';
 import Meetings from './meetings.jsx';
@@ -24,14 +22,20 @@ import { getWeeksArray, getAllWeeksArray, getAvailableTrainingModules, editPermi
 const TimelineHandler = (props) => {
   const [reorderable, setReorderable] = useState(false);
   const [editableTitles, setEditableTitles] = useState(false);
+  const resetWeekTitles = useRef(false);
 
-// Replace componentDidMount with useEffect hook
   useEffect(() => {
     document.title = `${props.course.title} - ${I18n.t('courses.timeline_link')}`;
     props.fetchAllTrainingModules();
   }, [props.course.title, props.fetchAllTrainingModules]);
 
-// Convert class methods to regular functions within the component
+  useEffect(() => {
+    if (resetWeekTitles.current) {
+      saveTimeline();
+      resetWeekTitles.current = false;
+    }
+  }, props.weeks);
+
   const _cancelBlockEditable = (blockId) => {
     // TODO: Restore to persisted state for this block only
     props.cancelBlockEditable(blockId);
@@ -54,7 +58,7 @@ const TimelineHandler = (props) => {
   const _resetTitles = () => {
     if (confirm(I18n.t('timeline.reset_titles_confirmation'))) {
       props.resetTitles();
-      saveTimeline();
+      resetWeekTitles.current = true;
     }
   };
 
@@ -124,7 +128,6 @@ const TimelineHandler = (props) => {
         edit_permissions={props.editPermissions}
         current_user={props.current_user}
       />
-      {/* {grading} */}
     </div>
   );
 };

--- a/app/assets/javascripts/reducers/timeline.js
+++ b/app/assets/javascripts/reducers/timeline.js
@@ -14,6 +14,7 @@ import {
   RESTORE_TIMELINE,
   EXERCISE_COMPLETION_UPDATE
 } from '../constants';
+import { cloneDeep } from 'lodash';
 
 const initialState = {
   blocks: {},
@@ -207,14 +208,14 @@ export default function timeline(state = initialState, action) {
       return { ...state, blocks };
     }
     case UPDATE_TITLE: {
-      const weeks = { ...state.weeks };
+      const weeks = cloneDeep(state.weeks);
       if (validateTitle(action.title)) {
         weeks[action.weekId].title = action.title;
       }
       return { ...state, weeks };
     }
     case RESET_TITLES: {
-      const weeks = { ...state.weeks };
+      const weeks = cloneDeep(state.weeks);
       Object.keys(weeks).forEach((weekId) => {
         weeks[weekId].title = '';
       });


### PR DESCRIPTION
## What this PR does

Fixes mutation in timeline reducer(s) which are handling the action `RESET_TITLES` & `UPDATE_TITLE`.

## Cause  Bug

For this finding the cause of bug was easy as the error message exaclty indicated where mutation was as shown below:

**For  `RESET_TITLES`:**

![RESET_TITLES](https://github.com/user-attachments/assets/b96a6c76-ae85-4003-a800-c72a76038b8c)

**For `UPDATE_TITLE`:**

![UPDATE_TITLE](https://github.com/user-attachments/assets/bd336bdd-27e3-4b20-a64e-57f2366cb122)

The spread operator doesn’t work as expected with deeply nested objects because it copies the values of the top-level properties of weeks  to new addresses/references, but the inner objects retain the same addresses/references.

## Fix

Resolved by using lodash [cloneDeep](https://lodash.com/docs/4.17.15#cloneDeep).

- **Why the changes in TimelineHandler component?**
    - **In Redux**:
      - **Mutation**: Changes are immediate since we were previously directly modifying the same object reference - 
            any code holding that reference sees the changes instantly.
      - **Immutable**: Creates a new object reference, requiring React/Redux to process and batch the state update, 
            making the changes not immediately available. Also, after resetting the timeline week titles, the saveTimeline 
            was called immediately, leading to an API call right away. During this time, Redux had not yet received the 
           new updates.

## Note:
While testing this https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6138 changes should be available😅 or else /timeline page may not work.`(KEEPPING IT IN DRAFT UNTIL THEN)`

## Screenshots
Before:

https://github.com/user-attachments/assets/0a63ef3a-fb07-4549-badb-2c65e44c5918



After:


https://github.com/user-attachments/assets/6c76078b-37cf-4844-8ef5-6cc132e6d6ac