### PR TITLE
Part 4: Remove redundant index on course_id from courses_users table

### DIFF
--- a/db/migrate/20250703191048_remove_index_courses_users_on_course_id.rb
+++ b/db/migrate/20250703191048_remove_index_courses_users_on_course_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexCoursesUsersOnCourseId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :courses_users, name: "index_courses_users_on_course_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_03_191048) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -324,7 +324,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.integer "total_uploads"
     t.integer "references_count", default: 0
     t.index ["course_id", "user_id", "role"], name: "index_courses_users_on_course_id_and_user_id_and_role", unique: true
-    t.index ["course_id"], name: "index_courses_users_on_course_id"
     t.index ["user_id"], name: "index_courses_users_on_user_id"
   end
 


### PR DESCRIPTION
## What this PR does

This PR removes the `index_courses_users_on_course_id` index from the `courses_users` table.

This index was redundant due to the presence of a more selective composite index: `index_courses_users_on_course_id_and_user_id_and_role`. Since the composite index already includes `course_id` as its leading column, the standalone index provides no additional benefit. Removing it reduces index maintenance costs and improves write performance.

**Removed:** `index_courses_users_on_course_id`
No application logic is affected by this change.