### PR TITLE
Fix State Mutation in Timeline Reducer and Refactor TimelineHandler for Immutable Week Title Updates

### DIFF
--- a/app/assets/javascripts/components/timeline/timeline_handler.jsx
+++ b/app/assets/javascripts/components/timeline/timeline_handler.jsx
@@ -1,5 +1,5 @@
 // Import necessary hooks (useState, useEffect) and useNavigate from react-router-dom
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import TransitionGroup from '../common/css_transition_group';
@@ -25,11 +25,20 @@ const TimelineHandler = (props) => {
   const [reorderable, setReorderable] = useState(false);
   const [editableTitles, setEditableTitles] = useState(false);
 
-// Replace componentDidMount with useEffect hook
+  const resetWeekTitles = useRef(false);
+
+  // Replace componentDidMount with useEffect hook
   useEffect(() => {
     document.title = `${props.course.title} - ${I18n.t('courses.timeline_link')}`;
     props.fetchAllTrainingModules();
   }, [props.course.title, props.fetchAllTrainingModules]);
+
+  useEffect(() => {
+    if (resetWeekTitles.current) {
+      saveTimeline();
+      resetWeekTitles.current = false;
+    }
+  }, [props.weeks]);
 
 // Convert class methods to regular functions within the component
   const _cancelBlockEditable = (blockId) => {
@@ -54,7 +63,7 @@ const TimelineHandler = (props) => {
   const _resetTitles = () => {
     if (confirm(I18n.t('timeline.reset_titles_confirmation'))) {
       props.resetTitles();
-      saveTimeline();
+      resetWeekTitles.current = true;
     }
   };
 

--- a/app/assets/javascripts/reducers/timeline.js
+++ b/app/assets/javascripts/reducers/timeline.js
@@ -14,6 +14,7 @@ import {
   RESTORE_TIMELINE,
   EXERCISE_COMPLETION_UPDATE
 } from '../constants';
+import { produce } from 'immer';
 
 const initialState = {
   blocks: {},
@@ -207,18 +208,18 @@ export default function timeline(state = initialState, action) {
       return { ...state, blocks };
     }
     case UPDATE_TITLE: {
-      const weeks = { ...state.weeks };
-      if (validateTitle(action.title)) {
-        weeks[action.weekId].title = action.title;
-      }
-      return { ...state, weeks };
+      return produce(state, (draft) => {
+        if (validateTitle(action.title)) {
+          draft.weeks[action.weekId].title = action.title;
+        }
+      });
     }
     case RESET_TITLES: {
-      const weeks = { ...state.weeks };
-      Object.keys(weeks).forEach((weekId) => {
-        weeks[weekId].title = '';
+      return produce(state, (draft) => {
+        Object.keys(draft.weeks).forEach((weekId) => {
+            draft.weeks[weekId].title = '';
+        });
       });
-      return { ...state, weeks };
     }
     case RESTORE_TIMELINE: {
       return { ...state, blocks: { ...state.blocksPersisted }, weeks: deepCopyWeeks(state.weeksPersisted), editableBlockIds: [] };

--- a/app/assets/javascripts/selectors/index.js
+++ b/app/assets/javascripts/selectors/index.js
@@ -254,8 +254,7 @@ export const getWeeksArray = createSelector(
     });
 
     weekIds.forEach((weekId) => {
-      const newWeek = weeks[weekId];
-      newWeek.blocks = blocksByWeek[weekId] || [];
+      const newWeek = { ...weeks[weekId], blocks: blocksByWeek[weekId] || [] };
       weeksArray.push(newWeek);
     });
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -8,6 +8,9 @@ The stylesheet language used is Stylus along with its Rupture utility.
 ### Resources
 - [Thinking in React](https://facebook.github.io/react/docs/thinking-in-react.html)
 - [Redux docs](http://redux.js.org/)
+- [Redux Toolkit docs - The official, opinionated toolkit for Redux development](https://redux-toolkit.js.org/)
+- [Immer docs - Library for working with immutable state](https://immerjs.github.io/immer/)
+- [Immutability in React and Redux: The Complete Guide](https://daveceddia.com/react-redux-immutability-guide/)
 - [Getting Started with Redux](https://egghead.io/courses/getting-started-with-redux)
 - [React DnD](http://gaearon.github.io/react-dnd/) - The library used for drag-and-drop interactions on the timeline
 - [Stylus](https://github.com/stylus/stylus/)
@@ -20,6 +23,10 @@ New features should rely on actions in the form of plain objects that are dispat
 
 ### Redux store
 Redux uses a single store, which is built up from many independent reducer functions that handle different actions. Container components — those that determine which child components to render based on application state ­— can then use `connect()` to subscribe to the store, typically with `mapStateToProps()` and `mapDispatchToProps()` functions used to filter out just the data and actions that the Component needs. Using this standard Redux pattern, we pass only the props needed by the immediate child components. This minimizes the amount of rendering, since a React component re-renders whenever its props change.
+
+### Immer Usage
+For components still using traditional Redux, you can use Immer's [produce](https://immerjs.github.io/immer/produce) function directly to simplify immutable updates.
+
 
 ### Components
 Components are the view layer of the JS application. They contain HTML markup and methods that trigger Actions based on user input.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "^7.20.5",
     "fetch-jsonp": "^1.2.1",
     "i18n-js": "^4.2.2",
+    "immer": "^10.1.1",
     "jeet": "^7.2.0",
     "jest": "^26.0.1",
     "jquery": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,6 +2817,7 @@ __metadata:
     eslint-webpack-plugin: ^3.1.1
     fetch-jsonp: ^1.2.1
     i18n-js: ^4.2.2
+    immer: ^10.1.1
     jeet: ^7.2.0
     jest: ^26.0.1
     jquery: ^3.5.1
@@ -6866,7 +6867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^10.0.3":
+"immer@npm:^10.0.3, immer@npm:^10.1.1":
   version: 10.1.1
   resolution: "immer@npm:10.1.1"
   checksum: 07c67970b7d22aded73607193d84861bf786f07d47f7d7c98bb10016c7a88f6654ad78ae1e220b3c623695b133aabbf24f5eb8d9e8060cff11e89ccd81c9c10b


### PR DESCRIPTION
## Note

Previously, I considered opening this as two separate PRs (#6138 and #6143). However, later i realized both require a common component change, specifically the TimelineHandler component.

For testing please set `enableMutationChecks` to true in create_store.js

## What this PR does
- Fixes state immutability issues in the weeks property of the timeline slice done by `getWeeksArray` selector.
- Fixes mutation in timeline reducer(s) which are handling the action `RESET_TITLES` & `UPDATE_TITLE`

## Cause of Bug (For `getWeeksArray` selector)
 - The bug lies in the direct modification of the `newWeek object`, which is a reference to the `weeks` property of the 
Redux state (Timeline Slice).

https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/88a89ecc3e5bac1092b875977d16f4438d7abd32/app/assets/javascripts/selectors/index.js#L257


## Fix  (For `getWeeksArray` selector)
- Resolved by using `spread operator` since we are modifying only the top level properties of the object.


## Cause of Bug (For `RESET_TITLES` & `UPDATE_TITLE`)

For this finding the cause of bug was easy as the error message exaclty indicated where mutation was as shown below:

**For** `RESET_TITLES`:

![RESET_TITLES](https://github.com/user-attachments/assets/fa764209-9933-4292-95d0-dc9d2bd99a28)


**For** `UPDATE_TITLE` 

![UPDATE_TITLE](https://github.com/user-attachments/assets/b77364a8-6dda-48d0-a1db-3edeaa236606)

The spread operator doesn’t work as expected with deeply nested objects because it copies the values of the top-level properties of weeks to new addresses/references, but the inner objects retain the same addresses/references which are the one's updated by mutation.

## Fix (For `RESET_TITLES` & `UPDATE_TITLE`)
Resolved by using [`Immer Produce`.](https://immerjs.github.io/immer/produce/)


## Why the changes in TimelineHandler component?


Previously, the `getWeeksArray` selector was mutating the `weeks` property of the `timeline slice` directly. This meant that dispatching `SAVED_TIMELINE` from the `saveTimeline` function immediately after dispatching `RESET_TITLES` from the `_resetTitles` function worked without issues because both were referencing the same mutated weeks array from `getWeeksArray` selector.

So, after updating immutable way immediately dispatching won't work as the existing weeks in the TimlineHandler from selector doesn't have the same reference.

**Little bit detail about redux for future reference:**
 - **In Redux**:
      - **Mutation**: Changes are immediate since we were previously directly modifying the same object reference - 
            any code holding that reference sees the changes instantly.
      - **Immutable**: Creates a new object reference, requiring React/Redux to process and batch the state update, 
            making the changes not immediately available. Also, after resetting the timeline week titles, the saveTimeline 
            was called immediately, leading to an API call right away. During this time, Redux had not yet received the 
           new updates.
      - **Source**: [Immutability in React and Redux: The Complete Guide](https://daveceddia.com/react-redux-immutability-guide/) 



## Screenshots (For `getWeeksArray` selector)
Before:


https://github.com/user-attachments/assets/9037304e-38b5-45c0-9993-f352f7743332



After:


https://github.com/user-attachments/assets/d70cd94f-6c7c-471b-9c5a-ab17e0938931



## Screenshots (For `RESET_TITLES` & `UPDATE_TITLE`)
Before:


https://github.com/user-attachments/assets/9803c068-e403-4c84-8ae0-0bc86f835301



After:


https://github.com/user-attachments/assets/f8751d9e-d901-4263-99a8-0ed18839d7a6

