### PR TITLE
Improvement/update performance of assignment status checker

### DIFF
--- a/app/services/check_assignment_status.rb
+++ b/app/services/check_assignment_status.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require 'pp'
 # Checks whether expected sandboxes have been created,
 # or if they've been created already, checks their
 # current size and location
@@ -7,82 +7,91 @@ class CheckAssignmentStatus
   def self.check_current_assignments
     return unless Features.wiki_ed?
 
-    Course.current.each do |course|
-      course.assignments.where.not(user: nil).each do |assignment|
-        new(assignment)
+    assignments = Assignment.joins(:course).merge(Course.current).where.not(user: nil)
+    sandboxes_to_check = collect_sandboxes(assignments)
+
+    process_sandboxes(sandboxes_to_check)
+  end
+
+  class << self
+    private
+
+    def collect_sandboxes(assignments)
+      sandboxes = []
+      assignments.each do |assignment|
+        case assignment.role
+        when Assignment::Roles::ASSIGNED_ROLE
+          add_assigned_sandboxes(sandboxes, assignment)
+        when Assignment::Roles::REVIEWING_ROLE
+          add_assigned_sandboxes(sandboxes, assignment)
+          add_review_sandbox(sandboxes, assignment)
+        end
+      end
+      sandboxes
+    end
+
+    def add_assigned_sandboxes(sandboxes, assignment)
+      sandboxes << { assignment: assignment, key: :draft, wiki: assignment.wiki, pagename: assignment.sandbox_pagename }
+      sandboxes << { assignment: assignment, key: :bibliography, wiki: assignment.wiki, pagename: assignment.bibliography_pagename }
+    end
+
+    def add_review_sandbox(sandboxes, assignment)
+      sandboxes << { assignment: assignment, key: :review, wiki: assignment.wiki, pagename: assignment.peer_review_pagename }
+    end
+
+    def process_sandboxes(sandboxes)
+      grouped_by_wiki = sandboxes.group_by { |s| s[:wiki] }
+
+      grouped_by_wiki.each do |wiki, entries|
+        pagenames = entries.map { |e| e[:pagename] }.uniq
+
+        pagenames.each_slice(50) do |batch|
+          api = WikiApi.new(wiki)
+          page_infos = api.get_page_info(batch)
+
+          process_batch(entries, batch, page_infos)
+        end
       end
     end
-  end
 
-  def initialize(assignment)
-    @assignment = assignment
-    @sandboxes = {}
+    def process_batch(entries, batch, page_infos)
+      return unless page_infos && page_infos['pages']
 
-    case @assignment.role
-    when Assignment::Roles::ASSIGNED_ROLE
-      set_assigned_sandboxes
-    when Assignment::Roles::REVIEWING_ROLE
-      # For reviews, we also need to check whether the draft sandboxes to review exist.
-      # An alternative strategy would be to use the corresponding ASSIGNED_ROLE assignment
-      # to get data about it, but this way keeps the records independent.
-      set_assigned_sandboxes
-      set_review_sandbox
+      # Convert pages hash to array maintaining API response order
+      pages_array = page_infos['pages'].values.sort_by { |page| page['index'] }
+
+      batch.each_with_index do |pagename, index|
+        # Get page data by index instead of searching by title
+        page_data = pages_array[index]
+        status = if page_data
+                  status_from_namespace(page_data['ns'])
+                else
+                  AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST
+                end
+
+        entries_for_pagename = entries.select { |e| e[:pagename] == pagename }
+
+        entries_for_pagename.each do |entry|
+          entry[:assignment].update_sandbox_status(entry[:key], status)
+        end
+      end
     end
 
-    update_status
-    # what are the expected sandboxes?
-    # do we already know that some of them exist?
-    # what are the Article records for each of them that exist?
-  end
-
-  def set_assigned_sandboxes
-    @sandboxes[:draft] = {
-      wiki: @assignment.wiki,
-      pagename: @assignment.sandbox_pagename
-    }
-    @sandboxes[:bibliography] = {
-      wiki: @assignment.wiki,
-      pagename: @assignment.bibliography_pagename
-    }
-  end
-
-  def set_review_sandbox
-    @sandboxes[:review] = {
-      wiki: @assignment.wiki,
-      pagename: @assignment.peer_review_pagename
-    }
-  end
-
-  def update_status
-    @sandboxes.each do |sandbox_key, page_details|
-      info = WikiApi.new(page_details[:wiki]).get_page_info page_details[:pagename]
-      new_status = page_status(info)
-      @assignment.update_sandbox_status(sandbox_key, new_status)
+    def find_page_data(page_infos, pagename)
+      page_infos['pages']&.values&.find { |pd| pd['title'] == pagename }
     end
-    # Do any already have corresponding Article records?
-    # If not, have any been created?
-    # If so, what namespaces are they in? what are their current titles? how big are they?
-  end
 
-  # Takes a hash of page info from the MediaWiki API and returns a status for
-  # the Assignment record
-  def page_status(page_info)
-    return AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST unless page_present?(page_info)
-
-    case page_info['pages'].values.first['ns']
-    when Article::Namespaces::USER
-      AssignmentPipeline::SandboxStatuses::EXISTS_IN_USERSPACE
-    when Article::Namespaces::DRAFT
-      AssignmentPipeline::SandboxStatuses::EXISTS_IN_DRAFT_SPACE
-    when Article::Namespaces::MAINSPACE
-      AssignmentPipeline::SandboxStatuses::EXISTS_IN_MAINSPACE
-    else
-      AssignmentPipeline::SandboxStatuses::EXISTS_ELSEWHERE
+    def status_from_namespace(namespace)
+      case namespace
+      when Article::Namespaces::USER
+        AssignmentPipeline::SandboxStatuses::EXISTS_IN_USERSPACE
+      when Article::Namespaces::DRAFT
+        AssignmentPipeline::SandboxStatuses::EXISTS_IN_DRAFT_SPACE
+      when Article::Namespaces::MAINSPACE
+        AssignmentPipeline::SandboxStatuses::EXISTS_IN_MAINSPACE
+      else
+        AssignmentPipeline::SandboxStatuses::EXISTS_ELSEWHERE
+      end
     end
-  end
-
-  def page_present?(page_info)
-    return false unless page_info.present?
-    page_info.dig('pages', '-1', 'missing').nil?
   end
 end

--- a/app/services/check_assignment_status.rb
+++ b/app/services/check_assignment_status.rb
@@ -8,119 +8,121 @@ class CheckAssignmentStatus
 
     assignments = Assignment.joins(:course).merge(Course.current).where.not(user: nil)
     sandboxes_to_check = collect_sandboxes(assignments)
-
     process_sandboxes(sandboxes_to_check)
   end
 
-  class << self
-    private
-
-    def collect_sandboxes(assignments)
-      sandboxes = []
-      assignments.each do |assignment|
-        case assignment.role
-        when Assignment::Roles::ASSIGNED_ROLE
-          add_assigned_sandboxes(sandboxes, assignment)
-        when Assignment::Roles::REVIEWING_ROLE
-          add_assigned_sandboxes(sandboxes, assignment)
-          add_review_sandbox(sandboxes, assignment)
-        end
-      end
-      sandboxes
-    end
-
-    def add_assigned_sandboxes(sandboxes, assignment)
-      sandboxes << { assignment:,
-        key: :draft,
-        wiki: assignment.wiki,
-        pagename: assignment.sandbox_pagename }
-      sandboxes << { assignment:,
-        key: :bibliography,
-        wiki: assignment.wiki,
-        pagename: assignment.bibliography_pagename }
-    end
-
-    def add_review_sandbox(sandboxes, assignment)
-      sandboxes << { assignment:,
-        key: :review,
-        wiki: assignment.wiki,
-        pagename: assignment.peer_review_pagename }
-    end
-
-    def process_sandboxes(sandboxes)
-      grouped_by_wiki = sandboxes.group_by { |s| s[:wiki] }
-
-      grouped_by_wiki.each do |wiki, entries|
-        pagenames = entries.map { |e| e[:pagename] }.uniq # rubocop:disable Rails/Pluck
-
-        pagenames.each_slice(50) do |batch|
-          api = WikiApi.new(wiki)
-          page_infos = api.get_page_info(batch)
-
-          process_batch(entries, batch, page_infos)
-        end
+  def self.collect_sandboxes(assignments)
+    sandboxes = []
+    assignments.each do |assignment|
+      case assignment.role
+      when Assignment::Roles::ASSIGNED_ROLE
+        add_assigned_sandboxes(sandboxes, assignment)
+      when Assignment::Roles::REVIEWING_ROLE
+        add_assigned_sandboxes(sandboxes, assignment)
+        add_review_sandbox(sandboxes, assignment)
       end
     end
+    sandboxes
+  end
 
-    def process_batch(entries, batch, page_infos)
-      return unless page_infos && page_infos['pages']
+  def self.add_assigned_sandboxes(sandboxes, assignment)
+    sandboxes << { assignment:,
+      key: :draft,
+      wiki: assignment.wiki,
+      pagename: assignment.sandbox_pagename }
+    sandboxes << { assignment:,
+      key: :bibliography,
+      wiki: assignment.wiki,
+      pagename: assignment.bibliography_pagename }
+  end
 
-      pages_by_normalized_title = build_pages_by_normalized_title(page_infos)
+  def self.add_review_sandbox(sandboxes, assignment)
+    sandboxes << { assignment:,
+      key: :review,
+      wiki: assignment.wiki,
+      pagename: assignment.peer_review_pagename }
+  end
 
-      Assignment.transaction do
-        update_assignments_for_batch(entries, batch, pages_by_normalized_title)
+  def self.process_sandboxes(sandboxes)
+    grouped_by_wiki = sandboxes.group_by { |s| s[:wiki] }
+
+    grouped_by_wiki.each do |wiki, entries|
+      pagenames = entries.map { |e| e[:pagename] }.uniq # rubocop:disable Rails/Pluck
+
+      pagenames.each_slice(50) do |batch|
+        new(wiki, entries, batch).process
       end
     end
+  end
 
-    def build_pages_by_normalized_title(page_infos)
-      page_infos['pages'].each_with_object({}) do |(_, page), hash|
-        normalized_title = page['title'].tr(' ', '_')
-        page['present'] = !page.key?('missing')
-        hash[normalized_title] = page
-      end
+  def initialize(wiki, entries, batch)
+    @wiki = wiki
+    @entries = entries
+    @batch = batch
+    @page_infos = nil
+  end
+
+  def process
+    @page_infos = WikiApi.new(@wiki).get_page_info(@batch)
+    process_batch
+  end
+
+  private
+
+  def process_batch
+    return unless @page_infos && @page_infos['pages']
+
+    pages_by_normalized_title = build_pages_by_normalized_title
+
+    Assignment.transaction do
+      update_assignments_for_batch(pages_by_normalized_title)
     end
+  end
 
-    def update_assignments_for_batch(entries, batch, pages_by_normalized_title)
-      batch.each do |pagename|
-        normalized_pagename = pagename.tr(' ', '_')
-        page_data = pages_by_normalized_title[normalized_pagename]
-        status = determine_status(page_data)
-
-        update_entries_for_pagename(entries, pagename, status)
-      end
+  def build_pages_by_normalized_title
+    @page_infos['pages'].each_with_object({}) do |(_, page), hash|
+      normalized_title = page['title'].tr(' ', '_')
+      page['present'] = !page.key?('missing')
+      hash[normalized_title] = page
     end
+  end
 
-    def determine_status(page_data)
-      if page_data
-        status_from_namespace(page_data['ns'], page_data['present'])
-      else
-        AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST
-      end
+  def update_assignments_for_batch(pages_by_normalized_title)
+    @batch.each do |pagename|
+      normalized_pagename = pagename.tr(' ', '_')
+      page_data = pages_by_normalized_title[normalized_pagename]
+      status = determine_status(page_data)
+
+      update_entries_for_pagename(pagename, status)
     end
+  end
 
-    def update_entries_for_pagename(entries, pagename, status)
-      entries.select { |e| e[:pagename] == pagename }.each do |entry|
-        entry[:assignment].update_sandbox_status(entry[:key], status)
-      end
+  def determine_status(page_data)
+    if page_data
+      status_from_namespace(page_data['ns'], page_data['present'])
+    else
+      AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST
     end
+  end
 
-    def find_page_data(page_infos, pagename)
-      page_infos['pages']&.values&.find { |pd| pd['title'] == pagename }
+  def update_entries_for_pagename(pagename, status)
+    @entries.select { |e| e[:pagename] == pagename }.each do |entry|
+      entry[:assignment].update_sandbox_status(entry[:key], status)
     end
+  end
 
-    def status_from_namespace(namespace, present)
-      return AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST unless present
+  def status_from_namespace(namespace, present)
+    return AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST unless present
 
-      case namespace
-      when Article::Namespaces::USER
-        AssignmentPipeline::SandboxStatuses::EXISTS_IN_USERSPACE
-      when Article::Namespaces::DRAFT
-        AssignmentPipeline::SandboxStatuses::EXISTS_IN_DRAFT_SPACE
-      when Article::Namespaces::MAINSPACE
-        AssignmentPipeline::SandboxStatuses::EXISTS_IN_MAINSPACE
-      else
-        AssignmentPipeline::SandboxStatuses::EXISTS_ELSEWHERE
-      end
+    case namespace
+    when Article::Namespaces::USER
+      AssignmentPipeline::SandboxStatuses::EXISTS_IN_USERSPACE
+    when Article::Namespaces::DRAFT
+      AssignmentPipeline::SandboxStatuses::EXISTS_IN_DRAFT_SPACE
+    when Article::Namespaces::MAINSPACE
+      AssignmentPipeline::SandboxStatuses::EXISTS_IN_MAINSPACE
+    else
+      AssignmentPipeline::SandboxStatuses::EXISTS_ELSEWHERE
     end
   end
 end

--- a/spec/services/check_assignment_status_spec.rb
+++ b/spec/services/check_assignment_status_spec.rb
@@ -22,7 +22,6 @@ describe CheckAssignmentStatus do
     end
 
     it 'updates status for all current course assignments' do
-      # ActiveRecord::Base.logger = Logger.new(STDOUT)
       expect(assignment_1.draft_sandbox_status).to eq('does_not_exist')
       expect(assignment_2.peer_review_sandbox_status).to eq('does_not_exist')
 
@@ -32,15 +31,13 @@ describe CheckAssignmentStatus do
 
       assignment_1.reload
 
-      pp assignment_1
-
       expect(assignment_1.reload.draft_sandbox_status).to eq('exists_in_userspace')
       expect(assignment_2.reload.peer_review_sandbox_status).to eq('exists_in_userspace')
     end
 
     context 'when the draft sandbox exists' do
       let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
-  
+
       it 'updates the Assignment draft sandbox status' do
         expect(assignment.draft_sandbox_status).to eq('does_not_exist')
         VCR.use_cassette 'assignment_status' do
@@ -54,7 +51,7 @@ describe CheckAssignmentStatus do
 
     context 'when the bibliography sandbox exists' do
       let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox_empty' }
-  
+
       it 'updates the bibliography draft sandbox status' do
         expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
         VCR.use_cassette 'assignment_status' do
@@ -64,10 +61,10 @@ describe CheckAssignmentStatus do
         expect(assignment.draft_sandbox_status).to eq('does_not_exist')
         expect(assignment.bibliography_sandbox_status).to eq('exists_in_userspace')
       end
-  
+
       context 'whent the sandbox include URL-encoded characters' do
         let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Sage (Wiki Ed)/Fender_%28company%29' }
-  
+
         it 'still works' do
           expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
           VCR.use_cassette 'assignment_status' do
@@ -84,7 +81,7 @@ describe CheckAssignmentStatus do
       let(:role) { Assignment::Roles::REVIEWING_ROLE }
       let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
       # Peer review sandbox: https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox/Ragesock_Peer_Review
-  
+
       it 'updates the peer review sandbox sandbox status' do
         expect(assignment.peer_review_sandbox_status).to eq('does_not_exist')
         VCR.use_cassette 'assignment_status' do
@@ -97,7 +94,7 @@ describe CheckAssignmentStatus do
 
     context 'when an assignment pipeline status is set' do
       let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
-  
+
       it 'does not overwrite it when updating sandbox status' do
         assignment.update_status('assignment_completed')
         expect(assignment.draft_sandbox_status).to eq('does_not_exist')

--- a/spec/services/check_assignment_status_spec.rb
+++ b/spec/services/check_assignment_status_spec.rb
@@ -6,7 +6,8 @@ describe CheckAssignmentStatus do
   let(:user) { create(:user, username: 'Ragesock') }
   let(:subject) { described_class.check_current_assignments }
   let(:role) { Assignment::Roles::ASSIGNED_ROLE }
-  let(:assignment) { create(:assignment, role:, sandbox_url:, user:) }
+  let(:course) { create(:course, start: 1.day.ago, end: 1.day.from_now) }
+  let(:assignment) { create(:assignment, role:, sandbox_url:, user:, course:) }
 
   describe '.check_current_assignments' do
     let(:course) { create(:course, start: 1.day.ago, end: 1.day.from_now) }
@@ -21,12 +22,17 @@ describe CheckAssignmentStatus do
     end
 
     it 'updates status for all current course assignments' do
+      # ActiveRecord::Base.logger = Logger.new(STDOUT)
       expect(assignment_1.draft_sandbox_status).to eq('does_not_exist')
       expect(assignment_2.peer_review_sandbox_status).to eq('does_not_exist')
 
       VCR.use_cassette 'assignment_status' do
         subject
       end
+
+      assignment_1.reload
+
+      pp assignment_1
 
       expect(assignment_1.reload.draft_sandbox_status).to eq('exists_in_userspace')
       expect(assignment_2.reload.peer_review_sandbox_status).to eq('exists_in_userspace')
@@ -43,6 +49,64 @@ describe CheckAssignmentStatus do
         assignment.reload
         expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
         expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
+      end
+    end
+
+    context 'when the bibliography sandbox exists' do
+      let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox_empty' }
+  
+      it 'updates the bibliography draft sandbox status' do
+        expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
+        VCR.use_cassette 'assignment_status' do
+          subject
+        end
+        assignment.reload
+        expect(assignment.draft_sandbox_status).to eq('does_not_exist')
+        expect(assignment.bibliography_sandbox_status).to eq('exists_in_userspace')
+      end
+  
+      context 'whent the sandbox include URL-encoded characters' do
+        let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Sage (Wiki Ed)/Fender_%28company%29' }
+  
+        it 'still works' do
+          expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
+          VCR.use_cassette 'assignment_status' do
+            subject
+          end
+          assignment.reload
+          expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
+          expect(assignment.bibliography_sandbox_status).to eq('exists_in_userspace')
+        end
+      end
+    end
+
+    context 'when a peer review sandbox exists' do
+      let(:role) { Assignment::Roles::REVIEWING_ROLE }
+      let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
+      # Peer review sandbox: https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox/Ragesock_Peer_Review
+  
+      it 'updates the peer review sandbox sandbox status' do
+        expect(assignment.peer_review_sandbox_status).to eq('does_not_exist')
+        VCR.use_cassette 'assignment_status' do
+          subject
+        end
+        assignment.reload
+        expect(assignment.peer_review_sandbox_status).to eq('exists_in_userspace')
+      end
+    end
+
+    context 'when an assignment pipeline status is set' do
+      let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
+  
+      it 'does not overwrite it when updating sandbox status' do
+        assignment.update_status('assignment_completed')
+        expect(assignment.draft_sandbox_status).to eq('does_not_exist')
+        VCR.use_cassette 'assignment_status' do
+          subject
+        end
+        assignment.reload
+        expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
+        expect(assignment.status).to eq('assignment_completed')
       end
     end
   end

--- a/spec/services/check_assignment_status_spec.rb
+++ b/spec/services/check_assignment_status_spec.rb
@@ -4,81 +4,9 @@ require 'rails_helper'
 
 describe CheckAssignmentStatus do
   let(:user) { create(:user, username: 'Ragesock') }
-  let(:subject) { described_class.new(assignment) }
+  let(:subject) { described_class.check_current_assignments }
   let(:role) { Assignment::Roles::ASSIGNED_ROLE }
   let(:assignment) { create(:assignment, role:, sandbox_url:, user:) }
-
-  context 'when the draft sandbox exists' do
-    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
-
-    it 'updates the Assignment draft sandbox status' do
-      expect(assignment.draft_sandbox_status).to eq('does_not_exist')
-      VCR.use_cassette 'assignment_status' do
-        subject
-      end
-      assignment.reload
-      expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
-      expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
-    end
-  end
-
-  context 'when the bibliography sandbox exists' do
-    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox_empty' }
-
-    it 'updates the bibliography draft sandbox status' do
-      expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
-      VCR.use_cassette 'assignment_status' do
-        subject
-      end
-      assignment.reload
-      expect(assignment.draft_sandbox_status).to eq('does_not_exist')
-      expect(assignment.bibliography_sandbox_status).to eq('exists_in_userspace')
-    end
-
-    context 'whent the sandbox include URL-encoded characters' do
-      let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Sage (Wiki Ed)/Fender_%28company%29' }
-
-      it 'still works' do
-        expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
-        VCR.use_cassette 'assignment_status' do
-          subject
-        end
-        assignment.reload
-        expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
-        expect(assignment.bibliography_sandbox_status).to eq('exists_in_userspace')
-      end
-    end
-  end
-
-  context 'when a peer review sandbox exists' do
-    let(:role) { Assignment::Roles::REVIEWING_ROLE }
-    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
-    # Peer review sandbox: https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox/Ragesock_Peer_Review
-
-    it 'updates the peer review sandbox sandbox status' do
-      expect(assignment.peer_review_sandbox_status).to eq('does_not_exist')
-      VCR.use_cassette 'assignment_status' do
-        subject
-      end
-      assignment.reload
-      expect(assignment.peer_review_sandbox_status).to eq('exists_in_userspace')
-    end
-  end
-
-  context 'when an assignment pipeline status is set' do
-    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
-
-    it 'does not overwrite it when updating sandbox status' do
-      assignment.update_status('assignment_completed')
-      expect(assignment.draft_sandbox_status).to eq('does_not_exist')
-      VCR.use_cassette 'assignment_status' do
-        subject
-      end
-      assignment.reload
-      expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
-      expect(assignment.status).to eq('assignment_completed')
-    end
-  end
 
   describe '.check_current_assignments' do
     let(:course) { create(:course, start: 1.day.ago, end: 1.day.from_now) }
@@ -97,20 +25,24 @@ describe CheckAssignmentStatus do
       expect(assignment_2.peer_review_sandbox_status).to eq('does_not_exist')
 
       VCR.use_cassette 'assignment_status' do
-        described_class.check_current_assignments
+        subject
       end
 
       expect(assignment_1.reload.draft_sandbox_status).to eq('exists_in_userspace')
       expect(assignment_2.reload.peer_review_sandbox_status).to eq('exists_in_userspace')
     end
-  end
 
-  describe '#page_present?' do
-    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
-
-    context 'when there is no page_info' do
-      it 'returns false' do
-        expect(subject.page_present?(nil)).to eq(false)
+    context 'when the draft sandbox exists' do
+      let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
+  
+      it 'updates the Assignment draft sandbox status' do
+        expect(assignment.draft_sandbox_status).to eq('does_not_exist')
+        VCR.use_cassette 'assignment_status' do
+          subject
+        end
+        assignment.reload
+        expect(assignment.draft_sandbox_status).to eq('exists_in_userspace')
+        expect(assignment.bibliography_sandbox_status).to eq('does_not_exist')
       end
     end
   end


### PR DESCRIPTION
#6224

## What this PR does
**Performance Optimization**: Replaces N individual DB updates with a single transactional batch update.

## Screenshots
Before:
```rb
Course.current.each do |course|
      course.assignments.where.not(user: nil).each do |assignment|
        new(assignment)`
 ```       
Previously, We were looping through each of the `Course` and `assignment` and also initializing each assignment

After:
```rb
assignments = Assignment.joins(:course).merge(Course.current).where.not(user: nil)
```

We're making a single database call to get the assignments in the new update. 


Before:
```rb
def page_status(page_info)
    return AssignmentPipeline::SandboxStatuses::DOES_NOT_EXIST unless page_present?(page_info)

    case page_info['pages'].values.first['ns']
    when Article::Namespaces::USER
      AssignmentPipeline::SandboxStatuses::EXISTS_IN_USERSPACE
    when Article::Namespaces::DRAFT
      AssignmentPipeline::SandboxStatuses::EXISTS_IN_DRAFT_SPACE
    when Article::Namespaces::MAINSPACE
      AssignmentPipeline::SandboxStatuses::EXISTS_IN_MAINSPACE
    else
      AssignmentPipeline::SandboxStatuses::EXISTS_ELSEWHERE
end
```
This function checks the namespace of a single page and assigns a status based on predefined conditions.

It only processes one page at a time, making it inefficient when handling multiple pages.

The lookup is done using page_info['pages'].values.first, which assumes only one page exists per call.

After:
```rb
def process_batch(entries, batch, page_infos)
      return unless page_infos && page_infos['pages']

      pages_by_normalized_title = build_pages_by_normalized_title(page_infos)

      Assignment.transaction do
        update_assignments_for_batch(entries, batch, pages_by_normalized_title)
      end
end


```

Batch Processing: Instead of handling pages one at a time, it now processes an entire batch in a single database transaction.
Caching Data: Instead of repeatedly checking page_infos, it builds a hash (pages_by_normalized_title) for faster lookups.

Efficient Database Updates: Uses Assignment.transaction to minimize DB writes, improving performance when updating multiple pages at once.
