### PR TITLE
Add script to deduplicate articles courses

### DIFF
--- a/docs/cleanup_scripts/deduplicate_articles_courses.rb
+++ b/docs/cleanup_scripts/deduplicate_articles_courses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # If two (or more) course updates run at the same time, we end up with duplicate articles courses.
-# This script deduplicate articles courses, deleting the first one.
+# This script deduplicates articles courses, deleting the first one.
 # Note that you may need to deduplicate an article several times if the article appears three
 # times or more.
 dups = ArticlesCourses.all.group(:course_id, :article_id).having('count(*) > 1').count


### PR DESCRIPTION
## What this PR does
This PR is part of issue #5956. It adds a one-off script to delete existing duplicate records. It's based on the existing `docs/cleanup_scripts/deduplicate_courses_users.rb` script. Note that some articles_courses records are not just duplicated but triplicated, so we may need to run the script multiple times until no duplicates remain.
The script deletes always the first articles_courses record, but there should be no difference in deleting the first one or the last one created.
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
