### PR TITLE
Optimize campaign articles using deferred join for pagination v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,13 @@ jobs:
             cp config/application.example.yml config/application.yml
             cp config/database.example.yml config/database.yml
             bin/rails db:migrate RAILS_ENV=test
-        
+          
+      - name: Check eager loading (catch autoloading issues)
+        env:
+          RAILS_ENV: test
+          DATABASE_PORT: 3306
+        run: bundle exec rails runner "Rails.application.eager_load!"
+
       - name: Cache Webpack cache
         id: cache-webpack
         uses: actions/cache@v3

--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -2,7 +2,6 @@
 
 require_dependency "#{Rails.root}/lib/word_count"
 require_dependency "#{Rails.root}/lib/analytics/histogram_plotter"
-require_dependency "#{Rails.root}/app/presenters/query/ranked_articles_courses_query"
 
 #= Presenter for courses / campaign view
 class CoursesPresenter
@@ -65,7 +64,7 @@ class CoursesPresenter
   def articles_courses_scope
     return @articles_courses_scope unless @articles_courses_scope.nil?
 
-    @articles_courses_scope = RankedArticlesCoursesQuery.new(
+    @articles_courses_scope = Query::RankedArticlesCoursesQuery.new(
       courses: course_ids_and_slugs,
       per_page: PER_PAGE,
       offset:,

--- a/app/presenters/query/ranked_articles_courses_query.rb
+++ b/app/presenters/query/ranked_articles_courses_query.rb
@@ -16,7 +16,7 @@ class Query::RankedArticlesCoursesQuery
   def scope
     ArticlesCourses
       .joins("INNER JOIN (#{subquery.to_sql}) AS ranked_articles USING (id)")
-      .select(:article_id, :course_id, :character_sum, :references_count, :view_count)
+      .select(:article_id, :course_id, :character_sum, :references_count, :view_count, :updated_at)
   end
 
   private

--- a/app/presenters/query/ranked_articles_courses_query.rb
+++ b/app/presenters/query/ranked_articles_courses_query.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# RankedArticlesCoursesQuery builds a subquery and join scope for retrieving articles_courses
+# with optional ordering, pagination, and filtering for tracked articles only.
+# This is used to cleanly separate query logic from presenter code.
+# It uses a deferred join via a subquery for improved performance on large datasets.
+class RankedArticlesCoursesQuery
+  def initialize(courses:, per_page:, offset:, too_many:)
+    @courses = courses
+    @per_page = per_page
+    @offset = offset
+    @too_many = too_many
+  end
+
+  # Builds the final scope by joining the subquery on ID, used to fetch paginated and ranked results. # rubocop:disable Layout/LineLength
+  def scope
+    ArticlesCourses
+      .joins("INNER JOIN (#{subquery.to_sql}) AS ranked_articles USING (id)")
+      .select(:article_id, :course_id, :character_sum, :references_count, :view_count)
+  end
+
+  private
+
+  # Builds a subquery that includes optional ordering and pagination depending on the "too_many" flag. # rubocop:disable Layout/LineLength
+  def subquery
+    ArticlesCourses
+      .includes(:article)
+      .where(course_id: @courses.map(&:id), tracked: true)
+      .select(:id)
+      .then do |q|
+        @too_many ? q : q.order('articles.deleted ASC, articles_courses.character_sum DESC')
+      end
+      .limit(@per_page)
+      .offset(@offset)
+  end
+end

--- a/app/presenters/query/ranked_articles_courses_query.rb
+++ b/app/presenters/query/ranked_articles_courses_query.rb
@@ -4,7 +4,7 @@
 # with optional ordering, pagination, and filtering for tracked articles only.
 # This is used to cleanly separate query logic from presenter code.
 # It uses a deferred join via a subquery for improved performance on large datasets.
-class RankedArticlesCoursesQuery
+class Query::RankedArticlesCoursesQuery
   def initialize(courses:, per_page:, offset:, too_many:)
     @courses = courses
     @per_page = per_page

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -13,4 +13,4 @@
       = "#{article.wiki.language}.#{article.wiki.project}"
   %td.course_title
     %small
-      = link_to article_course.course.slug.gsub('_',' '), "/courses/#{article_course.course.slug}"
+      = link_to course.slug.gsub('_',' '), "/courses/#{course.slug}"

--- a/app/views/campaigns/articles.html.haml
+++ b/app/views/campaigns/articles.html.haml
@@ -59,18 +59,23 @@
             = t("#{@presenter.course_string_prefix}.courses")
             %span.sortable-indicator
 
-      - articles = @presenter.campaign_articles
+      -  result = @presenter.campaign_articles
+      -  articles_courses = result[:articles_courses]
+      -  courses = result[:courses]
+      -  articles = result[:articles]
 
-      = will_paginate articles
+      = will_paginate articles_courses
 
       %tbody.list
-        - if articles.empty?
+        - if articles_courses.empty?
           %tr.disabled
             %td{:class => "text-center", :colSpan => 7}
               %span= I18n.t('articles.none')
         - else
-          - articles.each do |ac|
+          - articles_courses.each do |ac|
+            - course = courses[ac.course_id]
+            - article = articles[ac.article_id]
             - cache [ac, locale] do
-              = render 'campaigns/article_row', article: ac.article, article_course: ac
+              = render 'campaigns/article_row', article:, article_course: ac, course:
 
-    = will_paginate articles
+    = will_paginate articles_courses

--- a/app/views/tagged_courses/articles.html.haml
+++ b/app/views/tagged_courses/articles.html.haml
@@ -72,7 +72,8 @@
               %span= I18n.t('articles.none')
         - else
           - articles.each do |ac|
+            - course = ac.course
             - cache [ac, locale] do
-              = render 'campaigns/article_row', article: ac.article, article_course: ac
+              = render 'campaigns/article_row', article: ac.article, article_course: ac, course:
 
     = will_paginate articles

--- a/spec/presenters/courses_presenter_spec.rb
+++ b/spec/presenters/courses_presenter_spec.rb
@@ -35,8 +35,8 @@ describe CoursesPresenter do
     end
 
     it 'only includes tracked articles' do
-      expect(subject.count).to eq(1)
-      expect(subject.first.article.title).to eq(article.title)
+      expect(subject[:articles_courses].count).to eq(1)
+      expect(subject[:articles].first[1].title).to eq(article.title)
     end
   end
 


### PR DESCRIPTION
## References

- [Deferred joins (Planetscale)](https://planetscale.com/learn/courses/mysql-for-developers/examples/deferred-joins)
- [Efficient MySQL pagination using deferred joins -  Aaron](https://aaronfrancis.com/2022/efficient-mysql-pagination-using-deferred-joins-15d0de14)
- [Deferred Join: A Deep Dive](https://hackmysql.com/deferred-join-deep-dive/)
- [Autoloading and Reloading Constants](https://guides.rubyonrails.org/v8.0/autoloading_and_reloading_constants.html)

## Problems this PR Resolves

**1.** Resolves [Sentry#29f69f95](https://wiki-education.sentry.io/issues/6388168027/?project=6269916&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)


**2.** Addresses a **MySQL Slow Query** that occurs in the months of **March** and **June**:

*  [select\_count\_distinct\_articles\_courses\_id.txt](https://github.com/userattachments/files/21427206/select_count_distinct_articles_courses_id.txt)

**3.** Fixes a dependency loading error that led to a production failure ([#6422](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6422))


**4.** Added test to resolve **ActionView::Template::Error**  [Sentry #14907356](https://wiki-education.sentry.io/issues/6772066298/?project=6269916&referrer=github-pr-bot)  (#6429)


# What this PR does

## 1. Resolves [Sentry#29f69f95](https://wiki-education.sentry.io/issues/6388168027/?project=6269916&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)

Refactors the campaign articles functionality to use deferred joins and structured data loading, significantly improving performance for large datasets while maintaining the same user experience and improving page load time.

The previous implementation had performance issues when dealing with large numbers of articles, particularly during pagination and sorting operations. The query approach was causing slow page loads for campaigns with extensive article collections.


**Solution**
Implemented a deferred join pattern with structured data separation:

**Key Changes**

#### 1. **Deferred Join Pattern**
- Replaced direct query with `ranked_articles_subquery` that pre-filters and ranks articles
- Uses `INNER JOIN` with the ranked subquery for optimal performance
- Maintains conditional sorting logic based on article count

#### 2. **Structured Data Loading**
- `campaign_articles` now returns a hash with three separate collections:
  - `articles_courses`: Paginated articles_courses data
  - `courses`: Indexed courses by ID for efficient lookup
  - `articles`: Indexed articles by ID for efficient lookup

#### 3. **Custom Pagination**
- Implements manual pagination using `WillPaginate::Collection`
- Proper offset/limit handling with `total_articles_count`
- Maintains existing pagination interface in views

#### 4. **Optimized Data Fetching**
- Uses `.select()` to load only required fields
- Implements instance variable caching for expensive operations
- Separates concerns with dedicated methods for each data type

### Performance Improvements
- **Query Optimization**: Deferred join reduces query complexity for large datasets
- **Memory Efficiency**: Loads only necessary fields and data structures
- **Caching**: Instance variables prevent redundant database calls
- **Scalability**: Handles large article counts without performance degradation

### View Updates
Updated templates to work with the new data structure:
- `articles.html.haml`: Uses structured data from the hash
- `_article_row.html.haml`: Accepts pre-loaded course and article objects
- Maintains existing UI/UX with no user-facing changes

### Technical Details

### Method Organization
The refactored presenter follows a logical data flow:
1. **Main interface**: `campaign_articles`
2. **Data sources**: `campaigns_courses_ids`, `load_courses`
3. **Query builders**: `ranked_articles_subquery`, `articles_courses_scope`
4. **Data fetchers**: `fetched_articles`
5. **Pagination**: `paginated_articles_courses`, `total_articles_count`
6. **Helpers**: `per_page`, `current_page`, `offset`

### Database Impact
- Reduces complex joins through deferred pattern
- Maintains existing indexes and relationships
- No schema changes required

### Testing
- Verify pagination works correctly for large datasets
- Confirm sorting behavior matches previous implementation
- Test performance with campaigns containing 1000+ articles
- Ensure view rendering remains consistent



## Screenshots  `(WITH SORTING)`

**Before:**

**`PAGE 1`**  **(4841 ms)**

![Screenshot from 2025-07-08 22-25-49](https://github.com/user-attachments/assets/d23b0996-18bc-4bf8-9c6f-a15a2959daab)

**`PAGE 1197`**  **(5870 ms)**

![Screenshot from 2025-07-08 22-27-28](https://github.com/user-attachments/assets/021b5cda-7630-4cbe-b5af-25406d2910a1)


**After:** 

**`PAGE 1`**  **(732 ms)**

![Screenshot from 2025-07-08 22-20-37](https://github.com/user-attachments/assets/6dfdb91b-ff24-410f-87b1-c29885f7c5a7)


**`PAGE 1197`**  **(831 ms)**

![Screenshot from 2025-07-08 22-22-26](https://github.com/user-attachments/assets/bcd53c29-c9ca-4037-b3d1-8e81b5fec3ed)


## Screenshots  `(WITHOUT SORTING)`


**BEFORE**

**`PAGE 1`**  **(430 ms)**


![Screenshot from 2025-07-09 17-52-56](https://github.com/user-attachments/assets/f262a555-515b-417c-adc9-42621cc56e1b)



**`PAGE 1197`** **(2068 ms)**

![Screenshot from 2025-07-09 17-50-41](https://github.com/user-attachments/assets/02c71022-88dd-4227-8581-0a89ab0ddaf6)



**AFTER**


**`PAGE 1`**  **(307 ms)**

![Screenshot from 2025-07-09 17-26-46](https://github.com/user-attachments/assets/60071fc7-3232-4cbc-95a2-111c57d7b148)


**`PAGE 1197`**  **(268 ms)**

![Screenshot from 2025-07-09 17-28-31](https://github.com/user-attachments/assets/7cda7c3e-01a5-4132-aa34-4ab79ffd19e2)




## 2. Addresses a **MySQL Slow Query** that occurs in the months of **March** and **June**:

**This PR not only resolves [Sentry#29f69f95](https://wiki-education.sentry.io/issues/6388168027/?project=6269916&query=is%3Aunresolved&referrer=issue-stream&stream_index=0), but also addresses a slow query from the MySQL slow log that I came across (shown below). This issue is likely resolved by the newly introduced [`paginated_articles_courses`](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6424/files#diff-e132e74b4f6657fb776d13c16588ee540fdf249594d26e586fa66947083156e0R87) method in this PR.**

[select_count_distinct_articles_courses_id.txt](https://github.com/user-attachments/files/21349964/select_count_distinct_articles_courses_id.txt)


### Screenshots:

`a) MYSQL SLOW LOG QUERY`

<img width="1167" height="569" alt="Screenshot from 2025-07-21 20-10-34" src="https://github.com/user-attachments/assets/0d17dfa3-7382-4c63-97a0-2ade99274a53" />


`b) Screenshot from my local development log`

<img width="1348" height="111" alt="Screenshot from 2025-07-21 20-15-48" src="https://github.com/user-attachments/assets/b4c8f0ab-0523-409a-982a-4f4c2d3d5674" />


`c) Source code responsible for the slowquery Highlighted`  (views/campaigns/articles.html.haml [Line 64])

<img width="1253" height="251" alt="Screenshot from 2025-07-21 20-19-38" src="https://github.com/user-attachments/assets/09977b2a-ff64-4e05-970f-9154c7469110" />


## 3. Fixes a dependency loading error that led to a production failure ([#6422](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6422))


Fixes a **Zeitwerk autoloading error** that caused a production deployment to fail due to a constant name mismatch during eager loading.



### Background

In PR [#6422](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6422), a new class `RankedArticlesCoursesQuery` was introduced under the path:

```
app/presenters/query/ranked_articles_courses_query.rb
```

However, the file defined a **top-level constant**:

```ruby
class RankedArticlesCoursesQuery
```

Zeitwerk, which manages Rails autoloading, expected the file to define:

```ruby
Query::RankedArticlesCoursesQuery
```

This mismatch caused the production environment (where `eager_load = true`) to raise the following error at boot:

```
uninitialized constant Query::RankedArticlesCoursesQuery
```

The issue was not detected in development or CI due to:

* Lazy loading in non-production environments
* Manual `require_dependency` masking the inconsistency

---
**Changes:**

* Properly namespaces the class as `Query::RankedArticlesCoursesQuery`
* Removes the manual `require_dependency` from `CoursesPresenter`
* Updates all references to use the correct fully qualified constant

---
**Fixes:**
* Prevents production boot failures caused by autoloading errors
* Aligns with Zeitwerk conventions and Rails best practices
* Makes the application safe to eager load in any environment

---

### Screenshot (Detects Zeitwerk autoloading error in the CI)


<img width="420" height="182" alt="470281006-a70cf643-eba7-49cd-91b7-5418826b8e7e" src="https://github.com/user-attachments/assets/98cf14a0-be3e-42a3-9390-5c8a8fb84c8f" />


## 4. Add Test

Added tests for CampaignsController#articles to verify presence of critical attributes (e.g., updated_at, id, article_id, course_id) on articles_courses.This prevents ActionView::Template::Error due to missing attributes when
fragment caching is enabled in production.

`I have added few more minor test that i thought will be helpful.`

### Screenshot

- Now, it detects the Issue properly both in [CI](https://github.com/WikiEducationFoundation/WikiEduDashboard/actions/runs/16563914948/job/46839285720) when the test runs and locally too as shown below


https://github.com/user-attachments/assets/fc7360f0-25ea-4452-9719-96b872a41526

<img width="1001" height="153" alt="Screenshot from 2025-07-28 17-15-44" src="https://github.com/user-attachments/assets/e3bbd34e-134e-4439-b4ff-c163d57c1c60" />

