### PR TITLE
Part 2: Remove redundant index on wiki_id from categories table

### DIFF
--- a/db/migrate/20250703174009_remove_index_categories_on_wiki_id.rb
+++ b/db/migrate/20250703174009_remove_index_categories_on_wiki_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexCategoriesOnWikiId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :categories, name: "index_categories_on_wiki_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_03_174009) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -184,7 +184,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.string "source", default: "category"
     t.index ["name"], name: "index_categories_on_name"
     t.index ["wiki_id", "name", "depth", "source"], name: "index_categories_on_wiki_id_and_name_and_depth_and_source", unique: true
-    t.index ["wiki_id"], name: "index_categories_on_wiki_id"
   end
 
   create_table "categories_courses", charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
This PR removes the `index_categories_on_wiki_id` index from the `categories` table.

The index was redundant due to the presence of a composite index: `index_categories_on_wiki_id_and_name_and_depth_and_source`, which already includes `wiki_id` as its leading column. Since composite indexes can be used to satisfy queries filtered solely on their leading column, this standalone index is unnecessary. Removing it helps reduce index bloat and improves performance during insert and update operations on the `categories` table.

**Removed:** `index_categories_on_wiki_id`
No application logic is affected by this change.