### PR TITLE
Optimize revision count aggregation using ActiveRecord sum for CourseCsvBuilder#revisions_by_namespace

### DIFF
--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -101,7 +101,7 @@ class CourseCsvBuilder
            .where(tracked: true)
            .joins(:article)
            .where(articles: { namespace: })
-           .sum(&:revision_count)
+           .sum(:revision_count)
   end
 
   def training_completion_rate


### PR DESCRIPTION
## What this PR does

`Log File`

- [course_csv_builder_revisions_by_namespace.txt](https://github.com/user-attachments/files/21515974/course_csv_builder_revisions_by_namespace.txt)


Updates the `revisions_by_namespace` method to replace a Ruby-side summation with a SQL-level aggregation using ActiveRecord's `.sum(:revision_count)`. This change significantly reduces execution time by delegating the computation to the database instead of performing it in Ruby.

---

### Performance Comparions [(Using benchmark/ips)](https://github.com/evanphx/benchmark-ips):

 - `Benchmark/ips code`

```ruby


  def ruby_sum_revisions_by_namespace
    @course.scoped_article_timeslices
           .where(tracked: true)
           .joins(:article)
           .where(articles: { namespace: 0 })
           .sum(&:revision_count)
  end

  def active_record_sum_revisions_by_namespace
    @course.scoped_article_timeslices
           .where(tracked: true)
           .joins(:article)
           .where(articles: { namespace: 0 })
           .sum(:revision_count)
  end

  def call_revisions_by_namespace
    # Warm-up to avoid first-query penalty
    ruby_sum_revisions_by_namespace
    active_record_sum_revisions_by_namespace

    Benchmark.ips do |x|
      x.report('Ruby sum ') { ruby_sum_revisions_by_namespace }
      x.report('ActiveRecord sum ') { active_record_sum_revisions_by_namespace }
      x.compare!
    end
  end

``` 

**IPS Benchmark (Iterations per Second):**

```
ActiveRecord sum : 57.1 i/s
Ruby sum         : 8.9 i/s  (6.42x slower)
```

```

Comparison:
   ActiveRecord sum :       57.1 i/s
           Ruby sum :        8.9 i/s - 6.42x  slower

=> #<Benchmark::IPS::Report:0x0000700cf50e9968
 @data=nil,
 @entries=
  [#<Benchmark::IPS::Report::Entry:0x0000700cf516bdf0
    @iterations=44,
    @label="Ruby sum ",
    @measurement_cycle=1,
    @microseconds=5066503.984004974,
    @show_total_time=true,
    @stats=
     #<Benchmark::IPS::Stats::SD:0x0000700cf51640a0
      @error=1,
      @mean=8.90138084964979,
      @samples=
       [8.955697997836701,
        7.545513443072059,
        5.1636810469018055,
        7.2985448001654945,
        9.883008112374487,
        8.880808458354242,
        8.736726640548769,
        8.819911147006433,
        8.732664700005355,
        7.825941360061375,
        9.734232101313708,
        8.787569617333741,
        10.708833426410626,
        10.258731781021165,
        10.124111995029075,
        7.417591430927282,
        10.486710794412913,
        10.743490242803812,
        10.699791966973041,
        8.652272613343005,
        9.812106693528424,
        7.199814515547566,
        8.626132596132305,
        8.374073479741483,
        7.391350765423866,
        7.963606763052883,
        9.136050315696371,
        8.049753724634996,
        8.607364934786801,
        8.738962013562634,
        8.341283619282962,
        9.646739673100809,
        10.343310828941531,
        7.784872097057569,
        10.363354011397114,
        7.107997593174597,
        10.522747692163865,
        10.196801636627924,
        7.744551243472192,
        10.575372493286935,
        8.08706966182763,
        10.594575973605977,
        10.365927503023737,
        6.6311038796255675]>>,
   #<Benchmark::IPS::Report::Entry:0x0000700cf55114c8
    @iterations=280,
    @label="ActiveRecord sum ",
    @measurement_cycle=5,
    @microseconds=5025481.173000336,
    @show_total_time=true,
    @stats=
     #<Benchmark::IPS::Stats::SD:0x0000700cf5511540
      @error=8,
      @mean=57.137576345766874,
      @samples=
       [36.24591280180593,
        47.626767238091325,
        55.700300831846214,
        55.4059735854465,
        47.78194126138219,
        55.497354247916235,
        45.1556886879363,
        43.02103554807348,
        54.019434896921645,
        60.01464501294343,
        60.705559594116764,
        60.83529019375086,
        60.23411168272754,
        68.27984072138511,
        62.597411744778164,
        63.400463307418214,
        62.169738805386814,
        64.04402622149554,
        64.77331922690045,
        66.26229351154083,
        66.51722728858584,
        61.130566048438865,
        63.628182557459,
        62.300436905118474,
        32.54393548421423,
        46.68464859682181,
        51.765409599241366,
        44.156406514510245,
        44.44598049621621,
        56.630482015908676,
        58.215178740402784,
        52.27346007525547,
        55.10598501131679,
        53.32361847998638,
        45.1122094038058,
        48.29632912121178,
        53.66830484417506,
        60.16055600920494,
        67.11784264827045,
        66.1919582419919,
        64.40490135334802,
        65.89236287559854,
        66.50005123274612,
        67.34290979937066,
        64.50009555739942,
        64.68765649111026,
        51.720603809015024,
        60.92573758109036,
        60.091622416301185,
        63.72565788143038,
        62.94543573731337,
        62.536410260772264,
        59.75419466486737,
        57.73729392734432,
        53.22874608565675,
        50.6707684855812]>>]>


```

---

### Performance Comparions (Using Benchamark)



``` ruby

# BENCHMARK CODE (DOING SUM IN ruby)
def revisions_by_namespace
  benchmark = Benchmark.measure do
    @course.scoped_article_timeslices
      .where(tracked: true)
      .joins(:article)
      .where(articles: { namespace: 0 })
      .sum(&:revision_count)
  end
  
  puts benchmark
end

```

```sql

SELECT `article_course_timeslices`.* 
FROM `article_course_timeslices` 
INNER JOIN `articles` 
ON `articles`.`id` = `article_course_timeslices`.`article_id` 
WHERE `article_course_timeslices`.`course_id` = 10000 
AND `article_course_timeslices`.`tracked` = TRUE 
AND `articles`.`namespace` = 0

```

``` ruby

# BENCHMARK CODE (DOING SUM IN DB/AR)
def revisions_by_namespace
  benchmark = Benchmark.measure do
    @course.scoped_article_timeslices
      .where(tracked: true)
      .joins(:article)
      .where(articles: { namespace: 0 })
      .sum(:revision_count)
  end
  
  puts benchmark
end

```

```sql

SELECT SUM(`article_course_timeslices`.`revision_count`) 
FROM `article_course_timeslices` 
INNER JOIN `articles` 
ON `articles`.`id` = `article_course_timeslices`.`article_id`
WHERE `article_course_timeslices`.`course_id` = 10000 
AND `article_course_timeslices`.`tracked` = TRUE 
AND `articles`.`namespace` = 0;

```

```
Ruby Sum Benchmark

1)  0.089073   0.006794   0.095867 (  0.147799)
2)  0.128411   0.006878   0.135289 (  0.179985)
3)  0.096763   0.005518   0.102281 (  0.137877)
4)  0.102194   0.000279   0.102473 (  0.180583)
5)  0.116427   0.006883   0.123310 (  0.172014)
6)  0.092180   0.006671   0.098851 (  0.129743)
7)   0.096612   0.001139   0.097751 (  0.140720)
8)   0.110584   0.000000   0.110584 (  0.144919)
9)   0.106098   0.004637   0.110735 (  0.143969)
10)   0.197047   0.001052   0.198099 (  0.239536)


Active Sum Benchmark 

1)  0.001848   0.000162   0.002010 (  0.030434)
2)  0.003596   0.000000   0.003596 (  0.034473)
3)  0.003759   0.000000   0.003759 (  0.035154)
4) 0.002036   0.000008   0.002044 (  0.020059)
5) 0.001917   0.000000   0.001917 (  0.032906)
6) 0.001976   0.000000   0.001976 (  0.017110)
7) 0.003439   0.000085   0.003524 (  0.036948)
8) 0.003060   0.000205   0.003265 (  0.038266)
9) 0.002712   0.000141   0.002853 (  0.035292)
10) 0.002237   0.000000   0.002237 (  0.026210)



```

`Benchmark Comparison with Performance Gain (Average)`

| Run     | Ruby User (s) | Ruby Sys (s) | Ruby Total (s) | Ruby Real (s) | AR User (s)  | AR Sys (s)   | AR Total (s) | AR Real (s)  | Speedup (×) |
| ------- | ------------- | ------------ | -------------- | ------------- | ------------ | ------------ | ------------ | ------------ | ----------- |
| 1       | 0.089073      | 0.006794     | 0.095867       | 0.147799      | 0.001848     | 0.000162     | 0.002010     | 0.030434     | 4.86×       |
| 2       | 0.128411      | 0.006878     | 0.135289       | 0.179985      | 0.003596     | 0.000000     | 0.003596     | 0.034473     | 5.22×       |
| 3       | 0.096763      | 0.005518     | 0.102281       | 0.137877      | 0.003759     | 0.000000     | 0.003759     | 0.035154     | 3.92×       |
| 4       | 0.102194      | 0.000279     | 0.102473       | 0.180583      | 0.002036     | 0.000008     | 0.002044     | 0.020059     | 9.00×       |
| 5       | 0.116427      | 0.006883     | 0.123310       | 0.172014      | 0.001917     | 0.000000     | 0.001917     | 0.032906     | 5.23×       |
| 6       | 0.092180      | 0.006671     | 0.098851       | 0.129743      | 0.001976     | 0.000000     | 0.001976     | 0.017110     | 7.58×       |
| 7       | 0.096612      | 0.001139     | 0.097751       | 0.140720      | 0.003439     | 0.000085     | 0.003524     | 0.036948     | 3.81×       |
| 8       | 0.110584      | 0.000000     | 0.110584       | 0.144919      | 0.003060     | 0.000205     | 0.003265     | 0.038266     | 3.79×       |
| 9       | 0.106098      | 0.004637     | 0.110735       | 0.143969      | 0.002712     | 0.000141     | 0.002853     | 0.035292     | 4.08×       |
| 10      | 0.197047      | 0.001052     | 0.198099       | 0.239536      | 0.002237     | 0.000000     | 0.002237     | 0.026210     | 9.13×       |
| **Avg** | **0.113539**  | **0.003985** | **0.117524**   | **0.161515**  | **0.002664** | **0.000060** | **0.002724** | **0.030885** | **5.23×**   |

This shows an average **5.23× speedup** by using `ActiveRecord.sum(:revision_count)` instead of Ruby's `sum(&:revision_count)`.


### Screenshot

**Before:**

<img width="1364" height="76" alt="Screenshot from 2025-07-30 23-42-37" src="https://github.com/user-attachments/assets/4a717bbf-b438-4991-bb2f-5aa398153fbc" />


**After:**


<img width="1364" height="76" alt="Screenshot from 2025-07-30 23-39-39" src="https://github.com/user-attachments/assets/21cd7ad5-8518-4459-90c9-09e08bafb53c" />
