### PR TITLE
feat: Exit Survey Preview Mode

### DIFF
--- a/app/assets/stylesheets/survey_modules/survey.styl
+++ b/app/assets/stylesheets/survey_modules/survey.styl
@@ -47,3 +47,10 @@
   color sprout
   font-weight 600
   padding 5px
+
+.preview-content
+  display flex
+  align-items center
+  justify-content center
+  gap 20px
+

--- a/app/views/surveys/show.html.haml
+++ b/app/views/surveys/show.html.haml
@@ -2,7 +2,7 @@
   .survey-previewing
     .preview-content
       Preview Mode
-      = link_to "Exit", edit_survey_path(params[:id]), class: "button"
+      = link_to t('survey.edit_survey'), edit_survey_path(params[:id]), class: "button"
       
 // Used for logging survey data via Sentry
 :javascript

--- a/app/views/surveys/show.html.haml
+++ b/app/views/surveys/show.html.haml
@@ -1,6 +1,9 @@
 - if params.key?("preview")
-  .survey-previewing Preview Mode
-
+  .survey-previewing
+    .preview-content
+      Preview Mode
+      = link_to "Exit", edit_survey_path(params[:id]), class: "button"
+      
 // Used for logging survey data via Sentry
 :javascript
   SurveyDetails = {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1748,6 +1748,7 @@ en:
       link: "Take Survey"
     follow_up:
       message: "This is a reminder about the survey for your course, %{course_title}. Feedback from this survey helps us to improve our support for Wikipedia assignments like yours."
+    edit_survey: "Edit Survey"
 
   feedback_form_responses:
     no_responses: "There are no feedback responses yet."

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -902,6 +902,7 @@ qqq:
       link: Link to take survey from email
     follow_up:
       message: Survey invitation email text. (Wiki Ed only)
+    edit_survey: Button label for editing a survey
   article_finder:
     add_available_article: Button label to add an article finder result to available
       articles


### PR DESCRIPTION
## What this PR does
This pull request adds an Exit button to exit the Survey Preview Mode, addressing the issue where users currently have no clear way to exit preview mode and return back to editing mode.

Fixes #6166 

### Changes:

- Added an "Exit Preview Mode" button at the bottom of the preview page.
- Positioned the button alongside the "Preview Mode" label for visibility.

Steps to Test:

> - Navigate to the survey page (/survey).
> - Click "Edit Survey" to open the editor.
> - Click "Preview Survey" to enter preview mode.
> - The "Exit Preview Mode" button appears at the bottom.
> - Click the button and it returns you back to the editing mode.

### Impact:

Provides a clear way for users to exit preview mode and return back to the editing mode.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/28c245ff-caa6-4e8e-b9c8-dd804be338fe)


After:
![image](https://github.com/user-attachments/assets/a603177a-71af-40b7-a814-f63d802f206c)

