### PR TITLE
Add "Join Slack Community" Button to GitHub README for One-Click Email Access

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@
 We love contributions! If you're looking for a way to get involved, contact
 Sage Ross (`ragesoss`). Our main venue for collaboration is Slack; ask Sage (sage at wikiedu.org) for an invite.
 
+[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
+
 ## Quick start guide
 
 * Set up a dev environment. Follow the [setup docs](docs/setup.md). Try the automatic scripts, and report any problems that force you to use the manual instructions. For Windows, use WSL 2 (not RubyInstaller or RailsInstaller).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Open Source Helpers](https://www.codetriage.com/wikieducationfoundation/wikiedudashboard/badges/users.svg)](https://www.codetriage.com/wikieducationfoundation/wikiedudashboard)
 
 
-[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
 
 The Wiki Education Dashboard is a web application that supports Wikipedia education assignments, edit-a-thons, and other editing projects. It provides data and course management features for groups of editors — instructors, students, and others — who are working on Wikipedia, Wikidata, and other Wikimedia wikis. Users log in with their Wikipedia accounts (through OAuth) and allow the Dashboard to make edits on their behalf. The Dashboard automates many of the standard elements of organizing and participating in a Wikipedia classroom assignment, edit-a-thon, or other wiki contribution campaign.
 
@@ -28,6 +27,8 @@ Overview:
 ## Contribute!
 
 This project welcomes contributions, and we try to be as newbie-friendly as possible. Check out [the CONTRIBUTING file](CONTRIBUTING.md) for more details.
+
+[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
 
 ### Setup
 - [Setting up a development environment](docs/setup.md)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Code Climate](https://codeclimate.com/github/WikiEducationFoundation/WikiEduDashboard/badges/gpa.svg)](https://codeclimate.com/github/WikiEducationFoundation/WikiEduDashboard)
 [![Open Source Helpers](https://www.codetriage.com/wikieducationfoundation/wikiedudashboard/badges/users.svg)](https://www.codetriage.com/wikieducationfoundation/wikiedudashboard)
 
+
+[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
+
 The Wiki Education Dashboard is a web application that supports Wikipedia education assignments, edit-a-thons, and other editing projects. It provides data and course management features for groups of editors — instructors, students, and others — who are working on Wikipedia, Wikidata, and other Wikimedia wikis. Users log in with their Wikipedia accounts (through OAuth) and allow the Dashboard to make edits on their behalf. The Dashboard automates many of the standard elements of organizing and participating in a Wikipedia classroom assignment, edit-a-thon, or other wiki contribution campaign.
 
 The Dashboard code runs two main sites: the Wiki Education Dashboard — [dashboard.wikiedu.org](https://dashboard.wikiedu.org) — and the Wikimedia Programs & Events Dashboard — [outreachdashboard.wmflabs.org](https://outreachdashboard.wmflabs.org). dashboard.wikiedu.org is used for Wiki Education programs, primarily focused on higher education in the United States and Canada. outreachdashboard.wmflabs.org is for the global Wikimedia community to organize all kinds of programs, including edit-a-thons, education programs, and other events.


### PR DESCRIPTION
## What this PR does
As discussed in [Issue #6416 ] the current Slack onboarding process requires users to manually draft and send an email. This PR introduces a streamlined approach by embedding a pre-filled email link inside a modern Slack-branded badge

## Screenshots
Before:
<img width="1871" height="528" alt="Screenshot 2025-07-25 195927" src="https://github.com/user-attachments/assets/5b9b13ac-e3c2-404a-9f02-be024b2be35a" />

After:
<img width="1731" height="708" alt="Screenshot 2025-07-25 195550" src="https://github.com/user-attachments/assets/38fd9301-3572-4cd5-9c1e-f2c6c7eb96d3" />
<img width="1756" height="615" alt="Screenshot 2025-07-25 195608" src="https://github.com/user-attachments/assets/ce88a064-f27d-4837-ba00-305321424037" />

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
