### PR TITLE
[Data-rearchitecture] Fix courses with overlapped timeslices

### DIFF
--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -2,6 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
+require_dependency "#{Rails.root}/lib/timeslice_manager"
 
 # Ensures that the necessary timeslices are created prior to a new update
 # of the course statistics.

--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -27,11 +27,6 @@ class PrepareTimeslices
   # Updates timeslices, making changes based on modifications to course data,
   # such as some wiki/users were added or removed, the start/end course dates changed.
   def adjust_timeslices
-    # Ensure initial timeslices are created if this is the first course update
-    unless @course.was_course_ever_updated?
-      @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
-      return
-    end
     # Execute update tasks in a specific order
     UpdateTimeslicesCourseWiki.new(@course).run
     UpdateTimeslicesCourseUser.new(@course, update_service: @update_service).run

--- a/spec/services/prepare_timeslices_spec.rb
+++ b/spec/services/prepare_timeslices_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PrepareTimeslices do
+  let(:course) { create(:basic_course, start: '2021-01-24 05:00:00', end: '2021-01-30 05:00:00') }
+
+  describe '#adjust_timeslices' do
+    let(:subject) { described_class.new(course, UpdateDebugger.new(course)) }
+
+    it 'creates timeslices during the first update' do
+      expect(course.course_wiki_timeslices.count).to eq(0)
+      subject.adjust_timeslices
+
+      expect(course.course_wiki_timeslices.count).to eq(7)
+    end
+
+    it 'works if start and end datetimes change to future time' do
+      subject.adjust_timeslices
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      first_timeslice = course.course_wiki_timeslices.first
+      last_timeslice = course.course_wiki_timeslices.last
+
+      course.update(start: '2021-01-24 17:00:00')
+      course.update(end: '2021-01-30 17:00:00')
+      subject.adjust_timeslices
+
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.first).to eq(first_timeslice)
+      expect(course.course_wiki_timeslices.last).to eq(last_timeslice)
+    end
+
+    it 'works if start and end datetimes change to previous time' do
+      subject.adjust_timeslices
+      expect(course.course_wiki_timeslices.count).to eq(7)
+
+      course.update(start: '2021-01-23 22:00:00')
+      course.update(end: '2021-01-29 22:00:00')
+      subject.adjust_timeslices
+
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.minimum(:start)).to eq('2021-01-23 05:00:00')
+      expect(course.course_wiki_timeslices.maximum(:end)).to eq('2021-01-30 05:00:00')
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
Closes #6333. This PR removes the particular branch when course was never updated in `PrepareTimeslices#adjust_timeslices` method, as the general case already creates the necessary timeslices for the course.

I cloned course 72 Hours Marathon Virtual Edit-a-thon 2.0 locally  (mentioned in issue #6333) and was able to reproduce the error. Running two updates, once with start time at 5 AM, and the following with start time at 5 PM generates duplicate timeslices. Running the same updates after the changes avoid the generation of duplicate timeslices, as the original set of timeslices:
- [2025-05-28 05:00:00, 2025-05-29 05:00:00)
- [2025-05-29 05:00:00, 2025-05-30 05:00:00)
- [2025-05-30 05:00:00, 2025-05-31 05:00:00)
- [2025-05-31 05:00:00, 2025-06-01 05:00:00)

already involves the new course period: [2025-05-28 17:00:00, 2025-05-31 17:00:00]

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
