### PR TITLE
Optimize survey results data loading (PART 2): Refactor answer and answer group loading

### DIFF
--- a/app/helpers/question_results_helper.rb
+++ b/app/helpers/question_results_helper.rb
@@ -14,7 +14,7 @@ module QuestionResultsHelper
       question:,
       sentiment: question.track_sentiment ? question_answers_average_sentiment(processed_answers) : nil, # rubocop:disable Layout/LineLength
       answer_options: question.answer_options.split(Rapidfire.answers_delimiter),
-      answers: parse_answers(question),
+      answers: parse_answers(answers),
       answers_data: processed_answers,
       grouped_question: question.validation_rules[:question_question],
       follow_up_question_text: question.follow_up_question_text,
@@ -22,9 +22,13 @@ module QuestionResultsHelper
     }.to_json
   end
 
-  def parse_answers(question)
-    answers = question.answers.pluck(:answer_text).compact
-    answers.map { |a| a.split(Rapidfire.answers_delimiter) }.flatten
+  def parse_answers(answers)
+    return [] if answers.nil?
+
+    answers
+      .filter_map(&:answer_text)
+      .flat_map { |text| text.to_s.split(Rapidfire.answers_delimiter) }
+      .reject(&:blank?)
   end
 
   def question_answers(question, answers, id_to_answer_groups, users)

--- a/app/helpers/question_results_helper.rb
+++ b/app/helpers/question_results_helper.rb
@@ -7,18 +7,18 @@
 require 'sentimental'
 
 module QuestionResultsHelper
-  def question_results_data(question, users)
-    answers = question_answers(question, users)
+  def question_results_data(question, answers, id_to_answer_groups, users)
+    processed_answers = question_answers(question, answers, id_to_answer_groups, users)
     {
       type: question_type_to_string(question),
       question:,
-      sentiment: question.track_sentiment ? question_answers_average_sentiment(answers) : nil,
+      sentiment: question.track_sentiment ? question_answers_average_sentiment(processed_answers) : nil, # rubocop:disable Layout/LineLength
       answer_options: question.answer_options.split(Rapidfire.answers_delimiter),
       answers: parse_answers(question),
-      answers_data: answers,
+      answers_data: processed_answers,
       grouped_question: question.validation_rules[:question_question],
       follow_up_question_text: question.follow_up_question_text,
-      follow_up_answers: follow_up_answers(answers)
+      follow_up_answers: follow_up_answers(processed_answers)
     }.to_json
   end
 
@@ -27,12 +27,22 @@ module QuestionResultsHelper
     answers.map { |a| a.split(Rapidfire.answers_delimiter) }.flatten
   end
 
-  def question_answers(question, users)
-    question.answers.map do |answer|
-      user = users[answer.answer_group.user_id]
+  def question_answers(question, answers, id_to_answer_groups, users)
+    return [] unless answers
+
+    answers.map do |answer|
+      answer_group = id_to_answer_groups[answer.answer_group_id]
+      user = users[answer_group.user_id]
       course = user.respond_to?(:survey_course) ? user.survey_course : nil
-      { data: answer, user: answer.user, course:, campaigns: course&.campaigns,
-        tags: course&.tags, sentiment: calculate_sentiment(question, answer) }
+      {
+        data: { id: answer.id, answer_text: answer.answer_text,
+                follow_up_answer_text: answer.follow_up_answer_text },
+        user:,
+        course:,
+        campaigns: course&.campaigns,
+        tags: course&.tags,
+        sentiment: calculate_sentiment(question, answer)
+      }
     end
   end
 
@@ -47,7 +57,7 @@ module QuestionResultsHelper
   end
 
   def question_answers_average_sentiment(answers)
-    scores = answers.collect { |a| a[:sentiment][:score] }
+    scores = answers.filter_map { |a| a[:sentiment][:score] }
     average = 0
     average = scores.sum / scores.length unless scores.empty?
     label = 'negative'
@@ -76,10 +86,10 @@ module QuestionResultsHelper
 
   def follow_up_answers(answers)
     follow_ups = {}
-    answers.each do |answer|
+    answers&.each do |answer|
       answer_record = answer[:data]
-      next unless answer_record.follow_up_answer_text.present?
-      follow_ups[answer_record.id] = answer_record.follow_up_answer_text
+      next unless answer_record[:follow_up_answer_text].present?
+      follow_ups[answer_record[:id]] = answer_record[:follow_up_answer_text]
     end
 
     return follow_ups

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -90,23 +90,21 @@ module SurveysHelper
                                                               user: current_user,
                                                               question_group: @question_group)
 
-    includes_options = is_results_view ? { answers: :user } : :answers
-
     @questions = surveys_question_group
                  .rapidfire_question_group
                  .questions
-                 .includes(includes_options)
 
     @id_to_question = {}
     @questions.each do |question|
       @id_to_question[question.id] = question
     end
 
-    @question_answers_count = Rapidfire::Answer
-                              .where(question_id: @questions.pluck(:id))
-                              .group(:question_id).count
+    enrich_answers_with_question
 
-    enrich_answers_with_users_and_courses(is_results_view)
+    if is_results_view
+      load_and_prepare_question_answers
+      load_answer_group_and_user
+    end
 
     return { question_group: @question_group,
       answer_group_builder: @answer_group_builder,
@@ -116,29 +114,49 @@ module SurveysHelper
       results: is_results_view }
   end
 
-  def enrich_answers_with_users_and_courses(is_results_view)
-    @user_ids = Set.new # Initialize a Set to collect unique user IDs from answers
+  # Eager load answers with their groups, index them by question ID, and count per question.
+  def load_and_prepare_question_answers
+    # Used in QuestionResultsHelper#question_results_data via view: _question_group.html.haml
+    @rapidfire_answers_by_question_id = Hash.new { |h, k| h[k] = [] }
+    @question_answers_count = Hash.new(0) # Used in view: _question_results.html.haml
+    @all_rapidfire_answers = []
 
+    Rapidfire::Answer.includes(:answer_group)
+                     .where(question_id: @id_to_question.keys)
+                     .each do |answer|
+      @rapidfire_answers_by_question_id[answer.question_id] << answer
+      @question_answers_count[answer.question_id] += 1
+      @all_rapidfire_answers << answer
+    end
+  end
+
+  # Builds cache of unique answer groups and their associated users to avoid N+1 queries
+  def load_answer_group_and_user
+    seen_group_ids = Set.new
+    user_ids = Set.new
+    rapidfire_answer_groups = []
+
+    @all_rapidfire_answers.each do |answer|
+      group = answer.answer_group
+      next if seen_group_ids.include?(group.id)
+
+      seen_group_ids.add(group.id)
+      rapidfire_answer_groups << group
+      user_ids.add(group.user_id) if group.user_id
+    end
+
+    # Used in QuestionResultsHelper#question_results_data via view: _question_group.html.haml
+    @rapidfire_answer_groups_by_id = rapidfire_answer_groups.index_by(&:id)
+
+    # Used in QuestionResultsHelper#question_results_data via view: _question_group.html.haml
+    @users_by_id = User.where(id: user_ids.to_a).select(:id, :username).index_by(&:id)
+  end
+
+  def enrich_answers_with_question
     @answer_group_builder.answers.each do |answer|
       question = @id_to_question[answer.question_id]
       answer.question = question
-      if is_results_view
-        store_user_ids(question.answers.map(&:user)) # Collect user IDs from answers to later fetch user info # rubocop:disable Layout/LineLength
-      end
     end
-
-    return unless is_results_view
-
-    store_users_by_id # Fetch and store user records in a hash indexed by ID
-    user_survey_courses # Attach course data to each user via dynamic method
-  end
-
-  def store_user_ids(users)
-    users.each { |user| @user_ids.add(user.id) }
-  end
-
-  def store_users_by_id
-    @users_by_id = User.where(id: @user_ids.to_a).select(:id, :username).index_by(&:id)
   end
 
   # Attaches course data to users via dynamic method for easy access to course campaigns and tags

--- a/app/views/surveys/_question_group.html.haml
+++ b/app/views/surveys/_question_group.html.haml
@@ -35,7 +35,7 @@
 
           - if results
             = render partial: "rapidfire/answers/question_text", locals: {f: answer_form, answer: answer}
-            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id], users: @users_by_id  }
+            = render partial: "question_results", locals: { question: @id_to_question[answer.question.id], answers: @rapidfire_answers_by_question_id[answer.question.id], id_to_answer_groups: @rapidfire_answer_groups_by_id, users: @users_by_id  }
           - else
             = render_answer_form_helper(answer, answer_form)
 

--- a/app/views/surveys/_question_results.html.haml
+++ b/app/views/surveys/_question_results.html.haml
@@ -1,4 +1,4 @@
-%div{data: { question_results: question_results_data(question, users) }}
+%div{data: { question_results: question_results_data(question, answers, id_to_answer_groups, users) }}
 .results__question-footer
   %strong= respondents(question, @question_answers_count)
   = link_to "Download Results CSV", question_results_path(question, format: 'csv')

--- a/app/views/surveys/results.html.haml
+++ b/app/views/surveys/results.html.haml
@@ -12,5 +12,5 @@
       %span Download Survey Results CSV
 
   .results
-    - @surveys_question_groups.includes(rapidfire_question_group: { questions: { answers: :answer_group }}).each_with_index do |group, index|
+    - @surveys_question_groups.includes(rapidfire_question_group: :questions).each_with_index do |group, index|
       = render partial: "question_group", locals: question_group_locals(group, index, @surveys_question_groups.length, is_results_view: true)


### PR DESCRIPTION
**NOTE:**

This is the second PR which breaks down PR  #6329 into smaller PRs First PR was #6375

## What this PR does

Refactors how survey answers are loaded and processed to improve performance. The main focus is on loading  answers and the answer group they belong to at once,

- Reworked `question_results_data` to accept preloaded answers and answer group data
- Introduced `load_and_prepare_question_answers` and `load_answer_group_and_user` to handle eager-loading in `SurveysHelper`
- Modified `question_answers` of `QuestionResultsHelper` to return normalized data, reducing direct model coupling
- Used `filter_map` for sentiment score extraction to exclude nil values efficiently
- Refactor `parse_answers` of `QuestionResultsHelper` to use passed answers and improve null handling
- Updated HAML views to pass the new data structure (`answers`, and `id_to_answer_groups`)
- Removed unnecessary eager-loading of nested associations in `results.html.haml`

## Screenshots
Before:

**`Survey results view html`**

![Screenshot from 2025-06-26 01-35-23](https://github.com/user-attachments/assets/1822dd57-83b0-40d8-b046-6db4109b3e98)

**`Survey show view`**

![Screenshot from 2025-06-26 01-36-29](https://github.com/user-attachments/assets/84a2d374-cbaa-4d30-ba52-20b9890e6361)



After:

**`Survey results view html`**

![Screenshot from 2025-06-26 01-51-27](https://github.com/user-attachments/assets/2f7a4e0a-74fd-44d4-b8fe-9cb57b7aa654)

**`Survey show view`**

![Screenshot from 2025-06-26 01-37-11](https://github.com/user-attachments/assets/432179b9-b0c6-4e86-924a-08ec5c5f1a72)
