### PR TITLE
Part 5: Remove redundant index on course_id from courses_wikis table

### DIFF
--- a/db/migrate/20250703193116_remove_index_courses_wikis_on_course_id.rb
+++ b/db/migrate/20250703193116_remove_index_courses_wikis_on_course_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexCoursesWikisOnCourseId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :courses_wikis, name: "index_courses_wikis_on_course_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_03_193116) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -334,7 +334,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id", "wiki_id"], name: "index_courses_wikis_on_course_id_and_wiki_id", unique: true
-    t.index ["course_id"], name: "index_courses_wikis_on_course_id"
     t.index ["wiki_id"], name: "index_courses_wikis_on_wiki_id"
   end
 


### PR DESCRIPTION
## What this PR does

This PR removes the `index_courses_wikis_on_course_id` index from the `courses_wikis` table.

The standalone index was made redundant by the existing composite index: `index_courses_wikis_on_course_id_and_wiki_id`. Because `course_id` is already the leading column in that composite index, the additional index does not improve query performance and only adds overhead. This cleanup helps streamline database operations.

**Removed:** `index_courses_wikis_on_course_id`
No application logic is affected by this change.


