### PR TITLE
Part 1: Improve performance of PerWikiCourseStats#stats 

### DIFF
--- a/lib/analytics/per_wiki_course_stats.rb
+++ b/lib/analytics/per_wiki_course_stats.rb
@@ -21,7 +21,7 @@ class PerWikiCourseStats
                                        .where(tracked: true)
                                        .joins(:article)
                                        .where(articles: { wiki: })
-                                       .sum(&:revision_count),
+                                       .sum(:revision_count),
       "#{wiki.domain}_articles_edited" => @course.articles.where(wiki:).count,
       "#{wiki.domain}_articles_created" => @course.new_articles_on(wiki).count
     }


### PR DESCRIPTION
Part 1: #6434
Part 2: #6438
Part 3(Final): #6439

## What this PR does

This PR optimizes the `PerWikiCourseStats#stats` method by replacing Ruby’s `.sum(&:revision_count)` with ActiveRecord’s `.sum(:revision_count)`, enabling SQL-level aggregation.

---


### Performance Comparions [(Using benchmark/ips)](https://github.com/evanphx/benchmark-ips):

 - `Benchmark/ips code`

```ruby 

def benchmark_ips_sums(wiki)
  puts "\n== Benchmark for Wiki: #{wiki} =="

  Benchmark.ips do |x|
    x.report('Ruby sum') do
      @course.scoped_article_timeslices
        .where(tracked: true)
        .joins(:article)
        .where(articles: { wiki: })
        .sum(&:revision_count)
    end

    x.report('ActiveRecord sum') do
      @course.scoped_article_timeslices
        .where(tracked: true)
        .joins(:article)
        .where(articles: { wiki: })
        .sum(:revision_count)
    end

    x.compare!
  end
end

```

**IPS Benchmark (Iterations per Second):**

```

Comparison:
    ActiveRecord sum:       54.2 i/s
            Ruby sum:        5.6 i/s - 9.76x  slower

```


```
54.164 (±14.8%) i/s   (18.46 ms/i) -    265.000 in   5.022983s

Comparison:
    ActiveRecord sum:       54.2 i/s
            Ruby sum:        5.6 i/s - 9.76x  slower

=> #<Benchmark::IPS::Report:0x000070a96f351928
 @data=nil,
 @entries=
  [#<Benchmark::IPS::Report::Entry:0x000070a96f8b4758
    @iterations=28,
    @label="Ruby sum",
    @measurement_cycle=1,
    @microseconds=5117874.216993332,
    @show_total_time=true,
    @stats=
     #<Benchmark::IPS::Stats::SD:0x000070a96f8b4a00
      @error=1,
      @mean=5.551463284660258,
      @samples=
       [5.599634290136805,
        5.860301282426077,
        5.701383906034999,
        5.275120173705312,
        5.765944491358081,
        6.6385769886511135,
        6.267456472303016,
        5.05576409207275,
        3.5258390568826607,
        6.049458558328403,
        5.006989406743183,
        5.1114981310158765,
        4.952713203020218,
        4.932781407066623,
        5.785989967061746,
        5.80566859676762,
        5.389323634565496,
        5.652344736746212,
        5.389910926495056,
        6.463942101283465,
        5.379131864515319,
        6.114875244872154,
        6.29667453289639,
        5.249921516295348,
        6.080470996228224,
        5.878400201149228,
        5.291917376759463,
        4.918938815106339]>>,
   #<Benchmark::IPS::Report::Entry:0x000070a96d6bc790
    @iterations=265,
    @label="ActiveRecord sum",
    @measurement_cycle=5,
    @microseconds=5022982.670995712,
    @show_total_time=true,
    @stats=
     #<Benchmark::IPS::Stats::SD:0x000070a96d6bc808
      @error=8,
      @mean=54.163972509234235,
      @samples=
       [50.04623521451748,
        51.852882380020816,
        54.56846477752819,
        44.80781230300752,
        47.92768134679957,
        53.51691948630201,
        60.32605266225011,
        60.820635809505895,
        50.96623105975988,
        62.43493343432386,
        61.204331836863695,
        57.464132210127644,
        59.09300114435496,
        60.666491784915664,
        60.23915087460702,
        63.67527200593728,
        59.74184592484462,
        47.76630476790361,
        60.827160329710686,
        24.463281954379813,
        53.43735063285127,
        52.263076943360865,
        46.71642445479088,
        45.52043794379564,
        53.027190816185964,
        55.94637580181343,
        50.5892529952888,
        50.1196637040553,
        47.6954530090954,
        43.093761838616075,
        49.02577788142575,
        60.911226589750875,
        59.59733631877385,
        62.50362286630596,
        59.698922810193004,
        53.68555985323139,
        63.040987813190085,
        58.86686304109627,
        63.64289756376612,
        59.98205313031886,
        61.994905035129605,
        60.47317940676394,
        57.654429175870284,
        64.38258211171673,
        64.74550103921545,
        43.88654194891515,
        51.8442809739621,
        45.49353217096532,
        45.070179588073124,
        49.34266296523226,
        47.738364432399905,
        48.10898031100701,
        48.18234651459735]>>]>
```

---


### Performance Comparsion (Using Benchmark)

- BENCHMARK CODE (DOING SUM IN ruby)

```ruby

# BENCHMARK CODE (DOING SUM IN ruby)
def benchmark
  benchmark_result = Benchmark.measure do
    @course.scoped_article_timeslices
           .where(tracked: true)
           .joins(:article)
           .where(articles: { wiki: 2 })
           .sum(&:revision_count)
  end
  puts benchmark_result
end

```

```sql

SELECT `article_course_timeslices`.* 
FROM `article_course_timeslices` 
INNER JOIN `articles` 
ON `articles`.`id` = `article_course_timeslices`.`article_id` 
WHERE `article_course_timeslices`.`course_id` = 10000 
AND `article_course_timeslices`.`tracked` = TRUE 
AND `articles`.`wiki_id` = 2

```

- BENCHMARK CODE (DOING SUM IN DB/AR)

```ruby
# BENCHMARK CODE (DOING SUM IN DB/AR)
def benchmark
  benchmark_result = Benchmark.measure do
    @course.scoped_article_timeslices
           .where(tracked: true)
           .joins(:article)
           .where(articles: { wiki: 2 })
           .sum(:revision_count)
  end
  puts benchmark_result
end

```

```sql

SELECT SUM(`article_course_timeslices`.`revision_count`) 
FROM `article_course_timeslices` 
INNER JOIN `articles` 
ON `articles`.`id` = `article_course_timeslices`.`article_id` 
WHERE `article_course_timeslices`.`course_id` = 10000 
AND `article_course_timeslices`.`tracked` = TRUE 
AND `articles`.`wiki_id` = 2
```


```

Ruby Sum Benchmark
 
1) 0.143129   0.000867   0.143996 (  0.181727)
2) 0.158813   0.002520   0.161333 (  0.214212)
3) 0.150240   0.007887   0.158127 (  0.209985)
4) 0.139453   0.007293   0.146746 (  0.191553)
5) 0.143124   0.001711   0.144835 (  0.199498)
6) 0.113973   0.015175   0.129148 (  0.175524)
7) 0.122230   0.012882   0.135112 (  0.163877)
8) 0.149317   0.007582   0.156899 (  0.183703)
9) 0.141135   0.006363   0.147498 (  0.177229)
10) 0.133894   0.001843   0.135737 (  0.169019)


AR Sum Benchmark

1) 0.014512   0.003908   0.018420 (  0.033588)
2) 0.002345   0.000875   0.003220 (  0.034910)
3) 0.003328   0.000062   0.003390 (  0.034037)
4) 0.002353   0.000068   0.002421 (  0.021593)
5) 0.003003   0.000192   0.003195 (  0.037584)
6) 0.003249   0.000047   0.003296 (  0.033970)
7) 0.002764   0.000147   0.002911 (  0.033598)
8) 0.002116   0.000022   0.002138 (  0.025888)
9) 0.001738   0.000142   0.001880 (  0.019009)
10) 0.003511   0.000098   0.003609 (  0.037952)

```

| Run     | Ruby User (s) | Ruby Sys (s) | Ruby Total (s) | Ruby Real (s) | AR User (s)  | AR Sys (s)   | AR Total (s) | AR Real (s)  | Speedup (×) |
| ------- | ------------- | ------------ | -------------- | ------------- | ------------ | ------------ | ------------ | ------------ | ----------- |
| 1       | 0.143129      | 0.000867     | 0.143996       | 0.181727      | 0.014512     | 0.003908     | 0.018420     | 0.033588     | 5.41×       |
| 2       | 0.158813      | 0.002520     | 0.161333       | 0.214212      | 0.002345     | 0.000875     | 0.003220     | 0.034910     | 6.13×       |
| 3       | 0.150240      | 0.007887     | 0.158127       | 0.209985      | 0.003328     | 0.000062     | 0.003390     | 0.034037     | 6.17×       |
| 4       | 0.139453      | 0.007293     | 0.146746       | 0.191553      | 0.002353     | 0.000068     | 0.002421     | 0.021593     | 8.87×       |
| 5       | 0.143124      | 0.001711     | 0.144835       | 0.199498      | 0.003003     | 0.000192     | 0.003195     | 0.037584     | 5.31×       |
| 6       | 0.113973      | 0.015175     | 0.129148       | 0.175524      | 0.003249     | 0.000047     | 0.003296     | 0.033970     | 5.17×       |
| 7       | 0.122230      | 0.012882     | 0.135112       | 0.163877      | 0.002764     | 0.000147     | 0.002911     | 0.033598     | 4.88×       |
| 8       | 0.149317      | 0.007582     | 0.156899       | 0.183703      | 0.002116     | 0.000022     | 0.002138     | 0.025888     | 7.10×       |
| 9       | 0.141135      | 0.006363     | 0.147498       | 0.177229      | 0.001738     | 0.000142     | 0.001880     | 0.019009     | 9.33×       |
| 10      | 0.133894      | 0.001843     | 0.135737       | 0.169019      | 0.003511     | 0.000098     | 0.003609     | 0.037952     | 4.45×       |
| **Avg** | **0.139631**  | **0.006912** | **0.146543**   | **0.187433**  | **0.003092** | **0.000356** | **0.003448** | **0.031213** | **6.01×**   |


This shows an average **\~6.01× speedup** by using `ActiveRecord.sum(:revision_count)` instead of Ruby's `sum(&:revision_count)`.
