### PR TITLE
Minor: Refactor training_modules method to improve query performance

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -305,7 +305,7 @@ class Course < ApplicationRecord
   end
 
   def training_modules
-    @training_modules ||= TrainingModule.all.select { |tm| training_module_ids.include?(tm.id) }
+    @training_modules ||= TrainingModule.where(id: training_module_ids)
   end
 
   def training_module_ids


### PR DESCRIPTION
## What this PR does

Refactored the `training_modules` method to use `TrainingModule.where(id: @training_module_ids)` instead of selecting from all records.

This change improves performance by querying the database directly rather than loading all records into memory and filtering in Ruby. It also aligns with best practices for using ActiveRecord efficiently.


## Screenshots

Before:


https://github.com/user-attachments/assets/359c60f5-c11e-4c4d-a88e-76fa89fd204d



After:


https://github.com/user-attachments/assets/f52fd503-55ae-4d22-ab51-70a956b24deb


