### PR TITLE
Optimize Article Batch Performance by Removing distinct Dependency

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -89,6 +89,7 @@ class Course < ApplicationRecord
 
   has_many :articles_courses, class_name: 'ArticlesCourses', dependent: :destroy
   has_many :articles, -> { distinct }, through: :articles_courses
+  has_many :all_articles, through: :articles_courses, source: :article
   has_many :assignments, dependent: :destroy
 
   has_many :categories_courses, class_name: 'CategoriesCourses', dependent: :destroy

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -88,8 +88,7 @@ class Course < ApplicationRecord
   end, through: :students)
 
   has_many :articles_courses, class_name: 'ArticlesCourses', dependent: :destroy
-  has_many :articles, -> { distinct }, through: :articles_courses
-  has_many :all_articles, through: :articles_courses, source: :article
+  has_many :articles, through: :articles_courses
   has_many :assignments, dependent: :destroy
 
   has_many :categories_courses, class_name: 'CategoriesCourses', dependent: :destroy

--- a/lib/articles_courses_cleaner_timeslice.rb
+++ b/lib/articles_courses_cleaner_timeslice.rb
@@ -159,8 +159,6 @@ class ArticlesCoursesCleanerTimeslice # rubocop:disable Metrics/ClassLength
   end
 
   def reset_articles_in_untracked_namespaces
-    # Get relevant article IDs for the course
-
     @course.all_articles.in_batches do |article_batch|
       tracked = @course.tracked_namespaces.each.flat_map do |wiki_ns|
         wiki_id = wiki_ns[:wiki].id

--- a/lib/articles_courses_cleaner_timeslice.rb
+++ b/lib/articles_courses_cleaner_timeslice.rb
@@ -160,9 +160,8 @@ class ArticlesCoursesCleanerTimeslice # rubocop:disable Metrics/ClassLength
 
   def reset_articles_in_untracked_namespaces
     # Get relevant article IDs for the course
-    article_ids = ArticlesCourses.where(course_id: @course.id).pluck(:article_id)
 
-    Article.where(id: article_ids).in_batches do |article_batch|
+    @course.all_articles.in_batches do |article_batch|
       tracked = @course.tracked_namespaces.each.flat_map do |wiki_ns|
         wiki_id = wiki_ns[:wiki].id
         namespace = wiki_ns[:namespace]

--- a/lib/articles_courses_cleaner_timeslice.rb
+++ b/lib/articles_courses_cleaner_timeslice.rb
@@ -159,7 +159,7 @@ class ArticlesCoursesCleanerTimeslice # rubocop:disable Metrics/ClassLength
   end
 
   def reset_articles_in_untracked_namespaces
-    @course.all_articles.in_batches do |article_batch|
+    @course.articles.in_batches do |article_batch|
       tracked = @course.tracked_namespaces.each.flat_map do |wiki_ns|
         wiki_id = wiki_ns[:wiki].id
         namespace = wiki_ns[:namespace]

--- a/lib/articles_courses_cleaner_timeslice.rb
+++ b/lib/articles_courses_cleaner_timeslice.rb
@@ -159,7 +159,10 @@ class ArticlesCoursesCleanerTimeslice # rubocop:disable Metrics/ClassLength
   end
 
   def reset_articles_in_untracked_namespaces
-    @course.articles.in_batches do |article_batch|
+    # Get relevant article IDs for the course
+    article_ids = ArticlesCourses.where(course_id: @course.id).pluck(:article_id)
+
+    Article.where(id: article_ids).in_batches do |article_batch|
       tracked = @course.tracked_namespaces.each.flat_map do |wiki_ns|
         wiki_id = wiki_ns[:wiki].id
         namespace = wiki_ns[:namespace]


### PR DESCRIPTION
## Note (IMPORTANT)

The optimization assumes that the `ArticlesCourses` table does **not** contain duplicate `(course_id, article_id)` pairs. If such duplicates exist, the behavior may be incorrect due to missing deduplication in SQL.

If deduplication is still needed, maybe we can shift that logic to Ruby (e.g., using `.uniq`) after querying — this allows us to retain the fast, index-only query path without `DISTINCT`.


## Example from production log

**1)** [Example from production slow log.txt](https://github.com/user-attachments/files/21101241/Example.from.production.slow.log.txt)

**2)** [Time: 250629  3:48:06.txt](https://github.com/user-attachments/files/21321430/Time.250629.3.48.06.txt)




![Screenshot from 2025-07-07 16-36-13](https://github.com/user-attachments/assets/977a223c-5ee6-42dd-bd94-f3b2899e834d)

<img width="1360" height="640" alt="Screenshot from 2025-07-18 23-53-59" src="https://github.com/user-attachments/assets/31ebd3e1-38d4-4daa-8e34-9039478fe3c7" />



## What this PR does

This PR introduces a new `has_many :all_articles` association on the `Course` model that bypasses the `distinct` constraint on the existing `articles` association.


Using the original `@course.articles` with `.in_batches` caused ActiveRecord to generate `SELECT DISTINCT` queries. This triggered the use of **temporary tables** and **increased query latency** significantly.

**Before (with `DISTINCT`):**

* Queries used: `Using temporary`
* Execution times: \~30ms per batch
* Rows scanned: often 15K+ per 1000 actual rows needed

**After (with `JOIN` only):**

* Queries use: `Using index`, no temporary tables
* Execution times: \~2–7ms per batch
* Rows scanned: exactly 1000 (as expected)

## Screenshots

**Before:**

<img width="1359" height="604" alt="Before 1" src="https://github.com/user-attachments/assets/99de26fe-e850-4ac7-b2a8-37b840d566f9" />


<img width="1336" height="486" alt="Before 1" src="https://github.com/user-attachments/assets/5ded9497-1af2-4434-85ea-3c943db785fd" />



**After:**


<img width="1359" height="604" alt="Screenshot from 2025-07-19 00-14-06" src="https://github.com/user-attachments/assets/b85a16a7-f826-4249-94fb-8473952b54e5" />

<img width="1357" height="470" alt="Before 2" src="https://github.com/user-attachments/assets/bcdb3f72-39df-4927-bdd4-679155fa0c8e" />



