### PR TITLE
[Data rearchitecture] Clean models

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -4,19 +4,18 @@
 # Table name: article_course_timeslices
 #
 #  id               :bigint           not null, primary key
+#  course_id        :integer          not null
+#  article_id       :integer          not null
 #  start            :datetime
 #  end              :datetime
-#  last_mw_rev_id   :integer
 #  character_sum    :integer          default(0)
 #  references_count :integer          default(0)
+#  revision_count   :integer          default(0)
 #  user_ids         :text(65535)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  article_id       :integer          not null
-#  course_id        :integer          not null
 #  new_article      :boolean          default(FALSE)
 #  tracked          :boolean          default(TRUE)
-#  revision_count   :integer          default(0)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 class ArticleCourseTimeslice < ApplicationRecord
   belongs_to :article

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -15,7 +15,6 @@
 #  tracked          :boolean          default(TRUE)
 #  user_ids         :text(65535)
 #  first_revision   :datetime
-#  revision_count   :integer          default(0)
 #
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
@@ -92,7 +91,6 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def update_cache_from_timeslices
-    self.revision_count = article_course_timeslices.sum(&:revision_count)
     self.character_sum = article_course_timeslices.sum(&:character_sum)
     self.references_count = article_course_timeslices.sum(&:references_count)
     self.user_ids = article_course_timeslices.sum([], &:user_ids).uniq

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -10,8 +10,6 @@
 #  wiki_id             :integer          not null
 #  start               :datetime
 #  end                 :datetime
-#  last_mw_rev_id      :integer
-#  total_uploads       :integer          default(0)
 #  character_sum_ms    :integer          default(0)
 #  character_sum_us    :integer          default(0)
 #  character_sum_draft :integer          default(0)
@@ -76,7 +74,6 @@ class CourseUserWikiTimeslice < ApplicationRecord
     @revisions = revisions
     @liverevisions = live_revisions
     tracked_namespace_revisions = live_revisions_in_tracked_namespaces
-    self.total_uploads = course.uploads.where(user:).count
     update_character_sum(@liverevisions, tracked_namespace_revisions)
     self.references_count = references_sum(tracked_namespace_revisions)
 

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -5,22 +5,18 @@
 # Table name: course_wiki_timeslices
 #
 #  id                   :bigint           not null, primary key
+#  course_id            :integer          not null
+#  wiki_id              :integer          not null
 #  start                :datetime
 #  end                  :datetime
-#  last_mw_rev_id       :integer
 #  character_sum        :integer          default(0)
 #  references_count     :integer          default(0)
 #  revision_count       :integer          default(0)
-#  upload_count         :integer          default(0)
-#  uploads_in_use_count :integer          default(0)
-#  upload_usages_count  :integer          default(0)
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  course_id            :integer          not null
-#  wiki_id              :integer          not null
+#  stats                :text(65535)
 #  last_mw_rev_datetime :datetime
 #  needs_update         :boolean          default(FALSE)
-#  stats                :text(65535)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #
 class CourseWikiTimeslice < ApplicationRecord
   belongs_to :course
@@ -90,9 +86,6 @@ class CourseWikiTimeslice < ApplicationRecord
     update_character_sum
     update_references_count
     update_revision_count
-    update_upload_count
-    update_uploads_in_use_count
-    update_upload_usages_count
     update_stats
     update_needs_update
     save
@@ -133,21 +126,6 @@ class CourseWikiTimeslice < ApplicationRecord
     end
 
     self.revision_count = tracked_revisions.count { |rev| !rev.deleted && !rev.system }
-  end
-
-  def update_upload_count
-    # TODO: count only uploads updated at during the timeslice range
-    self.upload_count = course.uploads.count
-  end
-
-  def update_uploads_in_use_count
-    # TODO: count only uploads updated at during the timeslice range
-    self.uploads_in_use_count = course.uploads_in_use.count
-  end
-
-  def update_upload_usages_count
-    # TODO: count only uploads updated at during the timeslice range
-    self.upload_usages_count = course.uploads_in_use.sum(:usage_count)
   end
 
   def update_stats

--- a/app/services/update_wiki_namespace_stats_timeslice.rb
+++ b/app/services/update_wiki_namespace_stats_timeslice.rb
@@ -53,6 +53,11 @@ class UpdateWikiNamespaceStatsTimeslice
            deleted: false }).where(tracked: true)
   end
 
+  def articles_timeslices_filtered_by_wiki_namespace
+    @course.article_course_timeslices
+           .where(article_id: articles_filtered_by_wiki_namespace.pluck(:article_id))
+  end
+
   def edited_articles_count
     articles = articles_filtered_by_wiki_namespace
     articles.count
@@ -64,7 +69,9 @@ class UpdateWikiNamespaceStatsTimeslice
   end
 
   def revision_count
-    articles_filtered_by_wiki_namespace.sum(:revision_count)
+    # Compute revision_count using timeslices, since ArticlesCourses records
+    # do not have a revision_count field.
+    articles_timeslices_filtered_by_wiki_namespace.sum(:revision_count)
   end
 
   def user_count

--- a/db/migrate/20240522214522_create_course_wiki_timeslices.rb
+++ b/db/migrate/20240522214522_create_course_wiki_timeslices.rb
@@ -1,18 +1,24 @@
+# frozen_string_literal: true
 class CreateCourseWikiTimeslices < ActiveRecord::Migration[7.0]
   def change
     create_table :course_wiki_timeslices do |t|
-      t.integer :course_wiki_id, null: false
+      t.integer :course_id, null: false
+      t.integer :wiki_id, null: false
       t.datetime :start
       t.datetime :end
-      t.integer :last_mw_rev_id
       t.integer :character_sum, default: 0
       t.integer :references_count, default: 0
       t.integer :revision_count, default: 0
-      t.integer :upload_count, default: 0
-      t.integer :uploads_in_use_count, default: 0
-      t.integer :upload_usages_count, default: 0
+      t.text :stats, limit: 65535
+      t.datetime :last_mw_rev_datetime
+      t.boolean :needs_update, default: false
 
       t.timestamps
     end
+
+    add_index :course_wiki_timeslices,
+              [:course_id, :wiki_id, :start, :end],
+              unique: true,
+              name: 'course_wiki_timeslice_by_course_wiki_start_and_end'
   end
 end

--- a/db/migrate/20240522233334_create_article_course_timeslices.rb
+++ b/db/migrate/20240522233334_create_article_course_timeslices.rb
@@ -1,15 +1,31 @@
 class CreateArticleCourseTimeslices < ActiveRecord::Migration[7.0]
   def change
     create_table :article_course_timeslices do |t|
-      t.integer :article_course_id, null: false
+      t.integer :course_id, null: false
+      t.integer :article_id, null: false
       t.datetime :start
       t.datetime :end
-      t.integer :last_mw_rev_id
       t.integer :character_sum, default: 0
       t.integer :references_count, default: 0
-      t.text :user_ids, default: ""
+      t.integer :revision_count, default: 0
+      t.text :user_ids
+      t.boolean :new_article, default: false
+      t.boolean :tracked, default: true
 
       t.timestamps
     end
+
+    add_index :article_course_timeslices,
+              [:article_id, :course_id, :start, :end],
+              unique: true,
+              name: 'article_course_timeslice_by_article_course_start_and_end'
+
+    add_index :article_course_timeslices,
+              [:course_id, :updated_at, :article_id],
+              name: 'article_course_timeslice_by_updated_at'
+
+    add_index :article_course_timeslices,
+              [:course_id, :tracked],
+              name: 'article_course_timeslice_by_tracked'
   end
 end

--- a/db/migrate/20240523012004_create_course_user_wiki_timeslices.rb
+++ b/db/migrate/20240523012004_create_course_user_wiki_timeslices.rb
@@ -1,12 +1,12 @@
+# frozen_string_literal: true
 class CreateCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
   def change
     create_table :course_user_wiki_timeslices do |t|
-      t.integer :course_user_id, null: false
-      t.integer :wiki_id, null:false
+      t.integer :course_id, null: false
+      t.integer :user_id, null: false
+      t.integer :wiki_id, null: false
       t.datetime :start
       t.datetime :end
-      t.integer :last_mw_rev_id
-      t.integer :total_uploads, default: 0
       t.integer :character_sum_ms, default: 0
       t.integer :character_sum_us, default: 0
       t.integer :character_sum_draft, default: 0
@@ -15,5 +15,10 @@ class CreateCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
+
+    add_index :course_user_wiki_timeslices,
+              [:course_id, :user_id, :wiki_id, :start, :end],
+              unique: true,
+              name: 'course_user_wiki_timeslice_by_course_user_wiki_start_and_end'
   end
 end

--- a/db/migrate/20240617164324_change_user_ids_default_in_article_course_timeslices.rb
+++ b/db/migrate/20240617164324_change_user_ids_default_in_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class ChangeUserIdsDefaultInArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    change_column_default :article_course_timeslices, :user_ids, nil
-  end
-end

--- a/db/migrate/20240715143811_add_article_id_to_article_course_timeslices.rb
+++ b/db/migrate/20240715143811_add_article_id_to_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class AddArticleIdToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :article_course_timeslices, :article_id, :integer, null: false
-  end
-end

--- a/db/migrate/20240715144154_add_course_id_to_article_course_timeslices.rb
+++ b/db/migrate/20240715144154_add_course_id_to_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class AddCourseIdToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :article_course_timeslices, :course_id, :integer, null: false
-  end
-end

--- a/db/migrate/20240715144459_remove_article_course_id_from_article_course_timeslices.rb
+++ b/db/migrate/20240715144459_remove_article_course_id_from_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class RemoveArticleCourseIdFromArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :article_course_timeslices, :article_course_id, :integer
-  end
-end

--- a/db/migrate/20240715171618_add_course_id_to_course_user_wiki_timeslices.rb
+++ b/db/migrate/20240715171618_add_course_id_to_course_user_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddCourseIdToCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_user_wiki_timeslices, :course_id, :integer, null: false
-  end
-end

--- a/db/migrate/20240715171639_add_user_id_to_course_user_wiki_timeslices.rb
+++ b/db/migrate/20240715171639_add_user_id_to_course_user_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddUserIdToCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_user_wiki_timeslices, :user_id, :integer, null: false
-  end
-end

--- a/db/migrate/20240715171753_remove_course_user_id_from_course_user_wiki_timeslices.rb
+++ b/db/migrate/20240715171753_remove_course_user_id_from_course_user_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class RemoveCourseUserIdFromCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :course_user_wiki_timeslices, :course_user_id, :integer
-  end
-end

--- a/db/migrate/20240715201035_add_course_id_to_course_wiki_timeslices.rb
+++ b/db/migrate/20240715201035_add_course_id_to_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddCourseIdToCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_wiki_timeslices, :course_id, :integer, null:false
-  end
-end

--- a/db/migrate/20240715201052_add_wiki_id_to_course_wiki_timeslices.rb
+++ b/db/migrate/20240715201052_add_wiki_id_to_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddWikiIdToCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_wiki_timeslices, :wiki_id, :integer, null:false
-  end
-end

--- a/db/migrate/20240715201123_remove_course_wiki_id_from_course_wiki_timeslices.rb
+++ b/db/migrate/20240715201123_remove_course_wiki_id_from_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class RemoveCourseWikiIdFromCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :course_wiki_timeslices, :course_wiki_id, :integer
-  end
-end

--- a/db/migrate/20240716185258_add_last_mw_rev_datetime_to_course_wiki_timeslices.rb
+++ b/db/migrate/20240716185258_add_last_mw_rev_datetime_to_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddLastMwRevDatetimeToCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_wiki_timeslices, :last_mw_rev_datetime, :datetime
-  end
-end

--- a/db/migrate/20240719225230_add_unique_index_to_course_wiki_timeslices.rb
+++ b/db/migrate/20240719225230_add_unique_index_to_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_index :course_wiki_timeslices, [:course_id, :wiki_id, :start, :end], unique: true, name: 'course_wiki_timeslice_by_course_wiki_start_and_end'
-  end
-end

--- a/db/migrate/20240910223540_add_needs_update_to_course_wiki_timeslices.rb
+++ b/db/migrate/20240910223540_add_needs_update_to_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddNeedsUpdateToCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_wiki_timeslices, :needs_update, :boolean, :default => false
-  end
-end

--- a/db/migrate/20241022155600_add_unique_index_to_course_user_wiki_timeslices.rb
+++ b/db/migrate/20241022155600_add_unique_index_to_course_user_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_index :course_user_wiki_timeslices, [:course_id, :user_id, :wiki_id, :start, :end], unique: true, name: 'course_user_wiki_timeslice_by_course_user_wiki_start_and_end'
-  end
-end

--- a/db/migrate/20241022155746_add_unique_index_to_article_course_wiki_timeslices.rb
+++ b/db/migrate/20241022155746_add_unique_index_to_article_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToArticleCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_index :article_course_timeslices, [:article_id, :course_id, :start, :end], unique: true, name: 'article_course_timeslice_by_article_course_start_and_end'
-  end
-end

--- a/db/migrate/20241025210718_add_new_article_to_article_course_timeslices.rb
+++ b/db/migrate/20241025210718_add_new_article_to_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class AddNewArticleToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :article_course_timeslices, :new_article, :boolean, default: false
-  end
-end

--- a/db/migrate/20241029150227_add_tracked_to_article_course_timeslices.rb
+++ b/db/migrate/20241029150227_add_tracked_to_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class AddTrackedToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :article_course_timeslices, :tracked, :boolean, default: true
-  end
-end

--- a/db/migrate/20241115161634_add_updated_at_index_to_article_course_wiki_timeslices.rb
+++ b/db/migrate/20241115161634_add_updated_at_index_to_article_course_wiki_timeslices.rb
@@ -1,5 +1,0 @@
-class AddUpdatedAtIndexToArticleCourseWikiTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_index :article_course_timeslices, [:course_id, :updated_at, :article_id], name: 'article_course_timeslice_by_updated_at'
-  end
-end

--- a/db/migrate/20241118190824_add_tracked_index_to_article_course_timeslices.rb
+++ b/db/migrate/20241118190824_add_tracked_index_to_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class AddTrackedIndexToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_index :article_course_timeslices, [:course_id, :tracked], name: 'article_course_timeslice_by_tracked'
-  end
-end

--- a/db/migrate/20241126201744_add_revision_count_to_article_course_timeslices.rb
+++ b/db/migrate/20241126201744_add_revision_count_to_article_course_timeslices.rb
@@ -1,5 +1,0 @@
-class AddRevisionCountToArticleCourseTimeslices < ActiveRecord::Migration[7.0]
-  def change
-    add_column :article_course_timeslices, :revision_count, :integer, default: 0
-  end
-end

--- a/db/migrate/20241127233337_add_revision_count_to_articles_courses.rb
+++ b/db/migrate/20241127233337_add_revision_count_to_articles_courses.rb
@@ -1,5 +1,0 @@
-class AddRevisionCountToArticlesCourses < ActiveRecord::Migration[7.0]
-  def change
-    add_column :articles_courses, :revision_count, :integer, default: 0
-  end
-end

--- a/db/migrate/20241212015747_add_stats_to_course_wiki_timeslice.rb
+++ b/db/migrate/20241212015747_add_stats_to_course_wiki_timeslice.rb
@@ -1,5 +1,0 @@
-class AddStatsToCourseWikiTimeslice < ActiveRecord::Migration[7.0]
-  def change
-    add_column :course_wiki_timeslices, :stats, :text
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,11 +223,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
   end
 
   create_table "course_user_wiki_timeslices", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "course_id", null: false
+    t.integer "user_id", null: false
     t.integer "wiki_id", null: false
     t.datetime "start"
     t.datetime "end"
-    t.integer "last_mw_rev_id"
-    t.integer "total_uploads", default: 0
     t.integer "character_sum_ms", default: 0
     t.integer "character_sum_us", default: 0
     t.integer "character_sum_draft", default: 0
@@ -235,8 +235,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.integer "revision_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "course_id", null: false
-    t.integer "user_id", null: false
     t.index ["course_id", "user_id", "wiki_id", "start", "end"], name: "course_user_wiki_timeslice_by_course_user_wiki_start_and_end", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,22 +249,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
   end
 
   create_table "course_wiki_timeslices", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "course_id", null: false
+    t.integer "wiki_id", null: false
     t.datetime "start"
     t.datetime "end"
-    t.integer "last_mw_rev_id"
     t.integer "character_sum", default: 0
     t.integer "references_count", default: 0
     t.integer "revision_count", default: 0
-    t.integer "upload_count", default: 0
-    t.integer "uploads_in_use_count", default: 0
-    t.integer "upload_usages_count", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "course_id", null: false
-    t.integer "wiki_id", null: false
+    t.text "stats"
     t.datetime "last_mw_rev_datetime"
     t.boolean "needs_update", default: false
-    t.text "stats"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["course_id", "wiki_id", "start", "end"], name: "course_wiki_timeslice_by_course_wiki_start_and_end", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,19 +33,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
   end
 
   create_table "article_course_timeslices", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "course_id", null: false
+    t.integer "article_id", null: false
     t.datetime "start"
     t.datetime "end"
-    t.integer "last_mw_rev_id"
     t.integer "character_sum", default: 0
     t.integer "references_count", default: 0
+    t.integer "revision_count", default: 0
     t.text "user_ids"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "article_id", null: false
-    t.integer "course_id", null: false
     t.boolean "new_article", default: false
     t.boolean "tracked", default: true
-    t.integer "revision_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["article_id", "course_id", "start", "end"], name: "article_course_timeslice_by_article_course_start_and_end", unique: true
     t.index ["course_id", "tracked"], name: "article_course_timeslice_by_tracked"
     t.index ["course_id", "updated_at", "article_id"], name: "article_course_timeslice_by_updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,7 +92,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.boolean "tracked", default: true
     t.text "user_ids"
     t.datetime "first_revision"
-    t.integer "revision_count", default: 0
     t.index ["article_id"], name: "index_articles_courses_on_article_id"
     t.index ["course_id"], name: "index_articles_courses_on_course_id"
   end

--- a/spec/factories/article_course_timeslices.rb
+++ b/spec/factories/article_course_timeslices.rb
@@ -4,19 +4,18 @@
 # Table name: article_course_timeslices
 #
 #  id               :bigint           not null, primary key
+#  course_id        :integer          not null
+#  article_id       :integer          not null
 #  start            :datetime
 #  end              :datetime
-#  last_mw_rev_id   :integer
 #  character_sum    :integer          default(0)
 #  references_count :integer          default(0)
+#  revision_count   :integer          default(0)
 #  user_ids         :text(65535)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  article_id       :integer          not null
-#  course_id        :integer          not null
 #  new_article      :boolean          default(FALSE)
 #  tracked          :boolean          default(TRUE)
-#  revision_count   :integer          default(0)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 
 FactoryBot.define do

--- a/spec/factories/articles_courses.rb
+++ b/spec/factories/articles_courses.rb
@@ -15,7 +15,6 @@
 #  tracked          :boolean          default(TRUE)
 #  user_ids         :text(65535)
 #  first_revision   :datetime
-#  revision_count   :integer          default(0)
 #
 
 FactoryBot.define do

--- a/spec/factories/course_user_wiki_timeslices.rb
+++ b/spec/factories/course_user_wiki_timeslices.rb
@@ -9,8 +9,6 @@
 #  wiki_id             :integer          not null
 #  start               :datetime
 #  end                 :datetime
-#  last_mw_rev_id      :integer
-#  total_uploads       :integer          default(0)
 #  character_sum_ms    :integer          default(0)
 #  character_sum_us    :integer          default(0)
 #  character_sum_draft :integer          default(0)

--- a/spec/factories/course_wiki_timeslices.rb
+++ b/spec/factories/course_wiki_timeslices.rb
@@ -5,22 +5,18 @@
 # Table name: course_wiki_timeslices
 #
 #  id                   :bigint           not null, primary key
+#  course_id            :integer          not null
+#  wiki_id              :integer          not null
 #  start                :datetime
 #  end                  :datetime
-#  last_mw_rev_id       :integer
 #  character_sum        :integer          default(0)
 #  references_count     :integer          default(0)
 #  revision_count       :integer          default(0)
-#  upload_count         :integer          default(0)
-#  uploads_in_use_count :integer          default(0)
-#  upload_usages_count  :integer          default(0)
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  course_id            :integer          not null
-#  wiki_id              :integer          not null
+#  stats                :text(65535)
 #  last_mw_rev_datetime :datetime
 #  needs_update         :boolean          default(FALSE)
-#  stats                :text(65535)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #
 
 FactoryBot.define do

--- a/spec/lib/course_cache_manager_spec.rb
+++ b/spec/lib/course_cache_manager_spec.rb
@@ -33,10 +33,7 @@ describe CourseCacheManager do
            end: 9.days.ago,
            character_sum: 9000,
            references_count: 4,
-           revision_count: 5,
-           upload_count: 400,
-           uploads_in_use_count: 200,
-           upload_usages_count: 200)
+           revision_count: 5)
     create(:course_wiki_timeslice,
            course:,
            wiki:,
@@ -44,10 +41,7 @@ describe CourseCacheManager do
            end: 8.days.ago,
            character_sum: 10,
            references_count: 3,
-           revision_count: 1,
-           upload_count: 30,
-           uploads_in_use_count: 200,
-           upload_usages_count: 200)
+           revision_count: 1)
     create(:course_wiki_timeslice,
            course:,
            wiki:,
@@ -55,10 +49,7 @@ describe CourseCacheManager do
            end: 7.days.ago,
            character_sum: 100,
            references_count: 4,
-           revision_count: 4,
-           upload_count: 330,
-           uploads_in_use_count: 100,
-           upload_usages_count: 200)
+           revision_count: 4)
   end
 
   describe '#update_cache_from_timeslices' do

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -4,19 +4,18 @@
 # Table name: article_course_timeslices
 #
 #  id               :bigint           not null, primary key
+#  course_id        :integer          not null
+#  article_id       :integer          not null
 #  start            :datetime
 #  end              :datetime
-#  last_mw_rev_id   :integer
 #  character_sum    :integer          default(0)
 #  references_count :integer          default(0)
+#  revision_count   :integer          default(0)
 #  user_ids         :text(65535)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  article_id       :integer          not null
-#  course_id        :integer          not null
 #  new_article      :boolean          default(FALSE)
 #  tracked          :boolean          default(TRUE)
-#  revision_count   :integer          default(0)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 
 require 'rails_helper'

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -15,7 +15,6 @@
 #  tracked          :boolean          default(TRUE)
 #  user_ids         :text(65535)
 #  first_revision   :datetime
-#  revision_count   :integer          default(0)
 #
 
 require 'rails_helper'
@@ -119,8 +118,7 @@ describe ArticlesCourses, type: :model do
              end: '2024-07-07',
              character_sum: 9000,
              references_count: 4,
-             user_ids: [2, 3],
-             revision_count: 3)
+             user_ids: [2, 3])
 
       create(:article_course_timeslice,
              article:,
@@ -130,8 +128,7 @@ describe ArticlesCourses, type: :model do
              character_sum: 12,
              references_count: 5,
              user_ids: [2, user.id],
-             new_article: true,
-             revision_count: 4)
+             new_article: true)
 
       # Empty timeslice, which should not count towards stats.
       create(:article_course_timeslice,
@@ -154,7 +151,6 @@ describe ArticlesCourses, type: :model do
       expect(article_course.user_ids).to eq([2, 3, user.id])
       expect(article_course.view_count).to eq(0)
       expect(article_course.new_article).to be true
-      expect(article_course.revision_count).to eq(7)
     end
   end
 

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -9,8 +9,6 @@
 #  wiki_id             :integer          not null
 #  start               :datetime
 #  end                 :datetime
-#  last_mw_rev_id      :integer
-#  total_uploads       :integer          default(0)
 #  character_sum_ms    :integer          default(0)
 #  character_sum_us    :integer          default(0)
 #  character_sum_draft :integer          default(0)
@@ -43,7 +41,6 @@ describe CourseUserWikiTimeslice, type: :model do
            course:,
            user:,
            wiki_id: wiki.id,
-           total_uploads: 0,
            character_sum_ms: 3,
            character_sum_us: 4,
            character_sum_draft: 2,
@@ -184,9 +181,6 @@ describe CourseUserWikiTimeslice, type: :model do
              article:,
              course:)
 
-      # Create a common upload for the user
-      create(:commons_upload, user:, uploaded_at: '2015-02-01'.to_date)
-
       # create the CoursesUsers record
       courses_user
     end
@@ -198,7 +192,6 @@ describe CourseUserWikiTimeslice, type: :model do
       # Fetch the created CourseUserWikiTimeslice entry
       course_user_wiki_timeslice = described_class.all.first
 
-      expect(course_user_wiki_timeslice.total_uploads).to eq(1)
       # Don't consider deleted revisions, automatic revisions, or revisions for
       # articles that don't exist
       expect(course_user_wiki_timeslice.revision_count).to eq(4)

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -50,7 +50,6 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
            character_sum_ms: 9000,
            character_sum_us: 500,
            character_sum_draft: 400,
-           total_uploads: 200,
            references_count: 4,
            revision_count: 5)
     create(:course_user_wiki_timeslice,
@@ -62,7 +61,6 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
            character_sum_ms: 10,
            character_sum_us: 20,
            character_sum_draft: 30,
-           total_uploads: 200,
            references_count: 3,
            revision_count: 1)
     # Course user wiki timeslice for non-student
@@ -75,7 +73,6 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
            character_sum_ms: 100,
            character_sum_us: 200,
            character_sum_draft: 330,
-           total_uploads: 100,
            references_count: 4,
            revision_count: 4)
 

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -5,22 +5,18 @@
 # Table name: course_wiki_timeslices
 #
 #  id                   :bigint           not null, primary key
+#  course_id            :integer          not null
+#  wiki_id              :integer          not null
 #  start                :datetime
 #  end                  :datetime
-#  last_mw_rev_id       :integer
 #  character_sum        :integer          default(0)
 #  references_count     :integer          default(0)
 #  revision_count       :integer          default(0)
-#  upload_count         :integer          default(0)
-#  uploads_in_use_count :integer          default(0)
-#  upload_usages_count  :integer          default(0)
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  course_id            :integer          not null
-#  wiki_id              :integer          not null
+#  stats                :text(65535)
 #  last_mw_rev_datetime :datetime
 #  needs_update         :boolean          default(FALSE)
-#  stats                :text(65535)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
 #
 require 'rails_helper'
 
@@ -44,9 +40,6 @@ describe CourseWikiTimeslice, type: :model do
     create(:courses_user, id: 2, course:, user_id: 2)
     create(:courses_user, id: 3, course:, user_id: 2,
 role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
-
-    create(:commons_upload, user_id: 1, uploaded_at: 10.days.ago, usage_count: 3)
-    create(:commons_upload, user_id: 2, uploaded_at: 10.days.ago, usage_count: 4)
 
     create(:course_user_wiki_timeslice,
            course:,
@@ -143,9 +136,6 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
         expect(course_wiki_timeslice.character_sum).to eq(9010)
         expect(course_wiki_timeslice.references_count).to eq(7)
         expect(course_wiki_timeslice.revision_count).to eq(3)
-        expect(course_wiki_timeslice.upload_count).to eq(2)
-        expect(course_wiki_timeslice.uploads_in_use_count).to eq(2)
-        expect(course_wiki_timeslice.upload_usages_count).to eq(7)
         expect(course_wiki_timeslice.needs_update).to eq(false)
       end
 
@@ -160,9 +150,6 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
         expect(course_wiki_timeslice.references_count).to eq(7)
         # Don't add any new revision count
         expect(course_wiki_timeslice.revision_count).to eq(0)
-        expect(course_wiki_timeslice.upload_count).to eq(2)
-        expect(course_wiki_timeslice.uploads_in_use_count).to eq(2)
-        expect(course_wiki_timeslice.upload_usages_count).to eq(7)
       end
     end
 

--- a/spec/models/courses_users_spec.rb
+++ b/spec/models/courses_users_spec.rb
@@ -149,7 +149,6 @@ describe CoursesUsers, type: :model do
              character_sum_ms: 9000,
              character_sum_us: 500,
              character_sum_draft: 400,
-             total_uploads: 200,
              references_count: 4,
              revision_count: 5)
 
@@ -162,7 +161,6 @@ describe CoursesUsers, type: :model do
              character_sum_ms: 10,
              character_sum_us: 20,
              character_sum_draft: 30,
-             total_uploads: 200,
              references_count: 3,
              revision_count: 1)
 
@@ -176,7 +174,6 @@ describe CoursesUsers, type: :model do
              character_sum_ms: 0,
              character_sum_us: 0,
              character_sum_draft: 0,
-             total_uploads: 0,
              references_count: 0,
              revision_count: 0)
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -107,9 +107,6 @@ describe UpdateCourseWikiTimeslices do
       expect(timeslice.character_sum).to eq(78)
       expect(timeslice.references_count).to eq(0)
       expect(timeslice.revision_count).to eq(1)
-      expect(timeslice.upload_count).to eq(0)
-      expect(timeslice.uploads_in_use_count).to eq(0)
-      expect(timeslice.upload_usages_count).to eq(0)
       expect(timeslice.last_mw_rev_datetime).to eq('20181129180841'.to_datetime)
       expect(timeslice.stats).to be_empty
 
@@ -119,9 +116,6 @@ describe UpdateCourseWikiTimeslices do
       expect(timeslice.character_sum).to eq(7867)
       expect(timeslice.references_count).to eq(-2)
       expect(timeslice.revision_count).to eq(27)
-      expect(timeslice.upload_count).to eq(0)
-      expect(timeslice.uploads_in_use_count).to eq(0)
-      expect(timeslice.upload_usages_count).to eq(0)
       expect(timeslice.last_mw_rev_datetime).to eq('20181124045740'.to_datetime)
       expect(timeslice.stats['references removed']).to eq(2)
     end


### PR DESCRIPTION
## What this PR does
This PR cleans up model migrations:
- Delete unused `last_mw_rev_id`, `upload_count`, `uploads_in_use_count` and `upload_usages_count` fields from `CourseWikiTimeslice`.
- Delete unused `last_mw_rev_id` and `total_uploads` fields from `CourseUserWikiTimeslice`.
- Delete unused `last_mw_rev_id` field from `ArticleCourseTimeslice`.

In addition, it reverts the changes in #6048 for adding a new `revision_count` field to `ArticlesCourses`. Since we don't create the complete universe of article course timeslices anymore (see #6069), it's reasonable to compute `revision_count` for `UpdateWikiNamespaceStatsTimeslice` based on article course timeslices.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
