### PR TITLE
Refactor monitors for `HighQualityArticleEditAlert` and `DiscretionarySanctionsEditAlert`.

### DIFF
--- a/lib/alerts/high_quality_article_monitor.rb
+++ b/lib/alerts/high_quality_article_monitor.rb
@@ -51,15 +51,11 @@ class HighQualityArticleMonitor
 
   def create_edit_alert(articles_course)
     return if unresolved_edit_alert_already_exists?(articles_course)
-    revisions = articles_course.course.revisions.where(article_id: articles_course.article_id)
-    last_revision = revisions.last
-    return if resolved_alert_covers_latest_revision?(articles_course, last_revision)
-    first_revision = revisions.first
+    return if resolved_alert_covers_latest_revision?(articles_course)
     alert = Alert.create!(type: 'HighQualityArticleEditAlert',
                           article_id: articles_course.article_id,
-                          user_id: first_revision&.user_id,
-                          course_id: articles_course.course_id,
-                          revision_id: first_revision&.id)
+                          user_id: articles_course&.user_ids&.first,
+                          course_id: articles_course.course_id)
     alert.email_content_expert
   end
 
@@ -84,12 +80,58 @@ class HighQualityArticleMonitor
                                               resolved: false)
   end
 
-  def resolved_alert_covers_latest_revision?(articles_course, last_revision)
-    return false if last_revision.nil?
+  def resolved_alert_covers_latest_revision?(articles_course)
     last_resolved = HighQualityArticleEditAlert.where(article_id: articles_course.article_id,
                                                       course_id: articles_course.course_id,
                                                       resolved: true).last
     return false unless last_resolved.present?
-    last_resolved.created_at > last_revision.date
+
+    course = Course.find(articles_course.course_id)
+    # If the last resolved alert was created after the course end, do not create a new one
+    return true if last_resolved.created_at > course.end
+
+    mw_page_id = articles_course.article.mw_page_id
+    return !course_edit_after?(course, mw_page_id, last_resolved.created_at)
+  end
+
+  # Returns true if there was an edit made by a course student to the specified page
+  # within the period from the creation date of the last resolved alert to the course end date.
+  def course_edit_after?(course, page_id, last_resolved_date)
+    @api = WikiApi.new @wiki
+    @query_params = query_params(course, page_id, last_resolved_date)
+    @continue = true
+    until @continue.nil?
+      response = @api.query(@query_params)
+      return false unless response
+      reivisons = filter_revisions(response, page_id, course)
+      # If we found an edit made by the user then return true
+      return true if reivisons.present?
+      @continue = response['continue']
+      @query_params['rvcontinue'] = @continue['rvcontinue'] if @continue
+    end
+    false
+  end
+
+  # Filters the API response to exclude edits made by users who are not course students.
+  # Returns only the edits associated with the course.
+  def filter_revisions(response, page_id, course)
+    revisions = response.data['pages'][page_id.to_s]['revisions']
+    return if revisions.nil?
+    students = course.students.pluck(:username)
+    revisions.select { |revision| students.include?(revision['user']) }
+  end
+
+  # Queries for edits made to the specified page within the period
+  # [last resolved alert, course end]
+  def query_params(course, page_id, last_resolved_date)
+    {
+      action: 'query',
+      prop: 'revisions',
+      pageids: page_id,
+      rvend: last_resolved_date.strftime('%Y%m%d%H%M%S'),
+      rvstart: course.end.strftime('%Y%m%d%H%M%S'),
+      rvdir: 'older', # List newest first. rvstart has to be later than rvend.
+      rvlimit: 500
+  }
   end
 end

--- a/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
+++ b/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
@@ -28,7 +28,7 @@ describe DiscretionarySanctionsMonitor do
     let!(:articles_course) do
       create(:articles_course, article_id: article.id,
                                course_id: course.id,
-                               user_ids: [student.id])
+                               user_ids: [student.id, 45])
     end
 
     let!(:assignment) do
@@ -52,6 +52,8 @@ describe DiscretionarySanctionsMonitor do
       expect(DiscretionarySanctionsAssignmentAlert.count).to eq(1)
       alerted_edit_article_ids = DiscretionarySanctionsEditAlert.all.pluck(:article_id)
       expect(alerted_edit_article_ids).to include(article.id)
+      alerted_edit_user_ids = DiscretionarySanctionsEditAlert.all.pluck(:user_id)
+      expect(alerted_edit_user_ids).to include(student.id)
       alerted_assignment_article_ids = DiscretionarySanctionsAssignmentAlert.all.pluck(:article_id)
       expect(alerted_assignment_article_ids).to include(article.id)
     end

--- a/spec/lib/alerts/high_quality_article_monitor_spec.rb
+++ b/spec/lib/alerts/high_quality_article_monitor_spec.rb
@@ -56,6 +56,8 @@ describe HighQualityArticleMonitor do
       expect(HighQualityArticleAssignmentAlert.count).to eq(1)
       alerted_edit_article_ids = HighQualityArticleEditAlert.all.pluck(:article_id)
       expect(alerted_edit_article_ids).to include(article.id)
+      alerted_edit_user_ids = HighQualityArticleEditAlert.all.pluck(:user_id)
+      expect(alerted_edit_user_ids).to include(student.id)
       alerted_assignment_article_ids = HighQualityArticleAssignmentAlert.all.pluck(:article_id)
       expect(alerted_assignment_article_ids).to include(article.id)
     end

--- a/spec/lib/alerts/high_quality_article_monitor_spec.rb
+++ b/spec/lib/alerts/high_quality_article_monitor_spec.rb
@@ -49,9 +49,7 @@ describe HighQualityArticleMonitor do
     end
 
     it 'creates Alert records for edited Good articles' do
-      VCR.use_cassette 'high_quality' do
-        described_class.create_alerts_for_course_articles
-      end
+      described_class.create_alerts_for_course_articles
       expect(HighQualityArticleEditAlert.count).to eq(1)
       expect(HighQualityArticleAssignmentAlert.count).to eq(1)
       alerted_edit_article_ids = HighQualityArticleEditAlert.all.pluck(:article_id)
@@ -64,9 +62,7 @@ describe HighQualityArticleMonitor do
 
     it 'emails a greeter' do
       create(:courses_user, user_id: content_expert.id, course_id: course.id, role: 4)
-      VCR.use_cassette 'high_quality' do
-        described_class.create_alerts_for_course_articles
-      end
+      described_class.create_alerts_for_course_articles
       expect(Alert.last.email_sent_at).not_to be_nil
     end
 
@@ -74,9 +70,7 @@ describe HighQualityArticleMonitor do
       Alert.create(type: 'HighQualityArticleAssignmentAlert', article_id: assignment.article_id,
                    course_id: assignment.course_id, user_id: assignment.user_id)
       expect(HighQualityArticleAssignmentAlert.count).to eq(1)
-      VCR.use_cassette 'high_quality' do
-        described_class.create_alerts_for_course_articles
-      end
+      described_class.create_alerts_for_course_articles
       expect(HighQualityArticleAssignmentAlert.count).to eq(1)
     end
 


### PR DESCRIPTION
## What this PR does
This PR refactors both `DiscretionarySanctionsMonitor` and  `HighQualityArticleMonitor` to work without relying on revisions in the data base. 
The refactor involves two main things:
1. The user id assigned to the alert is taken from `user_ids` `ArticlesCourses` field instead of using the revision (similar to PR #6147)
2. `resolved_edit_alert_covers_latest_revision?` definition changes. To decide whether to create a new alert when a resolved alert already exists, now we query the API to retrieve all edits made to the specified page after the resolved alert's creation date. A new alert is created if any of those edits were made by a course student (I didn't find any way to retrieve revisions for a given page id made by a list of users, the `rvuser` parameter allows a single user according to [docs](https://www.mediawiki.org/wiki/API:Revisions)). Note that we only hit edits made within the period from the `creation date of the last resolved alert` to the `course end date` (would we prefer to use `course end date + UPDATE_LENGTH`?). 

Closes #6141 

## Open questions and concerns
1. Now alert record is created with a nil `revision_id`.
2. I made an effort to mock the API requests in the specs instead of using VCR cassette, but I didn't find a way to make the `MediawikiApi::Response`  double instance work when implementing `continue`. 
3. This PR has a lot of  duplicate code. However, because of how the alerts are implemented, I didn't find a good place to put common code. A reasonable thing to do would be to move the logic for retrieving revisions made to a given article to the `WikiAPI` class. However, the current implementation is interrupting requests if it finds a positive result, to avoid making unnecessary continue requests (considering that the previous implementation did not make any requests because it used the persisted revisions in the database). Therefore IMHO it has quite a lot of use-specific logic to move it to the `WikiApi` class.