### PR TITLE
Part 7 (FINAL): Remove redundant index on owner_id and owner_type from revision_fuzzies table

### DIFF
--- a/db/migrate/20250703195934_remove_index_trigrams_index_by_owner.rb
+++ b/db/migrate/20250703195934_remove_index_trigrams_index_by_owner.rb
@@ -1,0 +1,5 @@
+class RemoveIndexTrigramsIndexByOwner < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :trigrams, name: "index_by_owner"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_03_195934) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -598,7 +598,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.string "owner_type"
     t.string "fuzzy_field"
     t.index ["owner_id", "owner_type", "fuzzy_field", "trigram", "score"], name: "index_for_match"
-    t.index ["owner_id", "owner_type"], name: "index_by_owner"
   end
 
   create_table "user_profiles", id: :integer, charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
## What this PR does

This PR removes the `index_by_owner` index from the `trigrams` table.

The index was redundant because the existing composite index `index_for_match` already includes both `owner_id` and `owner_type` as its leading columns. Maintaining both indexes adds unnecessary overhead with no added query performance. Removing it helps streamline index usage and improve write efficiency.

**Removed:** `index_by_owner`
No application logic is affected by this change.
