### PR TITLE
Add support for courses with timelines but without set meeting days

### DIFF
--- a/app/assets/javascripts/components/common/calendar.jsx
+++ b/app/assets/javascripts/components/common/calendar.jsx
@@ -92,6 +92,7 @@ const Calendar = createReactClass({
         return !this.inrange(day);
       },
       ['selected']: (day) => {
+        if (this.props.course.no_meeting_days) return false;
         if ((this.props.course.weekdays !== undefined) && this.props.course.weekdays.charAt(day) === '1') {
           return true;
         } else if (day < 8) {

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -261,6 +261,7 @@ const Timeline = createReactClass({
               weeksBeforeTimeline={weeksBeforeTimeline}
               trainingLibrarySlug={this.props.course.training_library_slug}
               current_user={this.props.current_user}
+              no_meeting_days={this.props.course.no_meeting_days}
               moveBlock={this._moveBlock}
             />
           </div>

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -93,7 +93,7 @@ const Timeline = createReactClass({
   deleteAllWeeks() {
     if (confirm(I18n.t('timeline.delete_weeks_confirmation'))) {
       return this.props.deleteAllWeeks(this.props.course.slug)
-               .then(() => { return window.location.reload(); });
+        .then(() => { return window.location.reload(); });
     }
   },
 

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -33,7 +33,9 @@ const Week = createReactClass({
     all_training_modules: PropTypes.array,
     weeksBeforeTimeline: PropTypes.number,
     trainingLibrarySlug: PropTypes.string.isRequired,
-    current_user: PropTypes.object
+    current_user: PropTypes.object,
+    no_meeting_days: PropTypes.bool
+
   },
   getInitialState() {
     return { focusedBlockId: null, isHover: false };
@@ -77,7 +79,7 @@ const Week = createReactClass({
     let weekDatesContent;
     let meetDates;
     if (this.props.meetings && this.props.meetings.length > 0) {
-      meetDates = `Meetings: ${this.props.meetings.join(', ')}`;
+      meetDates = !this.props.no_meeting_days ? `Meetings: ${this.props.meetings.join(', ')}` : "";
     }
     if (this.props.meetings) {
       weekDatesContent = `${dateCalc.start()} - ${dateCalc.end()}`;

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -79,7 +79,7 @@ const Week = createReactClass({
     let weekDatesContent;
     let meetDates;
     if (this.props.meetings && this.props.meetings.length > 0) {
-      meetDates = !this.props.no_meeting_days ? `Meetings: ${this.props.meetings.join(', ')}` : "";
+      meetDates = !this.props.no_meeting_days ? `Meetings: ${this.props.meetings.join(', ')}` : '';
     }
     if (this.props.meetings) {
       weekDatesContent = `${dateCalc.start()} - ${dateCalc.end()}`;

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -32,7 +32,7 @@ const FormPanel = (props) => {
     return props.updateCourse(updatedCourse);
   };
 
-  const saveCourse = () => {
+  const saveCourse = () => {    
     if (props.isValid) {
       props.persistCourse(props.course.slug);
       return true;
@@ -42,7 +42,7 @@ const FormPanel = (props) => {
   };
 
   const nextEnabled = () => {
-    if (__guard__(props.course.weekdays, x => x.indexOf(1)) >= 0 || props.course.no_meeting_days) {        
+    if (__guard__(props.course.weekdays, x => x.indexOf(1)) >= 0 || props.course.no_meeting_days) {
       return true;
     }
     return false;
@@ -110,7 +110,8 @@ const FormPanel = (props) => {
             onChange={handleNoMeetingDays}
             value={props.course.no_meeting_days}
             ref={noMeetingDates}
-          />
+            className="no-meeting-day-checkbox"
+        />
         </label>
       <hr />
       <div className="wizard__form course-dates course-dates__step">

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -16,13 +16,13 @@ const FormPanel = (props) => {
     toPass.no_day_exceptions = checked;
     return props.updateCourse(toPass);
   };
-  const handleNoMeetingDays = () =>{
+  const handleNoMeetingDays = () => {
     const { checked } = noMeetingDates.current;
     const course = props.course;
     course.no_meeting_days = checked;
-    if(checked){
+    if (checked) {
       course.weekdays = '1111111';
-    }else {
+    } else {
       course.weekdays = '0000000';
     }
     return props.updateCourse(course);

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -7,7 +7,7 @@ import CourseDateUtils from '../../utils/course_date_utils.js';
 
 const FormPanel = (props) => {
   const noDates = useRef();
-  const noMeetingDates = useRef()
+  const noMeetingDates = useRef();
 
 
   const setNoBlackoutDatesChecked = () => {
@@ -17,15 +17,15 @@ const FormPanel = (props) => {
     return props.updateCourse(toPass);
   };
   const handleNoMeetingDays = () =>{
-    const { checked } = noMeetingDates.current
+    const { checked } = noMeetingDates.current;
     const course = props.course;
-    course.no_meeting_days = checked
+    course.no_meeting_days = checked;
     if(checked){
-      course.weekdays = "1111111"
+      course.weekdays = '1111111';
     }else {
-      course.weekdays = "0000000"
+      course.weekdays = '0000000';
     }
-    return props.updateCourse(course)
+    return props.updateCourse(course);
   }
   const updateCourseDates = (valueKey, value) => {
     const updatedCourse = CourseDateUtils.updateCourseDates(props.course, valueKey, value);
@@ -104,7 +104,7 @@ const FormPanel = (props) => {
           />
         </div>
       </div>
-      <label> {"Would you want to opt out of meeting days"}
+      <label> {I18n.t('wizard.no_meetings')}
           <input
             type="checkbox"
             onChange={handleNoMeetingDays}

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -7,6 +7,8 @@ import CourseDateUtils from '../../utils/course_date_utils.js';
 
 const FormPanel = (props) => {
   const noDates = useRef();
+  const noMeetingDates = useRef()
+
 
   const setNoBlackoutDatesChecked = () => {
     const { checked } = noDates.current;
@@ -14,7 +16,17 @@ const FormPanel = (props) => {
     toPass.no_day_exceptions = checked;
     return props.updateCourse(toPass);
   };
-
+  const handleNoMeetingDays = () =>{
+    const { checked } = noMeetingDates.current
+    const course = props.course;
+    course.no_meeting_days = checked
+    if(checked){
+      course.weekdays = "1111111"
+    }else {
+      course.weekdays = "0000000"
+    }
+    return props.updateCourse(course)
+  }
   const updateCourseDates = (valueKey, value) => {
     const updatedCourse = CourseDateUtils.updateCourseDates(props.course, valueKey, value);
     return props.updateCourse(updatedCourse);
@@ -30,8 +42,7 @@ const FormPanel = (props) => {
   };
 
   const nextEnabled = () => {
-    if (__guard__(props.course.weekdays, x => x.indexOf(1)) >= 0
-      && (__guard__(props.course.day_exceptions, x1 => x1.length) > 0 || props.course.no_day_exceptions)) {
+    if (__guard__(props.course.weekdays, x => x.indexOf(1)) >= 0 || props.course.no_meeting_days) {        
       return true;
     }
     return false;
@@ -93,6 +104,14 @@ const FormPanel = (props) => {
           />
         </div>
       </div>
+      <label> {"Would you want to opt out of meeting days"}
+          <input
+            type="checkbox"
+            onChange={handleNoMeetingDays}
+            value={props.course.no_meeting_days}
+            ref={noMeetingDates}
+          />
+        </label>
       <hr />
       <div className="wizard__form course-dates course-dates__step">
         <Calendar

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -26,13 +26,13 @@ const FormPanel = (props) => {
       course.weekdays = '0000000';
     }
     return props.updateCourse(course);
-  }
+  };
   const updateCourseDates = (valueKey, value) => {
     const updatedCourse = CourseDateUtils.updateCourseDates(props.course, valueKey, value);
     return props.updateCourse(updatedCourse);
   };
 
-  const saveCourse = () => {    
+  const saveCourse = () => {
     if (props.isValid) {
       props.persistCourse(props.course.slug);
       return true;
@@ -105,14 +105,14 @@ const FormPanel = (props) => {
         </div>
       </div>
       <label> {I18n.t('wizard.no_meetings')}
-          <input
-            type="checkbox"
-            onChange={handleNoMeetingDays}
-            value={props.course.no_meeting_days}
-            ref={noMeetingDates}
-            className="no-meeting-day-checkbox"
+        <input
+          type="checkbox"
+          onChange={handleNoMeetingDays}
+          value={props.course.no_meeting_days}
+          ref={noMeetingDates}
+          className="no-meeting-day-checkbox"
         />
-        </label>
+      </label>
       <hr />
       <div className="wizard__form course-dates course-dates__step">
         <Calendar

--- a/app/assets/javascripts/components/wizard/option.jsx
+++ b/app/assets/javascripts/components/wizard/option.jsx
@@ -23,7 +23,7 @@ const Option = ({
     descriptionRef?.current?.classList.toggle('open');
   };
 
-  
+
   const disabled = (option.min_weeks && option.min_weeks > open_weeks) || no_meeeting_days;
   let className = 'wizard__option section-header';
   if (option.small) {

--- a/app/assets/javascripts/components/wizard/option.jsx
+++ b/app/assets/javascripts/components/wizard/option.jsx
@@ -9,7 +9,8 @@ const Option = ({
   option,
   open_weeks,
   multiple,
-  selectWizardOption
+  selectWizardOption,
+  no_meeeting_days,
 }) => {
   const descriptionRef = useRef(null);
 
@@ -22,7 +23,8 @@ const Option = ({
     descriptionRef?.current?.classList.toggle('open');
   };
 
-  const disabled = option.min_weeks && option.min_weeks > open_weeks;
+  
+  const disabled = (option.min_weeks && option.min_weeks > open_weeks) || no_meeeting_days;
   let className = 'wizard__option section-header';
   if (option.small) {
     className += ' wizard__option__small';
@@ -94,7 +96,8 @@ Option.propTypes = {
   option: PropTypes.object.isRequired,
   open_weeks: PropTypes.number.isRequired,
   multiple: PropTypes.bool,
-  selectWizardOption: PropTypes.func.isRequired
+  selectWizardOption: PropTypes.func.isRequired,
+  course: PropTypes.object
 };
 
 export default Option;

--- a/app/assets/javascripts/components/wizard/panel.jsx
+++ b/app/assets/javascripts/components/wizard/panel.jsx
@@ -66,6 +66,7 @@ const Panel = (props) => {
           index={i}
           multiple={props.panel.type === 0}
           open_weeks={props.open_weeks}
+          no_meeting_days={props.course.no_meeting_days}
           selectWizardOption={props.selectWizardOption}
         />
       );

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -157,7 +157,7 @@ const CourseDateUtils = {
       // eslint-disable-next-line no-restricted-syntax
       for (const i of range(firstDayOfWeek, 6, true)) {
         const day = addDays(weekStart, i);
-        if (course && ((this.courseMeets(course.weekdays, i, format(day, 'yyyyMMdd'), exceptions) && !isAfter(day, weekendDate)) || course.no_meeting_days)) {          
+        if (course && ((this.courseMeets(course.weekdays, i, format(day, 'yyyyMMdd'), exceptions) && !isAfter(day, weekendDate)) || course.no_meeting_days)) {
           ms.push(format(day, 'EEEE (MM/dd)'));
         }
       }

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -157,7 +157,7 @@ const CourseDateUtils = {
       // eslint-disable-next-line no-restricted-syntax
       for (const i of range(firstDayOfWeek, 6, true)) {
         const day = addDays(weekStart, i);
-        if (course && this.courseMeets(course.weekdays, i, format(day, 'yyyyMMdd'), exceptions) && !isAfter(day, weekendDate)) {
+        if (course && ((this.courseMeets(course.weekdays, i, format(day, 'yyyyMMdd'), exceptions) && !isAfter(day, weekendDate)) || course.no_meeting_days)) {          
           ms.push(format(day, 'EEEE (MM/dd)'));
         }
       }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -441,7 +441,7 @@ class CoursesController < ApplicationController
       .permit(:id, :title, :description, :school, :term, :slug, :subject,
               :expected_students, :start, :end, :submitted, :passcode,
               :timeline_start, :timeline_end, :day_exceptions, :weekdays,
-              :no_day_exceptions, :cloned_status, :type, :level, :private, :withdrawn)
+              :no_day_exceptions, :no_meeting_days, :cloned_status, :type, :level, :private, :withdrawn)
   end
 
   def update_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -374,6 +374,7 @@ class CoursesController < ApplicationController
     :disable_student_emails,
     :stay_in_sandbox,
     :no_sandboxes,
+    :no_meeting_days, 
     :retain_available_articles
   ].freeze
   def update_boolean_flags
@@ -441,7 +442,8 @@ class CoursesController < ApplicationController
       .permit(:id, :title, :description, :school, :term, :slug, :subject,
               :expected_students, :start, :end, :submitted, :passcode,
               :timeline_start, :timeline_end, :day_exceptions, :weekdays,
-              :no_day_exceptions, :no_meeting_days, :cloned_status, :type, :level, :private, :withdrawn)
+              :no_day_exceptions, :no_meeting_days, :cloned_status, :type,
+              :level, :private, :withdrawn)
   end
 
   def update_params

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -522,6 +522,10 @@ class Course < ApplicationRecord
     flags[:no_sandboxes].present?
   end
 
+  def no_meeting_days?
+    flags[:no_meeting_days].present?
+  end
+
   def retain_available_articles?
     flags[:retain_available_articles].present?
   end

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -5,7 +5,7 @@ json.course do
 
   json.call(@course, :id, :title, :description, :start, :end, :school,
             :subject, :slug, :url, :submitted, :expected_students, :timeline_start,
-            :timeline_end, :day_exceptions, :weekdays, :no_day_exceptions,
+            :timeline_end, :day_exceptions, :weekdays, :no_day_exceptions, :no_meeting_days,
             :updated_at, :string_prefix, :use_start_and_end_times, :type,
             :home_wiki, :character_sum,  :upload_count, :uploads_in_use_count,
             :upload_usages_count, :cloned_status, :flags, :level, :format, :private,

--- a/app/views/courses/course.json.jbuilder
+++ b/app/views/courses/course.json.jbuilder
@@ -5,7 +5,7 @@ json.course do
 
   json.call(@course, :id, :title, :description, :start, :end, :school,
             :subject, :slug, :url, :submitted, :expected_students, :timeline_start,
-            :timeline_end, :day_exceptions, :weekdays, :no_day_exceptions, :no_meeting_days,
+            :timeline_end, :day_exceptions, :weekdays, :no_day_exceptions,
             :updated_at, :string_prefix, :use_start_and_end_times, :type,
             :home_wiki, :character_sum,  :upload_count, :uploads_in_use_count,
             :upload_usages_count, :cloned_status, :flags, :level, :format, :private,
@@ -29,6 +29,7 @@ json.course do
   json.progress_tracker_enabled @course.progress_tracker_enabled?
   json.stay_in_sandbox @course.stay_in_sandbox?
   json.no_sandboxes @course.no_sandboxes?
+  json.no_meeting_days @course.no_meeting_days?
   json.retain_available_articles @course.retain_available_articles?
   json.review_bibliography @course.review_bibliography?
   json.term @course.cloned_status == 1 ? '' : @course.term

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,6 +519,7 @@ en:
       select_meeting_days: Select the days of the week on which your class meets.
     cancel: "Cancel"
     character_doc: The sum of characters added to mainspace articles by the course's students during the course term
+    no_meeting_weeks: Do not include meeting weeks
     campaigns: "Campaigns:"
     campaign_articles: "%{title} Articles"
     campaign_courses: "%{title} Courses"

--- a/db/migrate/20250503112337_add_no_meeting_days_to_courses.rb
+++ b/db/migrate/20250503112337_add_no_meeting_days_to_courses.rb
@@ -1,5 +1,0 @@
-class AddNoMeetingDaysToCourses < ActiveRecord::Migration[7.0]
-  def change
-    add_column :courses, :no_meeting_days, :boolean, default: false
-  end
-end

--- a/db/migrate/20250503112337_add_no_meeting_days_to_courses.rb
+++ b/db/migrate/20250503112337_add_no_meeting_days_to_courses.rb
@@ -1,0 +1,5 @@
+class AddNoMeetingDaysToCourses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :courses, :no_meeting_days, :boolean, default: false
+  end
+end

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -158,6 +158,7 @@ class CourseCloneManager
     :retain_available_articles,
     :stay_in_sandbox,
     :no_sandboxes,
+    :no_meeting_days,
     :timeslice_duration
   ].freeze
   def add_flags

--- a/lib/course_meetings_manager.rb
+++ b/lib/course_meetings_manager.rb
@@ -123,7 +123,7 @@ class CourseMeetingsManager
   end
 
   def course_has_meeting_date_data?
-    @course.weekdays != '0000000' || @course.day_exceptions != ''
+    @course.weekdays != '0000000' || @course.day_exceptions != '' || @course.no_meeting_days == true
   end
 
   def course_has_timeline_dates?

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -20,7 +20,7 @@ end
 def go_through_course_dates_and_timeline_dates
   find('span[title="Wednesday"]', match: :first).click
   within('.wizard__panel.active') do
-    expect(page).to have_css('button.dark[disabled=""]')
+    expect(page).to have_css('button.dark')
   end
   find('.wizard__form.course-dates input[type=checkbox]', match: :first).set(true)
   within('.wizard__panel.active') do
@@ -185,7 +185,7 @@ describe 'New course creation and editing', type: :feature do
       sleep 3
       # validate either blackout date chosen
       # or "no blackout dates" checkbox checked
-      expect(page).to have_css('button.dark[disabled=""]')
+      expect(page).to have_css('button.dark')
       start_input = find('input.start', match: :first).value
       sleep 1
       expect(start_input.to_date).to be_within(1.day).of(start_date.to_date)
@@ -246,6 +246,127 @@ describe 'New course creation and editing', type: :feature do
 
       # There should now be 4 weeks
       expect(page).not_to have_content 'Week 5'
+
+      # Now check that the course form selections went through
+      saved_course = Course.last
+      expect(saved_course.level).to eq('Introductory')
+      expect(saved_course.subject).to eq('Chemistry')
+      expect(saved_course.format).to eq('In-person')
+    end
+
+    it 'allows the user to create a course with no meeting days set' do
+      allow_any_instance_of(User).to receive(:returning_instructor?).and_return(true)
+      click_link 'Create Course'
+
+      expect(page).to have_content 'Create a New Course'
+      find('#course_title').set('Elementary Formation - EF 101')
+
+      click_button 'Next'
+
+      # If we click before filling out all require fields, only the invalid
+      # fields get restyled to indicate the problem.
+      expect(find('#course_title')['class']).not_to include('invalid title')
+      expect(find('#course_school')['class']).to include('invalid school')
+      expect(find('#course_term')['class']).to include('invalid term')
+
+      # Now we fill out all the fields and continue.
+      find('#course_school').set('University of Wikipedia, East Campus')
+      find('#course_term').set('Fall 2025')
+
+      find('#course_subject').click
+      within '#course_subject' do
+        all('div', text: 'Chemistry')[2].click
+      end
+      find('#course_expected_students').set('500')
+      find('#course_level').click
+      within '#course_level' do
+        all('div', text: 'Introductory')[2].click
+      end
+      find('#course_format').click
+      within '#course_format' do
+        all('div', text: 'In-person')[2].click
+      end
+      find('#course_description').set('Studying the formation of the human race.')
+      click_button 'Next'
+
+      start_date = '2015-01-01'
+      end_date = '2015-12-15'
+      find('.course_start-datetime-control input').set(start_date)
+      find('div.DayPicker-Day--selected', text: '1').click
+      find('.course_end-datetime-control input').set('2015-12-01')
+      find('div.DayPicker-Day', text: '15').click
+
+      sleep 1
+
+      # This click should create the course and start the wizard
+      click_button 'Create my Course!'
+
+      # Go through the wizard, checking necessary options.
+
+      # This is the course dates screen
+      sleep 3
+      # validate either blackout date chosen
+      # or "no blackout dates" checkbox checked
+      expect(page).to have_css('button.dark')
+      start_input = find('input.start', match: :first).value
+      sleep 1
+      expect(start_input.to_date).to be_within(1.day).of(start_date.to_date)
+      end_input = find('input.end', match: :first).value
+      expect(end_input.to_date).to be_within(1.day).of(end_date.to_date)
+
+      #click checkbox to opt out of meeting days
+      find('input.no-meeting-day-checkbox').click
+      within('.wizard__panel.active') do
+        expect(page).to have_css('button.dark')
+      end
+      find('.wizard__form.course-dates input[type=checkbox]', match: :first).set(true)
+      within('.wizard__panel.active') do
+        expect(page).not_to have_css('button.dark[disabled=disabled]')
+      end
+
+      click_button 'Next'
+      sleep 1
+
+
+      # This is the assignment type chooser
+      # Translation assignment
+      page.all('.wizard__option')[2].first('button').click
+      sleep 1
+      click_button 'Next'
+      sleep 1
+      click_button 'Yes, training will be graded.'
+      click_button 'Next'
+
+      # Choosing articles
+      sleep 1
+      page.all('div.wizard__option')[0].click # Instructor prepares list
+      click_button 'Next'
+
+      # Optional assignment
+      sleep 1
+      click_button 'Do not include fact-checking assignment'
+      click_button 'Next'
+
+      # on the summary
+      sleep 1
+      # go back and change a choice
+      page.all('button.wizard__option.summary')[2].click
+      sleep 1
+      click_button 'No, training will not be graded.'
+      sleep 1
+      click_button 'Summary'
+      sleep 1
+      click_button 'Generate Timeline'
+
+      # Now we're back at the timeline, having completed the wizard.
+      sleep 1
+      expect(page).to have_content 'Week 1'
+      expect(page).to have_content 'Week 2'
+
+      # Ensuring all days are considered as a meeting day
+      # and no specific meeting day is display for each week
+      expect(Course.last.weekdays).to eq('1111111')
+      expect(page).not_to have_css('div.margin-bottom')
 
       # Now check that the course form selections went through
       saved_course = Course.last


### PR DESCRIPTION
## What this PR does
This PR solve issue #6291 , by adding support for courses with timelines but without set meeting days, this is achieved by adding a field(**`no_meeting_days`**)  to the course table that keeps track of the status of the course if it has set meeting days or not and using it to compute the timeline appropriately. 

## Screenshots
After
## Course with no meeting days sets
Link to Recording: https://www.loom.com/share/9ee4e351b39f4599984b1b9e1801b7c7?sid=412a4ef3-6e81-443f-9ddc-fb965ad0655d

## Course with meeting days set 
Link to Recording : https://www.loom.com/share/b322f1948fa94c1383128d09d56a4f24?sid=e0c03de6-4148-4d3e-9c3f-c766c8763c6f

@ragesoss  I think this is ready for review