### PR TITLE
[Data rearchitecture] Create admin view to change timeslice duration

### DIFF
--- a/app/controllers/timeslice_duration_controller.rb
+++ b/app/controllers/timeslice_duration_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require_dependency "#{Rails.root}/lib/timeslice_manager"
+
+#= Controller for requesting and updating timeslice duration
+class TimesliceDurationController < ApplicationController
+  respond_to :html
+  before_action :require_super_admin_permissions, :set_course
+  def index; end
+
+  def show
+    timeslice_manager = TimesliceManager.new(@course)
+    @results = @course.wikis.index_with { |wiki| timeslice_manager.timeslice_duration(wiki) }
+    render :update
+  rescue NoMethodError
+    redirect_to(timeslice_duration_path)
+  end
+
+  def update
+    wiki = Wiki.find(params[:wiki_id])
+    timeslice_duration = params[:duration].to_i
+    update_duration_flag(wiki, timeslice_duration)
+    redirect_to(timeslice_duration_path,
+                notice: "Timeslice duration updated for course id #{@course.id} wiki id #{wiki.id}")
+  rescue ActiveRecord::RecordNotFound
+    redirect_to(timeslice_duration_path,
+                flash: { error: 'Wiki not found' })
+  end
+
+  private
+
+  def update_duration_flag(wiki, timeslice_duration)
+    # Ensure timeslice_duration flag exists
+    @course.flags[:timeslice_duration] ||= { default: TimesliceManager::TIMESLICE_DURATION }
+    @course.flags[:timeslice_duration][wiki.domain.to_sym] = timeslice_duration
+    @course.save
+  end
+
+  def set_course
+    return unless params[:course_id].present?
+    @course = Course.find(params[:course_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to(timeslice_duration_path,
+                flash: { error: 'Course not found' })
+  end
+end

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -30,6 +30,8 @@
     %li
       %a{href: '/unsubmitted_courses'} Unsubmitted Courses
     %li
+      %a{href: '/timeslice_duration'} Update timeslice duration
+    %li
       %a{href: '/update_username'} Update username
     %li
       %a{href: '/usage'} Usage

--- a/app/views/timeslice_duration/index.html.haml
+++ b/app/views/timeslice_duration/index.html.haml
@@ -1,0 +1,16 @@
+- content_for :before_title, "Timeslice duration"
+.container.dashboard
+  %header
+    %h1
+      = 'View and update timeslice duration'
+
+%section
+  .container
+    %hr
+
+.container
+  %form#course-form{action: '/timeslice_duration/update', method: 'get'}
+    %label{for: "course-id"} Enter Course ID:
+    %input#course-id{type: "text", name: "course_id"}
+    %button{type: 'submit'}
+      %div.button.dark View timeslice duration

--- a/app/views/timeslice_duration/update.html.haml
+++ b/app/views/timeslice_duration/update.html.haml
@@ -1,0 +1,42 @@
+- content_for :before_title, "Timeslice duration"
+.container.dashboard
+  %header
+    %h1
+      = 'View and update timeslice duration'
+
+.container
+  - if @course.present? && @results.present?
+    %div#results
+      %hr
+      %h2 Results
+      %h3 Course: #{@course.slug}
+      %ul
+        %table.table.table--striped
+          %thead
+          %tr
+            %th Wiki ID
+            %th Wiki Domain
+            %th Duration (seconds)
+          %tbody
+            - @results.each do |wiki, duration|
+              %tr
+              %td{style: "text-align: center;"}= wiki.id.to_s
+              %td{style: "text-align: center;"}= wiki.domain.to_s
+              %td{style: "text-align: center;"}= duration.to_s
+
+    %div#update
+      %hr
+      %h2 Update timeslice duration
+      %h4 Suggested durations: 1 day (86400 s) or 10 days (864000 s)
+    %form#timeslice-form{action: '/timeslice_duration/update', method: 'post'}
+      = csrf_meta_tags
+      %input{name: "authenticity_token", type: "hidden", value: form_authenticity_token}
+      
+      %input#course_id{type: "hidden", name: "course_id", value: @course.id}
+
+      %label{for: "wiki-id"} Wiki id (example: 1):
+      %input#wiki-id{type: "number", name: "wiki_id"}
+      %label{for: "duration"} New timeslice duration (in seconds):
+      %input#duration{type: "number", name: "duration"}
+      %button{type: 'submit'}
+        %div.button.dark Update timeslice duration    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,11 @@ Rails.application.routes.draw do
   get 'copy_course' => 'copy_course#index'
   post 'copy_course' => 'copy_course#copy'
 
+  # Change timeslice duration
+  get 'timeslice_duration' => 'timeslice_duration#index'
+  get 'timeslice_duration/update' => 'timeslice_duration#show'
+  post 'timeslice_duration/update' => 'timeslice_duration#update'
+
   # Self-enrollment: joining a course by entering a passcode or visiting a url
   get 'courses/:course_id/enroll/(:passcode)' => 'self_enrollment#enroll_self',
       constraints: { course_id: /.*/ }

--- a/spec/controllers/timeslice_duration_controller_spec.rb
+++ b/spec/controllers/timeslice_duration_controller_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TimesliceDurationController, type: :request do
+  describe '#index' do
+    let(:user) { create(:user) }
+    let(:superadmin) { create(:admin, permissions: 3) }
+
+    context 'when the user is a superadmin' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user)
+          .and_return(superadmin)
+      end
+
+      it 'shows the feature to update timeslice duration' do
+        get timeslice_duration_path
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when the user is not an admin' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      end
+
+      it 'returns a 401 error' do
+        get timeslice_duration_path
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  describe '#show' do
+    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:course) { create(:course) }
+    let(:superadmin) { create(:admin, permissions: 3) }
+    let(:timeslice_duration_update_path) { '/timeslice_duration/update' }
+
+    context 'when the course does not exist' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user)
+          .and_return(superadmin)
+        get timeslice_duration_update_path, params: { course_id: -1 }
+      end
+
+      it 'renders the error' do
+        expect(response).to redirect_to(timeslice_duration_path)
+        expect(flash[:error]).to eq('Course not found')
+      end
+    end
+
+    context 'when the course exists' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user)
+          .and_return(superadmin)
+        get timeslice_duration_update_path, params: { course_id: course.id }
+      end
+
+      it 'renders the timeslice duration' do
+        expect(response.status).to eq(200)
+        expect(response.body).to include(wiki.domain)
+        expect(response.body).to include(TimesliceManager::TIMESLICE_DURATION.to_s)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:course) { create(:course) }
+    let(:superadmin) { create(:admin, permissions: 3) }
+    let(:timeslice_duration_update_path) { '/timeslice_duration/update' }
+
+    context 'when the wiki does not exist' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user)
+          .and_return(superadmin)
+        post timeslice_duration_update_path, params: { course_id: course.id, wiki_id: 145 }
+      end
+
+      it 'renders the error' do
+        expect(response).to redirect_to(timeslice_duration_path)
+        expect(flash[:error]).to eq('Wiki not found')
+      end
+    end
+
+    context 'when the update is successful' do
+      before do
+        allow_any_instance_of(ApplicationController).to receive(:current_user)
+          .and_return(superadmin)
+        post timeslice_duration_update_path, params: {
+          course_id: course.id, duration: 456789, wiki_id: wiki.id
+        }
+        course.reload
+      end
+
+      it 'updates the timeslice duration and renders the success message' do
+        expect(course.flags[:timeslice_duration][wiki.domain.to_sym]).to eq(456789)
+        expect(response).to redirect_to(timeslice_duration_path)
+        expect(flash[:notice])
+          .to eq("Timeslice duration updated for course id #{course.id} wiki id #{wiki.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR adds a basic admin view to update the timeslice duration. The admin view allows you to check the current timeslice duration for a given course, and to update the `timeslice_duration` flag for a given wiki id.

## Screenshots
Before:
No admin view

After:
[timeslice-duration-admin-view.webm](https://github.com/user-attachments/assets/56652224-3a83-4e90-8a93-6bfcec51b216)

[timeslice-duration-admin-view.webm](https://github.com/user-attachments/assets/8bca55c8-9df9-4766-b365-4a06f4ffb587)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
