### PR TITLE
[Data rearchitecture] Fix bug when updating timeslice duration

### DIFF
--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -58,6 +58,8 @@ class UpdateTimeslicesCourseWiki
       # Continue if timeslice duration didn't change for the wiki
       next unless effective_timeslice_duration != real_timeslice_duration
       @timeslice_cleaner.delete_course_wiki_timeslices_after_date([wiki], start - 1.second)
+      @timeslice_cleaner.delete_course_user_wiki_timeslices_after_date([wiki], start - 1.second)
+      @timeslice_cleaner.delete_article_course_timeslices_after_date([wiki], start - 1.second)
       @timeslice_manager.create_wiki_timeslices_up_to_new_course_end_date(wiki)
     end
   end

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -56,6 +56,33 @@ class TimesliceCleaner
     delete_course_wiki_timeslice_ids(timeslice_ids)
   end
 
+  # Deletes course user wiki timeslices records with a start date later than the
+  # specific given date
+  def delete_course_user_wiki_timeslices_after_date(wikis, date)
+    # Delete course wiki timeslices
+    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
+                                           .where(wiki: wikis)
+                                           .where('start > ?', date)
+                                           .pluck(:id)
+
+    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+  end
+
+  # Deletes article course timeslices records with a start date later than the
+  # specific given date
+  def delete_article_course_timeslices_after_date(wikis, date)
+    # Collect the ids of articles to be deleted
+    article_ids = @course.articles_from_timeslices(wikis).pluck(:id)
+
+    # Delete course wiki timeslices
+    timeslice_ids = ArticleCourseTimeslice.where(course: @course)
+                                          .where(article_id: article_ids)
+                                          .where('start > ?', date)
+                                          .pluck(:id)
+
+    delete_article_course_timeslice_ids(timeslice_ids)
+  end
+
   # Deletes course user wiki timeslices records with a date prior to the current start date
   def delete_course_user_wiki_timeslices_prior_to_start_date
     # Delete course user wiki timeslices
@@ -68,12 +95,7 @@ class TimesliceCleaner
 
   # Deletes course user wiki timeslices records with a start date later than the current end date
   def delete_course_user_wiki_timeslices_after_end_date
-    # Delete course user wiki timeslices
-    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
-                                           .where('start > ?', @course.end)
-                                           .pluck(:id)
-
-    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+    delete_course_user_wiki_timeslices_after_date(@course.wikis, @course.end)
   end
 
   # Resets course wiki timeslices. This involves:

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -59,7 +59,6 @@ class TimesliceCleaner
   # Deletes course user wiki timeslices records with a start date later than the
   # specific given date
   def delete_course_user_wiki_timeslices_after_date(wikis, date)
-    # Delete course wiki timeslices
     timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
                                            .where(wiki: wikis)
                                            .where('start > ?', date)
@@ -74,7 +73,6 @@ class TimesliceCleaner
     # Collect the ids of articles to be deleted
     article_ids = @course.articles_from_timeslices(wikis).pluck(:id)
 
-    # Delete course wiki timeslices
     timeslice_ids = ArticleCourseTimeslice.where(course: @course)
                                           .where(article_id: article_ids)
                                           .where('start > ?', date)

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -199,10 +199,9 @@ describe TimesliceCleaner do
 
   describe '#delete_course_user_wiki_timeslices_after_date' do
     before do
-      create(:courses_wikis, wiki: wikibooks, course:)
       create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
               start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
-      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: wikibooks,
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: wikidata,
               start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
       create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
               start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
@@ -215,7 +214,6 @@ describe TimesliceCleaner do
       timeslice_cleaner.delete_course_user_wiki_timeslices_after_date([enwiki], date)
       course.reload
 
-      # Course user wiki timeslices prior to the new start date were deleted
       expect(course.course_user_wiki_timeslices.size).to eq(2)
     end
   end
@@ -237,7 +235,6 @@ describe TimesliceCleaner do
       timeslice_cleaner.delete_article_course_timeslices_after_date([enwiki], date)
       course.reload
 
-      # Course user wiki timeslices prior to the new start date were deleted
       expect(course.article_course_timeslices.size).to eq(2)
     end
   end

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -156,9 +156,6 @@ describe TimesliceCleaner do
   describe '#delete_course_user_wiki_timeslices_after_end_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)
-      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks,
-                                                                       wikidata,
-                                                                       enwiki])
       create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
               start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
       create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
@@ -197,6 +194,51 @@ describe TimesliceCleaner do
       course.reload
 
       expect(course.course_wiki_timeslices.size).to eq(295)
+    end
+  end
+
+  describe '#delete_course_user_wiki_timeslices_after_date' do
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+              start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: wikibooks,
+              start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: enwiki,
+              start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+    end
+
+    it 'deletes course user wiki timeslices for dates after the end date properly' do
+      expect(course.course_user_wiki_timeslices.size).to eq(3)
+
+      date = '2024-04-11'.to_datetime - 1.second
+      timeslice_cleaner.delete_course_user_wiki_timeslices_after_date([enwiki], date)
+      course.reload
+
+      # Course user wiki timeslices prior to the new start date were deleted
+      expect(course.course_user_wiki_timeslices.size).to eq(2)
+    end
+  end
+
+  describe '#delete_article_course_timeslices_after_date' do
+    before do
+      create(:article_course_timeslice, course:, article: article1,
+              start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:article_course_timeslice, course:, article: article1,
+              start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+      create(:article_course_timeslice, course:, article: article2,
+              start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+    end
+
+    it 'deletes article course timeslices for dates after the end date properly' do
+      expect(course.article_course_timeslices.size).to eq(3)
+
+      date = '2024-04-11'.to_datetime - 1.second
+      timeslice_cleaner.delete_article_course_timeslices_after_date([enwiki], date)
+      course.reload
+
+      # Course user wiki timeslices prior to the new start date were deleted
+      expect(course.article_course_timeslices.size).to eq(2)
     end
   end
 

--- a/spec/services/update_timeslices_course_wiki_spec.rb
+++ b/spec/services/update_timeslices_course_wiki_spec.rb
@@ -97,6 +97,22 @@ describe UpdateTimeslicesCourseWiki do
       expect(limit_timeslice.end - limit_timeslice.start).to eq(86400)
       last_timeslice = course.course_wiki_timeslices.where(start: '2018-11-30'.to_datetime).first
       expect(last_timeslice.end - last_timeslice.start).to eq(86400)
+
+      # Add article course timeslices manually
+      create(:article_course_timeslice, course:, article:, start: '2018-11-24'.to_datetime,
+      end: '2018-11-25'.to_datetime)
+      create(:article_course_timeslice, course:, article:, start: '2018-11-26'.to_datetime,
+      end: '2018-11-27'.to_datetime)
+      create(:article_course_timeslice, course:, article:, start: '2018-11-30'.to_datetime,
+      end: '2018-12-01'.to_datetime)
+
+      # Add course user wiki timeslices manually
+      create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki,
+      start: '2018-11-24'.to_datetime, end: '2018-11-25'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki,
+      start: '2018-11-26'.to_datetime, end: '2018-11-27'.to_datetime)
+      create(:course_user_wiki_timeslice, course:, user:, wiki: enwiki,
+      start: '2018-11-30'.to_datetime, end: '2018-12-01'.to_datetime)
     end
 
     it 'updates current and future timeslices if new timeslice duration is smaller' do
@@ -105,12 +121,28 @@ describe UpdateTimeslicesCourseWiki do
       course.save
 
       described_class.new(course).run
-      first_timeslice = course.course_wiki_timeslices.where(start: '2018-11-24'.to_datetime).first
-      expect(first_timeslice.end - first_timeslice.start).to eq(86400)
-      limit_timeslice = course.course_wiki_timeslices.where(start: '2018-11-26'.to_datetime).first
-      expect(limit_timeslice.end - limit_timeslice.start).to eq(43200)
-      last_timeslice = course.course_wiki_timeslices.where(start: '2018-11-30'.to_datetime).first
-      expect(last_timeslice.end - last_timeslice.start).to eq(43200)
+      first_cwt = course.course_wiki_timeslices.where(start: '2018-11-24'.to_datetime).first
+      expect(first_cwt.end - first_cwt.start).to eq(86400)
+      first_cuwt = course.course_user_wiki_timeslices.where(start: '2018-11-24'.to_datetime).first
+      expect(first_cuwt.end - first_cuwt.start).to eq(86400)
+      first_act = course.article_course_timeslices.where(start: '2018-11-24'.to_datetime).first
+      expect(first_act.end - first_act.start).to eq(86400)
+
+      limit_cwt = course.course_wiki_timeslices.where(start: '2018-11-26'.to_datetime).first
+      expect(limit_cwt.end - limit_cwt.start).to eq(43200)
+      # Following timeslices were deleted
+      limit_cuwt = course.course_user_wiki_timeslices.where(start: '2018-11-26'.to_datetime)
+      expect(limit_cuwt).to be_empty
+      limit_act = course.article_course_timeslices.where(start: '2018-11-26'.to_datetime)
+      expect(limit_act).to be_empty
+
+      last_cwt = course.course_wiki_timeslices.where(start: '2018-11-30'.to_datetime).first
+      expect(last_cwt.end - last_cwt.start).to eq(43200)
+      # Following timeslices were deleted
+      last_cuwt = course.course_user_wiki_timeslices.where(start: '2018-11-30'.to_datetime)
+      expect(last_cuwt).to be_empty
+      last_act = course.article_course_timeslices.where(start: '2018-11-30'.to_datetime)
+      expect(last_act).to be_empty
     end
 
     it 'updates current and future timeslices if new timeslice duration is greater' do
@@ -120,12 +152,28 @@ describe UpdateTimeslicesCourseWiki do
 
       described_class.new(course).run
 
-      first_timeslice = course.course_wiki_timeslices.where(start: '2018-11-24'.to_datetime).first
-      expect(first_timeslice.end - first_timeslice.start).to eq(86400)
-      limit_timeslice = course.course_wiki_timeslices.where(start: '2018-11-26'.to_datetime).first
-      expect(limit_timeslice.end - limit_timeslice.start).to eq(172800)
-      last_timeslice = course.course_wiki_timeslices.where(start: '2018-11-28'.to_datetime).first
-      expect(last_timeslice.end - last_timeslice.start).to eq(172800)
+      first_cwt = course.course_wiki_timeslices.where(start: '2018-11-24'.to_datetime).first
+      expect(first_cwt.end - first_cwt.start).to eq(86400)
+      first_cuwt = course.course_user_wiki_timeslices.where(start: '2018-11-24'.to_datetime).first
+      expect(first_cuwt.end - first_cuwt.start).to eq(86400)
+      first_act = course.article_course_timeslices.where(start: '2018-11-24'.to_datetime).first
+      expect(first_act.end - first_act.start).to eq(86400)
+
+      limit_cwt = course.course_wiki_timeslices.where(start: '2018-11-26'.to_datetime).first
+      expect(limit_cwt.end - limit_cwt.start).to eq(172800)
+      # Following timeslices were deleted
+      limit_cuwt = course.course_user_wiki_timeslices.where(start: '2018-11-26'.to_datetime)
+      expect(limit_cuwt).to be_empty
+      limit_act = course.article_course_timeslices.where(start: '2018-11-26'.to_datetime)
+      expect(limit_act).to be_empty
+
+      last_cwt = course.course_wiki_timeslices.where(start: '2018-11-30'.to_datetime).first
+      expect(last_cwt.end - last_cwt.start).to eq(172800)
+      # Following timeslices were deleted
+      last_cuwt = course.course_user_wiki_timeslices.where(start: '2018-11-30'.to_datetime)
+      expect(last_cuwt).to be_empty
+      last_act = course.article_course_timeslices.where(start: '2018-11-30'.to_datetime)
+      expect(last_act).to be_empty
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR fixes a minor bug in `UpdateTimeslicesCourseWiki` class. The `update_timeslices_durations` method was deleting current and future course wiki timeslices, but course user wiki and article course timeslices remained. That caused the existence of multiple timeslices with the same `start` but with different timeslice duration (i.e different `end`). This bug was found in data-rearchitecture instance.

## Open questions and concerns
Logic in `TimesliceCleaner` class and `ArticlesCoursesCleanerTimeslice` class should be better defined.