### PR TITLE
Adds rescue block in StudentGreetingChecker's `talk_page_blank?`

### DIFF
--- a/lib/student_greeting_checker.rb
+++ b/lib/student_greeting_checker.rb
@@ -45,6 +45,9 @@ class StudentGreetingChecker
     def talk_page_blank?
       # Non-existent pages will return '', but API errors will return nil
       WikiApi.new(@wiki).get_page_content(@student.talk_page) == ''
+    rescue WikiApi::PageFetchError => e
+      return true if e.status == 429
+      raise e
     end
 
     def contributors_to_page(page_title)

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -124,7 +124,10 @@ class WikiApi
   end
 
   class PageFetchError < StandardError
+    attr_reader :status
+
     def initialize(page, status)
+      @status = status
       message = "Failed to fetch content for #{page} with response status: #{status.inspect}"
       super(message)
     end

--- a/spec/lib/student_greeting_checker_spec.rb
+++ b/spec/lib/student_greeting_checker_spec.rb
@@ -43,5 +43,21 @@ describe StudentGreetingChecker do
       subject
       expect(User.find(2).greeted).to eq(true)
     end
+
+    describe '.check' do
+      let(:course) { Course.find(1) }
+      let(:wiki) { course.home_wiki }
+      let(:greeters) { [User.find(1)] }
+      let(:checker) { StudentGreetingChecker::Check.new(User.find(2), wiki, greeters) }
+
+      describe '#talk_page_blank?' do
+        it 'returns true when a PageFetchError with status 429 is raised' do
+          allow_any_instance_of(WikiApi).to receive(:get_page_content)
+            .and_raise(WikiApi::PageFetchError.new('User:Ragesoss', 429))
+
+          expect(checker.send(:talk_page_blank?)).to eq(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What this PR does
- Adds rescue block in `talk_page_blank?` method to return true if wiki_api `get_page_content` raises a `PageFetchError` with status `429`
- Stores the `response.status` as an instance variable in PageFetchError and make it accessible

## Screenshots
Before adding rescue block:
![image](https://github.com/user-attachments/assets/71b3caad-f140-4e91-be50-ec54d270cdae)

After adding rescue but before adding status as an instance variable in the `PageFetchError` definition:
![image](https://github.com/user-attachments/assets/588a5627-2451-49b1-8eb7-3df108d598b1)

After:
![image](https://github.com/user-attachments/assets/69e753c9-0af4-499e-9298-3cd5a2e9f4e4)

