### PR TITLE
[Data-rearchitecture] Fix bug in `new_revisions?` method

### DIFF
--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -87,7 +87,7 @@ class CourseRevisionUpdater
     live_revisions = revisions.reject(&:system)
     revision_count = live_revisions.count
     timeslice = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
-                                   .where(start: timeslice_start)
+                                   .for_datetime(timeslice_start)
                                    .first
     if timeslice.nil?
       # This scenario is unexpected, so we log the message to understand why this happens.


### PR DESCRIPTION
## What this PR does
This PR fixes "No timeslice found for revision date" [Sentry logs](https://wiki-education.sentry.io/issues/6457423903/events/65d0e069022d45e1afb97f2c8c9be910/) found recently. This error happens because sometimes we don't need to fetch revisions for the complete timeslice duration, but for a partial timeslice. This can only occur for the first or the last timeslice of a course.

### Example

Course 31343 [Wikimedia_México/Editatona_Mujeres_que_han_hecho_historia_en_la_República_Mexicana_(20_de_marzo)](https://outreachdashboard.wmflabs.org/courses/Wikimedia_M%C3%A9xico/Editatona_Mujeres_que_han_hecho_historia_en_la_Rep%C3%BAblica_Mexicana_(20_de_marzo)) starts at 2025-03-20 16:00:00:

```
MariaDB [dashboard]> SELECT id, start, end, timeline_start, timeline_end, updated_at FROM courses WHERE id = 31343;
+-------+---------------------+---------------------+---------------------+---------------------+---------------------+
| id    | start               | end                 | timeline_start      | timeline_end        | updated_at          |
+-------+---------------------+---------------------+---------------------+---------------------+---------------------+
| 31343 | 2025-03-20 16:00:00 | 2025-03-22 05:59:00 | 2025-03-20 16:00:00 | 2025-03-21 16:00:00 | 2025-03-25 13:34:14 |
+-------+---------------------+---------------------+---------------------+---------------------+---------------------+
```
However, timeslices start at 22:00:00

```
MariaDB [dashboard]> SELECT course_id, wiki_id, start, end, last_mw_rev_datetime, updated_at FROM course_wiki_timeslices WHERE course_id = 31343;
+-----------+---------+----------------------------+----------------------------+----------------------------+----------------------------+
| course_id | wiki_id | start                      | end                        | last_mw_rev_datetime       | updated_at                 |
+-----------+---------+----------------------------+----------------------------+----------------------------+----------------------------+
|     31343 |       5 | 2025-03-19 22:00:00.000000 | 2025-03-20 22:00:00.000000 | 2025-03-20 21:55:29.000000 | 2025-03-23 13:35:56.059270 |
|     31343 |       5 | 2025-03-20 22:00:00.000000 | 2025-03-21 22:00:00.000000 | 2025-03-21 15:39:45.000000 | 2025-03-22 05:46:08.322321 |
|     31343 |       5 | 2025-03-21 22:00:00.000000 | 2025-03-22 22:00:00.000000 | 2025-03-22 05:48:25.000000 | 2025-03-22 17:21:05.193638 |
|     31343 |      40 | 2025-03-19 22:00:00.000000 | 2025-03-20 22:00:00.000000 | 2025-03-20 21:34:01.000000 | 2025-03-22 05:46:34.825999 |
|     31343 |      40 | 2025-03-20 22:00:00.000000 | 2025-03-21 22:00:00.000000 | NULL                       | 2025-03-22 05:46:35.129727 |
|     31343 |      40 | 2025-03-21 22:00:00.000000 | 2025-03-22 22:00:00.000000 | NULL                       | 2025-03-22 05:46:35.408624 |
|     31343 |     101 | 2025-03-19 22:00:00.000000 | 2025-03-20 22:00:00.000000 | 2025-03-20 20:46:53.000000 | 2025-03-22 05:47:00.284767 |
|     31343 |     101 | 2025-03-20 22:00:00.000000 | 2025-03-21 22:00:00.000000 | NULL                       | 2025-03-22 05:47:00.534370 |
|     31343 |     101 | 2025-03-21 22:00:00.000000 | 2025-03-22 22:00:00.000000 | NULL                       | 2025-03-22 05:47:00.783375 |
+-----------+---------+----------------------------+----------------------------+----------------------------+----------------------------+
```

This is likely because the course was created with `2025-03-20 22:00:00`  start date, but then it changed to `2025-03-20 16:00:00`. So, for first timeslice (from 2025-03-19 22:00:00 to 2025-03-20 22:00:00), we want to retrieve only partial revisions (from 2025-03-20 16:00:00 to 2025-03-20 22:00:00).

### Strategy

The strategy is to retrieve the timeslice using `for_datetime` instead of matching the exact start date, as maybe we're retrieving revisions for a partial timeslice.

## Open questions and concerns
I'll analyse each case from [these sentry logs](https://wiki-education.sentry.io/issues/6457423903/events/65d0e069022d45e1afb97f2c8c9be910/events/), but I don't believe we'll need to manually reprocess any timeslices. Even if the message is logged, the process should have completed correctly.

Courses with logs:
- Wikimedia_México/Editatona_Mujeres_que_han_hecho_historia_en_la_República_Mexicana_(20_de_marzo)
- Robert_B._Haas_Family_Arts_Library/Yale_Robert_B._Haas_Family_Arts_Library_Art_And_Feminism_2025

```
MariaDB [dashboard]> SELECT slug, start, end FROM courses WHERE id = 30457;
+--------------------------------------------------------------------------------------------------+---------------------+---------------------+
| slug                                                                                             | start               | end                 |
+--------------------------------------------------------------------------------------------------+---------------------+---------------------+
| Robert_B._Haas_Family_Arts_Library/Yale_Robert_B._Haas_Family_Arts_Library_Art_And_Feminism_2025 | 2025-03-25 04:00:00 | 2025-03-26 03:00:00 |
+--------------------------------------------------------------------------------------------------+---------------------+---------------------+
```

```
MariaDB [dashboard]> SELECT * FROM course_wiki_timeslices WHERE course_id = 30457;
+---------+-----------+---------+----------------------------+----------------------------+---------------+------------------+----------------+-------+----------------------------+--------------+----------------------------+----------------------------+
| id      | course_id | wiki_id | start                      | end                        | character_sum | references_count | revision_count | stats | last_mw_rev_datetime       | needs_update | created_at                 | updated_at                 |
+---------+-----------+---------+----------------------------+----------------------------+---------------+------------------+----------------+-------+----------------------------+--------------+----------------------------+----------------------------+
| 1036993 |     30457 |       1 | 2025-03-24 06:30:00.000000 | 2025-03-25 06:30:00.000000 |             0 |                0 |              0 | NULL  | NULL                       |            0 | 2025-03-25 18:18:49.371964 | 2025-03-25 18:38:01.816557 |
| 1032393 |     30457 |       1 | 2025-03-25 06:30:00.000000 | 2025-03-26 06:30:00.000000 |          7109 |               17 |             24 | NULL  | 2025-03-25 20:25:23.000000 |            0 | 2025-03-25 06:35:34.244861 | 2025-03-25 23:29:54.604990 |
+---------+-----------+---------+----------------------------+----------------------------+---------------+------------------+----------------+-------+----------------------------+--------------+----------------------------+----------------------------+
```