### PR TITLE
[Data rearchitecture] Make students CSV report work without revisions

### DIFF
--- a/spec/lib/analytics/course_students_csv_builder_spec.rb
+++ b/spec/lib/analytics/course_students_csv_builder_spec.rb
@@ -18,12 +18,12 @@ describe CourseStudentsCsvBuilder do
     create(:articles_course, article:, course:, user_ids: [user1.id, user2.id],
            new_article: true, tracked: true)
   end
-  let!(:revision1) do
-    create(:revision, article:, user: user1, new_article: true,
-           date: course.start + 10.minutes)
+  let(:article2) do
+    create(:article, created_at: course.start + 15.minutes, namespace: 0, deleted: false)
   end
-  let!(:revision2) do
-    create(:revision, article:, user: user2, date: course.start + 15.minutes)
+  let!(:articles_course2) do
+    create(:articles_course, article: article2, course:, user_ids: [user2.id],
+           new_article: true, tracked: true)
   end
   let(:subject) { described_class.new(course).generate_csv }
 
@@ -33,9 +33,9 @@ describe CourseStudentsCsvBuilder do
     lines.shift # Remove headers
 
     expected_result = {
-      'user1' => { articles_created: '1', articles_updated: '1' },
-      'user2' => { articles_created: '0', articles_updated: '1' },
-      'user3' => { articles_created: '0', articles_updated: '0' }
+      'user1' => { articles_updated: '1' },
+      'user2' => { articles_updated: '2' },
+      'user3' => { articles_updated: '0' }
     }
 
     lines.each do |line|
@@ -44,10 +44,8 @@ describe CourseStudentsCsvBuilder do
       user_result = expected_result[username]
       # column 10 is 'registered_during_project', which should be true
       expect(columns[9]).to eq('true')
-      # column 11 is 'total_articles_created'
-      expect(columns[10]).to eq(user_result[:articles_created])
-      # column 12 is 'total_articles_edited'
-      expect(columns[11]).to eq(user_result[:articles_updated])
+      # column 11 is 'total_articles_edited'
+      expect(columns[10]).to eq(user_result[:articles_updated])
     end
   end
 end


### PR DESCRIPTION
## What this PR does
This PR updates `CourseStudentsCsvBuilder` to work without raw revisions. The only change is to remove `total_articles_created` row (no other column depends on raw revisions).

It deals with "Download editors data in CSV format" slow query mentioned in https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6267

### Example:

[Education and Social Change in the Black Diaspora](https://dashboard.wikiedu.org/courses/Rutgers_University-Newark/Education_and_Social_Change_in_the_Black_Diaspora_(Fall_2023)/home) course.

**Before**: locally generated after running `manual_update`: 
[Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Revisions_(April_2025)-editors-2025-04-24.csv](https://github.com/user-attachments/files/19898551/Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Revisions_.April_2025.-editors-2025-04-24.csv)

**After**: locally generated after running `manual_update_timeslice`:
[Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Timeslices_.April_2025.-editors-2025-04-24.csv](https://github.com/user-attachments/files/19948681/Rutgers_University-Newark_Education_and_Social_Change_in_the_Black_Diaspora_Timeslices_.April_2025.-editors-2025-04-24.csv)


## Open questions and concerns
Note: originally this was implemented using another approach (PR #6297) but then we decided to go with this.