### PR TITLE
Fix Redux state mutation in `updateDetails` and `updateSlugPart` function of `Details Component`

### DIFF
--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -77,15 +77,13 @@ const Details = createReactClass({
   },
 
   updateDetails(valueKey, value) {
-    const updatedCourse = this.props.course;
-    updatedCourse[valueKey] = value;
-    return this.props.updateCourse(updatedCourse);
+    return this.props.updateCourse({ ...this.props.course, [valueKey]: value });
   },
 
   updateSlugPart(valueKey, value) {
-    const updatedCourse = this.props.course;
-    updatedCourse[valueKey] = value;
+    const updatedCourse = { ...this.props.course, [valueKey]: value };
     updatedCourse.slug = CourseUtils.generateTempId(updatedCourse);
+
     return this.props.updateCourse(updatedCourse);
   },
 


### PR DESCRIPTION
## What this PR does

Fixes State Mutation caused by `updateDetails` and `updateSlugPart` function of `Details` Component.

## Fix of Mutation

Now, both functions create a new `top-level reference`. Since Redux determines state changes by comparing the new reference with the old one when an update is dispatched, it will detect the change.

## Screenshots

Before:


https://github.com/user-attachments/assets/045e79f2-9cca-402f-8c68-abf9b2e49f11



After:


https://github.com/user-attachments/assets/8f2fb96a-d95e-48d3-806b-69142796dcb9

## Open questions and concerns

The screenshot below shows that all `options (yes/no)` cause Redux mutation due to the `YesNoSelector` component handling the no/yes options.  

Additionally, the mutation caused by the `Type (Wikipedia Student Program)` options is due to the `CourseTypeSelector` component.  

I will resolve these issues in a separate PR to make the review process easier.

![Screenshot from 2025-03-30 22-48-52](https://github.com/user-attachments/assets/9e64d3d2-e893-4201-953d-066be2a969fd)

- Mutation is only caused for this course, as shown below (still figuring this out).

https://github.com/user-attachments/assets/5d11a431-f763-4a78-a5df-56156d9c9848


- I also noticed a slight delay in all input text boxes of the `Details` component.  My best guess is that the state is being 
  updated in the Redux store instead of using the respective component's local state,  causing every child of `Details` to 
  re-render.

 


