### PR TITLE
Part 6: Remove redundant index on article_id from revisions table

### DIFF
--- a/db/migrate/20250703194401_remove_index_revisions_on_article_id.rb
+++ b/db/migrate/20250703194401_remove_index_revisions_on_article_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexRevisionsOnArticleId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :revisions, name: "index_revisions_on_article_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_03_194401) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -438,7 +438,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.text "features_previous"
     t.text "summary"
     t.index ["article_id", "date"], name: "index_revisions_on_article_id_and_date"
-    t.index ["article_id"], name: "index_revisions_on_article_id"
     t.index ["user_id"], name: "index_revisions_on_user_id"
     t.index ["wiki_id", "mw_rev_id"], name: "index_revisions_on_wiki_id_and_mw_rev_id", unique: true
   end


### PR DESCRIPTION
## What this PR does

This PR removes the `index_revisions_on_article_id` index from the `revisions` table.

The index was redundant because a more selective composite index exists: `index_revisions_on_article_id_and_date`. Since `article_id` is already the leading column in that index, the standalone version is unnecessary and adds overhead during write operations. This change optimizes index usage without affecting query functionality.

**Removed:** `index_revisions_on_article_id`
No application logic is affected by this change.