### PR TITLE
feat: Add tooltip for enable account requests button in the campaign dashboard

### DIFF
--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -39,14 +39,22 @@
           %button.button.dark
             = t('editable.edit')
       - if (current_user&.admin?)
+        
         - if (!@campaign.register_accounts)
-          = form_tag("/requested_accounts_campaigns/#{@campaign.slug}/enable_account_requests", method: :put, class: 'campaign-create') do
-            %button.button.dark
-              = t('campaign.enable_account_requests')
+          .tooltip-trigger
+            = form_tag("/requested_accounts_campaigns/#{@campaign.slug}/enable_account_requests", method: :put, class: 'campaign-create') do
+              %button.button.dark
+                = t('campaign.enable_account_requests')
+            .tooltip.dark
+              %p= t('campaign.enable_account_requests_doc')
         - else
-          = form_tag("/requested_accounts_campaigns/#{@campaign.slug}/disable_account_requests", method: :put, class: 'campaign-create') do
-            %button.button.dark
-              = t('campaign.disable_account_requests')
+          .tooltip-trigger
+            = form_tag("/requested_accounts_campaigns/#{@campaign.slug}/disable_account_requests", method: :put, class: 'campaign-create') do
+              %button.button.dark
+                = t('campaign.disable_account_requests')
+            .tooltip.dark
+              %p= t('campaign.enable_account_requests_doc')
+        
       - if (current_user&.admin? && @campaign.requested_accounts.any?)
         = form_tag("/requested_accounts_campaigns/#{@campaign.slug}", method: :get, class: 'campaign-create') do
           %button.button.dark

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,7 @@ en:
     delete_course_tooltip: Delete and remove from the campaign.
     disable_account_requests: Disable account requests
     enable_account_requests: Enable account requests
+    enable_account_requests_doc: The account requests feature adds an account request form to the enrollment link for an event. Users who don't have accounts yet can enter their email and desired username, and event facilitators can use the Dashboard to create the requested accounts. Users who request accounts are automatically added to the event upon account creation.
     newest_campaigns: Newest Campaigns
     featured_campaigns: Featured Campaigns
     instructors_course: instructors by course

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -304,6 +304,7 @@ qqq:
       Label for the input to change the title of a campaign
       {{Identical|Title}}
     use_start_end_dates: Label for checkbox to enable start and end dates for a campaign
+    enable_account_requests_doc: Tooltip explaining what the 'Enable Account Requests' button does
   categories:
     name: '{{Identical|Name}}'
     category_name: '{{Identical|Category name}}'


### PR DESCRIPTION
## What this PR does
This PR enhances the user experience by adding a tooltip to the "Enable Account Requests" button, providing a concise explanation of its functionality.

### Changes Implemented

- Added a tooltip to the "Enable Account Requests" button.
- Added its variable to the ```en.yml```


## Screenshots

Before:

![image](https://github.com/user-attachments/assets/70d35f46-de5c-4577-8a47-cb63cc4f9c2e)


After:

![Screenshot from 2025-01-30 01-35-50](https://github.com/user-attachments/assets/5459180b-6cc0-4226-9ecd-2dd5cfa21060)

## Open questions and concerns
I also need to add the description for the different languages,..... right?
For that should I use Google translate to convert and add the description for every language or is there any better ideal approach that Wikimedia uses to solve it ?
