### PR TITLE
Set timeout for petscan requests manually as some of them take long time to resolve

### DIFF
--- a/lib/petscan_api.rb
+++ b/lib/petscan_api.rb
@@ -47,8 +47,7 @@ class PetScanApi
     conn
   end
 
-  TYPICAL_ERRORS = [Faraday::TimeoutError,
-                    Errno::EHOSTUNREACH].freeze
+  TYPICAL_ERRORS = [Errno::EHOSTUNREACH].freeze
 
   # The petscan request may take more than default timeout to complete so we set it to 4 minutes
   TIMEOUT = 240

--- a/lib/petscan_api.rb
+++ b/lib/petscan_api.rb
@@ -42,10 +42,14 @@ class PetScanApi
 
   def petscan
     conn = Faraday.new(url: 'https://petscan.wmcloud.org')
+    conn.options.timeout = TIMEOUT
     conn.headers['User-Agent'] = ENV['dashboard_url'] + ' ' + Rails.env
     conn
   end
 
   TYPICAL_ERRORS = [Faraday::TimeoutError,
                     Errno::EHOSTUNREACH].freeze
+
+  # The petscan request may take more than default timeout to complete so we set it to 4 minutes
+  TIMEOUT = 240
 end


### PR DESCRIPTION
## What this PR does
We noticed that course [Coordinate_Me_2025_IN_(2025)](https://outreachdashboard.wmflabs.org/courses/Wikidata/Coordinate_Me_2025_IN_(2025)/) had an empty Petscan category in the db (no article titles on it), although the Petscan category actually had more than 400K articles.

When reproducing the error locally, it turns out that the request takes long time to resolve and then timeouts. [These Sentry logs](https://wiki-education.sentry.io/issues/6415773334/events/dc0b5d0cc49a43a582a48840be1705dd/?project=6269916) are related to that problem.

The easiest solution is just to specify a longer timeout threshold (default timeout is 1 minute) to Faraday for petscan requests. We set it to 4 minutes and all requests were successful locally.

In addition, this PR removes `Faraday::TimeoutError` from typical errors. This means that timeout errors are not handled gracefully anymore. I think that if there is a timeout (which is now unlikely, given that we have a 4-minutes threshold), it's better for the update to fail than to continue with a false empty category.

### Screenshots (empty Petscan category)
![image](https://github.com/user-attachments/assets/98ffd1f0-cde1-427d-9ec1-08a023f6dd42)

## Open questions and concerns
We should improve the error handling for these requests, as we may end up clearing article titles for a category due to a transient error.