### PR TITLE
Temporarily disable Code Climate coverage upload to fix CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,16 +105,23 @@ jobs:
       
       - name: JavaScript linting
         run: yarn lint-non-build
+           
+      #temporarily disabling Code Climate coverage upload to fix failing CI builds.   
+      # - name: Ruby rspec test suite
+      #   uses: paambaati/codeclimate-action@v3.0.0
+      #   env:
+      #     COVERAGE: true
+      #     CC_TEST_REPORTER_ID: f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
+      #   with:
+      #     coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
+      #     coverageLocations: |
+      #       ${{github.workspace}}/public/js_coverage/lcov.info:lcov
 
+      #Keep all tests and local coverage generation intact
       - name: Ruby rspec test suite
-        uses: paambaati/codeclimate-action@v3.0.0
         env:
           COVERAGE: true
-          CC_TEST_REPORTER_ID: f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
-        with:
-          coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
-          coverageLocations: |
-            ${{github.workspace}}/public/js_coverage/lcov.info:lcov
+        run: bundle exec rspec spec/ --color --profile --format documentation
       
       - name: Archive capybara failure screenshots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
###  Fix CI failures by temporarily disabling Code Climate coverage upload
Fixes #6418 

###  Problem
- All builds are failing due to Code Climate coverage report upload errors
- This appears to be a service disruption or API change with Code Climate
- PRs unrelated to coverage are being blocked

###  Solution
- Temporarily disable Code Climate coverage upload in CI workflow
- Keep all tests and local coverage generation intact
- This is a minimal change to unblock builds while we investigate the Code Climate issue

###  Changes
- Modified `.github/workflows/ci.yml` to run RSpec tests directly instead of through Code Climate action
- Removed Code Climate reporter configuration (commented out)
- Preserved `COVERAGE: true` environment variable for local coverage generation

###  Next Steps
- This is a temporary fix to unblock development
- Follow-up PR will restore Code Climate integration once the service issue is resolved

