### PR TITLE
Update specs that still use `update_cache` instead of `update_cache_from_timeslices`

### DIFF
--- a/spec/features/course_stats_spec.rb
+++ b/spec/features/course_stats_spec.rb
@@ -4,57 +4,56 @@ require 'rails_helper'
 require "#{Rails.root}/lib/course_training_progress_manager"
 
 describe 'course stats', type: :feature, js: true do
-  let(:trained)    { 1 }
-  let(:course)     do
+  include ActionView::Helpers::NumberHelper
+  let(:wiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
+  let(:trained) { 1 }
+  let(:course) do
     create(:course, trained_count: trained,
                     start: CourseTrainingProgressManager::TRAINING_BOOLEAN_CUTOFF_DATE + 1.day,
                     end: 1.year.from_now.to_date)
   end
-  let(:views)      { 10 }
+  let(:first_revision) { course.start + 1.day }
+  # There is no easy way to mock UTC_TIMESTAMP() so this spec depends on the day it runs.
+  let(:days_since_first_revision) { (Time.zone.today - first_revision.to_date).floor }
+  let(:average_views) { 10 }
   let(:chars)      { 10 }
   let(:student)    { 0 }
-  let(:refs_tags_key) { 'feature.wikitext.revision.ref_tags' }
-  let(:article)    { create(:article, namespace: 0) }
+  let(:article)    { create(:article, namespace: 0, average_views:) }
   let!(:ac)        do
     create(:articles_course, course_id: course.id, article_id: article.id,
-                             new_article: true, view_count: views)
+                             new_article: true, first_revision:)
   end
-  let(:revision) do
-    create(:revision, article_id: article.id, characters: chars,
-                      features: {
-                        refs_tags_key => 22
-                      },
-                      features_previous: {
-                        refs_tags_key => 17
-                      }, date: course.start + 1.day, user_id: user.id)
+  let(:cwt1) do
+    create(:course_wiki_timeslice, course:, wiki:, character_sum: chars, references_count: 5,
+           revision_count: 1, start: course.start + 1.day, end: course.start + 2.days)
   end
-  let(:revision2) do
-    create(:revision, article_id: article.id, new_article: true,
-                      characters: chars, date: course.start + 1.day, user_id: user.id)
+  let(:cwt2) do
+    create(:course_wiki_timeslice, course:, wiki:, character_sum: chars, revision_count: 1,
+           start: course.start + 2.days, end: course.start + 3.days)
   end
   let(:user)       { create(:user) }
   let!(:cu)        { create(:courses_user, course_id: course.id, user_id: user.id, role: student) }
 
-  let!(:revisions) { [revision, revision2] }
+  let!(:cwts) { [cwt1, cwt2] }
   let(:articles)   { [article] }
   let(:users)      { [user] }
 
   it 'displays statistics about the course' do
-    cu.update_cache
-    course.update_cache
+    course.update_cache_from_timeslices
     visit "/courses/#{course.slug}"
     sleep 1
 
     expect(page.find('#articles-created')).to have_content articles.count
-    expect(page.find('#total-edits')).to have_content revisions.count
+    expect(page.find('#total-edits')).to have_content cwts.count
     expect(page.find('#articles-edited')).to have_content articles.count
     expect(page.find('#student-editors')).to have_content users.count
     find('#student-editors').click
     expect(page.find('#trained-info')).to have_content trained
-    word_count = WordCount.from_characters(chars * revisions.count)
-    references_count = revisions.sum(&:references_added)
+    word_count = WordCount.from_characters(chars * cwts.count)
+    references_count = cwts.sum(&:references_count)
     expect(page.find('#word-count')).to have_content word_count
     expect(page.find('#references-count')).to have_content references_count
-    expect(page.find('#view-count')).to have_content views.to_s
+    expect(page.find('#view-count'))
+      .to have_content number_to_human(days_since_first_revision * average_views)
   end
 end

--- a/spec/features/explore_page_spec.rb
+++ b/spec/features/explore_page_spec.rb
@@ -174,35 +174,20 @@ describe 'the explore page', type: :feature, js: true do
   end
 
   describe 'rows' do
-    let(:refs_tags_key) { 'feature.wikitext.revision.ref_tags' }
+    let(:wiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
 
     it 'shows the stats accurately' do
-      create(:article, id: 1,
-                       title: 'Selfie',
-                       namespace: 0)
-      create(:articles_course,
-             course:,
-             article_id: 1)
-      create(:revision,
-             user:,
-             article_id: 1,
-             date: 6.days.ago,
-             characters: 9000,
-             features: {
-               refs_tags_key => 22
-             },
-             features_previous: {
-               refs_tags_key => 17
-             })
-      Course.update_all_caches
+      create(:course_wiki_timeslice, course:, wiki:, references_count: 3,
+             start: 6.days.ago, end: 5.days.ago)
+      Course.all.each(&:update_cache_from_timeslices)
       visit '/explore'
       # Number of courses
       num_courses_human = page.find('#campaigns_list tr:first-child .num-courses-human').text
       expect(num_courses_human).to eq('1')
 
-      # Recent revisions
-      num_revisions = page.find('#active_courses .table tbody tr:first-child .revisions').text
-      expect(num_revisions).to eq('1')
+      # References added
+      num_references = page.find('#active_courses .table tbody tr:first-child .references').text
+      expect(num_references).to eq('3')
     end
   end
 

--- a/spec/lib/alerts/course_alert_manager_spec.rb
+++ b/spec/lib/alerts/course_alert_manager_spec.rb
@@ -115,6 +115,8 @@ describe CourseAlertManager do
     let(:course_start) { 2.months.ago }
 
     context 'when a course has no students' do
+      let(:user_count) { 0 }
+
       it 'does not create an alert' do
         expect(course.students.count).to eq(0)
         subject.create_untrained_students_alerts
@@ -125,11 +127,10 @@ describe CourseAlertManager do
     context 'when a course has no training modules' do
       before do
         enroll_student
-        course.update_cache
       end
 
       it 'does not create an alert' do
-        expect(course.user_count).to eq(1)
+        expect(course.students.count).to eq(1)
         subject.create_untrained_students_alerts
         expect(Alert.count).to eq(0)
       end
@@ -140,15 +141,12 @@ describe CourseAlertManager do
         week = Week.new
         week.blocks << Block.new(training_module_ids: [1, 2, 3])
         course.weeks << week
-        create(:courses_user,
-               course:,
-               user:,
-               role: CoursesUsers::Roles::STUDENT_ROLE)
+        enroll_student
         create(:campaigns_course, course:, campaign: Campaign.first)
-        course.update_cache
       end
 
       it 'creates an alert' do
+        expect(course.students.count).to eq(1)
         expect_any_instance_of(UntrainedStudentsAlertMailer)
           .to receive(:email).and_return(mock_mailer)
         subject.create_untrained_students_alerts

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -71,7 +71,6 @@ describe ArticleScopedProgram, type: :model do
 
     let(:asp) do
       create(:article_scoped_program,
-             id: 10001,
              start: 2.days.ago,
              end: Time.zone.today + 2.days)
     end

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -50,36 +50,73 @@
 #
 
 require 'rails_helper'
+require "#{Rails.root}/lib/replica"
 
 describe VisitingScholarship, type: :model do
   describe 'update caches' do
     before do
-      vs = create(:visiting_scholarship,
-                  id: 10001,
-                  start: 1.year.ago,
-                  end: Time.zone.today + 1.year)
-      scholar = create(:user)
       create(:courses_user,
              user_id: scholar.id,
              course_id: vs.id,
              role: CoursesUsers::Roles::STUDENT_ROLE)
-      random_article = create(:article, title: 'Random', id: 1, namespace: 0)
-      assigned_article = create(:article, title: 'Assigned', id: 2, namespace: 0)
       create(:assignment, user_id: scholar.id, course_id: vs.id,
                           article_id: 2, article_title: 'Assigned')
-      create(:revision, id: 1, user_id: scholar.id,
-                        article_id: random_article.id, date: 1.day.ago)
-      create(:revision, id: 2, user_id: scholar.id,
-                        article_id: assigned_article.id, date: 1.day.ago)
-      ArticlesCourses.update_from_course(vs)
-      ArticlesCourses.update_all_caches(vs.articles_courses)
-      CoursesUsers.update_all_caches(CoursesUsers.ready_for_update)
-      Course.update_all_caches
+
+      allow(Replica).to receive(:new).and_return(replica_instance)
+      allow(replica_instance).to receive(:get_revisions).and_return(revisions)
+      VCR.use_cassette 'course_update' do
+        UpdateCourseStatsTimeslice.new(vs)
+      end
     end
 
-    let(:out_of_scope_rev) { Revision.find(1) }
-    let(:in_scope_rev) { Revision.find(2) }
-    let(:vs) { Course.find(10001) }
+    let(:vs) do
+      create(:visiting_scholarship,
+             start: 2.days.ago,
+             end: Time.zone.today + 2.days)
+    end
+    let(:scholar) { create(:user) }
+    let(:random_article) { create(:article, title: 'Random', namespace: 0) }
+    let(:assigned_article) { create(:article, title: 'Assigned', namespace: 0) }
+    let(:replica_instance) { instance_double(Replica) }
+    let(:chars) { 1234 }
+    let(:revisions) do
+      [
+        [
+          random_article.mw_page_id.to_s,
+          {
+            'article' => {
+              'mw_page_id' => random_article.mw_page_id.to_s,
+              'title' => random_article.title,
+              'namespace' => '0',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '849116430', 'date' => 1.day.ago.strftime('%Y%m%d'),
+                'characters' => '569', 'mw_page_id' => random_article.mw_page_id.to_s,
+                'username' => scholar.username, 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ],
+        [
+          assigned_article.mw_page_id.to_s,
+          {
+            'article' => {
+              'mw_page_id' => assigned_article.mw_page_id.to_s,
+              'title' => assigned_article.title,
+              'namespace' => '0',
+              'wiki_id' => 1
+            },
+            'revisions' => [
+              { 'mw_rev_id' => '849116431', 'date' => 1.day.ago.strftime('%Y%m%d'),
+                'characters' => chars, 'mw_page_id' => assigned_article.mw_page_id.to_s,
+                'username' => scholar.username, 'new_article' => 'false',
+                'system' => 'false', 'wiki_id' => 1 }
+            ]
+          }
+        ]
+      ]
+    end
 
     it 'onlies count assigned articles' do
       expect(vs.article_count).to eq(1)
@@ -94,7 +131,7 @@ describe VisitingScholarship, type: :model do
     end
 
     it 'onlies count characters for assigned articles' do
-      expect(vs.character_sum).to eq(in_scope_rev.characters)
+      expect(vs.character_sum).to eq(chars)
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR is part of the cleaning up process. It updates the following specs:

- `spec/features/course_stats_spec.rb`. The approach is to replace the creation of revisions in the db with the creation of the related course wiki timeslices.
- `spec/features/campaign_overview_spec.rb` (it uses `Course.update_all_caches`)
- `spec/features/explore_page_spec.rb`
- `spec/models/article_scoped_program_spec.rb`
- `spec/models/visiting_scholarship_spec.rb`
- `spec/lib/alerts/course_alert_manager_spec.rb`

Closes #6312 
