### PR TITLE
Fix: #6228 Update Block types to support translations

### DIFF
--- a/app/assets/javascripts/components/timeline/block_type_select.jsx
+++ b/app/assets/javascripts/components/timeline/block_type_select.jsx
@@ -9,8 +9,8 @@ const KINDS = [
   I18n.t('timeline.block_in_class'),
   I18n.t('timeline.block_assignment'),
   I18n.t('timeline.block_milestone'),
-  I18n.t('timeline.block_in_custom'),
-  I18n.t('timeline.block_in_handouts'),
+  I18n.t('timeline.block_custom'),
+  I18n.t('timeline.block_handouts'),
   I18n.t('timeline.block_resources'),
 ];
 

--- a/app/assets/javascripts/components/timeline/block_type_select.jsx
+++ b/app/assets/javascripts/components/timeline/block_type_select.jsx
@@ -6,12 +6,12 @@ import Select from 'react-select';
 import selectStyles from '../../styles/single_select';
 
 const KINDS = [
-  I18.t('timeline.block_in_class'),
-  I18.t('timeline.block_assignment'),
-  I18.t('timeline.block_milestone'),
-  I18.t('timeline.block_in_custom'),
-  I18.t('timeline.block_in_handouts'),
-  I18.t('timeline.block_resources'),
+  I18n.t('timeline.block_in_class'),
+  I18n.t('timeline.block_assignment'),
+  I18n.t('timeline.block_milestone'),
+  I18n.t('timeline.block_in_custom'),
+  I18n.t('timeline.block_in_handouts'),
+  I18n.t('timeline.block_resources'),
 ];
 
 const BlockTypeSelect = ({ onChange, editable, id, value }) => {

--- a/app/assets/javascripts/components/timeline/block_type_select.jsx
+++ b/app/assets/javascripts/components/timeline/block_type_select.jsx
@@ -5,7 +5,14 @@ import InputHOC from '../high_order/input_hoc.jsx';
 import Select from 'react-select';
 import selectStyles from '../../styles/single_select';
 
-const KINDS = ['In Class', 'Assignment', 'Milestone', 'Custom', 'Handouts', 'Resources'];
+const KINDS = [
+  I18.t('timeline.block_in_class'),
+  I18.t('timeline.block_assignment'),
+  I18.t('timeline.block_milestone'),
+  I18.t('timeline.block_in_custom'),
+  I18.t('timeline.block_in_handouts'),
+  I18.t('timeline.block_resources'),
+];
 
 const BlockTypeSelect = ({ onChange, editable, id, value }) => {
   const handleClick = (selectedOption) => {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1379,6 +1379,8 @@ en:
     block_custom: Custom
     block_in_class: In Class
     block_milestone: Milestone
+    block_handouts: Handouts
+    block_resources: Resources
     block_type: >
       The block type is used to communicate to your students about this item on
       their timeline and to build useful tools for you (such as the milestone


### PR DESCRIPTION
#6228 
##  What this PR does
This PR enables support of translations of the block types.

### Screenshots
Before:
![before](https://github.com/user-attachments/assets/16e577a6-a6b8-49ab-a391-617d12875678)

After:
![after](https://github.com/user-attachments/assets/9c27bc9e-0ff7-461a-b8f1-a5abf3f3f32b)
