### PR TITLE
 [Data rearchitecture] Remove `article_course_timeslice_by_tracked` index

### DIFF
--- a/db/migrate/20240522233334_create_article_course_timeslices.rb
+++ b/db/migrate/20240522233334_create_article_course_timeslices.rb
@@ -23,9 +23,5 @@ class CreateArticleCourseTimeslices < ActiveRecord::Migration[7.0]
     add_index :article_course_timeslices,
               [:course_id, :updated_at, :article_id],
               name: 'article_course_timeslice_by_updated_at'
-
-    add_index :article_course_timeslices,
-              [:course_id, :tracked],
-              name: 'article_course_timeslice_by_tracked'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,7 +46,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["article_id", "course_id", "start", "end"], name: "article_course_timeslice_by_article_course_start_and_end", unique: true
-    t.index ["course_id", "tracked"], name: "article_course_timeslice_by_tracked"
     t.index ["course_id", "updated_at", "article_id"], name: "article_course_timeslice_by_updated_at"
   end
 


### PR DESCRIPTION
## What this PR does
Remove `article_course_timeslice_by_tracked` index because it's not used according to index stats

I enabled `userstat` and checked `SHOW INDEX_STATISTICS;`.  `article_course_timeslice_by_tracked` index didn't seem to be very useful. We can add better indexes analyzing slow queries once this is deployed to production.


