### PR TITLE
Minor: Skip redundant API calls on /survey routes to improve minor survey page performance

### DIFF
--- a/app/assets/javascripts/components/nav/news/news_nav_icon.jsx
+++ b/app/assets/javascripts/components/nav/news/news_nav_icon.jsx
@@ -23,7 +23,14 @@ const NewsNavIcon = ({ setIsOpen }) => {
   useEffect(() => {
     const fetchNewsData = async () => {
       try {
-        const newsContentList = await API.fetchNews(newsType);
+        let newsContentList = [];
+
+        // Skip fetching account requests if on a survey page.
+        // Survey tabs cause full page reloads, which would trigger unnecessary API calls.
+        // Admins can view updated requests/notifications from the homepage instead.
+        if (!location.pathname.startsWith('/survey')) {
+          newsContentList = await API.fetchNews(newsType);
+        }
 
         // Retrieve the last fetch timestamp from the cookie
         const userLastFetchTimestamp = Cookies.get(`lastFetchTimestamp_${newsType}`);

--- a/app/assets/javascripts/components/nav/notifications_bell.jsx
+++ b/app/assets/javascripts/components/nav/notifications_bell.jsx
@@ -15,10 +15,15 @@ const NotificationsBell = () => {
         .catch(err => err);
     }
 
-    request('/requested_accounts.json')
-      .then(res => res.json())
-      .then(({ requested_accounts }) => setHasRequestedAccounts(requested_accounts))
-      .catch(err => err); // If this errors, we're going to ignore it
+    // Skip fetching account requests if on a survey page.
+    // Survey tabs cause full page reloads, which would trigger unnecessary API calls.
+    // Admins can view updated requests/notifications from the homepage instead.
+    if (!location.pathname.startsWith('/survey')) {
+      request('/requested_accounts.json')
+        .then(res => res.json())
+        .then(({ requested_accounts }) => setHasRequestedAccounts(requested_accounts))
+        .catch(err => err); // If this errors, we're going to ignore it
+    }
   }, []);
 
   const path = Features.wikiEd ? '/admin' : '/requested_accounts';


### PR DESCRIPTION
Found this while working on PR #6329 

## What this PR does

This PR disables the API call to `/requested_accounts.json`  and `/faq/Programs_&_Events_Dashboard_News/handle_special_faq_query` when the current route starts with `/survey`. These routes are admin-only and are structured with full-page reloads for each tab, which was causing the API request to be triggered repeatedly—even though most of  the time data is not needed on these pages.

### Reason for Change
- The `/requested_accounts.json` and `/faq/Programs_&_Events_Dashboard_News/handle_special_faq_query` endpoint provides account requests and unread news notifications count, which are mostly relevant outside of  the survey context.
- Admins can still access updated data by navigating to the homepage or other relevant views.
- Preventing this call on `/survey` pages improves performance `(not dramatically noticeable, but both endpoints consistently add ~100ms each)` and reduces unnecessary backend traffic.
- Avoids polluting logs and metrics with redundant, contextually irrelevant requests.


### Implementation Details
- Added a pathname check using `location.pathname.startsWith('/survey')` to conditionally skip the request.
- Added a comment explaining the logic for future contributors.

No functionality is lost for admins, and the user experience remains fully intact.



## Screenshots
Before:


https://github.com/user-attachments/assets/b31be780-7092-4ce7-9168-e3c27473cc2c



After:


https://github.com/user-attachments/assets/7daf2222-9154-43f7-b279-2de493589578
