### PR TITLE
[Data rearchitecture] Avoid reprocessing same revisions multiple times

### DIFF
--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
+require_dependency "#{Rails.root}/lib/timeslice_cleaner"
+
 # Ensures that the necessary timeslices are created prior to a new update
 # of the course statistics.
 class PrepareTimeslices

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -13,6 +13,7 @@ class UpdateCourseWikiTimeslices
     @timeslice_manager = TimesliceManager.new(@course)
     @debugger = debugger
     @update_service = update_service
+    @revision_updater = CourseRevisionUpdater.new(@course, update_service:)
     @wikidata_stats_updater = UpdateWikidataStatsTimeslice.new(@course) if wikidata
     @processed_timeslices = 0
     @reprocessed_timeslices = 0
@@ -61,8 +62,9 @@ class UpdateCourseWikiTimeslices
 
       log_processing(wiki, start_date, end_date)
 
-      fetch_data(wiki, start_date, end_date)
-      process_timeslices(wiki)
+      fetch_data(wiki, start_date, end_date, only_new: true)
+      # Only process timeslices if there is new data
+      process_timeslices(wiki) if new_data?(wiki)
       current_start += @timeslice_manager.timeslice_duration(wiki)
       @processed_timeslices += 1
     end
@@ -76,23 +78,32 @@ class UpdateCourseWikiTimeslices
 
       log_reprocessing(wiki, start_date, end_date)
 
-      fetch_data(wiki, start_date, end_date)
+      fetch_data(wiki, start_date, end_date, only_new: false)
       process_timeslices(wiki)
       @reprocessed_timeslices += 1
     end
   end
 
-  def fetch_data(wiki, timeslice_start, timeslice_end)
+  def fetch_data(wiki, timeslice_start, timeslice_end, only_new:)
     # Fetches revision for wiki
-    @revisions = CourseRevisionUpdater
-                 .fetch_revisions_and_scores_for_wiki(@course,
-                                                      wiki,
-                                                      timeslice_start.strftime('%Y%m%d%H%M%S'),
-                                                      timeslice_end.strftime('%Y%m%d%H%M%S'),
-                                                      update_service: @update_service)
+    @revisions = @revision_updater.fetch_data_for_course_wiki(
+      wiki,
+      timeslice_start.strftime('%Y%m%d%H%M%S'),
+      timeslice_end.strftime('%Y%m%d%H%M%S'),
+      only_new:
+    )
+    # Return if only_new was true but no new data was found
+    return unless new_data?(wiki)
+    fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && @revisions.present?
+  end
 
-    # Only for wikidata project, fetch wikidata stats
-    return unless wiki.project == 'wikidata' && @revisions.present?
+  def new_data?(wiki)
+    return false if @revisions.blank?
+    @revisions[wiki][:new_data]
+  end
+
+  # Only for wikidata project, fetch wikidata stats
+  def fetch_wikidata_stats(wiki)
     wikidata_revisions = @revisions[wiki][:revisions].reject(&:deleted)
     @revisions[wiki][:revisions] =
       @wikidata_stats_updater.update_revisions_with_stats(wikidata_revisions)
@@ -112,7 +123,6 @@ class UpdateCourseWikiTimeslices
   end
 
   def update_timeslices(wiki)
-    return if @revisions.length.zero?
     update_course_user_wiki_timeslices_for_wiki(wiki, @revisions[wiki])
     update_article_course_timeslices_for_wiki(@revisions[wiki])
     CourseWikiTimeslice.update_course_wiki_timeslices(@course, wiki, @revisions[wiki])

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -34,7 +34,7 @@ class CourseRevisionUpdater
     # This avoids treating every update as a 'new users' update
     # for an ArcticleScopedProgram with highly active users
     # but no tracked articles.
-    return false unless @course.type == 'ArticleScopedProgram'
+    return false unless @course.only_scoped_articles_course?
     @course.assignments.none? && @course.categories.none?
   end
 

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -18,7 +18,7 @@ class RevisionDataManager
   end
 
   INCLUDED_NAMESPACES = [0, 2, 118].freeze
-  # This method gets revisions and scores for them from different APIs.
+  # This method gets course revisions for a given period.
   # Returns an array of Revision records.
   # As a side effect, it imports Article records.
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
@@ -43,6 +43,13 @@ class RevisionDataManager
                                                  users,
                                                  scoped_sub_data:,
                                                  articles: article_dict)
+    return @revisions
+  end
+
+  # This method gets scores for specific revisions from different APIs.
+  # Returns an array of Revision records with completed scores.
+  def fetch_score_data_for_course(revisions)
+    @revisions = revisions
 
     # We need to partition revisions because we don't want to calculate scores for revisions
     # out of important spaces

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -116,54 +116,123 @@ describe CourseRevisionUpdater do
     end
   end
 
-  describe '.fetch_revisions_and_scores_for_wiki' do
-    let(:course) { create(:course, start: '2016-03-20', end: '2016-03-31') }
+  describe '#fetch_data_for_course_wiki' do
     let(:user) { create(:user, username: 'Tedholtby') }
+    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
     let(:start_date) { '20160320000000' }
     let(:end_date) { '20160331235959' }
-    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-    let(:courses_user) do
-      create(:courses_user, course:,
-                          user:,
-                          role: CoursesUsers::Roles::STUDENT_ROLE)
-    end
 
-    before do
-      course && user && courses_user
-    end
+    context 'for regular courses' do
+      let(:course) { create(:course, start: '2016-03-20', end: '2016-03-31') }
+      let(:instance_class) { described_class.new(course) }
+      let!(:courses_user) do
+        create(:courses_user, course:,
+                            user:,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      end
 
-    it 'fetches all the revisions' do
-      VCR.use_cassette 'course_revision_updater' do
-        revision_data = described_class.fetch_revisions_and_scores_for_wiki(course,
-                                                                            wiki,
-                                                                            start_date,
-                                                                            end_date)
-        revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
-        expect(revisions.count).to eq(3)
+      before do
+        create(:course_wiki_timeslice, course:, wiki:, start: start_date,
+        end: end_date.to_datetime + 1.day)
+      end
 
-        expected_article = Article.find_by(wiki_id: 1,
-                                           title: '1978_Revelation_on_Priesthood',
-                                           mw_page_id: 15124285,
-                                           namespace: 0)
+      it 'fetches all the revisions with scores if only_new is false' do
+        VCR.use_cassette 'course_revision_updater' do
+          revision_data = instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date)
+          # add expect for :new_data
+          revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
+          expect(revisions.count).to eq(3)
 
-        expect(revisions.last.mw_rev_id).to eq(712907095)
-        expect(revisions.last.user_id).to eq(user.id)
-        expect(revisions.last.wiki_id).to eq(1)
-        expect(revisions.last.mw_page_id).to eq(15124285)
-        expect(revisions.last.characters).to eq(579)
-        expect(revisions.last.article_id).to eq(expected_article.id)
+          expected_article = Article.find_by(wiki_id: 1,
+                                             title: '1978_Revelation_on_Priesthood',
+                                             mw_page_id: 15124285,
+                                             namespace: 0)
+
+          expect(revisions.last.mw_rev_id).to eq(712907095)
+          expect(revisions.last.user_id).to eq(user.id)
+          expect(revisions.last.wiki_id).to eq(1)
+          expect(revisions.last.mw_page_id).to eq(15124285)
+          expect(revisions.last.characters).to eq(579)
+          expect(revisions.last.article_id).to eq(expected_article.id)
+          # fetched scores
+          expect(revisions.last.features).to eq({ 'num_ref' => 19 })
+          expect(revisions.last.features_previous).to eq({ 'num_ref' => 18 })
+          expect(revisions.last.wp10.to_f).to be_within(0.01).of(47.03)
+          expect(revisions.last.wp10_previous.to_f).to be_within(0.01).of(46.94)
+        end
+      end
+
+      it 'fetches all the revisions with scoress if only_new is true and new revisions' do
+        VCR.use_cassette 'course_revision_updater' do
+          revision_data = instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date,
+                                                                    only_new: true)
+          revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
+          puts revisions.inspect
+          expect(revisions.count).to eq(3)
+
+          expected_article = Article.find_by(wiki_id: 1,
+                                             title: '1978_Revelation_on_Priesthood',
+                                             mw_page_id: 15124285,
+                                             namespace: 0)
+
+          expect(revisions.last.mw_rev_id).to eq(712907095)
+          expect(revisions.last.user_id).to eq(user.id)
+          expect(revisions.last.wiki_id).to eq(1)
+          expect(revisions.last.mw_page_id).to eq(15124285)
+          expect(revisions.last.characters).to eq(579)
+          expect(revisions.last.article_id).to eq(expected_article.id)
+          # fetched scores
+          expect(revisions.last.features).to eq({ 'num_ref' => 19 })
+          expect(revisions.last.features_previous).to eq({ 'num_ref' => 18 })
+          expect(revisions.last.wp10.to_f).to be_within(0.01).of(47.03)
+          expect(revisions.last.wp10_previous.to_f).to be_within(0.01).of(46.94)
+        end
+      end
+
+      it 'does not fetch scoress if only_new is true and no new revisions' do
+        # complete the timeslice
+        course.course_wiki_timeslices.update(revision_count: 3,
+                                             last_mw_rev_datetime: '2016-03-31 19:50:54'.to_datetime)
+        VCR.use_cassette 'course_revision_updater' do
+          revision_data = instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date,
+                                                                    only_new: true)
+          revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
+          puts revisions.inspect
+          expect(revisions.count).to eq(3)
+
+          expected_article = Article.find_by(wiki_id: 1,
+                                             title: '1978_Revelation_on_Priesthood',
+                                             mw_page_id: 15124285,
+                                             namespace: 0)
+
+          expect(revisions.last.mw_rev_id).to eq(712907095)
+          expect(revisions.last.user_id).to eq(user.id)
+          expect(revisions.last.wiki_id).to eq(1)
+          expect(revisions.last.mw_page_id).to eq(15124285)
+          expect(revisions.last.characters).to eq(579)
+          expect(revisions.last.article_id).to eq(expected_article.id)
+          # no fetched scores
+          expect(revisions.last.features).to be_empty
+          expect(revisions.last.features_previous).to be_empty
+          expect(revisions.last.wp10).to be_nil
+          expect(revisions.last.wp10_previous).to be_nil
+        end
       end
     end
 
-    it 'skips import for ArticleScopedCourse with no tracked articles' do
-      expect_any_instance_of(RevisionDataManager).not_to receive(:fetch_revision_data_for_course)
-      course = create(:article_scoped_program)
-      student = create(:user)
-      create(:courses_user, course:, user: student)
-      described_class.fetch_revisions_and_scores_for_wiki(course,
-                                                          wiki,
-                                                          start_date,
-                                                          end_date)
+    context 'for ArticleScopedCourse' do
+      let(:scoped_course) { create(:article_scoped_program) }
+      let(:scoped_instance_class) { described_class.new(scoped_course) }
+      let!(:courses_user) do
+        create(:courses_user, course: scoped_course,
+                            user:,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      end
+
+      it 'skips import if no tracked articles' do
+        expect(scoped_instance_class).not_to receive(:get_data)
+        scoped_instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date)
+      end
     end
   end
 end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -139,7 +139,7 @@ describe CourseRevisionUpdater do
       it 'fetches all the revisions with scores if only_new is false' do
         VCR.use_cassette 'course_revision_updater' do
           revision_data = instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date)
-          # add expect for :new_data
+          expect(revision_data[wiki][:new_data]).to eq(true)
           revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
           expect(revisions.count).to eq(3)
 
@@ -166,6 +166,7 @@ describe CourseRevisionUpdater do
         VCR.use_cassette 'course_revision_updater' do
           revision_data = instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date,
                                                                     only_new: true)
+          expect(revision_data[wiki][:new_data]).to eq(true)
           revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
           puts revisions.inspect
           expect(revisions.count).to eq(3)
@@ -191,11 +192,13 @@ describe CourseRevisionUpdater do
 
       it 'does not fetch scoress if only_new is true and no new revisions' do
         # complete the timeslice
+        last_mw_rev_datetime = '2016-03-31 19:50:54'.to_datetime
         course.course_wiki_timeslices.update(revision_count: 3,
-                                             last_mw_rev_datetime: '2016-03-31 19:50:54'.to_datetime)
+                                             last_mw_rev_datetime:)
         VCR.use_cassette 'course_revision_updater' do
           revision_data = instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date,
                                                                     only_new: true)
+          expect(revision_data[wiki][:new_data]).to eq(false)
           revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
           puts revisions.inspect
           expect(revisions.count).to eq(3)

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -233,7 +233,7 @@ describe CourseRevisionUpdater do
       end
 
       it 'skips import if no tracked articles' do
-        expect(scoped_instance_class).not_to receive(:get_data)
+        expect(scoped_instance_class).not_to receive(:fetch_data)
         scoped_instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date)
       end
     end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -168,7 +168,6 @@ describe CourseRevisionUpdater do
                                                                     only_new: true)
           expect(revision_data[wiki][:new_data]).to eq(true)
           revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
-          puts revisions.inspect
           expect(revisions.count).to eq(3)
 
           expected_article = Article.find_by(wiki_id: 1,
@@ -200,7 +199,6 @@ describe CourseRevisionUpdater do
                                                                     only_new: true)
           expect(revision_data[wiki][:new_data]).to eq(false)
           revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
-          puts revisions.inspect
           expect(revisions.count).to eq(3)
 
           expected_article = Article.find_by(wiki_id: 1,

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -68,6 +68,92 @@ describe RevisionDataManager do
     end
     let(:filtered_sub_data) { [data1] }
 
+    before do
+      create(:courses_user, course:, user:)
+    end
+
+    it 'fetches all the revisions that occurred during the given period of time' do
+      VCR.use_cassette 'revision_importer/all' do
+        revisions = subject
+        expect(revisions.length).to eq(4)
+        # Fetches the right revision ids
+        expect(revisions[0].mw_rev_id).to eq(849116430)
+        expect(revisions[1].mw_rev_id).to eq(849116480)
+        expect(revisions[2].mw_rev_id).to eq(849116533)
+        expect(revisions[3].mw_rev_id).to eq(849116572)
+      end
+    end
+
+    it 'calls ArticeImporter as side effect' do
+      expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
+        .once
+        .with(revision_data)
+
+      VCR.use_cassette 'revision_importer/all' do
+        subject
+      end
+    end
+
+    it 'creates articles for all revisions even for article scoped programs' do
+      allow_any_instance_of(described_class).to receive(:get_course_revisions)
+        .and_return([sub_data, filtered_sub_data])
+
+      article_importer = instance_double(ArticleImporter)
+      allow(ArticleImporter).to receive(:new).and_return(article_importer)
+
+      expect(article_importer).to receive(:import_articles_from_revision_data)
+        .once
+        .with(revision_data2)
+
+      subject
+    end
+  end
+
+  describe '#fetch_score_data_for_course' do
+    let(:course) { create(:course, start: '2018-01-01', end: '2018-12-31') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+    let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:instance_class) { described_class.new(home_wiki, course) }
+    let(:revisions) { instance_class.fetch_revision_data_for_course('20180706', '20180707') }
+    let(:subject) do
+      instance_class.fetch_score_data_for_course(revisions)
+    end
+    let(:data1) do
+      [
+        '777',
+        {
+          'article' => {
+            'mw_page_id' => '777',
+            'title' => 'Ragesoss/citing_sources',
+            'namespace' => '4',
+            'wiki_id' => 1
+          },
+          'revisions' => [
+            { 'mw_rev_id' => '849116430', 'date' => '20180706', 'characters' => '569',
+              'mw_page_id' => '777', 'username' => 'Ragesoss', 'new_article' => 'false',
+              'system' => 'false', 'wiki_id' => 1 }
+          ]
+        }
+      ]
+    end
+    let(:data2) do
+      [
+        '123',
+        {
+          'article' => {
+            'mw_page_id' => '123',
+            'title' => 'Draft article',
+            'namespace' => '118',
+            'wiki_id' => 1
+          },
+          'revisions' => [
+            { 'mw_rev_id' => '456', 'date' => '20180706', 'characters' => '569',
+              'mw_page_id' => '123', 'username' => 'Ragesoss', 'new_article' => 'false',
+              'system' => 'false', 'wiki_id' => 1 }
+          ]
+        }
+      ]
+    end
     let(:data3) do
       [
         '55345266',
@@ -91,16 +177,10 @@ describe RevisionDataManager do
       create(:courses_user, course:, user:)
     end
 
-    it 'fetches all the revisions that occurred during the given period of time' do
+    it 'fetches all the revisions scores' do
       VCR.use_cassette 'revision_importer/all' do
         revisions = subject
         expect(revisions.length).to eq(4)
-        # Fetches the right revision ids
-        expect(revisions[0].mw_rev_id).to eq(849116430)
-        expect(revisions[1].mw_rev_id).to eq(849116480)
-        expect(revisions[2].mw_rev_id).to eq(849116533)
-        expect(revisions[3].mw_rev_id).to eq(849116572)
-
         # Fetches the scores
         expect(revisions[0].wp10).to be_within(0.01).of(18.29)
         expect(revisions[0].wp10_previous).to be_within(0.01).of(11.96)
@@ -157,6 +237,7 @@ describe RevisionDataManager do
       allow(scoped_course).to receive(:scoped_article_titles).and_return(['Scoped_article'])
       VCR.use_cassette 'revision_importer/all' do
         revisions = scoped_instance_class.fetch_revision_data_for_course('20180706', '20180707')
+        revisions = scoped_instance_class.fetch_score_data_for_course(revisions)
         # Returns all revisions
         expect(revisions.length).to eq(3)
         # Only the scoped revision in mainspace has scores
@@ -172,30 +253,6 @@ describe RevisionDataManager do
         expect(revisions[2].scoped).to eq(true)
         expect(revisions[2].features).to eq({ 'num_ref' => 0 })
       end
-    end
-
-    it 'calls ArticeImporter as side effect' do
-      expect_any_instance_of(ArticleImporter).to receive(:import_articles_from_revision_data)
-        .once
-        .with(revision_data)
-
-      VCR.use_cassette 'revision_importer/all' do
-        subject
-      end
-    end
-
-    it 'creates articles for all revisions even for article scoped programs' do
-      allow_any_instance_of(described_class).to receive(:get_course_revisions)
-        .and_return([sub_data, filtered_sub_data])
-
-      article_importer = instance_double(ArticleImporter)
-      allow(ArticleImporter).to receive(:new).and_return(article_importer)
-
-      expect(article_importer).to receive(:import_articles_from_revision_data)
-        .once
-        .with(revision_data2)
-
-      subject
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR implements an optimization to avoid:
- Requesting revision scores for revisions for which we already did.
- Process timeslices caches if it was already done with the same set of revisions.

The logic to avoid refetching scores for a set of revisions if we already did it lives in `CourseRevisionUpdater` class. It implements a new `new_revisions?` method that determines if there are new revisions, based on the number of revisions and the last revision datetime for the recently fetched revisions and the existing timeslice for them.

In the `UpdateCourseWikiTimeslices` class side, `fetch_data_and_process_timeslices` method only process timeslices if there are new revisions. However, `fetch_data_and_reprocess_timeslices` always process timeslices (no matter if there are new revisions or not).

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
