### PR TITLE
Optimize article deduplication with pluck and composite index

### DIFF
--- a/lib/duplicate_article_deleter.rb
+++ b/lib/duplicate_article_deleter.rb
@@ -34,9 +34,10 @@ class DuplicateArticleDeleter
   private
 
   def articles_grouped_by_title_and_namespace(articles)
-    articles ||= Article.where(deleted: false, wiki_id: @wiki.id)
-    titles = articles.map(&:title)
-    Article.where(title: titles, wiki_id: @wiki.id).group(%w[title namespace]).count
+    Article.where(namespace: articles.pluck(:namespace).uniq,
+                  title: articles.pluck(:title),
+                  wiki_id: @wiki.id)
+           .group(%w[title namespace]).count
   end
 
   def delete_duplicates_in(article_group)


### PR DESCRIPTION
## What this PR does

This refactor optimizes the `articles_grouped_by_title_and_namespace` method by:

* Replacing Ruby-level `map` calls with SQL `.pluck` for extracting `title` and `namespace` directly.
* Leveraging the existing composite index on `(namespace, wiki_id, title)` for faster lookups.



## Screenshots

Before:

![Screenshot from 2025-06-24 00-11-11](https://github.com/user-attachments/assets/9d96fa6f-af10-4661-a957-959c813a559c)


After:



![Screenshot from 2025-06-24 00-44-26](https://github.com/user-attachments/assets/28237f3c-4f7a-41e9-aa0b-7f7713ef4385)



