### PR TITLE
Add tests for Training Actions

### DIFF
--- a/test/actions/training_actions.spec.js
+++ b/test/actions/training_actions.spec.js
@@ -1,35 +1,35 @@
-import configureMockStore from "redux-mock-store";
-import thunk from "redux-thunk";
-import sinon from "sinon";
-import "../testHelper";
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import sinon from 'sinon';
+import '../testHelper';
 import {
   RECEIVE_ALL_TRAINING_MODULES,
   RECEIVE_TRAINING_MODULE,
   EXERCISE_COMPLETION_UPDATE,
   API_FAIL,
-} from "../../app/assets/javascripts/constants";
+} from '../../app/assets/javascripts/constants';
 import {
   fetchAllTrainingModules,
   fetchTrainingModule,
   setExerciseModuleComplete,
   setExerciseModuleIncomplete,
-} from "../../app/assets/javascripts/actions/training_actions";
-import * as requestModule from "../../app/assets/javascripts/utils/request";
+} from '../../app/assets/javascripts/actions/training_actions';
+import * as requestModule from '../../app/assets/javascripts/utils/request';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-describe("Training Module Actions", () => {
+describe('Training Module Actions', () => {
   beforeEach(() => {
-    sinon.stub(requestModule, "default");
+    sinon.stub(requestModule, 'default');
   });
 
   afterEach(() => {
     requestModule.default.restore();
   });
 
-  test("dispatches RECEIVE_ALL_TRAINING_MODULES on successful fetchAllTrainingModules", () => {
-    const mockData = [{ id: 1, title: "Module 1" }];
+  test('dispatches RECEIVE_ALL_TRAINING_MODULES on successful fetchAllTrainingModules', () => {
+    const mockData = [{ id: 1, title: 'Module 1' }];
     requestModule.default.resolves({
       ok: true,
       json: sinon.fake.returns(mockData),
@@ -45,10 +45,10 @@ describe("Training Module Actions", () => {
     });
   });
 
-  test("dispatches API_FAIL on failed fetchAllTrainingModules", () => {
-    requestModule.default.rejects(new Error("API error"));
+  test('dispatches API_FAIL on failed fetchAllTrainingModules', () => {
+    requestModule.default.rejects(new Error('API error'));
 
-    const expectedActions = [{ type: API_FAIL, data: new Error("API error") }];
+    const expectedActions = [{ type: API_FAIL, data: new Error('API error') }];
 
     const store = mockStore({});
     return store.dispatch(fetchAllTrainingModules()).then(() => {
@@ -56,8 +56,8 @@ describe("Training Module Actions", () => {
     });
   });
 
-  test("dispatches RECEIVE_TRAINING_MODULE on successful fetchTrainingModule", () => {
-    const mockData = { training_module: { slides: [{ slug: "slide-1" }] } };
+  test('dispatches RECEIVE_TRAINING_MODULE on successful fetchTrainingModule', () => {
+    const mockData = { training_module: { slides: [{ slug: 'slide-1' }] } };
     requestModule.default.resolves({
       ok: true,
       json: sinon.fake.returns(mockData),
@@ -66,33 +66,33 @@ describe("Training Module Actions", () => {
     const expectedActions = [
       {
         type: RECEIVE_TRAINING_MODULE,
-        data: { ...mockData, slide: "slide-1", valid: true },
+        data: { ...mockData, slide: 'slide-1', valid: true },
       },
     ];
 
     const store = mockStore({});
     return store
-      .dispatch(fetchTrainingModule({ slide_id: "slide-1" }))
+      .dispatch(fetchTrainingModule({ slide_id: 'slide-1' }))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
   });
 
-  test("dispatches API_FAIL on failed fetchTrainingModule", () => {
-    requestModule.default.rejects(new Error("API error"));
+  test('dispatches API_FAIL on failed fetchTrainingModule', () => {
+    requestModule.default.rejects(new Error('API error'));
 
-    const expectedActions = [{ type: API_FAIL, data: new Error("API error") }];
+    const expectedActions = [{ type: API_FAIL, data: new Error('API error') }];
 
     const store = mockStore({});
     return store
-      .dispatch(fetchTrainingModule({ slide_id: "slide-1" }))
+      .dispatch(fetchTrainingModule({ slide_id: 'slide-1' }))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
   });
 
-  test("dispatches EXERCISE_COMPLETION_UPDATE on successful setExerciseModuleComplete", () => {
-    const mockData = { status: "complete" };
+  test('dispatches EXERCISE_COMPLETION_UPDATE on successful setExerciseModuleComplete', () => {
+    const mockData = { status: 'complete' };
     requestModule.default.resolves({
       ok: true,
       json: sinon.fake.resolves(mockData),
@@ -108,10 +108,10 @@ describe("Training Module Actions", () => {
     });
   });
 
-  test("dispatches API_FAIL on failed setExerciseModuleIncomplete", () => {
-    requestModule.default.rejects(new Error("API error"));
+  test('dispatches API_FAIL on failed setExerciseModuleIncomplete', () => {
+    requestModule.default.rejects(new Error('API error'));
 
-    const expectedActions = [{ type: API_FAIL, data: new Error("API error") }];
+    const expectedActions = [{ type: API_FAIL, data: new Error('API error') }];
 
     const store = mockStore({});
     return store.dispatch(setExerciseModuleIncomplete(1, 2)).then(() => {

--- a/test/actions/training_actions.spec.js
+++ b/test/actions/training_actions.spec.js
@@ -1,28 +1,35 @@
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import sinon from 'sinon';
-import '../testHelper';
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import sinon from "sinon";
+import "../testHelper";
 import {
   RECEIVE_ALL_TRAINING_MODULES,
+  RECEIVE_TRAINING_MODULE,
+  EXERCISE_COMPLETION_UPDATE,
   API_FAIL,
-} from '../../app/assets/javascripts/constants';
-import { fetchAllTrainingModules } from '../../app/assets/javascripts/actions/training_actions';
-import * as requestModule from '../../app/assets/javascripts/utils/request';
+} from "../../app/assets/javascripts/constants";
+import {
+  fetchAllTrainingModules,
+  fetchTrainingModule,
+  setExerciseModuleComplete,
+  setExerciseModuleIncomplete,
+} from "../../app/assets/javascripts/actions/training_actions";
+import * as requestModule from "../../app/assets/javascripts/utils/request";
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-describe('Training Module Actions', () => {
+describe("Training Module Actions", () => {
   beforeEach(() => {
-    sinon.stub(requestModule, 'default');
+    sinon.stub(requestModule, "default");
   });
 
   afterEach(() => {
     requestModule.default.restore();
   });
 
-  test('dispatches RECEIVE_ALL_TRAINING_MODULES on successful fetchAllTrainingModules', () => {
-    const mockData = [{ id: 1, title: 'Module 1' }];
+  test("dispatches RECEIVE_ALL_TRAINING_MODULES on successful fetchAllTrainingModules", () => {
+    const mockData = [{ id: 1, title: "Module 1" }];
     requestModule.default.resolves({
       ok: true,
       json: sinon.fake.returns(mockData),
@@ -38,13 +45,76 @@ describe('Training Module Actions', () => {
     });
   });
 
-  test('dispatches API_FAIL on failed fetchAllTrainingModules', () => {
-    requestModule.default.rejects(new Error('API error'));
+  test("dispatches API_FAIL on failed fetchAllTrainingModules", () => {
+    requestModule.default.rejects(new Error("API error"));
 
-    const expectedActions = [{ type: API_FAIL, data: new Error('API error') }];
+    const expectedActions = [{ type: API_FAIL, data: new Error("API error") }];
 
     const store = mockStore({});
     return store.dispatch(fetchAllTrainingModules()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  test("dispatches RECEIVE_TRAINING_MODULE on successful fetchTrainingModule", () => {
+    const mockData = { training_module: { slides: [{ slug: "slide-1" }] } };
+    requestModule.default.resolves({
+      ok: true,
+      json: sinon.fake.returns(mockData),
+    });
+
+    const expectedActions = [
+      {
+        type: RECEIVE_TRAINING_MODULE,
+        data: { ...mockData, slide: "slide-1", valid: true },
+      },
+    ];
+
+    const store = mockStore({});
+    return store
+      .dispatch(fetchTrainingModule({ slide_id: "slide-1" }))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+  });
+
+  test("dispatches API_FAIL on failed fetchTrainingModule", () => {
+    requestModule.default.rejects(new Error("API error"));
+
+    const expectedActions = [{ type: API_FAIL, data: new Error("API error") }];
+
+    const store = mockStore({});
+    return store
+      .dispatch(fetchTrainingModule({ slide_id: "slide-1" }))
+      .then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+  });
+
+  test("dispatches EXERCISE_COMPLETION_UPDATE on successful setExerciseModuleComplete", () => {
+    const mockData = { status: "complete" };
+    requestModule.default.resolves({
+      ok: true,
+      json: sinon.fake.resolves(mockData),
+    });
+
+    const expectedActions = [
+      { type: EXERCISE_COMPLETION_UPDATE, data: mockData },
+    ];
+
+    const store = mockStore({});
+    return store.dispatch(setExerciseModuleComplete(1, 2)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  test("dispatches API_FAIL on failed setExerciseModuleIncomplete", () => {
+    requestModule.default.rejects(new Error("API error"));
+
+    const expectedActions = [{ type: API_FAIL, data: new Error("API error") }];
+
+    const store = mockStore({});
+    return store.dispatch(setExerciseModuleIncomplete(1, 2)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });


### PR DESCRIPTION

## What this PR Does
This PR adds tests for the following methods in the training actions:
- fetchTrainingModule
- setExerciseModuleComplete
- setExerciseModuleIncomplete

The tests dispatches the correct action on a successful request and an API_FAIL action on failed requests.