### PR TITLE
Fix N+1 query issues on survey assignments index view

### DIFF
--- a/app/controllers/survey_assignments_controller.rb
+++ b/app/controllers/survey_assignments_controller.rb
@@ -16,7 +16,8 @@ class SurveyAssignmentsController < ApplicationController
   # GET /survey_assignments
   # GET /survey_assignments.json
   def index
-    @survey_assignments = SurveyAssignment.all
+    @survey_assignments = SurveyAssignment.includes(:campaigns, :survey, :survey_notifications,
+                                                    :courses).all
   end
 
   # GET /survey_assignments/1

--- a/app/helpers/surveys_analytics_helper.rb
+++ b/app/helpers/surveys_analytics_helper.rb
@@ -38,14 +38,13 @@ module SurveysAnalyticsHelper
   end
 
   def assignment_response(survey_assignment)
-    completed = survey_assignment.survey_notifications.completed.length
+    completed = survey_assignment.survey_notifications.count(&:completed)
     notified = survey_assignment.survey_notifications.length
     response_summary_string(completed, notified)
   end
 
   def assignment_dismissal(survey_assignment)
-    dismissed = survey_assignment.survey_notifications
-                                 .where(dismissed: true, completed: false).length
+    dismissed = survey_assignment.survey_notifications.count { |n| !n.completed && n.dismissed }
     notified = survey_assignment.survey_notifications.length
     response_summary_string(dismissed, notified)
   end

--- a/app/views/survey_assignments/_survey_assignment.html.haml
+++ b/app/views/survey_assignments/_survey_assignment.html.haml
@@ -1,6 +1,6 @@
 .survey__admin-row.survey__admin-row--assignment
   .survey__admin-row__title
-    .contextual Target Campaign#{survey_assignment.campaigns.count > 1 ? 's' : ''}:
+    .contextual Target Campaign#{survey_assignment.campaigns.size > 1 ? 's' : ''}:
     %strong= survey_assignment.campaigns.pluck(:title).join(', ')
     .contextual Target User:
     %span.emphasis= user_role(survey_assignment)
@@ -40,8 +40,7 @@
 
       .survey__admin-row__col__detail
         .contextual Number of Courses
-        %span= survey_assignment.courses.count
-
+        %span= survey_assignment.courses.size
       .survey__admin-row__col__detail
         .contextual Estimated Recipients
         - total = survey_assignment.target_user_count

--- a/app/views/survey_assignments/_survey_assignment.html.haml
+++ b/app/views/survey_assignments/_survey_assignment.html.haml
@@ -17,10 +17,6 @@
         .contextual Notification Schedule:
         %span= notification_schedule_summary(survey_assignment)
 
-      -# .survey__admin-row__col__detail
-      -#   .contextual Assignment #:
-      -#   %span ##{survey_assignment.id}
-
       .survey__admin-row__col.survey__admin-row__col--actions
         = "##{survey_assignment.id}"
         %div &nbsp;
@@ -46,29 +42,3 @@
         - total = survey_assignment.target_user_count
         %span= total
         %span= user_role(survey_assignment, total)
-
-
-    -# %div.clearfix
-    -#   %button{:data => {:toggle_courses_table => true}}
-    -#     %span Expand
-    -#     %span.icon.icon-arrow-down
-
-  -# .survey__admin-row__col
-  -#   %strong Notes:
-  -#   %span= survey_assignment.notes
-
-  -# .survey__admin-row__expanded{:data => {:sortable_courses => true}}
-  -#   %table.survey-assignment__courses
-  -#     %thead
-  -#       %tr
-  -#         %th
-  -#           %button{:class => 'sort', :data => {:sort => 'title'}} Title
-  -#         %th
-  -#           %button{:class => 'sort', :data => {:sort => 'id'}} Id
-  -#
-  -#     %tbody.list
-  -#       - survey_assignment.campaigns.each do |campaign|
-  -#         - campaign.courses.each do |course|
-  -#           %tr
-  -#             %td{ :class => 'title' }= pretty_course_title(course)
-  -#             %td{ :class => 'id' }= course.id


### PR DESCRIPTION
## What this PR does

Fixes N+1 query issues on survey assignments index view by using `.includes`

## Where is the N+1 this fixes, and what do the N+1 queries look like

**a)  Where is the N+1 this fixes**


https://github.com/user-attachments/assets/32130701-10ca-454c-8d33-146eb0b8d8c1



**b) What do the N+1 queries look like**


https://github.com/user-attachments/assets/35e22076-a1d1-4108-b5fb-9358ce3792d3




## Performance & Resource Usage Average

| Metric               | Default | Initial Implementaion | Latest Version |
|----------------------|-------------|----------------|---------------------|
| **Total Time (ms)**  | 186.1       | **66.7**       | 128.6               |
| **View Time (ms)**   | 138.3       | **27.9**       | 99.4                |
| **AR Time (ms)**     | 42.5        | **22.4**       | 24.8                |
| **Allocations**      | 85494.3     | **20625.2**    | 50934               |


![Screenshot from 2025-06-11 18-46-11](https://github.com/user-attachments/assets/53f8aee9-c3e0-4347-bee5-e2eaada36325)

**Default Version**

![Screenshot from 2025-06-11 18-50-04](https://github.com/user-attachments/assets/359d9cb0-03ce-45e0-acc9-5cd14bd524c8)


**Initial Implementaion**

![After](https://github.com/user-attachments/assets/74a0b2da-c8af-49bf-8cd5-8a53e012a44f)

**Latest Version**

![Latest Version](https://github.com/user-attachments/assets/3b48e828-3560-43f2-b238-7f725ba1d833)



## Screenshots (Default & Latest Version)
Before:

https://github.com/user-attachments/assets/de528e88-9186-481a-95b7-2974f88f2f43

![Before](https://github.com/user-attachments/assets/0246e280-7df0-4df7-af65-846fc836c8e7)

![Screenshot from 2025-06-09 15-59-38](https://github.com/user-attachments/assets/a9d67cd7-43d2-4593-8504-ca2e01ed9e84)

After:


https://github.com/user-attachments/assets/8b43303f-8191-42fb-9336-35d00d4144f1


![Latest Version](https://github.com/user-attachments/assets/6b39e6f9-b6bf-44c2-a5fd-039f531f9538)


![Screenshot from 2025-06-11 19-19-26](https://github.com/user-attachments/assets/ef4647d9-4465-4795-84c1-5c15fa6e33a3)
