### PR TITLE
[Data rearchitecture] Ignore bad requests from reference counter api

### DIFF
--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -58,6 +58,9 @@ class ReferenceCounterApi
     response = toolforge_server.get(references_query_url(rev_id))
     parsed_response = Oj.load(response.body)
     return { 'num_ref' => parsed_response['num_ref'] } if response.status == 200
+    # If the response is bad request, then the language and/or the project is not supported.
+    # Leave the error empty in this case, as it is not a transient error.
+    return { 'num_ref' => nil } if response.status == 400
     # Log the error and return empty hash
     # Sentry.capture_message 'Non-200 response hitting references counter API', level: 'warning',
     # extra: { project_code: @project_code, language_code: @language_code, rev_id:,

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -735,4 +735,13 @@ module RequestHelpers
         headers: { 'Content-Type' => 'application/json' }
       )
   end
+
+  def stub_not_supported_wiki_reference_counter_response
+    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator/\d+})
+      .to_return(
+        status: 400,
+        body: { 'description' => 'Language incubator is not a valid language. ' }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
 end


### PR DESCRIPTION
## What this PR does
This PR updates the behavior of `ReferenceCounterApi` when a 400 Bad Request response is received. Previously, the error field included the message "Language _X_ is not a valid language." With this update, the error is ignored because it is not a transient error, and we want to avoid reprocessing any timeslice due to this response.


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
