### PR TITLE
[Data rearchitecture] Add new first revision strategy and skip article status manger for scoped courses

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -66,6 +66,8 @@ class ArticleCourseTimeslice < ApplicationRecord
       # Update cache for ArticleCourseTimeslice
       ac_timeslice.update_cache_from_revisions revisions_in_timeslice
     end
+    # Maybe update first_revision in article course record
+    ArticlesCourses.maybe_update_first_revision(course, article_id, revisions[:revisions])
   end
 
   ####################

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -346,6 +346,10 @@ class Course < ApplicationRecord
     end.flatten
   end
 
+  def only_scoped_articles_course?
+    false
+  end
+
   # The default implemention retrieves all the revisions.
   # A course type may override this implementation.
   def filter_revisions(_wiki, revisions)

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -95,11 +95,6 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.references_count = article_course_timeslices.sum(&:references_count)
     self.user_ids = article_course_timeslices.sum([], &:user_ids).uniq
     self.new_article = article_course_timeslices.any?(&:new_article)
-    # This was added as a hot fix after first timeslice deployment because
-    # all articles courses records had first_revision set to null after
-    # migration.
-    # IMPORTANT: only makes sense if using daily timeslice duration
-    self.first_revision = article_course_timeslices.minimum(:start) if first_revision.nil?
     save
   end
 
@@ -195,9 +190,8 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     tracked_wiki_ids = course.wikis.pluck(:id)
     new_article_ids = Article.where(id: article_ids_without_ac, wiki_id: tracked_wiki_ids)
                              .pluck(:id)
-    first_revisions = get_first_revisions(revisions, new_article_ids)
     new_records = new_article_ids.map do |id|
-      { article_id: id, course_id: course.id, first_revision: first_revisions[id] }
+      { article_id: id, course_id: course.id }
     end
 
     maybe_insert_new_records(new_records)
@@ -210,21 +204,6 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     min_revision = revisions.minimum(:date)
     return if first_revision && min_revision >= first_revision
     article_course.update(first_revision: min_revision)
-  end
-
-  # Given an array of revisions and an array of article ids,
-  # it returns a hash with the min revision datetime for every article id.
-  def self.get_first_revisions(revisions, new_article_ids)
-    # TODO: find a better way to ensure an always-greater value
-    max_time = Time.utc(9999, 12, 31)
-    min_dates = Hash.new(max_time)
-
-    revisions.each do |revision|
-      if new_article_ids.include?(revision.article_id)
-        min_dates[revision.article_id] = [min_dates[revision.article_id], revision.date].min
-      end
-    end
-    min_dates
   end
 
   def self.maybe_insert_new_records(new_records)

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -203,6 +203,15 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     maybe_insert_new_records(new_records)
   end
 
+  def self.maybe_update_first_revision(course, article_id, revisions)
+    article_course = ArticlesCourses.find_by(course:, article_id:)
+    return unless article_course
+    first_revision = article_course.first_revision
+    min_revision = revisions.minimum(:date)
+    return if first_revision && min_revision >= first_revision
+    article_course.update(first_revision: min_revision)
+  end
+
   # Given an array of revisions and an array of article ids,
   # it returns a hash with the min revision datetime for every article id.
   def self.get_first_revisions(revisions, new_article_ids)

--- a/app/models/course_types/article_scoped_program.rb
+++ b/app/models/course_types/article_scoped_program.rb
@@ -77,4 +77,8 @@ class ArticleScopedProgram < Course
   def passcode_required?
     false
   end
+
+  def only_scoped_articles_course?
+    true
+  end
 end

--- a/app/models/course_types/visiting_scholarship.rb
+++ b/app/models/course_types/visiting_scholarship.rb
@@ -81,4 +81,12 @@ class VisitingScholarship < Course
   def scoped_article_titles
     assigned_article_titles
   end
+
+  def scoped_article_ids
+    assigned_article_ids
+  end
+
+  def only_scoped_articles_course?
+    true
+  end
 end

--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -123,6 +123,9 @@ class UpdateCourseStatsTimeslice
 
   TEN_MINUTES = 600
   def should_update_article_status?
+    # Never run article status manager for courses that work only with a specific
+    # list of articles.
+    return false if @course.only_scoped_articles_course?
     return true if Features.wiki_ed?
     # To cut down on overwhelming the system
     # for courses with huge numbers of articles

--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -34,7 +34,8 @@ class UpdateTimeslicesCourseDate
 
     remove_timeslices_prior_to_start_date
     remove_timeslices_after_end_date
-    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
+    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis,
+                                                                     needs_update: true)
   end
 
   def update_timeslices_if_start_date_changed

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -16,7 +16,7 @@ class UpdateTimeslicesScopedArticle
   end
 
   def run
-    return unless %w[ArticleScopedProgram VisitingScholarship].include? @course.type
+    return unless @course.only_scoped_articles_course?
     # Get the scoped articles that don't have articles courses but do have ac timeslices
     articles_with_timeslices = @course.article_course_timeslices
                                       .where(article_id: @scoped_article_ids)
@@ -43,7 +43,7 @@ class UpdateTimeslicesScopedArticle
     return if article_ids.empty?
 
     Rails.logger.info "UpdateTimeslicesScopedArticle: Course: #{@course.slug}\
-    Resetting #{@article_ids}"
+    Resetting #{article_ids}"
 
     # Mark course wiki timeslices to be re-proccesed
     articles = Article.where(id: article_ids)

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -18,9 +18,9 @@ class TimesliceManager
 
   # Creates course wiki timeslices records for new course wikis
   # Takes a collection of Wikis
-  def create_timeslices_for_new_course_wiki_records(wikis)
+  def create_timeslices_for_new_course_wiki_records(wikis, needs_update: false)
     wikis.each do |wiki|
-      create_empty_course_wiki_timeslices(start_dates(wiki), wiki)
+      create_empty_course_wiki_timeslices(start_dates(wiki), wiki, needs_update:)
     end
   end
 

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -223,7 +223,6 @@ describe ArticlesCourses, type: :model do
       expect(described_class.count).to eq(0)
       described_class.update_from_course_revisions(course, array_revisions)
       expect(described_class.count).to eq(2)
-      expect(described_class.first.first_revision).to eq('2024-07-06 20:05:10')
     end
   end
 

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -226,4 +226,44 @@ describe ArticlesCourses, type: :model do
       expect(described_class.first.first_revision).to eq('2024-07-06 20:05:10')
     end
   end
+
+  describe '.maybe_update_first_revision' do
+    let(:array_revisions) { [] }
+    let(:subject) do
+      described_class.maybe_update_first_revision(course, article.id, array_revisions)
+    end
+
+    before do
+      array_revisions << build(:revision, article:, user:, date: '2024-07-07',
+            system: true, new_article: true, scoped: true)
+      array_revisions << build(:revision, article:, user:, date: '2024-07-06 20:05:10',
+            system: true, new_article: true, scoped: true)
+      array_revisions << build(:revision, article:, user:, date: '2024-07-06 20:06:11',
+            system: true, new_article: true, scoped: true)
+    end
+
+    it 'returns immediately if no article course' do
+      subject
+    end
+
+    it 'does not update first_revision if existing value is a previous date' do
+      date = '2024-07-05 23:59:52'
+      create(:articles_course, course:, article:, first_revision: date)
+      subject
+      expect(described_class.find_by(course:, article:).first_revision).to eq(date)
+    end
+
+    it 'updates first_revision if existing value is a later date' do
+      date = '2024-07-07 05:59:52'
+      create(:articles_course, course:, article:, first_revision: date)
+      subject
+      expect(described_class.find_by(course:, article:).first_revision).to eq('2024-07-06 20:05:10')
+    end
+
+    it 'updates first_revision if existing value is nil' do
+      create(:articles_course, course:, article:)
+      subject
+      expect(described_class.find_by(course:, article:).first_revision).to eq('2024-07-06 20:05:10')
+    end
+  end
 end

--- a/spec/services/update_course_stats_timeslice_spec.rb
+++ b/spec/services/update_course_stats_timeslice_spec.rb
@@ -206,5 +206,27 @@ describe UpdateCourseStatsTimeslice do
         subject
       end
     end
+
+    context 'when course is ArticleScopedProgram type' do
+      let(:course) do
+        create(:article_scoped_program, start: 1.day.ago, end: 1.year.from_now)
+      end
+
+      it 'skips article status updates' do
+        expect_any_instance_of(described_class).not_to receive(:update_article_status)
+        subject
+      end
+    end
+
+    context 'when course is VistingScholarship type' do
+      let(:course) do
+        create(:visiting_scholarship, start: 1.day.ago, end: 1.year.from_now)
+      end
+
+      it 'skips article status updates' do
+        expect_any_instance_of(described_class).not_to receive(:update_article_status)
+        subject
+      end
+    end
   end
 end

--- a/spec/services/update_timeslices_course_date_spec.rb
+++ b/spec/services/update_timeslices_course_date_spec.rb
@@ -146,7 +146,7 @@ describe UpdateTimeslicesCourseDate do
       described_class.new(course).run
       # Timeslices from old period were deleted and new ones were created
       expect(course.course_wiki_timeslices.count).to eq(11)
-      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(11)
       expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.article_course_timeslices.count).to eq(0)
     end
@@ -168,7 +168,7 @@ describe UpdateTimeslicesCourseDate do
       described_class.new(course).run
       # Timeslices from old period were deleted and new ones were created
       expect(course.course_wiki_timeslices.count).to eq(11)
-      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(11)
       expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.article_course_timeslices.count).to eq(0)
     end


### PR DESCRIPTION
## What this PR does
This PR cherry-picks 4 commits already deployed to data-rearchitecture instance. This PR changes two things: 

1. changes the `first_revision` population strategy to work without matter the timeslice duration (see PR #6230 ) and
2. skip article status manager for `ArticleScopedProgram` and `VisitingScholarship` courses (see PR #6235)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
