### PR TITLE
Deleted the button to download nonexistent revision data csv from /campaigns including backend

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign_row.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_row.jsx
@@ -15,9 +15,6 @@ const CampaignRow = ({ campaign }) => {
       <td>
         <a href={`/campaigns/${campaign.slug}/articles_csv.csv`}>{I18n.t('campaign.pages_edited_small')}</a>
       </td>
-      <td>
-        <a href={`/campaigns/${campaign.slug}/revisions_csv.csv`}>{I18n.t('campaign.revision_data')}</a>
-      </td>
     </tr>
   );
 };

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -10,7 +10,7 @@ class CampaignsController < ApplicationController
   before_action :set_campaign, only: %i[overview programs articles users edit
                                         update destroy add_organizer remove_organizer
                                         remove_course courses ores_plot articles_csv
-                                         alerts students instructors
+                                        alerts students instructors
                                         wikidata active_courses]
   before_action :require_create_permissions, only: [:create]
   before_action :require_write_permissions, only: %i[update destroy add_organizer

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -6,8 +6,7 @@ require_dependency "#{Rails.root}/lib/analytics/ores_diff_csv_builder"
 #= Controller for campaign data
 class CampaignsController < ApplicationController
   layout 'admin', only: %i[index create]
-  before_action :require_signed_in, only: %i[instructors courses articles_csv
-                                             ]
+  before_action :require_signed_in, only: %i[instructors courses articles_csv]
   before_action :set_campaign, only: %i[overview programs articles users edit
                                         update destroy add_organizer remove_organizer
                                         remove_course courses ores_plot articles_csv

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -7,11 +7,11 @@ require_dependency "#{Rails.root}/lib/analytics/ores_diff_csv_builder"
 class CampaignsController < ApplicationController
   layout 'admin', only: %i[index create]
   before_action :require_signed_in, only: %i[instructors courses articles_csv
-                                             revisions_csv]
+                                             ]
   before_action :set_campaign, only: %i[overview programs articles users edit
                                         update destroy add_organizer remove_organizer
                                         remove_course courses ores_plot articles_csv
-                                        revisions_csv alerts students instructors
+                                         alerts students instructors
                                         wikidata active_courses]
   before_action :require_create_permissions, only: [:create]
   before_action :require_write_permissions, only: %i[update destroy add_organizer
@@ -251,10 +251,6 @@ class CampaignsController < ApplicationController
 
   def articles_csv
     csv_of('articles')
-  end
-
-  def revisions_csv
-    csv_of('revisions')
   end
 
   def wikidata

--- a/app/workers/campaign_csv_worker.rb
+++ b/app/workers/campaign_csv_worker.rb
@@ -29,8 +29,6 @@ class CampaignCsvWorker
       builder.courses_to_csv
     when 'articles'
       builder.articles_to_csv
-    when 'revisions'
-      builder.revisions_to_csv
     when 'wikidata'
       builder.wikidata_to_csv
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,7 +286,6 @@ Rails.application.routes.draw do
       get 'courses'
       get 'ores_plot'
       get 'articles_csv'
-      get 'revisions_csv'
       get 'alerts'
       get 'wikidata'
       put 'add_organizer'


### PR DESCRIPTION
###  What this PR does

Fixes -> #6302 
This pull request removes the unused revisions_csv feature from the application.
It eliminates a dead code path related to campaign revisions CSV exports, addressing technical debt and improving maintainability.

### How did we fix

We removed all references to revisions_csv from the application codebase. Specifically:
-Eliminated the revisions_csv action from the CampaignsController.
-Removed the corresponding revisions_csv route in routes.rb.
-Cleaned up related conditional checks and headers in CampaignCsvBuilder and verified it was not referenced elsewhere.
-Ensured there are no remaining background job triggers or CSV generation logic depending on revisions_csv.

### Files we modified
```
app/controllers/campaigns_controller.rb

config/routes.rb

lib/analytics/campaign_csv_builder.rb

app/workers/campaign_csv_worker.rb
```

### Screenshots

Before:
<img width="1610" height="768" alt="Screenshot 2025-07-15 195847" src="https://github.com/user-attachments/assets/59359062-f17f-4e68-aeb7-e2f4093693ed" />


After:
<img width="1912" height="867" alt="Screenshot 2025-07-15 195713" src="https://github.com/user-attachments/assets/5fbeae7a-cb8e-49be-85b6-8a89d6a97a4b" />

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
