### PR TITLE
 Improvement/change edits link to global edits

### DIFF
--- a/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
@@ -116,7 +116,7 @@ const Student = createReactClass({
           <div className="sandbox-link">
             <a onClick={this.stop} href={student.sandbox_url} target="_blank">{I18n.t('users.sandboxes')}</a>
             &nbsp;
-            <a onClick={this.stop} href={student.contribution_url} target="_blank">{I18n.t('users.edits')}</a>
+            <a onClick={this.stop} href={student.global_contribution_url} target="_blank">{I18n.t('users.edits')}</a>
           </div>
           <ExerciseProgressDescription student={student} />
           <TrainingProgressDescription student={student} />

--- a/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/Student/Student.jsx
@@ -59,6 +59,10 @@ const Student = createReactClass({
       showRecent, student
     } = this.props;
 
+    const editsLink = course.wikis.length > 1
+    ? student.global_contribution_url
+    : student.contribution_url;
+
     let recentRevisions;
     if (showRecent) {
       recentRevisions = (
@@ -116,7 +120,7 @@ const Student = createReactClass({
           <div className="sandbox-link">
             <a onClick={this.stop} href={student.sandbox_url} target="_blank">{I18n.t('users.sandboxes')}</a>
             &nbsp;
-            <a onClick={this.stop} href={student.global_contribution_url} target="_blank">{I18n.t('users.edits')}</a>
+            <a onClick={this.stop} href={editsLink} target="_blank">{I18n.t('users.edits')}</a>
           </div>
           <ExerciseProgressDescription student={student} />
           <TrainingProgressDescription student={student} />

--- a/app/models/course_data/courses_users.rb
+++ b/app/models/course_data/courses_users.rb
@@ -76,6 +76,10 @@ class CoursesUsers < ApplicationRecord
     "#{course.home_wiki.base_url}/wiki/Special:Contributions/#{user.url_encoded_username}"
   end
 
+  def global_contribution_url
+    "https://guc.toolforge.org/?user=#{user.url_encoded_username}"
+  end
+
   # Provides a link to the list of all of a user's subpages, ie, sandboxes.
   def sandbox_url
     "#{course.home_wiki.base_url}/wiki/Special:PrefixIndex/User:#{user.url_encoded_username}"

--- a/app/views/courses/_users.json.jbuilder
+++ b/app/views/courses/_users.json.jbuilder
@@ -6,7 +6,7 @@ show_instructor_identity = user_signed_in? && current_user.nonvisitor?(course)
 json.users course.courses_users.eager_load(:user, :course) do |cu|
   json.call(cu, :character_sum_ms, :character_sum_us, :character_sum_draft, :references_count,
             :role, :role_description, :recent_revisions, :content_expert, :program_manager,
-            :contribution_url, :sandbox_url, :total_uploads)
+            :contribution_url, :sandbox_url, :global_contribution_url, :total_uploads)
   json.call(cu.user, :id, :username)
   json.enrolled_at cu.created_at
   json.admin cu.user.admin?


### PR DESCRIPTION
#6236 

## What this PR does
This PR modifies the "Edits" link to "Global edits" on Campaign Dashboard application

## Screenshots
Before:
<img width="1472" alt="Screenshot 2025-03-21 at 7 39 40 PM" src="https://github.com/user-attachments/assets/04a0ce61-46f6-421e-b13e-93e4b8686b75" />

After:
<img width="959" alt="Screenshot 2025-03-21 at 7 41 46 PM" src="https://github.com/user-attachments/assets/eff5f310-9135-46a2-a86f-62aadd9192a5" />

Video with latest changes (showing condition)



https://github.com/user-attachments/assets/7b61eb48-b55b-41f7-82ec-dc8a4e1a3b31

