### PR TITLE
fix: mark survey conditional questional required or not

### DIFF
--- a/config/initializers/surveys.rb
+++ b/config/initializers/surveys.rb
@@ -234,7 +234,7 @@ Rails.application.config.to_prepare do
         :placeholder_text => placeholder_text,
         :track_sentiment => track_sentiment,
         :validation_rules => {
-          :presence => !conditionals.nil? && !conditionals.empty? ? "0" : answer_presence,
+          :presence => answer_presence,
           :grouped => answer_grouped,
           :grouped_question => answer_grouped_question,
           :minimum  => answer_minimum_length,


### PR DESCRIPTION
## Description
When creating a survey with conditional questions, it was unable to mark these questions as required or not.
Even when the "Question is Required" checkbox was selected in the form, conditional questions were always saved with the ```presence``` validation rule set to "0". This was happening because of hardcoded logic in the ```to_question_params``` method that forced conditional questions to be optional.

Fixes #935

Based on the logs, when submitted the form with marked conditional question as required, means setting answer_presence to "1" , i.e., question should be required, but in the actual SQL INSERT statement, the presence value is being saved as "0", i.e., not required.
```
Parameters: {"question"=>{"type"=>"Rapidfire::Questions::Checkbox", "answer_presence"=>"1", ...}
```
```
INSERT INTO `rapidfire_questions` (...) VALUES (..., '---\n:presence: \'0\'\n:grouped: \'0\'\n...
```

## Fix
Modified the ```to_question_params``` method to respect the user's choice for required fields, even when the question has conditionals.
This change allows survey creators to mark conditional questions as required, giving them more flexibility in designing survey logic.

## Screenshots

After:

![image](https://github.com/user-attachments/assets/55f37b1e-c4d3-4e08-8050-5d5a2540d926)
