### PR TITLE
[WIP] [Data rearchitecture] Re-implement overview CSV report without revisions

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -356,6 +356,10 @@ class Course < ApplicationRecord
     revisions
   end
 
+  def scoped_article_timeslices
+    article_course_timeslices
+  end
+
   def scoped_article_titles(wiki)
     assigned_article_titles(wiki) + category_article_titles(wiki)
   end

--- a/app/models/course_types/custom_revision_filter.rb
+++ b/app/models/course_types/custom_revision_filter.rb
@@ -17,4 +17,8 @@ module CustomRevisionFilter
     end
     filtered_data
   end
+
+  def scoped_article_timeslices
+    article_course_timeslices.where(article_id: scoped_article_ids)
+  end
 end

--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -104,7 +104,11 @@ class CourseCsvBuilder
   end
 
   def revisions_by_namespace(namespace)
-    @course.tracked_revisions.joins(:article).where(articles: { namespace: }).count
+    @course.scoped_article_timeslices
+           .where(tracked: true)
+           .joins(:article)
+           .where(articles: { namespace: })
+           .sum(&:revision_count)
   end
 
   def training_completion_rate

--- a/lib/analytics/per_wiki_course_stats.rb
+++ b/lib/analytics/per_wiki_course_stats.rb
@@ -17,7 +17,11 @@ class PerWikiCourseStats
 
   def wiki_stats(wiki)
     {
-      "#{wiki.domain}_edits" => @course.tracked_revisions.where(wiki:).count,
+      "#{wiki.domain}_edits" => @course.scoped_article_timeslices
+                                       .where(tracked: true)
+                                       .joins(:article)
+                                       .where(articles: { wiki: })
+                                       .sum(&:revision_count),
       "#{wiki.domain}_articles_edited" => @course.articles.where(wiki:).count,
       "#{wiki.domain}_articles_created" => @course.new_articles_on(wiki).count
     }


### PR DESCRIPTION
## What this PR does
This PR updates `CourseCsvBuilder` based on article course timeslices instead of using raw revisions. Note that this new implementation is not compatible with historical courses that never ran a timeslice update, meaning that old courses will have empty `mainspace_edits`, `article_talk_edits`, `userspace_edits` and per wiki edits columns for CSV reports. We could have both versions coexisting and decide which one use based on the last course update, but I don't think that makes sense if the plan is to remove the revisions table at some point.

It deals with "Download overview data in CSV format" slow query mentioned in https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6267


## Open questions and concerns
Note that timeslices for untracked articles courses are not included in the report. However, when an article is recently untracked, its existing timeslices won't be immediately untracked. As a result, the report may continue to include data for that article until the next course update, at which point all of its timeslices will be properly marked as untracked.