### PR TITLE
Fix: Prevents `MediawikiApi::ApiError Could not normalize image parameters filename.pdf. (urlparamnormal)` error

### DIFF
--- a/spec/lib/commons_spec.rb
+++ b/spec/lib/commons_spec.rb
@@ -145,17 +145,19 @@ describe Commons do
       end
     end
 
-    it 'does not fail for files that have placeholder thumbnails' do
+    it 'assigns a placeholder thumbnail for pdf and djvu files' do
       VCR.use_cassette 'commons/get_urls_with_placeholder_thumbnails' do
-        # MediaWiki can't generate a real thumbnail of this file.
-        # It used to cause a 'iiurlparamnormal' error, but since late February
-        # 2016, it fails gracefully with a placeholder image.
-        create(:commons_upload,
-               id: 28591020,
-               file_name: 'File:Jewish Encyclopedia Volume 6.pdf',
-               thumburl: nil)
-        response = described_class.get_urls(CommonsUpload.all)
-        expect(response).not_to be_empty
+        # MediaWiki can't generate thumbnails of .pdf / .djvu files,
+        # which causes a 'iiurlparamnormal' error, so placeholder
+        # thumbnail values are assigned to it instead
+        pdf_file = create(:commons_upload,
+                          id: 28591020,
+                          file_name: 'File:Jewish Encyclopedia Volume 6.pdf')
+        described_class.get_urls(CommonsUpload.all)
+        pdf_file.reload # ensures changes are saved to the database
+        expect(pdf_file.thumburl).to eq('https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/No_image_3x4.svg/200px-No_image_3x4.svg.png')
+        expect(pdf_file.thumbwidth).to eq('200')
+        expect(pdf_file.thumbheight).to eq('150')
       end
     end
   end


### PR DESCRIPTION
## What this PR does
Refactors `get_urls` method to assign placeholder thumbnails to `.pdf` and `.djvu` files and only query `mediawiki` accepted file formats and adds a `save_placeholder_thumbnail` method that assigns placeholder values
- Doing this solves the `MediawikiApi::ApiError: Could not normalize image parameters filename.pdf. (urlparamnormal)`

The logic used was derived from @ragesoss 's logic in this [commit](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/9bf97424b06bebae844a107d580d29b14138b4f3) used to solve issue #330 : 'Upload importer attempts to get thumbnails over and over for invalid files'. It was  later removed as per issue #699 : 'Commons spec is failing' in [this commit](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/5b2921db4537f31b8fcf7ba47180b62af2df0066) as `mediawiki` handled it. It has however resurfaced again.

## Screenshots
#### Before:

I tested a failing set of pageids:
![image](https://github.com/user-attachments/assets/a8e4d88d-2b5c-47ba-b0af-09a79359d404)

I then cloned the course that experienced the error: https://outreachdashboard.wmflabs.org/courses/Wikimedia_Indonesia/1Lib1Ref_di_Indonesia_Januari_2025/uploads and altered the code so the upload thumbnails would not be added and ran a manual update:

![before no thumbnail](https://github.com/user-attachments/assets/e5e7f909-8976-4fc1-9486-aa605a0a8729)

#### After refactoring:

![after yes thumbnail](https://github.com/user-attachments/assets/f3c8195a-71f8-4ee1-9333-8b386bea3192)

### Proof (logs / info) it works (I extracted snippets):

```
File:Van Dorp's Officieele Reisgids voor Spoor- en Tramswegen op Java (1900).pdf
[2025-02-08 17:05:36.119 DEBUG] CommonsUpload Load (5.5ms)  SELECT `commons_uploads`.* FROM `commons_uploads` WHERE `commons_uploads`.`file_name` = 'File:Van Dorp\'s Officieele Reisgids voor Spoor- en Tramswegen op Java (1900).pdf' LIMIT 1
#<CommonsUpload:0x00007f8958cc87e0>
[2025-02-08 17:05:36.209 DEBUG] TRANSACTION (0.3ms)  BEGIN
[2025-02-08 17:05:36.216 DEBUG] CommonsUpload Update (0.5ms)  UPDATE `commons_uploads` SET `commons_uploads`.`updated_at` = '2025-02-08 16:05:36', `commons_uploads`.`thumburl` = 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/No_image_3x4.svg/200px-No_image_3x4.svg.png', `commons_uploads`.`thumbwidth` = '200', `commons_uploads`.`thumbheight` = '150' WHERE `commons_uploads`.`id` = 158163184
[2025-02-08 17:05:36.250 DEBUG] TRANSACTION (2.6ms)  COMMIT
File:Van Dorp's Officieele Reisgids voor Spoor- en Tramswegen op Java (1898).pdf
[2025-02-08 17:05:36.268 DEBUG] CommonsUpload Load (0.9ms)  SELECT `commons_uploads`.* FROM `commons_uploads` WHERE `commons_uploads`.`file_name` = 'File:Van Dorp\'s Officieele Reisgids voor Spoor- en Tramswegen op Java (1898).pdf' LIMIT 1
#<CommonsUpload:0x00007f8958c743e8>
[2025-02-08 17:05:36.286 DEBUG] TRANSACTION (0.2ms)  BEGIN
[2025-02-08 17:05:36.292 DEBUG] CommonsUpload Update (0.4ms)  UPDATE `commons_uploads` SET `commons_uploads`.`updated_at` = '2025-02-08 16:05:36', `commons_uploads`.`thumburl` = 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/No_image_3x4.svg/200px-No_image_3x4.svg.png', `commons_uploads`.`thumbwidth` = '200', `commons_uploads`.`thumbheight` = '150' WHERE `commons_uploads`.`id` = 158163185
[2025-02-08 17:05:36.313 DEBUG] TRANSACTION (1.5ms)  COMMIT
File:Officieele reisgids der spoor- en tramwegen en aansluitende automobieldiensten op Java en Madoera (1935).pdf
[2025-02-08 17:05:36.329 DEBUG] CommonsUpload Load (0.9ms)  SELECT `commons_uploads`.* FROM `commons_uploads` WHERE `commons_uploads`.`file_name` = 'File:Officieele reisgids der spoor- en tramwegen en aansluitende automobieldiensten op Java en Madoera (1935).pdf' LIMIT 1
#<CommonsUpload:0x00007f8958c7d4e8>
[2025-02-08 17:05:36.345 DEBUG] TRANSACTION (0.2ms)  BEGIN
[2025-02-08 17:05:36.354 DEBUG] CommonsUpload Update (0.7ms)  UPDATE `commons_uploads` SET `commons_uploads`.`updated_at` = '2025-02-08 16:05:36', `commons_uploads`.`thumburl` = 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/No_image_3x4.svg/200px-No_image_3x4.svg.png', `commons_uploads`.`thumbwidth` = '200', `commons_uploads`.`thumbheight` = '150' WHERE `commons_uploads`.`id` = 158172982
[2025-02-08 17:05:36.380 DEBUG] TRANSACTION (1.6ms)  COMMIT

=> [{"pageid"=>158196457,
  "ns"=>6,
  "title"=>"File:Aerial view of Halte Bendo Kediri.tiff",
  "imagerepository"=>"local",
  "imageinfo"=>
   [{"thumburl"=>
      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Aerial_view_of_Halte_Bendo_Kediri.tiff/lossy-page1-480px-Aerial_view_of_Halte_Bendo_Kediri.tiff.jpg",
     "thumbwidth"=>480,
     "thumbheight"=>480,
     "responsiveUrls"=>
      {"1.5"=>
        "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Aerial_view_of_Halte_Bendo_Kediri.tiff/lossy-page1-720px-Aerial_view_of_Halte_Bendo_Kediri.tiff.jpg",
       "2"=>
        "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Aerial_view_of_Halte_Bendo_Kediri.tiff/lossy-page1-960px-Aerial_view_of_Halte_Bendo_Kediri.tiff.jpg"},
     "url"=>"https://upload.wikimedia.org/wikipedia/commons/0/0d/Aerial_view_of_Halte_Bendo_Kediri.tiff",
     "descriptionurl"=>"https://commons.wikimedia.org/wiki/File:Aerial_view_of_Halte_Bendo_Kediri.tiff",
     "descriptionshorturl"=>"https://commons.wikimedia.org/w/index.php?curid=158196457"}]},
     {"pageid"=>158445924,
  "ns"=>6,
  "title"=>"File:Foto uit een album over de suikeronderneming Pesantren - (cropped).png",
  "imagerepository"=>"local",
  "imageinfo"=>
   [{"thumburl"=>
      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png/854px-Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png",
     "thumbwidth"=>854,
     "thumbheight"=>480,
     "responsiveUrls"=>
      {"1.5"=>
        "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png/1281px-Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png",
       "2"=>"https://upload.wikimedia.org/wikipedia/commons/a/ac/Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png"},
     "url"=>"https://upload.wikimedia.org/wikipedia/commons/a/ac/Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png",
     "descriptionurl"=>"https://commons.wikimedia.org/wiki/File:Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_(cropped).png",
     "descriptionshorturl"=>"https://commons.wikimedia.org/w/index.php?curid=158445924"},
    {"thumburl"=>
      "https://upload.wikimedia.org/wikipedia/commons/archive/a/ac/20250124113940%21Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png",
     "thumbwidth"=>190,
     "thumbheight"=>135,
     "url"=>"https://upload.wikimedia.org/wikipedia/commons/archive/a/ac/20250124113940%21Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_%28cropped%29.png",
     "descriptionurl"=>"https://commons.wikimedia.org/wiki/File:Foto_uit_een_album_over_de_suikeronderneming_Pesantren_-_(cropped).png",
     "descriptionshorturl"=>"https://commons.wikimedia.org/w/index.php?curid=158445924"}]},
 {"pageid"=>158659677,
  "ns"=>6,
  "title"=>"File:LL-Q13324 (min)-Zhilal Darma-nabu.wav",
  "imagerepository"=>"local",
  "imageinfo"=>
   [{"thumburl"=>"https://commons.wikimedia.org/w/resources/assets/file-type-icons/fileicon-ogg.png",
     "thumbwidth"=>400,
     "thumbheight"=>400,
     "url"=>"https://upload.wikimedia.org/wikipedia/commons/5/5d/LL-Q13324_%28min%29-Zhilal_Darma-nabu.wav",
     "descriptionurl"=>"https://commons.wikimedia.org/wiki/File:LL-Q13324_(min)-Zhilal_Darma-nabu.wav",
     "descriptionshorturl"=>"https://commons.wikimedia.org/w/index.php?curid=158659677"}]},
```
     
     
### Test
Before:
![b4 fail](https://github.com/user-attachments/assets/0170f3d3-3f0a-49c9-9ad9-1f756e1c2ab3)
After:
![after pass](https://github.com/user-attachments/assets/9c738084-f3a2-4283-8cfe-4232ab8c13a4)

