### PR TITLE
Fix: Include require for histogram_plotter.rb in spec file

### DIFF
--- a/spec/lib/analytics/histogram_plotter_spec.rb
+++ b/spec/lib/analytics/histogram_plotter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/analytics/histogram_plotter.rb"
 
 describe HistogramPlotter do
   let(:course) do


### PR DESCRIPTION

## What this PR does
This PR adds a require statement for histogram_plotter.rb in the relevant spec file to ensure all dependencies are properly loaded during test execution. This prevents potential NameError or missing constant issues when running the test suite.

Changes:
Added `require "#{Rails.root}/lib/analytics/histogram_plotter.rb"` in the spec file

Don't know how this worked on CI , but it failed locally which is expected
