### PR TITLE
Coverage report CI/Built Fix PR-2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 engines:
   rubocop:
     enabled: true
@@ -23,13 +25,6 @@ ratings:
   - "**.css"
   - Gemfile.lock
 
-# For all languages, we support a standard set of Glob patterns.
-# exclude_paths:
-# - app/helpers/users_helper.php # Exclude a specific file
-# - app/controllers/* # Exclude all contents of a folder (including all subfolders)
-# - app/controllers/*.py # Exclude specific files type within a folder/subfolders
-# - lib/**/*.rb # Recursively ignore all files ending in .rb
-
 exclude_paths:
 - public/*
 - db/*
@@ -38,3 +33,28 @@ exclude_paths:
 - spec/*
 - docs/*
 - setup/*
+- node_modules/*
+- tmp/*
+- coverage/*
+
+# Essential quality checks - these prevent major code quality issues
+checks:
+  # Prevents overly complex methods (most important)
+  method-complexity:
+    config:
+      threshold: 8
+  
+  # Prevents methods from becoming too long (crucial for maintainability)
+  method-lines:
+    config:
+      threshold: 50
+  
+  # Prevents files from becoming massive (important for team collaboration)
+  file-lines:
+    config:
+      threshold: 400
+  
+  # Prevents too many parameters (reduces complexity)
+  argument-count:
+    config:
+      threshold: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,23 +105,20 @@ jobs:
       
       - name: JavaScript linting
         run: yarn lint-non-build
-           
-      #temporarily disabling Code Climate coverage upload to fix failing CI builds.   
-      # - name: Ruby rspec test suite
-      #   uses: paambaati/codeclimate-action@v3.0.0
-      #   env:
-      #     COVERAGE: true
-      #     CC_TEST_REPORTER_ID: f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
-      #   with:
-      #     coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
-      #     coverageLocations: |
-      #       ${{github.workspace}}/public/js_coverage/lcov.info:lcov
 
-      #Keep all tests and local coverage generation intact
       - name: Ruby rspec test suite
         env:
           COVERAGE: true
         run: bundle exec rspec spec/ --color --profile --format documentation
+
+      - name: Upload coverage to Code Climate
+        uses: paambaati/codeclimate-action@v5.0.0
+        env:
+          CC_TEST_REPORTER_ID: f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
+        with:
+          coverageLocations: |
+            ${{github.workspace}}/public/js_coverage/lcov.info:lcov
+        continue-on-error: true
       
       - name: Archive capybara failure screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,16 +105,23 @@ jobs:
       
       - name: JavaScript linting
         run: yarn lint-non-build
+           
+      #temporarily disabling Code Climate coverage upload to fix failing CI builds.   
+      # - name: Ruby rspec test suite
+      #   uses: paambaati/codeclimate-action@v3.0.0
+      #   env:
+      #     COVERAGE: true
+      #     CC_TEST_REPORTER_ID: f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
+      #   with:
+      #     coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
+      #     coverageLocations: |
+      #       ${{github.workspace}}/public/js_coverage/lcov.info:lcov
 
+      #Keep all tests and local coverage generation intact
       - name: Ruby rspec test suite
-        uses: paambaati/codeclimate-action@v3.0.0
         env:
           COVERAGE: true
-          CC_TEST_REPORTER_ID: f0d5d763ddc6b3f980ba0fb0c38e7c27c0dffc4a5787cd7d5b8c2b0c3b2e27e2
-        with:
-          coverageCommand: bundle exec rspec spec/ --color --profile --format documentation
-          coverageLocations: |
-            ${{github.workspace}}/public/js_coverage/lcov.info:lcov
+        run: bundle exec rspec spec/ --color --profile --format documentation
       
       - name: Archive capybara failure screenshots
         uses: actions/upload-artifact@v4

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,14 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-  collectCoverage: false,
+  collectCoverage: true,
+  coverageDirectory: 'public/js_coverage',
+  coverageReporters: ['lcov', 'text-summary'],
+  collectCoverageFrom: [
+    'app/assets/javascripts/**/*.{js,jsx}',
+    '!app/assets/javascripts/**/*.spec.{js,jsx}',
+    '!app/assets/javascripts/**/__tests__/**'
+  ],
   roots: [
     'test',
     'app/assets/javascripts'


### PR DESCRIPTION
PR fixes #6418 and progression of #6420 

### Current status :
-Needs brutal refining and testing : To be done
-CI/Tests pass on GitHub : To be done
- Confirm .codeclimate.yml is valid :To be done

### PR Description:
This PR fully restores and updates Code Climate test coverage reporting in CI by:
-Upgrading to the latest codeclimate-action@v5.0.0
-Making the upload step non-blocking with continue-on-error: true
-Enabling proper JavaScript coverage output via Jest
-Updating .codeclimate.yml to use version 2 with useful code quality checks

 ### PR Does:
 -Restores coverage upload to Code Climate
- Avoids CI breaks due to external service outages
- Makes coverage data available for both JS and Ruby
- Improves project code health and analysis with clear rules
- Aligns with current best practices for GitHub Actions and Code Climate integration



