### PR TITLE
Fix: Optimize error logging for non-200 responses in ReferenceCounterApi

### DIFF
--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -37,6 +37,7 @@ class ReferenceCounterApi
   def get_number_of_references_from_revision_ids(rev_ids)
     # Restart errors array
     @errors = []
+    @non_200_responses = {}
     results = {}
     rev_ids.each do |rev_id|
       results.deep_merge!({ rev_id.to_s => get_number_of_references_from_revision_id(rev_id) })
@@ -60,10 +61,20 @@ class ReferenceCounterApi
     return { 'num_ref' => parsed_response['num_ref'] } if response.status == 200
     # Leave the error empty if it is not a transient error.
     return { 'num_ref' => nil } if non_transient_error? response.status
-    # Log the error and return empty hash
-    # Sentry.capture_message 'Non-200 response hitting references counter API', level: 'warning',
-    # extra: { project_code: @project_code, language_code: @language_code, rev_id:,
-    #                        status_code: response.status, content: parsed_response }
+    
+    # Track non-200 responses for batch logging
+    status_key = response.status.to_s
+    @non_200_responses[status_key] ||= { count: 0, examples: [] }
+    @non_200_responses[status_key][:count] += 1
+    
+    # Store a limited number of examples for debugging
+    if @non_200_responses[status_key][:examples].length < 5
+      @non_200_responses[status_key][:examples] << {
+        rev_id: rev_id,
+        content: parsed_response
+      }
+    end
+    
     return { 'num_ref' => nil, 'error' => parsed_response }
   rescue StandardError => e
     tries -= 1
@@ -102,6 +113,21 @@ class ReferenceCounterApi
                     Faraday::ConnectionFailed].freeze
 
   def log_error_batch(rev_ids)
+    # Log consolidated non-200 responses
+    unless @non_200_responses.empty?
+      log_error(
+        StandardError.new('Non-200 responses hitting references counter API'),
+        update_service: @update_service,
+        sentry_extra: { 
+          project_code: @project_code,
+          language_code: @language_code,
+          rev_id_count: rev_ids.length,
+          response_stats: @non_200_responses
+        }
+      )
+    end
+    
+    # Log other errors
     return if @errors.empty?
 
     log_error(@errors.first, update_service: @update_service,

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -80,26 +80,12 @@ describe ReferenceCounterApi do
     end
   end
 
-  # it 'logs the message if response is not 200 OK', vcr: true do
-  #   ref_counter_api = described_class.new(en_wikipedia)
-  #   expect(Sentry).to receive(:capture_message).with(
-  #     'Non-200 response hitting references counter API',
-  #     level: 'warning',
-  #     extra: {
-  #       project_code: 'wikipedia',
-  #       language_code: 'en',
-  #       rev_id: 708326238,
-  #       status_code: 403,
-  #       content: {
-  #           'description' =>
-  #           "mwapi error: permissiondenied - You don't have permission to view deleted " \
-  #           'text or changes between deleted revisions.'
-  #       }
-  #     }
-  #   )
-  #   response = ref_counter_api.get_number_of_references_from_revision_ids deleted_rev_ids
-  #   expect(response.dig('708326238')).to eq({ 'num_ref' => nil })
-  # end
+  it 'logs the message if response is not 200 OK', vcr: true do
+    ref_counter_api = described_class.new(en_wikipedia)
+    expect(ref_counter_api).to receive(:log_error_batch).with([708326238])
+    response = ref_counter_api.get_number_of_references_from_revision_ids deleted_rev_ids
+    expect(response.dig('708326238')).to eq({ 'num_ref' => nil })
+  end
 
   it 'logs the error once if an unexpected error raises several times', vcr: true do
     reference_counter_api = described_class.new(es_wiktionary)


### PR DESCRIPTION
#5755

## What this PR does
This PR consolidates non-200 responses in ReferenceCounterApi

The changes I've made improve the Sentry logging efficiency by:

1. Tracking non-200 responses in a consolidated way instead of individual Sentry logs

2. Grouping similar response codes together with counters

3. Storing a limited number of examples (only 5 per status code) for debugging

4. Sending a single Sentry log for all non-200 responses in a batch

This approach significantly reduces the number of Sentry events created while still preserving the essential debugging information. Instead of creating a separate event for each non-200 response, it now aggregates them by status code and sends a single consolidated log

Also updated the `reference_counter_api_spec.rb` to match the changes.