### PR TITLE
[Data rearchitecture] Handle duplicate articles for revisions

### DIFF
--- a/lib/duplicate_article_deleter.rb
+++ b/lib/duplicate_article_deleter.rb
@@ -32,6 +32,8 @@ class DuplicateArticleDeleter
       delete_duplicates_in(article_group)
     end
 
+    return if @deleted_ids.empty?
+
     articles = Article.where(id: @deleted_ids)
     # Get all courses with at least one deleted article
     course_ids = ArticlesCourses.where(article_id: @deleted_ids).pluck(:course_id).uniq

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -31,8 +31,7 @@ class RevisionDataManager
 
     # Import articles. We do this here to avoid saving article data in memory.
     # Note that we create articles for all sub data (not only for scoped revisions).
-    ArticleImporter.new(@wiki).import_articles_from_revision_data(articles)
-    @articles = Article.where(wiki_id: @wiki.id, mw_page_id: articles.map { |a| a['mw_page_id'] })
+    import_and_resolve_duplicate_articles articles
 
     # Prep: get a user dictionary for all users referred to by revisions.
     users = user_dict_from_sub_data(all_sub_data)
@@ -44,8 +43,6 @@ class RevisionDataManager
                                                  users,
                                                  scoped_sub_data:,
                                                  articles: article_dict)
-
-    DuplicateArticleDeleter.new(@wiki).resolve_duplicates_for_timeslices(@articles)
 
     # We need to partition revisions because we don't want to calculate scores for revisions
     # out of important spaces
@@ -67,6 +64,12 @@ class RevisionDataManager
   # Helpers #
   ###########
   private
+
+  def import_and_resolve_duplicate_articles(articles)
+    ArticleImporter.new(@wiki).import_articles_from_revision_data(articles)
+    @articles = Article.where(wiki_id: @wiki.id, mw_page_id: articles.map { |a| a['mw_page_id'] })
+    DuplicateArticleDeleter.new(@wiki).resolve_duplicates_for_timeslices(@articles)
+  end
 
   # Returns a list of revisions for users during the given period:
   # [all_sub_data, sub_data].

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -4,6 +4,7 @@ require_dependency "#{Rails.root}/lib/replica"
 require_dependency "#{Rails.root}/lib/importers/article_importer"
 require_dependency "#{Rails.root}/app/helpers/encoding_helper"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
+require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
 
 #= Fetches revision data from API
 class RevisionDataManager
@@ -44,8 +45,7 @@ class RevisionDataManager
                                                  scoped_sub_data:,
                                                  articles: article_dict)
 
-    # TODO: resolve duplicates
-    # DuplicateArticleDeleter.new(@wiki).resolve_duplicates(@articles)
+    DuplicateArticleDeleter.new(@wiki).resolve_duplicates_for_timeslices(@articles)
 
     # We need to partition revisions because we don't want to calculate scores for revisions
     # out of important spaces

--- a/spec/lib/duplicate_article_deleter_spec.rb
+++ b/spec/lib/duplicate_article_deleter_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require "#{Rails.root}/lib/duplicate_article_deleter"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
 
 describe DuplicateArticleDeleter do
   describe '.resolve_duplicates' do
@@ -77,6 +78,99 @@ describe DuplicateArticleDeleter do
       described_class.new.resolve_duplicates([deleted_article, duplicate_deleted_article])
       expect(deleted_article.reload.deleted).to eq(true)
       expect(duplicate_deleted_article.reload.deleted).to eq(true)
+    end
+  end
+
+  describe '.resolve_duplicates_for_timeslices' do
+    let(:en_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:deleted_article) do
+      create(:article, title: 'Columbian_exchange',
+                       namespace: 0,
+                       mw_page_id: 5589352,
+                       created_at: '2017-08-23',
+                       wiki: en_wiki,
+                       deleted: true)
+    end
+    let(:extant_article) do
+      create(:article, title: 'Columbian_exchange',
+                       namespace: 0,
+                       mw_page_id: 622746,
+                       created_at: '2017-12-08',
+                       wiki: en_wiki,
+                       deleted: false)
+    end
+    let(:duplicate_deleted_article) do
+      create(:article, title: 'Columbian_exchange',
+                       namespace: 0,
+                       mw_page_id: 622746,
+                       created_at: '2017-12-08',
+                       wiki: en_wiki,
+                       deleted: true)
+    end
+    let!(:new_article) do
+      create(:article,
+                     id: 2262715,
+                     title: 'Kostanay',
+                     namespace: 0,
+                     created_at: 1.day.from_now)
+    end
+    let!(:duplicate_article) do
+      create(:article,
+                      id: 46349871,
+                      title: 'Kostanay',
+                      namespace: 0,
+                      created_at: 1.day.ago)
+    end
+
+    it 'marks oldest one deleted when there are two ids for one page' do
+      described_class.new.resolve_duplicates_for_timeslices([new_article])
+      undeleted = Article.where(
+        title: 'Kostanay',
+        namespace: 0,
+        deleted: false
+      )
+
+      expect(undeleted.count).to eq(1)
+      expect(undeleted.first.id).to eq(new_article.id)
+    end
+
+    it 'does not mark any deleted when articles different in title case' do
+      first = create(:article,
+                     id: 123,
+                     title: 'Communicative_language_teaching',
+                     namespace: 0)
+      second = create(:article,
+                      id: 456,
+                      title: 'Communicative_Language_Teaching',
+                      namespace: 0)
+      described_class.new.resolve_duplicates_for_timeslices([first, second])
+      expect(first.reload.deleted).to eq(false)
+      expect(second.reload.deleted).to eq(false)
+    end
+
+    it 'marks does not end up leaving both articles deleted' do
+      described_class.new.resolve_duplicates_for_timeslices([deleted_article, extant_article])
+      expect(deleted_article.reload.deleted).to eq(true)
+      expect(extant_article.reload.deleted).to eq(false)
+    end
+
+    it 'does not error if all articles are already deleted' do
+      described_class.new.resolve_duplicates_for_timeslices([deleted_article,
+                                                             duplicate_deleted_article])
+      expect(deleted_article.reload.deleted).to eq(true)
+      expect(duplicate_deleted_article.reload.deleted).to eq(true)
+    end
+
+    it 'resets articles for all courses involved' do
+      course1 = create(:course)
+      course2 = create(:course, slug: 'Another course')
+
+      create(:articles_course, course_id: course1.id, article_id: new_article.id)
+      create(:articles_course, course_id: course2.id, article_id: duplicate_article.id)
+
+      expect(ArticlesCoursesCleanerTimeslice).to receive(:reset_specific_articles).once
+
+      described_class.new.resolve_duplicates_for_timeslices([new_article, extant_article])
     end
   end
 end

--- a/spec/lib/duplicate_article_deleter_spec.rb
+++ b/spec/lib/duplicate_article_deleter_spec.rb
@@ -109,17 +109,17 @@ describe DuplicateArticleDeleter do
     end
     let!(:new_article) do
       create(:article,
-                     id: 2262715,
-                     title: 'Kostanay',
-                     namespace: 0,
-                     created_at: 1.day.from_now)
+             id: 2262715,
+             title: 'Kostanay',
+             namespace: 0,
+             created_at: 1.day.from_now)
     end
     let!(:duplicate_article) do
       create(:article,
-                      id: 46349871,
-                      title: 'Kostanay',
-                      namespace: 0,
-                      created_at: 1.day.ago)
+             id: 46349871,
+             title: 'Kostanay',
+             namespace: 0,
+             created_at: 1.day.ago)
     end
 
     it 'marks oldest one deleted when there are two ids for one page' do


### PR DESCRIPTION
## What this PR does
This PR implements a new method called `resolve_duplicates_for_timeslices` that resolve duplicate articles in the timeslice world. If there are duplicate articles (that means, same wiki, title and namespace but different `mw_page_id`), then it marks all except for the newest article as 'deleted', and resets timeslices for all courses that have an article course for that article.

## Open questions and concerns
I ran some queries on the data-rearchitecture instance and it doesn't look like we have duplicate articles in the db.