### PR TITLE
[WIP] [Data rearchitecture] Hot fix to populate first_revision for existing articles courses

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -95,6 +95,11 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.references_count = article_course_timeslices.sum(&:references_count)
     self.user_ids = article_course_timeslices.sum([], &:user_ids).uniq
     self.new_article = article_course_timeslices.any?(&:new_article)
+    # This was added as a hot fix after first timeslice deployment because
+    # all articles courses records had first_revision set to null after
+    # migration.
+    # IMPORTANT: only makes sense if using daily timeslice duration
+    self.first_revision = article_course_timeslices.minimum(:start) if first_revision.nil?
     save
   end
 

--- a/lib/alerts/continued_course_activity_alert_manager.rb
+++ b/lib/alerts/continued_course_activity_alert_manager.rb
@@ -33,7 +33,7 @@ class ContinuedCourseActivityAlertManager
   def count_revisions_for_wiki(course, wiki)
     # 50 is the max users for query
     course.students.pluck(:username).in_groups_of(40, false).sum do |usernames|
-      response = WikiApi.new(wiki).query(query(course, usernames), http_method: :post)
+      response = WikiApi.new(wiki).query(query(course, usernames))
       response.data['usercontribs'].count
     end
   end

--- a/lib/alerts/continued_course_activity_alert_manager.rb
+++ b/lib/alerts/continued_course_activity_alert_manager.rb
@@ -33,7 +33,7 @@ class ContinuedCourseActivityAlertManager
   def count_revisions_for_wiki(course, wiki)
     # 50 is the max users for query
     course.students.pluck(:username).in_groups_of(40, false).sum do |usernames|
-      response = WikiApi.new(wiki).query(query(course, usernames))
+      response = WikiApi.new(wiki).query(query(course, usernames), http_method: :post)
       response.data['usercontribs'].count
     end
   end


### PR DESCRIPTION
## What this PR does
Populate first_revision field as part of the article course update cache based on the start date for the first article course timeslice record. Only if first_revision is null. This is a hot-fix because I did not take into account that all existing articles courses would have first_revision set to nil after migration. IMPORTANT: only accurate if using daily timeslices.
## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
