### PR TITLE
Fix: issue with course_assignment returning an empty object 

### DIFF
--- a/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
+++ b/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
@@ -9,7 +9,11 @@ end
 
 describe DiscretionarySanctionsMonitor do
   describe '.create_alerts_for_course_articles' do
-    let(:course) { create(:course, start: '2024-12-10', end: '2025-01-20') }
+    let(:course) do
+      travel_to Date.new(2025, 1, 20) do
+        create(:course, start: '2024-12-10', end: Date.new(2025, 1, 20))
+      end
+    end
     let(:student) { create(:user, username: 'Gelasin') }
     let!(:courses_user) do
       create(:courses_user, user_id: student.id,

--- a/spec/lib/alerts/high_quality_article_monitor_spec.rb
+++ b/spec/lib/alerts/high_quality_article_monitor_spec.rb
@@ -5,7 +5,7 @@ require "#{Rails.root}/lib/alerts/high_quality_article_monitor"
 
 describe HighQualityArticleMonitor do
   describe '.create_alerts_for_course_articles' do
-    let(:course) { create(:course, start: '2024-01-01', end: '2025-01-01') }
+    let(:course) { create(:course, start: '2024-01-01', end: 30.days.from_now) }
     let(:student) { create(:user, username: 'Leemyongpak', email: 'learn@school.edu') }
     let(:instructor) { create(:user, username: 'instructor', email: 'teach@school.edu') }
     let!(:courses_user) do

--- a/spec/lib/alerts/high_quality_article_monitor_spec.rb
+++ b/spec/lib/alerts/high_quality_article_monitor_spec.rb
@@ -5,7 +5,11 @@ require "#{Rails.root}/lib/alerts/high_quality_article_monitor"
 
 describe HighQualityArticleMonitor do
   describe '.create_alerts_for_course_articles' do
-    let(:course) { create(:course, start: '2024-01-01', end: 30.days.from_now) }
+    let(:course) do
+      travel_to Date.new(2025, 1, 10) do
+        create(:course, start: '2024-01-01', end: Date.new(2025, 1, 10))
+      end
+    end
     let(:student) { create(:user, username: 'Leemyongpak', email: 'learn@school.edu') }
     let(:instructor) { create(:user, username: 'instructor', email: 'teach@school.edu') }
     let!(:courses_user) do


### PR DESCRIPTION
## What this PR does
This PR provides a quick fix for the recent [CI build error](https://github.com/WikiEducationFoundation/WikiEduDashboard/actions/runs/13120619294/job/36605410577), where the HighQualityArticleAssignmentAlert count was not as expected. The issue was due to the following:

- The `create_alerts_from_page_titles` method in `HighQualityArticleMonitor` filters assignments based on the current active course.
- However, this was returning an empty object for `course_assignments` because the end date specified in the test for the course had already passed.
- As a result, no assignment alerts were created since there were no active courses.
## Fix
The end date in the test has been updated to be dynamic, ending 30 days from the current time. This ensures that the course remains active during the test.


 Before ScreenShot 

<img width="1378" alt="Screenshot 2025-02-03 at 21 31 54" src="https://github.com/user-attachments/assets/d9834b24-5b16-46c0-99b0-127f048da7e7" />

After ScreenShot

<img width="1336" alt="Screenshot 2025-02-03 at 21 29 31" src="https://github.com/user-attachments/assets/9d0077da-7011-41f6-8141-e0a5744ba097" />

@gabina I wish to confirm if this is the expected behaviour of this test. @ragesoss  could you review this when you are chanced
