### PR TITLE
[Data rearchitecture] fix bug when creating timeslices

### DIFF
--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -29,6 +29,9 @@ class UpdateTimeslicesCourseDate
 
     return unless drastic_change
 
+    Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
+    Drastic date change. Recreating timeslices."
+
     remove_timeslices_prior_to_start_date
     remove_timeslices_after_end_date
     @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -133,7 +133,7 @@ class TimesliceManager
     old_start = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
                                    .minimum(:start)
     current_start = old_start - timeslice_duration(wiki)
-    while current_start >= @course.start
+    while current_start > @course.start - timeslice_duration(wiki)
       start_dates << current_start
       current_start -= timeslice_duration(wiki)
     end

--- a/spec/lib/article_status_manager_timeslice_spec.rb
+++ b/spec/lib/article_status_manager_timeslice_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 require "#{Rails.root}/lib/article_status_manager_timeslice"
 
 describe ArticleStatusManagerTimeslice do
-  before { stub_wiki_validation }
+  before do
+    stub_wiki_validation
+    stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
+  end
 
   # CHANGE THIS
   # For update_article_status_for_course, updated_at: 2.days.ago is used

--- a/spec/lib/articles_courses_cleaner_timeslice_spec.rb
+++ b/spec/lib/articles_courses_cleaner_timeslice_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe ArticlesCoursesCleanerTimeslice do
   let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
@@ -13,6 +14,8 @@ describe ArticlesCoursesCleanerTimeslice do
   let(:article2) { create(:article, wiki: wikidata) }
   let(:article3) { create(:article, wiki: wikidata, namespace: 3) }
   let(:article4) { create(:article, wiki: wikidata) }
+
+  before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
 
   describe '.clean_articles_courses_for_wiki_ids' do
     before do

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require "#{Rails.root}/lib/timeslice_cleaner"
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe TimesliceCleaner do
   let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
@@ -18,6 +19,7 @@ describe TimesliceCleaner do
 
   before do
     stub_wiki_validation
+    stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
     travel_to Date.new(2024, 1, 21)
     enwiki_course
     wikidata_course

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -18,6 +18,7 @@ describe TimesliceManager do
 
   before do
     stub_wiki_validation
+    allow(course).to receive(:flags).and_return({ timeslice_duration: { default: 86400 } })
     travel_to Date.new(2024, 1, 21)
     enwiki_course
     wikidata_course
@@ -71,7 +72,7 @@ describe TimesliceManager do
 
         timeslice_manager.create_wiki_timeslices_for_new_course_start_date(wikibooks)
         course.reload
-        # Create course and user timeslices for the period between 2023-12-20 and 2024-01-01
+        # Create course timeslices for the period between 2023-12-20 and 2024-01-01
         expect(course.course_wiki_timeslices.size).to eq(123)
         expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(12)
       end

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -18,7 +18,7 @@ describe TimesliceManager do
 
   before do
     stub_wiki_validation
-    allow(course).to receive(:flags).and_return({ timeslice_duration: { default: 86400 } })
+    stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
     travel_to Date.new(2024, 1, 21)
     enwiki_course
     wikidata_course

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -22,6 +22,8 @@ require 'rails_helper'
 require "#{Rails.root}/lib/timeslice_manager"
 
 describe CourseUserWikiTimeslice, type: :model do
+  before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
+
   let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:refs_tags_key) { 'feature.wikitext.revision.ref_tags' }
   let(:user) { create(:user, username: 'User') }

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe UpdateCourseStatsTimeslice do
+  before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
+
   let(:course) { create(:course, start: '2018-11-24', end: '2018-11-30', flags:) }
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -16,6 +16,7 @@ describe UpdateCourseWikiTimeslices do
 
   before do
     stub_wiki_validation
+    stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
     travel_to Date.new(2018, 12, 1)
     course.campaigns << Campaign.first
     course.wikis << Wiki.get_or_create(language: nil, project: 'wikidata')

--- a/spec/services/update_timeslices_course_date_spec.rb
+++ b/spec/services/update_timeslices_course_date_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe UpdateTimeslicesCourseDate do
   let(:start) { '2021-01-24'.to_datetime }
@@ -15,6 +16,7 @@ describe UpdateTimeslicesCourseDate do
 
   before do
     stub_wiki_validation
+    stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
     # Add two users
     course.campaigns << Campaign.first
     JoinCourse.new(course:, user: user1, role: 0)

--- a/spec/services/update_timeslices_course_user_spec.rb
+++ b/spec/services/update_timeslices_course_user_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe UpdateTimeslicesCourseUser do
+  before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
+
   let(:start) { '2021-01-24'.to_datetime }
   let(:course) { create(:course, start:, end: '2021-01-30') }
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }

--- a/spec/services/update_timeslices_course_wiki_spec.rb
+++ b/spec/services/update_timeslices_course_wiki_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe UpdateTimeslicesCourseWiki do
+  before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
+
   let(:course) { create(:course, start: '2018-11-24', end: '2018-11-30') }
   let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }

--- a/spec/services/update_timeslices_scoped_article_spec.rb
+++ b/spec/services/update_timeslices_scoped_article_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe UpdateTimeslicesScopedArticle do
+  before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
+
   let(:course) { create(:article_scoped_program) }
   let(:basic_course) { create(:course) }
   let(:assigned_article) { create(:article, title: 'Assigned', id: 2, namespace: 0) }

--- a/spec/services/update_timeslices_untracked_article_spec.rb
+++ b/spec/services/update_timeslices_untracked_article_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/timeslice_manager"
 
 describe UpdateTimeslicesUntrackedArticle do
   let(:start) { '2021-01-24'.to_datetime }
@@ -17,6 +18,7 @@ describe UpdateTimeslicesUntrackedArticle do
 
   before do
     stub_wiki_validation
+    stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
     # Add two users
     course.campaigns << Campaign.first
     JoinCourse.new(course:, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)


### PR DESCRIPTION
## What this PR does
This PR fixes a bug when creating timeslices due to a change in the start date. It worked fine for daily timeslices, but failed for 10-day timeslices. Now it should work fine no matter the tiemslice duration.

In addition, it stubs the `TIMESLICE_DURATION` env variable to be one day (86400 seconds) in several specs so they work no matter how the envvar is set.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
