### PR TITLE
Scope Article Lookup to Relevant Namespaces in HighQualityArticleMonitor

### DIFF
--- a/lib/alerts/high_quality_article_monitor.rb
+++ b/lib/alerts/high_quality_article_monitor.rb
@@ -51,7 +51,12 @@ class HighQualityArticleMonitor
   end
 
   def set_article_ids
-    @article_ids = Article.where(title: @page_titles, wiki_id: @wiki.id).pluck(:id)
+    # Restrict to relevant namespaces:
+    # - MAINSPACE (0): Good/Featured articles reside here
+    # - TALK (1): Included for completeness, though these categories typically apply to mainspace
+    # Helps ensure index-efficient lookups and avoids irrelevant matches
+    namespace = [Article::Namespaces::MAINSPACE, Article::Namespaces::TALK]
+    @article_ids = Article.where(namespace:, title: @page_titles, wiki_id: @wiki.id).pluck(:id)
   end
 
   def create_edit_alert(articles_course)


### PR DESCRIPTION
## What this PR does

Includes `Namspace` to fully ulitize composite index for articles DB table search.

For this the AR speed for both before and after are same but the number of rows it will have to go through and space it will consume  during search will be very less as explained in PR #6379

## Screenshots

Before:

![Screenshot from 2025-06-25 22-16-40](https://github.com/user-attachments/assets/f53a1f10-e850-4cc7-8dda-581e962faac7)



After:

![Screenshot from 2025-06-25 22-19-21](https://github.com/user-attachments/assets/4afa90b4-3f4e-49cf-98fe-6c4b0facd991)


