### PR TITLE
[Data rearchitecture] Update minimum revisions for ContinuedCourseActivityAlertManager

### DIFF
--- a/lib/alerts/continued_course_activity_alert_manager.rb
+++ b/lib/alerts/continued_course_activity_alert_manager.rb
@@ -22,7 +22,7 @@ class ContinuedCourseActivityAlertManager
 
   private
 
-  MINIMUM_REVISIONS_AFTER_COURSE_END = 20
+  MINIMUM_REVISIONS_AFTER_COURSE_END = 5
   def significant_activity_after_course_end?(course)
     total_revisions = course.wikis.sum do |wiki|
       count_revisions_for_wiki(course, wiki)

--- a/spec/lib/alerts/continued_course_activity_alert_manager_spec.rb
+++ b/spec/lib/alerts/continued_course_activity_alert_manager_spec.rb
@@ -52,7 +52,7 @@ describe ContinuedCourseActivityAlertManager do
 
   context 'when there is significant after the course ends' do
     let(:content) do
-      { 'usercontribs' => Array.new(21) { |_| contribution } }
+      { 'usercontribs' => Array.new(6) { |_| contribution } }
     end
 
     it 'creates an alert' do


### PR DESCRIPTION
## What this PR does
After talking to Sage about this, we decided to use 5 as the `MINIMUM_REVISIONS_AFTER_COURSE_END` to trigger the continued course activity alert.

