### PR TITLE
Fix Redux state mutation in `CourseTypeSelector` and `YesNoSelector` component

### DIFF
--- a/app/assets/javascripts/components/overview/course_type_selector.jsx
+++ b/app/assets/javascripts/components/overview/course_type_selector.jsx
@@ -20,19 +20,16 @@ const CourseTypeSelector = (props) => {
   const [selectedOption, setSelectedOption] = useState({ value: props.course.type, label: _getFormattedCourseType(props.course.type) });
 
   const _handleChange = (e) => {
-    const course = props.course;
     const courseType = e.value;
-    course.type = courseType;
+    let { timeline_start, timeline_end } = props.course;
     setSelectedOption(e);
-    if (courseType === 'ClassroomProgramCourse' || course.timeline_enabled) {
-      if (!course.timeline_start) {
-        course.timeline_start = course.start;
-      }
-      if (!course.timeline_end) {
-        course.timeline_end = course.end;
-      }
+
+    if (courseType === 'ClassroomProgramCourse' || props.course.timeline_enabled) {
+      timeline_start = timeline_start ?? props.course.start;
+      timeline_end = timeline_end ?? props.course.end;
     }
-    return props.updateCourse(course);
+
+    return props.updateCourse({ ...props.course, type: courseType, timeline_start, timeline_end });
   };
 
     const currentType = _getFormattedCourseType(props.course.type);

--- a/app/assets/javascripts/components/overview/yes_no_selector.jsx
+++ b/app/assets/javascripts/components/overview/yes_no_selector.jsx
@@ -4,20 +4,24 @@ import Select from 'react-select';
 import selectStyles from '../../styles/single_select';
 
 const YesNoSelector = (props) => {
-    const initialState = props.course[props.courseProperty] ? I18n.t('application.opt_yes') : I18n.t('application.opt_no');
-    const [selectedOption, setSelectedOption] = useState({ value: initialState, label: initialState });
+  const initialState = props.course[props.courseProperty] ? I18n.t('application.opt_yes') : I18n.t('application.opt_no');
+  const [selectedOption, setSelectedOption] = useState({ value: initialState, label: initialState });
 
   const _handleChange = (e) => {
-    const course = props.course;
     const value = e.value;
+    let coursePropertyValue = props.course[props.courseProperty];
+
     setSelectedOption(e);
+
     if (value === I18n.t('application.opt_yes')) {
-      course[props.courseProperty] = true;
+      coursePropertyValue = true;
     } else if (value === I18n.t('application.opt_no')) {
-      course[props.courseProperty] = false;
+      coursePropertyValue = false;
     }
-    return props.updateCourse(course);
+
+    return props.updateCourse({ ...props.course, [props.courseProperty]: coursePropertyValue });
   };
+
 
   const currentValue = props.course[props.courseProperty];
   let selector = (


### PR DESCRIPTION
## What this PR does


This PR fixes all the Redux state mutations caused by the options shown below in the screenshot.


![Screenshot from 2025-04-01 20-49-26](https://github.com/user-attachments/assets/12d7b8f7-9b1a-4fb2-8a5c-2ce38fefb7f6)


## Fix for the mutation

This fix is similar to other Redux state mutation fixes in the codebase, i.e., creating a new reference for the object before modifying its value.


## Screenshots

Before:



https://github.com/user-attachments/assets/7ddeceee-4e6d-4139-b7de-040bfa45cd82





After:


https://github.com/user-attachments/assets/c4987c92-94fb-4158-9e19-fc8415d2fe3d



## Open questions and concerns

@ragesoss, I’m not sure why, but the Rack Mini Profiler on the course page appears briefly and then disappears immediately. This only happens on the course page. Do you have any idea what might be causing this? Also, could this be an issue specific to my local development? I’m not sure.


https://github.com/user-attachments/assets/6435b231-dd60-4cfa-8ce2-926fbe535c31


