### PR TITLE
[Data-rearchitecture] Change behavior `UpdateCourseWikiTimeslices`  to make full updates work progressively

### DIFF
--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -21,7 +21,10 @@ class PrepareTimeslices
     # Destroy articles courses records to re-create article courses timeslices, except for
     # untracked articles courses so that we don't miss they're untracked.
     @course.articles_courses.tracked.destroy_all
-    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis)
+    # Re-create timeslices, all of them set to be reprocessed so that if the full update process
+    # dies, it continues from the last point on the next update.
+    @timeslice_manager.create_timeslices_for_new_course_wiki_records(@course.wikis,
+                                                                     needs_update: true)
     @debugger.log_update_progress :timeslices_recreated
   end
 

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -21,6 +21,7 @@ class UpdateCourseWikiTimeslices # rubocop:disable Metrics/ClassLength
 
   def run(all_time:)
     pre_update(all_time)
+    @course.update(needs_update: false)
     fetch_data_and_process_timeslices_for_every_wiki(all_time)
     [@processed_timeslices, @reprocessed_timeslices]
   end


### PR DESCRIPTION
## What this PR does
This PR changes behavior in `UpdateCourseWikiTimeslices` class when a full update is required. Now, the timeslices are re-created with `needs_update` set to true, and the `needs_update`  course flagis set to false right after doing that. This is to make the full update process able to work progressively. It also adds basic specs for it.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
