### PR TITLE
Minor Chore: Remove N+1 Query From Download Single Question Results CSV

### DIFF
--- a/config/initializers/surveys.rb
+++ b/config/initializers/surveys.rb
@@ -120,7 +120,7 @@ Rails.application.config.to_prepare do
                 'Follow Up Answer',
                 'Username',
                 'User Email']
-        answers.order(:answer_text).collect do |answer|
+        answers.includes(:user).order(:answer_text).collect do |answer|
           csv << [
             question_text,
             validation_rules[:grouped_question],


### PR DESCRIPTION


## What this PR does

This is a minor N+1 Query Fix for Download Single Question Results CSV which is resolved by using `.includes(:user)`

## Screenshots

Before:
![Before](https://github.com/user-attachments/assets/c4448458-25bf-4b53-a981-81cf622f0092)

https://github.com/user-attachments/assets/cb46d2b2-2bf4-4770-a3a2-ef1cf273de84



After:

![After](https://github.com/user-attachments/assets/bfdedd57-47eb-4428-9147-d0d2ce4b39e8)

https://github.com/user-attachments/assets/1ef10633-f9de-402b-abf4-92ae030d8e1a


