### PR TITLE
[Data rearchitecture] Improve logs during course updates

### DIFF
--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -4,10 +4,11 @@ require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 # Ensures that the necessary timeslices are created prior to a new update
 # of the course statistics.
 class PrepareTimeslices
-  def initialize(course)
+  def initialize(course, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
     @debugger = UpdateDebugger.new(@course)
+    @update_service = update_service
   end
 
   # Deletes all existing timeslices and recreates them from scratch.
@@ -32,7 +33,7 @@ class PrepareTimeslices
     end
     # Execute update tasks in a specific order
     UpdateTimeslicesCourseWiki.new(@course).run
-    UpdateTimeslicesCourseUser.new(@course).run
+    UpdateTimeslicesCourseUser.new(@course, update_service: @update_service).run
     UpdateTimeslicesUntrackedArticle.new(@course).run
     UpdateTimeslicesCourseDate.new(@course).run
     UpdateTimeslicesScopedArticle.new(@course).run

--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -4,10 +4,10 @@ require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 # Ensures that the necessary timeslices are created prior to a new update
 # of the course statistics.
 class PrepareTimeslices
-  def initialize(course, update_service: nil)
+  def initialize(course, debugger, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
-    @debugger = UpdateDebugger.new(@course)
+    @debugger = debugger
     @update_service = update_service
   end
 

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -29,7 +29,8 @@ class UpdateCourseStatsTimeslice
     import_uploads
     update_categories
     update_article_status if should_update_article_status?
-    UpdateCourseWikiTimeslices.new(@course, update_service: self).run(all_time: @full_update)
+    UpdateCourseWikiTimeslices.new(@course, @debugger,
+                                   update_service: self).run(all_time: @full_update)
     update_average_pageviews
     update_caches
     update_wikidata_stats if wikidata

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -29,7 +29,7 @@ class UpdateCourseStatsTimeslice
     import_uploads
     update_categories
     update_article_status if should_update_article_status?
-    @timeslice_errors = UpdateCourseWikiTimeslices.new(@course).run(all_time: @full_update)
+    UpdateCourseWikiTimeslices.new(@course, update_service: self).run(all_time: @full_update)
     update_average_pageviews
     update_caches
     update_wikidata_stats if wikidata
@@ -109,7 +109,7 @@ class UpdateCourseStatsTimeslice
     UpdateLogger.update_course(@course, 'start_time' => @start_time.to_datetime,
                                          'end_time' => @end_time.to_datetime,
                                          'sentry_tag_uuid' => sentry_tag_uuid,
-                                         'error_count' => error_count + @timeslice_errors)
+                                         'error_count' => error_count)
   end
 
   def wikidata

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -29,8 +29,9 @@ class UpdateCourseStatsTimeslice
     import_uploads
     update_categories
     update_article_status if should_update_article_status?
-    UpdateCourseWikiTimeslices.new(@course, @debugger,
-                                   update_service: self).run(all_time: @full_update)
+    @processed, @reprocessed = UpdateCourseWikiTimeslices.new(@course, @debugger,
+                                                              update_service: self)
+                                                         .run(all_time: @full_update)
     update_average_pageviews
     update_caches
     update_wikidata_stats if wikidata
@@ -110,7 +111,9 @@ class UpdateCourseStatsTimeslice
     UpdateLogger.update_course(@course, 'start_time' => @start_time.to_datetime,
                                          'end_time' => @end_time.to_datetime,
                                          'sentry_tag_uuid' => sentry_tag_uuid,
-                                         'error_count' => error_count)
+                                         'error_count' => error_count,
+                                         'proccesed' => @processed,
+                                         'reprocessed' => @reprocessed)
   end
 
   def wikidata

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -25,7 +25,7 @@ class UpdateCourseWikiTimeslices
 
   def pre_update(from_scratch)
     @debugger.log_update_progress :pre_update_start
-    prepare_timeslices = PrepareTimeslices.new(@course)
+    prepare_timeslices = PrepareTimeslices.new(@course, update_service: @update_service)
     from_scratch ? prepare_timeslices.recreate_timeslices : prepare_timeslices.adjust_timeslices
     @debugger.log_update_progress :pre_update_finish
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -8,10 +8,10 @@ require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 # It updates all the tracked wikis for the course, from the latest start time for every wiki
 # up to the end of update (today or end date course).
 class UpdateCourseWikiTimeslices
-  def initialize(course, update_service: nil)
+  def initialize(course, debugger, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
-    @debugger = UpdateDebugger.new(@course)
+    @debugger = debugger
     @update_service = update_service
     @wikidata_stats_updater = UpdateWikidataStatsTimeslice.new(@course) if wikidata
   end
@@ -25,7 +25,7 @@ class UpdateCourseWikiTimeslices
 
   def pre_update(from_scratch)
     @debugger.log_update_progress :pre_update_start
-    prepare_timeslices = PrepareTimeslices.new(@course, update_service: @update_service)
+    prepare_timeslices = PrepareTimeslices.new(@course, @debugger, update_service: @update_service)
     from_scratch ? prepare_timeslices.recreate_timeslices : prepare_timeslices.adjust_timeslices
     @debugger.log_update_progress :pre_update_finish
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -58,6 +58,9 @@ class UpdateCourseWikiTimeslices
       start_date = [current_start, @course.start].max
       end_date = [current_start + @timeslice_manager.timeslice_duration(wiki) - 1.second,
                   @course.end].min
+
+      log_processing(wiki, start_date, end_date)
+
       fetch_data(wiki, start_date, end_date)
       process_timeslices(wiki)
       current_start += @timeslice_manager.timeslice_duration(wiki)
@@ -71,6 +74,9 @@ class UpdateCourseWikiTimeslices
     to_reprocess.each do |t|
       start_date = [t.start, @course.start].max
       end_date = [t.end - 1.second, @course.end].min
+
+      log_reprocessing(wiki, start_date, end_date)
+
       fetch_data(wiki, start_date, end_date)
       process_timeslices(wiki)
     end
@@ -153,7 +159,17 @@ class UpdateCourseWikiTimeslices
   end
 
   def log_error(error)
-    Sentry.capture_message "#{@course.title} update timeslices error: #{error}",
+    Sentry.capture_message "#{@course.slug} update timeslices error: #{error}",
                            level: 'error'
+  end
+
+  def log_processing(wiki, start_date, end_date)
+    Rails.logger.info "UpdateCourseWikiTimeslices: Course: #{@course.slug} Wiki: #{wiki.id}.\
+    Processing timeslice [#{start_date}, #{end_date}]"
+  end
+
+  def log_reprocessing(wiki, start_date, end_date)
+    Rails.logger.info "UpdateCourseWikiTimeslices: Course: #{@course.slug} Wiki: #{wiki.id}.\
+    Reprocessing timeslice [#{start_date}, #{end_date}]"
   end
 end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -14,11 +14,14 @@ class UpdateCourseWikiTimeslices
     @debugger = debugger
     @update_service = update_service
     @wikidata_stats_updater = UpdateWikidataStatsTimeslice.new(@course) if wikidata
+    @processed_timeslices = 0
+    @reprocessed_timeslices = 0
   end
 
   def run(all_time:)
     pre_update(all_time)
     fetch_data_and_process_timeslices_for_every_wiki(all_time)
+    [@processed_timeslices, @reprocessed_timeslices]
   end
 
   private
@@ -64,6 +67,7 @@ class UpdateCourseWikiTimeslices
       fetch_data(wiki, start_date, end_date)
       process_timeslices(wiki)
       current_start += @timeslice_manager.timeslice_duration(wiki)
+      @processed_timeslices += 1
     end
     @debugger.log_update_progress "fetch_and_process_timeslices_finish_#{wiki.id}".to_sym
   end
@@ -79,6 +83,7 @@ class UpdateCourseWikiTimeslices
 
       fetch_data(wiki, start_date, end_date)
       process_timeslices(wiki)
+      @reprocessed_timeslices += 1
     end
     @debugger.log_update_progress "fetch_and_reprocess_timeslices_finish_#{wiki.id}".to_sym
   end

--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -49,7 +49,8 @@ class UpdateTimeslicesCourseDate
   def add_wiki_timeslices_up_to_new_end_date(wiki)
     mark_old_last_wiki_timeslce_as_needs_update(wiki)
 
-    Rails.logger.info "UpdateTimeslicesCourseDate: Adding data up to: #{@course.end}"
+    Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
+    Adding data up to: #{@course.end}"
 
     @timeslice_manager.create_wiki_timeslices_up_to_new_course_end_date(wiki)
   end
@@ -57,7 +58,8 @@ class UpdateTimeslicesCourseDate
   def remove_timeslices_prior_to_start_date
     mark_new_first_timeslce_as_needs_update
 
-    Rails.logger.info "UpdateTimeslicesCourseDate: Removing data prior to: #{@course.start}"
+    Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
+    Removing data prior to: #{@course.start}"
 
     # Delete course and course user timeslices
     @timeslice_manager.delete_course_wiki_timeslices_prior_to_start_date
@@ -70,7 +72,8 @@ class UpdateTimeslicesCourseDate
   def remove_timeslices_after_end_date
     mark_old_last_timeslce_as_needs_update
 
-    Rails.logger.info "UpdateTimeslicesCourseDate: Removing data after to: #{@course.end}"
+    Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
+    Removing data after to: #{@course.end}"
 
     # Delete course and course user timeslices
     @timeslice_manager.delete_course_wiki_timeslices_after_end_date
@@ -83,7 +86,8 @@ class UpdateTimeslicesCourseDate
   def add_wiki_timeslices_from_new_start_date(wiki)
     mark_new_wiki_first_timeslce_as_needs_update(wiki)
 
-    Rails.logger.info "UpdateTimeslicesCourseDate: Adding data after to: #{@course.start}"
+    Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
+    Adding data after to: #{@course.start}"
 
     @timeslice_manager.create_wiki_timeslices_for_new_course_start_date(wiki)
   end

--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -49,11 +49,15 @@ class UpdateTimeslicesCourseDate
   def add_wiki_timeslices_up_to_new_end_date(wiki)
     mark_old_last_wiki_timeslce_as_needs_update(wiki)
 
+    Rails.logger.info "UpdateTimeslicesCourseDate: Adding data up to: #{@course.end}"
+
     @timeslice_manager.create_wiki_timeslices_up_to_new_course_end_date(wiki)
   end
 
   def remove_timeslices_prior_to_start_date
     mark_new_first_timeslce_as_needs_update
+
+    Rails.logger.info "UpdateTimeslicesCourseDate: Removing data prior to: #{@course.start}"
 
     # Delete course and course user timeslices
     @timeslice_manager.delete_course_wiki_timeslices_prior_to_start_date
@@ -66,6 +70,8 @@ class UpdateTimeslicesCourseDate
   def remove_timeslices_after_end_date
     mark_old_last_timeslce_as_needs_update
 
+    Rails.logger.info "UpdateTimeslicesCourseDate: Removing data after to: #{@course.end}"
+
     # Delete course and course user timeslices
     @timeslice_manager.delete_course_wiki_timeslices_after_end_date
     @timeslice_manager.delete_course_user_wiki_timeslices_after_end_date
@@ -76,6 +82,8 @@ class UpdateTimeslicesCourseDate
 
   def add_wiki_timeslices_from_new_start_date(wiki)
     mark_new_wiki_first_timeslce_as_needs_update(wiki)
+
+    Rails.logger.info "UpdateTimeslicesCourseDate: Adding data after to: #{@course.start}"
 
     @timeslice_manager.create_wiki_timeslices_for_new_course_start_date(wiki)
   end

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -37,7 +37,8 @@ class UpdateTimeslicesCourseUser
   def add_user_ids(user_ids)
     return if user_ids.empty?
 
-    Rails.logger.info "UpdateTimeslicesCourseUser: Adding new users: #{user_ids}"
+    Rails.logger.info "UpdateTimeslicesCourseUser: Course: #{@course.slug}\
+    Adding new users: #{user_ids}"
 
     @course.wikis.each do |wiki|
       fetch_users_revisions_for_wiki(wiki, user_ids)
@@ -58,7 +59,8 @@ class UpdateTimeslicesCourseUser
   def remove_courses_users(user_ids)
     return if user_ids.empty?
 
-    Rails.logger.info "UpdateTimeslicesCourseUser: Removing old users: #{user_ids}"
+    Rails.logger.info "UpdateTimeslicesCourseUser: Course: #{@course.slug}\
+    Removing old users: #{user_ids}"
     # Delete course user wiki timeslices for the deleted users
     @timeslice_manager.delete_course_user_timeslices_for_deleted_course_users user_ids
 

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -37,6 +37,8 @@ class UpdateTimeslicesCourseUser
   def add_user_ids(user_ids)
     return if user_ids.empty?
 
+    Rails.logger.info "UpdateTimeslicesCourseUser: Adding new users: #{user_ids}"
+
     @course.wikis.each do |wiki|
       fetch_users_revisions_for_wiki(wiki, user_ids)
     end
@@ -55,6 +57,8 @@ class UpdateTimeslicesCourseUser
 
   def remove_courses_users(user_ids)
     return if user_ids.empty?
+
+    Rails.logger.info "UpdateTimeslicesCourseUser: Removing old users: #{user_ids}"
     # Delete course user wiki timeslices for the deleted users
     @timeslice_manager.delete_course_user_timeslices_for_deleted_course_users user_ids
 

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -5,9 +5,10 @@ require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
 require_dependency "#{Rails.root}/lib/revision_data_manager"
 
 class UpdateTimeslicesCourseUser
-  def initialize(course)
+  def initialize(course, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(course)
+    @update_sercice = update_service
   end
 
   def run
@@ -44,7 +45,7 @@ class UpdateTimeslicesCourseUser
   def fetch_users_revisions_for_wiki(wiki, user_ids)
     users = User.find(user_ids)
 
-    manager = RevisionDataManager.new(wiki, @course)
+    manager = RevisionDataManager.new(wiki, @course, update_service: @update_service)
     # Fetch the revisions for users for the complete period
     revisions = manager.fetch_revision_data_for_users(users,
                                                       @course.start.strftime('%Y%m%d%H%M%S'),

--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -30,6 +30,8 @@ class UpdateTimeslicesCourseWiki
   private
 
   def remove_courses_wikis(wiki_ids)
+    return if wiki_ids.empty?
+    Rails.logger.info { "UpdateTimeslicesCourseWiki: Deleting wikis: #{wiki_ids}" }
     # Delete timeslices for the deleted wikis
     @timeslice_manager.delete_timeslices_for_deleted_course_wikis wiki_ids
     # Delete articles courses
@@ -37,7 +39,9 @@ class UpdateTimeslicesCourseWiki
   end
 
   def add_courses_wikis(wiki_ids)
+    return if wiki_ids.empty?
     wikis = Wiki.where(id: wiki_ids)
+    Rails.logger.info { "UpdateTimeslicesCourseWiki: Adding wikis: #{wiki_ids}" }
     # Create course wiki timeslice records for new wikis
     @timeslice_manager.create_timeslices_for_new_course_wiki_records(wikis)
   end

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -42,6 +42,8 @@ class UpdateTimeslicesScopedArticle
   def reset(article_ids)
     return if article_ids.empty?
 
+    Rails.logger.info "UpdateTimeslicesUntrackedArticle: Resetting #{@article_ids}"
+
     # Mark course wiki timeslices to be re-proccesed
     articles = Article.where(id: article_ids)
     ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, articles)

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -42,7 +42,8 @@ class UpdateTimeslicesScopedArticle
   def reset(article_ids)
     return if article_ids.empty?
 
-    Rails.logger.info "UpdateTimeslicesUntrackedArticle: Resetting #{@article_ids}"
+    Rails.logger.info "UpdateTimeslicesScopedArticle: Course: #{@course.slug}\
+    Resetting #{@article_ids}"
 
     # Mark course wiki timeslices to be re-proccesed
     articles = Article.where(id: article_ids)

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -9,7 +9,7 @@ describe UpdateCourseWikiTimeslices do
   end
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
-  let(:updater) { described_class.new(course) }
+  let(:updater) { described_class.new(course, UpdateDebugger.new(course)) }
   let(:subject) { updater.run(all_time: false) }
   let(:flags) { nil }
   let(:user) { create(:user, username: 'Ragesoss') }

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -17,7 +17,9 @@ describe UpdateCourseWikiTimeslices do
   context 'when debugging is not enabled' do
     it 'posts no Sentry logs' do
       expect(Sentry).not_to receive(:capture_message)
-      subject
+      processed, reprocessed = subject
+      expect(processed).to eq(7)
+      expect(reprocessed).to eq(0)
     end
   end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -14,11 +14,19 @@ describe UpdateCourseWikiTimeslices do
   let(:flags) { nil }
   let(:user) { create(:user, username: 'Ragesoss') }
 
+  before do
+    stub_wiki_validation
+    travel_to Date.new(2018, 12, 1)
+    course.campaigns << Campaign.first
+    course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
+    JoinCourse.new(course:, user:, role: 0)
+  end
+
   context 'when debugging is not enabled' do
     it 'posts no Sentry logs' do
       expect(Sentry).not_to receive(:capture_message)
       processed, reprocessed = subject
-      expect(processed).to eq(7)
+      expect(processed).to eq(14)
       expect(reprocessed).to eq(0)
     end
   end
@@ -33,15 +41,6 @@ describe UpdateCourseWikiTimeslices do
   end
 
   context 'when there are revisions' do
-    before do
-      stub_wiki_validation
-      travel_to Date.new(2018, 12, 1)
-      course.campaigns << Campaign.first
-      # Create course wiki timeslices manually for wikidata
-      course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')
-      JoinCourse.new(course:, user:, role: 0)
-    end
-
     it 'updates article course timeslices caches' do
       VCR.use_cassette 'course_update' do
         subject

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -159,7 +159,7 @@ describe UpdateCourseWikiTimeslices do
       expected_dates.each do |start_time, end_time|
         expected_wikis.each do |wiki|
           expect(CourseRevisionUpdater).to receive(:fetch_revisions_and_scores_for_wiki)
-            .with(course, wiki, start_time, end_time, update_service: updater)
+            .with(course, wiki, start_time, end_time, update_service: nil)
             .once
         end
       end
@@ -167,54 +167,6 @@ describe UpdateCourseWikiTimeslices do
       VCR.use_cassette 'course_update' do
         subject
       end
-    end
-  end
-
-  context 'sentry course update error tracking' do
-    let(:flags) { { debug_updates: true } }
-    let(:user) { create(:user, username: 'Ragesoss') }
-
-    before do
-      travel_to Date.new(2018, 11, 28)
-      course.campaigns << Campaign.first
-      JoinCourse.new(course:, user:, role: 0)
-    end
-
-    it 'tracks update errors properly in Replica' do
-      allow(Sentry).to receive(:capture_exception)
-
-      # Raising errors only in Replica
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
-      VCR.use_cassette 'course_update/replica' do
-        subject
-      end
-      sentry_tag_uuid = updater.sentry_tag_uuid
-
-      # Checking whether Sentry receives correct error and tags as arguments
-      expect(Sentry).to have_received(:capture_exception).exactly(5).times.with(
-        Errno::ECONNREFUSED, anything
-      )
-      expect(Sentry).to have_received(:capture_exception)
-        .exactly(5).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
-                                                    course: course.slug })
-    end
-
-    it 'tracks update errors properly in LiftWing' do
-      allow(Sentry).to receive(:capture_exception)
-
-      # Raising errors only in LiftWing
-      stub_request(:any, %r{https://api.wikimedia.org/service/lw.*}).to_raise(Faraday::ConnectionFailed)
-      VCR.use_cassette 'course_update/lift_wing_api' do
-        subject
-      end
-      sentry_tag_uuid = updater.sentry_tag_uuid
-
-      # Checking whether Sentry receives correct error and tags as arguments
-      expect(Sentry).to have_received(:capture_exception)
-        .exactly(2).times.with(Faraday::ConnectionFailed, anything)
-      expect(Sentry).to have_received(:capture_exception)
-        .exactly(2).times.with anything, hash_including(tags: { update_service_id: sentry_tag_uuid,
-                                                                course: course.slug })
     end
   end
 end


### PR DESCRIPTION
## What this PR does
This PR makes some refactors to improve logs during course updates:
- Pass in the right `update_service` and `debugger` instance to keep all logs in Sentry together.
- Add some basic logs through `Rails.logger` to be easier understand course metadata changes and timeslices processing.
- Adds number of timeslices processed and re-processed to the course logs in `flags`.

## Open questions and concerns
TODO: see if using `Rails.logger.info` is OK.