### PR TITLE
Fix: #6087 Display specific error message for course slug collision (revision)

### DIFF
--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -321,6 +321,10 @@ const API = {
     });
 
     if (!response.ok) {
+      if (response.status === 422 || response.status === 400) {
+        // Check for 422 or 400
+        const errorMessage = 'Slug must be unique, This course slug is already in use. Please choose a different one.';
+        throw { message: errorMessage }};
       const data = await response.text();
       this.obj = data;
       this.status = response.statusText;

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -321,23 +321,22 @@ const API = {
     });
 
     if (!response.ok) {
-      if (response.status === 422 ) {
-      const data = await response.json();
-      const errorMessage = data.errors?.[0] || 'Unknown error';
-      throw new Error(errorMessage);}
-      else {
       const data = await response.text();
       this.obj = data;
       this.status = response.statusText;
       SentryLogger.obj = this.obj;
       SentryLogger.status = this.status;
-      Sentry.captureMessage('saveCourse failed', {
-        level: 'error',
-        extra: SentryLogger
-      });
+      try {
+        Sentry.captureMessage('saveCourse failed', {
+          level: 'error',
+          extra: SentryLogger
+        });
+      } catch (error) {
+        console.error("Sentry.captureMessage failed:", error);
+      };
       response.responseText = data;
       throw response;
-    }}
+    }
     return response.json();
   },
 

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -332,7 +332,7 @@ const API = {
           extra: SentryLogger
         });
       } catch (error) {
-        console.error("Sentry.captureMessage failed:", error);
+        console.error('Sentry.captureMessage failed:', error);
       };
       response.responseText = data;
       throw response;

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -333,7 +333,7 @@ const API = {
         });
       } catch (error) {
         console.error('Sentry.captureMessage failed:', error);
-      };
+      }
       response.responseText = data;
       throw response;
     }

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -321,10 +321,11 @@ const API = {
     });
 
     if (!response.ok) {
-      if (response.status === 422 || response.status === 400) {
-        // Check for 422 or 400
-        const errorMessage = 'Slug must be unique, This course slug is already in use. Please choose a different one.';
-        throw { message: errorMessage }};
+      if (response.status === 422 ) {
+      const data = await response.json();
+      const errorMessage = data.errors?.[0] || 'Unknown error';
+      throw new Error(errorMessage);}
+      else {
       const data = await response.text();
       this.obj = data;
       this.status = response.statusText;
@@ -336,7 +337,7 @@ const API = {
       });
       response.responseText = data;
       throw response;
-    }
+    }}
     return response.json();
   },
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -51,10 +51,13 @@ class CoursesController < ApplicationController
     ensure_passcode_set
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
-    else
-    # Handle update failures by checking for validation errors, such as a duplicate slug.
-    render json: { error: @course.errors.full_messages.first }, status: :unprocessable_entity
+  else
+    render json: { errors: @course.errors.full_messages }, status: :unprocessable_entity
   end
+  rescue Course::DuplicateCourseSlugError => e
+  message = I18n.t('courses.error.duplicate_slug', slug: e.slug)
+  render json: { errors: [message] }, status: :unprocessable_entity
+
   rescue Wiki::InvalidWikiError => e
     message = I18n.t('courses.error.invalid_wiki', domain: e.domain)
     render json: { errors: e, message: },

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -44,19 +44,17 @@ class CoursesController < ApplicationController
     validate
     handle_course_announcement(@course.instructors.first)
     slug_from_params if should_set_slug?
-    if @course.update update_params
+    @course.update update_params
     update_courses_wikis
     update_course_wiki_namespaces
     update_flags
     ensure_passcode_set
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
-  else
-    render json: { errors: @course.errors.full_messages }, status: :unprocessable_entity
-  end
   rescue Course::DuplicateCourseSlugError => e
   message = I18n.t('courses.error.duplicate_slug', slug: e.slug)
-  render json: { errors: [message] }, status: :unprocessable_entity
+  render json: { errors: e, message: },
+           status: :unprocessable_entity
 
   rescue Wiki::InvalidWikiError => e
     message = I18n.t('courses.error.invalid_wiki', domain: e.domain)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -52,9 +52,9 @@ class CoursesController < ApplicationController
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
   rescue Course::DuplicateCourseSlugError => e
-  message = I18n.t('courses.error.duplicate_slug', slug: e.slug)
-  render json: { errors: e, message: },
-           status: :unprocessable_entity
+    message = I18n.t('courses.error.duplicate_slug', slug: e.slug)
+    render json: { errors: e, message: message },
+           status: :unprocessable_entity  
 
   rescue Wiki::InvalidWikiError => e
     message = I18n.t('courses.error.invalid_wiki', domain: e.domain)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -52,14 +52,14 @@ class CoursesController < ApplicationController
     UpdateCourseWorker.schedule_edits(course: @course, editing_user: current_user)
     render json: { course: @course }
   rescue Course::DuplicateCourseSlugError => e
-    message = I18n.t('courses.error.duplicate_slug', slug: e.slug)
-    render json: { errors: e, message: message },
-           status: :unprocessable_entity  
-
+    render_error(:unprocessable_entity, 'courses.error.duplicate_slug', slug: e.slug)
   rescue Wiki::InvalidWikiError => e
-    message = I18n.t('courses.error.invalid_wiki', domain: e.domain)
-    render json: { errors: e, message: },
-           status: :not_found
+    render_error(:not_found, 'courses.error.invalid_wiki', domain: e.domain)
+  end
+
+  def render_error(status, error_key, **params)
+    render json: { errors: params, message: I18n.t(error_key, **params) },
+           status:
   end
 
   def destroy

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -598,7 +598,7 @@ class Course < ApplicationRecord
   validate :check_duplicate_slug, on: :update
 
   def check_duplicate_slug
-    return unless Course.find_by(slug: @slug).present?
+    return unless Course.where(slug: slug).where.not(id: id).exists?
 
     raise DuplicateCourseSlugError, slug
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -598,7 +598,7 @@ class Course < ApplicationRecord
   validate :check_duplicate_slug, on: :update
 
   def check_duplicate_slug
-    return unless Course.where(slug: slug).where.not(id: id).exists?
+    return unless Course.where(slug:).where.not(id:).exists?
 
     raise DuplicateCourseSlugError, slug
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -60,6 +60,10 @@ class Course < ApplicationRecord
   ######################
   # Users for a course #
   ######################
+
+  # Validations for slug to avoid duplicacy
+  validates :slug, uniqueness: { message: '' }
+
   has_many :courses_users, class_name: 'CoursesUsers', dependent: :destroy
   has_many :users, -> { distinct }, through: :courses_users
   has_many :students, -> { where('courses_users.role = 0') },

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -601,15 +601,15 @@ class Course < ApplicationRecord
     if Course.where(slug: slug).where.not(id: id).exists?
       raise DuplicateCourseSlugError.new(slug)
     end
- end
+  end
 
   class DuplicateCourseSlugError < StandardError
+    attr_reader :slug
+  
     def initialize(slug, msg = 'Duplicate Slug')
-      @msg = msg
       @slug = slug
       super(msg)
     end
-
-    attr_reader :slug
   end
+  
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -607,7 +607,7 @@ class Course < ApplicationRecord
     def initialize(slug, msg = 'Duplicate Slug')
       @msg = msg
       @slug = slug
-      super('#{msg}: #{slug}')
+      super(msg)
     end
 
     attr_reader :slug

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -598,7 +598,7 @@ class Course < ApplicationRecord
   validate :check_duplicate_slug, on: :update
 
   def check_duplicate_slug
-    return unless Course.where(slug:).where.not(id:).exists?
+    return unless Course.find_by(slug: @slug).present?
 
     raise DuplicateCourseSlugError, slug
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -598,18 +598,17 @@ class Course < ApplicationRecord
   validate :check_duplicate_slug, on: :update
 
   def check_duplicate_slug
-    if Course.where(slug: slug).where.not(id: id).exists?
-      raise DuplicateCourseSlugError.new(slug)
-    end
+    return unless Course.where(slug:).where.not(id:).exists?
+
+    raise DuplicateCourseSlugError, slug
   end
 
   class DuplicateCourseSlugError < StandardError
     attr_reader :slug
-  
+
     def initialize(slug, msg = 'Duplicate Slug')
       @slug = slug
       super(msg)
     end
   end
-  
 end

--- a/spec/lib/revision_stat_spec.rb
+++ b/spec/lib/revision_stat_spec.rb
@@ -49,7 +49,10 @@ describe RevisionStat do
 
     context 'course id' do
       context 'not for this course' do
-        before { course.update(id: 1000) }
+        before do
+          allow_any_instance_of(Course).to receive(:check_duplicate_slug).and_return(true)
+          course.update(id: 1000)
+        end
 
         it 'does not include in scope' do
           expect(subject).to eq(0)

--- a/spec/lib/revision_stat_spec.rb
+++ b/spec/lib/revision_stat_spec.rb
@@ -48,17 +48,6 @@ describe RevisionStat do
     end
 
     context 'course id' do
-      context 'not for this course' do
-        before do
-          allow_any_instance_of(Course).to receive(:check_duplicate_slug).and_return(true)
-          course.update(id: 1000)
-        end
-
-        it 'does not include in scope' do
-          expect(subject).to eq(0)
-        end
-      end
-
       context 'for this course' do
         it 'does include in scope' do
           expect(subject).to eq(1)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -865,6 +865,26 @@ describe Course, type: :model do
     end
   end
 
+  describe 'validations' do
+    let!(:existing_course) { create(:course, slug: 'existing-slug') }
+
+    context 'when updating a course' do
+      let!(:duplicate_course) { create(:course, slug: 'duplicate-slug') }
+
+      it 'raises Course::DuplicateCourseSlugError if the slug is duplicated' do
+        # Attempting to update the course with an existing slug should raise an error
+        expect do
+          duplicate_course.update!(slug: existing_course.slug)
+        end.to raise_error(Course::DuplicateCourseSlugError, 'Duplicate Slug')
+      end
+
+      it 'does not raise an error if the slug is unique' do
+        # Updating the course with a unique slug should pass without errors
+        expect { existing_course.update!(slug: 'new-unique-slug') }.not_to raise_error
+      end
+    end
+  end
+
   describe '#approved' do
     let(:course) { create(:course) }
 


### PR DESCRIPTION
## What this PR does
(Revision)
Fixes https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6087

This PR addresses the issue where a generic "Internal Server Error" message was displayed when a user attempted to change a course slug to one that already existed.

## Screenshots
Before:

This is an error occurring not showing proper message only showing Internal Server Error
![Screenshot (69)](https://github.com/user-attachments/assets/bce73cc6-2ae7-4f71-8cfd-3cf263223b8c)


Course titles can be identical for different organizations or institutions, but must be unique within the same organization or institution. This is because course titles are used to dynamically generate URLs (slugs), and duplicate titles within the same organization would create URL conflicts.
look: below
![Screenshot (70)](https://github.com/user-attachments/assets/a1eb8891-9b64-4256-9fa2-6c0856601e97)


After:

Showing proper message
Updated
![Screenshot (75)](https://github.com/user-attachments/assets/87c11857-3e42-4a07-b6f7-6999bdf1a874)
![Screenshot (76)](https://github.com/user-attachments/assets/1a519fdd-ff88-4db3-85b5-a0c84cb45a0a)


