### PR TITLE
Secure CheckAssignmentStatus#page_present? against nil parameters

### DIFF
--- a/app/services/check_assignment_status.rb
+++ b/app/services/check_assignment_status.rb
@@ -82,6 +82,7 @@ class CheckAssignmentStatus
   end
 
   def page_present?(page_info)
+    return false unless page_info.present?
     page_info.dig('pages', '-1', 'missing').nil?
   end
 end

--- a/spec/services/check_assignment_status_spec.rb
+++ b/spec/services/check_assignment_status_spec.rb
@@ -104,4 +104,13 @@ describe CheckAssignmentStatus do
       expect(assignment_2.reload.peer_review_sandbox_status).to eq('exists_in_userspace')
     end
   end
+
+  describe '#page_present?' do
+    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
+    context 'when there is no page_info' do
+      it 'should return false' do
+        expect(subject.page_present?(nil)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does
If the `page_info` param was `nil`, this method would throw

```
NoMethodError: undefined method `dig' for nil:NilClass
```

Now, it will instead early return `false`

See issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6246

## Open questions and concerns
please feel free to nit 
