### PR TITLE
[Data-rearchitecture] Clean article_id for assignment if updating title fails due to duplicate assignment record.

### DIFF
--- a/lib/assignment_updater.rb
+++ b/lib/assignment_updater.rb
@@ -20,6 +20,12 @@ class AssignmentUpdater
   def self.update_assignment_from_article(assignment, article)
     assignment.article_id = article.id
     assignment.article_title = article.title # update assignment to match case
+    assignment.save!
+  rescue ActiveRecord::RecordInvalid
+    # If there is already an assignment for article_title/course_id/user_id/role/wiki_id,
+    # then clean the article id
+    assignment.reload
+    assignment.article_id = nil
     assignment.save
   end
 

--- a/spec/lib/assignment_updater_spec.rb
+++ b/spec/lib/assignment_updater_spec.rb
@@ -81,7 +81,7 @@ describe AssignmentUpdater do
                             article_title: 'DSF')
       end
 
-      it 'clean the article id and does not raise an error' do
+      it 'cleans the article id for duplicate one and does not raise an error' do
         described_class.update_assignments_for_article(article)
         expect(Assignment.find(assignment.id).article_title).to eq('Deep_Sea_Fishing')
         expect(Assignment.find(assignment.id).article_id).to eq(article.id)

--- a/spec/lib/assignment_updater_spec.rb
+++ b/spec/lib/assignment_updater_spec.rb
@@ -61,6 +61,36 @@ describe AssignmentUpdater do
     end
   end
 
+  describe '.update_assignments_for_article' do
+    context 'when two assignments for the same article id exist' do
+      let!(:article) { create(:article, title: 'Deep_Sea_Fishing') }
+
+      # Set both assignments to the same article id but different title
+      let!(:assignment) do
+        create(:assignment, course_id: course.id,
+                            user_id: user.id,
+                            role: 0,
+                            article_id: article.id,
+                            article_title: 'Deep_Sea_Fishing')
+      end
+      let!(:duplicate_assignment) do
+        create(:assignment, course_id: course.id,
+                            user_id: user.id,
+                            role: 0,
+                            article_id: article.id,
+                            article_title: 'DSF')
+      end
+
+      it 'clean the article id and does not raise an error' do
+        described_class.update_assignments_for_article(article)
+        expect(Assignment.find(assignment.id).article_title).to eq('Deep_Sea_Fishing')
+        expect(Assignment.find(assignment.id).article_id).to eq(article.id)
+        expect(Assignment.find(duplicate_assignment.id).article_title).to eq('DSF')
+        expect(Assignment.find(duplicate_assignment.id).article_id).to eq(nil)
+      end
+    end
+  end
+
   describe '.clean_assignment_for_deleted_article' do
     it 'sets article_id to nil for article assignments' do
       deleted_article = create(:article, title: 'Deep_Sea_Fishing', deleted: true)


### PR DESCRIPTION
## What this PR does
This PR attempts to fix the last bug found for course [11402 Visiting Scholars at Northeastern University - Rosiestep](https://dashboard.wikiedu.org/courses/Northeastern_University/Visiting_Scholars_at_Northeastern_University_-_Rosiestep_(2017)).

There is still a broken article that keeps reprocessing forever:
```
                "413456": {
                    "start_time": "2025-03-17T18:05:18.881+00:00",
                    "end_time": "2025-03-17T18:08:18.561+00:00",
                    "sentry_tag_uuid": "5696dee3-7cec-4a52-8bbc-40fd9ec064c9",
                    "error_count": 0,
                    "processed": 1,
                    "reprocessed": 1
                }
```
 
We have two assignments with different article title associated to the same article id. Article `51194777` is not deleted. When `update_assignments_for_article` get called, the assignment record update fails due to the uniqueness constraint for assignments done at the ruby level.
```
 +----------+---------------------+---------------------+-----------------+----------+-----------+------------+------+---------+-----------------------------------------------------------+---------------------------------------------------------------------------------+
| id       | created_at          | updated_at          | article_title   | user_id  | course_id | article_id | role | wiki_id | sandbox_url                                               | flags                                                                           |
+----------+---------------------+---------------------+-----------------+----------+-----------+------------+------+---------+-----------------------------------------------------------+---------------------------------------------------------------------------------+
| 22918501 | 2018-06-28 00:24:27 | 2023-06-23 20:34:25 | Alice_Flowerdew | 28425743 |     11402 |   51194777 |    0 |       1 | https://en.wikipedia.org/wiki/User:Rosiestep/sandbox      | ---|
| 23111083 | 2023-11-27 20:21:39 | 2023-12-11 18:14:47 | A._Flowerdew    | 28425743 |     11402 |   51194777 |    0 |       1 | https://en.wikipedia.org/wiki/User:Rosiestep/A._Flowerdew | ---|  
```
The strategy of this PR is just to clean up the `article_id` field if the assignment update is roll-backed due to uniqueness constraint.
 
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
