### PR TITLE
[Data rearchitecture] Re-implement articles CSV report without revisions

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -356,6 +356,10 @@ class Course < ApplicationRecord
     revisions
   end
 
+  def scoped_article_timeslices
+    article_course_timeslices
+  end
+
   def scoped_article_titles(wiki)
     assigned_article_titles(wiki) + category_article_titles(wiki)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -356,6 +356,8 @@ class Course < ApplicationRecord
     revisions
   end
 
+  # The default implemention retrieves all the ACTs.
+  # A course type may override this implementation.
   def scoped_article_timeslices
     article_course_timeslices
   end

--- a/app/models/course_types/custom_revision_filter.rb
+++ b/app/models/course_types/custom_revision_filter.rb
@@ -18,6 +18,8 @@ module CustomRevisionFilter
     filtered_data
   end
 
+  # For only-scoped-articles courses, we want to retrieve only the ACTs related
+  # to scoped articles.
   def scoped_article_timeslices
     article_course_timeslices.where(article_id: scoped_article_ids)
   end

--- a/app/models/course_types/custom_revision_filter.rb
+++ b/app/models/course_types/custom_revision_filter.rb
@@ -17,4 +17,8 @@ module CustomRevisionFilter
     end
     filtered_data
   end
+
+  def scoped_article_timeslices
+    article_course_timeslices.where(article_id: scoped_article_ids)
+  end
 end

--- a/lib/analytics/course_articles_csv_builder.rb
+++ b/lib/analytics/course_articles_csv_builder.rb
@@ -29,22 +29,22 @@ class CourseArticlesCsvBuilder
   # rubocop:disable Metrics/AbcSize
   def set_articles_edited
     @articles_edited = {}
-    @course.scoped_article_timeslices.includes(article: :wiki).each do |edit|
-      next unless valid_timeslice(edit)
+    @course.scoped_article_timeslices.includes(article: :wiki).each do |act|
+      next unless valid_timeslice(act)
 
-      article_edits = @articles_edited[edit.article_id] || new_article_entry(edit)
-      article_edits[:characters] += edit.character_sum # if edit.character_sum.positive?
-      article_edits[:revisions] += edit.revision_count
-      article_edits[:references] += edit.references_count
-      article_edits[:new_article] = true if edit.new_article
-      article_edits[:usernames] += edit.user_ids
-      @articles_edited[edit.article_id] = article_edits
+      article_edits = @articles_edited[act.article_id] || new_article_entry(act)
+      article_edits[:characters] += act.character_sum
+      article_edits[:revisions] += act.revision_count
+      article_edits[:references] += act.references_count
+      article_edits[:new_article] = true if act.new_article
+      article_edits[:usernames] += act.user_ids
+      @articles_edited[act.article_id] = article_edits
     end
   end
   # rubocop:enable Metrics/AbcSize
 
-  def new_article_entry(edit)
-    article = edit.article
+  def new_article_entry(act)
+    article = act.article
     {
       new_article: false,
       characters: 0,
@@ -86,9 +86,7 @@ class CourseArticlesCsvBuilder
     row << article_data[:url]
     row << article_data[:revisions]
     row << article_data[:characters]
-    # row << character_sum(article_data)
     row << article_data[:references]
-    # row << references_sum(article_data)
     row << article_data[:new_article]
     row << article_data[:deleted]
     row << article_data[:pageview_url]
@@ -97,8 +95,8 @@ class CourseArticlesCsvBuilder
 
   # If the Article record is missing or the ACT is empty or it's untracked
   # then we don't want to take that ACT into account for the report.
-  def valid_timeslice(edit)
-    edit.article && edit.revision_count.positive? && edit.tracked
+  def valid_timeslice(act)
+    act.article && act.revision_count.positive? && act.tracked
   end
 
   def to_usernames(user_ids)

--- a/spec/controllers/campaigns_controller_spec.rb
+++ b/spec/controllers/campaigns_controller_spec.rb
@@ -387,7 +387,10 @@ describe CampaignsController, type: :request do
     let(:campaign) { create(:campaign) }
     let(:article) { create(:article) }
     let(:user) { create(:user) }
-    let!(:revision) { create(:revision, article:, user:, date: course.start + 1.hour) }
+    let!(:act) do
+      create(:article_course_timeslice, course:, article:, user_ids: [user.id], revision_count: 12,
+      start: course.start, end: course.start + 1.day)
+    end
     let!(:course_stats) do
       create(:course_stats, stats_hash: { 'www.wikidata.org' => {
                'claims created' => 12, 'other updates' => 1, 'unknown' => 1


### PR DESCRIPTION
## What this PR does
This PR re-implements `CourseArticlesCsvBuilder` based on article course timeslices instead of using raw revisions. Note that this new implementation is not compatible with historical courses that never ran a timeslice update, meaning that old courses will have empty CSV reports. We could have both versions coexisting and decide which one use based on the last course update, but I don't think that makes sense if the plan is to remove the revisions table at some point.

It deals with "Download articles data in CSV format" slow query mentioned in #6267 

The CSV report contains the same information as before, with one exception: the username field has been renamed to usernames, as an article may have been edited by multiple users and all of their usernames should be included. It seems that PR #4885, which introduced the original username field, has a bug — it overwrites the username value each time a new revision is processed for the same article. As a result, the report only displays the last username instead of aggregating all usernames into a list, which I guess it's a more desirable behavior.

The columns that were re-implemented are the ones depending on raw revisions:
- edit_count
- characters_added
- references_added
- new
- usernames

### Example:
 [Inclusive Physical Activity](https://dashboard.wikiedu.org/courses/Western_Colorado_University/Inclusive_Physical_Activity_(Spring_2025)/) course.

**Before**: locally generated after running `manual_update`: 
[Western_Colorado_University_Inclusive_Physical_Activity_Revisions_(April_2025)-articles-2025-04-22.csv](https://github.com/user-attachments/files/19860525/Western_Colorado_University_Inclusive_Physical_Activity_Revisions_.April_2025.-articles-2025-04-22.csv)

**After**: locally generated after running `manual_update_timeslice`: 
[Western_Colorado_University_Inclusive_Physical_Activity_Timeslices_(April_2025)-articles-2025-04-23.csv](https://github.com/user-attachments/files/19860541/Western_Colorado_University_Inclusive_Physical_Activity_Timeslices_.April_2025.-articles-2025-04-23.csv)

## Open questions and concerns
Note that timeslices for untracked articles courses are not included in the report. However, when an article is recently untracked, its existing timeslices won't be immediately untracked. As a result, the report may continue to include data for that article until the next course update, at which point all of its timeslices will be properly marked as untracked.

We may want to improve some ACT queries in the future.