### PR TITLE
Fixes `414 request-uri too long` for `import_articles_by_title` by using a POST request .2

### DIFF
--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -34,7 +34,7 @@ class ArticleImporter
         prop: 'info',
         titles: some_article_titles.join('|')
       }
-      response = api_post(@wiki, params)
+      response = api_post(@wiki.api_url, params)
       results = response.dig('query', 'pages')
       next if results.blank?
       import_articles_from_title_query(results)
@@ -71,9 +71,9 @@ class ArticleImporter
   # API methods #
   ###############
 
-  def api_post(wiki, params)
+  def api_post(api_url, params)
     tries ||= 3
-    response = do_post(wiki, params)
+    response = do_post(api_url, params)
     return unless response
     parsed_body = JSON.parse(response.body)
     return if parsed_body.empty?
@@ -83,12 +83,12 @@ class ArticleImporter
     sleep 1 if too_many_requests?(e)
     retry unless tries.zero?
     log_error(e, update_service: @update_service,
-              sentry_extra: { params:, api_url: @api_url })
+              sentry_extra: { params:, api_url: })
     return nil
   end
 
-  def do_post(wiki, params)
-    uri = URI(wiki.api_url)
+  def do_post(api_url, params)
+    uri = URI(api_url)
     https = Net::HTTP.new(uri.host, uri.port)
     https.use_ssl = true
 

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/replica"
+require_dependency "#{Rails.root}/lib/errors/api_error_handling"
 
 #= Imports articles from Wikipedia into the dashboard database
 class ArticleImporter
+  include ApiErrorHandling
+
   def initialize(wiki)
     @wiki = wiki
     @articles = []
@@ -25,11 +28,14 @@ class ArticleImporter
     # Slice size is limited by max URI length.
     # 40 is too much for some languages, such as bn.wipedia.org
     titles.each_slice(30) do |some_article_titles|
-      query = { prop: 'info', titles: some_article_titles }
-      response = WikiApi.new(@wiki).query(query)
-      results = response&.data
-      next if results.blank?
-      results = results['pages']
+      params = {
+        action: 'query',
+        format: 'json',
+        prop: 'info',
+        titles: some_article_titles.join('|')
+      }
+      response = api_post(@wiki, params)
+      results = response.dig('query', 'pages')
       next if results.blank?
       import_articles_from_title_query(results)
     end
@@ -59,5 +65,41 @@ class ArticleImporter
                               namespace: page_data['ns'].to_i)
     end
     Article.import articles, on_duplicate_key_update: [:title, :namespace]
+  end
+
+  ###############
+  # API methods #
+  ###############
+
+  def api_post(wiki, params)
+    tries ||= 3
+    response = do_post(wiki, params)
+    return unless response
+    parsed_body = JSON.parse(response.body)
+    return if parsed_body.empty?
+    parsed_body
+  rescue StandardError => e
+    tries -= 1
+    sleep 1 if too_many_requests?(e)
+    retry unless tries.zero?
+    log_error(e, update_service: @update_service,
+              sentry_extra: { params:, api_url: @api_url })
+    return nil
+  end
+
+  def do_post(wiki, params)
+    uri = URI(wiki.api_url)
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+
+    request = Net::HTTP::Post.new(uri)
+    request['Content-Type'] = 'application/x-www-form-urlencoded'
+    request.body = URI.encode_www_form(params)
+    https.request(request)
+  end
+
+  def too_many_requests?(e)
+    return false unless e.instance_of?(MediawikiApi::HttpError)
+    e.status == 429
   end
 end

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -35,7 +35,7 @@ class ArticleImporter
         titles: some_article_titles.join('|')
       }
       response = api_post(@wiki.api_url, params)
-      results = response.dig('query', 'pages')
+      results = response&.dig('query', 'pages')
       next if results.blank?
       import_articles_from_title_query(results)
     end
@@ -102,4 +102,8 @@ class ArticleImporter
     return false unless e.instance_of?(MediawikiApi::HttpError)
     e.status == 429
   end
+
+  TYPICAL_ERRORS = [Net::ReadTimeout,
+                    MediawikiApi::HttpError,
+                    MediawikiApi::ApiError].freeze
 end

--- a/spec/lib/importers/article_importer_spec.rb
+++ b/spec/lib/importers/article_importer_spec.rb
@@ -8,6 +8,7 @@ describe ArticleImporter do
 
   let(:en_wiki) { Wiki.default_wiki }
   let(:es_wiki) { create(:wiki, language: 'es', project: 'wikipedia') }
+  let(:kn_wiki) { create(:wiki, language: 'kn', project: 'wikipedia') }
 
   describe '.import_articles' do
     it 'creates an Article from a English Wikipedia page_id' do
@@ -65,6 +66,51 @@ describe ArticleImporter do
       VCR.use_cassette 'article_importer/collisions' do
         described_class.new(en_wiki).import_articles_by_title(['Istanbul'])
         expect(Article.find_by(title: 'Istanbul').mw_page_id).to eq(3391396)
+      end
+    end
+
+    it 'returns the correct number of titles without raising error 414' do
+      VCR.use_cassette 'article_importer/some_article_titles' do
+        titles = %w[
+          ವಿಕಿಪೀಡಿಯ:ಬದಲಿ
+          ವಿಕಿಪೀಡಿಯ:Talk_page_templates
+          ವಿಕಿಪೀಡಿಯ:ಸ್ಪಾಯ್ಲರ್
+          ವಿಕಿಪೀಡಿಯ:Revision_deletion
+          ವಿಕಿಪೀಡಿಯ:Open_proxies
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಭಾರತೀಯ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಖಗೋಳ_ವಸ್ತುಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪುಸ್ತಕಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪ್ರಸಾರ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ರಸಾಯನಶಾಸ್ತ್ರ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪಾದ್ರಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಕಾಮಿಕ್ಸ್)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಕಂಪನಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ದೇಶ-ನಿರ್ದಿಷ್ಟ_ವಿಷಯಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿನ_ಸಂಪ್ರದಾಯಗಳು_(ನಿರ್ದಿಷ್ಟ_ಅಥವಾ_ಅನಿರ್ದಿಷ್ಟ_ಲೇಖನ_ಹೆಸರಿನ_ಆರಂಭದಲ್ಲಿ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಜನಾಂಗೀಯಗಳು_ಮತ್ತು_ಬುಡಕಟ್ಟುಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪ್ರಾಣಿ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಚಲನಚಿತ್ರಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಭೌಗೋಳಿಕ_ಹೆಸರುಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಸರ್ಕಾರ_ಮತ್ತು_ಕಾನೂನು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಐಸ್_ಹಾಕಿ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಭಾಷೆಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಕಾನೂನು_ಜಾರಿ_ಏಜೆನ್ಸಿ_ವರ್ಗಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪಟ್ಟಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಹಸ್ತಪ್ರತಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಸಂಗೀತ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಸಂಖ್ಯೆಗಳು_ಮತ್ತು_ದಿನಾಂಕಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಜನರು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಬಹುವಚನಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ರಾಜಕೀಯ_ಪಕ್ಷಗಳು)
+        ]
+
+        described_class.new(kn_wiki).import_articles_by_title(titles)
+        response = VCR.current_cassette.serializable_hash.dig('http_interactions', 0, 'response')
+
+        title_count_in_response = response['body']['string'].scan(/"title":/).count
+
+        expect(response['status']['code']).not_to eq(414)
+        expect(title_count_in_response).to eq(titles.count)
       end
     end
   end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -285,7 +285,8 @@ module RequestHelpers
       'gl.wikipedia.org',
       'nl.wikipedia.org',
       'sv.wikipedia.org',
-      'uk.wikipedia.org'
+      'uk.wikipedia.org',
+      'kn.wikipedia.org'
     ]
 
     wikis.each do |wiki|


### PR DESCRIPTION
## What this PR does
Fixes `414 request-uri too long` for `import_articles_by_title` by using a POST request to send the query parameters in the `request.body` instead of a GET request:
- Adds `kn.wikipedia.org` to list of stubbed wiki validations
- Adds 3 API post methods, `api_post`, `do_post` and `too_many_requests` for creating and sending the post requests
- Refactors `import_articles_by_title` since response is now a hash
- Adds a test that confirms `414 request-uri too long` no longer occurs and a new vcr-cassette `some_article_titles.yml`

Adds `TYPICAL_ERRORS` array and safe navigation operator `&.` to `results = response&.dig('query', 'pages')` to prevent:
- `NameError: uninitialized constant ArticleImporter::TYPICAL_ERRORS` when `ApiErrorHandling` sets the error level
- `NoMethodError: undefined method dig for nil:NilClass results = response.dig('query', 'pages')` when response is nil ( for example when methods that call `import_articles_by_title` are mocked, the api_post response becomes `nil`)

The idea of `api_post` and `do_post` was gotten from a similar implementation in [replica.rb](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/60ffa77191a16d2e3986ca12cc72938d9bb63c91/lib/replica.rb#L140) and I tried to follow the flow of wiki_api.rb too.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/a231e7f4-667f-4045-8340-66a73037f7a8)

After:
![image](https://github.com/user-attachments/assets/9fdcf520-f27e-4793-9f6e-ac01c86c6b7a)
![image](https://github.com/user-attachments/assets/ce2600e5-437a-4b0e-8600-4147d5bafffc)

