### PR TITLE
[Data rearchitecture] Track errors when getting scores

### DIFF
--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -94,7 +94,7 @@ class CourseWikiTimeslice < ApplicationRecord
     update_uploads_in_use_count
     update_upload_usages_count
     update_stats
-    self.needs_update = false
+    update_needs_update
     save
   end
 
@@ -153,5 +153,9 @@ class CourseWikiTimeslice < ApplicationRecord
   def update_stats
     return unless wiki.project == 'wikidata'
     self.stats = UpdateWikidataStatsTimeslice.new(course).build_stats_from_revisions(@revisions)
+  end
+
+  def update_needs_update
+    self.needs_update = !@revisions.select(&:revision_with_error).empty?
   end
 end

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -111,4 +111,8 @@ class Revision < ApplicationRecord
   def scoped_revision
     !views.zero?
   end
+
+  def revision_with_error
+    !ithenticate_id.nil?
+  end
 end

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -190,11 +190,16 @@ class RevisionScoreImporter
     rev.features = rev_scores['features']
     rev.wp10 = rev_scores['wp10']
     rev.deleted = rev_scores['deleted'] # double check if this is a boolean
+    # TODO: use another field for this
+    rev.ithenticate_id = 1 if rev_scores['error'] # tocuh ithenticate_id if there was an error
   end
 
   def update_previous_scores(rev, parent_rev_scores)
     rev.wp10_previous = parent_rev_scores['wp10']
     rev.features_previous = parent_rev_scores['features']
+    # TODO: use another field for this
+    # tocuh ithenticate_id if there was an error
+    rev.ithenticate_id = 1 if parent_rev_scores['error']
   end
 
   class InvalidWikiError < StandardError; end

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -117,8 +117,7 @@ class LiftWingApi
                  end),
       'features' => score.dig('features'),
       'deleted' => false,
-      'prediction' => score.dig('score', 'prediction'), # only for revision feedback
-      'error' => nil
+      'prediction' => score.dig('score', 'prediction') # only for revision feedback
     }
   end
 

--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -68,14 +68,15 @@ class LiftWingApi
     # If the responses contain an error, do not try to calculate wp10 or features.
     if parsed_response.key? 'error'
       return { 'wp10' => nil, 'features' => nil, 'deleted' => deleted?(parsed_response),
-      'prediction' => nil }
+      'prediction' => nil, 'error' => parsed_response.dig('error') }
     end
     build_successful_response(rev_id, parsed_response)
   rescue StandardError => e
     tries -= 1
     retry unless tries.zero?
     @errors << e
-    return { 'wp10' => nil, 'features' => nil, 'deleted' => false, 'prediction' => nil }
+    return { 'wp10' => nil, 'features' => nil, 'deleted' => false, 'prediction' => nil,
+             'error' => e }
   end
 
   class InvalidProjectError < StandardError
@@ -116,7 +117,8 @@ class LiftWingApi
                  end),
       'features' => score.dig('features'),
       'deleted' => false,
-      'prediction' => score.dig('score', 'prediction') # only for revision feedback
+      'prediction' => score.dig('score', 'prediction'), # only for revision feedback
+      'error' => nil
     }
   end
 

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -8,6 +8,7 @@ class ReferenceCounterApi
   include ApiErrorHandling
 
   TOOLFORGE_SERVER_URL = 'https://reference-counter.toolforge.org'
+  RETRY_COUNT = 5
 
   # This class is not designed for use with wikidata, as that wiki works pretty
   # different from other wikis and it has its own method of calculating references.
@@ -53,20 +54,20 @@ class ReferenceCounterApi
   # If the API response is not 200 or an error occurs, it returns nil.
   # Any encountered errors are logged in Sentry at the batch level.
   def get_number_of_references_from_revision_id(rev_id)
-    tries ||= 5
+    tries ||= RETRY_COUNT
     response = toolforge_server.get(references_query_url(rev_id))
     parsed_response = Oj.load(response.body)
-    return { 'num_ref' => parsed_response['num_ref'] } if response.status == 200
+    return { 'num_ref' => parsed_response['num_ref'], 'error' => nil } if response.status == 200
     # Log the error and return empty hash
     # Sentry.capture_message 'Non-200 response hitting references counter API', level: 'warning',
     # extra: { project_code: @project_code, language_code: @language_code, rev_id:,
     #                        status_code: response.status, content: parsed_response }
-    return { 'num_ref' => nil }
+    return { 'num_ref' => nil, 'error' => parsed_response }
   rescue StandardError => e
     tries -= 1
     retry unless tries.zero?
     @errors << e
-    return { 'num_ref' => nil }
+    return { 'num_ref' => nil, 'error' => e }
   end
 
   class InvalidProjectError < StandardError

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -57,7 +57,7 @@ class ReferenceCounterApi
     tries ||= RETRY_COUNT
     response = toolforge_server.get(references_query_url(rev_id))
     parsed_response = Oj.load(response.body)
-    return { 'num_ref' => parsed_response['num_ref'], 'error' => nil } if response.status == 200
+    return { 'num_ref' => parsed_response['num_ref'] } if response.status == 200
     # Log the error and return empty hash
     # Sentry.capture_message 'Non-200 response hitting references counter API', level: 'warning',
     # extra: { project_code: @project_code, language_code: @language_code, rev_id:,

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -24,13 +24,15 @@ class RevisionScoreApiHandler
   #     { "wp10"=>0.296976285416441736e2,
   #       "features"=> { "num_ref"=>0 },
   #       "deleted"=>false,
-  #       "prediction"=>"Start" },
+  #       "prediction"=>"Start",
+  #       "start" => false },
   #   ...,
   #   "rev_n"=>
   #     { "wp10"=>0.2929458626376752846e2,
   #       "features"=> nil,
   #       "deleted"=>false,
-  #       "prediction"=>"Start" }
+  #       "prediction"=>"Start",
+  #       "start" => false }
   # }
   #
   # For wikidata, "features" key contains Liftwing features. For other wikis, "features"
@@ -60,6 +62,9 @@ class RevisionScoreApiHandler
 
   def complete_score(score)
     completed_score = {}
+
+    # If the score already has error is key is because some API request failed some way
+    completed_score['error'] = score.key?('error')
 
     # Fetch the value for 'wp10' and 'prediction', or default to nil if not present.
     completed_score['wp10'] = score.fetch('wp10', nil)

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -221,6 +221,8 @@ describe RevisionScoreImporter do
         expect(revisions[2].deleted).to eq(true)
         expect(revisions[2].wp10).to be_nil
         expect(revisions[2].features).to eq({})
+        # TODO: use another field for this. For now we use ithenticate_id as an error field
+        expect(revisions[2].ithenticate_id).to eq(1)
       end
     end
 
@@ -230,6 +232,8 @@ describe RevisionScoreImporter do
         expect(revisions[3].deleted).to eq(true)
         expect(revisions[3].wp10).to be_nil
         expect(revisions[3].features).to eq({})
+        # TODO: use another field for this. For now we use ithenticate_id as an error field
+        expect(revisions[3].ithenticate_id).to eq(1)
       end
     end
 
@@ -242,8 +246,8 @@ describe RevisionScoreImporter do
 
       revisions = described_class.new.get_revision_scores(array_revisions)
 
-      # no value changed for the revisions
-      expect(revisions).to eq(array_revisions)
+      # TODO: use another field for this. For now we use ithenticate_id as an error field
+      expect(revisions[0].ithenticate_id).to eq(1)
     end
   end
 end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -35,12 +35,14 @@ describe LiftWingApi do
         expect(subject0.dig('829840084', 'features')).to be_a(Hash)
         expect(subject0.dig('829840084', 'deleted')).to eq(false)
         expect(subject0.dig('829840084', 'prediction')).to eq('Stub')
+        expect(subject0.dig('829840084', 'error')).to be_nil
 
         expect(subject0).to be_a(Hash)
         expect(subject0.dig('829840085', 'wp10').to_f).to be_within(0.01).of(29.15)
         expect(subject0.dig('829840085', 'features')).to be_a(Hash)
         expect(subject0.dig('829840085', 'deleted')).to eq(false)
         expect(subject0.dig('829840085', 'prediction')).to eq('Start')
+        expect(subject0.dig('829840085', 'error')).to be_nil
       end
     end
 
@@ -60,20 +62,22 @@ describe LiftWingApi do
         expect(subject1.dig('829840084', 'features')).to be_a(Hash)
         expect(subject1.dig('829840084', 'deleted')).to eq(false)
         expect(subject1.dig('829840084', 'prediction')).to eq('D')
+        expect(subject1.dig('829840084', 'error')).to be_nil
 
         expect(subject1.dig('829840084')).to have_key('wp10')
         expect(subject1.dig('829840085', 'wp10')).to eq(nil)
         expect(subject1.dig('829840085', 'features')).to be_a(Hash)
         expect(subject1.dig('829840085', 'deleted')).to eq(false)
         expect(subject1.dig('829840085', 'prediction')).to eq('D')
+        expect(subject1.dig('829840085', 'error')).to be_nil
       end
     end
 
     it 'returns deleted equal to true if the revision was deleted' do
       VCR.use_cassette 'liftwing_api/deleted_revision' do
         expect(subject2).to be_a(Hash)
-        expect(subject2.dig('708326238')).to eq({ 'wp10' => nil,
-        'features' => nil, 'deleted' => true, 'prediction' => nil })
+        expect(subject2.dig('708326238', 'deleted')).to eq(true)
+        expect(subject2.dig('708326238', 'error').class).to be(String)
       end
     end
 
@@ -82,16 +86,14 @@ describe LiftWingApi do
         stub_request(:any, /.*api.wikimedia.org.*/)
           .to_raise(Errno::ETIMEDOUT)
         expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-        expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
-        'features' => nil, 'deleted' => false, 'prediction' => nil })
+        expect(subject0.dig('829840085', 'error')).not_to be(nil)
       end
 
       it 'logs connection refused once' do
         stub_request(:any, /.*api.wikimedia.org.*/)
           .to_raise(Faraday::ConnectionFailed)
         expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-        expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
-        'features' => nil, 'deleted' => false, 'prediction' => nil })
+        expect(subject0.dig('829840085', 'error')).not_to be(nil)
       end
 
       it 'logs unexpected error once' do
@@ -100,8 +102,7 @@ describe LiftWingApi do
             .to receive(:build_successful_response)
             .and_raise(StandardError)
           expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-          expect(subject0.dig('829840085')).to eq({ 'wp10' => nil,
-          'features' => nil, 'deleted' => false, 'prediction' => nil })
+          expect(subject0.dig('829840085', 'error')).not_to be(nil)
         end
       end
     end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -35,14 +35,14 @@ describe LiftWingApi do
         expect(subject0.dig('829840084', 'features')).to be_a(Hash)
         expect(subject0.dig('829840084', 'deleted')).to eq(false)
         expect(subject0.dig('829840084', 'prediction')).to eq('Stub')
-        expect(subject0.dig('829840084', 'error')).to be_nil
+        expect(subject0.dig('829840084').key?('error')).to eq(false)
 
         expect(subject0).to be_a(Hash)
         expect(subject0.dig('829840085', 'wp10').to_f).to be_within(0.01).of(29.15)
         expect(subject0.dig('829840085', 'features')).to be_a(Hash)
         expect(subject0.dig('829840085', 'deleted')).to eq(false)
         expect(subject0.dig('829840085', 'prediction')).to eq('Start')
-        expect(subject0.dig('829840085', 'error')).to be_nil
+        expect(subject0.dig('829840085').key?('error')).to eq(false)
       end
     end
 
@@ -62,14 +62,14 @@ describe LiftWingApi do
         expect(subject1.dig('829840084', 'features')).to be_a(Hash)
         expect(subject1.dig('829840084', 'deleted')).to eq(false)
         expect(subject1.dig('829840084', 'prediction')).to eq('D')
-        expect(subject1.dig('829840084', 'error')).to be_nil
+        expect(subject1.dig('829840084').key?('error')).to eq(false)
 
         expect(subject1.dig('829840084')).to have_key('wp10')
         expect(subject1.dig('829840085', 'wp10')).to eq(nil)
         expect(subject1.dig('829840085', 'features')).to be_a(Hash)
         expect(subject1.dig('829840085', 'deleted')).to eq(false)
         expect(subject1.dig('829840085', 'prediction')).to eq('D')
-        expect(subject1.dig('829840085', 'error')).to be_nil
+        expect(subject1.dig('829840085').key?('error')).to eq(false)
       end
     end
 

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -11,7 +11,6 @@ describe ReferenceCounterApi do
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
   let(:deleted_rev_ids) { [708326238] }
   let(:rev_ids) { [5006940, 5006942, 5006946] }
-  let(:response) { stub_reference_counter_response }
 
   it 'raises InvalidProjectError if using wikidata project' do
     expect do
@@ -22,7 +21,7 @@ describe ReferenceCounterApi do
   context 'returns the number of references' do
     before do
       stub_wiki_validation
-      stub_reference_counter_response
+      stub_es_wiktionary_reference_counter_response
     end
 
     # Get revision data for valid rev ids for Wikidata

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -30,8 +30,11 @@ describe ReferenceCounterApi do
       ref_counter_api = described_class.new(es_wiktionary)
       response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
       expect(response.dig('5006940', 'num_ref')).to eq(10)
+      expect(response.dig('5006940', 'error')).to be_nil
       expect(response.dig('5006942', 'num_ref')).to eq(4)
+      expect(response.dig('5006942', 'error')).to be_nil
       expect(response.dig('5006946', 'num_ref')).to eq(2)
+      expect(response.dig('5006946', 'error')).to be_nil
     end
   end
 
@@ -73,8 +76,11 @@ describe ReferenceCounterApi do
      }
     )
     response = reference_counter_api.get_number_of_references_from_revision_ids rev_ids
-    expect(response.dig('5006940')).to eq({ 'num_ref' => nil })
-    expect(response.dig('5006942')).to eq({ 'num_ref' => nil })
-    expect(response.dig('5006946')).to eq({ 'num_ref' => nil })
+    expect(response.dig('5006942', 'num_ref')).to be_nil
+    expect(response.dig('5006942', 'error')).not_to be_nil
+    expect(response.dig('5006946', 'num_ref')).to be_nil
+    expect(response.dig('5006946', 'error')).not_to be_nil
+    expect(response.dig('5006940', 'num_ref')).to be_nil
+    expect(response.dig('5006940', 'error')).not_to be_nil
   end
 end

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -30,11 +30,11 @@ describe ReferenceCounterApi do
       ref_counter_api = described_class.new(es_wiktionary)
       response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
       expect(response.dig('5006940', 'num_ref')).to eq(10)
-      expect(response.dig('5006940', 'error')).to be_nil
+      expect(response.dig('5006940').key?('error')).to eq(false)
       expect(response.dig('5006942', 'num_ref')).to eq(4)
-      expect(response.dig('5006942', 'error')).to be_nil
+      expect(response.dig('5006942').key?('error')).to eq(false)
       expect(response.dig('5006946', 'num_ref')).to eq(2)
-      expect(response.dig('5006946', 'error')).to be_nil
+      expect(response.dig('5006946').key?('error')).to eq(false)
     end
   end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -99,7 +99,7 @@ describe UpdateCourseWikiTimeslices do
       # 14 course wiki timeslices records were created: 7 for enwiki and 7 for wikidata
       expect(course.course_wiki_timeslices.count).to eq(14)
 
-      # Course user timeslices caches were updated
+      # Course wiki timeslices caches were updated
       # For enwiki
       timeslice = course.course_wiki_timeslices.where(wiki: enwiki,
                                                       start: '2018-11-29').first
@@ -215,6 +215,8 @@ describe UpdateCourseWikiTimeslices do
       expect(Sentry).to have_received(:capture_exception)
         .exactly(2).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
                                                                 course: course.slug })
+      # The timeslice for the revision with score errors is marked as 'needs update'
+      expect(course.course_wiki_timeslices.find_by(start: '2018-11-24').needs_update).to eq(true)
     end
   end
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -635,7 +635,7 @@ module RequestHelpers
       )
   end
 
-  def stub_revision_score_lift_wing_reponse
+  def stub_wikidata_lift_wing_reponse
     request_body =
       {
           'wikidatawiki' => {
@@ -692,12 +692,30 @@ module RequestHelpers
       )
   end
 
-  def stub_revision_score_reference_counter_reponse
+  def stub_es_wikipedia_reference_counter_reponse
     request_body = {
       '157412237' => { 'num_ref' => 111, 'lang' => 'es', 'project' => 'wikipedia',
       'revid' => 157412237 },
       '157417768' => { 'num_ref' => 42, 'lang' => 'es', 'project' => 'wikipedia',
-      'revid' => 157417768 },
+      'revid' => 157417768 }
+    }
+
+    # Stub the request to match the revision ID in the URL
+    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/es/\d+})
+      .to_return(
+        status: 200,
+        body: lambda do |request|
+          # Extract revision ID from the URL
+          rev_id = request.uri.path.split('/').last
+          # Return the appropriate response based on the revision ID
+          { 'num_ref' => request_body[rev_id.to_s]['num_ref'] }.to_json
+        end,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def stub_en_wikipedia_reference_counter_reponse
+    request_body = {
       '829840090' => { 'num_ref' => 132, 'lang' => 'es', 'project' => 'wikipedia',
       'revid' => 829840090 },
       '829840091' => { 'num_ref' => 1, 'lang' => 'es', 'project' => 'wikipedia',
@@ -705,7 +723,7 @@ module RequestHelpers
     }
 
     # Stub the request to match the revision ID in the URL
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/es/\d+})
+    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/en/\d+})
       .to_return(
         status: 200,
         body: lambda do |request|

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -611,7 +611,7 @@ module RequestHelpers
       )
   end
 
-  def stub_reference_counter_response
+  def stub_es_wiktionary_reference_counter_response
     # Define the response body in a hash with revision IDs as keys
     request_body = {
       '5006940' => { 'num_ref' => 10, 'lang' => 'es', 'project' => 'wiktionary',


### PR DESCRIPTION
## What this PR does
This PR marks timeslices as 'needs_udpate' when requests to LiftWing or ref-counter APIs fail.

The `RevisionScoreImporter` class is in charge of importing revision scoring data from Lift Wing and reference-counter APIs.  In the revision version, this importer is used as part of the `UpdateCourseStats`. Right after importing revisions, we import revision scoring data for all those revisions that are missing them. That means that we calculate “unscored revisions” for the entire course each time `UpdateCourseStats` executes. The advantage of this is that if a Lift Wing API or reference-counter API call fails due to a transient error, the next time the update runs for that course, we will retry to get the scores, and all the caches will be recalculated.

In the timeslice version, we have a `RevisionDataManager` class that fetches new revisions and revision scoring data for them. Right after fetching this, we process it and calculate timeslice cache that we persist to the db. If the the Lift Wing API or reference-counter API call fails due to a transient error, we’ll miss scores for that timeslice, probably without even noticing it. A consequence of this could be that the added references are left at 0, because they could not have been correctly retrieved.

This PR introduces an initial simple strategy for handling errors during score fetching. If an error occurs, it is propagated to the associated Revision record. This allows the timeslice to update its value while keeping the `needs_update` flag set to true.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
