### PR TITLE
Optimize article_ids query by batching titles to prevent large IN clause slowdowns

### DIFF
--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -78,7 +78,14 @@ class Category < ApplicationRecord
   end
 
   def article_ids
-    @article_ids ||= Article.where(namespace: 0, wiki_id:, title: article_titles).pluck(:id)
+    return @article_ids if @article_ids.present?
+
+    @article_ids = []
+    article_titles.each_slice(500) do |titles_batch|
+      @article_ids.concat(Article.where(namespace: 0, wiki_id:, title: titles_batch).pluck(:id))
+    end
+
+    @article_ids.uniq! || @article_ids
   end
 
   def name_with_prefix

--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -81,7 +81,7 @@ class Category < ApplicationRecord
     return @article_ids if @article_ids.present?
 
     @article_ids = []
-    article_titles.each_slice(2000) do |titles_batch|
+    article_titles.each_slice(5000) do |titles_batch|
       @article_ids.concat(Article.where(namespace: 0, wiki_id:, title: titles_batch).pluck(:id))
     end
 

--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -81,11 +81,11 @@ class Category < ApplicationRecord
     return @article_ids if @article_ids.present?
 
     @article_ids = []
-    article_titles.each_slice(500) do |titles_batch|
+    article_titles.each_slice(2000) do |titles_batch|
       @article_ids.concat(Article.where(namespace: 0, wiki_id:, title: titles_batch).pluck(:id))
     end
 
-    @article_ids.uniq! || @article_ids
+    @article_ids
   end
 
   def name_with_prefix


### PR DESCRIPTION
## Production Log (First Occurence is in the month of June)

<img width="1138" height="409" alt="Screenshot from 2025-07-15 19-59-03" src="https://github.com/user-attachments/assets/85b28842-0c2b-468f-b937-96b5f34a24aa" />


## What this PR does

Improves the performance of the `article_ids` method in the `Category` model by introducing batching on the `article_titles` array when querying `Article` records.

Previously, the query used a single large `IN` clause:
```ruby
@article_ids ||= Article.where(namespace: 0, wiki_id:, title: article_titles).pluck(:id)
````

When `article_titles` contained thousands of entries (e.g., 1000+), this resulted in:

* Very large SQL `IN (...)` clauses
* Query planner inefficiencies
* Memory-intensive materialization in MySQL
* Increased `Lock_time` and `Query_time` in production logs


We now batch the `article_titles` into slices of 500:

```ruby
@article_ids ||= article_titles.each_slice(500).flat_map do |titles_batch|
  Article.where(namespace: 0, wiki_id: wiki_id, title: titles_batch).pluck(:id)
end
```

*  **Smaller IN clauses** reduce MySQL's parsing and planning overhead
*  **Index usage is optimized** (`range` instead of `ALL`)
*  **Avoids materializing large subqueries**, saving memory
*  **Improves overall query time and reduces locking**
*  **EXPLAIN plans confirm efficient access paths** with `Using index` and `range` types

## Screenshots

**Before:** `1000 at once`

```
type: ALL
Subquery materialization
```

<img width="1359" height="643" alt="Screenshot from 2025-07-15 21-37-08" src="https://github.com/user-attachments/assets/ee684d57-c2a6-4fd8-b749-e9beb36408a9" />




**After:** `500 in batches`

```
type: range
key: index_articles_on_namespace_and_wiki_id_and_title
Extra: Using where; Using index
```

<img width="1359" height="579" alt="Screenshot from 2025-07-15 21-36-37" src="https://github.com/user-attachments/assets/ba3bb022-5a71-45bf-82e5-e37d8476013d" />




## **Benchmark Timing Breakdown (10 Runs per Method)**

# Single

| Run | Method          | User (s)   | System (s) | Total (s)  | Real (s)    |
| --- | --------------- | ---------- | ---------- | ---------- | ----------- |
| 1   | Single Query    | 2.3580     | 0.8188     | 3.1768     | 23.4926     |
| 2   | Single Query    | 2.2588     | 0.7845     | 3.0433     | 22.9931     |
| 3   | Single Query    | 2.1097     | 0.7519     | 2.8616     | 23.3423     |
| 4   | Single Query    | 2.0646     | 0.6570     | 2.7216     | 23.4222     |
| 5   | Single Query    | 2.1569     | 0.6499     | 2.8068     | 23.7333     |
| 6   | Single Query    | 2.0162     | 0.5740     | 2.5902     | 23.2345     |
| 7   | Single Query    | 2.1789     | 0.6311     | 2.8100     | 23.5475     |
| 8   | Single Query    | 2.2262     | 0.6690     | 2.8952     | 23.5060     |
| 9   | Single Query    | 2.4627     | 0.8091     | 3.2719     | 23.5800     |
| 10  | Single Query    | 2.2506     | 0.7278     | 2.9785     | 25.1082     |
|     | **Avg (Set 1)** | **2.2087** | **0.7072** | **2.9159** | **23.6960** |

---

# Batch

| Run | Method          | User (s)   | System (s) | Total (s)  | Real (s)    |
| --- | --------------- | ---------- | ---------- | ---------- | ----------- |
| 1   | Batched Query   | 3.8946     | 0.2639     | 4.1585     | 11.0029     |
| 2   | Batched Query   | 4.2386     | 0.3201     | 4.5587     | 10.9594     |
| 3   | Batched Query   | 4.0917     | 0.2321     | 4.3238     | 10.7075     |
| 4   | Batched Query   | 4.1782     | 0.3019     | 4.4801     | 10.9013     |
| 5   | Batched Query   | 4.0295     | 0.2899     | 4.3194     | 10.5783     |
| 6   | Batched Query   | 4.1714     | 0.3165     | 4.4879     | 11.0138     |
| 7   | Batched Query   | 3.9317     | 0.2578     | 4.1895     | 9.3219      |
| 8   | Batched Query   | 4.1886     | 0.3093     | 4.4978     | 11.7283     |
| 9   | Batched Query   | 4.0898     | 0.2790     | 4.3688     | 10.9055     |
| 10  | Batched Query   | 4.1529     | 0.3004     | 4.4534     | 10.9656     |
|     | **Avg (Set 2)** | **4.1967** | **0.2571** | **4.4538** | **10.8085** |


---

## **Benchmark Comparison: Single Query vs. Batched Query (2000-title slices)**

**Test Conditions:**

* Dataset: 782,495 unique titles
* Queries: 10 runs per method
* Metric: Time measured using Ruby’s `Benchmark.measure` (user, system, total, real)

---

### **Average Time per Query (10 runs)**

| Metric           | Single Query      | Batched Query (2000-title) | Less time required by          |
| ---------------- | ----------------- | -------------------------- | --------------- |
| **User**      | 2.21 seconds      | 4.20 seconds               | Single Query    |
| **System**    | 0.71 seconds      | 0.26 seconds               | **Batched**     |
| **Total CPU** | 2.92 seconds      | 4.45 seconds               | Single Query    |
| **Real Time** | **23.70 seconds** | **10.81 seconds**          | **Batched**  |



## [BenchMark Memory](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6410#issuecomment-3084221686)