### PR TITLE
Optimize Survey Recent Responses fetching to prevent N+1 queries

### DIFF
--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -5,11 +5,12 @@ class SurveyResponsesController < ApplicationController
   layout 'surveys'
 
   def index
-    @responses = []
-    Rapidfire::AnswerGroup.order(created_at: :desc).first(100).each do |answer_group|
-      @responses << { user: User.find(answer_group.user_id),
-                      answer_group:,
-                      question_group: answer_group.question_group }
+    answer_groups = Rapidfire::AnswerGroup.includes(:question_group, :user)
+                                          .order(created_at: :desc)
+                                          .limit(100)
+
+    @responses = answer_groups.map do |answer_group|
+      { user: answer_group.user, question_group: answer_group.question_group, answer_group: }
     end
   end
 


### PR DESCRIPTION
Found this while trying to resolve #984

## What this PR does

- Added `.includes(:question_group, :user)` to preload related models, preventing unnecessary queries `(1+N)`.

- Replaced `each` loop with `.map` to make array transformation **more efficient**.

- Used `.limit(100)` instead of .first(100) to ensure filtering happens at the database level.

##  Why This Change?

- Previously, fetching `AnswerGroup` records triggered  `additional queries` to load users individually `(User.find)`.
- Now, all required users and question groups are `loaded in bulk`, reducing additional queries

## Screenshots
**Before:**


https://github.com/user-attachments/assets/6ac67a05-33e4-4f60-b273-a311968704ba




**After:**


https://github.com/user-attachments/assets/179e4a02-a239-406c-8e98-73b03d130944

## Benchmark


https://github.com/user-attachments/assets/4dcb30b1-2d26-4a04-9be7-c30c0f4a621d


## Guard Logs

**Before**:

![Before](https://github.com/user-attachments/assets/cb124481-72c4-4a37-af7f-7cffac1bfc37)


**After**:


![After](https://github.com/user-attachments/assets/1a54784f-5500-4878-9e59-1f4e98612e10)
