### PR TITLE
Try to speed up queries in alert monitors

### DIFF
--- a/lib/alerts/articles_for_deletion_monitor.rb
+++ b/lib/alerts/articles_for_deletion_monitor.rb
@@ -54,11 +54,11 @@ class ArticlesForDeletionMonitor
     find_proposed_deletions
     find_candidates_for_speedy_deletion
     normalize_titles
+    set_article_ids
   end
 
   def create_alerts_from_page_titles
-    course_articles = ArticlesCourses.joins(:article)
-                                     .where(articles: { title: @page_titles, wiki_id: @wiki.id })
+    course_articles = ArticlesCourses.where(article_id: @article_ids)
     course_articles.each do |articles_course|
       create_alert(articles_course)
     end
@@ -100,6 +100,10 @@ class ArticlesForDeletionMonitor
     end
     @page_titles.compact!
     @page_titles.uniq!
+  end
+
+  def set_article_ids
+    @article_ids = Article.where(title: @page_titles, wiki_id: @wiki.id).pluck(:id)
   end
 
   def create_alert(articles_course)

--- a/lib/alerts/discretionary_sanctions_monitor.rb
+++ b/lib/alerts/discretionary_sanctions_monitor.rb
@@ -15,11 +15,11 @@ class DiscretionarySanctionsMonitor
     find_pages_tagged_for_discretionary_sanctions
     extract_page_titles_from_talk_titles
     normalize_titles
+    set_article_ids
   end
 
   def create_alerts_from_page_titles
-    course_articles = ArticlesCourses.joins(:article)
-                                     .where(articles: { title: @page_titles, wiki_id: @wiki.id })
+    course_articles = ArticlesCourses.where(article_id: @article_ids)
     course_assignments = Assignment.joins(:article)
                                    .where(articles: { title: @page_titles, wiki_id: @wiki.id })
                                    .where(course: Course.current)
@@ -53,6 +53,10 @@ class DiscretionarySanctionsMonitor
     end
     @page_titles.compact!
     @page_titles.uniq!
+  end
+
+  def set_article_ids
+    @article_ids = Article.where(title: @page_titles, wiki_id: @wiki.id).pluck(:id)
   end
 
   def create_edit_alert(articles_course)

--- a/lib/alerts/g_a_nomination_monitor.rb
+++ b/lib/alerts/g_a_nomination_monitor.rb
@@ -14,11 +14,11 @@ class GANominationMonitor
     find_pending_ga_nominations
     extract_page_titles_from_nominations
     normalize_titles
+    set_article_ids
   end
 
   def create_alerts_from_page_titles
-    course_articles = ArticlesCourses.joins(:article)
-                                     .where(articles: { title: @page_titles, wiki_id: @wiki.id })
+    course_articles = ArticlesCourses.where(article_id: @article_ids)
     course_articles.each do |articles_course|
       create_alert(articles_course)
     end
@@ -46,6 +46,10 @@ class GANominationMonitor
     end
     @page_titles.compact!
     @page_titles.uniq!
+  end
+
+  def set_article_ids
+    @article_ids = Article.where(title: @page_titles, wiki_id: @wiki.id).pluck(:id)
   end
 
   def create_alert(articles_course)

--- a/lib/alerts/high_quality_article_monitor.rb
+++ b/lib/alerts/high_quality_article_monitor.rb
@@ -14,11 +14,11 @@ class HighQualityArticleMonitor
     @wiki = Wiki.find_by(language: 'en', project: 'wikipedia')
     find_good_and_featured_articles
     normalize_titles
+    set_article_ids
   end
 
   def create_alerts_from_page_titles
-    course_articles = ArticlesCourses.joins(:article)
-                                     .where(articles: { title: @page_titles, wiki_id: @wiki.id })
+    course_articles = ArticlesCourses.where(article_id: @article_ids)
     course_assignments = Assignment.joins(:article)
                                    .where(articles: { title: @page_titles, wiki_id: @wiki.id })
                                    .where(course: Course.current)
@@ -47,6 +47,10 @@ class HighQualityArticleMonitor
     end
     @page_titles.compact!
     @page_titles.uniq!
+  end
+
+  def set_article_ids
+    @article_ids = Article.where(title: @page_titles, wiki_id: @wiki.id).pluck(:id)
   end
 
   def create_edit_alert(articles_course)


### PR DESCRIPTION
## What this PR does
This PR tries to speed up the queries done on some monitors. We found the following slow query in our logs:

`SELECT articles_courses.* FROM articles_courses INNER JOIN articles ON articles.id = articles_courses.article_id WHERE articles.title IN ('1946_Manchester_Borough_Council_election', ...) AND articles.wiki_id = 1;`

This same query seems to be done in different monitors: `ArticlesForDeletionMonitor`, `GANominationMonitor` and `HighQualityArticleMonitor`.

After some quick checks, the strategy of this PR is to split the original query by doing this:

1. `SELECT articles.id FROM articles WHERE title IN (...) and wiki_id =...;`  67 rows in set (6.270 sec)
2. `SELECT articles_courses WHERE article_id in (...);` 20 rows in set (0.003 sec)

Instead of:

1. `SELECT articles_courses.* FROM articles_courses INNER JOIN articles ON articles.id = articles_courses.article_id WHERE articles.title IN (...) AND articles.wiki_id = 1;` 20 rows in set (49.777 sec)

## Open questions and concerns
Note that similar queries are also done in:
-  `DYKNominationMonitor` (but a specific course is set)
```
    course_articles = ArticlesCourses.joins(:article)
                                     .where(course: Course.current)
                                     .where(articles: { title: @page_titles, wiki_id: @wiki.id }) 
```
