### PR TITLE
Extract survey results logic into separate SurveyResultsController

### DIFF
--- a/app/controllers/survey_results_controller.rb
+++ b/app/controllers/survey_results_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SurveyResultsController < SurveysController
+  layout 'surveys'
+
+  before_action :set_survey
+  before_action :set_question_groups
+
+  def results
+    protect_confidentiality { return }
+    respond_to do |format|
+      format.html
+      format.csv do
+        filename = "#{@survey.name}-results#{Time.zone.today}.csv"
+        send_data @survey.to_csv, filename:
+      end
+    end
+  end
+
+  private
+
+  def set_question_groups
+    super
+    @survey_user_cache = {}
+  end
+end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -15,14 +15,12 @@ class SurveysController < ApplicationController
     destroy
     edit_question_groups
     course_select
-    results
   ]
   before_action :ensure_logged_in
   before_action :set_question_groups, only: %i[
     show
     edit
     edit_question_groups
-    results
   ]
   before_action :check_if_closed, only: [:show]
   before_action :set_notification, only: [:show]
@@ -39,17 +37,6 @@ class SurveysController < ApplicationController
 
   def results_index
     @surveys = Survey.all
-  end
-
-  def results
-    protect_confidentiality { return }
-    respond_to do |format|
-      format.html
-      format.csv do
-        filename = "#{@survey.name}-results#{Time.zone.today}.csv"
-        send_data @survey.to_csv, filename:
-      end
-    end
   end
 
   # GET /surveys/1
@@ -155,7 +142,6 @@ class SurveysController < ApplicationController
   def set_question_groups
     @question_groups = Rapidfire::QuestionGroup.all
     @surveys_question_groups = SurveysQuestionGroup.by_position(params[:id])
-    @survey_user_cache = {}
   end
 
   # This removes the question groups that do not apply to the course, because

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -406,7 +406,7 @@ Rails.application.routes.draw do
   resources :survey_assignments, path: 'surveys/assignments'
   post '/survey_assignments/:id/send_test_email' => 'survey_assignments#send_test_email', as: 'send_test_email'
   put '/surveys/question_position' => 'questions#update_position'
-  get '/survey/results/:id' => 'surveys#results', as: 'survey_results'
+  get '/survey/results/:id' => 'survey_results#results', as: 'survey_results'
   get '/survey/question/results/:id' => 'questions#results', as: 'question_results'
   get '/surveys/question_group_question/:id' => 'questions#question'
   get '/surveys/:id/question_group' => 'surveys#edit_question_groups', :as => "edit_question_groups"


### PR DESCRIPTION
## What this PR does

This PR introduces a refactor that moves the `results` action from `SurveysController` into a new `SurveyResultsController`. The goal is to isolate logic related to survey results, reducing complexity in the main controller and setting the stage for further enhancements (performance improvements #6329).


## Screenshots

Before:



https://github.com/user-attachments/assets/ccf741aa-060d-4ef8-a61c-8eabdab8d57f



After:



https://github.com/user-attachments/assets/840a8f38-7948-492a-9e02-fc1c6e1670cc


