### PR TITLE
Add new user data endpoint

### DIFF
--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -7,6 +7,15 @@ class UserProfilesController < ApplicationController
   before_action :set_user_profile, only: [:update, :update_email_preferences]
   before_action :require_write_permissions, only: [:update]
 
+  def taught_courses_articles
+    user = User.find_by(username: params[:username])
+    return render json: { error: 'User not found' }, status: :not_found if user.nil?
+
+    data = user.taught_courses_with_edited_articles
+
+    render json: data, status: :ok
+  end
+
   def show
     if @user
       @last_courses_user = @user.courses_users.includes(:course)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,6 +208,24 @@ class User < ApplicationRecord
     (user_profile || create_user_profile).email_preferences_token
   end
 
+  def taught_courses_with_edited_articles
+    taught_courses = instructed_courses.includes(articles_courses: :article)
+
+    taught_courses.map do |course|
+      {
+        course_id: course.id,
+        course_title: course.title,
+        course_slug: course.slug,
+        articles: course.articles_courses.map do |ac|
+          {
+            article_id:   ac.article.id,
+            article_title: ac.article.title
+          }
+        end.uniq { |a| a[:article_id] }
+      }
+    end
+  end
+
   # Exclude tokens/secrets from json output
   def to_json(options={})
     options[:except] ||= %i[wiki_token wiki_secret remember_token]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,20 +208,26 @@ class User < ApplicationRecord
     (user_profile || create_user_profile).email_preferences_token
   end
 
-  def taught_courses_with_edited_articles
-    taught_courses = instructed_courses.includes(articles_courses: :article)
-
-    taught_courses.map do |course|
+  def mapped_articles(course)
+    article_maps = course.articles_courses.map do |ac|
       {
-        course_id: course.id,
+        article_id: ac.article.id,
+        article_title: ac.article.title
+      }
+    end
+
+    article_maps.uniq { |article| article[:article_id] }
+  end
+
+  def taught_courses_with_edited_articles
+    courses = instructed_courses.includes(articles_courses: :article, courses_users: :user)
+
+    courses.map do |course|
+      {
         course_title: course.title,
         course_slug: course.slug,
-        articles: course.articles_courses.map do |ac|
-          {
-            article_id:   ac.article.id,
-            article_title: ac.article.title
-          }
-        end.uniq { |a| a[:article_id] }
+        articles: mapped_articles(course),
+        users: course.users.distinct.map { |u| { username: u.username } }
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
 
   #UserProfilesController
   controller :user_profiles do
+    get 'users/:username/taught_courses_articles' => 'user_profiles#taught_courses_articles', constraints: { username: /.*/ }
     get 'users/:username' => 'user_profiles#show' , constraints: { username: /.*/ }
     get 'user_stats' => 'user_profiles#stats'
     get 'stats_graphs' => 'user_profiles#stats_graphs'


### PR DESCRIPTION

## What this PR does
This PR adds a new JSON endpoint `/users/username/taught_courses_articles.json` that fetches all courses taught by the specified user + all the articles edited in each course by any user of that course + all users belonging to each course. This endpoint is required for use in the wiki impact visualizer tool.

the returned data for a singular course would look like this:
```
[
  {
    course_title: "Course Title",
    course_slug: "course-slug",
    articles: [
      {
        article_id: ArticleID,
        article_title: "Article Title"
      },
      ...
    ],
    users: [
      {
        username: "Username"
      },
      ...
    ]
  },
  ...
]
```

## Video

https://github.com/user-attachments/assets/c427d3be-30d8-41f9-a947-48b49f3a7924

