### PR TITLE
Auto_focus_to_search_bar

### DIFF
--- a/app/assets/javascripts/components/article_finder/article_finder_search_bar.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_search_bar.jsx
@@ -1,17 +1,28 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { debounce } from 'lodash';
 import { fetchArticleAutocompleteResults } from '../../utils/article_finder_utils';
 
 // Controls Search bar and autocomplete functionality
-
 function ArticleFinderSearchBar({ value, onChange, onSearch, disabled, wiki }) {
   const [suggestions, setSuggestions] = useState([]);
   const [isAutocompleteLoading, setAutocompleteLoading] = useState(false);
+  const searchInputRef = useRef(null);
+
   let searchClass = 'article-finder-search-bar';
 
   if (suggestions.length > 0) {
     searchClass += ' autocomplete-on';
   }
+
+  // Auto-focus on the search input when component mounts
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchInputRef.current) {
+        searchInputRef.current.focus();
+      }
+    }, 100);
+    return () => clearTimeout(timer);
+  }, []);
 
   const _getSuggestionsApi = useCallback(debounce(async (q) => {
     setAutocompleteLoading(true);
@@ -61,15 +72,17 @@ function ArticleFinderSearchBar({ value, onChange, onSearch, disabled, wiki }) {
         onChange={inputChangeHandler}
         value={value}
         onKeyDown={onKeyDownHandler}
+        ref={searchInputRef}
       />
 
       {
-        isAutocompleteLoading && <div className="loader"><div className="loading__spinner"/></div>
+        isAutocompleteLoading && <div className="loader"><div className="loading__spinner" /></div>
       }
 
       <button onClick={searchHandler} disabled={disabled}>
         {I18n.t('article_finder.search')}
       </button>
+
       <div className="autocomplete">
         {
           suggestions.map((sug) => {


### PR DESCRIPTION
### This PR
This is clean version of #6408 
-Fixes-> https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6407
-This PR adds autofocus to the ArticleFinderSearchBar input field when the component mounts. It improves the user experience by allowing users to start typing immediately without needing to click the input box.

-This addresses the issue where the search input did not receive focus automatically . A friction point for users, especially those who rely on keyboard navigation.


###  Screenshots

### Before:

https://github.com/user-attachments/assets/88b5e08b-ecec-49ed-ac67-9f6dc6e32183


### After:

https://github.com/user-attachments/assets/583b1bde-97e7-458f-8179-459829e6f1b7




### How to fix it
1)Added a ref (searchInputRef) to directly access the search input element.
2)Used useEffect to auto-focus the input field when the component mounts.
3)Included a slight setTimeout to ensure smooth DOM rendering before focusing.
4)Attached the ref to the tag for focus control.
5)If input already has a value, the search is triggered automatically on mount.
6)Introduced a basic error state when user tries searching with empty input.
7)Highlighted the input and refocused it to guide the user.


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >


