### PR TITLE
[WIP] Auto-hide Wikidata stats section when all values are zero

### DIFF
--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -150,7 +150,7 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
           </div>
         </div>
         <div className="stat-display__row">
-          <h5 className="stats-label">Descriptions</h5>
+          <h5 className="stats-label">{I18n.t('metrics.descriptions')}</h5>
           <div className="stat-display__value-group">
             <OverviewStat
               id="descriptions-added"
@@ -176,7 +176,7 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
           </div>
         </div>
         <div className="stat-display__row">
-          <h5 className="stats-label">Aliases</h5>
+          <h5 className="stats-label">{I18n.t('metrics.aliases')}</h5>
           <div className="stat-display__value-group">
             <OverviewStat
               id="aliases-added"
@@ -202,7 +202,7 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
           </div>
         </div>
         <div className="stat-display__row double-row">
-          <h5 className="stats-label">Other</h5>
+          <h5 className="stats-label">{I18n.t('metrics.other')}</h5>
           <div className="stat-display__value-group double">
             <OverviewStat
               id="qualifiers-added"

--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -3,6 +3,45 @@ import PropTypes from 'prop-types';
 import OverviewStat from './OverviewStats/overview_stat';
 
 const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
+  // Helper function to check if all stats are zero
+  const allStatsAreZero = () => {
+    const statsToCheck = [
+      'total revisions',
+      'merged to',
+      'interwiki links added',
+      'items created',
+      'items cleared',
+      'claims created',
+      'claims changed',
+      'claims removed',
+      'labels added',
+      'labels changed',
+      'labels removed',
+      'descriptions added',
+      'descriptions changed',
+      'descriptions removed',
+      'aliases added',
+      'aliases changed',
+      'aliases removed',
+      'qualifiers added',
+      'references added',
+      'redirects created',
+      'reverts performed',
+      'restorations performed',
+      'other updates',
+      'lexeme items created'
+    ];
+
+    return statsToCheck.every(statKey =>
+      !statistics[statKey] || statistics[statKey] === 0
+    );
+  };
+
+  // If all stats are zero, don't render the component
+  if (allStatsAreZero()) {
+    return null;
+  }
+
   let containerClass = 'wikidata-stats-container';
   let title = 'Wikidata stats';
   if (isCourseOverview) {
@@ -26,14 +65,14 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
             <OverviewStat
               id="merged"
               className="stat-display__value-small"
-              stat = {statistics['merged to']}
+              stat={statistics['merged to']}
               statMsg={I18n.t('metrics.merged')}
               renderZero={true}
             />
             <OverviewStat
               id="interwiki-links"
               className="stat-display__value-small"
-              stat = {statistics['interwiki links added']}
+              stat={statistics['interwiki links added']}
               statMsg={I18n.t('metrics.interwiki_links_added')}
               renderZero={true}
             />
@@ -227,7 +266,7 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
         </div>
       </div>
     </div>
-    );
+  );
 };
 
 WikidataOverviewStats.propTypes = {
@@ -235,4 +274,4 @@ WikidataOverviewStats.propTypes = {
   isCourseOverview: PropTypes.bool
 };
 
-  export default WikidataOverviewStats;
+export default WikidataOverviewStats;


### PR DESCRIPTION
## What this PR does
Fixes #6413 
Auto-hides the Wikidata stats section when all statistics are zero, preventing unnecessary UI clutter.
### Problem
The Wikidata stats section was displayed even when all values were 0, taking up screen space and providing no value to users (as shown in campaigns like Wiki Loves Sport 2025).

### Solution
- Added `allStatsAreZero()` helper function to check if all Wikidata statistics are zero or undefined
- Component now returns `null` when all stats are zero, hiding the entire section
- Maintains existing functionality when any stat has a value > 0
- CSV download behavior remains unchanged as requested
- - Fixed ESLint warnings by replacing hardcoded strings with I18n translations for "Descriptions", "Aliases", and "Other" labels



###  Files Changed
- `app/assets/javascripts/components/common/wikidata_overview_stats.jsx`

### Testing
- Test with campaigns that have zero Wikidata activity (should hide the section)
- Test with campaigns that have Wikidata activity (should display normally)
- Test campaigns without Wikidata tracking (should remain unchanged)

