### PR TITLE
Optimize articles count query performance through better join ordering

### DIFF
--- a/db/migrate/20250728182700_add_index_to_campaigns_courses_on_campaign_id.rb
+++ b/db/migrate/20250728182700_add_index_to_campaigns_courses_on_campaign_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToCampaignsCoursesOnCampaignId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :campaigns_courses, :campaign_id, name: "index_campaigns_courses_on_campaign_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -154,6 +154,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.integer "course_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["campaign_id"], name: "index_campaigns_courses_on_campaign_id"
     t.index ["course_id", "campaign_id"], name: "index_campaigns_courses_on_course_id_and_campaign_id", unique: true
   end
 


### PR DESCRIPTION
## What this PR does

Related to **Sentry Issue** [a469f5b5](https://wiki-education.sentry.io/issues/6420930400/?project=6269916&query=is%3Aunresolved&referrer=issue-stream&stream_index=24)

Improves the performance of a  join query by introducing an index on `campaigns_courses.campaign_id`. The absence of this index previously led the query planner to use a suboptimal join order, increasing the row scan count unnecessarily. This change enables the query to use a more efficient execution plan, especially important when dealing with large datasets.

---

#### Change Introduced

```sql
CREATE INDEX index_campaigns_courses_on_campaign_id ON campaigns_courses(campaign_id);
```

---

#### Query Being Optimized:

```sql
SELECT COUNT(*)
FROM articles_courses
INNER JOIN courses ON articles_courses.course_id = courses.id
INNER JOIN campaigns_courses ON courses.id = campaigns_courses.course_id
WHERE campaigns_courses.campaign_id = 1;
```

---

#### `EXPLAIN EXTENDED` – Before Adding the Index:

| table                  | type    | key used                                                     | rows scanned | join condition                                                   |
| ---------------------- | ------- | ------------------------------------------------------------ | ------------ | ---------------------------------------------------------------- |
| **courses**            | index   | index\_courses\_on\_slug                                     | 114          | NULL (full index scan)                                           |
| **campaigns\_courses** | eq\_ref | index\_campaigns\_courses\_on\_course\_id\_and\_campaign\_id | 1            | `courses.id = campaigns_courses.course_id` AND `campaign_id = 1` |
| **articles\_courses**  | ref     | index\_articles\_on\_course\_id\_and\_article\_id            | 4157         | `courses.id = articles_courses.course_id`                        |

> **Issue**: Query begins with a full index scan on `courses`, which grows inefficient with large data.
> The optimizer bypasses filtering by `campaign_id` early, leading to unnecessary joins before filtering.

---

#### `EXPLAIN EXTENDED` – After Adding the Index:

| table                  | type    | key used                                          | rows scanned | join condition                             |
| ---------------------- | ------- | ------------------------------------------------- | ------------ | ------------------------------------------ |
| **campaigns\_courses** | ref     | index\_campaigns\_courses\_on\_campaign\_id       | 59           | `campaign_id = 1`                          |
| **courses**            | eq\_ref | PRIMARY                                           | 1            | `courses.id = campaigns_courses.course_id` |
| **articles\_courses**  | ref     | index\_articles\_on\_course\_id\_and\_article\_id | 4157         | `courses.id = articles_courses.course_id`  |

> **Improvement**: Query starts with the most selective filter — `campaigns_courses.campaign_id = 1`.
> **Join type `ref`/`eq_ref` used effectively**, leading to fewer rows read and better performance at scale.

---

* Reduces overall row scans by optimizing join order.
* Prioritizes the most selective filter first.
* Maintains index usage across all joins.
* Scales better as the size of `courses` and `articles_courses` grows.

### Screenshot 

**BEFORE**

<img width="1163" height="153" alt="Screenshot from 2025-08-06 01-12-19" src="https://github.com/user-attachments/assets/e09c1405-a80e-4aca-be12-81f55343c321" />


**AFTER**


<img width="1358" height="236" alt="Screenshot from 2025-08-06 01-12-59" src="https://github.com/user-attachments/assets/e7e46a00-111e-4932-9b24-09d3f6003407" />

