### PR TITLE
[WIP] Switch to using authenticated mediawiki requests to increase rate limits

### DIFF
--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -6,6 +6,8 @@ require "#{Rails.root}/lib/wiki_api"
 class UnexpectedError < StandardError; end
 
 describe WikiApi do
+  before { stub_log_in }
+
   describe 'handles errors by calling ApiErrorHandling method and raising a PageFetchError' do
     let(:subject) { described_class.new.get_page_content('Ragesoss') }
 
@@ -13,7 +15,7 @@ describe WikiApi do
       stub_wikipedia_503_error
       expect { subject }.to raise_error(
         WikiApi::PageFetchError,
-        /Failed to fetch content for Ragesoss with response status: 503/
+        /Failed to fetch content for Ragesoss with response status: nil/
       )
     end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -253,47 +253,63 @@ module RequestHelpers
       .to_return(status: 503, body: '', headers: {})
   end
 
-  def stub_wiki_validation
-    wikis = [
-      'incubator.wikimedia.org',
-      'es.wikipedia.org',
-      'pt.wikipedia.org',
-      'zh.wikipedia.org',
-      'mr.wikipedia.org',
-      'eu.wikipedia.org',
-      'fa.wikipedia.org',
-      'fr.wikipedia.org',
-      'ru.wikipedia.org',
-      'simple.wikipedia.org',
-      'tr.wikipedia.org',
-      'en.wiktionary.org',
-      'es.wiktionary.org',
-      'ta.wiktionary.org',
-      'es.wikibooks.org',
-      'en.wikibooks.org',
-      'ar.wikibooks.org',
-      'en.wikivoyage.org',
-      'wikisource.org',
-      'es.wikisource.org',
-      'www.wikidata.org',
-      'en.wikinews.org',
-      'pl.wikiquote.org',
-      'de.wikiversity.org',
-      'commons.wikimedia.org',
-      'de.wikipedia.org',
-      'en.wikipedia.org',
-      'gl.wikipedia.org',
-      'nl.wikipedia.org',
-      'sv.wikipedia.org',
-      'uk.wikipedia.org',
-      'kn.wikipedia.org'
-    ]
+  WIKIS = %w[
+    incubator.wikimedia.org
+    es.wikipedia.org
+    pt.wikipedia.org
+    zh.wikipedia.org
+    mr.wikipedia.org
+    eu.wikipedia.org
+    fa.wikipedia.org
+    fr.wikipedia.org
+    ru.wikipedia.org
+    simple.wikipedia.org
+    tr.wikipedia.org
+    en.wiktionary.org
+    es.wiktionary.org
+    ta.wiktionary.org
+    es.wikibooks.org
+    en.wikibooks.org
+    ar.wikibooks.org
+    en.wikivoyage.org
+    wikisource.org
+    es.wikisource.org
+    www.wikidata.org
+    en.wikinews.org
+    pl.wikiquote.org
+    de.wikiversity.org
+    commons.wikimedia.org
+    de.wikipedia.org
+    en.wikipedia.org
+    gl.wikipedia.org
+    nl.wikipedia.org
+    sv.wikipedia.org
+    uk.wikipedia.org
+    kn.wikipedia.org
+  ].freeze
 
-    wikis.each do |wiki|
+  def stub_wiki_validation
+    WIKIS.each do |wiki|
       stub_request(:get, "https://#{wiki}/w/api.php?action=query&format=json&meta=siteinfo")
         .to_return(status: 200,
                    body: "{\"query\":{\"general\":{\"servername\":\"#{wiki}\"}}}",
                    headers: {})
+    end
+  end
+
+  def stub_get_token(wiki)
+    fake_tokens = '{"query":{"tokens":{"logintoken":"faketoken+\\\\"}}}'
+    stub_request(:get, "https://#{wiki}/w/api.php?action=query&format=json&meta=tokens&type=login")
+      .to_return(status: 200, body: fake_tokens, headers: {})
+  end
+
+  def stub_log_in
+    WIKIS.each do |wiki|
+      stub_get_token(wiki)
+      success = '{"login":{"result":"Success","lguserid":92487,"lgusername":"Ragesoss"}}'
+      stub_request(:post, "https://#{wiki}/w/api.php")
+        .with(body: hash_including('action' => 'login'))
+        .to_return(status: 200, body: success, headers: {})
     end
   end
 


### PR DESCRIPTION
## What this PR does
Resources + Documentation used:
https://www.mediawiki.org/wiki/API:Login
https://www.mediawiki.org/wiki/Manual:Bot_passwords
https://en.wikipedia.org/wiki/Wikipedia:Using_AWB_with_2FA
https://github.com/ragesoss/mediawiki-ruby-api/blob/master/lib/mediawiki_api/client.rb

I created a bot for testing and added `bot_username:` and `bot_password:` to my `application.yml`

- Modifies `api_client` to store clients (i.e the api_urls) as a class variable
![using a class level variable](https://github.com/user-attachments/assets/0a761098-c0ab-4486-bb4e-196e9c7e5b10)

- Adds `ensure_logged_in` method that uses the `MediawikiApi::Client` methods `logged_in`, `get_token` and `log_in` to fetch login tokens and then use that to log in.
- Stubs the `log_in` and `get_token` methods for the purpose of tests

Note; I ran the `wiki_api_spec` tests and they passed, however we expect this to break a lot more tests so the ci/cd build won't pass yet + I need to write test cases to ensure the login process works fine and it is handled appropriately when it does not.

The tests are a bit tricky because any class that uses `WikiApi`'s `mediawiki` method now has to be authenticated which translates to the two extra requests. Now in specs that use VCR_cassettes, these 2 requests will be added to the cassette file unless stubbed. Just running the test suite however won't tell you all the specs this could happen in so we can stub it, since the number of requests in / order of requests is not being tested...

Another thing I noticed is the `stub_wiki_validation` is used 82 times in 53 files so i could use that to infer where to put the `stub_log_in` too.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
