### PR TITLE
[Data rearchitecture] Fix bug for scoped articles courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -346,8 +346,8 @@ class Course < ApplicationRecord
     end.flatten
   end
 
-  def article_status_manager_enabled?
-    true
+  def only_scoped_articles_course?
+    false
   end
 
   # The default implemention retrieves all the revisions.

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -346,6 +346,10 @@ class Course < ApplicationRecord
     end.flatten
   end
 
+  def article_status_manager_enabled?
+    true
+  end
+
   # The default implemention retrieves all the revisions.
   # A course type may override this implementation.
   def filter_revisions(_wiki, revisions)

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -78,7 +78,7 @@ class ArticleScopedProgram < Course
     false
   end
 
-  def article_status_manager_enabled?
-    false
+  def only_scoped_articles_course?
+    true
   end
 end

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -77,4 +77,8 @@ class ArticleScopedProgram < Course
   def passcode_required?
     false
   end
+
+  def article_status_manager_enabled?
+    false
+  end
 end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -82,6 +82,10 @@ class VisitingScholarship < Course
     assigned_article_titles
   end
 
+  def scoped_article_ids
+    assigned_article_ids
+  end
+
   def only_scoped_articles_course?
     true
   end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -81,4 +81,8 @@ class VisitingScholarship < Course
   def scoped_article_titles
     assigned_article_titles
   end
+
+  def article_status_manager_enabled?
+    false
+  end
 end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -82,7 +82,7 @@ class VisitingScholarship < Course
     assigned_article_titles
   end
 
-  def article_status_manager_enabled?
-    false
+  def only_scoped_articles_course?
+    true
   end
 end

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -123,6 +123,7 @@ class UpdateCourseStatsTimeslice
 
   TEN_MINUTES = 600
   def should_update_article_status?
+    return false unless @course.article_status_manager_enabled?
     return true if Features.wiki_ed?
     # To cut down on overwhelming the system
     # for courses with huge numbers of articles

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -123,7 +123,9 @@ class UpdateCourseStatsTimeslice
 
   TEN_MINUTES = 600
   def should_update_article_status?
-    return false unless @course.article_status_manager_enabled?
+    # Never run article status manager for courses that work only with a specific
+    # list of articles.
+    return false if @course.only_scoped_articles_course?
     return true if Features.wiki_ed?
     # To cut down on overwhelming the system
     # for courses with huge numbers of articles

--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -34,7 +34,8 @@ class UpdateTimeslicesCourseDate
 
     remove_timeslices_prior_to_start_date
     remove_timeslices_after_end_date
-    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
+    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis,
+                                                                     needs_update: true)
   end
 
   def update_timeslices_if_start_date_changed

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -43,7 +43,7 @@ class UpdateTimeslicesScopedArticle
     return if article_ids.empty?
 
     Rails.logger.info "UpdateTimeslicesScopedArticle: Course: #{@course.slug}\
-    Resetting #{@article_ids}"
+    Resetting #{article_ids}"
 
     # Mark course wiki timeslices to be re-proccesed
     articles = Article.where(id: article_ids)

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -16,7 +16,7 @@ class UpdateTimeslicesScopedArticle
   end
 
   def run
-    return unless %w[ArticleScopedProgram VisitingScholarship].include? @course.type
+    return unless @course.only_scoped_articles_course?
     # Get the scoped articles that don't have articles courses but do have ac timeslices
     articles_with_timeslices = @course.article_course_timeslices
                                       .where(article_id: @scoped_article_ids)

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -18,9 +18,9 @@ class TimesliceManager
 
   # Creates course wiki timeslices records for new course wikis
   # Takes a collection of Wikis
-  def create_timeslices_for_new_course_wiki_records(wikis)
+  def create_timeslices_for_new_course_wiki_records(wikis, needs_update: false)
     wikis.each do |wiki|
-      create_empty_course_wiki_timeslices(start_dates(wiki), wiki)
+      create_empty_course_wiki_timeslices(start_dates(wiki), wiki, needs_update:)
     end
   end
 

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -206,5 +206,27 @@ describe UpdateCourseStatsTimeslice do
         subject
       end
     end
+
+    context 'when course is ArticleScopedProgram type' do
+      let(:course) do
+        create(:article_scoped_program, start: 1.day.ago, end: 1.year.from_now)
+      end
+
+      it 'skips article status updates' do
+        expect_any_instance_of(described_class).not_to receive(:update_article_status)
+        subject
+      end
+    end
+
+    context 'when course is VistingScholarship type' do
+      let(:course) do
+        create(:visiting_scholarship, start: 1.day.ago, end: 1.year.from_now)
+      end
+
+      it 'skips article status updates' do
+        expect_any_instance_of(described_class).not_to receive(:update_article_status)
+        subject
+      end
+    end
   end
 end

--- a/spec/services/update_timeslices_course_date_spec.rb
+++ b/spec/services/update_timeslices_course_date_spec.rb
@@ -146,7 +146,7 @@ describe UpdateTimeslicesCourseDate do
       described_class.new(course).run
       # Timeslices from old period were deleted and new ones were created
       expect(course.course_wiki_timeslices.count).to eq(11)
-      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(11)
       expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.article_course_timeslices.count).to eq(0)
     end
@@ -168,7 +168,7 @@ describe UpdateTimeslicesCourseDate do
       described_class.new(course).run
       # Timeslices from old period were deleted and new ones were created
       expect(course.course_wiki_timeslices.count).to eq(11)
-      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(11)
       expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.article_course_timeslices.count).to eq(0)
     end


### PR DESCRIPTION
## What this PR does
This PR avoids running the article status manager for `ArticleScopedProgram` and `VisitingScholarship` courses. It was created after debugging course Visiting Scholars at Northeastern University - Rosiestep
 in Wiki Edu Dashboard (see [this](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6191#issuecomment-2695217137) comment).
 
 ### Explanation
 This is the documentation about `ArticleStatusManagerTimeslice`:
```
#= Updates articles to reflect deletion and page moves on Wikipedia
# This class is responsible for two main things (we may separate it in the future).
# - Iterate over article course timeslices to sync articles. This updates title,
# namespace, deleted and mw_page_id fields.
# - Reset articles according to their new status:
#   * Articles that were deleted or untracked. These are articles that were either
#   deleted or moved to a namespace not traceable by the course. Such articles
#   should be excluded from course statistics.
#   * Articles that were restored or re-tracked: These are articles that were
#   either undeleted or moved to a namespace relevant to the course. Such articles
#   should be included in course statistics.
```
The problem with this logic for `ArticleScopedProgram` or `VisitingScholarship` courses, is that it "thinks" that all articles that have an ACT record but do not have an article course record (because they're non-scoped articles) were "re-tracked". That's because those articles are indeed in a tracked wiki and namespace. As no article course record exists for them, the manager "thinks" they were recently moved to a tracked wiki namespace. Then, it marks all timeslices associated to them to be reprocessed.

Note that `UpdateTimeslicesScopedArticle` class takes care of checking if a scoped article was deleted from the list (for example because an assignment is deleted), or if a new one was added (for example, because a category was added). However, this class is not a replacement for the article status manager, since the article status manager checks deletion/movements of the article itself. As we don't expect wikipedia scoped articles to be deleted or moved to a different namespace frequently, we consider OK to skip the article status manager.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
