### PR TITLE
Fix: #6087 Display specific error message for course slug collision

### DIFF
--- a/app/assets/javascripts/actions/course_actions.js
+++ b/app/assets/javascripts/actions/course_actions.js
@@ -1,30 +1,48 @@
 import {
-  ADD_NOTIFICATION, API_FAIL, UPDATE_COURSE, RECEIVE_COURSE, RECEIVE_COURSE_UPDATE,
-  PERSISTED_COURSE, DISMISS_SURVEY_NOTIFICATION, TOGGLE_EDITING_SYLLABUS,
-  START_SYLLABUS_UPLOAD, SYLLABUS_UPLOAD_SUCCESS, LINKED_TO_SALESFORCE, COURSE_SLUG_EXISTS, RECEIVE_COURSE_SEARCH_RESULTS, SORT_COURSE_SEARCH_RESULTS, FETCH_COURSE_SEARCH_RESULTS, RECEIVE_ACTIVE_COURSES, SORT_ACTIVE_COURSES,
-  RECEIVE_CAMPAIGN_ACTIVE_COURSES, RECEIVE_WIKI_COURSES, SORT_WIKI_COURSES
-} from '../constants/index';
-import API from '../utils/api.js';
-import CourseUtils from '../utils/course_utils';
-import request from '../utils/request';
-import { toWikiDomain } from '../utils/wiki_utils';
+  ADD_NOTIFICATION,
+  API_FAIL,
+  UPDATE_COURSE,
+  RECEIVE_COURSE,
+  RECEIVE_COURSE_UPDATE,
+  PERSISTED_COURSE,
+  DISMISS_SURVEY_NOTIFICATION,
+  TOGGLE_EDITING_SYLLABUS,
+  START_SYLLABUS_UPLOAD,
+  SYLLABUS_UPLOAD_SUCCESS,
+  LINKED_TO_SALESFORCE,
+  COURSE_SLUG_EXISTS,
+  RECEIVE_COURSE_SEARCH_RESULTS,
+  SORT_COURSE_SEARCH_RESULTS,
+  FETCH_COURSE_SEARCH_RESULTS,
+  RECEIVE_ACTIVE_COURSES,
+  SORT_ACTIVE_COURSES,
+  RECEIVE_CAMPAIGN_ACTIVE_COURSES,
+  RECEIVE_WIKI_COURSES,
+  SORT_WIKI_COURSES,
+} from "../constants/index";
+import API from "../utils/api.js";
+import CourseUtils from "../utils/course_utils";
+import request from "../utils/request";
+import { toWikiDomain } from "../utils/wiki_utils";
 
-export const fetchCourse = courseSlug => (dispatch) => {
-  return API.fetch(courseSlug, 'course')
-    .then(data => dispatch({ type: RECEIVE_COURSE, data }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+export const fetchCourse = (courseSlug) => (dispatch) => {
+  return API.fetch(courseSlug, "course")
+    .then((data) => dispatch({ type: RECEIVE_COURSE, data }))
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
-export const refetchCourse = courseSlug => (dispatch) => {
-  return API.fetch(courseSlug, 'course')
-    .then(data => dispatch({ type: RECEIVE_COURSE_UPDATE, data }))
-    // These periodic refetches will error if network connection is lost.
-    // Missing a refetch is benign. Using `silent`, we don't clutter the
-    // interface with error notifications.
-    .catch(data => dispatch({ type: API_FAIL, data, silent: true }));
+export const refetchCourse = (courseSlug) => (dispatch) => {
+  return (
+    API.fetch(courseSlug, "course")
+      .then((data) => dispatch({ type: RECEIVE_COURSE_UPDATE, data }))
+      // These periodic refetches will error if network connection is lost.
+      // Missing a refetch is benign. Using `silent`, we don't clutter the
+      // interface with error notifications.
+      .catch((data) => dispatch({ type: API_FAIL, data, silent: true }))
+  );
 };
 
-export const updateCourse = course => ({ type: UPDATE_COURSE, course });
+export const updateCourse = (course) => ({ type: UPDATE_COURSE, course });
 
 export const resetCourse = () => (dispatch, getState) => {
   const persistedCourse = getState().persistedCourse;
@@ -33,134 +51,170 @@ export const resetCourse = () => (dispatch, getState) => {
 
 export const nameHasChanged = () => (_dispatch, getState) => {
   const { course, persistedCourse } = getState();
-  if (course.title !== persistedCourse.title) { return true; }
-  if (course.term !== persistedCourse.term) { return true; }
-  if (course.school !== persistedCourse.school) { return true; }
+  if (course.title !== persistedCourse.title) {
+    return true;
+  }
+  if (course.term !== persistedCourse.term) {
+    return true;
+  }
+  if (course.school !== persistedCourse.school) {
+    return true;
+  }
   return false;
 };
 
 const redirectCourse = (newSlug) => {
-  if (!newSlug) { return; }
+  if (!newSlug) {
+    return;
+  }
   window.location = `/courses/${newSlug}`;
 };
 
 const persistAndRedirect = (course, courseSlug, newSlug, dispatch) => {
   return API.saveCourse({ course }, courseSlug)
-    .then(resp => dispatch({ type: PERSISTED_COURSE, data: resp }))
+    .then((resp) => dispatch({ type: PERSISTED_COURSE, data: resp }))
     .then(() => redirectCourse(newSlug))
-    .catch(data => dispatch({ type: API_FAIL, data }));
-};
-
-export const persistCourse = (courseSlug = null, redirect = false) => (dispatch, getState) => {
-  let course = getState().course;
-
-  let newSlug;
-  if (redirect) {
-    course = CourseUtils.cleanupCourseSlugComponents(course);
-    newSlug = CourseUtils.generateTempId(course);
-    course.slug = newSlug;
-  }
-  return persistAndRedirect(course, courseSlug, newSlug, dispatch);
-};
-
-export const updateClonedCourse = (course, courseSlug, newSlug) => (dispatch) => {
-  // Ensure course name is unique
-  return API.fetch(newSlug, 'check')
-    .then((resp) => {
-      // Course name is all good, so save it.
-      if (!resp.course_exists) {
-        return persistAndRedirect(course, courseSlug, newSlug, dispatch);
+    .catch((error) => {
+      // Improved error handling
+      let errorMessage = "An error occurred."; // Default message
+      if (error && error.data && error.data.error) {
+        // Check for the error structure
+        errorMessage = error.data.error;
+      } else if (error && error.message) {
+        errorMessage = error.message;
+      } else if (error && error.data) {
+        errorMessage = error.data;
       }
-      // Course name is taken, so show a warning.
-      const message = 'This course already exists. Consider changing the name, school, or term to make it unique.';
-      return dispatch({ type: COURSE_SLUG_EXISTS, message });
-    })
-    .catch(data => ({ type: API_FAIL, data }));
+      dispatch({ type: API_FAIL, data: errorMessage }); // Dispatch the extracted message
+    });
 };
+
+export const persistCourse =
+  (courseSlug = null, redirect = false) =>
+  (dispatch, getState) => {
+    let course = getState().course;
+
+    let newSlug;
+    if (redirect) {
+      course = CourseUtils.cleanupCourseSlugComponents(course);
+      newSlug = CourseUtils.generateTempId(course);
+      course.slug = newSlug;
+    }
+    return persistAndRedirect(course, courseSlug, newSlug, dispatch);
+  };
+
+export const updateClonedCourse =
+  (course, courseSlug, newSlug) => (dispatch) => {
+    // Ensure course name is unique
+    return API.fetch(newSlug, "check")
+      .then((resp) => {
+        // Course name is all good, so save it.
+        if (!resp.course_exists) {
+          return persistAndRedirect(course, courseSlug, newSlug, dispatch);
+        }
+        // Course name is taken, so show a warning.
+        const message =
+          "This course already exists. Consider changing the name, school, or term to make it unique.";
+        return dispatch({ type: COURSE_SLUG_EXISTS, message });
+      })
+      .catch((data) => ({ type: API_FAIL, data }));
+  };
 
 const needsUpdatePromise = (courseSlug) => {
-  return API.fetch(courseSlug, 'needs_update')
-  .then((data) => {
+  return API.fetch(courseSlug, "needs_update")
+    .then((data) => {
       return data;
-  })
-  .catch((err) => {
+    })
+    .catch((err) => {
       return err;
-  });
+    });
 };
 
 const needsUpdateNotification = (response) => {
   return {
     message: response.result,
     closable: true,
-    type: 'success'
+    type: "success",
   };
 };
 
 export function needsUpdate(courseSlug) {
   return function (dispatch) {
     return needsUpdatePromise(courseSlug)
-      .then(resp => dispatch({ type: ADD_NOTIFICATION, notification: needsUpdateNotification(resp) }))
-      .catch(data => dispatch({ type: API_FAIL, data }));
+      .then((resp) =>
+        dispatch({
+          type: ADD_NOTIFICATION,
+          notification: needsUpdateNotification(resp),
+        })
+      )
+      .catch((data) => dispatch({ type: API_FAIL, data }));
   };
 }
 
-export const dismissNotification = id => (dispatch) => {
+export const dismissNotification = (id) => (dispatch) => {
   return API.dismissNotification(id)
     .then(() => dispatch({ type: DISMISS_SURVEY_NOTIFICATION, id }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
 export const toggleEditingSyllabus = () => {
   return { type: TOGGLE_EDITING_SYLLABUS };
 };
 
-export const uploadSyllabus = payload => (dispatch) => {
+export const uploadSyllabus = (payload) => (dispatch) => {
   dispatch({ type: START_SYLLABUS_UPLOAD });
   return API.uploadSyllabus(payload)
-    .then(data => dispatch({ type: SYLLABUS_UPLOAD_SUCCESS, syllabus: data.url }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+    .then((data) =>
+      dispatch({ type: SYLLABUS_UPLOAD_SUCCESS, syllabus: data.url })
+    )
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
 export const linkToSalesforce = (courseId, salesforceId) => (dispatch) => {
   return API.linkToSalesforce(courseId, salesforceId)
-    .then(data => dispatch({ type: LINKED_TO_SALESFORCE, data }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+    .then((data) => dispatch({ type: LINKED_TO_SALESFORCE, data }))
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
 // Actions not handled by redux, except for failures
 
-export const updateSalesforceRecord = courseId => (dispatch) => {
+export const updateSalesforceRecord = (courseId) => (dispatch) => {
   return API.updateSalesforceRecord(courseId)
-    .then(data => dispatch({ type: 'UPDATED_SALESFORCE_RECORD', data }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+    .then((data) => dispatch({ type: "UPDATED_SALESFORCE_RECORD", data }))
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
-export const deleteCourse = courseSlug => (dispatch) => {
+export const deleteCourse = (courseSlug) => (dispatch) => {
   return API.deleteCourse(courseSlug)
-    .then(data => dispatch({ type: 'DELETED_COURSE', data }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+    .then((data) => dispatch({ type: "DELETED_COURSE", data }))
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
-export const removeAndDeleteCourse = (courseSlug, campaignTitle, campaignId, campaignSlug) => (dispatch) => {
-  return API.removeAndDeleteCourse(courseSlug, campaignTitle, campaignId, campaignSlug)
-    .then(data => dispatch({ type: 'DELETED_COURSE', data }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
-};
+export const removeAndDeleteCourse =
+  (courseSlug, campaignTitle, campaignId, campaignSlug) => (dispatch) => {
+    return API.removeAndDeleteCourse(
+      courseSlug,
+      campaignTitle,
+      campaignId,
+      campaignSlug
+    )
+      .then((data) => dispatch({ type: "DELETED_COURSE", data }))
+      .catch((data) => dispatch({ type: API_FAIL, data }));
+  };
 
-export const notifyOverdue = courseSlug => (dispatch) => {
+export const notifyOverdue = (courseSlug) => (dispatch) => {
   return API.notifyOverdue(courseSlug)
-    .then(data => dispatch({ type: 'NOTIFIED_OVERDUE', data }))
-    .catch(data => dispatch({ type: API_FAIL, data }));
+    .then((data) => dispatch({ type: "NOTIFIED_OVERDUE", data }))
+    .catch((data) => dispatch({ type: API_FAIL, data }));
 };
 
-export const greetStudents = courseId => (dispatch) => {
+export const greetStudents = (courseId) => (dispatch) => {
   return API.greetStudents(courseId)
-    .then(data => dispatch({ type: 'GREETED_STUDENTS', data }))
-    .catch(data => ({ type: API_FAIL, data }));
+    .then((data) => dispatch({ type: "GREETED_STUDENTS", data }))
+    .catch((data) => ({ type: API_FAIL, data }));
 };
 
-
-export const searchPrograms = searchQuery => async (dispatch) => {
+export const searchPrograms = (searchQuery) => async (dispatch) => {
   dispatch({ type: FETCH_COURSE_SEARCH_RESULTS });
   const response = await request(`/courses/search.json?search=${searchQuery}`);
   if (!response.ok) {
@@ -171,24 +225,30 @@ export const searchPrograms = searchQuery => async (dispatch) => {
   return dispatch({ type: RECEIVE_COURSE_SEARCH_RESULTS, data });
 };
 
-export const sortCourseSearchResults = key => ({ type: SORT_COURSE_SEARCH_RESULTS, key });
+export const sortCourseSearchResults = (key) => ({
+  type: SORT_COURSE_SEARCH_RESULTS,
+  key,
+});
 
 // this fetches the active courses of a particular campaign(which currently is just the default campaign)
-export const fetchActiveCampaignCourses = campaign_slug => async (dispatch) => {
-  const response = await request(`/campaigns/${campaign_slug}/active_courses.json`);
-  if (!response.ok) {
-    const data = await response.text();
-    return dispatch({ type: API_FAIL, data });
-  }
-  const data = await response.json();
-  return dispatch({ type: RECEIVE_CAMPAIGN_ACTIVE_COURSES, data });
-};
+export const fetchActiveCampaignCourses =
+  (campaign_slug) => async (dispatch) => {
+    const response = await request(
+      `/campaigns/${campaign_slug}/active_courses.json`
+    );
+    if (!response.ok) {
+      const data = await response.text();
+      return dispatch({ type: API_FAIL, data });
+    }
+    const data = await response.json();
+    return dispatch({ type: RECEIVE_CAMPAIGN_ACTIVE_COURSES, data });
+  };
 
-export const sortActiveCourses = key => ({ type: SORT_ACTIVE_COURSES, key });
+export const sortActiveCourses = (key) => ({ type: SORT_ACTIVE_COURSES, key });
 
 // this fetches the active courses across all campaigns
 export const fetchActiveCourses = () => async (dispatch) => {
-  const response = await request('/active_courses.json');
+  const response = await request("/active_courses.json");
   if (!response.ok) {
     const data = await response.text();
     return dispatch({ type: API_FAIL, data });
@@ -197,7 +257,7 @@ export const fetchActiveCourses = () => async (dispatch) => {
   return dispatch({ type: RECEIVE_ACTIVE_COURSES, data });
 };
 
-export const fetchCoursesFromWiki = wiki => async (dispatch) => {
+export const fetchCoursesFromWiki = (wiki) => async (dispatch) => {
   const wiki_url = toWikiDomain(wiki);
   const response = await request(`/courses_by_wiki/${wiki_url}.json`);
   if (!response.ok) {
@@ -208,4 +268,4 @@ export const fetchCoursesFromWiki = wiki => async (dispatch) => {
   return dispatch({ type: RECEIVE_WIKI_COURSES, data });
 };
 
-export const sortWikiCourses = key => ({ type: SORT_WIKI_COURSES, key });
+export const sortWikiCourses = (key) => ({ type: SORT_WIKI_COURSES, key });

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -1,10 +1,10 @@
-import { capitalize } from './strings';
-import logErrorMessage from './log_error_message';
-import request from './request';
-import { stringify } from 'query-string';
-import Rails from '@rails/ujs';
-import { toWikiDomain } from './wiki_utils';
-import { formatCategoryName } from '../components/util/scoping_methods';
+import { capitalize } from "./strings";
+import logErrorMessage from "./log_error_message";
+import request from "./request";
+import { stringify } from "query-string";
+import Rails from "@rails/ujs";
+import { toWikiDomain } from "./wiki_utils";
+import { formatCategoryName } from "../components/util/scoping_methods";
 
 const SentryLogger = {};
 
@@ -14,16 +14,17 @@ const API = {
   // Getters /
   // /////////
   fetchFeedback(articleTitle, assignmentId) {
-    return request(`/revision_feedback.json?title=${articleTitle}&assignment_id=${assignmentId}`)
-      .then(res => {
+    return request(
+      `/revision_feedback.json?title=${articleTitle}&assignment_id=${assignmentId}`
+    )
+      .then((res) => {
         if (res.ok) {
           return res.json();
-        }
-        else {
+        } else {
           return Promise.reject({ statusText: res.statusText });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         logErrorMessage(error);
         return Promise.reject({ error });
       });
@@ -31,28 +32,38 @@ const API = {
 
   postFeedbackFormResponse(subject, body) {
     return request(`/feedback_form_responses`, {
-      method: 'POST',
-      body: JSON.stringify({ feedback_form_response: { subject: subject, body: body } }),
+      method: "POST",
+      body: JSON.stringify({
+        feedback_form_response: { subject: subject, body: body },
+      }),
     })
-      .then(res => {
+      .then((res) => {
         if (res.ok) {
           return Promise.resolve({ statusText: res.statusText });
-        }
-        else {
+        } else {
           return Promise.reject({ statusText: res.statusText });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         logErrorMessage(error);
         return Promise.reject({ error });
       });
   },
 
   async createCustomFeedback(assignmentId, text, userId) {
-    const response = await request(`/assignments/${assignmentId}/assignment_suggestions`, {
-      method: 'POST',
-      body: JSON.stringify({ feedback: { text: text, assignment_id: assignmentId, user_id: userId } })
-    });
+    const response = await request(
+      `/assignments/${assignmentId}/assignment_suggestions`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          feedback: {
+            text: text,
+            assignment_id: assignmentId,
+            user_id: userId,
+          },
+        }),
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -64,9 +75,12 @@ const API = {
   },
 
   async destroyCustomFeedback(assignmentId, id) {
-    const response = await request(`/assignments/${assignmentId}/assignment_suggestions/${id}`, {
-      method: 'DELETE',
-    });
+    const response = await request(
+      `/assignments/${assignmentId}/assignment_suggestions/${id}`,
+      {
+        method: "DELETE",
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -91,11 +105,16 @@ const API = {
 
   async updateArticleTrackedStatus(article_id, course_id, tracked) {
     const params = {
-      article_id,course_id, tracked
-    }
-    const response = await request(`/articles/status.json?${stringify(params)}`, {
-      method: 'POST'
-    });
+      article_id,
+      course_id,
+      tracked,
+    };
+    const response = await request(
+      `/articles/status.json?${stringify(params)}`,
+      {
+        method: "POST",
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -107,7 +126,9 @@ const API = {
   },
 
   async fetchArticleDetails(articleId, courseId) {
-    const response = await request(`/articles/details.json?article_id=${articleId}&course_id=${courseId}`);
+    const response = await request(
+      `/articles/details.json?article_id=${articleId}&course_id=${courseId}`
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -119,7 +140,9 @@ const API = {
   },
 
   async fetchDykArticles(opts = {}) {
-    const response = await request(`/revision_analytics/dyk_eligible.json?scoped=${opts.scoped || false}`);
+    const response = await request(
+      `/revision_analytics/dyk_eligible.json?scoped=${opts.scoped || false}`
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -131,7 +154,9 @@ const API = {
   },
 
   async fetchRecentUploads(opts = {}) {
-    const response = await request(`/revision_analytics/recent_uploads.json?scoped=${opts.scoped || false}`);
+    const response = await request(
+      `/revision_analytics/recent_uploads.json?scoped=${opts.scoped || false}`
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -143,11 +168,16 @@ const API = {
   },
 
   async cloneCourse(id, campaign, copyAssignments) {
-    const campaignQueryParam = campaign ? `?campaign_slug=${campaign}` : ''
-    const copyAssignmentsQueryParam = copyAssignments ? `?copy_assignments=${copyAssignments}` : '?copy_assignments=false'
-    const response = await request(`/clone_course/${id}${campaignQueryParam}${copyAssignmentsQueryParam}`, {
-      method: 'POST'
-    });
+    const campaignQueryParam = campaign ? `?campaign_slug=${campaign}` : "";
+    const copyAssignmentsQueryParam = copyAssignments
+      ? `?copy_assignments=${copyAssignments}`
+      : "?copy_assignments=false";
+    const response = await request(
+      `/clone_course/${id}${campaignQueryParam}${copyAssignmentsQueryParam}`,
+      {
+        method: "POST",
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -172,9 +202,12 @@ const API = {
 
   async deleteAssignment(assignment) {
     const queryString = stringify(assignment);
-    const response = await request(`/assignments/${assignment.id}?${queryString}`, {
-      method: 'DELETE'
-    });
+    const response = await request(
+      `/assignments/${assignment.id}?${queryString}`,
+      {
+        method: "DELETE",
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -188,7 +221,7 @@ const API = {
   async createAssignment(opts) {
     const queryString = stringify(opts);
     const response = await request(`/assignments.json?${queryString}`, {
-      method: 'POST'
+      method: "POST",
     });
 
     if (!response.ok) {
@@ -202,9 +235,12 @@ const API = {
 
   async createRandomPeerAssignments(opts) {
     const queryString = stringify(opts);
-    const response = await request(`/assignments/assign_reviewers_randomly?${queryString}`, {
-      method: 'POST'
-    });
+    const response = await request(
+      `/assignments/assign_reviewers_randomly?${queryString}`,
+      {
+        method: "POST",
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -217,17 +253,16 @@ const API = {
 
   fetch(courseId, endpoint) {
     return request(`/courses/${courseId}/${endpoint}.json`, {
-      credentials: "include"
+      credentials: "include",
     })
-      .then(res => {
+      .then((res) => {
         if (res.ok) {
           return res.json();
-        }
-        else {
+        } else {
           return Promise.reject({ statusText: res.statusText });
         }
       })
-      .catch(error => {
+      .catch((error) => {
         logErrorMessage(error);
         return Promise.reject({ error });
       });
@@ -235,15 +270,19 @@ const API = {
 
   async fetchNews() {
     // Determine the type of newsTitle content to fetch based on the `Features.wikiEd` flag
-    const newsTitle = Features.wikiEd ? 'Wiki Education News' : 'Programs & Events Dashboard News';
-     try {
-         const response = await request(`/faq/${newsTitle}/handle_special_faq_query`);
-         const { newsDetails } = await response.json();
-         return newsDetails;
-     } catch (error) {
-         logErrorMessage('Error creating news:', error)
-         throw error;
-     }
+    const newsTitle = Features.wikiEd
+      ? "Wiki Education News"
+      : "Programs & Events Dashboard News";
+    try {
+      const response = await request(
+        `/faq/${newsTitle}/handle_special_faq_query`
+      );
+      const { newsDetails } = await response.json();
+      return newsDetails;
+    } catch (error) {
+      logErrorMessage("Error creating news:", error);
+      throw error;
+    }
   },
 
   async fetchAllAdminCourseNotes(courseId) {
@@ -252,7 +291,7 @@ const API = {
       const data = await response.json();
       return data.AdminCourseNotes;
     } catch (error) {
-      logErrorMessage('Error fetching course notes:', error);
+      logErrorMessage("Error fetching course notes:", error);
       throw error;
     }
   },
@@ -261,19 +300,19 @@ const API = {
   // Setters #
   // /////////
   async saveTimeline(courseId, data) {
-    const cleanObject = object => {
+    const cleanObject = (object) => {
       if (object.is_new) {
         delete object.id;
         delete object.is_new;
       }
     };
 
-    const weeks = []
-    data.weeks.forEach(week => {
+    const weeks = [];
+    data.weeks.forEach((week) => {
       const cleanWeek = { ...week };
       const cleanBlocks = [];
-      cleanWeek.blocks.forEach(block => {
-        const cleanBlock = { ...block }
+      cleanWeek.blocks.forEach((block) => {
+        const cleanBlock = { ...block };
         cleanObject(cleanBlock);
         cleanBlocks.push(cleanBlock);
       });
@@ -283,22 +322,22 @@ const API = {
     });
 
     const req_data = { weeks };
-    SentryLogger.type = 'POST';
+    SentryLogger.type = "POST";
     const response = await request(`/courses/${courseId}/timeline.json`, {
-      method: 'POST',
-      body: JSON.stringify(req_data)
+      method: "POST",
+      body: JSON.stringify(req_data),
     });
 
     if (!response.ok) {
       const data = await response.text();
       this.obj = data;
       this.status = response.statusText;
-      console.error('Couldn\'t save timeline!');
+      console.error("Couldn't save timeline!");
       SentryLogger.obj = this.obj;
       SentryLogger.status = this.status;
-      Sentry.captureMessage('saveTimeline failed', {
-        level: 'error',
-        extra: SentryLogger
+      Sentry.captureMessage("saveTimeline failed", {
+        level: "error",
+        extra: SentryLogger,
       });
       response.responseText = data;
       throw response;
@@ -307,83 +346,139 @@ const API = {
   },
 
   async saveCourse(data, courseId = null) {
-    const append = (courseId != null) ? `/${courseId}` : '';
+    const append = courseId != null ? `/${courseId}` : "";
     // append = '.json'
-    const type = (courseId != null) ? 'PUT' : 'POST';
+    const type = courseId != null ? "PUT" : "POST";
     SentryLogger.type = type;
     let req_data = { course: data.course };
 
-    this.obj = null;
-    this.status = null;
-    const response = await request(`/courses${append}.json`, {
-      method: type,
-      body: JSON.stringify(req_data)
-    });
-
-    if (!response.ok) {
-      const data = await response.text();
-      this.obj = data;
-      this.status = response.statusText;
-      SentryLogger.obj = this.obj;
-      SentryLogger.status = this.status;
-      Sentry.captureMessage('saveCourse failed', {
-        level: 'error',
-        extra: SentryLogger
+    try {
+      // Add a try-catch block
+      const response = await request(`/courses${append}.json`, {
+        method: type,
+        body: JSON.stringify(req_data),
       });
-      response.responseText = data;
-      throw response;
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        try {
+          const errorData = JSON.parse(errorText);
+          const errorMessage =
+            errorData.error ||
+            (errorData.errors && errorData.errors[0]) ||
+            errorText;
+
+          // Capture error in Sentry with the extracted message
+          Sentry.captureMessage("saveCourse failed: " + errorMessage, {
+            level: "error",
+            extra: {
+              ...SentryLogger,
+              errorDetails: errorData,
+            },
+          });
+          throw {
+            // Throw a custom error object
+            status: response.status,
+            statusText: response.statusText,
+            data: errorData,
+            message:
+              errorData.error ||
+              (errorData.errors && errorData.errors[0]) ||
+              errorText, // Extract message
+          };
+        } catch (jsonError) {
+          console.error("Error parsing JSON:", jsonError, errorText);
+          // Capture error in Sentry with raw text if JSON parsing fails
+          Sentry.captureMessage(
+            "saveCourse failed (JSON parse error): " + errorText,
+            {
+              level: "error",
+              extra: {
+                ...SentryLogger,
+                rawErrorText: errorText,
+              },
+            }
+          );
+          throw {
+            status: response.status,
+            statusText: response.statusText,
+            message: errorText,
+          };
+        }
+      }
+      return response.json();
+    } catch (error) {
+      // Catch errors from the fetch/request
+      console.error("Error in saveCourse:", error);
+
+      Sentry.captureMessage(
+        "saveCourse failed (fetch error): " + error.message,
+        {
+          level: "error",
+          extra: {
+            ...SentryLogger,
+            fetchError: error,
+          },
+        }
+      );
+      throw error; // Re-throw the error to be caught by the caller
     }
-    return response.json();
   },
 
   async saveUpdatedAdminCourseNote(adminCourseNoteDetails) {
     try {
-        const response = await request(`/admin_course_notes/${adminCourseNoteDetails.id}`, {
-            method: 'PUT',
-            body: JSON.stringify(adminCourseNoteDetails)
-        });
+      const response = await request(
+        `/admin_course_notes/${adminCourseNoteDetails.id}`,
+        {
+          method: "PUT",
+          body: JSON.stringify(adminCourseNoteDetails),
+        }
+      );
 
-        const status = await response.json();
-        return status;
+      const status = await response.json();
+      return status;
     } catch (error) {
-        logErrorMessage('Error fetching course notes:', error);
-        throw error;
+      logErrorMessage("Error fetching course notes:", error);
+      throw error;
     }
   },
 
   async createAdminCourseNote(courseId, adminCourseNoteDetails) {
-     const modifiedDetails = { ...adminCourseNoteDetails, courses_id: courseId };
-     try {
-         const response = await request('/admin_course_notes', {
-             method: 'POST',
-             body: JSON.stringify(modifiedDetails)
-         });
+    const modifiedDetails = { ...adminCourseNoteDetails, courses_id: courseId };
+    try {
+      const response = await request("/admin_course_notes", {
+        method: "POST",
+        body: JSON.stringify(modifiedDetails),
+      });
 
-         const { created_admin_course_note } = await response.json();
-         return created_admin_course_note;
-     } catch (error) {
-         logErrorMessage('Error saving course notes:', error)
-         throw error;
-     }
+      const { created_admin_course_note } = await response.json();
+      return created_admin_course_note;
+    } catch (error) {
+      logErrorMessage("Error saving course notes:", error);
+      throw error;
+    }
   },
 
   async deleteAdminCourseNote(adminCourseNoteId) {
-     try {
-         const response = await request(`/admin_course_notes/${adminCourseNoteId}`, {
-             method: 'DELETE',
-         });
+    try {
+      const response = await request(
+        `/admin_course_notes/${adminCourseNoteId}`,
+        {
+          method: "DELETE",
+        }
+      );
 
-         const status = await response.json();
-         return status;
-     } catch (error) {
-         logErrorMessage('Error Deleting course notes:', error)
-         throw error;
-     }
+      const status = await response.json();
+      return status;
+    } catch (error) {
+      logErrorMessage("Error Deleting course notes:", error);
+      throw error;
+    }
   },
 
   async deleteCourse(courseId) {
     const response = await request(`/courses/${courseId}.json`, {
-      method: 'DELETE'
+      method: "DELETE",
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -392,14 +487,22 @@ const API = {
       throw response;
     }
     const result = await response.json();
-    window.location = '/';
+    window.location = "/";
     return result;
   },
 
-  async removeAndDeleteCourse(courseSlug, campaignTitle, campaignId, campaignSlug) {
-    const response = await request(`/courses/${courseSlug}.json/delete_from_campaign?campaign_title=${campaignTitle}&campaign_id=${campaignId}&campaign_slug=${campaignSlug}`, {
-      method: 'DELETE'
-    });
+  async removeAndDeleteCourse(
+    courseSlug,
+    campaignTitle,
+    campaignId,
+    campaignSlug
+  ) {
+    const response = await request(
+      `/courses/${courseSlug}.json/delete_from_campaign?campaign_title=${campaignTitle}&campaign_id=${campaignId}&campaign_slug=${campaignSlug}`,
+      {
+        method: "DELETE",
+      }
+    );
 
     if (!response.ok) {
       logErrorMessage(response);
@@ -408,13 +511,13 @@ const API = {
       throw response;
     }
     const result = await response.json();
-    window.location = '/';
+    window.location = "/";
     return result;
   },
 
   async deleteBlock(block_id) {
     const response = await request(`/blocks/${block_id}.json`, {
-      method: 'DELETE'
+      method: "DELETE",
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -422,12 +525,12 @@ const API = {
       response.responseText = data;
       throw response;
     }
-    return {block_id};
+    return { block_id };
   },
 
   async deleteWeek(week_id) {
     const response = await request(`/weeks/${week_id}.json`, {
-      method: 'DELETE'
+      method: "DELETE",
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -439,9 +542,12 @@ const API = {
   },
 
   async deleteAllWeeks(course_id) {
-    const response = await request(`/courses/${course_id}/delete_all_weeks.json`, {
-      method: 'DELETE'
-    });
+    const response = await request(
+      `/courses/${course_id}/delete_all_weeks.json`,
+      {
+        method: "DELETE",
+      }
+    );
     if (!response.ok) {
       logErrorMessage(response);
       const data = await response.text();
@@ -452,36 +558,38 @@ const API = {
   },
 
   async notifyOverdue(courseSlug) {
-    const response = await request(`/courses/${courseSlug}/notify_untrained.json`);
+    const response = await request(
+      `/courses/${courseSlug}/notify_untrained.json`
+    );
     if (!response.ok) {
-      logErrorMessage(response, 'Couldn\'t notify students! ');
+      logErrorMessage(response, "Couldn't notify students! ");
       const data = await response.text();
       response.responseText = data;
       throw response;
     }
-    alert('Students with overdue trainings notified!');
+    alert("Students with overdue trainings notified!");
     return response.text();
   },
 
   async greetStudents(courseId) {
     const response = await request(`/greeting?course_id=${courseId}`, {
-      method: 'PUT',
+      method: "PUT",
     });
     if (!response.ok) {
-      logErrorMessage(response, 'There was an error with the greetings! ');
+      logErrorMessage(response, "There was an error with the greetings! ");
       const data = await response.text();
       response.responseText = data;
       throw response;
     }
-    alert('Student greetings added to the queue.');
+    alert("Student greetings added to the queue.");
     return response.json();
   },
 
   async modify(model, courseSlug, data, add) {
-    const verb = add ? 'added' : 'removed';
+    const verb = add ? "added" : "removed";
     const response = await request(`/courses/${courseSlug}/${model}.json`, {
-      method: (add ? 'POST' : 'DELETE'),
-      body: JSON.stringify(data)
+      method: add ? "POST" : "DELETE",
+      body: JSON.stringify(data),
     });
     if (!response.ok) {
       logErrorMessage(response, `${capitalize(model)} not ${verb}: `);
@@ -493,9 +601,9 @@ const API = {
   },
 
   async dismissNotification(id) {
-    const response = await request('/survey_notification', {
-      method: 'PUT',
-      body: JSON.stringify( { survey_notification: { id, dismissed: true } })
+    const response = await request("/survey_notification", {
+      method: "PUT",
+      body: JSON.stringify({ survey_notification: { id, dismissed: true } }),
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -508,17 +616,17 @@ const API = {
 
   async uploadSyllabus({ courseId, file }) {
     const data = new FormData();
-    data.append('syllabus', file);
+    data.append("syllabus", file);
 
     // the request utility function assumes a header of "application/json"
     // since we're sending files here, we must NOT set a content type
     // see https://stackoverflow.com/a/49510941/5055190
     const response = await fetch(`/courses/${courseId}/update_syllabus`, {
-      method: 'POST',
+      method: "POST",
       body: data,
-      headers:{
-        'X-CSRF-Token': Rails.csrfToken()
-      }
+      headers: {
+        "X-CSRF-Token": Rails.csrfToken(),
+      },
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -530,52 +638,57 @@ const API = {
   },
 
   async createNews(NewsDetails) {
-    NewsDetails = { ...NewsDetails, title: Features.wikiEd ? 'Wiki Education News' : 'Programs & Events Dashboard News'}
+    NewsDetails = {
+      ...NewsDetails,
+      title: Features.wikiEd
+        ? "Wiki Education News"
+        : "Programs & Events Dashboard News",
+    };
     try {
-      const response = await request('/faq', {
-        method: 'POST',
-        body: JSON.stringify(NewsDetails)
+      const response = await request("/faq", {
+        method: "POST",
+        body: JSON.stringify(NewsDetails),
       });
 
       const status = response.json();
-      return status
+      return status;
     } catch (error) {
-      logErrorMessage('Error creating news:', error)
-         throw error;
+      logErrorMessage("Error creating news:", error);
+      throw error;
     }
   },
 
   async updateNews(NewsDetails) {
     try {
-       const response = await request(`/faq/${NewsDetails.id}`, {
-           method: 'PUT',
-           body: JSON.stringify(NewsDetails)
-       });
-       const status = await response?.json();
-       return status;
+      const response = await request(`/faq/${NewsDetails.id}`, {
+        method: "PUT",
+        body: JSON.stringify(NewsDetails),
+      });
+      const status = await response?.json();
+      return status;
     } catch (error) {
-       logErrorMessage('Error Deleting course notes:', error)
-       throw error;
+      logErrorMessage("Error Deleting course notes:", error);
+      throw error;
     }
   },
 
   async deleteNews(news_id) {
     try {
-       const response = await request(`/faq/${news_id}`, {
-           method: 'DELETE',
-       });
-       const status = await response.json();
-       return status
+      const response = await request(`/faq/${news_id}`, {
+        method: "DELETE",
+      });
+      const status = await response.json();
+      return status;
     } catch (error) {
-       logErrorMessage('Error Deleting course notes:', error)
-       throw error;
+      logErrorMessage("Error Deleting course notes:", error);
+      throw error;
     }
   },
 
   async createAlert(opts, alert_type) {
-    const response = await request('/alerts', {
-      method: 'POST',
-      body: JSON.stringify( { ...opts, alert_type })
+    const response = await request("/alerts", {
+      method: "POST",
+      body: JSON.stringify({ ...opts, alert_type }),
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -586,12 +699,22 @@ const API = {
     return response.json();
   },
 
-  async requestNewAccount(passcode, courseSlug, username, email, createAccountNow) {
-    const response = await request('/requested_accounts', {
-      method: 'PUT',
-      body: JSON.stringify(
-        { passcode, course_slug: courseSlug, username, email, create_account_now: createAccountNow }
-      )
+  async requestNewAccount(
+    passcode,
+    courseSlug,
+    username,
+    email,
+    createAccountNow
+  ) {
+    const response = await request("/requested_accounts", {
+      method: "PUT",
+      body: JSON.stringify({
+        passcode,
+        course_slug: courseSlug,
+        username,
+        email,
+        create_account_now: createAccountNow,
+      }),
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -603,7 +726,9 @@ const API = {
   },
 
   async enableAccountRequests(courseSlug) {
-    const response = await request(`/requested_accounts/${courseSlug}/enable_account_requests`);
+    const response = await request(
+      `/requested_accounts/${courseSlug}/enable_account_requests`
+    );
     if (!response.ok) {
       logErrorMessage(response);
       const data = await response.text();
@@ -614,9 +739,12 @@ const API = {
   },
 
   async linkToSalesforce(courseId, salesforceId) {
-    const response = await request(`/salesforce/link/${courseId}.json?salesforce_id=${salesforceId}`, {
-      method: 'PUT'
-    });
+    const response = await request(
+      `/salesforce/link/${courseId}.json?salesforce_id=${salesforceId}`,
+      {
+        method: "PUT",
+      }
+    );
     if (!response.ok) {
       logErrorMessage(response);
       const data = await response.text();
@@ -628,7 +756,7 @@ const API = {
 
   async updateSalesforceRecord(courseId) {
     const response = await request(`/salesforce/update/${courseId}.json`, {
-      method: 'PUT'
+      method: "PUT",
     });
     if (!response.ok) {
       logErrorMessage(response);
@@ -639,46 +767,53 @@ const API = {
     return response.json();
   },
 
-  async getCategoriesWithPrefix(wiki, search_term, depth, limit=10){
+  async getCategoriesWithPrefix(wiki, search_term, depth, limit = 10) {
     return this.searchForPages(
       wiki,
       search_term,
       14,
       // replace everything until first colon, then trim
-      (title)=>title.replace(/^[^:]+:/,'').trim(),
+      (title) => title.replace(/^[^:]+:/, "").trim(),
       depth,
-      limit,
+      limit
     );
   },
 
-  async getTemplatesWithPrefix(wiki, search_term, depth, limit=10){
+  async getTemplatesWithPrefix(wiki, search_term, depth, limit = 10) {
     return this.searchForPages(
       wiki,
       search_term,
       10,
-      (title)=>title.replace(/^[^:]+:/,'').trim(),
+      (title) => title.replace(/^[^:]+:/, "").trim(),
       depth,
-      limit,
+      limit
     );
   },
 
-  async searchForPages(wiki, search_term, namespace, map=(el)=>el, depth, limit=10){
+  async searchForPages(
+    wiki,
+    search_term,
+    namespace,
+    map = (el) => el,
+    depth,
+    limit = 10
+  ) {
     let search_query;
-    if(search_term.split(' ').length > 1){
+    if (search_term.split(" ").length > 1) {
       // if we have multiple words, search for the exact words
       search_query = `intitle:${search_term}`;
-    }else{
+    } else {
       // if we have a single word, search for the word anywhere in the title - as a substring
       search_query = `intitle:/${search_term}/i`;
     }
     const params = {
-      action: 'query',
-      list: 'search',
+      action: "query",
+      list: "search",
       srsearch: search_query,
       srnamespace: namespace,
-      origin: '*',
-      format: 'json',
-      srlimit: limit ?? 10
+      origin: "*",
+      format: "json",
+      srlimit: limit ?? 10,
     };
     const response = await fetch(
       `https://${toWikiDomain(wiki)}/w/api.php?${stringify(params)}`
@@ -700,7 +835,7 @@ const API = {
         label,
       };
     });
-  }
+  },
 };
 
 export default API;

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -44,13 +44,17 @@ class CoursesController < ApplicationController
     validate
     handle_course_announcement(@course.instructors.first)
     slug_from_params if should_set_slug?
-    @course.update update_params
+    if @course.update(update_params)
     update_courses_wikis
     update_course_wiki_namespaces
     update_flags
     ensure_passcode_set
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
+    else
+      # Handle update failures by checking for validation errors, such as a duplicate slug.
+      render json: { error: @course.errors.full_messages.first }, status: :unprocessable_entity
+    end
   rescue Wiki::InvalidWikiError => e
     message = I18n.t('courses.error.invalid_wiki', domain: e.domain)
     render json: { errors: e, message: },

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -60,6 +60,10 @@ class Course < ApplicationRecord
   ######################
   # Users for a course #
   ######################
+
+  # Validations for slug to avoid duplicacy
+  validates :slug, uniqueness: { message: ' must be unique, This course slug is already in use. Please choose a different one.' }
+
   has_many :courses_users, class_name: 'CoursesUsers', dependent: :destroy
   has_many :users, -> { distinct }, through: :courses_users
   has_many :students, -> { where('courses_users.role = 0') },


### PR DESCRIPTION
## What this PR does
Fixes #6087

This PR addresses the issue where a generic "Internal Server Error" message was displayed when a user attempted to change a course slug to one that already existed.

Key changes in code : 
Backend (Rails): Modified the Rails controller to send a JSON response containing a specific error message when a course slug collision occurs.  This message clarifies the reason for the error to the user.

Frontend: Updated the frontend code to correctly extract and display the specific error message received from the backend.  This replaces the generic "Internal Server Error" message with a user-friendly message indicating the slug collision.

## Screenshots
Before:
Course titles can be identical for different organizations or institutions, but must be unique within the same organization or institution.  This is because course titles are used to dynamically generate URLs (slugs), and duplicate titles within the same organization would create URL conflicts.
look: below
![Screenshot (70)](https://github.com/user-attachments/assets/4ac75e8c-215c-48fb-91d9-141eaf0dee10)

and this is an error occurring not showing proper message only showing Internal Server Error
![Screenshot (69)](https://github.com/user-attachments/assets/0d8fffa4-7089-4ce2-b70c-8614552f1cfa)


After:
Showing proper message
![Screenshot (71)](https://github.com/user-attachments/assets/bd473c68-0645-4e7c-b276-ea60b04fb532)


And should be a different title to avoid conflict in the URL
![Screenshot (72)](https://github.com/user-attachments/assets/c6b0efa5-dd55-49ff-a4ba-6e77a554005d)


## Learning
I took 3+ days to understand the codebase, and then I solved this
