### PR TITLE
[Data rearchitecture] fix minor bug in `UpdateTimeslicesCourseWiki`

### DIFF
--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -52,6 +52,7 @@ class UpdateTimeslicesCourseWiki
     @course.wikis.each do |wiki|
       start = @timeslice_manager.get_ingestion_start_time_for_wiki wiki
       timeslice = @course.course_wiki_timeslices.where(wiki:, start:).first
+      next unless timeslice
       effective_timeslice_duration = timeslice.end - timeslice.start
       real_timeslice_duration = @timeslice_manager.timeslice_duration(wiki)
       # Continue if timeslice duration didn't change for the wiki

--- a/spec/services/update_timeslices_course_wiki_spec.rb
+++ b/spec/services/update_timeslices_course_wiki_spec.rb
@@ -125,4 +125,10 @@ describe UpdateTimeslicesCourseWiki do
       expect(last_timeslice.end - last_timeslice.start).to eq(172800)
     end
   end
+
+  it 'doesnt fail if there are no timeslices for the ingestion start date' do
+    manager.create_timeslices_for_new_course_wiki_records([enwiki])
+    course.update(start: '2018-11-20')
+    described_class.new(course).run
+  end
 end


### PR DESCRIPTION
## What this PR does
This PR fixes a minor bug found in data-rearchitecture-for-dashboard instance. The error case was found when the course start date was changed to a previous date, without the course having any edit. Therefore, ingestion start date remained the same as course start, and the timeslice for that date had not yet been created when UpdateTimeslicesCourseWiki ran.

![image](https://github.com/user-attachments/assets/5c5be315-8ac3-4424-9a39-0e0b989b3078)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
