### PR TITLE
[Data-rearchitecture] Ensure new timeslice is added if course end date is updated to tomorrow

### DIFF
--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -64,7 +64,7 @@ class UpdateTimeslicesCourseDate
     # Each wiki may use a different timeslice duration, so this has to be done per wiki
     @course.wikis.each do |wiki|
       max_course_end = CourseWikiTimeslice.for_course_and_wiki(@course, wiki).maximum(:end)
-      add_wiki_timeslices_up_to_new_end_date(wiki) unless max_course_end >= @course.end
+      add_wiki_timeslices_up_to_new_end_date(wiki) unless max_course_end > @course.end
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR fixes a bug in the logic for adding new timeslices when course dates change. In particular, the problem was found for course 31579:

```
+-------+----------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+
| id    | slug                                                                       | start               | end                 | created_at          | updated_at          |
+-------+----------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+
| 31579 | Universidade_Federal_de_Mato_Grosso/Editatona_Mulheres_na_Ditadura_Militar | 2025-05-02 04:00:00 | 2025-05-13 04:00:00 | 2025-04-09 19:04:41 | 2025-05-13 22:01:22 |
+-------+----------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+
```

```
MariaDB [dashboard]> SELECT * FROM course_wiki_timeslices WHERE course_id = 31579;
+---------+-----------+---------+----------------------------+----------------------------+---------------+------------------+----------------+-------+----------------------------+--------------+----------------------------+----------------------------+
| id      | course_id | wiki_id | start                      | end                        | character_sum | references_count | revision_count | stats | last_mw_rev_datetime       | needs_update | created_at                 | updated_at                 |
+---------+-----------+---------+----------------------------+----------------------------+---------------+------------------+----------------+-------+----------------------------+--------------+----------------------------+----------------------------+
| 1182417 |     31579 |      12 | 2025-05-02 04:00:00.000000 | 2025-05-03 04:00:00.000000 |             0 |                0 |              0 | NULL  | NULL                       |            0 | 2025-05-02 05:55:21.134327 | 2025-05-02 05:55:21.134327 |
| 1182418 |     31579 |      12 | 2025-05-03 04:00:00.000000 | 2025-05-04 04:00:00.000000 |          9599 |               13 |             21 | NULL  | 2025-05-04 03:34:46.000000 |            0 | 2025-05-02 05:55:21.134327 | 2025-05-10 00:13:55.681577 |
| 1182419 |     31579 |      12 | 2025-05-04 04:00:00.000000 | 2025-05-05 04:00:00.000000 |           287 |                0 |             16 | NULL  | 2025-05-04 23:26:36.000000 |            0 | 2025-05-02 05:55:21.134327 | 2025-05-06 21:54:29.752591 |
| 1182420 |     31579 |      12 | 2025-05-05 04:00:00.000000 | 2025-05-06 04:00:00.000000 |             0 |                0 |              0 | NULL  | NULL                       |            0 | 2025-05-02 05:55:21.134327 | 2025-05-02 05:55:21.134327 |
| 1182421 |     31579 |      12 | 2025-05-06 04:00:00.000000 | 2025-05-07 04:00:00.000000 |          1348 |                3 |              4 | NULL  | 2025-05-06 23:05:18.000000 |            0 | 2025-05-02 05:55:21.134327 | 2025-05-06 23:47:37.935524 |
| 1182422 |     31579 |      12 | 2025-05-07 04:00:00.000000 | 2025-05-08 04:00:00.000000 |             0 |                0 |              0 | NULL  | NULL                       |            0 | 2025-05-02 05:55:21.134327 | 2025-05-02 05:55:21.134327 |
| 1182423 |     31579 |      12 | 2025-05-08 04:00:00.000000 | 2025-05-09 04:00:00.000000 |         14224 |               15 |             12 | NULL  | 2025-05-08 21:20:42.000000 |            0 | 2025-05-02 05:55:21.134327 | 2025-05-08 21:46:37.006794 |
| 1182424 |     31579 |      12 | 2025-05-09 04:00:00.000000 | 2025-05-10 04:00:00.000000 |          3116 |                4 |              6 | NULL  | 2025-05-09 23:31:47.000000 |            0 | 2025-05-02 05:55:21.134327 | 2025-05-10 00:14:09.063824 |
| 1182425 |     31579 |      12 | 2025-05-10 04:00:00.000000 | 2025-05-11 04:00:00.000000 |         10638 |               11 |              7 | NULL  | 2025-05-10 22:00:23.000000 |            0 | 2025-05-02 05:55:21.134327 | 2025-05-10 22:11:10.211341 |
| 1229658 |     31579 |      12 | 2025-05-11 04:00:00.000000 | 2025-05-12 04:00:00.000000 |             0 |                0 |              0 | NULL  | NULL                       |            0 | 2025-05-10 18:53:51.649012 | 2025-05-10 18:54:02.596602 |
| 1229659 |     31579 |      12 | 2025-05-12 04:00:00.000000 | 2025-05-13 04:00:00.000000 |             0 |                0 |              0 | NULL  | NULL                       |            0 | 2025-05-10 18:53:51.649012 | 2025-05-10 18:54:03.053470 |
+---------+-----------+---------+----------------------------+----------------------------+---------------+------------------+----------------+-------+----------------------------+--------------+----------------------------+----------------------------+
```

The course end date is 2025-05-13 04:00:00, but there is not timeslice for that point in time, as timeslice with id 1229659 corresponds to [2025-05-12 04:00:00.000000, 2025-05-13 04:00:00.000000)

I'm not entirely sure about what happened here, but looking at the DB records, I _suppose_ something like the following :
- 2025-05-02. Course dates were set to `START: 2025-05-02 04:00:00.000000` and `END: 2025-05-10 04:00:00.000000`
- 2025-05-02. Timeslices for that period were created successfully. Last timeslice: [2025-05-10 04:00:00, 2025-05-11 04:00:00)
- 2025-05-10. Course end date was changed to `END: 2025-05-14 04:00:00.000000`
 - 2025-05-10. Timeslices for that period were created successfully. Last timeslice: [2025-05-14 04:00:00, 2025-05-15 04:00:00)
 - 2025-05-13. Course end date was changed to `END: 2025-05-12 04:00:00.000000`.
 - 2025-05-13. Timeslices were deleted successfully. Last timeslice: [2025-05-12 04:00:00, 2025-05-13 04:00:00)
 - 2025-05-13. Course end date was changed to `END: 2025-05-13 04:00:00.000000` (current state).
 - No timeslice was added due to existing bug.

While I don't have enough evidence to be sure about this, obviously the bug discovered could have affected this course and is worth fixing.

