### PR TITLE
fix style/optionalBooleanParam cop 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -171,8 +171,6 @@ Style/DateTime:
   Enabled: false
 Rails/ContentTag:
   Enabled: false
-Style/OptionalBooleanParameter:
-  Enabled: false
 Style/ExplicitBlockArgument:
   Enabled: false
 Style/KeywordParametersOrder:

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -186,7 +186,7 @@ class SurveysController < ApplicationController
     return false
   end
 
-  def user_is_assigned_to_survey(return_notification = false)
+  def user_is_assigned_to_survey(return_notification: false)
     return false if current_user.nil?
     notifications = current_user.survey_notifications.select do |n|
       n if n.survey.id == @survey.id

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -25,7 +25,7 @@ class TicketsController < ApplicationController
 
   private
 
-  def send_ticket_notification(owner=false)
+  def send_ticket_notification(owner: false)
     set_ticket_details
     TicketNotificationMailer.notify_of_message(
       course: @course,

--- a/app/helpers/surveys_analytics_helper.rb
+++ b/app/helpers/surveys_analytics_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SurveysAnalyticsHelper
-  def survey_status(survey, count = false)
+  def survey_status(survey, count: false)
     assignments = SurveyAssignment.published.where(survey_id: survey.id)
     return assignments.count if count
     return "In Use (#{assignments.count})" unless assignments.empty?

--- a/app/mailers/instructor_notification_mailer.rb
+++ b/app/mailers/instructor_notification_mailer.rb
@@ -6,7 +6,7 @@ class InstructorNotificationMailer < ApplicationMailer
     email(alert, bcc_to_salesforce).deliver_now
   end
 
-  def email(alert, bcc_to_salesforce = true)
+  def email(alert, bcc_to_salesforce: true)
     @alert = alert
     set_email_parameters
     params = { to: @instructors.pluck(:email),

--- a/app/models/alert_types/instructor_notification_alert.rb
+++ b/app/models/alert_types/instructor_notification_alert.rb
@@ -36,7 +36,7 @@ class InstructorNotificationAlert < Alert
   end
 
   # deliver the actual email immediately
-  def send_email(bcc_to_salesforce=true)
+  def send_email(bcc_to_salesforce: true)
     return if emails_disabled?
     InstructorNotificationMailer.send_email(self, bcc_to_salesforce)
     update(email_sent_at: Time.zone.now)

--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -25,7 +25,7 @@ class TrainingModulesUsers < ApplicationRecord
     training_progress_manager.slide_further_than_previous?(slide_slug, last_slide_completed)
   end
 
-  def mark_completion(value=true, course_id=nil)
+  def mark_completion(value: true, course_id: nil)
     flags[course_id] = { marked_complete: value }
   end
 


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
This PR attempts to make progress on the issue #5297 by removing the Style/optionalBooleanParameters cop from `.rubocop.yml` and fix the offenses generated by it. This style changes the definition of default boolean parameters inside function definitions from `func_name(bool_val = true`) to `func_name(bool_val: true)`.

## Screenshots
No UI changes made.

## Open questions and concerns
I have only commit changes to function definitions. Even though this fixes all the offenses generated by removing this cop, it's better to add such definition to function calls, i.e, `func_name(true)` to `func_name(bool_val: true)` so that it is clear for what variable the boolean value is being passed for. However, adding this would require to scan through the codebase and find the exact function calls for those functions which is a little tedious especially for the "email" function as there are many email functions defined in different classes. What are your thoughts on this ?