### PR TITLE
[FEAT]: Improve Survey Progress Bar Clarity

### DIFF
--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -440,6 +440,8 @@ const Survey = {
     const width = `${progress}%`;
     this.surveyProgress.css('width', width);
 
+    $('.survey__progress-percentage').text(`${Math.round(progress)}%`);
+
     if (progress === 100 && !this.submittedAll) {
       this.submitAllQuestionGroups();
     }

--- a/app/assets/stylesheets/survey_modules/survey_page.styl
+++ b/app/assets/stylesheets/survey_modules/survey_page.styl
@@ -136,29 +136,47 @@ ul.list--survey
   background white
   padding 1rem 0
 
-.survey__progress
-  background sprout-dark
+.survey__progress__container
   position relative
   float right
-  width 200px
-  height 20px
-  border-radius 5px
-  overflow hidden
+  margin-left auto
+  display flex
+  align-items center
+  gap 10px
 
-  +above(tablet)
-    margin-left auto
-
-  &-bar
-    position absolute
-    left 0
-    top 0
-    width 0%
-    height 30px
+  .survey__progress
     background lighten(sprout, 50%)
-    transition width 500ms cubic-bezier(0.19, 1, 0.22, 1)
-    border-right 2px solid darken(sprout-dark, 10%)
+    width 200px
+    height 20px
+    border-radius 5px
+    overflow hidden
 
-    .label
-      padding-left 5px
-      font-size 85%
-      color $text_dk
+    +above(tablet)
+      margin-left auto
+
+    &-bar
+      position relative
+      left 0
+      top 0
+      width 0%
+      height 30px
+      background sprout-dark
+      transition width 500ms cubic-bezier(0.19, 1, 0.22, 1)
+
+    &-percentage
+      position absolute
+      right 5px
+      top 0
+      line-height 20px
+      font-size 12px
+      color #fff
+      font-weight bold
+
+  .progress-label
+    background #40ad90
+    width fit-content
+    color #fff
+    font-size 75%
+    padding 2px 6px
+    border-radius 5px
+

--- a/app/views/surveys/_header.html.haml
+++ b/app/views/surveys/_header.html.haml
@@ -3,7 +3,8 @@
     %div
       %strong= survey_course_title
 
-    %div.survey__progress
-      .survey__progress-bar{data: {survey_progress: true}}
-        .label
-          progress
+    .survey__progress__container
+      .progress-label Progress
+      %div.survey__progress
+        .survey__progress-bar{data: {survey_progress: true}}
+        .survey__progress-percentage 0%

--- a/spec/features/surveys_spec.rb
+++ b/spec/features/surveys_spec.rb
@@ -132,7 +132,7 @@ describe 'Surveys', type: :feature, js: true do
       visit survey_path(@survey)
       # Sets the course automatically
       expect(page).to have_content 'Survey for My Active Course'
-      expect(page).to have_content 'progress'
+      expect(page).to have_content 'Progress'
     end
 
     it 'sets the course and shows the progress bar by going to the course page' do
@@ -144,7 +144,7 @@ describe 'Surveys', type: :feature, js: true do
       click_link 'Take Survey'
       # Sets the course automatically
       expect(page).to have_content 'Survey for My Active Course'
-      expect(page).to have_content 'progress'
+      expect(page).to have_content 'Progress'
     end
 
     it 'renders an optout page' do


### PR DESCRIPTION

## What this PR does
This PR enhances the survey progress bar to make its meaning more intuitive for users. Based on issue #938,
users found the progress bar unclear. To address this, the following improvements have been made:

- Added a percentage label to indicate completion status.
- Added a clearly visible label, providing context for the progress bar.

## Screenshots
Before:

![image](https://github.com/user-attachments/assets/c44b93d6-ab54-4fee-9508-143817bfe2d5)

After:

[Screencast from 2025-02-25 19-31-05.webm](https://github.com/user-attachments/assets/4f654bc9-02aa-4346-96c4-90fd511da1a0)


## Additional Description
Yes, you were right @ragesoss. If the indicator with checks/circles for each question (the last proposed option) is implemented then the users might be confused about why the progress bar updates by a larger number of questions—including conditional ones—when they have only answered a single question. This could lead to misunderstandings about how progress is measured.
Therefore, in place of that I have implemented the progress bar with percentage completion and have tried to revamp it.

Let me know, if this approach isn't satisying enough, we can try something else.
