### PR TITLE
Chore: Fix minor N+1 in combined_wikidata_stats method

### DIFF
--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -177,8 +177,8 @@ class CoursesPresenter
   end
 
   def combined_wikidata_stats
-    @stats ||= courses.joins(:course_stat).where.not(course_stats: nil).filter_map do |course|
-      course.course_stat.stats_hash['www.wikidata.org']
+    @stats ||= courses.includes(:course_stat).where.not(course_stats: nil).filter_map do |course|
+      course.course_stat&.stats_hash&.[]('www.wikidata.org')
     end
 
     { 'www.wikidata.org' => @stats.inject { |a, b| a.merge(b) { |_, x, y| x + y } } }


### PR DESCRIPTION
## What this PR does

Fix minor N+1 in `combined_wikidata_stats` method  of  `course_presenter`

## Where is the N+1 this fixes, and what do the N+1 queries look like

a) **Where is the N+1 this fixes**

![Screenshot from 2025-06-18 19-48-53](https://github.com/user-attachments/assets/582a8202-a1d8-4b64-aed7-7b6d6a42b320)


b) **what do the N+1 queries look like**

![Screenshot from 2025-06-18 19-47-16](https://github.com/user-attachments/assets/7ca02b9d-17ea-4b70-830e-91d8b5b75a2a)


## Screenshots

Before:


https://github.com/user-attachments/assets/f802dc82-bf1d-45f3-b2b4-e521fcb242f7



![Before](https://github.com/user-attachments/assets/5c73b9bd-d151-4926-9c14-747a9db62ec7)


After:

![After 2](https://github.com/user-attachments/assets/d2efc799-02c1-422b-ab1c-5f0016bd4747)



https://github.com/user-attachments/assets/ffca1a11-adcf-478e-b7ae-ef51587a4325

