### PR TITLE
Fix: Prevents `414 request-uri too long` for `import_articles_by_title` by using a POST request

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -185,7 +185,7 @@ class Wiki < ApplicationRecord
 
   def ensure_wiki_exists
     return if errors.any? # Skip this check if the wiki had a validation error.
-    site_info = WikiApi.new(self).query(meta: :siteinfo)
+    site_info = WikiApi.new(self).meta(:siteinfo)
     raise InvalidWikiError, domain if site_info.nil?
     servername = site_info.data.dig('general', 'servername')
     raise InvalidWikiError, domain unless base_url == "https://#{servername}"

--- a/lib/importers/article_importer.rb
+++ b/lib/importers/article_importer.rb
@@ -26,7 +26,7 @@ class ArticleImporter
     # 40 is too much for some languages, such as bn.wipedia.org
     titles.each_slice(30) do |some_article_titles|
       query = { prop: 'info', titles: some_article_titles }
-      response = WikiApi.new(@wiki).query(query)
+      response = WikiApi.new(@wiki).query(query, http_method: :post)
       results = response&.data
       next if results.blank?
       results = results['pages']

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -20,8 +20,13 @@ class WikiApi
   ################
 
   # General entry point for making arbitrary queries of a MediaWiki wiki's API
-  def query(query_parameters)
-    mediawiki('query', query_parameters)
+  def query(query_parameters= {}, http_method: :get)
+    mediawiki('query', query_parameters.merge(http_method:))
+  end
+
+  def meta(type, params = {})
+    @mediawiki = api_client
+    @mediawiki.meta(type, params)
   end
 
   # Returns nil if it cannot get any info from the wiki, but returns

--- a/spec/lib/importers/article_importer_spec.rb
+++ b/spec/lib/importers/article_importer_spec.rb
@@ -8,6 +8,7 @@ describe ArticleImporter do
 
   let(:en_wiki) { Wiki.default_wiki }
   let(:es_wiki) { create(:wiki, language: 'es', project: 'wikipedia') }
+  let(:kn_wiki) { create(:wiki, language: 'kn', project: 'wikipedia') }
 
   describe '.import_articles' do
     it 'creates an Article from a English Wikipedia page_id' do
@@ -65,6 +66,59 @@ describe ArticleImporter do
       VCR.use_cassette 'article_importer/collisions' do
         described_class.new(en_wiki).import_articles_by_title(['Istanbul'])
         expect(Article.find_by(title: 'Istanbul').mw_page_id).to eq(3391396)
+      end
+    end
+
+    it 'returns the correct number of titles without raising error 414' do
+      VCR.use_cassette 'article_importer/some_article_titles' do
+        # Non-ASCII characters like those in the Kannada language shown
+        # below use 2 to 4 bytes per character in UTF-8 compared to the
+        # 1 byte of ASCII characters. If the titles below are appended
+        # to a GET request url as a parameter, the error '414 request uri too long'
+        # occurs. The fix is using a POST request instead and passing the titles
+        # as parameters in the request body.
+        titles = %w[
+          ವಿಕಿಪೀಡಿಯ:ಬದಲಿ
+          ವಿಕಿಪೀಡಿಯ:Talk_page_templates
+          ವಿಕಿಪೀಡಿಯ:ಸ್ಪಾಯ್ಲರ್
+          ವಿಕಿಪೀಡಿಯ:Revision_deletion
+          ವಿಕಿಪೀಡಿಯ:Open_proxies
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಭಾರತೀಯ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಖಗೋಳ_ವಸ್ತುಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪುಸ್ತಕಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪ್ರಸಾರ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ರಸಾಯನಶಾಸ್ತ್ರ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪಾದ್ರಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಕಾಮಿಕ್ಸ್)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಕಂಪನಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ದೇಶ-ನಿರ್ದಿಷ್ಟ_ವಿಷಯಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿನ_ಸಂಪ್ರದಾಯಗಳು_(ನಿರ್ದಿಷ್ಟ_ಅಥವಾ_ಅನಿರ್ದಿಷ್ಟ_ಲೇಖನ_ಹೆಸರಿನ_ಆರಂಭದಲ್ಲಿ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಜನಾಂಗೀಯಗಳು_ಮತ್ತು_ಬುಡಕಟ್ಟುಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪ್ರಾಣಿ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಚಲನಚಿತ್ರಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಭೌಗೋಳಿಕ_ಹೆಸರುಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಸರ್ಕಾರ_ಮತ್ತು_ಕಾನೂನು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಐಸ್_ಹಾಕಿ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಭಾಷೆಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಕಾನೂನು_ಜಾರಿ_ಏಜೆನ್ಸಿ_ವರ್ಗಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಪಟ್ಟಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಹಸ್ತಪ್ರತಿಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಸಂಗೀತ)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಸಂಖ್ಯೆಗಳು_ಮತ್ತು_ದಿನಾಂಕಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಜನರು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ಬಹುವಚನಗಳು)
+          ವಿಕಿಪೀಡಿಯ:ಹೆಸರಿಸುವ_ಸಂಪ್ರದಾಯಗಳು_(ರಾಜಕೀಯ_ಪಕ್ಷಗಳು)
+        ]
+
+        described_class.new(kn_wiki).import_articles_by_title(titles)
+
+        response = VCR.current_cassette.serializable_hash.dig('http_interactions', 0, 'response')
+        expect(response['status']['code']).not_to eq(414)
+
+        # Multiple titles could belong to a single article
+        # so count number of titles instead of articles
+        title_count_in_response = response['body']['string'].scan(/"title":/).count
+        expect(title_count_in_response).to eq(titles.count)
       end
     end
   end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -285,7 +285,8 @@ module RequestHelpers
       'gl.wikipedia.org',
       'nl.wikipedia.org',
       'sv.wikipedia.org',
-      'uk.wikipedia.org'
+      'uk.wikipedia.org',
+      'kn.wikipedia.org'
     ]
 
     wikis.each do |wiki|


### PR DESCRIPTION
## What this PR does
Fixes 414 request-uri too long for import_articles_by_title by using a POST request instead of a GET request:
- Adds kn.wikipedia.org to list of stubbed wiki validations
- Adds `meta` method in wiki_api to prevent:
```
      Failure/Error:
       def query(query_parameters = {}, http_method: :get)
         mediawiki('query', query_parameters.merge(http_method: http_method))

     ArgumentError:
       unknown keyword: :meta
     # ./lib/wiki_api.rb:23:in `query'
     # ./app/models/wiki.rb:188:in `ensure_wiki_exists'
```

The former code  ` site_info = WikiApi.new(self).query(meta: :siteinfo)` in `wiki.rb`'s[ `ensure_wiki_exists` method](https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/d0d5411c34cebc2c8de858e354e6229a1717458c/app/models/wiki.rb#L188) worked because the `query` method is a general entry point for all API requests and the `mediawiki` gem automatically processes `meta` requests since it is a valid method. My change to wiki_api's query method however bypasses the gem's automatic routing of `meta: :siteinfo` causing the error. 

The solution was implementing a `meta` method in the  `WikiApi` class that directly calls the [`meta` method](https://github.com/wikimedia/mediawiki-ruby-api/blob/84a1c3598524b048ab2b0cadf8ddbdbb07999114/lib/mediawiki_api/client.rb#L145) from the `mediawiki-api` gem.


- Adds a test that confirms `414 request-uri too long no longer occurs` and a new vcr-cassette `some_article_titles.yml`

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/88623a53-f485-435a-9ae4-7dffdff878f3)

After:
![image](https://github.com/user-attachments/assets/638670a5-8b35-4052-a27f-befa6d05c2dc)
![image](https://github.com/user-attachments/assets/938be12f-0b48-48bf-91a3-73fc4451f9fc)

