### PR TITLE
[WIP] [Data rearchitecture] Do not propagate error for `UnexpectedContentType` liftwing API response

### DIFF
--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -15,6 +15,9 @@ class LiftWingApi
     'MW API does not have any info'
   ].freeze
 
+  NON_TRANSIENT_ERRORS =
+    DELETED_REVISION_ERRORS + ['UnexpectedContentType'].freeze
+
   LIFT_WING_SERVER_URL = 'https://api.wikimedia.org'
 
   # All the wikis with an articlequality model as of 2023-06-28
@@ -121,7 +124,7 @@ class LiftWingApi
     deleted = deleted?(error)
     error_response = { 'wp10' => nil, 'features' => nil, 'deleted' => deleted, 'prediction' => nil }
     # Add error field only if the revision was not deleted
-    error_response['error'] = error unless deleted
+    error_response['error'] = error unless non_transient_error?(error)
 
     error_response
   end
@@ -139,7 +142,13 @@ class LiftWingApi
   end
 
   def deleted?(error)
-    LiftWingApi::DELETED_REVISION_ERRORS.any? do |revision_error|
+    DELETED_REVISION_ERRORS.any? do |revision_error|
+      error.include?(revision_error)
+    end
+  end
+
+  def non_transient_error?(error)
+    NON_TRANSIENT_ERRORS.any? do |revision_error|
       error.include?(revision_error)
     end
   end

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -24,54 +24,45 @@ describe LiftWingApi do
 
     let(:lift_wing_api_class_en_wiki) { described_class.new(Wiki.find(1)) }
 
-    # Get revision data for valid rev ids for English Wikipedia
-    let(:subject0) { lift_wing_api_class_en_wiki.get_revision_data(rev_ids) }
-
-    # Get revision data for deleted rev ids for English Wikipedia
-    let(:subject2) { lift_wing_api_class_en_wiki.get_revision_data([deleted_rev_id]) }
-
     it 'fetches json from api.wikimedia.org for wikipedia' do
       VCR.use_cassette 'liftwing_api/wikipedia' do
-        expect(subject0).to be_a(Hash)
-        expect(subject0.dig('829840084', 'wp10').to_f).to be_within(0.01).of(28.59)
-        expect(subject0.dig('829840084', 'features')).to be_a(Hash)
-        expect(subject0.dig('829840084', 'deleted')).to eq(false)
-        expect(subject0.dig('829840084', 'prediction')).to eq('Stub')
-        expect(subject0.dig('829840084').key?('error')).to eq(false)
+        # Get revision data for valid rev ids for English Wikipedia
+        subject = lift_wing_api_class_en_wiki.get_revision_data(rev_ids)
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('829840084', 'wp10').to_f).to be_within(0.01).of(28.59)
+        expect(subject.dig('829840084', 'features')).to be_a(Hash)
+        expect(subject.dig('829840084', 'deleted')).to eq(false)
+        expect(subject.dig('829840084', 'prediction')).to eq('Stub')
+        expect(subject.dig('829840084').key?('error')).to eq(false)
 
-        expect(subject0).to be_a(Hash)
-        expect(subject0.dig('829840085', 'wp10').to_f).to be_within(0.01).of(29.15)
-        expect(subject0.dig('829840085', 'features')).to be_a(Hash)
-        expect(subject0.dig('829840085', 'deleted')).to eq(false)
-        expect(subject0.dig('829840085', 'prediction')).to eq('Start')
-        expect(subject0.dig('829840085').key?('error')).to eq(false)
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('829840085', 'wp10').to_f).to be_within(0.01).of(29.15)
+        expect(subject.dig('829840085', 'features')).to be_a(Hash)
+        expect(subject.dig('829840085', 'deleted')).to eq(false)
+        expect(subject.dig('829840085', 'prediction')).to eq('Start')
+        expect(subject.dig('829840085').key?('error')).to eq(false)
       end
     end
 
-    context 'fetch json data from api.wikimedia.org' do
-      before do
-        stub_lift_wing_response
-      end
+    it 'fetch json data from api.wikimedia.org for wikidata' do
+      stub_lift_wing_response
 
       # Get revision data for valid rev ids for Wikidata
-      let(:subject1) { described_class.new(wiki).get_revision_data([829840084, 829840085]) }
+      subject = described_class.new(wiki).get_revision_data(rev_ids)
+      expect(subject).to be_a(Hash)
+      expect(subject.dig('829840084')).to have_key('wp10')
+      expect(subject.dig('829840084', 'wp10')).to eq(nil)
+      expect(subject.dig('829840084', 'features')).to be_a(Hash)
+      expect(subject.dig('829840084', 'deleted')).to eq(false)
+      expect(subject.dig('829840084', 'prediction')).to eq('D')
+      expect(subject.dig('829840084').key?('error')).to eq(false)
 
-      it 'fetches data for wikidata' do
-        expect(subject1).to be_a(Hash)
-        expect(subject1.dig('829840084')).to have_key('wp10')
-        expect(subject1.dig('829840084', 'wp10')).to eq(nil)
-        expect(subject1.dig('829840084', 'features')).to be_a(Hash)
-        expect(subject1.dig('829840084', 'deleted')).to eq(false)
-        expect(subject1.dig('829840084', 'prediction')).to eq('D')
-        expect(subject1.dig('829840084').key?('error')).to eq(false)
-
-        expect(subject1.dig('829840084')).to have_key('wp10')
-        expect(subject1.dig('829840085', 'wp10')).to eq(nil)
-        expect(subject1.dig('829840085', 'features')).to be_a(Hash)
-        expect(subject1.dig('829840085', 'deleted')).to eq(false)
-        expect(subject1.dig('829840085', 'prediction')).to eq('D')
-        expect(subject1.dig('829840085').key?('error')).to eq(false)
-      end
+      expect(subject.dig('829840084')).to have_key('wp10')
+      expect(subject.dig('829840085', 'wp10')).to eq(nil)
+      expect(subject.dig('829840085', 'features')).to be_a(Hash)
+      expect(subject.dig('829840085', 'deleted')).to eq(false)
+      expect(subject.dig('829840085', 'prediction')).to eq('D')
+      expect(subject.dig('829840085').key?('error')).to eq(false)
     end
 
     it 'fails silently if the error is not transient' do
@@ -85,25 +76,29 @@ describe LiftWingApi do
 
     it 'returns deleted equal to true if the revision was deleted' do
       VCR.use_cassette 'liftwing_api/deleted_revision' do
-        expect(subject2).to be_a(Hash)
-        expect(subject2.dig('708326238', 'deleted')).to eq(true)
-        expect(subject2.dig('708326238').key?('error')).to eq(false)
+        # Get revision data for deleted rev ids for English Wikipedia
+        subject = lift_wing_api_class_en_wiki.get_revision_data([deleted_rev_id])
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('708326238', 'deleted')).to eq(true)
+        expect(subject.dig('708326238').key?('error')).to eq(false)
       end
     end
 
     context 'if the same error happens several times' do
+      let(:subject) { lift_wing_api_class_en_wiki.get_revision_data(rev_ids) }
+
       it 'logs timeout error once' do
         stub_request(:any, /.*api.wikimedia.org.*/)
           .to_raise(Errno::ETIMEDOUT)
         expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-        expect(subject0.dig('829840085', 'error')).not_to be(nil)
+        expect(subject.dig('829840085', 'error')).not_to be(nil)
       end
 
       it 'logs connection refused once' do
         stub_request(:any, /.*api.wikimedia.org.*/)
           .to_raise(Faraday::ConnectionFailed)
         expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-        expect(subject0.dig('829840085', 'error')).not_to be(nil)
+        expect(subject.dig('829840085', 'error')).not_to be(nil)
       end
 
       it 'logs unexpected error once' do
@@ -112,7 +107,7 @@ describe LiftWingApi do
             .to receive(:build_successful_response)
             .and_raise(StandardError)
           expect(lift_wing_api_class_en_wiki).to receive(:log_error).once
-          expect(subject0.dig('829840085', 'error')).not_to be(nil)
+          expect(subject.dig('829840085', 'error')).not_to be(nil)
         end
       end
     end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -692,6 +692,21 @@ module RequestHelpers
       )
   end
 
+  def stub_400_wikidata_lift_wing_reponse
+    response_body = { error: "Unexpected content type for rev-id 2260577532: UnexpectedContentType:\
+    Expected content of type JSON, but the following can't be parsed (max 50 chars showed): == About\
+    me ==\n\n[[m:User:Arcstur|Find me at Meta-W"}
+
+    stub_request(:post, 'https://api.wikimedia.org/service/lw/inference/v1/models/wikidatawiki-itemquality:predict')
+      .with(
+        body: hash_including(rev_id: 2260577532, extended_output: true),
+        headers: { 'Content-Type': 'application/json' }
+      ).to_return(
+        status: 400,
+        body: response_body.to_json
+      )
+  end
+
   def stub_es_wikipedia_reference_counter_reponse
     request_body = {
       '157412237' => { 'num_ref' => 111, 'lang' => 'es', 'project' => 'wikipedia',

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -694,8 +694,8 @@ module RequestHelpers
 
   def stub_400_wikidata_lift_wing_reponse
     response_body = { error: "Unexpected content type for rev-id 2260577532: UnexpectedContentType:\
-    Expected content of type JSON, but the following can't be parsed (max 50 chars showed): == About\
-    me ==\n\n[[m:User:Arcstur|Find me at Meta-W"}
+    Expected content of type JSON, but the following can't be parsed (max 50 chars showed): ==\
+    About me ==\n\n[[m:User:Arcstur|Find me at Meta-W"}
 
     stub_request(:post, 'https://api.wikimedia.org/service/lw/inference/v1/models/wikidatawiki-itemquality:predict')
       .with(


### PR DESCRIPTION
## What this PR does
This PR adds `UnexpectedContentType` to the list of non-transient errors for LiftWingApi, ensuring these errors are ignored. Since reprocessing the timeslice won’t resolve them, we avoid propagating the error. This follows the same approach as PR #6176.

### Example

Request:
`curl -X POST -H "Content-Type: application/json"    -d '{"rev_id": 2260577532, "extended_output": true}'    https://api.wikimedia.org/service/lw/inference/v1/models/wikidatawiki-itemquality:predict`

Response:

`{"error":"Unexpected content type for rev-id 2260577532: UnexpectedContentType: Expected content of type JSON, but the following can't be parsed (max 50 chars showed): == About me ==\n\n[[m:User:Arcstur|Find me at Meta-W"}`

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
