### PR TITLE
[Data rearchitecture] Fix bug in UpdateCourseWikiTimeslices

### DIFF
--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -7,7 +7,7 @@ require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 #= Pulls in new revisions for a single course and updates the corresponding timeslices records.
 # It updates all the tracked wikis for the course, from the latest start time for every wiki
 # up to the end of update (today or end date course).
-class UpdateCourseWikiTimeslices
+class UpdateCourseWikiTimeslices # rubocop:disable Metrics/ClassLength
   def initialize(course, debugger, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
@@ -79,7 +79,7 @@ class UpdateCourseWikiTimeslices
       log_reprocessing(wiki, start_date, end_date)
 
       fetch_data(wiki, start_date, end_date, only_new: false)
-      process_timeslices(wiki)
+      process_timeslices(wiki) if data?
       @reprocessed_timeslices += 1
     end
   end
@@ -97,9 +97,12 @@ class UpdateCourseWikiTimeslices
     fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && @revisions.present?
   end
 
+  def data?
+    @revisions.present?
+  end
+
   def new_data?(wiki)
-    return false if @revisions.blank?
-    @revisions[wiki][:new_data]
+    data? && @revisions[wiki][:new_data]
   end
 
   # Only for wikidata project, fetch wikidata stats

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -169,16 +169,19 @@ describe UpdateCourseWikiTimeslices do
     end
   end
 
-  context 'when there are no revisions' do
-    context 'because there is no point in importing revisions' do
-      before do
-        CoursesUsers.find_by(course:, user:).destroy
-      end
+  context 'when there is no point in importing revisions' do
+    before do
+      CoursesUsers.find_by(course:, user:).destroy
+      # Create timeslices
+      TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
+      # Set timeslices to reprocess
+      course.course_wiki_timeslices.first.update(needs_update: true)
+    end
 
-      it 'does not fail' do
-        VCR.use_cassette 'course_update' do
-          subject
-        end
+    it 'does not fail and logs no errors' do
+      VCR.use_cassette 'course_update' do
+        expect(Sentry).not_to receive(:capture_message)
+        subject
       end
     end
   end


### PR DESCRIPTION
## What this PR does
In PR #6265 I incorrectly removed a [line](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6265/files#r2008268922) for a sanity check. This check was necessary when no point in importing revisions and some timeslice is set to be reprocessed. 

This PR fixes this error (see [this](https://wiki-education.sentry.io/issues/6382949119/events/76ec67a8785949a098d41b98cb094a8e/) sentry log) and makes the specs clearer.


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
