### PR TITLE
Force timeslices to process even when no point in importing revisions

### DIFF
--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -7,7 +7,7 @@ require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 #= Pulls in new revisions for a single course and updates the corresponding timeslices records.
 # It updates all the tracked wikis for the course, from the latest start time for every wiki
 # up to the end of update (today or end date course).
-class UpdateCourseWikiTimeslices # rubocop:disable Metrics/ClassLength
+class UpdateCourseWikiTimeslices
   def initialize(course, debugger, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
@@ -80,7 +80,7 @@ class UpdateCourseWikiTimeslices # rubocop:disable Metrics/ClassLength
       log_reprocessing(wiki, start_date, end_date)
 
       fetch_data(wiki, start_date, end_date, only_new: false)
-      process_timeslices(wiki) if data?
+      process_timeslices(wiki)
       @reprocessed_timeslices += 1
     end
   end
@@ -98,12 +98,8 @@ class UpdateCourseWikiTimeslices # rubocop:disable Metrics/ClassLength
     fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && @revisions.present?
   end
 
-  def data?
-    @revisions.present?
-  end
-
   def new_data?(wiki)
-    data? && @revisions[wiki][:new_data]
+    @revisions[wiki][:new_data]
   end
 
   # Only for wikidata project, fetch wikidata stats

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -93,9 +93,8 @@ class UpdateCourseWikiTimeslices
       timeslice_end.strftime('%Y%m%d%H%M%S'),
       only_new:
     )
-    # Return if only_new was true but no new data was found
-    return unless new_data?(wiki)
-    fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && @revisions.present?
+    # Only fetch wikidata stats if wikidata and there is new data
+    fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && new_data?(wiki)
   end
 
   def new_data?(wiki)

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -31,7 +31,7 @@ class CourseRevisionUpdater
   # revisions for that timeslice. The new_data field is true if new revisions were found.
   # This optimization was added to improve performance.
   def fetch_data_for_course_wiki(wiki, ts_start, ts_end, only_new: false)
-    return {} if no_point_in_importing_revisions?
+    return empty_response(wiki, ts_start, ts_end) if no_point_in_importing_revisions?
     revision_data, new_revisions = fetch_data(wiki, ts_start, ts_end, only_new:)
     response = format_revision_response(wiki, ts_start, ts_end, revision_data, new_revisions)
     # Get an array with all revisions
@@ -52,6 +52,10 @@ class CourseRevisionUpdater
     revisions[:revisions] = revision_data
     results[wiki] = revisions
     results
+  end
+
+  def empty_response(wiki, timeslice_start, timeslice_end)
+    format_revision_response(wiki, timeslice_start, timeslice_end, [], false)
   end
 
   # Fetches revisions and maybe scores for them.

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -55,7 +55,8 @@ class CourseRevisionUpdater
   end
 
   def empty_response(wiki, timeslice_start, timeslice_end)
-    format_revision_response(wiki, timeslice_start, timeslice_end, [], false)
+    new_revisions = new_revisions?([], wiki, timeslice_start)
+    format_revision_response(wiki, timeslice_start, timeslice_end, [], new_revisions)
   end
 
   # Fetches revisions and maybe scores for them.

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -157,7 +157,11 @@ class TimesliceManager
 
   # Takes an ActiveRecord::Relation of CourseWikiTimeslices and an array of revisions.
   # Updates the last_mw_rev_datetime field based on those revisions.
-  def update_timeslices(timeslices, revisions)
+  def update_timeslices(timeslices, revisions) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+    # First of all, clean the last_mw_rev_datetime. This is necessary when there are no
+    # revisions for the timeslice and last_mw_rev_datetime already has a datetime.
+    timeslices.each { |t| t.last_mw_rev_datetime = nil }
+
     # Iterate over the fetched revisions and update the last_mw_rev_datetime
     revisions.each do |revision|
       # Get the timeslice that we want to update

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -2,6 +2,8 @@
 
 require 'rails_helper'
 require "#{Rails.root}/lib/assignment_manager"
+require "#{Rails.root}/lib/course_revision_updater"
+require "#{Rails.root}/lib/importers/course_upload_importer"
 
 MILESTONE_BLOCK_KIND = 2
 
@@ -516,6 +518,7 @@ describe 'the course page', type: :feature, js: true do
 
       expect_any_instance_of(CourseRevisionUpdater).to receive(:fetch_data_for_course_wiki)
         .at_least(1)
+        .and_call_original
       expect(AverageViewsImporter).to receive(:update_outdated_average_views)
       expect_any_instance_of(CourseUploadImporter).to receive(:run)
       visit "/courses/#{slug}/manual_update"

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -153,7 +153,8 @@ describe CourseRevisionUpdater do
 
       it 'skips import if no tracked articles' do
         expect(scoped_instance_class).not_to receive(:fetch_data)
-        scoped_instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date)
+        response = scoped_instance_class.fetch_data_for_course_wiki(wiki, start_date, end_date)
+        expect(response[wiki][:revisions]).to eq([])
       end
     end
   end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -164,6 +164,7 @@ describe UpdateCourseWikiTimeslices do
           expect_any_instance_of(CourseRevisionUpdater).to receive(:fetch_data_for_course_wiki)
             .with(wiki, start_time, end_time, only_new: true)
             .once
+            .and_call_original
         end
       end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -179,13 +179,24 @@ describe UpdateCourseWikiTimeslices do
       # Create timeslices
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
       # Set timeslices to reprocess
-      course.course_wiki_timeslices.first.update(needs_update: true)
+      course.course_wiki_timeslices.first.update(revision_count: 15,
+                                                 last_mw_rev_datetime: '2018-11-24 10:25:00',
+                                                 needs_update: true)
     end
 
     it 'does not fail and logs no errors' do
       VCR.use_cassette 'course_update' do
         expect(Sentry).not_to receive(:capture_message)
         subject
+      end
+    end
+
+    it 'cleans old caches' do
+      VCR.use_cassette 'course_update' do
+        subject
+        expect(course.course_wiki_timeslices.first.revision_count).to eq(0)
+        expect(course.course_wiki_timeslices.first.needs_update).to eq(false)
+        expect(course.course_wiki_timeslices.first.last_mw_rev_datetime).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
## What this PR does
Closes #6399 

This PR fixes an existing bug for timeslices that keeps reprocessing forever.

### Example
Let's suppose we have the following non-empty timeslice set to reprocess for an article scoped program course.
```
id   |course_id|wiki_id|start              |end                |character_sum|references_count|revision_count|stats|last_mw_rev_datetime      |needs_update|created_at                |updated_at                
-----+---------+-------+-------------------+-------------------+-------------+----------------+--------------+-----+--------------------------+------------+--------------------------+--------------------------
10738|    10061|     13|2025-03-23 03:00:00|2025-03-24 03:00:00|           12|               2|            15|     |2025-03-23 19:07:25.818766|           1|2025-07-04 19:07:25.818766|2025-07-11 02:30:34.284429
```
Let's suppose all the editors were removed from the course, so each time the timeslice gets reprocessed, `no_point_in_importing_revisions` returned `true`. Because of that, `fetch_data_for_course_wiki` method returned {} and `process_timeslices` method was never called in `UpdateCourseWikiTimeslices` class.

### How to fix it
This PR makes the following changes to fix the bug:
- Make `CourseRevisionUpdater#fetch_data_for_course_wiki` always return something like` {wiki0 => {:start=>"20160320", :end=>"20160401", :new_data=>true, :revisions=>[...]}}`. If no point in importing revisions, then it returns `{wiki0 => {:start=>"20160320", :end=>"20160401", :new_data=>true, :revisions=>[]}}` (not {}).
- Make `TimesliceManager#update_last_mw_rev_datetime` always set the `last_mw_rev_datetime` field to nil as first step. This way, no matter if there are no revisions for the period, `last_mw_rev_datetime` is set to nil.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
