### PR TITLE
Do not fail gracefully if Petscan response contains 'error' key

### DIFF
--- a/lib/petscan_api.rb
+++ b/lib/petscan_api.rb
@@ -19,11 +19,11 @@ class PetScanApi
     titles = []
     titles_response = get_data(psid, update_service:)
     return titles if titles_response.empty?
-    # Using an invalid PSID, such as a non-integer or nonexistent ID,
-    # returns something like {"error":"ParseIntError { kind: InvalidDigit }"}
-    # Since this is typically user error, we just treat it as 0 titles
-    # and move on gracefully.
-    return titles if titles_response.key? 'error'
+    # Petscan query errors (such as invalid PSID but also server bugs) often return responses like:
+    # {"error":"some error message"}.
+    # We don't want to fail gracefully in these cases, as we risk
+    # emptying a category that was previously updated correctly.
+    raise PetscanResponseError if titles_response.key? 'error'
 
     page_data = titles_response['*'][0]['a']['*']
     page_data.each { |page| titles << page['title'] }
@@ -50,4 +50,6 @@ class PetScanApi
 
   # The petscan request may take more than default timeout to complete so we set it to 4 minutes
   TIMEOUT = 240
+
+  class PetscanResponseError < StandardError; end
 end


### PR DESCRIPTION
## What this PR does
This PR forces `PetScanApi` to raise `PetscanResponseError` if the petscan response contains 'error' key. The error is properly rescued in `refresh_titles` to avoid emptying a category that was previously updated correctly.

### Context
Today we found that petscan queries that involve wikidata failed with a 200 OK response :
`{"error":"PageList::run_batch_query: SQL query error[1]: Server(ServerError { code: 1146, message: \"Table 'wikidatawiki_p.wbt_item_terms' doesn't exist\", state: \"42S02\" })"}`

As it returned valid json, no error was raised and petscan categories were cleared.

There is already a [PR](https://github.com/magnusmanske/petscan_rs/issues/193) open in petscan repo for this bug.

### Courses affected

- [30189](https://outreachdashboard.wmflabs.org/courses/WMB/Editatona_Revistas_de_Hist%C3%B3ria_na_Wiki/articles/edited?tracked=both) WMB/Editatona_Revistas_de_História_na_Wiki
- [31372](https://outreachdashboard.wmflabs.org/courses/WLE/Wiki-Loves-Earth-Cup_(2025)/home) WLE/Wiki-Loves-Earth-Cup_(2025)
- [25447](https://outreachdashboard.wmflabs.org/courses/London_School_of_Economics_and_Political_Science/LSE_Suffrage_Interviews_Project/home) London_School_of_Economics_and_Political_Science/LSE_Suffrage_Interviews_Project
- [30852](https://outreachdashboard.wmflabs.org/courses/Network_Archives_Design_and_Digital_Culture/NADD_Wikidata_project_2025/articles/available) Network_Archives_Design_and_Digital_Culture/NADD_Wikidata_project_2025
- [31661](https://outreachdashboard.wmflabs.org/courses/wikidata/Stolpersteine_goes_WikiData_(2025)/articles/available) wikidata/Stolpersteine_goes_WikiData_(2025)
- [31754](https://outreachdashboard.wmflabs.org/courses/Wikidata/Coordinate_Me_2025_CA_(2025)) Wikidata/Coordinate_Me_2025_CA_(2025)
- [32250](https://outreachdashboard.wmflabs.org/courses/Wikimedistas_de_la_Universidad_Nacional_de_La_Plata,_Wikimedia_Chile/Concurso_Datos_Abiertos_por_la_Salud_Planetaria/articles/available) Wikimedistas_de_la_Universidad_Nacional_de_La_Plata,_Wikimedia_Chile/Concurso_Datos_Abiertos_por_la_Salud_Planetaria
- [31750](https://outreachdashboard.wmflabs.org/courses/Wikidata/Coordinate_Me_2025_AT_(2025)) Wikidata/Coordinate_Me_2025_AT_(2025)

