### PR TITLE
[Data rearchitecture] Fix minor bug in RevisionStatTimeslice

### DIFF
--- a/lib/revision_stat_timeslice.rb
+++ b/lib/revision_stat_timeslice.rb
@@ -7,7 +7,7 @@ class RevisionStatTimeslice
   def initialize(course, end_period = Time.zone.now)
     @course = course
     @end_period = end_period
-    @start_period = REVISION_TIMEFRAME.days.ago
+    @start_period = [REVISION_TIMEFRAME.days.ago, course.start].max
   end
 
   def recent_revisions_for_course


### PR DESCRIPTION
## What this PR does
This PR fixes a bug in `RevisionStatTimeslice`. Since the TIMEFRAME is set to 7 days, the `recent_revisions_for_courses_user` method fails if a course started yesterday because it attempts to retrieve a course wiki timeslice from seven days ago, which doesn't exist.

This fix ensures that the start period never references a date earlier than the course start date.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
