### PR TITLE
[Data rearchitecture] Add `CustomRevisionFilter` module to shared logic for filtering revisions.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -352,6 +352,18 @@ class Course < ApplicationRecord
     revisions
   end
 
+  def scoped_article_titles
+    assigned_article_titles + category_article_titles
+  end
+
+  def assigned_article_titles
+    assignments.pluck(:article_title)
+  end
+
+  def category_article_titles
+    categories.inject([]) { |ids, cat| ids + cat.article_titles }
+  end
+
   def scoped_article_ids
     assigned_article_ids + category_article_ids
   end

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -50,6 +50,7 @@
 #
 
 class ArticleScopedProgram < Course
+  include CustomRevisionFilter
   has_many(:revisions, lambda do |course|
     where('date >= ?', course.start)
     .where('date <= ?', course.end)
@@ -75,15 +76,6 @@ class ArticleScopedProgram < Course
 
   def passcode_required?
     false
-  end
-
-  def filter_revisions(wiki, revisions)
-    filtered_data = revisions.select do |_, details|
-      article_title = details['article']['title']
-      formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
-      scoped_article_titles.include?(formatted_article_title)
-    end
-    filtered_data
   end
 
   def scoped_article_titles

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -77,16 +77,4 @@ class ArticleScopedProgram < Course
   def passcode_required?
     false
   end
-
-  def scoped_article_titles
-    assigned_article_titles + category_article_titles
-  end
-
-  def assigned_article_titles
-    assignments.pluck(:article_title)
-  end
-
-  def category_article_titles
-    categories.inject([]) { |ids, cat| ids + cat.article_titles }
-  end
 end

--- a/app/models/course_types/custom_revision_filter.rb
+++ b/app/models/course_types/custom_revision_filter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CustomRevisionFilter
+  # This module contains the shared logic for ArticleScopedCourse
+  # and VisitingCourse
+  def filter_revisions(wiki, revisions)
+    filtered_data = revisions.select do |_, details|
+      article_title = details['article']['title']
+      formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
+      scoped_article_titles.include?(formatted_article_title)
+    end
+    filtered_data
+  end
+end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -55,7 +55,7 @@ class VisitingScholarship < Course
   has_many(:revisions, lambda do |course|
     where('date >= ?', course.start)
     .where('date <= ?', course.end)
-    .where(article_id: course.assignments.pluck(:article_id))
+    .where(article_id: course.assigned_article_ids)
   end, through: :students)
 
   def wiki_edits_enabled?
@@ -79,10 +79,6 @@ class VisitingScholarship < Course
   end
 
   def scoped_article_titles
-    assignments.pluck(:article_title)
-  end
-
-  def scoped_article_ids
-    assignments.pluck(:article_id)
+    assigned_article_titles
   end
 end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -50,6 +50,8 @@
 #
 
 class VisitingScholarship < Course
+  include CustomRevisionFilter
+
   has_many(:revisions, lambda do |course|
     where('date >= ?', course.start)
     .where('date <= ?', course.end)
@@ -74,15 +76,6 @@ class VisitingScholarship < Course
 
   def multiple_roles_allowed?
     true
-  end
-
-  def filter_revisions(wiki, revisions)
-    filtered_data = revisions.select do |_, details|
-      article_title = details['article']['title']
-      formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
-      scoped_article_titles.include?(formatted_article_title)
-    end
-    filtered_data
   end
 
   def scoped_article_titles


### PR DESCRIPTION
## What this PR does
Add `CustomRevisionFilter` module to avoid duplicating logic between  `ArticleScopedProgram` and `VisitingScholarship` course types.

## Open questions and concerns
TODO: remove the following definitions from Course class when doing final cleanup.

```
  def scoped_article_ids
    assigned_article_ids + category_article_ids
  end
  def assigned_article_ids
    assignments.pluck(:article_id)
  end
  def category_article_ids
    categories.inject([]) { |ids, cat| ids + cat.article_ids }
  end
```