### PR TITLE
[Data rearchitecture] Show article views stored in AC `view_count` field for historical courses

### DIFF
--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -48,7 +48,7 @@ module ArticleHelper
     return nil
   end
 
-  def view_count(first_revision, average_views, view_count)
+  def calculate_view_count(first_revision, average_views, view_count)
     # view_count AC Field is no longer used in the timeslice system
     # however, this is a hack to display article views for historical courses
     # that will not receive a new update

--- a/app/helpers/article_helper.rb
+++ b/app/helpers/article_helper.rb
@@ -48,8 +48,11 @@ module ArticleHelper
     return nil
   end
 
-  def view_count(first_revision, average_views)
-    return 0 if first_revision.nil? || average_views.nil?
+  def view_count(first_revision, average_views, view_count)
+    # view_count AC Field is no longer used in the timeslice system
+    # however, this is a hack to display article views for historical courses
+    # that will not receive a new update
+    return view_count if first_revision.nil? || average_views.nil?
     days = (Time.now.utc.to_date - first_revision.to_date).to_i
     (days * average_views).to_i
   end

--- a/app/views/courses/articles.json.jbuilder
+++ b/app/views/courses/articles.json.jbuilder
@@ -5,7 +5,7 @@ json.course do
     article = ac.article
     json.call(ac, :character_sum, :references_count, :view_count, :new_article, :tracked, :user_ids)
     json.call(article, :id, :namespace, :rating, :deleted, :mw_page_id, :url)
-    json.view_count view_count(ac.first_revision, article.average_views, ac.view_count)
+    json.view_count calculate_view_count(ac.first_revision, article.average_views, ac.view_count)
     json.title article.full_title
     json.language article.wiki.language
     json.project article.wiki.project

--- a/app/views/courses/articles.json.jbuilder
+++ b/app/views/courses/articles.json.jbuilder
@@ -5,7 +5,7 @@ json.course do
     article = ac.article
     json.call(ac, :character_sum, :references_count, :view_count, :new_article, :tracked, :user_ids)
     json.call(article, :id, :namespace, :rating, :deleted, :mw_page_id, :url)
-    json.view_count view_count(ac.first_revision, article.average_views)
+    json.view_count view_count(ac.first_revision, article.average_views, ac.view_count)
     json.title article.full_title
     json.language article.wiki.language
     json.project article.wiki.project


### PR DESCRIPTION
## What this PR does
Update `view_count` article helper to return AC `view_count` field when `first_revision` field is null. This is for historical courses, that won't receive a new update in timeslice system, so they don't have `first_revision` populated but they still have the article views stored in `view_count` field. Note that `view_count` has 0 as default value so it's safe to be returned. For articles that have `first_revision` (and `average_views`) populated, `view_count` method will prioritize that count and won't return `view_count`.

## Screenshots
Before:
views on the Articles tab are zero for all articles

![articles_view_count_for_old_system](https://github.com/user-attachments/assets/b991396e-31e5-4891-bbf8-d54f5e9716f2)

After:
views on the Articles tab are taken from `view_count` field for all articles

![articles_view_count_for_old_system_fixed](https://github.com/user-attachments/assets/2a00e679-f009-4024-9411-1318a5dd37f7)


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
