### PR TITLE
[Data rearchitecture] Address sage reviews

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -348,7 +348,7 @@ class Course < ApplicationRecord
 
   # The default implemention retrieves all the revisions.
   # A course type may override this implementation.
-  def filter_revisions(revisions)
+  def filter_revisions(_wiki, revisions)
     revisions
   end
 

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -180,7 +180,7 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.update_from_course_revisions(course, revisions)
-    revisions = revisions.select(&:scoped_revision)
+    revisions = revisions.select(&:scoped)
     course_article_ids = course.articles.where(wiki: course.wikis).pluck(:id)
     revision_article_ids = article_ids_by_namespaces_from_revisions(course, revisions)
 

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -77,9 +77,8 @@ class ArticleScopedProgram < Course
     false
   end
 
-  def filter_revisions(revisions)
+  def filter_revisions(wiki, revisions)
     filtered_data = revisions.select do |_, details|
-      wiki = Wiki.find(details['article']['wiki_id'])
       article_title = details['article']['title']
       formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
       scoped_article_titles.include?(formatted_article_title)

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -76,9 +76,8 @@ class VisitingScholarship < Course
     true
   end
 
-  def filter_revisions(revisions)
+  def filter_revisions(wiki, revisions)
     filtered_data = revisions.select do |_, details|
-      wiki = Wiki.find(details['article']['wiki_id'])
       article_title = details['article']['title']
       formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
       scoped_article_titles.include?(formatted_article_title)

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -50,7 +50,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
                        .for_revisions_between(rev_start, rev_end)
     timeslices.each do |timeslice|
       # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select(&:scoped_revision).select do |revision|
+      revisions_in_timeslice = revisions[:revisions].select(&:scoped).select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
       # Get or create article course timeslice based on course, article_id,

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -120,6 +120,6 @@ class CourseWikiTimeslice < ApplicationRecord
   end
 
   def update_needs_update
-    self.needs_update = !@revisions.select(&:revision_with_error).empty?
+    self.needs_update = @revisions.any?(&:error)
   end
 end

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -52,7 +52,7 @@ class CourseWikiTimeslice < ApplicationRecord
                                                 .for_revisions_between(rev_start, rev_end)
     course_wiki_timeslices.each do |timeslice|
       # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select(&:scoped_revision).select do |revision|
+      revisions_in_timeslice = revisions[:revisions].select(&:scoped).select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
       # Update cache for CourseWikiTimeslice

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -43,7 +43,7 @@ class Revision < ApplicationRecord
   serialize :features, Hash
   serialize :features_previous, Hash
 
-  attr_accessor :scoped
+  attr_accessor :scoped, :error
 
   include ArticleHelper
 
@@ -108,9 +108,5 @@ class Revision < ApplicationRecord
     JSON.parse(summary) if summary.present? && summary.start_with?('{', '[')
   rescue JSON::ParserError
     nil # Return nil if parsing fails (i.e., not diff_stats)
-  end
-
-  def revision_with_error
-    !ithenticate_id.nil?
   end
 end

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -43,6 +43,8 @@ class Revision < ApplicationRecord
   serialize :features, Hash
   serialize :features_previous, Hash
 
+  attr_accessor :scoped
+
   include ArticleHelper
 
   ####################
@@ -106,10 +108,6 @@ class Revision < ApplicationRecord
     JSON.parse(summary) if summary.present? && summary.start_with?('{', '[')
   rescue JSON::ParserError
     nil # Return nil if parsing fails (i.e., not diff_stats)
-  end
-
-  def scoped_revision
-    !views.zero?
   end
 
   def revision_with_error

--- a/app/views/campaigns/programs.html.haml
+++ b/app/views/campaigns/programs.html.haml
@@ -50,7 +50,7 @@
               %span.sortable-indicator
               %span.tooltip-indicator
               .tooltip.dark
-                %p= t('courses.revisions_doc', timeframe: RevisionStatTimeslice::REVISION_TIMEFRAME)
+                %p= t('courses.revisions_doc', timeframe: RevisionStatTimeslice::REVISION_WINDOW_DAYS)
           %th.sort.sortable{style: 'width: 172px;', 'data-default-order' => 'desc', 'data-sort' => 'characters'}
             .tooltip-trigger
               = t('metrics.word_count')

--- a/app/views/dashboard/_admin_courses.html.haml
+++ b/app/views/dashboard/_admin_courses.html.haml
@@ -10,7 +10,7 @@
             = t("metrics.revisions")
             %span.sortable-indicator
             .tooltip.dark
-              %p= t("courses.revisions_doc", timeframe: RevisionStatTimeslice::REVISION_TIMEFRAME)
+              %p= t("courses.revisions_doc", timeframe: RevisionStatTimeslice::REVISION_WINDOW_DAYS)
         %th.sort.sortable{"data-sort" => "characters", :style => "width: 172px;"}
           .tooltip-trigger
             = t("metrics.word_count")

--- a/app/views/tagged_courses/programs.html.haml
+++ b/app/views/tagged_courses/programs.html.haml
@@ -55,7 +55,7 @@
               %span.sortable-indicator
               %span.tooltip-indicator
               .tooltip.dark
-                %p= t('courses.revisions_doc', timeframe: RevisionStatTimeslice::REVISION_TIMEFRAME)
+                %p= t('courses.revisions_doc', timeframe: RevisionStatTimeslice::REVISION_WINDOW_DAYS)
           %th.sort.sortable{style: 'width: 172px;', 'data-default-order' => 'desc', 'data-sort' => 'characters'}
             .tooltip-trigger
               = t('metrics.word_count')

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -190,16 +190,13 @@ class RevisionScoreImporter
     rev.features = rev_scores['features']
     rev.wp10 = rev_scores['wp10']
     rev.deleted = rev_scores['deleted'] # double check if this is a boolean
-    # TODO: use another field for this
-    rev.ithenticate_id = 1 if rev_scores['error'] # tocuh ithenticate_id if there was an error
+    rev.error = rev_scores['error']
   end
 
   def update_previous_scores(rev, parent_rev_scores)
     rev.wp10_previous = parent_rev_scores['wp10']
     rev.features_previous = parent_rev_scores['features']
-    # TODO: use another field for this
-    # tocuh ithenticate_id if there was an error
-    rev.ithenticate_id = 1 if parent_rev_scores['error']
+    rev.error = parent_rev_scores['error']
   end
 
   class InvalidWikiError < StandardError; end

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -143,9 +143,6 @@ class RevisionDataManager
   end
 
   # Creates a revision record for the given revision data.
-  # Note that views field is currently used to track if the revision
-  # is a scoped one.
-  # TODO: change the field name. Review this
   def create_revision(rev_data, scoped_sub_data, users, articles)
     mw_page_id = rev_data['mw_page_id'].to_i
     Revision.new({

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -79,7 +79,7 @@ class RevisionDataManager
     all_sub_data = get_revisions(users, start, end_date)
     # Filter revisions based on the course type.
     # Important for ArticleScopedProgram/VisitingScholarship courses
-    [all_sub_data, @course.filter_revisions(all_sub_data)]
+    [all_sub_data, @course.filter_revisions(@wiki, all_sub_data)]
   end
 
   # Get revisions made by a set of users between two dates.

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -158,7 +158,7 @@ class RevisionDataManager
           new_article: string_to_boolean(rev_data['new_article']),
           system: string_to_boolean(rev_data['system']),
           wiki_id: rev_data['wiki_id'],
-          views: scoped_revision?(scoped_sub_data, mw_page_id, rev_data['mw_rev_id'])
+          scoped: scoped_revision?(scoped_sub_data, mw_page_id, rev_data['mw_rev_id'])
         })
   end
 

--- a/lib/revision_stat_timeslice.rb
+++ b/lib/revision_stat_timeslice.rb
@@ -2,12 +2,12 @@
 
 #= Provides a count of recent revisions by a user(s)
 class RevisionStatTimeslice
-  REVISION_TIMEFRAME = 7
+  REVISION_WINDOW_DAYS = 7
 
   def initialize(course, end_period = Time.zone.now)
     @course = course
     @end_period = end_period
-    @start_period = [REVISION_TIMEFRAME.days.ago, course.start].max
+    @start_period = [REVISION_WINDOW_DAYS.days.ago, course.start].max
   end
 
   def recent_revisions_for_course
@@ -17,7 +17,7 @@ class RevisionStatTimeslice
                                       .for_revisions_between(@start_period, @end_period)
       next if timeslices.empty?
       start = timeslices.minimum(:start)
-      revisions += calculate_revisions_in_timeframe(timeslices, start, @end_period)
+      revisions += calculate_revisions_in_window(timeslices, start, @end_period)
     end
     revisions.ceil
   end
@@ -36,17 +36,17 @@ class RevisionStatTimeslice
                                  .for_datetime(@start_period)
                                  .first
                                  .start
-      revisions += calculate_revisions_in_timeframe(timeslices, start, @end_period)
+      revisions += calculate_revisions_in_window(timeslices, start, @end_period)
     end
     revisions.ceil
   end
 
   private
 
-  def calculate_revisions_in_timeframe(timeslices, start, end_period)
+  def calculate_revisions_in_window(timeslices, start, end_period)
     rev_count = timeslices.sum(&:revision_count)
     seconds = (end_period - start).seconds
     revisions_per_day = rev_count * 1.day.seconds / seconds
-    revisions_per_day * REVISION_TIMEFRAME
+    revisions_per_day * REVISION_WINDOW_DAYS
   end
 end

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -221,8 +221,7 @@ describe RevisionScoreImporter do
         expect(revisions[2].deleted).to eq(true)
         expect(revisions[2].wp10).to be_nil
         expect(revisions[2].features).to eq({})
-        # TODO: use another field for this. For now we use ithenticate_id as an error field
-        expect(revisions[2].ithenticate_id).to be_nil
+        expect(revisions[2].error).to eq(false)
       end
     end
 
@@ -232,8 +231,7 @@ describe RevisionScoreImporter do
         expect(revisions[3].deleted).to eq(true)
         expect(revisions[3].wp10).to be_nil
         expect(revisions[3].features).to eq({})
-        # TODO: use another field for this. For now we use ithenticate_id as an error field
-        expect(revisions[3].ithenticate_id).to be_nil
+        expect(revisions[3].error).to eq(false)
       end
     end
 
@@ -245,9 +243,7 @@ describe RevisionScoreImporter do
         .to_raise(Errno::ECONNREFUSED)
 
       revisions = described_class.new.get_revision_scores(array_revisions)
-
-      # TODO: use another field for this. For now we use ithenticate_id as an error field
-      expect(revisions[0].ithenticate_id).to eq(1)
+      expect(revisions[0].error).to eq(true)
     end
   end
 end

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -99,6 +99,7 @@ describe ArticleScopedProgram, type: :model do
   end
 
   describe '#filter_revisions' do
+    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
     let(:course) { create(:article_scoped_program, start: '2018-01-01', end: '2018-12-31') }
     let(:user) { create(:user, username: 'Ragesoss') }
     let(:revisions) do
@@ -154,7 +155,7 @@ describe ArticleScopedProgram, type: :model do
       ]
     end
     let(:subject) do
-      course.filter_revisions(revisions)
+      course.filter_revisions(wiki, revisions)
     end
 
     before do

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -204,15 +204,15 @@ describe ArticlesCourses, type: :model do
       create(:courses_user, user:, course:,
                             role: CoursesUsers::Roles::STUDENT_ROLE)
       array_revisions << build(:revision, article:, user:, date: '2024-07-07',
-                        system: true, new_article: true, views: true)
+                        system: true, new_article: true, scoped: true)
       array_revisions << build(:revision, article:, user:, date: '2024-07-06 20:05:10',
-                        system: true, new_article: true, views: true)
+                        system: true, new_article: true, scoped: true)
       array_revisions << build(:revision, article:, user:, date: '2024-07-06 20:06:11',
-                        system: true, new_article: true, views: true)
+                        system: true, new_article: true, scoped: true)
       array_revisions << build(:revision, article:, user:, date: '2024-07-08 20:03:01',
-                        system: true, new_article: true, views: true)
+                        system: true, new_article: true, scoped: true)
       array_revisions << build(:revision, article: article3, user:, date: '2024-07-07',
-                        system: true, new_article: true, views: true)
+                        system: true, new_article: true, scoped: true)
       # revision for a non-tracked wiki
       array_revisions << build(:revision, article: article2, user:, date: '2024-07-06')
       # revision for a non-tracked namespace

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -55,7 +55,7 @@ describe CourseUserWikiTimeslice, type: :model do
            features: { 'num_ref' => 8 },
            features_previous: { 'num_ref' => 1 },
            user_id: user.id,
-           views: true)
+           scoped: true)
   end
   let(:revision1) do
     build(:revision, article: talk_page, date: start,
@@ -63,7 +63,7 @@ describe CourseUserWikiTimeslice, type: :model do
            features: { 'num_ref' => 12 },
            features_previous: { 'num_ref' => 10 },
            user_id: user.id,
-           views: true)
+           scoped: true)
   end
   let(:revision2) do
     build(:revision, article: sandbox, date: start,
@@ -71,7 +71,7 @@ describe CourseUserWikiTimeslice, type: :model do
            features: { 'num_ref' => 1 },
            features_previous: { 'num_ref' => 2 },
            user_id: user.id,
-           views: true)
+           scoped: true)
   end
   let(:revision3) do
     build(:revision, article: draft, date: start,
@@ -79,7 +79,7 @@ describe CourseUserWikiTimeslice, type: :model do
            features: { 'num_ref' => 3 },
            features_previous: { 'num_ref' => 3 },
            user_id: user.id,
-           views: true)
+           scoped: true)
   end
   let(:revision4) do
     build(:revision, article:, date: start,
@@ -88,7 +88,7 @@ describe CourseUserWikiTimeslice, type: :model do
             features: { 'num_ref' => 2 },
             features_previous: { 'num_ref' => 0 },
             user_id: user.id,
-            views: true)
+            scoped: true)
   end
   let(:revision5) do
     build(:revision, article_id: -1, # revision for a non-existing article
@@ -98,7 +98,7 @@ describe CourseUserWikiTimeslice, type: :model do
             features: { 'num_ref' => 2 },
             features_previous: { 'num_ref' => 0 },
             user_id: user.id,
-            views: true)
+            scoped: true)
   end
   let(:revision6) do
     build(:revision, article: draft, date: start,
@@ -107,7 +107,7 @@ describe CourseUserWikiTimeslice, type: :model do
            features_previous: { 'num_ref' => 0 },
            user_id: user.id,
            system: true, # revision made by the system
-           views: true)
+           scoped: true)
   end
   let(:revisions) { [revision0, revision1, revision2, revision3, revision4, revision5, revision6] }
   let(:subject) { course_user_wiki_timeslice.update_cache_from_revisions revisions }
@@ -115,9 +115,12 @@ describe CourseUserWikiTimeslice, type: :model do
   describe '.update_course_user_wiki_timeslices' do
     before do
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
-      revisions << build(:revision, article:, user_id: user.id, date: start + 26.hours, views: true)
-      revisions << build(:revision, article:, user_id: user.id, date: start + 50.hours, views: true)
-      revisions << build(:revision, article:, user_id: user.id, date: start + 51.hours, views: true)
+      revisions << build(:revision, article:, user_id: user.id, date: start + 26.hours,
+                         scoped: true)
+      revisions << build(:revision, article:, user_id: user.id, date: start + 50.hours,
+                         scoped: true)
+      revisions << build(:revision, article:, user_id: user.id, date: start + 51.hours,
+                         scoped: true)
     end
 
     it 'creates the right article timeslices based on the revisions' do

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -160,7 +160,7 @@ role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
       before do
         TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wiki])
         array_revisions << build(:revision, article:, user_id: 1, date: start + 51.hours,
-        scoped: true, ithenticate_id: 1) # add revision with error
+        scoped: true, error: true) # add revision with error
       end
 
       it 'keeps needs_update flag if revisions with error' do

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -99,6 +99,7 @@ describe VisitingScholarship, type: :model do
   end
 
   describe '#filter_revisions' do
+    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
     let(:course) { create(:visiting_scholarship, start: '2018-01-01', end: '2018-12-31') }
     let(:user) { create(:user, username: 'Ragesoss') }
     let(:revisions) do
@@ -138,7 +139,7 @@ describe VisitingScholarship, type: :model do
       ]
     end
     let(:subject) do
-      course.filter_revisions(revisions)
+      course.filter_revisions(wiki, revisions)
     end
 
     before do


### PR DESCRIPTION
## What this PR does
This PR addresses Sage's comments in PR #6195.

In addition, it adds `error` revision field as `attr_accessor :error` instead of using `ithenticate_id` field. See PR #6145 for tracking errors when getting scores.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
