### PR TITLE
[Fix]: Active Navigation Tab for Sub-Routes

### DIFF
--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -162,7 +162,7 @@ module SurveysHelper
   def survey_class_for_path(req, path)
     current_path_segments = req.path.split('/').reject(&:blank?)
     active_path = path.split('/').reject(&:blank?).last
-    current_path_segments.last == active_path ? 'active' : nil
+    current_path_segments.include?(active_path) ? 'active' : nil
   end
 
   ######################


### PR DESCRIPTION
## What this PR does
This pull request fixes the issue where the active navigation tab does not persist when navigating to sub-routes.
The navigation bar now consistently reflects the current location, maintaining the active tab state across all sub-routes and URLs with query parameters.

Fixes #6181

## Screenshots
Before:

![Image](https://github.com/user-attachments/assets/1a8279a5-855f-4726-a3ac-22553f1d4b30)

![Image](https://github.com/user-attachments/assets/8a329406-e24d-41da-b2fc-456aa4f59298)

After:
![image](https://github.com/user-attachments/assets/ce528154-a66c-45e0-b8c6-6c0eef3aebd1)

