### PR TITLE
 Optimize Question Group Rendering and Eliminate N+1 Queries

### DIFF
--- a/app/helpers/surveys_analytics_helper.rb
+++ b/app/helpers/surveys_analytics_helper.rb
@@ -22,17 +22,19 @@ module SurveysAnalyticsHelper
     return user.username unless user.nil?
   end
 
-  def question_group_status(question_group)
-    survey_question_groups = SurveysQuestionGroup.where(
-      rapidfire_question_group_id: question_group.id
-    )
+  def question_group_survey_author(version)
+    return '--' if version.blank? || version.whodunnit.nil?
+    user = User.find(version.whodunnit)
+    return user.username unless user.nil?
+  end
 
-    return '--' if survey_question_groups.empty?
+  def question_group_status(survey_question_groups, surveys)
+    return '--' if survey_question_groups.blank?
     total_published_surveys = 0
-    survey_question_groups.each do |sqg|
-      next if sqg.survey.nil?
-      total_published_surveys += survey_status(sqg.survey, true)
-    end
+      survey_question_groups.each do |sqg|
+        next if surveys[sqg.survey_id].blank?
+        total_published_surveys += survey_status(surveys[sqg.survey_id].first, true)
+      end
     return '--' if total_published_surveys.zero?
     return "In Use (#{total_published_surveys})"
   end

--- a/app/views/rapidfire/question_groups/_question_group.html.haml
+++ b/app/views/rapidfire/question_groups/_question_group.html.haml
@@ -3,13 +3,13 @@
     %strong.name= question_group.name
   .survey__admin-row__col
     .contextual Status
-    %strong.question-group-color.status= question_group_status(question_group)
+    %strong.question-group-color.status= question_group_status(@survey_question_groups[question_group.id], @surveys)
   .survey__admin-row__col
     .contextual Questions
-    %strong= question_group.questions.count
+    %strong= @rapidfire_questions[question_group.id].length
   .survey__admin-row__col
     .contextual Last Author
-    %span.author= survey_author(question_group)
+    %span.author= question_group_survey_author(@latest_question_groups_version[question_group.id])
   -# .survey__admin-row__col
   -#   .contextual Created
   -#   %span= question_group.created_at.strftime("%B %d, %Y")
@@ -23,7 +23,7 @@
       = link_to "Clone", "/surveys/question_group/clone/#{question_group.id}", method: :post
     -# .course-list__col
     -#   = link_to "Add Question", new_question_group_question_path(question_group)
-    - if question_group.questions.length > 0
+    - if @rapidfire_questions[question_group.id].length > 0
       .course-list__col
         = link_to "Preview", "#{new_question_group_answer_group_path(question_group)}?preview"
     .course-list__col

--- a/app/views/rapidfire/question_groups/index.html.haml
+++ b/app/views/rapidfire/question_groups/index.html.haml
@@ -2,6 +2,21 @@
 
 = render 'admin_header'
 .container.survey__edit
+  - # Extract all question group IDs from @question_groups
+  - question_groups_id = @question_groups.pluck(:id)
+  
+  - # Group survey-question group mappings by question group ID
+  - @survey_question_groups = SurveysQuestionGroup.where(rapidfire_question_group_id: question_groups_id).group_by(&:rapidfire_question_group_id)
+  
+  - # Fetch surveys linked to question groups, preload assignments, and group by survey ID
+  - @surveys = Survey.includes(:survey_assignments).where(id: @survey_question_groups.values.flatten.map(&:survey_id).uniq).group_by(&:id)
+  
+  - # Group all questions by their question group ID
+  - @rapidfire_questions = Rapidfire::Question.where(question_group_id: question_groups_id).group_by(&:question_group_id) 
+  
+  - # Get the latest version for each question group using PaperTrail versioning
+  - @latest_question_groups_version = PaperTrail::Version.where(item_type: 'Rapidfire::QuestionGroup', item_id: question_groups_id).group_by(&:item_id).transform_values(&:last)
+
   - if @question_groups.length > 0
     %ul.list.survey__admin__row-container= render partial: "question_group", collection: @question_groups.reverse
   - else


### PR DESCRIPTION
## What this PR does

This PR improves the performance and maintainability of the admin survey question group interface by:

- Eliminating N+1 queries across question group rendering.

- Preloading and grouping related data (Survey, SurveyAssignment, Rapidfire::Question, and PaperTrail::Version) for efficient access in views.

- Refactoring helper methods to accept preloaded data and reduce query load during rendering.

## Changes

- **View (`index.html.haml`)**
   - Preloaded question group-related associations: survey mappings, surveys with assignments, related questions, and version history.
   - Passed preloaded data to partials to reduce query repetition.

- **Partial (`_question_group.html.haml`)**
   - Switched to using preloaded data for questions, status, and author display.
   - Ensured fallback behavior remains consistent.

- **Helper (`SurveysAnalyticsHelper`)**
  - Added `question_group_survey_author` to retrieve author from a version object.
  - Updated `question_group_status` to accept grouped objects instead of fetching them dynamically.


## Where is the N+1 this fixes, and what do the N+1 queries look like

**a) Where is the N+1 this fixes**


https://github.com/user-attachments/assets/af514b95-f7b3-4719-a706-018193e841eb



**b) what do the N+1 queries look like**


https://github.com/user-attachments/assets/cb49f42c-2ae4-462e-8d36-a45019623d45



## Rails Log Performance Comparison (Average)

| Metric                | Before (N+1)      | After (Optimized) | Improvement         |
| --------------------- | ----------------- | ----------------- | ------------------- |
| **Avg Response Time** | ~218 ms           | ~63 ms            | ~71% faster         |
| **Avg DB Time**       | ~82 ms            | ~18 ms            | ~78% reduction      |
| **Avg Allocations**   | ~68,000+ objects  | ~27,000 objects   | ~60% fewer objects  |

![Screenshot from 2025-06-13 15-05-18](https://github.com/user-attachments/assets/5cf93860-18a9-4afc-99f2-75f2278df537)


## Screenshots
Before:


https://github.com/user-attachments/assets/c17f2ac2-0da6-46b9-8938-bf0396be6f51


![Before Screenshot](https://github.com/user-attachments/assets/ff987a36-e0e9-4199-ab10-38568df116a8)


![Before Rails Log](https://github.com/user-attachments/assets/248abb7c-5dac-4abf-a6ee-70ea7c74dc88)



After:


![After Rails Log](https://github.com/user-attachments/assets/991fd9ba-86c6-42f7-8659-766382eb37af)

![After Screenshot](https://github.com/user-attachments/assets/a3d0ca9e-a971-4df5-a46f-4503737a335b)


https://github.com/user-attachments/assets/0ba4d319-71aa-48de-856a-7eade0c5d3a5

