### PR TITLE
Improve error handling when refreshing categories

### DIFF
--- a/app/assets/javascripts/components/categories/category.jsx
+++ b/app/assets/javascripts/components/categories/category.jsx
@@ -19,16 +19,34 @@ const Category = ({ course, category, remove, editable }) => {
   const catName = CourseUtils.formattedCategoryName(category, course.home_wiki);
   let depth;
   let link;
-  if (category.source === 'category') {
+  if (category.source.includes('category')) {
     depth = category.depth;
   }
-  if (category.source === 'psid') {
+  if (category.source.includes('psid')) {
     link = `https://petscan.wmcloud.org/?psid=${category.name}`;
-  } else if (category.source === 'pileid') {
+  } else if (category.source.includes('pileid')) {
     link = `https://pagepile.toolforge.org/api.php?id=${category.name}&action=get_data`;
   } else {
     link = `https://${course.home_wiki.language}.${course.home_wiki.project}.org/wiki/${catName}`;
   }
+  const errored = category.source.includes('Error');
+
+  const cateNameLink = (
+    <a target="_blank" href={link}>
+      {catName}
+    </a>
+  );
+
+  const cateNameLinkWarning = (
+    <div className="tooltip-trigger">
+      {cateNameLink}
+      <span className="tooltip-indicator" />
+      <div className="tooltip dark">
+        <p>{I18n.t('categories.category_error')}</p>
+      </div>
+    </div>
+  );
+
   const lastUpdate = toDate(category.updated_at);
   let lastUpdateMessage;
   const beenUpdated = !isSameDay(toDate(category.created_at), lastUpdate);
@@ -41,11 +59,9 @@ const Category = ({ course, category, remove, editable }) => {
   }
   return (
     <>
-      <tr>
+      <tr className={errored ? 'warning-background' : undefined}>
         <td>
-          <a target="_blank" href={link}>
-            {catName}
-          </a>
+          {errored ? cateNameLinkWarning : cateNameLink}
         </td>
         <td>{depth}</td>
         <td>

--- a/app/assets/stylesheets/_variables.styl
+++ b/app/assets/stylesheets/_variables.styl
@@ -7,6 +7,7 @@ $header-font = 'Source Sans Pro', arial, sans-serif
 // Colors
 warning = #D95757
 $warning-background = #FAE8E8
+$warning-light = lighten(warning, 60%)
 
 mischka = #CED1DD
 athens = #F0F1F3

--- a/app/assets/stylesheets/modules/_error_messages.styl
+++ b/app/assets/stylesheets/modules/_error_messages.styl
@@ -3,6 +3,9 @@ div.warning
   margin 2em 0
   padding 1em
   color darken(warning, 50%)
-  background lighten(warning, 60%)
+  background $warning-light
   &.slim
     margin 1em 2em
+
+.warning-background
+  background-color $warning-light !important

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -465,6 +465,7 @@ en:
     remove: Remove
     tracked_categories: Tracked Categories, PSID, PagePile id & Templates
     timestamp: Last Updated On
+    category_error: This scoping method has too many items to be updated. Please try using smaller ones.
 
   courses:
     school_system: Academic System

--- a/lib/pagepile_api.rb
+++ b/lib/pagepile_api.rb
@@ -37,7 +37,7 @@ class PagePileApi
   rescue StandardError => e
     log_error(e, update_service:,
               sentry_extra: { api_url: url })
-    @pile_data = {}
+    raise e
   end
 
   # This ensures the Category has the same wiki as the PagePile.

--- a/lib/petscan_api.rb
+++ b/lib/petscan_api.rb
@@ -46,6 +46,8 @@ class PetScanApi
     conn
   end
 
+  TYPICAL_ERRORS = [Errno::EHOSTUNREACH].freeze
+
   # The petscan request may take more than default timeout to complete so we set it to 4 minutes
   TIMEOUT = 240
 end

--- a/lib/petscan_api.rb
+++ b/lib/petscan_api.rb
@@ -12,8 +12,7 @@ class PetScanApi
   rescue StandardError => e
     log_error(e, update_service:,
               sentry_extra: { psid:, api_url: url })
-    raise e unless TYPICAL_ERRORS.include?(e.class)
-    return {}
+    raise e
   end
 
   def page_titles_for_psid(psid, update_service: nil)
@@ -46,8 +45,6 @@ class PetScanApi
     conn.headers['User-Agent'] = ENV['dashboard_url'] + ' ' + Rails.env
     conn
   end
-
-  TYPICAL_ERRORS = [Errno::EHOSTUNREACH].freeze
 
   # The petscan request may take more than default timeout to complete so we set it to 4 minutes
   TIMEOUT = 240

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Category, type: :model do
       end
       let(:course) { create(:course) }
 
-      it 'labels the source with error' do
+      it 'labels the source with error and article_titles is not cleared' do
         allow_any_instance_of(PetScanApi).to receive(:page_titles_for_psid).and_return(%w[Q1 Q2])
         call_count = 0
         allow_any_instance_of(described_class).to receive(:save)
@@ -94,6 +94,7 @@ RSpec.describe Category, type: :model do
 
         described_class.refresh_categories_for(course)
         expect(category.reload.source).to eq('psidError')
+        expect(category.article_titles).to eq(['Q0'])
       end
     end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Category, type: :model do
     end
 
     context 'for psid-source Category' do
-      let(:category) { create(:category, name: 9964305, source: 'psid', article_titles: ['Q0']) }
+      let(:category) { create(:category, name: 9964305, source: 'psid') }
       let(:course) { create(:course) }
       let!(:article) { create(:article, title: 'A cappella') }
 
@@ -133,6 +133,7 @@ RSpec.describe Category, type: :model do
       end
 
       it 'fails when PetScan is unreachable but article_titles is not cleared' do
+        category.update(article_titles: ['Q0'])
         expect(category.article_titles).to eq(['Q0'])
         expect_any_instance_of(PetScanApi).to receive(:petscan).and_raise(Errno::EHOSTUNREACH)
         described_class.refresh_categories_for(course)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Category, type: :model do
     end
 
     context 'for psid-source Category' do
-      let(:category) { create(:category, name: 9964305, source: 'psid') }
+      let(:category) { create(:category, name: 9964305, source: 'psid', article_titles: ['Q0']) }
       let(:course) { create(:course) }
       let!(:article) { create(:article, title: 'A cappella') }
 
@@ -95,10 +95,11 @@ RSpec.describe Category, type: :model do
         pass_pending_spec
       end
 
-      it 'fails gracefully when PetScan is unreachable' do
+      it 'fails when PetScan is unreachable but article_titles is not cleared' do
+        expect(category.article_titles).to eq(['Q0'])
         expect_any_instance_of(PetScanApi).to receive(:petscan).and_raise(Errno::EHOSTUNREACH)
         described_class.refresh_categories_for(course)
-        expect(described_class.last.article_ids).to be_empty
+        expect(described_class.last.article_titles).to eq(['Q0'])
       end
     end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -165,11 +165,12 @@ RSpec.describe Category, type: :model do
         pass_pending_spec
       end
 
-      it 'fails gracefully when fetching a PagePile errors' do
+      it 'fails when fetching a PagePile errors but article_titles is not cleared' do
+        category.update(article_titles: ['Q0'])
         expect_any_instance_of(PagePileApi).to receive(:pagepile).and_raise(StandardError)
         expect(Sentry).to receive(:capture_exception)
         described_class.refresh_categories_for(course)
-        expect(described_class.last.article_titles).to be_empty
+        expect(described_class.last.article_titles).to eq(['Q0'])
       end
     end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Category, type: :model do
       end
     end
 
+    context 'for a category labeled with error' do
+      let(:category) do
+        create(:category, name: 'Harvard_University', source: 'categoryError')
+      end
+      let(:course) { create(:course) }
+
+      it 'does not try to update the category' do
+        expect(ArticleUtils).not_to receive(:format_article_title)
+        described_class.refresh_categories_for(course)
+      end
+    end
+
     context 'for category-source Category' do
       let(:category) { create(:category, name: 'Homo sapiens fossils') }
       let(:course) { create(:course) }


### PR DESCRIPTION
## What this PR does
This PR improves error handling when refreshing categories. It was created after some problems we had with petscan API (see PR #6387) but it works for categories no matter the source.
- On one hand, we were worried about importing categories with such a huge number of articles that they cannot be saved in the `article_titles` field (which is `mediumtext`, that means 16,777,215 chars). The discussed approach to "deal" with this situation - before migrating the db to change the field size- is to detect these cases and mark the category with error (by changing the source field to `previous_source + 'Error'`). This PR adds `rescue ActiveRecord::ValueTooLong` statement. That's the error caused when trying to run `save` when the title array is too long. Now, when that error is identified, we only modify the source, avoiding future refreshing for that category.
- On the other hand, this PR adds an empty `rescue StandardError` statement and ensures Petscan class raises the error if the given API fails. This is to prevent the `article_titles` field to be cleared when some unexpected error happens hitting the API. `TYPICAL_ERRORS` remains existing because `ApiErrorHandling` class needs it to choose the log level. A similar thing was done for `PagePileApi`.

In addition, this PR makes frontend changes to show errors for categories with too many articles to the user know what's going on.

### How this was reproduced locally
We're being proactive in handling categories with too many articles to fit in `article_titles`. Because of that, I didn't have any specific category to reproduce the error. I played around with petscan to find a query returning something obviously greater than `mediumtext`, but when I added many levels of depth to the category (to make it have more articles) the query never finished. So I used a "normal" petscan category and manually enlarged that array (I concatenated it several times with itself). When I did that, the first error I found was the following:
```
ActiveRecord::ConnectionNotEstablished: MySQL client is not connected
from /home/gabina/.rvm/gems/ruby-3.1.2/gems/mysql2-0.5.4/lib/mysql2/client.rb:148:in _query'
Caused by Mysql2::Error: MySQL client is not connected
from /home/gabina/.rvm/gems/ruby-3.1.2/gems/mysql2-0.5.4/lib/mysql2/client.rb:148:in _query'
Caused by ActiveRecord::StatementInvalid: Mysql2::Error::ConnectionError: Got a packet bigger than 'max_allowed_packet' bytes
from /home/gabina/.rvm/gems/ruby-3.1.2/gems/mysql2-0.5.4/lib/mysql2/client.rb:148:in _query'
Caused by Mysql2::Error::ConnectionError: Got a packet bigger than 'max_allowed_packet' bytes
from /home/gabina/.rvm/gems/ruby-3.1.2/gems/mysql2-0.5.4/lib/mysql2/client.rb:148:in _query'
```
I had `max_allowed_packet` variable set to 16,777,216 bytes locally, so I had to change it to the production value, which is 1,073,741,824 bytes. Once I updated that, I found the real `ActiveRecord::ValueTooLong` error.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/f736051b-652d-4ad8-b684-895111adcccb)


### After
![image](https://github.com/user-attachments/assets/6f1a373c-7c3f-42ad-81b7-aa53609b0824)
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
