### PR TITLE
[Data rearchitecture] Update MonthlyReport and CourseStatistics classes to work without revisions table

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -28,8 +28,6 @@ class AnalyticsController < ApplicationController
   def results
     if params[:monthly_report]
       monthly_report
-    elsif params[:campaign_stats]
-      campaign_stats
     elsif params[:campaign_intersection]
       campaign_intersection
     end
@@ -107,16 +105,6 @@ class AnalyticsController < ApplicationController
 
   def monthly_report
     @monthly_report = MonthlyReport.run
-  end
-
-  def campaign_stats
-    @campaign_stats = {}
-    @articles_edited = {}
-    Campaign.all.each do |campaign|
-      course_ids = campaign.courses.pluck(:id)
-      stats = CourseStatistics.new(course_ids, campaign: campaign.slug)
-      @campaign_stats.merge! stats.report_statistics
-    end
   end
 
   def campaign_intersection

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -334,7 +334,12 @@ class Course < ApplicationRecord
   end
 
   def tracked_article_course_timeslices
-    article_course_timeslices.where(tracked: true)
+    # This method tries to replicate the idea of "tracked revisions"
+    # 'revision_count > 0' condition is because we may create empty timeslices
+    # due to system revisions
+    # 'tracked: true' condition is to avoid timeslices for untracked articles courses
+    article_course_timeslices.where('revision_count > 0')
+                             .where(tracked: true)
   end
 
   def tracked_namespaces

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -333,6 +333,10 @@ class Course < ApplicationRecord
              .where(wiki_id: wiki_ids)
   end
 
+  def tracked_article_course_timeslices
+    article_course_timeslices.where(tracked: true)
+  end
+
   def tracked_namespaces
     courses_wikis.map do |course_wiki|
       wiki = course_wiki.wiki

--- a/lib/analytics/course_statistics.rb
+++ b/lib/analytics/course_statistics.rb
@@ -11,7 +11,6 @@ class CourseStatistics
   def initialize(course_ids, opts = {})
     @course_ids = course_ids
     @opts = opts
-    # find_contribution_ids
     find_course_counts
     find_upload_ids
     find_upload_usage

--- a/lib/analytics/course_statistics.rb
+++ b/lib/analytics/course_statistics.rb
@@ -93,7 +93,6 @@ class CourseStatistics
     new_article_ids = []
     @courses.each do |course|
       new_article_ids += course.tracked_article_course_timeslices
-                               .where('revision_count > 0')
                                .where(new_article: true)
                                .pluck(:article_id)
                                .uniq
@@ -108,7 +107,6 @@ class CourseStatistics
     @all_article_ids = []
     @courses.each do |course|
       @all_article_ids += course.tracked_article_course_timeslices
-                                .where('revision_count > 0')
                                 .pluck(:article_id)
                                 .uniq
     end

--- a/lib/analytics/monthly_report.rb
+++ b/lib/analytics/monthly_report.rb
@@ -66,7 +66,7 @@ class MonthlyReport
   def act_ids_for(courses)
     act_ids = []
     courses.each do |course|
-      act_ids += course.article_course_timeslices.pluck(:id)
+      act_ids += course.tracked_article_course_timeslices.pluck(:id)
     end
     act_ids
   end

--- a/lib/analytics/monthly_report.rb
+++ b/lib/analytics/monthly_report.rb
@@ -50,8 +50,8 @@ class MonthlyReport
   end
 
   def monthly_articles_edited_for(courses, month, year)
-    revisions = revisions_during_month(courses, month, year)
-    article_count(revisions)
+    timeslices = article_course_timeslices_during_month(courses, month, year)
+    article_count(timeslices)
   end
 
   def monthly_uploads_for(courses, month, year)
@@ -63,24 +63,24 @@ class MonthlyReport
     uploads.count
   end
 
-  def revision_ids_for(courses)
-    revision_ids = []
+  def act_ids_for(courses)
+    act_ids = []
     courses.each do |course|
-      revision_ids += course.tracked_revisions.pluck(:id)
+      act_ids += course.article_course_timeslices.pluck(:id)
     end
-    revision_ids.uniq
+    act_ids
   end
 
-  def revisions_during_month(courses, month, year)
-    all_course_revision_ids = revision_ids_for(courses)
-    Revision
-      .where(id: all_course_revision_ids)
-      .where('extract(month from date) = ?', month)
-      .where('extract(year from date) = ?', year)
+  def article_course_timeslices_during_month(courses, month, year)
+    all_act_ids = act_ids_for(courses)
+    ArticleCourseTimeslice
+      .where(id: all_act_ids)
+      .where('extract(month from start) = ?', month)
+      .where('extract(year from start) = ?', year)
   end
 
-  def article_count(revisions)
-    article_ids = revisions.pluck(:article_id)
+  def article_count(timeslices)
+    article_ids = timeslices.pluck(:article_id)
     articles = Article.where(id: article_ids, namespace: 0, deleted: false)
     articles.distinct.count
   end

--- a/lib/analytics/monthly_report.rb
+++ b/lib/analytics/monthly_report.rb
@@ -75,7 +75,6 @@ class MonthlyReport
     all_act_ids = act_ids_for(courses)
     ArticleCourseTimeslice
       .where(id: all_act_ids)
-      .where('revision_count > 0') # we may create empty timeslices due to system revisions
       .where('extract(month from start) = ?', month)
       .where('extract(year from start) = ?', year)
   end

--- a/lib/analytics/monthly_report.rb
+++ b/lib/analytics/monthly_report.rb
@@ -75,6 +75,7 @@ class MonthlyReport
     all_act_ids = act_ids_for(courses)
     ArticleCourseTimeslice
       .where(id: all_act_ids)
+      .where('revision_count > 0') # we may create empty timeslices due to system revisions
       .where('extract(month from start) = ?', month)
       .where('extract(year from start) = ?', year)
   end

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -26,11 +26,6 @@ describe AnalyticsController, type: :request do
       expect(response.status).to eq(200)
     end
 
-    it 'returns campaign statistics' do
-      post '/analytics', params: { campaign_stats: true }
-      expect(response.status).to eq(200)
-    end
-
     it 'return campaign intersection statistics' do
       post '/analytics', params: { campaign_intersection: true,
                                 campaign_1: { id: 1 },

--- a/spec/lib/analytics/course_statistics_spec.rb
+++ b/spec/lib/analytics/course_statistics_spec.rb
@@ -72,7 +72,8 @@ describe CourseStatistics do
 
     it 'counts only tracked articles' do
       ArticleCourseTimeslice.find_by(course_id: 1, article_id: 1).update(tracked: false)
-      expect(subject[:articles_edited]).to eq(course_ids.count - 1)
+      ArticleCourseTimeslice.find_by(course_id: 2, article_id: 2).update(revision_count: 0)
+      expect(subject[:articles_edited]).to eq(course_ids.count - 2)
     end
 
     it 'counts only articles in namespace' do

--- a/spec/lib/analytics/monthly_report_spec.rb
+++ b/spec/lib/analytics/monthly_report_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/monthly_report"
+
+describe MonthlyReport do
+  let(:course_ids) { [1, 2, 3, 10001, 10002, 10003] }
+
+  before do
+    travel_to Date.new(2025, 5, 6)
+
+    course_ids.each do |i|
+      # Course
+      id = i
+      id2 = id + 100
+      create(:course, id:, start: 2.years.ago, end: Time.zone.today, slug: "foo/#{id}")
+      create(:user, id:, username: "user#{id}")
+      create(:courses_user, id:, user_id: id, course_id: id, role: 0)
+      # Create two articles
+      create(:article, id:, title: "Article_#{id}", namespace: Article::Namespaces::MAINSPACE)
+      # Create timeslices
+      create(:article_course_timeslice, course_id: id, article_id: id,
+      start: 1.month.ago, end: 1.month.ago + 1.day)
+      create(:article_course_timeslice, course_id: id, article_id: id,
+      start: 1.month.ago + 1.day, end: 1.month.ago + 2.days)
+      create(:article_course_timeslice, course_id: id, article_id: id,
+      start: 2.months.ago, end: 2.months.ago + 1.day)
+      # Create uploads
+      create(:commons_upload, id:, user_id: id, uploaded_at: 1.month.ago, usage_count: 1)
+
+      # only create old revision for some courses
+      next unless id2.odd?
+      create(:user, id: id2, username: "second_user#{id}")
+      create(:courses_user, id: id2, user_id: id2, course_id: id, role: 0)
+      # Create article
+      create(:article, id: id2, title: "Article_#{id2}")
+      # Create timeslice
+      create(:article_course_timeslice, course_id: id, article_id: id2,
+      start: 13.months.ago, end: 13.months.ago + 1.day)
+      # Create uploads
+      create(:commons_upload, user_id: id2, uploaded_at: 13.months.ago, usage_count: 1)
+      create(:commons_upload, user_id: id2, uploaded_at: 13.months.ago, usage_count: 1)
+    end
+  end
+
+  after do
+    travel_back
+  end
+
+  describe '.run' do
+    let(:subject) { described_class.run }
+
+    it 'counts articles and uploads' do
+      expect(subject[:'2025-4']).to(eq({ articles_edited: 6, uploads: 6 }))
+      expect(subject[:'2024-4']).to(eq({ articles_edited: 4, uploads: 8 }))
+    end
+  end
+end

--- a/spec/lib/analytics/monthly_report_spec.rb
+++ b/spec/lib/analytics/monthly_report_spec.rb
@@ -19,11 +19,11 @@ describe MonthlyReport do
       # Create two articles
       create(:article, id:, title: "Article_#{id}", namespace: Article::Namespaces::MAINSPACE)
       # Create timeslices
-      create(:article_course_timeslice, course_id: id, article_id: id,
+      create(:article_course_timeslice, course_id: id, article_id: id, revision_count:,
       start: 1.month.ago, end: 1.month.ago + 1.day)
-      create(:article_course_timeslice, course_id: id, article_id: id,
+      create(:article_course_timeslice, course_id: id, article_id: id, revision_count:,
       start: 1.month.ago + 1.day, end: 1.month.ago + 2.days)
-      create(:article_course_timeslice, course_id: id, article_id: id,
+      create(:article_course_timeslice, course_id: id, article_id: id, revision_count:,
       start: 2.months.ago, end: 2.months.ago + 1.day)
       # Create uploads
       create(:commons_upload, id:, user_id: id, uploaded_at: 1.month.ago, usage_count: 1)
@@ -35,7 +35,7 @@ describe MonthlyReport do
       # Create article
       create(:article, id: id2, title: "Article_#{id2}")
       # Create timeslice
-      create(:article_course_timeslice, course_id: id, article_id: id2,
+      create(:article_course_timeslice, course_id: id, article_id: id2, revision_count:,
       start: 13.months.ago, end: 13.months.ago + 1.day)
       # Create uploads
       create(:commons_upload, user_id: id2, uploaded_at: 13.months.ago, usage_count: 1)
@@ -48,11 +48,24 @@ describe MonthlyReport do
   end
 
   describe '.run' do
-    let(:subject) { described_class.run }
+    context 'when timeslices have revisions' do
+      let(:revision_count) { 15 }
+      let(:subject) { described_class.run }
 
-    it 'counts articles and uploads' do
-      expect(subject[:'2025-4']).to(eq({ articles_edited: 6, uploads: 6 }))
-      expect(subject[:'2024-4']).to(eq({ articles_edited: 4, uploads: 8 }))
+      it 'counts articles and uploads' do
+        expect(subject[:'2025-4']).to(eq({ articles_edited: 6, uploads: 6 }))
+        expect(subject[:'2024-4']).to(eq({ articles_edited: 4, uploads: 8 }))
+      end
+    end
+
+    context 'when timeslices are empty' do
+      let(:revision_count) { 0 }
+      let(:subject) { described_class.run }
+
+      it 'only counts uploads' do
+        expect(subject[:'2025-4']).to(eq({ articles_edited: 0, uploads: 6 }))
+        expect(subject[:'2024-4']).to(eq({ articles_edited: 0, uploads: 8 }))
+      end
     end
   end
 end

--- a/spec/lib/analytics/monthly_report_spec.rb
+++ b/spec/lib/analytics/monthly_report_spec.rb
@@ -56,6 +56,18 @@ describe MonthlyReport do
         expect(subject[:'2025-4']).to(eq({ articles_edited: 6, uploads: 6 }))
         expect(subject[:'2024-4']).to(eq({ articles_edited: 4, uploads: 8 }))
       end
+
+      it 'counts only articles in namespace' do
+        Article.find(1).update(namespace: Article::Namespaces::WIKIJUNIOR)
+        expect(subject[:'2025-4']).to(eq({ articles_edited: 5, uploads: 6 }))
+        expect(subject[:'2024-4']).to(eq({ articles_edited: 4, uploads: 8 }))
+      end
+
+      it 'counts only tracked articles' do
+        ArticleCourseTimeslice.where(course_id: 1, article_id: 1).update_all(tracked: false) # rubocop:disable Rails/SkipsModelValidations
+        expect(subject[:'2025-4']).to(eq({ articles_edited: 5, uploads: 6 }))
+        expect(subject[:'2024-4']).to(eq({ articles_edited: 4, uploads: 8 }))
+      end
     end
 
     context 'when timeslices are empty' do


### PR DESCRIPTION
## What this PR does
This PR updates (hopefully) the last two classes that still depended on revisions table:
- `MonthlyReport` 
- `CourseStatistics`

Both clases are used through the analytics controller.

Closes #6311

## Screenshots MonthlyReport
### After
I don't put a "before" image because the numbers are pretty different given all the local courses I have on my computer (and I don't want to wipe my db).

![image](https://github.com/user-attachments/assets/0581c4b9-44f3-4571-ad25-1c5acb64a579)

## Screenshots CourseStatistics
Note that `revisions after = (revisions before) * 2`. This is because without having `mw_page_id` we have no way to determine if we're counting the same revisions for different courses. This behavior is the same as we see in `references_added` . While we see 28 `references_added`, there were only 14 references added in the campaign (but two courses have the same exact new references). The duplication of references added is a preexisting problem since they were calculated based on `courses_users` and not based on revisions (see commit 4f5444a). Same thing happens for characters added/words added.

### After
![image](https://github.com/user-attachments/assets/f2adc712-31c3-4d54-8453-aeea99f53394)

### Before
![image](https://github.com/user-attachments/assets/47421496-26d2-4fda-aa1a-9513d3ac64d8)

## Open questions and concerns
Note that while `MonthlyReport.run` class method has `opts={}` parameter, we never used it?

There is room for improvement in the `MonthlyReport` specs, however, since there were no previous specs to adapt, I simply created some basic tests.

There is also room for improvement in the `CourseStatistics` specs, making notorious the unexpected behaviors in terms of duplicated metrics mentioned in this PR.

This PR adds a new Course method called `tracked_article_course_timeslices`. I did not do an exhaustive search in the code for places where it might be possible to use this method instead of calculating it manually.

This PR deletes dead code in `AnalyticsController`.