### PR TITLE
Optimize survey results data loading (PART 1): Enrich answers with user and course data while eliminating N+1 queries

### DIFF
--- a/app/controllers/survey_results_controller.rb
+++ b/app/controllers/survey_results_controller.rb
@@ -16,11 +16,4 @@ class SurveyResultsController < SurveysController
       end
     end
   end
-
-  private
-
-  def set_question_groups
-    super
-    @survey_user_cache = {}
-  end
 end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -93,9 +93,9 @@ module SurveysHelper
     includes_options = is_results_view ? { answers: :user } : :answers
 
     @questions = surveys_question_group
-                  .rapidfire_question_group
-                  .questions
-                  .includes(includes_options)
+                 .rapidfire_question_group
+                 .questions
+                 .includes(includes_options)
 
     @id_to_question = {}
     @questions.each do |question|

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -83,7 +83,7 @@ module SurveysHelper
     answer.question.validation_rules[:grouped_question]
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength,Lint/MissingCopEnableDirective
   def question_group_locals(surveys_question_group, index, total, is_results_view:)
     @question_group = surveys_question_group.rapidfire_question_group
     @answer_group_builder = Rapidfire::AnswerGroupBuilder.new(params: {},

--- a/app/models/surveys/survey_notification.rb
+++ b/app/models/surveys/survey_notification.rb
@@ -18,7 +18,7 @@
 #
 
 class SurveyNotification < ApplicationRecord
-  belongs_to :courses_user, class_name: 'CoursesUsers'
+  belongs_to :courses_user, class_name: 'CoursesUsers', foreign_key: 'courses_users_id'
   belongs_to :survey_assignment
   belongs_to :course
 

--- a/app/views/surveys/_question_group.html.haml
+++ b/app/views/surveys/_question_group.html.haml
@@ -35,7 +35,7 @@
 
           - if results
             = render partial: "rapidfire/answers/question_text", locals: {f: answer_form, answer: answer}
-            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id], survey_user_cache: @survey_user_cache }
+            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id], users: @users_by_id  }
           - else
             = render_answer_form_helper(answer, answer_form)
 

--- a/app/views/surveys/_question_results.html.haml
+++ b/app/views/surveys/_question_results.html.haml
@@ -1,4 +1,4 @@
-%div{data: { question_results: question_results_data(question, survey_user_cache) }}
+%div{data: { question_results: question_results_data(question, users) }}
 .results__question-footer
   %strong= respondents(question, @question_answers_count)
   = link_to "Download Results CSV", question_results_path(question, format: 'csv')

--- a/app/views/surveys/results.html.haml
+++ b/app/views/surveys/results.html.haml
@@ -12,5 +12,5 @@
       %span Download Survey Results CSV
 
   .results
-    - @surveys_question_groups.includes(rapidfire_question_group: { questions: { answers: { answer_group: :user}}}).each_with_index do |group, index|
+    - @surveys_question_groups.includes(rapidfire_question_group: { questions: { answers: :answer_group }}).each_with_index do |group, index|
       = render partial: "question_group", locals: question_group_locals(group, index, @surveys_question_groups.length, is_results_view: true)


### PR DESCRIPTION
**Note: This is the first PR which breaks down #6329**

## What this PR does

This PR refactors how survey answers are processed and enriched in order to:
- Attach associated questions to each answer
- Collect and preload related users
- Dynamically attach each user's related course via `SurveyNotification`
- Preload associated `campaigns` and `tags` for each course
- Replace the legacy `survey_user_cache` approach

---

Previously, rendering answer-related data introduced **severe N+1 query problems**, including:

- One query per course to fetch `campaigns` and `tags`
- One query per user to retrieve completed `survey_notifications`
- Multiple queries per answer when calling `answer.course(@survey.id, user)`

This PR eliminates those N+1s by:
- Collecting user IDs in one pass
- Batch-loading users and their course info
- Eager-loading `campaigns` and `tags` with `.includes`
- Caching course information via a dynamically defined method: `user.survey_course`

---

- Added a new method: `enrich_answers_with_users_and_courses` in `SurveysHelper`
- Introduced helper methods:
  - `store_user_ids`
  - `store_users_by_id`
  - `user_survey_courses`
- Updated `question_group_locals` to invoke this enrichment process
- Updated `QuestionResultsHelper` and all relevant views to replace `survey_user_cache` with `@users_by_id`
- Removed now-unnecessary instance variables and logic in `SurveyResultsController` and `_question_results.html.haml`

---

This refactor prevents N+1 queries like:

- `SELECT * FROM courses WHERE id = ... LIMIT 1`
- `SELECT * FROM tags WHERE course_id = ...`
- `SELECT * FROM survey_notifications WHERE user_id = ...`
- `SELECT * FROM campaigns_courses WHERE course_id = ...`

All of these are now executed as **batch queries**, resulting in faster page loads and reduced DB load.


## Where is the N+1 this fixes, and what do the N+1 queries look like

**a) Where is the N+1 this fixes**

![Where is the N+1 this fixes](https://github.com/user-attachments/assets/0cf39b5c-8165-4ab2-856f-77763135f1a5)



**b) what do the N+1 queries look like**


https://github.com/user-attachments/assets/fe6253c8-8028-4317-bb90-6a6350096423



## Screenshots

Before:

![Before](https://github.com/user-attachments/assets/3595ebc6-5264-4120-9804-0899d1786c5f)



After:

![After](https://github.com/user-attachments/assets/9c3b92a3-9062-472f-a839-f4ac4e497c58)


