### PR TITLE
[Data-rearchitecture] Improve `UpdateTimeslicesCourseUser` logic to prevent re-marking users as newly added

### DIFF
--- a/spec/services/update_timeslices_course_user_spec.rb
+++ b/spec/services/update_timeslices_course_user_spec.rb
@@ -138,5 +138,32 @@ describe UpdateTimeslicesCourseUser do
       expect(course.course_wiki_timeslices.needs_update.count).to eq(6)
       expect(course.course_user_wiki_timeslices.count).to eq(1)
     end
+
+    it 'doesnt update course wiki timeslices twice' do
+      course.flags = update_logs
+      course.save
+      # There is one user and one wiki
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
+
+      VCR.use_cassette 'course_user_updater' do
+        described_class.new(course).run
+      end
+
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(6)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
+
+      course.course_wiki_timeslices.update(needs_update: false)
+
+      VCR.use_cassette 'course_user_updater' do
+        described_class.new(course).run
+      end
+
+      expect(course.course_wiki_timeslices.count).to eq(7)
+      expect(course.course_wiki_timeslices.needs_update.count).to eq(0)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
## What this PR does
This PR updates `created_at` field for courses users right after considered them as newly added (and set timeslices to reprocess) in `UpdateTimeslicesCourseUser`, so they're not considered new users again in the next update if the process dies unexpectedly.

### Context
I was reproducing locally the update for course [Coordinate Me 2025 LV](https://outreachdashboard.wmflabs.org/courses/Wikidata/Coordinate_Me_2025_LV_(2025)). The addition of new course users with so many revisions triggers a re-processing of every timeslice in the course. While I don't think there is so much we can do around that, I think we can do make an improvement on the process. As it is working now, a new user is identified by comparing the `created_at` field for the course user and the `start_time` for the last successful update. If the user was created after the last `start_time`, then it's a new user. The thing is that if the update dies in the middle of the process, the user is considered new in the next update, setting as `needs_update` some timeslices that maybe were already re-processed in the previous update that didn't finish successfully. We could make a change so that, once the timeslices were set to `needs_update`, those users are no longer considered new (regardless of whether the update finishes successfully or dies in the middle). That way, in the next update, the remaining timeslices will be reprocessed until it eventually finishes successfully.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
