### PR TITLE
Fix: Revert to ignoring the VCR cassette and removing the cached folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@
 /config/newrelic.yml
 /config/secrets.yml
 /dockerAuth.json
-/fixtures/vcr_cassettes/*
-!/fixtures/vcr_cassettes/cached/
-!/fixtures/vcr_cassettes/cached/*
+/fixtures
 /node_modules
 /js_coverage
 /vendor/*

--- a/spec/features/assigned_articles_spec.rb
+++ b/spec/features/assigned_articles_spec.rb
@@ -19,7 +19,7 @@ describe 'Assigned Articles view', type: :feature, js: true do
   it 'lets users submit feedback about articles' do
     # This makes a call to the LiftWing API from the server,
     # we need to use VCR to avoid getting stopped by WebMock
-    VCR.use_cassette('cached/assigned_articles_view') do
+    VCR.use_cassette('assigned_articles_view') do
       visit "/courses/#{course.slug}/articles/assigned"
       expect(page).to have_content('Nancy Tuana')
       find('a', text: 'Feedback').click


### PR DESCRIPTION

## What this PR does
This PR is a cleanup of the codebase. Previously, to reduce build time, VCR cassettes were included on the remote server so that each test could use its respective cassette and minimize actual API calls. However, since a new approach has been implemented to address the issue, I am reverting to ignoring the VCR cassettes and removing the cached folder.
