### PR TITLE
Keep track when a course starts an update that never ends

### DIFF
--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -26,7 +26,8 @@ class UpdateCourseStatsTimeslice
     @full_update = @course.needs_update
     @debugger = UpdateDebugger.new(@course)
 
-    @start_time = Time.zone.now
+    @start_time = Time.zone.now.to_datetime
+    UpdateLogger.update_course_with_unfinished_update(@course, 'start_time' => @start_time)
     import_uploads
     update_categories
     update_article_status if should_update_article_status?
@@ -104,9 +105,9 @@ class UpdateCourseStatsTimeslice
 
   def log_end_of_update
     @course.update(needs_update: false)
-    @end_time = Time.zone.now
-    UpdateLogger.update_course(@course, 'start_time' => @start_time.to_datetime,
-                                         'end_time' => @end_time.to_datetime,
+    @end_time = Time.zone.now.to_datetime
+    UpdateLogger.update_course(@course, 'start_time' => @start_time,
+                                         'end_time' => @end_time,
                                          'sentry_tag_uuid' => sentry_tag_uuid,
                                          'error_count' => error_count,
                                          'processed' => @processed,

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -30,7 +30,7 @@ class UpdateLogger
     logs&.keys&.max || 0
   end
 
-  def self.update_course_with_unifinished_update(course, new_logs)
+  def self.update_course_with_unfinished_update(course, new_logs)
     logs = course.flags['unfinished_update_logs']
     updated_logs = new(logs).update(new_logs)
     course.flags['unfinished_update_logs'] = updated_logs

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -6,9 +6,12 @@ class UpdateLogger
   ################
   def self.update_course(course, new_logs)
     logs = course.flags['update_logs']
-    updated_logs = new(logs).update(new_logs)
+    updater = new(logs)
+    updated_logs = updater.update(new_logs)
     course.flags['update_logs'] = updated_logs
     course.flags['average_update_delay'] = average_delay(updated_logs)
+    course.flags['unfinished_update_logs'] =
+      updater.delete_unfinished_log(new_logs, course.flags['unfinished_update_logs'])
     course.save
   end
 
@@ -25,6 +28,13 @@ class UpdateLogger
     setting = Setting.find_or_create_by(key: 'metrics_update')
     logs = setting.value['constant_update']
     logs&.keys&.max || 0
+  end
+
+  def self.update_course_with_unifinished_update(course, new_logs)
+    logs = course.flags['unfinished_update_logs']
+    updated_logs = new(logs).update(new_logs)
+    course.flags['unfinished_update_logs'] = updated_logs
+    course.save
   end
 
   ###########
@@ -51,5 +61,12 @@ class UpdateLogger
     @log_hash[@update_number] = new_logs
     @log_hash.delete(@log_hash.keys.min) until @log_hash.count <= MAX_UPDATES
     @log_hash
+  end
+
+  # Deletes the unfinished_update_logs record for start_time since the update did finish.
+  def delete_unfinished_log(new_logs, unfinished_logs)
+    unfinished_logs.delete_if do |_, log|
+      log['start_time'] == new_logs['start_time']
+    end
   end
 end

--- a/lib/data_cycle/update_logger.rb
+++ b/lib/data_cycle/update_logger.rb
@@ -65,6 +65,7 @@ class UpdateLogger
 
   # Deletes the unfinished_update_logs record for start_time since the update did finish.
   def delete_unfinished_log(new_logs, unfinished_logs)
+    return if unfinished_logs.nil?
     unfinished_logs.delete_if do |_, log|
       log['start_time'] == new_logs['start_time']
     end

--- a/spec/lib/data_cycle/update_logger_spec.rb
+++ b/spec/lib/data_cycle/update_logger_spec.rb
@@ -51,7 +51,7 @@ describe UpdateLogger do
 
     before do
       # Add unfinished updates
-      described_class.update_course_with_unifinished_update(course, 'start_time' => start_time)
+      described_class.update_course_with_unfinished_update(course, 'start_time' => start_time)
     end
 
     it 'removes unfinished update log if the update finished' do

--- a/spec/lib/data_cycle/update_logger_spec.rb
+++ b/spec/lib/data_cycle/update_logger_spec.rb
@@ -43,4 +43,28 @@ describe UpdateLogger do
       expect(delay).to be(nil)
     end
   end
+
+  describe '.update_course' do
+    let(:course) { create(:course) }
+    let(:start_time) { Time.zone.now }
+    let(:end_time) { Time.zone.now + 1.day }
+
+    before do
+      # Add unfinished updates
+      described_class.update_course_with_unifinished_update(course, 'start_time' => start_time)
+    end
+
+    it 'removes unfinished update log if the update finished' do
+      # Expect unfinished_update_logs flag to exist
+      expect(course.flags['unfinished_update_logs'][1]['start_time']).to eq(start_time)
+
+      # Update logs once the update finished
+      described_class.update_course(course, 'start_time' => start_time, 'end_time' => end_time)
+
+      # Expect update_logs flag to exist
+      expect(course.flags['update_logs'][1]['start_time']).to eq(start_time)
+      # Expect unfinished_update_logs flag to no longer exist
+      expect(course.flags['unfinished_update_logs'].first).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does
Closes #6326 .
This PR adds a new `update_course_with_unifinished_update` method to log course updates that didn't finish yet. The idea is that as soon as a course update starts, a new `unfinished_update_logs` flag is added, saving the `start_time` of an update. Once the course update ran all the steps, the original `update_logs` flag is updated as usual, and the `unfinished_update_logs` added at the start of the update is deleted (as the update finished successfully). This means that, if the update breaks unexpectedly without finishing all the steps, an `unfinished_update_logs` flag will remain indicating that.

Note that I didn't re-use the existing `update_logs` flag because that flag is used along the code under the assumption that it indicates updates that finished successfully (meaning that if there exists a `start_time`, there is also an `end_time`). Re-using the same flag to indicate updates that still didn't finish would break that assumption.

## Examples

Flags for a course that had a successful update on April and a second update on May that failed unexpectedly.
```
"flags": {
            "timeline_enabled": true,
            "wiki_edits_enabled": false,
            "online_volunteers_enabled": false,
            "disable_student_emails": false,
            "stay_in_sandbox": false,
            "retain_available_articles": false,
            "edit_settings": {
                "wiki_course_page_enabled": false,
                "assignment_edits_enabled": false,
                "enrollment_edits_enabled": false
            },
            "academic_system": null,
            "format": null,
            "update_logs": {
                "1": {
                    "start_time": "2025-04-25T19:19:34.982+00:00",
                    "end_time": "2025-04-25T19:22:11.162+00:00",
                    "sentry_tag_uuid": "e7ee1240-6b9e-451f-8f82-1a62df434c7a",
                    "error_count": 0
                }
            },
            "average_update_delay": null,
            "no_sandboxes": false,
            "unfinished_update_logs": {
                "1": {
                    "start_time": "2025-05-28T19:50:05.734+00:00"
                }
            }
        },
```
Flags after the course had a new successful update.

```
 "flags": {
            "timeline_enabled": true,
            "wiki_edits_enabled": false,
            "online_volunteers_enabled": false,
            "disable_student_emails": false,
            "stay_in_sandbox": false,
            "retain_available_articles": false,
            "edit_settings": {
                "wiki_course_page_enabled": false,
                "assignment_edits_enabled": false,
                "enrollment_edits_enabled": false
            },
            "academic_system": null,
            "format": null,
            "update_logs": {
                "1": {
                    "start_time": "2025-04-25T19:19:34.982+00:00",
                    "end_time": "2025-04-25T19:22:11.162+00:00",
                    "sentry_tag_uuid": "e7ee1240-6b9e-451f-8f82-1a62df434c7a",
                    "error_count": 0
                },
                "2": {
                    "start_time": "2025-05-28T19:56:17.294+00:00",
                    "end_time": "2025-05-28T19:56:31.653+00:00",
                    "sentry_tag_uuid": "8769df7c-d84d-4236-8ed2-b735e6b5c8bc",
                    "error_count": 0,
                    "processed": 3,
                    "reprocessed": 3
                }
            },
            "average_update_delay": 2853260,
            "no_sandboxes": false,
            "unfinished_update_logs": {
                "1": {
                    "start_time": "2025-05-28T19:50:05.734+00:00"
                }
            }
        },
```

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
