### PR TITLE
[WIP]: Optimize article_course_timeslices queries by adding composite index on course_id and tracked

### DIFF
--- a/db/migrate/20250711134708_add_index_to_article_course_timeslices_on_course_id_and_tracked.rb
+++ b/db/migrate/20250711134708_add_index_to_article_course_timeslices_on_course_id_and_tracked.rb
@@ -1,0 +1,5 @@
+class AddIndexToArticleCourseTimeslicesOnCourseIdAndTracked < ActiveRecord::Migration[7.0]
+  def change
+    add_index :article_course_timeslices, [:course_id, :tracked], name: :article_course_timeslice_by_course_id_and_tracked
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_11_134708) do
   create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
@@ -47,6 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_15_163420) do
     t.datetime "updated_at", null: false
     t.datetime "first_revision"
     t.index ["article_id", "course_id", "start", "end"], name: "article_course_timeslice_by_article_course_start_and_end", unique: true
+    t.index ["course_id", "tracked"], name: "article_course_timeslice_by_course_id_and_tracked"
     t.index ["course_id", "updated_at", "article_id"], name: "article_course_timeslice_by_updated_at"
   end
 


### PR DESCRIPTION
## What this PR does


This PR adds a composite index on the `article_course_timeslices table` for the `(course_id, tracked)` columns to improve the performance of queries that filter by both fields.

## Screenshot From Production Log

<img width="990" height="503" alt="Screenshot from 2025-07-11 20-48-18" src="https://github.com/user-attachments/assets/1cebe079-fdac-43d3-8dc6-37b5385ca1b0" />


## Screenshot

**Code generating this query**

<img width="806" height="107" alt="Screenshot from 2025-07-11 21-22-14" src="https://github.com/user-attachments/assets/46c6af1c-cd4c-4aac-84f3-12f5fd0b8aa6" />


**Before:**


<img width="1357" height="265" alt="Screenshot from 2025-07-11 21-11-46" src="https://github.com/user-attachments/assets/c8d809d2-9ed2-4e93-bd3a-df55c286c444" />





**After:**

<img width="1357" height="248" alt="Screenshot from 2025-07-11 21-05-48" src="https://github.com/user-attachments/assets/27dbefd6-4ce4-4612-8ebd-e7bc7a76dd14" />

