### PR TITLE
`DuplicateArticleDeleter`: fix existing bug to keep the most recently created article instead of the oldest one

### DIFF
--- a/lib/duplicate_article_deleter.rb
+++ b/lib/duplicate_article_deleter.rb
@@ -49,7 +49,8 @@ class DuplicateArticleDeleter
   def delete_duplicates(title, ns)
     articles = Article.where(title:, namespace: ns, wiki_id: @wiki.id, deleted: false)
                       .order(:created_at)
-    keeper = articles.first
+    # Default order is ascendent, so we want to keep the last article
+    keeper = articles.last
     return [] if keeper.nil?
 
     # Here we must verify that the titles match, since searching by title is case-insensitive.

--- a/spec/lib/duplicate_article_deleter_spec.rb
+++ b/spec/lib/duplicate_article_deleter_spec.rb
@@ -31,26 +31,26 @@ describe DuplicateArticleDeleter do
                        deleted: true)
     end
 
-    it 'marks one deleted when there are two ids for one page' do
-      first = create(:article,
-                     id: 2262715,
-                     title: 'Kostanay',
-                     namespace: 0,
-                     created_at: 1.day.from_now)
-      second = create(:article,
-                      id: 46349871,
-                      title: 'Kostanay',
-                      namespace: 0,
-                      created_at: 1.day.ago)
-      described_class.new.resolve_duplicates([first])
-      undeleted = Article.where(
+    it 'marks oldest one deleted when there are two ids for one page' do
+      new_article = create(:article,
+                           id: 2262715,
+                           title: 'Kostanay',
+                           namespace: 0,
+                           created_at: 1.day.from_now)
+      duplicate_article = create(:article,
+                                 id: 46349871,
+                                 title: 'Kostanay',
+                                 namespace: 0,
+                                 created_at: 1.day.ago)
+      described_class.new.resolve_duplicates([new_article])
+      deleted = Article.where(
         title: 'Kostanay',
         namespace: 0,
-        deleted: false
+        deleted: true
       )
 
-      expect(undeleted.count).to eq(1)
-      expect(undeleted.first.id).to eq(second.id)
+      expect(deleted.count).to eq(1)
+      expect(deleted.first.id).to eq(duplicate_article.id)
     end
 
     it 'does not mark any deleted when articles different in title case' do


### PR DESCRIPTION
## What this PR does
This PR modifies the article deletion criteria in the `DuplicateArticleDeleter` class to be consistent with the comment:
```
  # Delete all articles with the given title
  # and namespace except for the most recently created
```
 
According to [docs](https://apidock.com/rails/ActiveRecord/QueryMethods/order), the default ordering for ActiveRecord is ascending, meaning that  `keeper = articles.first` ends up with the oldest article in `keeper`. This PR changes that to keep the last one.

Note that there were a lot of changes in this class (and its specs) along the time so I don't know how this should really work.
At some point we kept the last article instead of the first one (see commit 8ea90c5 where that was changes). In addition, we also forced the order to be descending (see commit ba8ff9c).

I'm changing the behavior to be consistent with the comment.

## Open questions and concerns

I need to replicate the behavior of `DuplicateArticleDeleter` for timeslices, so I want to clarify the exact criteria we should follow.