### PR TITLE
Fix: Handle boolean closed_date values in AdminQuickActions

### DIFF
--- a/app/assets/javascripts/components/overview/admin_quick_actions.jsx
+++ b/app/assets/javascripts/components/overview/admin_quick_actions.jsx
@@ -24,6 +24,19 @@ const DetailsText = ({ flags }) => (
 
 const isCourseClosed = flags => !!(flags && flags.closed_date);
 
+// checks if the closed date is a boolean
+const formatClosedDate = (closedDate) => {
+  if (typeof closedDate === 'boolean') {
+    return 'an unspecified date';
+  }
+
+  try {
+    return format(toDate(parseISO(closedDate)), 'PPPP');
+  } catch (error) {
+    return 'an unspecified date';
+  }
+};
+
 const NoDetailsText = () => (
   <p>
     This course has not yet been marked as having been reviewed by a staff member.
@@ -50,7 +63,7 @@ export const AdminQuickActions = ({ course, current_user, persistCourse, greetSt
         <div style={{ marginBottom: '15px' }}>
           <p>
             <strong>This course was closed on:</strong>&nbsp;
-            {format(toDate(parseISO(course.flags.closed_date)), 'PPPP')}.
+            {formatClosedDate(course.flags.closed_date)}.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Issue#6262
Some older courses have a boolean value `true` for the `closed_date` flag instead of a proper date string. This causes an error when trying to format the date with `format(toDate(parseISO(course.flags.closed_date)), 'PPPP')`, which breaks the entire course page.

So I added a `formatClosedDate` helper function that:
- Checks if the closed_date is a boolean value
- Returns a graceful fallback message "an unspecified date" if it's a boolean
- Properly formats the date if it's a valid date string
- Catches any parsing errors and returns the fallback message

