### PR TITLE
add is_monday_start option to course creation and cloning.

### DIFF
--- a/app/assets/javascripts/components/common/calendar.jsx
+++ b/app/assets/javascripts/components/common/calendar.jsx
@@ -75,7 +75,8 @@ const Calendar = createReactClass({
     } else {
       weekdays = toPass.weekdays.split('');
     }
-    weekdays[weekday] = weekdays[weekday] === '1' ? '0' : '1';
+    const adjustedWeekDay = this.props.course.flags.is_monday_start ? (weekday + 1) % 7 : weekday;
+    weekdays[adjustedWeekDay] = weekdays[adjustedWeekDay] === '1' ? '0' : '1';
     toPass.weekdays = weekdays.join('');
     return this.props.updateCourse(toPass);
   },
@@ -146,7 +147,6 @@ const Calendar = createReactClass({
       }
     }
 
-
     const onWeekdayClick = this.props.editable ? this.selectWeekday : null;
     const onDayClick = this.props.editable ? this.selectDay : null;
 
@@ -157,6 +157,7 @@ const Calendar = createReactClass({
           <WeekdayPicker
             modifiers={modifiers}
             onWeekdayClick={onWeekdayClick}
+            is_monday_start={this.props.course.flags.is_monday_start}
           />
         </div>
         <hr />
@@ -167,6 +168,7 @@ const Calendar = createReactClass({
               modifiers={modifiers}
               onDayClick={onDayClick}
               initialMonth={this.state.initialMonth}
+              firstDayOfWeek={this.props.course.flags.is_monday_start ? 1 : 0}
             />
             <div className="course-dates__calendar-key">
               <h3>{I18n.t('courses.calendar.legend')}</h3>

--- a/app/assets/javascripts/components/common/date_picker.jsx
+++ b/app/assets/javascripts/components/common/date_picker.jsx
@@ -34,7 +34,8 @@ const DatePicker = createReactClass({
     onClick: PropTypes.func,
     append: PropTypes.string,
     date_props: PropTypes.object,
-    showTime: PropTypes.bool
+    showTime: PropTypes.bool,
+    is_monday_start: PropTypes.bool
   },
 
   getDefaultProps() {
@@ -291,7 +292,6 @@ const DatePicker = createReactClass({
             onKeyDown={this.handleDateFieldKeyDown}
             placeholder={this.props.placeholder}
           />
-
           <DayPicker
             className={this.state.datePickerVisible ? 'DayPicker--visible ignore-react-onclickoutside' : null}
             ref="daypicker"
@@ -300,6 +300,7 @@ const DatePicker = createReactClass({
             disabledDays={this.isDayDisabled}
             onDayClick={this.handleDatePickerChange}
             month={currentMonth}
+            firstDayOfWeek={this.props.is_monday_start ? 1 : 0}
           />
         </div>
       );

--- a/app/assets/javascripts/components/common/weekday_picker.jsx
+++ b/app/assets/javascripts/components/common/weekday_picker.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const WEEKDAYS_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-const WEEKDAYS_SHORT = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const WEEKDAYS_LONG = {
+  sundayStart: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  mondayStart: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+};
+
+const WEEKDAYS_SHORT = {
+  sundayStart: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+  mondayStart: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+};
 
 const localeUtils = {
-  formatWeekdayLong(weekday) {
-    return WEEKDAYS_LONG[weekday];
+  formatWeekdayLong(weekday, is_monday_start) {
+    return is_monday_start ? WEEKDAYS_LONG.mondayStart[weekday] : WEEKDAYS_LONG.sundayStart[weekday];
   },
-  formatWeekdayShort(weekday) {
-    return WEEKDAYS_SHORT[weekday];
+  formatWeekdayShort(weekday, is_monday_start) {
+    return is_monday_start ? WEEKDAYS_SHORT.mondayStart[weekday] : WEEKDAYS_SHORT.sundayStart[weekday];
   }
 };
 
@@ -26,6 +33,8 @@ const WeekdayPicker = ({
   tabIndex,
 
   modifiers,
+
+  is_monday_start,
 
   locale,
   onWeekdayClick,
@@ -138,7 +147,8 @@ const WeekdayPicker = ({
     let customModifiers = [];
 
     if (modifiers) {
-      const propModifiers = getModifiersForDay(weekday, modifiers);
+      const adjustedWeekDay = is_monday_start ? (weekday + 1) % 7 : weekday;
+      const propModifiers = getModifiersForDay(adjustedWeekDay, modifiers);
       customModifiers = [...customModifiers, ...propModifiers];
     }
 
@@ -159,12 +169,12 @@ const WeekdayPicker = ({
     const onMouseLeaveHandler = onWeekdayMouseLeave ? e => handleWeekdayMouseLeave(e, weekday, customModifiers) : null;
 
     const ariaLabelMessage = ariaSelected
-      ? I18n.t('weekday_picker.aria.weekday_selected', { weekday: localeUtils.formatWeekdayLong(weekday), })
-      : I18n.t('weekday_picker.aria.weekday_select', { weekday: localeUtils.formatWeekdayLong(weekday), });
+      ? I18n.t('weekday_picker.aria.weekday_selected', { weekday: localeUtils.formatWeekdayLong(weekday, is_monday_start), })
+      : I18n.t('weekday_picker.aria.weekday_select', { weekday: localeUtils.formatWeekdayLong(weekday, is_monday_start), });
 
     const ariaLiveMessage = ariaSelected
-      ? I18n.t('weekday_picker.aria.weekday_selected', { weekday: localeUtils.formatWeekdayLong(weekday), })
-      : I18n.t('weekday_picker.aria.weekday_unselected', { weekday: localeUtils.formatWeekdayLong(weekday), });
+      ? I18n.t('weekday_picker.aria.weekday_selected', { weekday: localeUtils.formatWeekdayLong(weekday, is_monday_start), })
+      : I18n.t('weekday_picker.aria.weekday_unselected', { weekday: localeUtils.formatWeekdayLong(weekday, is_monday_start), });
 
     return (
       <button
@@ -177,8 +187,8 @@ const WeekdayPicker = ({
         onMouseEnter={onMouseEnterHandler}
         onMouseLeave={onMouseLeaveHandler}
       >
-        <span title={localeUtils.formatWeekdayLong(weekday)}>
-          {localeUtils.formatWeekdayShort(weekday)}
+        <span title={localeUtils.formatWeekdayLong(weekday, is_monday_start)}>
+          {localeUtils.formatWeekdayShort(weekday, is_monday_start)}
         </span>
         {/* Aria-live region for screen reader announcements for confirmation of when a week day is selected or unselected */}
         <div aria-live="assertive" aria-atomic="true" className="sr-WeekdayPicker-aria-live">
@@ -215,6 +225,8 @@ WeekdayPicker.propTypes = {
   tabIndex: PropTypes.number,
 
   modifiers: PropTypes.object,
+
+  is_monday_start: PropTypes.bool,
 
   locale: PropTypes.string,
   onWeekdayClick: PropTypes.func,

--- a/app/assets/javascripts/components/course_creator/course_creator.jsx
+++ b/app/assets/javascripts/components/course_creator/course_creator.jsx
@@ -481,6 +481,7 @@ const CourseCreator = createReactClass({
               showEventDatesState={this.state.showEventDates}
               stringPrefix={this.state.course_string_prefix}
               updateCourseProps={this.props.updateCourse}
+              updateCourseAction={this.updateCourse}
               enableTimeline={this.props.courseCreator.useStartAndEndTimes}
               // the following properties are only required when scopingModalEnabled is enabled
               // that is, when the selected course type is ArticleScopedProgram

--- a/app/assets/javascripts/components/course_creator/course_dates.jsx
+++ b/app/assets/javascripts/components/course_creator/course_dates.jsx
@@ -11,6 +11,12 @@ const CourseDates = (props) => {
     props.updateCourseProps(updatedCourse);
     setHasUpdatedDateProps(true);
   };
+
+  const handleCalendarStartDayChange = (e) => {
+    const value = e.target.value === '1';
+    props.updateCourseProps({ is_monday_start: value });
+    props.updateCourseAction('is_monday_start', value);
+  };
   const dateProps = CourseDateUtils.dateProps(props.course);
   const timeZoneMessage = (
     <p className="form-help-text">
@@ -34,6 +40,7 @@ const CourseDates = (props) => {
         id="course_timeline_start"
         onChange={updateCourseDates}
         value={props.course.timeline_start}
+        isMondayStart={props.course.is_monday_start}
         value_key="timeline_start"
         editable
         label={CourseUtils.i18n('creator.assignment_start', props.stringPrefix)}
@@ -51,6 +58,7 @@ const CourseDates = (props) => {
         id="course_timeline_end"
         onChange={updateCourseDates}
         value={props.course.timeline_end}
+        isMondayStart={props.course.is_monday_start}
         value_key="timeline_end"
         editable
         label={CourseUtils.i18n('creator.assignment_end', props.stringPrefix)}
@@ -64,11 +72,26 @@ const CourseDates = (props) => {
       />
     );
   }
+
+  const calendarDropdown = (
+    <div>
+      <p><strong>Select a Day for the calendar:</strong></p>
+      <select onChange={handleCalendarStartDayChange} value={props.course.is_monday_start ? '1' : '0'}>
+        <option value="none" disabled>Select Option</option>
+        <option value="0">Sunday - Saturday</option>
+        <option value="1">Monday - Sunday</option>
+      </select>
+    </div>
+  );
+
   return (
     <div className={props.courseDateClass}>
       <p>{CourseUtils.i18n('creator.course_dates_info', props.stringPrefix)}</p>
+      {calendarDropdown}
+      {/*  The key ensures the component re-renders when the is_monday_start value changes */}
       <DatePicker
         id="course_start"
+        key={`course_start_${props.course.is_monday_start}`}
         onChange={updateCourseDates}
         value={props.course.start}
         value_key="start"
@@ -79,9 +102,11 @@ const CourseDates = (props) => {
         blank
         isClearable={false}
         showTime={props.showTimeValues}
+        is_monday_start={props.course.is_monday_start}
       />
       <DatePicker
         id="course_end"
+        key={`course_end_${props.course.is_monday_start}`}
         onChange={updateCourseDates}
         value={props.course.end}
         value_key="end"
@@ -95,6 +120,7 @@ const CourseDates = (props) => {
         isClearable={false}
         showTime={props.showTimeValues}
         rerenderHoc={hasUpdatedDateProps}
+        is_monday_start={props.course.is_monday_start}
       />
       {timelineText}
       {timelineStart}

--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -153,10 +153,13 @@ const CourseClonedModal = createReactClass({
     return true;
   },
 
+
   render() {
     const i18nPrefix = this.props.course.string_prefix;
     let buttonClass = 'button dark';
     buttonClass += this.state.isPersisting ? ' working' : '';
+
+    console.log('I am in this ', this.props.course);
 
     let errorMessage;
     if (this.props.firstErrorMessage) {
@@ -223,6 +226,7 @@ const CourseClonedModal = createReactClass({
             placeholder={I18n.t('courses.creator.start_date_placeholder')}
             validation={CourseDateUtils.isDateValid}
             isClearable={false}
+            is_monday_start={this.state.course.flags.is_monday_start}
           />
           <DatePicker
             id="course_end"
@@ -238,6 +242,7 @@ const CourseClonedModal = createReactClass({
             validation={CourseDateUtils.isDateValid}
             enabled={Boolean(this.state.course.start)}
             isClearable={false}
+            is_monday_start={this.state.course.flags.is_monday_start}
           />
           <DatePicker
             id="timeline_start"
@@ -252,6 +257,7 @@ const CourseClonedModal = createReactClass({
             validation={CourseDateUtils.isDateValid}
             enabled={Boolean(this.state.course.start)}
             isClearable={false}
+            is_monday_start={this.state.course.flags.is_monday_start}
           />
           <DatePicker
             id="timeline_end"
@@ -266,6 +272,7 @@ const CourseClonedModal = createReactClass({
             validation={CourseDateUtils.isDateValid}
             enabled={Boolean(this.state.course.start)}
             isClearable={false}
+            is_monday_start={this.state.course.flags.is_monday_start}
           />
         </div>
       );

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -55,6 +55,7 @@ const FormPanel = (props) => {
             editable={true}
             validation={CourseDateUtils.isDateValid}
             label="Course Start"
+            is_monday_start={props.course.flags.is_monday_start}
           />
           <DatePicker
             onChange={updateCourseDates}
@@ -65,6 +66,7 @@ const FormPanel = (props) => {
             label="Course End"
             date_props={dateProps.end}
             enabled={Boolean(props.course.start)}
+            is_monday_start={props.course.flags.is_monday_start}
           />
         </div>
       </div>
@@ -80,6 +82,7 @@ const FormPanel = (props) => {
             validation={CourseDateUtils.isDateValid}
             label={I18n.t('courses.assignment_start')}
             date_props={dateProps.timeline_start}
+            is_monday_start={props.course.flags.is_monday_start}
           />
           <DatePicker
             onChange={updateCourseDates}
@@ -90,6 +93,7 @@ const FormPanel = (props) => {
             label={I18n.t('courses.assignment_end')}
             date_props={dateProps.timeline_end}
             enabled={Boolean(props.course.start)}
+            is_monday_start={props.course.flags.is_monday_start}
           />
         </div>
       </div>

--- a/app/assets/javascripts/reducers/course.js
+++ b/app/assets/javascripts/reducers/course.js
@@ -33,6 +33,7 @@ const initialState = {
   home_wiki: { language: 'en', project: 'wikipedia' },
   day_exceptions: '',
   weekdays: '0000000',
+  is_monday_start: false,
   editingSyllabus: false,
   training_library_slug: 'students',
   loading: true,

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -405,6 +405,11 @@ class CoursesController < ApplicationController
     @course.save
   end
 
+  def update_course_calendar_view
+    @course.flags[:is_monday_start] = params.dig(:course, :is_monday_start)
+    @course.save
+  end
+
   def update_last_reviewed
     username = params.dig(:course, 'last_reviewed', 'username')
     timestamp = params.dig(:course, 'last_reviewed', 'timestamp')
@@ -421,6 +426,7 @@ class CoursesController < ApplicationController
     update_course_wiki_namespaces
     update_academic_system
     update_course_format
+    update_course_calendar_view
   end
 
   def course_params

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -152,7 +152,8 @@ class CourseCloneManager
     :peer_review_count,
     :retain_available_articles,
     :stay_in_sandbox,
-    :no_sandboxes
+    :no_sandboxes,
+    :is_monday_start
   ].freeze
   def add_flags
     FLAGS_TO_CARRY_OVER.each do |flag_key|


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

#5689

## What this PR does
This PR adds the `is_monday_start` flag to the course model, allowing the system to track whether a course follows a Monday–Sunday or a Sunday–Saturday schedule.

## Screenshots
Before:
https://github.com/user-attachments/assets/eb5b308f-9f44-424d-8c24-6d05ed832123
After:

course creation 
https://github.com/user-attachments/assets/c972ef0b-ba9b-4ab9-beb6-b8afea4e3a86

course cloning 

https://github.com/user-attachments/assets/d966ed36-bb5a-4a1f-bc05-4882749bcb97
