### PR TITLE
fix: make feedback response required

### DIFF
--- a/app/views/feedback_form_responses/new.html.haml
+++ b/app/views/feedback_form_responses/new.html.haml
@@ -15,5 +15,5 @@
 
   = simple_form_for @feedback_form_response do |f|
     = f.input :subject,  as: :hidden, input_html: { value: @subject }
-    = f.input :body, label: false
+    = f.input :body, label: false, required: true
     = f.submit 'Submit', class: 'button dark'


### PR DESCRIPTION
## What this PR does
This update ensures that the ```body``` field in the feedback form is required, preventing empty and unnecessary feedback submissions.

### Changes:

Added ```required: true``` to the body field for feedback response form

### Why this is needed:

Prevents users from submitting blank feedback

