### PR TITLE
change edits link to global edits

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/Header.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/Header.jsx
@@ -21,6 +21,10 @@ export const Header = ({
     reviewable, assignable
   } = groupByAssignmentType(assignments, selected.id);
 
+  const editsLink = course.wikis.length > 1
+    ? selected.global_contribution_url
+    : selected.contribution_url;
+
   return (
     <aside className="header">
       <section>
@@ -28,7 +32,7 @@ export const Header = ({
         <div className="sandbox-link">
           <a href={selected.sandbox_url} target="_blank">{I18n.t('users.sandboxes')}</a>
             &nbsp;
-          <a href={selected.contribution_url} target="_blank">{I18n.t('users.edits')}</a>
+          <a href={editsLink} target="_blank">{I18n.t('users.edits')}</a>
             &nbsp;
           <a href={`/users/${encodeURIComponent(selected.username)}`}>{I18n.t('users.profile')}</a>
         </div>

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/Contributions.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/Contributions.jsx
@@ -22,7 +22,7 @@ export const Contributions = ({ course, revisions, selectedIndex, student, wikid
   ));
 
   if (rows.length === 0) rows.push(<NoRevisionsRow key="no-revisions" student={student} />);
-  rows.push(<FullHistoryRow key="full-history" student={student} />);
+  rows.push(<FullHistoryRow key="full-history" student={student} course={course} />);
 
   return (
     <table className="table">

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/FullHistoryRow.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/FullHistoryRow.jsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const FullHistoryRow = ({ student }) => (
-  <tr key={`${student.id}-contribs`}>
-    <td colSpan="7" className="text-center">
-      <p><a href={student.contribution_url} target="_blank">{I18n.t('users.contributions_history_full')}</a></p>
-    </td>
-  </tr>
-);
+export const FullHistoryRow = ({ student, course }) => {
+  const editLinks = course.wikis.length > 1
+  ? student.global_contribution_url
+  : student.contribution_url;
+
+  return (
+    <tr key={`${student.id}-contribs`}>
+      <td colSpan="7" className="text-center">
+        <p><a href={editLinks} target="_blank">{I18n.t('users.contributions_history_full')}</a></p>
+      </td>
+    </tr>
+  );
+};
 
 FullHistoryRow.propTypes = {
   student: PropTypes.shape({
     id: PropTypes.number.isRequired,
-    contribution_url: PropTypes.string.isRequired
+    contribution_url: PropTypes.string.isRequired,
+    global_contribution_url: PropTypes.string.isRequired
   }).isRequired
 };
 


### PR DESCRIPTION
#6236

## What this PR does
This PR modifies the "Edits" link to "Global edits" on Campaign Dashboard application

## Screenshots

Before:
<img width="1491" alt="Screenshot 2025-03-27 at 7 24 40 PM" src="https://github.com/user-attachments/assets/dcf3c0e0-d794-400b-8a86-df9101a9fa08" />
<img width="1427" alt="Screenshot 2025-03-27 at 7 26 38 PM" src="https://github.com/user-attachments/assets/4c52a862-788c-4f7e-b420-1c8c920278ea" />


After:



https://github.com/user-attachments/assets/d270e879-916c-4d4c-8d4b-713a3262c6df




