### PR TITLE
Optimize response method by preloading and grouping Rapidfire answers csv Download (PART 3)

### DIFF
--- a/app/models/surveys/survey.rb
+++ b/app/models/surveys/survey.rb
@@ -93,11 +93,33 @@ class Survey < ApplicationRecord
     end
   end
 
-  def response(user)
+  def prepare_rapidfire_answers
+    @answers ||= begin
+      answer_group_ids = answer_groups_by_user_id.values.flatten.map(&:id)
+      question_ids = questions_with_separate_followups.map { |q| q[:question].id }
+
+      Rapidfire::Answer.where(
+        answer_group_id: answer_group_ids,
+        question_id: question_ids
+      )
+    end
+
+    @answers_by_group_and_question ||= @answers.group_by do |answer|
+      [answer.answer_group_id, answer.question_id]
+    end
+  end
+
+  def response(user) # rubocop:disable Metrics/CyclomaticComplexity
     answer_group_ids = answer_groups_by_user_id[user.id].map(&:id)
+    prepare_rapidfire_answers
+
     questions_with_separate_followups.map do |question_hash|
-      answer = Rapidfire::Answer.where(answer_group_id: answer_group_ids,
-                                       question_id: question_hash[:question].id).first
+      question_id = question_hash[:question].id
+
+      answer = answer_group_ids.map do |group_id|
+        @answers_by_group_and_question[[group_id, question_id]]&.first
+      end.find(&:present?)
+
       question_hash[:followup] ? answer&.follow_up_answer_text : answer&.answer_text
     end
   end

--- a/app/models/surveys/survey.rb
+++ b/app/models/surveys/survey.rb
@@ -109,6 +109,11 @@ class Survey < ApplicationRecord
     end
   end
 
+  # This method is intended to be called only through `to_csv`.
+  # It relies on `prepare_rapidfire_answers`, which loads data for all respondents
+  # ahead of time. Calling `response` independently will not work correctly, as it
+  # assumes that this data is already loaded. Do not use this method outside of the
+  # `to_csv` flow.
   def response(user) # rubocop:disable Metrics/CyclomaticComplexity
     answer_group_ids = answer_groups_by_user_id[user.id].map(&:id)
     prepare_rapidfire_answers


### PR DESCRIPTION
This PR is dependent on  #6360 (merged) and  #6361(merged)

## What this PR does

This PR improves the `response` method performance by introducing an answer preloading mechanism via the `prepare_rapidfire_answers` method.

### Key Improvements:

* **Bulk preloading:** Answers are fetched in a single query using pre-collected `answer_group_ids` and `question_ids`.
* **Grouped access:** Answers are grouped by `[answer_group_id, question_id]` to avoid lookup overhead during iteration.
* **N+1 elimination:** Removes per-question, per-user database queries from the response generation loop.


Previously, every call to `response(user)` would issue multiple `Answer.where` calls — one for each question per user. This update consolidates those into a single query and enables fast in-memory access, greatly improving performance on views or reports involving many users.


## Where is the N+1 this fixes, and what do the N+1 queries look like


**a) Where is the N+1 this fixes**



![Screenshot from 2025-06-16 17-13-11](https://github.com/user-attachments/assets/ca41fa14-aa11-435c-b004-c5b41f2b1c23)



**b) what do the N+1 queries look like**

![Screenshot from 2025-06-16 16-41-47](https://github.com/user-attachments/assets/1e53f363-7c4e-4633-861d-8074525e7694)


## Screenshots from rails log for CSV Download

**Before:**

![Before Logs](https://github.com/user-attachments/assets/8f5dc507-2fee-40f8-833d-fb0368582305)


**After:** 

![After Logs](https://github.com/user-attachments/assets/cb93cc69-1ce9-4a2a-95c8-fa435794275e)


## Screenshots

**Before:**



https://github.com/user-attachments/assets/5c44eb5e-8cdc-478a-8854-7dd5836d1bc4



**After:**


https://github.com/user-attachments/assets/65250489-29ab-4ef3-a966-c63ffa8d6606



