### PR TITLE
Don't use WikidataDiffAnalyzer for unscoped revisions

### DIFF
--- a/app/services/update_wikidata_stats_timeslice.rb
+++ b/app/services/update_wikidata_stats_timeslice.rb
@@ -80,6 +80,7 @@ class UpdateWikidataStatsTimeslice
     revision_ids = revisions.select(&:scoped).pluck(:mw_rev_id)
     analyzed_revisions = WikidataDiffAnalyzer.analyze(revision_ids)[:diffs]
     revisions.each do |revision|
+      next unless revision.scoped
       rev_id = revision.mw_rev_id
       individual_stat = analyzed_revisions[rev_id]
       serialized_stat = individual_stat.to_json

--- a/app/services/update_wikidata_stats_timeslice.rb
+++ b/app/services/update_wikidata_stats_timeslice.rb
@@ -76,7 +76,8 @@ class UpdateWikidataStatsTimeslice
   # the wikidata stats. wikidata-diff-analyzer gem is used to fetch the stats.
   # Returns the updated array.
   def update_revisions_with_stats(revisions)
-    revision_ids = revisions.pluck(:mw_rev_id)
+    # We will only use the diff stats for in-scope revisions, and this is very slow.
+    revision_ids = revisions.select(&:scoped).pluck(:mw_rev_id)
     analyzed_revisions = WikidataDiffAnalyzer.analyze(revision_ids)[:diffs]
     revisions.each do |revision|
       rev_id = revision.mw_rev_id

--- a/spec/services/update_wikidata_stats_timeslice_spec.rb
+++ b/spec/services/update_wikidata_stats_timeslice_spec.rb
@@ -9,9 +9,10 @@ describe UpdateWikidataStatsTimeslice do
       create(:course, start: Date.new(2022, 1, 5), end: Date.new(2022, 1, 7),
                       home_wiki: wikidata)
     end
-    let(:revision1) { create(:revision, wiki: wikidata, mw_rev_id: 1556860240) }
-    let(:revision2) { create(:revision, wiki: wikidata, mw_rev_id: 99682036) }
-    let(:revisions) { [revision1, revision2] }
+    let(:revision1) { create(:revision, wiki: wikidata, mw_rev_id: 1556860240, scoped: true) }
+    let(:revision2) { create(:revision, wiki: wikidata, mw_rev_id: 99682035, scoped: true) }
+    let(:unscoped_revision) { create(:revision, wiki: wikidata, mw_rev_id: 99682036) }
+    let(:revisions) { [revision1, revision2, unscoped_revision] }
     let(:updater) { described_class.new(course) }
 
     before do
@@ -23,9 +24,11 @@ describe UpdateWikidataStatsTimeslice do
         expect(rev.summary).to be_nil
       end
       updater.update_revisions_with_stats(revisions)
-      revisions.each do |rev|
-        expect(rev.summary).not_to be_nil
-      end
+      expect(revision1.summary).not_to be_nil
+      expect(revision1.summary).not_to eq('null')
+      expect(revision2.summary).not_to be_nil
+      expect(revision2.summary).not_to eq('null')
+      expect(unscoped_revision.summary).to be_nil
     end
 
     it 'creates record in CourseStat table', :vcr do


### PR DESCRIPTION
For ArticleScopedPrograms, this filters the revisions sent to WikidataDiffAnalyzer so that we only do the slow diff analysis for revisions that are in-scope.

For other program types, all revisions are in scope via `Course#filter_revisions`. For Wikidata programs like https://outreachdashboard.wmflabs.org/campaigns/coordinate_me_2025/programs (where users are making very large numbers of Wikidata edits but only a small fraction are in scope for a given program) this should dramatically reduce processing time.