### PR TITLE
Fix: macOS setup script

### DIFF
--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -106,6 +106,7 @@ else
 fi
 
 printf '[*] Installing Gems... \n'
+output_line "bundle config build.nio4r --with-cflags='-Wno-incompatible-pointer-types'"
 output_line "bundle install" && print_success "${CLEAR_LINE}[+] Gems installed\n"
 
 printf '[*] Checking for application configurations... \n'

--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+unset SDKROOT
+
 . "$(dirname "$0")/color-helpers.sh"
 
 clear

--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# unset SDKROOT set by xcode tools to resolve bug in ruby 3.1.2
+# https://github.com/rbenv/ruby-build/discussions/2123
 unset SDKROOT
 
 . "$(dirname "$0")/color-helpers.sh"


### PR DESCRIPTION
This is a small change to bring the macOS setup script up to date: https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/5296

On a fresh installation of macOS I am now able to get a working dashboard using the setup script on this branch!

## What this PR does
- Add compatibility flag to bundler in macOS setup script
    - This adds a compatibility flag to resolve errors like the following
        - ```sh
            compiling selector.c selector.c:301:26: error: incompatible function pointer types passing 'VALUE (*)(VALUE *)' (aka 'unsigned long (*)(unsigned long *)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-function-pointer-types]```
        - Source: https://stackoverflow.com/questions/78313570/unable-to-bundle-install-nio4r-on-a-new-mac-m3


- Unset environment variable `SDKROOT`, which is set by apples xcode tools when the setup script is invoked from python3. This is a bug that exists in our current version of Ruby. Ruby version 3.2.1 is the first version released with a fix for this bug, but this work around suffices for now!
    - sources:
        - https://github.com/rbenv/ruby-build/discussions/2123
        - https://bugs.ruby-lang.org/issues/19403
        - https://stackoverflow.com/questions/46377667/docker-for-mac-mkmf-rb-cant-find-header-files-for-ruby 
