### PR TITLE
Optimize survey results data loading (PART 3 FINAL): streamline answer data processing and view queries

### DIFF
--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -90,9 +90,7 @@ module SurveysHelper
                                                               user: current_user,
                                                               question_group: @question_group)
 
-    @questions = surveys_question_group
-                 .rapidfire_question_group
-                 .questions
+    @questions = Rapidfire::Question.where(question_group_id: @question_group.id)
 
     @id_to_question = {}
     @questions.each do |question|

--- a/app/views/surveys/results.html.haml
+++ b/app/views/surveys/results.html.haml
@@ -12,5 +12,5 @@
       %span Download Survey Results CSV
 
   .results
-    - @surveys_question_groups.includes(rapidfire_question_group: :questions).each_with_index do |group, index|
+    - @surveys_question_groups.includes(:rapidfire_question_group).each_with_index do |group, index|
       = render partial: "question_group", locals: question_group_locals(group, index, @surveys_question_groups.length, is_results_view: true)


### PR DESCRIPTION
**NOTE:**

This is the second PR which breaks down PR #6329 into smaller PRs First and Second  PR was #6375, #6383

## What this PR does


This PR continues the optimization of survey results data loading. Key improvements include:

*  **Conditional Data Building**: Introduced `prepare_answers_data` to avoid processing answers unless required (e.g., sentiment, specific question types, follow-ups).
*  **New Helper Methods**: Added `check_question_type?` and `follow_ups?` for clearer logic separation and reuse.
*  **Database Query Optimization**: Replaced `surveys_question_group.rapidfire_question_group.questions` with a direct query to `Rapidfire::Question` to minimize memory usage.
*  **View Efficiency**: Streamlined `includes` in `results.html.haml` to reduce overhead during view rendering.



## Screenshots
Before:

![Screenshot from 2025-06-26 18-16-54](https://github.com/user-attachments/assets/5f28395f-06b1-46e8-862b-ed057911ee61)


After:

![Screenshot from 2025-06-26 18-15-08](https://github.com/user-attachments/assets/3cdd2597-76c1-413c-b68c-73fa0a0f370b)


