### PR TITLE
Fix: Issue with high_quality_article_monitor_spec

### DIFF
--- a/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
+++ b/spec/lib/alerts/discretionary_sanctions_monitor_spec.rb
@@ -9,11 +9,8 @@ end
 
 describe DiscretionarySanctionsMonitor do
   describe '.create_alerts_for_course_articles' do
-    let(:course) do
-      travel_to Date.new(2025, 1, 20) do
-        create(:course, start: '2024-12-10', end: Date.new(2025, 1, 20))
-      end
-    end
+    let(:course) { create(:course, start: '2024-12-10', end: '2025-01-20') }
+
     let(:student) { create(:user, username: 'Gelasin') }
     let!(:courses_user) do
       create(:courses_user, user_id: student.id,
@@ -43,11 +40,16 @@ describe DiscretionarySanctionsMonitor do
     end
 
     before do
+      travel_to Time.zone.local(2024, 12, 20, 0o1, 0o4, 44)
       allow_any_instance_of(CategoryImporter).to receive(:page_titles_for_category)
         .with('Category:Wikipedia pages about contentious topics', 1)
         .and_return(['Talk:1948 war',
                      'Talk:Ahmed Mohamed clock incident',
                      'Talk:Armenian Genocide denial'])
+    end
+
+    after do
+      travel_back
     end
 
     it 'creates Alert records for assignments and edited articles under discretionary sanctions' do

--- a/spec/lib/alerts/high_quality_article_monitor_spec.rb
+++ b/spec/lib/alerts/high_quality_article_monitor_spec.rb
@@ -5,11 +5,7 @@ require "#{Rails.root}/lib/alerts/high_quality_article_monitor"
 
 describe HighQualityArticleMonitor do
   describe '.create_alerts_for_course_articles' do
-    let(:course) do
-      travel_to Date.new(2025, 1, 10) do
-        create(:course, start: '2024-01-01', end: Date.new(2025, 1, 10))
-      end
-    end
+    let(:course)  { create(:course, start: '2024-01-01', end: '2025-01-01') }
     let(:student) { create(:user, username: 'Leemyongpak', email: 'learn@school.edu') }
     let(:instructor) { create(:user, username: 'instructor', email: 'teach@school.edu') }
     let!(:courses_user) do
@@ -37,6 +33,7 @@ describe HighQualityArticleMonitor do
     end
 
     before do
+      travel_to Time.zone.local(2024, 0o5, 11, 0o1, 0o4, 44)
       create(:courses_user, course:, user: instructor,
                             role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
 
@@ -50,6 +47,10 @@ describe HighQualityArticleMonitor do
         .and_return(["Petter's big-footed mouse",
                      'Phan Đình Phùng',
                      'The Phantom Tollbooth'])
+    end
+
+    after do
+      travel_back
     end
 
     it 'creates Alert records for edited Good articles' do


### PR DESCRIPTION

## What this PR does
This PR addresses the recent [CI build failure](https://github.com/WikiEducationFoundation/WikiEduDashboard/actions/runs/13120619294/job/36605410577) and improves upon the previous [fix](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6172), which was inefficient.

### Issue with the Previous Fix:
- The **`travel_to`** helper method was only applied when creating the course, meaning that subsequent interactions in the test used the **current system time** instead of the **intended past time**. This caused failures when the test logic compared dates, as the current time was beyond the course end date. 

- The previous fix also relied on` Date.new`, which does not account for time zones, making it ineffective for this scenario.

### Improvements in This Fix:

- Replaced Date.new with Time.zone.local  which is Rails-specific and handle time zones .
- Moved `travel_to` into the before block to ensure that all test interactions occur within the correct time frame.
- Ensured proper reset to the system time after the test completes using  `travel_back`   method .

<img width="1278" alt="Screenshot 2025-02-10 at 21 24 06" src="https://github.com/user-attachments/assets/7024d40f-401b-48a7-8303-a243260e422b" />







This fix travels to a time between the **start and end date** to  ensures that all test blocks operate within the intended date context, leading to more reliable and consistent test execution.

A detail explanation of how these helpers work is found [here](https://api.rubyonrails.org/v5.2.1/classes/ActiveSupport/Testing/TimeHelpers.html)


@gabina , your assumption about how travel_to was used previously is correct. Thank you for your input