### PR TITLE
Part 1: Remove redundant index on course_id from assignments table

### DIFF
--- a/db/migrate/20250702174753_remove_index_assignments_on_course_id.rb
+++ b/db/migrate/20250702174753_remove_index_assignments_on_course_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexAssignmentsOnCourseId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :assignments, name: "index_assignments_on_course_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_02_174753) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -117,7 +117,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.text "sandbox_url"
     t.text "flags"
     t.index ["course_id", "user_id"], name: "index_assignments_on_course_id_and_user_id"
-    t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
   create_table "blocks", id: :integer, charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
Part 1 #6391
Part 2 #6392
Part 3 #6393
Part 4 #6394
Part 5 #6395
Part 6 #6396
Part 7 (FINAL) #6397

## What this PR does


This PR removes the `index_assignments_on_course_id` from the `assignments` table.

The index was redundant due to the presence of a more selective composite index: `index_assignments_on_course_id_and_user_id`, which already covers the same leading column (`course_id`). Removing this standalone index helps reduce duplication and optimizes index maintenance during write operations.

* Removed: `index_assignments_on_course_id`

No application logic is affected by this change.