### PR TITLE
Minor Chore: Refactor survey question results components for cleaner props and conditional rendering

### DIFF
--- a/app/assets/javascripts/surveys/components/BarGraph.jsx
+++ b/app/assets/javascripts/surveys/components/BarGraph.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { answerTotals } from './utils';
 
-const BarGraph = (props) => {
-  const answers = answerTotals(props);
-  const totalAnswers = props.answers.length;
+const BarGraph = ({ answers, answer_options }) => {
+  const optionCounts = answerTotals(answers, answer_options);
+  const totalAnswers = answers.length;
 
   return (
     <div className="results__bar-graph">
-      {keys(answers).map((key) => {
-        const total = answers[key];
+      {keys(optionCounts).map((key) => {
+        const total = optionCounts[key];
         const width = ((total / totalAnswers) * 100).toFixed(2);
         const nullWidth = isNaN(width);
         const widthPercent = nullWidth ? '0%' : `${width}%`;

--- a/app/assets/javascripts/surveys/components/FollowUpQuestionResults.jsx
+++ b/app/assets/javascripts/surveys/components/FollowUpQuestionResults.jsx
@@ -3,10 +3,6 @@ import PropTypes from 'prop-types';
 import TextResults from './TextResults.jsx';
 
 const FollowUpQuestionResults = (props) => {
-  const answerCount = Object.keys(props.follow_up_answers).length;
-  if (answerCount === 0) {
-    return null;
-  }
   return (
     <div>
       <h4>Follow Up Question</h4>

--- a/app/assets/javascripts/surveys/components/QuestionResults.jsx
+++ b/app/assets/javascripts/surveys/components/QuestionResults.jsx
@@ -11,12 +11,19 @@ const QuestionResults = (props) => {
       case 'radio':
       case 'checkbox':
       case 'select':
-        return <BarGraph {...question} />;
+        return <BarGraph answer_options = {question.answer_options} answers = {question.answers} />;
       case 'rangeinput':
-        return <RangeGraph {...question} />;
+        return <RangeGraph question = {question.question} answers = {question.answers} />;
       case 'text':
       case 'long':
-        return <TextResults {...question} />;
+        return (
+          <TextResults
+            answers_data={question.answers_data}
+            follow_up_answers={question.follow_up_answers}
+            sentiment={question.sentiment}
+            question={question.question}
+          />
+        );
       default:
         return null;
     }
@@ -25,7 +32,7 @@ const QuestionResults = (props) => {
   return (
     <div>
       {_renderQuestionResults(props)}
-      <FollowUpQuestionResults {...props} />
+      { Object.keys(props.follow_up_answers).length && <FollowUpQuestionResults {...props} /> }
     </div>
   );
 };

--- a/app/assets/javascripts/surveys/components/utils.js
+++ b/app/assets/javascripts/surveys/components/utils.js
@@ -1,8 +1,8 @@
-export function answerTotals(question) {
+export function answerTotals(answers, answer_options) {
   const optionTotals = {};
-  question.answer_options.forEach((option) => {
+  answer_options.forEach((option) => {
     let count = 0;
-    question.answers.forEach((answer) => {
+    answers.forEach((answer) => {
       if (option === answer) {
         count += 1;
       }


### PR DESCRIPTION
## What this PR does

Cleans up and strengthens the React component architecture for rendering survey question results:

* **Improved Prop Contracts**: Refactored components like `BarGraph`, `RangeGraph`, and `TextResults` to accept only the props they use, avoiding `...question` spreading.
* **Utility Clarity**: `answerTotals` now works directly with `answers` and `answer_options`, reducing dependency on shape assumptions.
* **Conditional Rendering Fixes**: Prevented unnecessary rendering of `FollowUpQuestionResults` when no answers are present.



## Screenshots

Before:

![Screenshot from 2025-06-26 18-57-41](https://github.com/user-attachments/assets/c3cceee1-3ef8-4456-aa81-b0d85579d1f6)



After:

![Screenshot from 2025-06-26 18-55-52](https://github.com/user-attachments/assets/b12102fc-5b71-482f-bb26-24e0b83087a4)
