### PR TITLE
[Data-rearchitecture] Ensures that Revisions records in RAM always has a non-nil characters value

### DIFF
--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -24,6 +24,7 @@ class RevisionDataManager
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
     all_sub_data, scoped_sub_data = get_course_revisions(@course.students, timeslice_start,
                                                          timeslice_end)
+
     @revisions = []
 
     # Extract all article data from the slice. Outputs a hash with article attrs.
@@ -156,7 +157,7 @@ class RevisionDataManager
     Revision.new({
           mw_rev_id: rev_data['mw_rev_id'],
           date: rev_data['date'],
-          characters: rev_data['characters'],
+          characters: rev_data['characters'] || 0,
           article_id: articles.nil? ? nil : articles[mw_page_id],
           mw_page_id:,
           user_id: users[rev_data['username']],

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -24,7 +24,6 @@ class RevisionDataManager
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
     all_sub_data, scoped_sub_data = get_course_revisions(@course.students, timeslice_start,
                                                          timeslice_end)
-
     @revisions = []
 
     # Extract all article data from the slice. Outputs a hash with article attrs.


### PR DESCRIPTION
## What this PR does
This PR fixes [this Sentry log](https://wiki-education.sentry.io/issues/6382949119/events/a8002f26737949b28c99fb839ab16649/):

```
Egypt_Wikimedians_UG/Writing_activities_of_Egypt_Wikimedians_UG_July_2024-_June_2025 update timeslices error: undefined method `>=' for nil:NilClass

      article_ids_in_namespace.include?(rev.article_id) && rev.characters >= 0
                                                                          ^^

```
The error happens because some revisions retrieved from replica have a nil `characters` field, so comparing it against 0 fails.

Example (for wiki `ar.wikipedia`):

```
{"mw_rev_id"=>"68681280", "date"=>Fri, 29 Nov 2024 13:43:59 +0000, "characters"=>nil, "mw_page_id"=>"9760503", "username"=>"كريم رائد", "new_article"=>"false", "system"=>"false", "wiki_id"=>125}
{"mw_rev_id"=>"68686586", "date"=>Sat, 30 Nov 2024 10:00:41 +0000, "characters"=>nil, "mw_page_id"=>"9760503", "username"=>"كريم رائد", "new_article"=>"false", "system"=>"false", "wiki_id"=>125}
```

It looks like this error causes timeslices set as `needs_update` to be constantly reprocessed for course 31221 [Egypt_Wikimedians_UG/Writing_activities_of_Egypt_Wikimedians_UG_July_2024-_June_2025](https://outreachdashboard.wmflabs.org/courses/Egypt_Wikimedians_UG/Writing_activities_of_Egypt_Wikimedians_UG_July_2024-_June_2025).

The strategy for this PR is just to set the default `characters` field value to 0 if it's `nil`.
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
