### PR TITLE
[Data rearchitecture] Fix bug in RevisionScoreImporter

### DIFF
--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -196,7 +196,8 @@ class RevisionScoreImporter
   def update_previous_scores(rev, parent_rev_scores)
     rev.wp10_previous = parent_rev_scores['wp10']
     rev.features_previous = parent_rev_scores['features']
-    rev.error = parent_rev_scores['error']
+    # turn on error if there was an error fetching parent scores
+    rev.error = true if parent_rev_scores['error']
   end
 
   class InvalidWikiError < StandardError; end


### PR DESCRIPTION
## What this PR does
This PR fixes a bug that Sage pointed out [here](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6199#discussion_r1972266818). If fetching revision scores failed, but fetching parent revision scores worked, the `Revision.error` field was incorrectly set to `false`. This bug was introduced in commit 6b27c5d5c18ac9f0c199269f855bf4879d860234, and specs didn't detect it.

This PR fixes the bug by minimizing the changes in the code (since we are going to do the first deployment tomorrow). New tests were added to catch cases such as these. I first added the tests and confirmed that one failed. Then, I modified `RevisionScoreImporter` and the specs were fixed.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
