### PR TITLE
Ensure no duplicate article titles for categories

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -354,12 +354,12 @@ class Course < ApplicationRecord
   end
 
   def scoped_article_titles(wiki)
-    assigned_article_titles(wiki) + category_article_titles(wiki)
+    (assigned_article_titles(wiki) + category_article_titles(wiki)).uniq
   end
 
   def assigned_article_titles(wiki)
     @assigned_article_titles ||= {}
-    @assigned_article_titles[wiki] ||= assignments.where(wiki:).pluck(:article_title)
+    @assigned_article_titles[wiki] ||= assignments.where(wiki:).pluck(:article_title).uniq
   end
 
   def category_article_titles(wiki)

--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -77,7 +77,7 @@ class Category < ApplicationRecord
     return unless VALID_SOURCES.include? source
     self.article_titles = title_list_from_wiki(update_service:).map do |title|
       sanitize_4_byte_string ArticleUtils.format_article_title(title)
-    end
+    end.uniq
     save
     # rubocop:disable Rails/SkipsModelValidations
     # Using touch to update the timestamps even when there is actually no

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -237,6 +237,11 @@ RSpec.describe Category, type: :model do
       create(:category, name: 'Redirects from emoji', wiki: Wiki.find(1), source: 'category')
     end
 
+    let(:es_wiki) { create(:wiki, language: 'es', project: 'wikipedia') }
+    let(:duplicate_cat) do
+      create(:category, name: 'Lesbianas', wiki: es_wiki, source: 'category', depth: 2)
+    end
+
     it 'escapes four-byte emoji titles' do
       VCR.use_cassette 'categories' do
         emoji_cat.refresh_titles
@@ -256,6 +261,13 @@ RSpec.describe Category, type: :model do
       VCR.use_cassette 'categories' do
         category2.refresh_titles
         expect(category2.article_titles.select { |title| title.include? 'Talk:' }).to eq([])
+      end
+    end
+
+    it 'does not include duplicate titles' do
+      VCR.use_cassette 'categories' do
+        duplicate_cat.refresh_titles
+        expect(duplicate_cat.article_titles.count).to eq(duplicate_cat.article_titles.uniq.count)
       end
     end
   end


### PR DESCRIPTION
## What this PR does
Closes #6415 

Note that categories with duplicate articles will be deduplicated in the next refreshing (once this is deployed).
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
