### PR TITLE
Raises a custom `PageFetchError` when the `response.status `is not 200 or 404

### DIFF
--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -125,7 +125,7 @@ class WikiApi
 
   class PageFetchError < StandardError
     def initialize(page, status)
-      message = "Failed to fetch content for #{page} with response status: #{status}."
+      message = "Failed to fetch content for #{page} with response status: #{status.inspect}"
       super(message)
     end
   end

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -33,6 +33,8 @@ class WikiApi
       response.body.force_encoding('UTF-8')
     when 404
       ''
+    else
+      raise PageFetchError.new(page_title, response&.status)
     end
   end
 
@@ -119,6 +121,13 @@ class WikiApi
   def too_many_requests?(e)
     return false unless e.instance_of?(MediawikiApi::HttpError)
     e.status == 429
+  end
+
+  class PageFetchError < StandardError
+    def initialize(page, status)
+      message = "Failed to fetch content for #{page} with response status: #{status}."
+      super(message)
+    end
   end
 
   TYPICAL_ERRORS = [Faraday::TimeoutError,

--- a/spec/controllers/users/enrollment_controller_spec.rb
+++ b/spec/controllers/users/enrollment_controller_spec.rb
@@ -18,6 +18,7 @@ describe Users::EnrollmentController, type: :request do
       allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
       allow_any_instance_of(WikiCourseEdits).to receive(:remove_assignment)
       allow_any_instance_of(WikiCourseEdits).to receive(:update_assignments)
+      allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return('Some content')
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       course.campaigns << Campaign.first
     end

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -63,6 +63,21 @@ describe WikiApi do
         expect(response).not_to be_blank
       end
     end
+
+    it 'raises a PageFetchError for unexpected response statuses' do
+      # some possible status codes
+      unexpected_statuses = [401, 403, 406, 408, 409, 413, 414, 429]
+      unexpected_statuses.each do |status_code|
+        allow_any_instance_of(described_class).to receive(:mediawiki)
+          .and_return(OpenStruct.new(status: status_code))
+        expect do
+          described_class.new.get_page_content('SomePage')
+        end.to raise_error(
+          WikiApi::PageFetchError,
+          /Failed to fetch content for SomePage with response status: #{status_code}/
+        )
+      end
+    end
   end
 
   describe '#fetch_all' do

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -6,7 +6,7 @@ require "#{Rails.root}/lib/wiki_api"
 class UnexpectedError < StandardError; end
 
 describe WikiApi do
-  describe 'error handling and calls ApiErrorHandling method' do
+  describe 'handles errors by calling ApiErrorHandling method and raising a PageFetchError' do
     let(:subject) { described_class.new.get_page_content('Ragesoss') }
 
     it 'handles mediawiki 503 errors gracefully' do
@@ -23,7 +23,7 @@ describe WikiApi do
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect { subject }.to raise_error(
         WikiApi::PageFetchError,
-        /Failed to fetch content for Ragesoss with response status: ./
+        /Failed to fetch content for Ragesoss with response status: nil/
       )
     end
 
@@ -33,7 +33,7 @@ describe WikiApi do
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect { subject }.to raise_error(
         WikiApi::PageFetchError,
-        /Failed to fetch content for Ragesoss with response status: ./
+        /Failed to fetch content for Ragesoss with response status: nil/
       )
     end
 
@@ -43,7 +43,7 @@ describe WikiApi do
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect { subject }.to raise_error(
         WikiApi::PageFetchError,
-        /Failed to fetch content for Ragesoss with response status: ./
+        /Failed to fetch content for Ragesoss with response status: nil/
       )
     end
   end


### PR DESCRIPTION
## What this PR does
Raises a custom PageFetchError error when the response.status is not 200 or 404:

- Creates a custom `PageFetchError` with a descriptive error message
- Adds test to ensure this expected behaviour is enforced

## Screenshots
Before:
![before pagefetchtest](https://github.com/user-attachments/assets/9dfd3b2e-0a3c-46a8-a82e-19910b5dba2b)

After:
![after pagefetchtest](https://github.com/user-attachments/assets/b30e41c5-5844-467a-b1c1-6eebf9ab3bd2)