### PR TITLE
[Data rearchitecture] Add warning when downloading stats for historical courses

### DIFF
--- a/app/assets/javascripts/components/overview/course_stats_download_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_stats_download_modal.jsx
@@ -35,10 +35,16 @@ const CourseStatsDownloadModal = ({ course }) => {
     );
   }
 
+  let warning;
+  if (!course.timeslice_update_ran) {
+    warning = <div className="warning">{I18n.t('courses.data_download_warning')}</div>;
+  }
+
   return (
     <div className="basic-modal course-stats-download-modal">
       <button onClick={hideStats} className="pull-right article-viewer-button icon-close" />
       <h2>{I18n.t('courses.data_download_info')}</h2>
+      {warning}
       <hr />
       <p>
         <a href={overviewCsvLink} className="button right">{I18n.t('courses.data_overview')}</a>

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -542,6 +542,14 @@ class Course < ApplicationRecord
     flags['update_logs'].present?
   end
 
+  # Determines if at least one timeslice update ran for the course based on the
+  # 'processed' field into update_logs flag.
+  def timeslice_update_ran?
+    update_logs = flags['update_logs']
+    return false unless update_logs
+    update_logs.values.any? { |f| f.key?('processed') }
+  end
+
   # Overridden for ClassroomProgramCourse
   def progress_tracker_enabled?
     false

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -14,6 +14,7 @@ json.course do
 
   json.wikis @course.wikis, :language, :project
   json.namespaces format_wiki_namespaces(@course.course_wiki_namespaces)
+  json.timeslice_update_ran @course.timeslice_update_ran?
   json.timeline_enabled @course.timeline_enabled?
   json.disable_student_emails @course.disable_student_emails?
   json.academic_system @course.academic_system

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -639,6 +639,10 @@ en:
       included.
     data_revisions_info: Revision data includes revision count of the course, revision id, article id, which pages are new and pageviews totals.
     data_download_info: Download data in CSV format.
+    data_download_warning: >
+      This course is not up to date within the new system yet. Stats may be incomplete.
+      Before downloading them, please schedule a data update for this course and wait for
+      it to finish. If this is an on-going course, please wait until the current update is complete.
     data_overview: Overview data
     data_overview_info: Overview data provides cumulative statistics for the whole project.
     data_edits: Edits data

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -425,6 +425,35 @@ describe Course, type: :model do
     end
   end
 
+  describe '#timeslice_update_ran?' do
+    let(:course) { build(:basic_course, flags:) }
+    let(:subject) { course.timeslice_update_ran? }
+
+    context 'when the update_logs flag does not exist' do
+      let(:flags) { {} }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when the update_logs flag exists but for old system' do
+      let(:flags) { { 'update_logs' => { '1' => { 'error_count' => 0 } } } }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when the update_logs flag exists for timeslices system' do
+      let(:flags) { { 'update_logs' => { '1' => { 'error_count' => 0, 'processed' => 10 } } } }
+
+      it 'returns true' do
+        expect(subject).to be true
+      end
+    end
+  end
+
   describe '#cloneable?' do
     let(:subject) { course.cloneable? }
 


### PR DESCRIPTION
## What this PR does
This PR adds a warning message to the `CourseStatsDownloadModal` to alert users that want to download CSV reports that never ran a timeslice update.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/957d9205-0c05-49e2-8113-3d8736857446)

After:
![image](https://github.com/user-attachments/assets/2fc26760-018b-4ae2-9e2d-5aa6e6662480)


## Open questions and concerns
TODO: revisit `was_course_ever_updated?` method definition. I created this method to identify if the one running is the first course update. However, now I note that it returned `true` for every historical course, because they did have `update_logs` flag for the old system. That makes me think that `was_course_ever_updated?` uses weren't really necessary in `PrepareTimeslices` and `UpdateTimeslicesCourseUser`, but I'll improve this in a separate PR.