### PR TITLE
Optimize article duplicate detection by aligning grouping with composite index

### DIFF
--- a/lib/duplicate_article_deleter.rb
+++ b/lib/duplicate_article_deleter.rb
@@ -35,15 +35,14 @@ class DuplicateArticleDeleter
 
   def articles_grouped_by_title_and_namespace(articles)
     Article.where(namespace: articles.pluck(:namespace).uniq,
-                  title: articles.pluck(:title),
-                  wiki_id: @wiki.id)
-           .group(%w[title namespace]).count
+                  wiki_id: @wiki.id,
+                  title: articles.pluck(:title)).group(%w[namespace wiki_id title]).count
   end
 
   def delete_duplicates_in(article_group)
     return unless article_group[1] > 1
-    title = article_group[0][0]
-    namespace = article_group[0][1]
+    title = article_group[0][2]
+    namespace = article_group[0][0]
     Rails.logger.debug { "Resolving duplicates for '#{title}, ns #{namespace}'" }
     @deleted_ids += delete_duplicates(title, namespace)
   end


### PR DESCRIPTION
## Example from production log


[Example From Production Log.txt](https://github.com/user-attachments/files/21100977/Example.From.Production.Log.txt)


## What this PR does

Improves the logic and performance of the `DuplicateArticleDeleter` by aligning the grouping logic in it's SQL query with the database's composite index: (namespace, wiki_id, title) so MySQL doesn't have to use `filesort` and `temporary table`

## What was the issue with previous implementation?

The original implementation grouped by only `title` and `namespace`, ignoring `wiki_id`. This led to:
- Inefficient query execution (seen via `EXPLAIN EXTENDED`)
- Use of `temporary table` and `file sort`, despite a suitable index being available

## Fix

- Grouping changed to: `namspace`, `wiki_id`, `title` to match proper column order of composite index.
- Group key unpacking in `delete_duplicates_in` adjusted accordingly.
- The updated grouping now matches the composite index:
   `index_articles_on_namespace_and_wiki_id_and_title` 


**SQL Performance Impact**

**Before** (group by `title, namespace`):

```
Extra: Using where; Using index; Using temporary; Using filesort
```

**After** (group by `namespace, wiki_id, title`):

```
Extra: Using where; Using index
```

The query now fully leverages the index, eliminating filesort and temporary usage.


## Screenshots
Before:


![Untitled design (3)](https://github.com/user-attachments/assets/763256a6-a952-4b98-a457-12cf5fbeaca6)



After:


![Untitled design (2)](https://github.com/user-attachments/assets/14066705-db63-4bc5-b962-14bc0ce23a56)



