### PR TITLE
Disable ores plot feature temporarily

### DIFF
--- a/app/assets/javascripts/components/common/campaign_navbar.jsx
+++ b/app/assets/javascripts/components/common/campaign_navbar.jsx
@@ -46,9 +46,10 @@ const CampaignNavbar = ({ campaign }) => {
                 <a href={`/campaigns/${campaign.slug}/users`}>{CourseUtils.i18n('students', campaign.course_string_prefix)}</a>
               </p>
             </div>
-            <div className="nav__item">
+            {/* Disabling ores plot feature for every campaign until re-implementing. See issue #6327 */}
+            {/* <div className="nav__item">
               <p><NavLink to={`/campaigns/${campaign.slug}/ores_plot`}>{I18n.t('courses.ores_plot')}</NavLink></p>
-            </div>
+            </div> */}
             <div className="nav__item">
               <p><NavLink to={`/campaigns/${campaign.slug}/alerts`}>{I18n.t('courses.alerts')}</NavLink></p>
             </div>

--- a/app/assets/javascripts/utils/article_finder_language_mappings.js
+++ b/app/assets/javascripts/utils/article_finder_language_mappings.js
@@ -286,8 +286,11 @@ export const LiftwingWeights = {
 
 // Update the server side mapping in sync.
 export const ORESSupportedWiki = {
-  projects: ['wikipedia', 'wikidata'],
-  languages: ['en', 'gl', 'fr', 'simple', 'tr', 'ru', 'eu', 'fa', 'sv']
+  // Disabling ores plot feature for every project/language until re-implementing. See issue #6327
+  // projects: ['wikipedia', 'wikidata'],
+  // languages: ['en', 'gl', 'fr', 'simple', 'tr', 'ru', 'eu', 'fa', 'sv']
+  projects: [],
+  languages: []
 };
 
 // Refer: https://xtools.wmflabs.org/api/project/assessments

--- a/spec/features/ores_plots_spec.rb
+++ b/spec/features/ores_plots_spec.rb
@@ -13,10 +13,12 @@ describe 'ORES plots', type: :feature do
     end
 
     it 'rerenders via the refresh link', js: true do
+      pending 'This fails because ores plot feature was disabled from frontend. See issue #6327'
       visit "/courses/#{escaped_slug course.slug}/articles/edited"
       click_button 'Change in Structural Completeness'
       click_link 'Refresh Cached Data'
       expect(page).to have_text('This graph visualizes')
+      pass_pending_spec
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR disables ores plot feature for every campaign and course language/project until re-implementing the feature for the new system. Read issue #6327

## Screenshots
Before:
**Ores plot for campaigns**
![campaign_before](https://github.com/user-attachments/assets/f9d8cb5e-45d7-4573-b7df-1170517ab1fd)

**Ores plot for courses**
![course_before](https://github.com/user-attachments/assets/5cc88b0d-097c-45e1-b695-1205dd86926d)

After:
**Ores plot for campaigns**
![campaign_after](https://github.com/user-attachments/assets/a4a657f7-c04a-411d-a690-aeae497d2d99)

**Ores plot for courses**
![course_after](https://github.com/user-attachments/assets/170b40cf-161e-49a7-ab21-cfc8cf8fb3e4)
