### PR TITLE
fix: optimize surveys_controller#index by removing N+1 queries with eager loading

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -33,7 +33,8 @@ class SurveysController < ApplicationController
   # GET /surveys
   # GET /surveys.json
   def index
-    @surveys = Survey.all
+    @surveys = Survey.includes(:versions, :survey_assignments,
+                               rapidfire_question_groups: :questions).all
   end
 
   def results_index

--- a/app/helpers/surveys_analytics_helper.rb
+++ b/app/helpers/surveys_analytics_helper.rb
@@ -2,17 +2,17 @@
 
 module SurveysAnalyticsHelper
   def survey_status(survey, count = false)
-    assignments = SurveyAssignment.published.where(survey_id: survey.id)
-    return assignments.count if count
-    return "In Use (#{assignments.count})" unless assignments.empty?
-    return '--'
+    assignments = survey.survey_assignments.select(&:published?)
+    return assignments.size if count
+    return "In Use (#{assignments.size})" unless assignments.empty?
+    '--'
   end
 
   def survey_question_stats(survey)
     question_groups = survey.rapidfire_question_groups
-    qg_count = question_groups.count
+    qg_count = question_groups.size
     question_total = 0
-    question_groups.collect { |qg| question_total += qg.questions.count }
+    question_groups.collect { |qg| question_total += qg.questions.size }
     "#{qg_count} | #{question_total}"
   end
 


### PR DESCRIPTION

## What this PR does


This pull request addresses performance issues in the `surveys_controller#index` caused by **N+1 queries**. Specifically, the previous implementation fetched associated records lazily, leading to excessive database queries.

### Before

- `Survey.all` loaded surveys without their related data.
- Each view access to `survey.versions`, `survey.survey_assignments`, and `survey.rapidfire_question_groups.questions` triggered additional queries per survey.

### After

- Replaced `Survey.all` with:
  ```ruby
  Survey.includes(:versions, :survey_assignments, rapidfire_question_groups: :questions).all


## Where is the N+1 this fixes, and what do the N+1 queries look like

**a) Where is the N+1 this fixes**

![Where is the N+1 this fixes](https://github.com/user-attachments/assets/6e9216aa-334e-4065-ba27-0f0d36c39378)


**b) what do the N+1 queries look like**


https://github.com/user-attachments/assets/792f5e2c-67b3-4953-92ea-354088e3636f


## Rails Log Performance Comparison (Average)

| Metric              | Main Branch (N+1) | Fix Branch (No N+1) | Improvement      |
|---------------------|-------------------|----------------------|------------------|
| Total Time (ms)     | 135.2             | 60.9                 | ↓ ~55%           |
| Views Time (ms)     | 79.52             | 37.57                | ↓ ~53%           |
| ActiveRecord (ms)   | 50.36             | 18.4                 | ↓ ~63%           |
| Allocations         | 39,336.3          | 26,406.8             | ↓ ~33%           |

![AVERAGE](https://github.com/user-attachments/assets/c9d99b5f-c53b-4fc3-98b3-569b8315cbac)


## **Screenshots**

### Before:


https://github.com/user-attachments/assets/53b2b92e-7e8b-40c6-9d4e-0eceee9c93b0

![Before](https://github.com/user-attachments/assets/4d2431ed-3302-4293-bdc0-e5bba8eaf055)


### After:

![After](https://github.com/user-attachments/assets/b176accf-5a39-40f6-aeb3-c8198a09c5c1)


https://github.com/user-attachments/assets/fc7a29e4-5e92-42d2-a3e4-67ba4141e21d



