### PR TITLE
Part 3: Remove redundant index on course_id from categories_courses table

### DIFF
--- a/db/migrate/20250703181200_remove_index_categories_courses_on_course_id.rb
+++ b/db/migrate/20250703181200_remove_index_categories_courses_on_course_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexCategoriesCoursesOnCourseId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :categories_courses, name: "index_categories_courses_on_course_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_03_181200) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -194,7 +194,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_categories_courses_on_category_id"
     t.index ["course_id", "category_id"], name: "index_categories_courses_on_course_id_and_category_id", unique: true
-    t.index ["course_id"], name: "index_categories_courses_on_course_id"
   end
 
   create_table "commons_uploads", id: :integer, charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
## What this PR does

This PR removes the `index_categories_courses_on_course_id` index from the `categories_courses` table.

This index was redundant due to the presence of the composite index: `index_categories_courses_on_course_id_and_category_id`. Since `course_id` is the leading column of that composite index, the standalone index does not provide additional query benefit. Removing it helps reduce index duplication and improves efficiency during data modification operations.

**Removed:** `index_categories_courses_on_course_id`
No application logic is affected by this change.
