### PR TITLE
[WIP]: Caching slow test on github CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,26 @@ jobs:
               sudo ln -s $(which magick) /usr/bin/$cmd
             fi
           done
+        
+      # Cache for slow tests (cached folder)
+      - name: Cache VCR cassettes (Slow Tests)
+        uses: actions/cache@v3
+        with:
+          path: fixtures/vcr_cassettes/cached
+          key: vcr-cached-v1  # Static key to keep the cache stable
+          restore-keys: |
+            vcr-cached-
+
+      # Cache for other tests (dynamic cache)
+      - name: Cache VCR cassettes (Other Tests)
+        uses: actions/cache@v3
+        with:
+          path: fixtures/vcr_cassettes
+          exclude: fixtures/vcr_cassettes/cached  # Exclude the cached folder
+          key: vcr-dynamic-${{ hashFiles('spec/**/*_spec.rb') }}
+          restore-keys: |
+            vcr-dynamic-
+
 
       - name: setup Redis
         uses: supercharge/redis-github-action@1.4.0

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 /config/newrelic.yml
 /config/secrets.yml
 /dockerAuth.json
-/fixtures/vcr_cassettes/*
-!/fixtures/vcr_cassettes/cached/
-!/fixtures/vcr_cassettes/cached/*
+/fixtures
+# /fixtures/vcr_cassettes/*
+# !/fixtures/vcr_cassettes/cached/
+# !/fixtures/vcr_cassettes/cached/*
 /node_modules
 /js_coverage
 /vendor/*


### PR DESCRIPTION

## What this PR does
This PR is a work in progress to reduce the build time on the CI pipeline by caching the response for slow test and running any other test when the test file changes

