### PR TITLE
[FEAT]: Add Exit/Edit Mode Option from Question Groups Preview

### DIFF
--- a/app/views/rapidfire/answer_groups/new.html.haml
+++ b/app/views/rapidfire/answer_groups/new.html.haml
@@ -1,5 +1,8 @@
 - if params.key?("preview")
-  .survey-previewing Preview Mode
+  .survey-previewing
+    .preview-content
+      Preview Mode
+      = link_to t('question_groups.edit_question_group'), edit_question_group_path(@question_group), class: "button"
 .loading{"data-survey-form-container" => ""}
   = render partial: "surveys/question_group", locals: { |
       question_group: @question_group,                  |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1923,4 +1923,7 @@ en:
       weekday_select: "{{weekday}} Press Return key to select"
       weekday_selected: "{{weekday}} Selected Press Return Key to unselect"
       weekday_unselected: "{{weekday}} Unselected"
+
+  question_groups:
+    edit_question_group: "Edit Question Group"
       

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -947,4 +947,6 @@ qqq:
     footer:
       wiki_education_dashboard:
         link_text: '{{optional}}'
+  question_groups:
+    edit_question_group: Button label for editing a question group
 ...


### PR DESCRIPTION
## What this PR does
This pull request adds the option to Edit Question Group in the Preview Mode, addressing the issue where users currently have no clear way to exit preview mode and return back to editing mode. Also displays an option to edit the question group when the user arrives from a non-editing page.

Fixes #6179 

### Changes:

- Added an "Edit Question Group" button at the bottom of the preview page.
- Positioned the button alongside the "Preview Mode" label for visibility.

Steps to Test:

- Navigate to ```/surveys/rapidfire/question_groups```
- Click on "Edit" of any of the question group
- Click on "Preview Question Group" to enter preview mode.
> - The "Edit Question Group" button appears at the bottom.
> - Click the button and it returns you back to the editing mode.

### Impact:

Provides a clear way for users to redirect back to the editing mode.

## Screenshots
Before:
![Image](https://github.com/user-attachments/assets/ebb8daf8-98d3-4b9f-820c-b346169cb6aa)


After:

[Screencast from 2025-02-07 04-50-19.webm](https://github.com/user-attachments/assets/a7329d15-9401-49be-a616-9bd575b4c44f)

