### PR TITLE
Optimize admin course loading for P&E Homepage by conditionally eager-loading students only for Wiki Ed

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -40,7 +40,12 @@ class DashboardController < ApplicationController
 
     return unless current_user.admin?
     @submitted = Course.submitted_but_unapproved
-    @strictly_current = current_user.courses.strictly_current.includes(:students)
+    @strictly_current = if Features.wiki_ed?
+                          # Reduce number of queries to show ungreeted student count using includes(:students) # rubocop:disable Layout/LineLength
+                          current_user.courses.strictly_current.includes(:students)
+                        else
+                          current_user.courses.strictly_current
+                        end
   end
 
   def current_courses

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -55,6 +55,20 @@ describe DashboardController, type: :request do
         expect(assigns(:blog_posts)).to eq([])
       end
     end
+
+    context 'when Wiki Ed feature is disabled' do
+      before do
+        allow(Features).to receive(:wiki_ed?).and_return(false)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+        create(:courses_user, user_id: admin.id, course_id: course.id)
+      end
+
+      it 'does not eager-load students for strictly_current courses' do
+        get '/course_creator'
+        expect(assigns(:pres)).to be_a(DashboardPresenter)
+        expect(assigns(:pres).past.count).to eq(1)
+      end
+    end
   end
 
   describe '#my_account' do


### PR DESCRIPTION
## What this PR does

This PR refines the `set_admin_courses_if_admin` method to avoid eager loading student associations unless necessary.

- Prevents unnecessary eager loading when student associations aren't used.
- Improves performance for admin users in non-Wiki Ed contexts.
- Keeps code aligned with actual data needs based on feature flags.

### Before
`current_user.courses.strictly_current.includes(:students)` was always called for admin users, even when student data wasn’t needed.

### After
Student data is now eager-loaded **only** if `Features.wiki_ed?` is enabled. In other cases, we load only the courses, reducing database overhead.


## .includes(:students) was only using Wik Edu Dashboard and not by P&E as shown in the screenhot below of `_admin_courses.html.haml`

![Screenshot from 2025-06-17 17-51-40](https://github.com/user-attachments/assets/22e304f1-9478-4df1-bbca-90ebde727b13)


## Screenshots
**Before:**

![Before Rails includes](https://github.com/user-attachments/assets/e4297ef0-aa92-4de1-9b10-aaa217a864e1)

![Before](https://github.com/user-attachments/assets/eb0e4f23-49c3-49e8-845e-f14140873dfb)


**After:**

![After](https://github.com/user-attachments/assets/299cdcd7-c41f-4eb0-ac4e-c0e26efa5d55)


![After not using includes](https://github.com/user-attachments/assets/410e9afe-6e1f-43b4-a97f-8df7d807473c)
