### PR TITLE
Chore: Add pre-commit hook for linting checks (Rubocop)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Notify that the pre-commit hook is running
+echo "Pre-commit hook is running..."
+
+# Run Rubocop with parallel processing
+bundle exec rubocop --parallel
+
+# Check the status of Rubocop
+if [ $? -ne 0 ]; then
+  echo "🔴 Linting failed! Please fix the offenses before committing."
+  echo "You can run 'bundle exec rubocop -a' to auto-correct the issues."
+  exit 1
+fi
+
+# Notify that there are no linting issues and the commit can proceed
+echo "✅ No linting issues found. Proceeding with commit.\n"

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-# Notify that the pre-commit hook is running
-echo "Pre-commit hook is running..."
+echo "⚡ Pre-commit hook is running..."
 
 # Run Rubocop with parallel processing
 bundle exec rubocop --parallel
 
 # Check the status of Rubocop
 if [ $? -ne 0 ]; then
-  echo "🔴 Linting failed! Please fix the offenses before committing."
+  echo -e "🔴 Linting failed! Please fix the offenses before committing."
   echo "You can run 'bundle exec rubocop -a' to auto-correct the issues."
   exit 1
 fi
 
-# Notify that there are no linting issues and the commit can proceed
-echo "✅ No linting issues found. Proceeding with commit.\n"
+echo -e "🟢 No linting issues found. Proceeding with commit.\n"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -76,8 +76,11 @@ If you know your way around Rails, here's the very short version. Some additiona
 10. **Building assets:**
       * `yarn start` to built the development version
       * `yarn build` to generate the production version
-11. Finally, start rails with `guard` or `rails s`and open http://localhost:3000 in a web browser.
-12. Now, you're up and running!!
+11. (Recommended) Configure Git
+      * `git config core.hooksPath .git-hooks` to recognize the .git-hooks directory as the hooks directory
+      * `chmod +x .git-hooks/pre-commit` to make the pre-commit hook executable
+12. Finally, start rails with `guard` or `rails s`and open http://localhost:3000 in a web browser.
+13. Now, you're up and running!!
 
 ## Detailed instructions
 
@@ -148,6 +151,13 @@ If you know your way around Rails, here's the very short version. Some additiona
 
 - (Optional) Set up a [`post-merge`](https://git-scm.com/docs/githooks#_post_merge) hook to update all dependencies if `package.json` or `Gemfile` changes.
   - Copy `.git-hooks/pull-update-deps` to `.git/hooks/post-merge`
+
+- (Recommended) Set up a [`pre-commit`](https://git-scm.com/docs/githooks#_pre-commit) hook to run linting before making a commit
+  - `git config core.hooksPath .git-hooks` Configure Git to recognize the .git-hooks directory as the hooks directory
+  - `chmod +x .git-hooks/pre-commit` Make the pre-commit hook executable
+  
+
+
 ## Initialize
 1. **Migrate the development and test databases**
   - $ `rake db:migrate`


### PR DESCRIPTION

## What this PR does
To improve the development process and reduce build times, I have added a pre-commit hook that runs `bundle exec rubocop --parallel ` to check for any linting offenses before committing. This allows developers to catch and fix issues locally, preventing unnecessary build failures in the CI pipeline due to code style violations.

With this pre-commit hook in place, developers will now be prompted to fix any linting issues before committing their code. This enhances the development workflow by minimizing delays caused by having to re-run the CI build.

## Screenshots
Before:
<img width="1289" alt="Screenshot 2025-02-12 at 13 20 24" src="https://github.com/user-attachments/assets/7e5e6634-b389-49b0-bebb-75e1272bc348" />


<img width="1292" alt="Screenshot 2025-02-12 at 13 20 56" src="https://github.com/user-attachments/assets/8b20d696-34f5-4d79-ae30-975f5de52cc5" />


After:

<img width="1278" alt="Screenshot 2025-02-12 at 13 21 42" src="https://github.com/user-attachments/assets/e90c3e20-62eb-472d-bfc7-f5ff8be2b787" />

## Open questions and concerns
- Since Git recognizes hooks in the `.git/hooks` directory by default, and not `.git-hooks`, I had to configure Git to recognize the .git-hooks directory by running the following command, 
`git config core.hooksPath .git-hooks` and changing the mode to executable  `chmod +x .git-hooks/pre-commit`

- Is it preferable to include instructions for configuring the pre-commit and  changing the mode of the pre-commit file in the documentation, or should we automate this setup (perhaps via a script) to ensure consistency across all clones of the repository?

