### PR TITLE
Chore: Fix very minor N+1 in surveys CSV download (PART 1)

### DIFF
--- a/app/models/surveys/survey.rb
+++ b/app/models/surveys/survey.rb
@@ -98,13 +98,16 @@ class Survey < ApplicationRecord
   end
 
   def question_groups_in_order
-    @question_groups_in_order ||= SurveysQuestionGroup.where(survey_id: id).order(:position)
-                                                      .map(&:rapidfire_question_group)
+    @question_groups_in_order ||= SurveysQuestionGroup
+                                  .includes(rapidfire_question_group: :questions)
+                                  .where(survey_id: id)
+                                  .order(:position)
+                                  .map(&:rapidfire_question_group)
   end
 
   def questions_in_order
     @questions_in_order ||= question_groups_in_order.map do |question_group|
-      question_group.questions.order(:position)
+      question_group.questions.sort_by(&:position)
     end.to_a.flatten
   end
 


### PR DESCRIPTION
## What this PR does

This is just a very small change among the changes  i am making to the CSV download code in `Survey.rb`


## Where is the N+1 this fixes, and what do the N+1 queries look like

**a) Where is the N+1 this fixes**

![Where is the N+1 this Fixes](https://github.com/user-attachments/assets/ef908bfe-3426-4245-85a6-c886b51cf214)


**b) what do the N+1 queries look like**

![What do N+1 Query Looks like](https://github.com/user-attachments/assets/40f0662c-20de-4a0e-a60e-b33d4ef7a32a)


## Screenshots From rails log but only for the part of the code which causes N+1 

`Note: There is no difference this was just a cleanup/chore to clear up this N+1`

**Before**

![RAILS LOG BEFORE ONLY FOR THE N+1 CODE](https://github.com/user-attachments/assets/31e851ac-f085-4fae-9c6d-6d4d5d8b792f)


**After**

![RAILS LOG AFTER ONLY FOR THE N+1 CODE](https://github.com/user-attachments/assets/f336759d-5c17-41ec-9022-a650ced01e11)





## Screenshots

Before:


https://github.com/user-attachments/assets/76cd1848-2079-4d16-bc8d-2400dc261ba0



After:




https://github.com/user-attachments/assets/20b5e361-7e2c-4da3-9f94-172782d843a9

