### PR TITLE
fix to redirect_parameter in ArticleViewer

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/utils/URLBuilder.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/URLBuilder.js
@@ -16,7 +16,7 @@ export class URLBuilder {
       const query = `${base}/w/api.php?action=parse&oldid=${lastRevisionId}&disableeditsection=true&format=json`;
       url = `${query}`;
     } else {
-      const query = `${base}/w/api.php?action=parse&disableeditsection=true&format=json`;
+      const query = `${base}/w/api.php?action=parse&disableeditsection=true&format=json&redirects=true`;
       url = `${query}&page=${encodeURIComponent(title)}`;
     }
     return url;

--- a/app/assets/javascripts/components/common/ArticleViewer/utils/URLBuilder.spec.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/utils/URLBuilder.spec.js
@@ -13,7 +13,7 @@ describe('URLBuilder', () => {
   describe('#parsedArticleURL', () => {
     it('should create a parsedArticleURL when given a valid article', () => {
       const helper = new URLBuilder({ article: defaults.article });
-      const expected = 'https://en.wikipedia.org/w/api.php?action=parse&disableeditsection=true&format=json&page=Brown%20Bear%2C%20Brown%20Bear%2C%20What%20Do%20You%20See%3F';
+      const expected = 'https://en.wikipedia.org/w/api.php?action=parse&disableeditsection=true&format=json&redirects=true&page=Brown%20Bear%2C%20Brown%20Bear%2C%20What%20Do%20You%20See%3F';
       expect(helper.parsedArticleURL()).toEqual(expected);
     });
     it('should throw an error if the project is missing', () => {
@@ -29,7 +29,7 @@ describe('URLBuilder', () => {
     it('should correctly encode page titles as URL parameters', () => {
       const article = { language: 'en', project: 'wikipedia', title: 'Bed Bath & Beyond' };
       const helper = new URLBuilder({ article });
-      const expected = 'https://en.wikipedia.org/w/api.php?action=parse&disableeditsection=true&format=json&page=Bed%20Bath%20%26%20Beyond';
+      const expected = 'https://en.wikipedia.org/w/api.php?action=parse&disableeditsection=true&format=json&redirects=true&page=Bed%20Bath%20%26%20Beyond';
       expect(helper.parsedArticleURL()).toEqual(expected);
     });
   });


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
#6369 -Fixes
Problem: URLs with redirect=no were showing redirect pages instead of actual content
Solution:
1. ArticleViewerAPI.js - MAIN FIX
What Changed: Modified the fetchParsedArticle method
Why: This is where the actual Wikipedia API call happens. Added logic to:

Detect if Wikipedia returns a redirect response
Automatically make a second API call to get the target article
Return the actual article content instead of redirect content

Specific Change: Added redirect detection and handling in the .then() chain

2. URLBuilder.js - SUPPORTING CHANGE
What Changed: Added &redirects=true parameter to the Wikipedia API URL
Why: This tells Wikipedia's API to include redirect information in the response, so we can detect when an article is a redirect
Specific Change: In parsedArticleURL() method, changed the query string to include redirect info

##Result:

"Selfies" URLs now automatically redirect to "Selfie" content
Clean URLs stored in database
No more redirect pages in ArticleViewer
Test passes 


### Before

https://github.com/user-attachments/assets/10d73dde-4e7f-4f99-b81d-cefb7d7ce83b

### After


https://github.com/user-attachments/assets/0ba889f5-cb97-4627-b6f1-01c5da6767f7


