### PR TITLE
[Data-rearchitecture] Force revisions to be associated to non-deleted articles

### DIFF
--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -67,7 +67,8 @@ class RevisionDataManager
 
   def import_and_resolve_duplicate_articles(articles)
     ArticleImporter.new(@wiki).import_articles_from_revision_data(articles)
-    @articles = Article.where(wiki_id: @wiki.id, mw_page_id: articles.map { |a| a['mw_page_id'] })
+    @articles = Article.where(wiki_id: @wiki.id, deleted: false,
+                              mw_page_id: articles.map { |a| a['mw_page_id'] })
     DuplicateArticleDeleter.new(@wiki).resolve_duplicates_for_timeslices(@articles)
   end
 


### PR DESCRIPTION
## What this PR does
This PR ensures the recently fetched revisions are associated to a non-deleted article. It's a quick try to fix the bug that it's causing [all these sentry logs](https://wiki-education.sentry.io/issues/6338758408/events/?project=6251155&referrer=issue-stream&statsPeriod=90d&stream_index=0).

## Open questions and concerns
What if there are no non-deleted article for a given `mw_page_id`?