### PR TITLE
[Data rearchitecture] Update recent revisions tooltip

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -789,7 +789,9 @@ en:
       Once you're satisfied, you can submit it for approval by Wiki Education staff.
       Once approved, you'll receive an enrollment URL that students can use to
       join the course and access the trainings. (Note: You'll still be able to make edits later.)
-    revisions_doc: The number of edits in the past %{timeframe} days
+    revisions_doc: >
+      The estimated number of edits in the past %{timeframe} days, based on the
+      average edits per day over the last period.
     revisions_none: This course has no recent Wikipedia editing activity.
     school: School
     school_and_term: Institution/Term
@@ -1561,7 +1563,9 @@ en:
       success_message: "Success: %{result_description}"
       failure_message: "Failure: %{result_description}"
     revision_characters_and_views: "Chars Added: %{characters}, Views: %{views}"
-    revisions_doc: The number of edits made by this editor in the past 7 days
+    revisions_doc: >
+      The estimated number of edits made by this editor in the past 7 days,
+      based on the average edits per day over the last period.
     references_doc: The number of references added or removed by this editor
     reviewers: Reviewer(s)
     reviewing: Reviewing


### PR DESCRIPTION
## What this PR does
This PR updates the recent edits tooltip for the timeslice version.

## Screenshots
Before:
**User level**
![image](https://github.com/user-attachments/assets/4b309c11-db4d-4adc-abb3-2cc027e754b5)


**Corse level**
![image](https://github.com/user-attachments/assets/34e116ea-b707-460a-90b1-0a9e55c4b065)

After:
**User level**
![image](https://github.com/user-attachments/assets/97260053-8db0-455f-8d6a-3d3da513d1b0)

**Course level**
![image](https://github.com/user-attachments/assets/541304d8-9367-416a-95c7-55dc0b7fd1fd)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
