### PR TITLE
Identify articles that move from one namespace to another

### DIFF
--- a/app/services/update_course_stats_timeslice.rb
+++ b/app/services/update_course_stats_timeslice.rb
@@ -2,6 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/course_revision_updater"
 require_dependency "#{Rails.root}/lib/article_status_manager_timeslice"
+require_dependency "#{Rails.root}/lib/article_namespaces_manager"
 require_dependency "#{Rails.root}/lib/importers/course_upload_importer"
 require_dependency "#{Rails.root}/lib/data_cycle/update_logger"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
@@ -30,7 +31,7 @@ class UpdateCourseStatsTimeslice
     UpdateLogger.update_course_with_unfinished_update(@course, 'start_time' => @start_time)
     import_uploads
     update_categories
-    update_article_status if should_update_article_status?
+    update_articles
     @processed, @reprocessed = UpdateCourseWikiTimeslices.new(@course, @debugger,
                                                               update_service: self)
                                                          .run(all_time: @full_update)
@@ -59,6 +60,16 @@ class UpdateCourseStatsTimeslice
   def update_article_status
     ArticleStatusManagerTimeslice.update_article_status_for_course(@course)
     @debugger.log_update_progress :article_status_updated
+  end
+
+  def update_article_namespaces
+    ArticleNamespacesManager.new(@course)
+    @debugger.log_update_progress :article_namespaces_updated
+  end
+
+  def update_articles
+    update_article_status if should_update_article_status?
+    update_article_namespaces
   end
 
   def update_average_pageviews

--- a/lib/article_namespaces_manager.rb
+++ b/lib/article_namespaces_manager.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+
+##= Identifies articles that move to a different namespace during the course timeline.
+# Specifically, it handles the following cases:
+#
+# 1- Articles that moved from a non-tracked namespace to a tracked namespace (usually mainspace).
+#   These are identified when the article course record is created *after* some of its article
+#   course timeslices.
+#   This implies the article had revisions that didn't trigger article course record creation
+#   (because it wasn't relevant yet). Later, the article course record was created —likely because
+#   the article moved to a tracked namespace and became relevant.
+#   In such cases, we need to flag the timeslices for reprocessing, since previous stats weren't
+#   counted as tracked-namespace stats.
+#
+# 2- Articles that moved from a tracked namespace to a non-tracked namespace.
+#
+# Note: This class depends on the namespace attribute in the articles table. It does not update
+# this attribute; it simply trusts its current value.
+
+class ArticleNamespacesManager
+  def initialize(course)
+    @course = course
+
+    reset_articles_that_moved_to_mainspace
+
+    ArticlesCoursesCleanerTimeslice.reset_articles_in_untracked_namespaces(@course)
+  end
+
+  private
+
+  def reset_articles_that_moved_to_mainspace
+    articles = Article.find(moved_to_mainspace)
+    ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, articles)
+  end
+
+  # Articles that have an article course record that was created *after* some of its article
+  # course timeslices.
+  def moved_to_mainspace
+    @course.articles_courses
+           .joins('INNER JOIN article_course_timeslices act ON act.course_id = articles_courses.course_id AND act.article_id = articles_courses.article_id') # rubocop:disable Layout/LineLength
+           .where('act.created_at < articles_courses.created_at')
+           .pluck(:article_id)
+           .uniq
+  end
+end

--- a/spec/lib/article_namespaces_manager_spec.rb
+++ b/spec/lib/article_namespaces_manager_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/article_namespaces_manager"
+
+describe ArticleNamespacesManager do
+  let(:course) { create(:course, start: 1.year.ago, end: 1.year.from_now) }
+  let(:wiki) { course.home_wiki }
+  let(:moved_to_mainspace) { 2.weeks.ago }
+  let(:first_revision) { 2.months.ago }
+  let(:mainspace_article) { create(:article, namespace: 0, updated_at: moved_to_mainspace) }
+  let(:subject) { described_class.new(course) }
+
+  context 'when an article moved from userspace to mainspace' do
+    before do
+      create(:articles_course, course:, article_id: mainspace_article.id,
+             created_at: moved_to_mainspace)
+      create(:course_wiki_timeslice, course:, wiki:, start: first_revision.beginning_of_day)
+      create(:course_wiki_timeslice, course:, wiki:, start: moved_to_mainspace.beginning_of_day)
+      create(:article_course_timeslice, course:, article_id: mainspace_article.id,
+              start: first_revision.beginning_of_day, created_at: first_revision.beginning_of_day)
+      create(:article_course_timeslice, course:, article_id: mainspace_article.id,
+              start: moved_to_mainspace.beginning_of_day,
+              created_at: moved_to_mainspace.beginning_of_day)
+    end
+
+    it 'resets timeslices for article' do
+      expect(course.course_wiki_timeslices.where(needs_update: true).count).to eq(0)
+      expect(ArticlesCourses.where(article_id: mainspace_article.id).count).to eq(1)
+      expect(ArticleCourseTimeslice.where(article_id: mainspace_article.id).count).to eq(2)
+      subject
+      expect(course.course_wiki_timeslices.where(needs_update: true).count).to eq(2)
+      expect(ArticlesCourses.where(article_id: mainspace_article.id)).to be_empty
+      expect(ArticleCourseTimeslice.where(article_id: mainspace_article.id).count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This is a work in progress.

For now, it adds a new class: `ArticleNamespacesManager`. I have to test how bad it performs for big courses.

The query that the class runs:

```
SELECT ac.article_id
FROM article_course_timeslices act INNER JOIN articles_courses ac ON ac.course_id = act.course_id AND ac.article_id = act.article_id
WHERE act.created_at <= ac.created_at AND ac.course_id = ?;
```
helps to find articles that moved to mainspace.

I ran the query for some bigs courses and I found the following:
- Course [30721 WikiSendero Andes](https://outreachdashboard.wmflabs.org/courses/Wikimedia_Small_Projects/WikiSendero_Andes_(2025)). 
Article 774862181 ([Puerto_España](https://es.wikivoyage.org/w/index.php?title=Puerto_Espa%C3%B1a&action=history)). 
Article 778310222 ([Georgetown_(Guyana)](https://es.wikivoyage.org/w/index.php?title=Georgetown_(Guyana)&action=history)).
Both articles seem to have moved from userspace to mainspace. However, I cannot find the articles listed in the [course articles tab](https://outreachdashboard.wmflabs.org/courses/Wikimedia_Small_Projects/WikiSendero_Andes_(2025)/articles/edited?newness=existing&wiki=es.wikivoyage) because I have to click on "See more" a lot of times.
- Course [25877 Grupo_de_Usuários_Wiki_Movimento_Brasil/WikiConecta](https://outreachdashboard.wmflabs.org/courses/Grupo_de_Usu%C3%A1rios_Wiki_Movimento_Brasil/WikiConecta).
 Article 777650700 ([Sergio_Muniz_Oliva_Filho](https://pt.wikipedia.org/w/index.php?title=Sergio_Muniz_Oliva_Filho&action=history)). See revisions close to 2025-04-10. 
 Article 776483178 ([Pedra_de_Xangô](https://pt.wikipedia.org/w/index.php?title=Pedra_de_Xang%C3%B4&action=history)). See revisions close to 2025-03-25.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
