### PR TITLE
[Data rearchitecture] Re-implement students CSV report without revisions

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -89,6 +89,11 @@ class ArticleCourseTimeslice < ApplicationRecord
     save
   end
 
+  def article_creator
+    return nil unless new_article
+    user_ids.first
+  end
+
   private
 
   # Returns an array containing all the user ids in the given revisions.

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -89,7 +89,7 @@ class ArticleCourseTimeslice < ApplicationRecord
     save
   end
 
-  # Returns the id of the user that created the article for and ACT record with
+  # Returns the id of the user that created the article for an ACT record with
   # new_article set to true that was populated after CREATOR_FIRST_DEPLOY_DATE.
   def article_creator
     return nil unless new_article && creator_first_ensured?

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -89,12 +89,22 @@ class ArticleCourseTimeslice < ApplicationRecord
     save
   end
 
+  # Returns the id of the user that created the article for and ACT record with
+  # new_article set to true that was populated after CREATOR_FIRST_DEPLOY_DATE.
   def article_creator
-    return nil unless new_article
+    return nil unless new_article && creator_first_ensured?
     user_ids.first
   end
 
   private
+
+  # From this day, article creator is guaranteed to be the first user id in
+  # the ACT user_ids field when new_article is true. See associated_user_ids.
+  CREATOR_FIRST_DEPLOY_DATE = Date.new(2025, 4, 20)
+
+  def creator_first_ensured?
+    updated_at && updated_at > CREATOR_FIRST_DEPLOY_DATE
+  end
 
   # Returns an array containing all the user ids in the given revisions.
   # If the first article revision is present, then the article creator is guaranteed

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -91,8 +91,14 @@ class ArticleCourseTimeslice < ApplicationRecord
 
   private
 
+  # Returns an array containing all the user ids in the given revisions.
+  # If the first article revision is present, then the article creator is guaranteed
+  # to be the first user_id in the array.
   def associated_user_ids(revisions)
     return [] if revisions.blank?
-    revisions.filter_map(&:user_id).uniq
+    user_ids = revisions.filter_map(&:user_id).uniq
+    # Force the article creator to be the first user_id if it exists
+    first_revision = revisions.find(&:new_article)
+    first_revision ? user_ids.unshift(first_revision.user_id).uniq : user_ids
   end
 end

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -72,6 +72,16 @@ class ArticlesCourses < ApplicationRecord # rubocop:disable Metrics/ClassLength
     article.revisions.where('date >= ?', course.start).where('date <= ?', course.end)
   end
 
+  # Returns the article creator if the article was created by a course user
+  # during the course period.
+  # Note that only ensures a non-nil result for timeslices populated after
+  # CREATOR_FIRST_DEPLOY_DATE
+  def article_creator
+    timeslice = article_course_timeslices.where(new_article: true).first
+    return nil if timeslice.nil?
+    timeslice.article_creator
+  end
+
   def update_cache
     revisions = live_manual_revisions.load
 

--- a/lib/analytics/course_students_csv_builder.rb
+++ b/lib/analytics/course_students_csv_builder.rb
@@ -78,7 +78,7 @@ class CourseStudentsCsvBuilder
     @course.new_articles_courses.pluck(:article_id).each do |article_id|
       timeslice = ArticleCourseTimeslice.find_by(course: @course, article_id:,
                                                  new_article: true)
-      @created_articles[timeslice.user_ids.first] += 1
+      @created_articles[timeslice.article_creator] += 1
     end
   end
 

--- a/lib/analytics/course_students_csv_builder.rb
+++ b/lib/analytics/course_students_csv_builder.rb
@@ -13,8 +13,7 @@ class CourseStudentsCsvBuilder
   end
 
   def generate_csv
-    # Only populate created articles if we can guarantee information about the article creator id
-    populate_created_articles if creator_first_ensured?
+    populate_created_articles
     populate_edited_articles
     populate_training_data
     csv_data = [CSV_HEADERS]
@@ -25,15 +24,6 @@ class CourseStudentsCsvBuilder
   end
 
   private
-
-  # From this day, article creator is guaranteed to be the first user id in the ACT user_ids
-  # field when new_article is true. See associated_user_ids ACT method.
-  CREATOR_FIRST_DEPLOY_DATE = Date.new(2025, 4, 20)
-
-  def creator_first_ensured?
-    first_updated_at = @course.article_course_timeslices.minimum(:updated_at)
-    first_updated_at && first_updated_at > CREATOR_FIRST_DEPLOY_DATE
-  end
 
   def populate_training_data
     courses_users.each do |courses_user|
@@ -72,13 +62,10 @@ class CourseStudentsCsvBuilder
   end
 
   def populate_created_articles
-    # A user has created an article during the course if
-    # the user id is the first id in the user_ids field in an ACT
-    # record with new_article: true
-    @course.new_articles_courses.pluck(:article_id).each do |article_id|
-      timeslice = ArticleCourseTimeslice.find_by(course: @course, article_id:,
-                                                 new_article: true)
-      @created_articles[timeslice.article_creator] += 1
+    @course.new_articles_courses.each do |article_course|
+      creator = article_course.article_creator
+      next if creator.nil?
+      @created_articles[creator] += 1
     end
   end
 

--- a/spec/lib/analytics/course_students_csv_builder_spec.rb
+++ b/spec/lib/analytics/course_students_csv_builder_spec.rb
@@ -18,12 +18,10 @@ describe CourseStudentsCsvBuilder do
     create(:articles_course, article:, course:, user_ids: [user1.id, user2.id],
            new_article: true, tracked: true)
   end
-  let!(:revision1) do
-    create(:revision, article:, user: user1, new_article: true,
-           date: course.start + 10.minutes)
-  end
-  let!(:revision2) do
-    create(:revision, article:, user: user2, date: course.start + 15.minutes)
+  let!(:act) do
+    create(:article_course_timeslice, course:, article:, user_ids: [user1.id, user2.id],
+          new_article: true, updated_at: Date.new(2025, 4, 24), start: course.start,
+          end: course.start + 1.day)
   end
   let(:subject) { described_class.new(course).generate_csv }
 

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -73,7 +73,7 @@ describe ArticleCourseTimeslice, type: :model do
            date: start + 12.hours,
            system: true) # revision made automatically
   end
-  let(:revisions) { [revision1, revision2, revision3, revision4, revision5] }
+  let(:revisions) { [revision2, revision1, revision3, revision4, revision5] }
   let(:article_course_timeslice) do
     create(:article_course_timeslice,
            article:,
@@ -115,6 +115,7 @@ describe ArticleCourseTimeslice, type: :model do
       article_course_timeslice_1 = described_class.find_by(course:, article:, start: start + 1.day)
       article_course_timeslice_2 = described_class.find_by(course:, article:, start: start + 2.days)
 
+      # creator id (25) is the first one in the array
       expect(article_course_timeslice_0.user_ids).to eq([25, 1])
       expect(article_course_timeslice_1.user_ids).to eq([1])
       expect(article_course_timeslice_2.user_ids).to eq([3, 7])


### PR DESCRIPTION
## What this PR does
This PR re-implements `CourseStudentsCsvBuilder` based on article course timeslices instead of using raw revisions. Note that this new implementation is not compatible with historical courses that never ran a timeslice update, meaning that old courses will have empty `total_articles_created` column for CSV reports. We could have both versions coexisting and decide which one use based on the last course update, but I don't think that makes sense if the plan is to remove the revisions table at some point.

It deals with "Download editors data in CSV format" slow query mentioned in https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6267

The CSV report contains the same information as before. The only column that was re-implemented is `total_articles_created` (the one depending on raw revisions). To calculate this column we used to retrieve all course revisions with `new` set to true to identify the article creator id, and use that to count the number of articles created by students. Without using revisions, we had two options: 1) delete `total_articles_created` column or 2) find a way to deduce the article creator for new articles. This PR implements option 2) using a small hack in `ArticleCourseTimeslices`: as ACT records have a `user_ids` array field with a list of all user ids that edited a given article in timeslice, we know that for ACT records with `new_article` true, the article creator id is one of the ids in `user_ids` field. This PR implements a small change in `associated_user_ids` method to guarantee that the article creator is always the first user id in the `user_ids` field. Note that this is done when we still have revisions in RAM. In addition, this PR adds a new ACT `article_creator` method that returns the first user id in `user_ids` when it corresponds to the article creator or nil otherwise (for example, if the timeslice is not for a new article). A new `ArticlesCourses#article_creator` method was also added to be able to retrieve article creator from a given article course. This way the logic of this hack is more encapsulated.

Note that already populated ACT records don't have this guarantee, so `article_creator` makes the best effort to return the user id of the article creator and returns `nil` if that's not possible. Because of that, some report rows may have `total_articles_created` incorrectly set to 0 because it wasn't possible to deduce the article creator in some cases.
Other thing to notice is that `ArticlesCourses#user_ids` method doesn't have the guarantee that the first user id in `user_ids` is the article creator (we could try to do that if we want).

### Example:

[Education and Social Change in the Black Diaspora](https://dashboard.wikiedu.org/courses/Rutgers_University-Newark/Education_and_Social_Change_in_the_Black_Diaspora_(Fall_2023)/home) course.

**Before**: locally generated after running `manual_update`: 
[Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Revisions_(April_2025)-editors-2025-04-24.csv](https://github.com/user-attachments/files/19898551/Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Revisions_.April_2025.-editors-2025-04-24.csv)

**After**: locally generated after running `manual_update_timeslice`:
[Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Timeslices_(April_2025)-editors-2025-04-24.csv](https://github.com/user-attachments/files/19898600/Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Timeslices_.April_2025.-editors-2025-04-24.csv)


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
