### PR TITLE
[Data rearchitecture] Reimplement individual statistics presenter

### DIFF
--- a/app/assets/javascripts/components/user_profiles/student_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/student_stats.jsx
@@ -33,26 +33,10 @@ const StudentStats = ({ username, stats, maxProject }) => {
         </div>
         <div className= "stat-display__stat">
           <div className="stat-display__value">
-            {stats.individual_article_views}
-          </div>
-          <small>
-            {I18n.t(`metrics.${ArticleUtils.projectSuffix(maxProject, 'view_count_description')}`)}
-          </small>
-        </div>
-        <div className= "stat-display__stat">
-          <div className="stat-display__value">
             {stats.individual_article_count}
           </div>
           <small>
             {I18n.t(`metrics.${ArticleUtils.projectSuffix(maxProject, 'articles_edited')}`)}
-          </small>
-        </div>
-        <div className= "stat-display__stat">
-          <div className="stat-display__value">
-            {stats.individual_articles_created}
-          </div>
-          <small>
-            {I18n.t(`metrics.${ArticleUtils.projectSuffix(maxProject, 'articles_created')}`)}
           </small>
         </div>
         <div className ="stat-display__stat tooltip-trigger">

--- a/app/assets/javascripts/components/user_profiles/student_stats.jsx
+++ b/app/assets/javascripts/components/user_profiles/student_stats.jsx
@@ -15,21 +15,35 @@ const StudentStats = ({ username, stats, maxProject }) => {
             {I18n.t(`${stats.course_string_prefix}.courses_enrolled`)}
           </small>
         </div>
-        <div className= "stat-display__stat">
+        <div className= "stat-display__stat tooltip-trigger">
           <div className="stat-display__value">
             {stats.individual_word_count}
+            <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
           </div>
           <small>
             {I18n.t('metrics.word_count')}
           </small>
+          <div className="tooltip dark">
+            <h4> {stats.individual_word_count} </h4>
+            <p>
+              {I18n.t('user_profiles.words_added_disclaimer')}
+            </p>
+          </div>
         </div>
-        <div className= "stat-display__stat">
+        <div className= "stat-display__stat tooltip-trigger">
           <div className="stat-display__value">
             {stats.individual_references_count}
+            <img src ="/assets/images/info.svg" alt = "tooltip default logo" />
           </div>
           <small>
             {I18n.t('metrics.references_count')}
           </small>
+          <div className="tooltip dark">
+            <h4> {stats.individual_references_count} </h4>
+            <p>
+              {I18n.t('user_profiles.references_disclaimer')}
+            </p>
+          </div>
         </div>
         <div className= "stat-display__stat">
           <div className="stat-display__value">

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -40,7 +40,7 @@ class UserProfilesController < ApplicationController
 
   def stats
     @courses_users = @user.courses_users.includes(:course).where(courses: { private: false })
-    @individual_stats_presenter = IndividualStatisticsPresenter.new(user: @user)
+    @individual_stats_presenter = IndividualStatisticsTimeslicePresenter.new(user: @user)
     @courses_list = public_courses
                     .where(courses_users: { role: CoursesUsers::Roles::INSTRUCTOR_ROLE })
     @courses_presenter = CoursesPresenter.new(current_user:,

--- a/app/presenters/individual_statistics_timeslice_presenter.rb
+++ b/app/presenters/individual_statistics_timeslice_presenter.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/word_count"
+
+# Presenter to provide statistics about a user's individual contributions during
+# courses in which the user was a student.
+class IndividualStatisticsTimeslicePresenter
+  def initialize(user:)
+    @user = user
+    set_data_from_course_user
+    set_data_from_article_course
+    set_upload_usage_counts
+  end
+
+  def individual_courses
+    @user.courses.nonprivate.where(courses_users: { role: CoursesUsers::Roles::STUDENT_ROLE })
+  end
+
+  def course_string_prefix
+    Features.default_course_string_prefix
+  end
+
+  def individual_word_count
+    WordCount.from_characters individual_character_count
+  end
+
+  def individual_character_count
+    @course_user_data[:characters]
+  end
+
+  def individual_references_count
+    @course_user_data[:references]
+  end
+
+  def individual_upload_count
+    @upload_usage_counts.length
+  end
+
+  def individual_upload_usage_count
+    @upload_usage_counts.values.sum
+  end
+
+  def individual_article_count
+    @article_course_data[:count]
+  end
+
+  private
+
+  def set_data_from_course_user
+    @course_user_data = {}
+    @course_user_data[:characters] = 0
+    @course_user_data[:references] = 0
+    individual_courses.each do |course|
+      course_user_records(course).each do |course_user|
+        @course_user_data[:characters] += course_user.character_sum_ms
+        @course_user_data[:references] += course_user.references_count
+      end
+    end
+  end
+
+  def set_data_from_article_course
+    @article_course_data = {}
+    @article_course_data[:count] = 0
+    individual_courses.each do |course|
+      article_course_records(course).each do |_article_course|
+        @article_course_data[:count] += 1
+      end
+    end
+  end
+
+  def set_upload_usage_counts
+    @upload_usage_counts = {}
+    individual_courses.each do |course|
+      course.uploads.where(user_id: @user.id).each do |upload|
+        @upload_usage_counts[upload.id] = upload.usage_count || 0
+      end
+    end
+  end
+
+  def article_course_records(course)
+    course.articles_courses
+          .where('user_ids LIKE ?', "%- #{@user.id}\n%")
+          .joins(:article)
+          .includes(:article)
+          .where(articles: { namespace: Article::Namespaces::MAINSPACE, deleted: false })
+  end
+
+  def course_user_records(course)
+    course.courses_users.where(user: @user)
+  end
+end

--- a/app/presenters/individual_statistics_timeslice_presenter.rb
+++ b/app/presenters/individual_statistics_timeslice_presenter.rb
@@ -41,7 +41,7 @@ class IndividualStatisticsTimeslicePresenter
   end
 
   def individual_article_count
-    @article_course_data[:count]
+    @article_course_data.length
   end
 
   private
@@ -60,10 +60,9 @@ class IndividualStatisticsTimeslicePresenter
 
   def set_data_from_article_course
     @article_course_data = {}
-    @article_course_data[:count] = 0
     individual_courses.each do |course|
-      article_course_records(course).each do |_article_course|
-        @article_course_data[:count] += 1
+      article_course_records(course).each do |article_course|
+        @article_course_data[article_course.article_id] = 1
       end
     end
   end

--- a/app/views/user_profiles/stats.json.jbuilder
+++ b/app/views/user_profiles/stats.json.jbuilder
@@ -42,12 +42,8 @@ if @user.course_student?
     json.individual_word_count number_to_human @individual_stats_presenter.individual_word_count
     json.individual_references_count number_to_human @individual_stats_presenter
       .individual_references_count
-    json.individual_article_views number_to_human @individual_stats_presenter
-      .individual_article_views
     json.individual_article_count number_to_human @individual_stats_presenter
       .individual_article_count
-    json.individual_articles_created number_to_human @individual_stats_presenter
-      .individual_articles_created
     json.individual_upload_count number_to_human @individual_stats_presenter
       .individual_upload_count
     json.individual_upload_usage_count number_to_human @individual_stats_presenter

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1639,6 +1639,8 @@ en:
     location_placeholder: Add your location (optional)
     institution_placeholder: Institution name (optional)
     image_link_placeholder: Add link to image (optional)
+    references_disclaimer: References might be overcounted if the same user edit is considered part of multiple courses.
+    words_added_disclaimer: Words added might be overcounted if the same user edit is considered part of multiple courses.
 
   wiki_edits:
     notify_overdue:

--- a/spec/presenters/individual_statistics_timeslice_presenter_spec.rb
+++ b/spec/presenters/individual_statistics_timeslice_presenter_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../app/presenters/individual_statistics_presenter'
+
+describe IndividualStatisticsTimeslicePresenter do
+  describe 'individual_article_views' do
+    subject { described_class.new(user:) }
+
+    let(:start) { 1.year.ago.beginning_of_day }
+    let(:course_end) { 1.day.ago.end_of_day }
+    let(:course1) { create(:course, start:, end: course_end) }
+    let(:course2) { create(:course, slug: 'foo/2', start:, end: course_end) }
+    let(:user) { create(:user) }
+    let(:article) { create(:article, average_views: 10) }
+    let(:refs_tags_key) { 'feature.wikitext.revision.ref_tags' }
+    let(:array_revisions) { [] }
+
+    context 'when a user is in two courses that overlap' do
+      before do
+        create(:commons_upload, user_id: user.id, usage_count: 1,
+                                uploaded_at: start + 1.minute)
+        array_revisions << create(:revision, views: 100, user_id: user.id, article_id: article.id,
+                          date: start + 1.minute, new_article: true, characters: 100,
+                          features: {
+                            refs_tags_key => 22
+                          }, scoped: true)
+        create(:courses_user, user_id: user.id, course_id: course1.id)
+        create(:courses_user, user_id: user.id, course_id: course2.id)
+        create(:articles_course, article_id: article.id, course_id: course1.id)
+        create(:articles_course, article_id: article.id, course_id: course2.id)
+        ArticlesCourses.update_from_course_revisions(course1, array_revisions)
+        ArticlesCourses.update_from_course_revisions(course2, array_revisions)
+        TimesliceManager.new(course1).create_timeslices_for_new_course_wiki_records(course1.wikis)
+        TimesliceManager.new(course2).create_timeslices_for_new_course_wiki_records(course2.wikis)
+
+        revision_data = { start:, end: start + 1.day - 1.second,
+                          revisions: array_revisions }
+        CourseUserWikiTimeslice.update_course_user_wiki_timeslices(course1, user.id,
+                                                                   course1.wikis.first,
+                                                                   revision_data)
+        CourseUserWikiTimeslice.update_course_user_wiki_timeslices(course2, user.id,
+                                                                   course2.wikis.first,
+                                                                   revision_data)
+        CoursesUsers.update_all_caches_from_timeslices(CoursesUsers.all)
+
+        ArticleCourseTimeslice.update_article_course_timeslices(course1, article.id,
+                                                                revision_data)
+        ArticleCourseTimeslice.update_article_course_timeslices(course2, article.id,
+                                                                revision_data)
+        ArticlesCourses.update_all_caches_from_timeslices(ArticlesCourses.all)
+        course1.update_cache_from_timeslices
+        course2.update_cache_from_timeslices
+      end
+
+      it 'does\'t double count the same articles in multiple courses' do
+        expect(course1.articles_courses.count).to eq(1)
+        expect(course2.articles_courses.count).to eq(1)
+
+        # double count character count and references
+        expect(subject.individual_character_count).to eq(200)
+        expect(subject.individual_references_count).to eq(44)
+
+        # does not double count article count
+        expect(subject.individual_article_count).to eq(1)
+      end
+
+      it 'does not double count upload stats' do
+        expect(course1.uploads.count).to eq(1)
+        expect(course2.uploads.count).to eq(1)
+        expect(subject.individual_upload_count).to eq(1)
+        expect(subject.individual_upload_usage_count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR implements a new `IndividualStatisticsTimeslicePresenter` class to support user profile without revisions. Two metrics are deleted: article views and articles created. Note that we could implement those metrics with a lot of extra effort (however, they will be approximations -upper bound of created items, and lower bound of item views)

## Screenshots
### Before:

![before_0](https://github.com/user-attachments/assets/82039be6-a01d-4831-95c3-17ccd5500c0e)

![before_1](https://github.com/user-attachments/assets/2b01d5ee-3c2e-4a72-8e4b-7c76c4db923b)

### After (metrics don't match because I had different courses in my local env, but the point is noting that individual stats now don't show article views and articles created)

![after_0](https://github.com/user-attachments/assets/c62d9c50-7080-4d73-ba4b-4a3b6dd522e3)

![after_1](https://github.com/user-attachments/assets/4f04bd33-3385-41f3-89be-7f246e05d558)
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
