### PR TITLE
Conditional Questions Persisting When Parent Selection Changes in Surveys

### DIFF
--- a/app/assets/javascripts/surveys/modules/Survey.js
+++ b/app/assets/javascripts/surveys/modules/Survey.js
@@ -627,48 +627,36 @@ const Survey = {
   },
 
   handleParentConditionalChange(value, conditionalGroup, $parent) {
-    let { currentAnswers } = conditionalGroup;
     let conditional;
-    // let resetQuestions = false;
 
-    if (Array.isArray(value)) {
-      // Check if empty
-      if (value.length === 0 && currentAnswers) {
-        conditionalGroup.currentAnswers = [];
-      }
-
-      // Check if conditional was present and is no longer
-      currentAnswers.forEach((a) => {
-        if (value.indexOf(a) === -1) {
-          const index = currentAnswers.indexOf(a);
-          if (currentAnswers.length === 1) {
-            currentAnswers = [];
-          } else {
-            currentAnswers = currentAnswers.slice(index, index + 1);
-          }
-        }
-      });
-      // Check if value matches a conditional question
-      value.forEach((v) => {
-        if (conditionalGroup[v] !== undefined
-            && currentAnswers.indexOf(v) === -1) {
-          conditional = conditionalGroup[v];
-          currentAnswers.push(v);
-          conditionalGroup.currentAnswers = currentAnswers;
-        }
-      });
-
-      if (currentAnswers.length === 0) {
-        conditionalGroup.currentAnswers = [];
-      }
-    } else {
-      conditional = conditionalGroup[value];
-    }
-
+    // Always reset all conditional questions first to clear any previously shown conditionals
     this.resetConditionalGroupChildren(conditionalGroup);
 
-    if (typeof conditional !== 'undefined' && conditional !== null) {
-      this.activateConditionalQuestion($(conditional), $parent);
+    if (Array.isArray(value)) {
+      // Handle multi-select (checkbox) values
+      conditionalGroup.currentAnswers = [];
+
+      if (value.length === 0) {
+        return; // No values selected, all conditionals already reset
+      }
+
+      // Show conditionals for all selected values
+      value.forEach((v) => {
+        if (conditionalGroup[v] !== undefined) {
+          conditional = conditionalGroup[v];
+          conditionalGroup.currentAnswers.push(v);
+          this.activateConditionalQuestion($(conditional), $parent);
+        }
+      });
+    } else {
+      // Handle single-select (radio/dropdown) values
+      conditionalGroup.currentAnswers = [];
+
+      if (value && conditionalGroup[value] !== undefined) {
+        conditional = conditionalGroup[value];
+        conditionalGroup.currentAnswers = [value];
+        this.activateConditionalQuestion($(conditional), $parent);
+      }
     }
 
     // this.indexBlocks();
@@ -702,27 +690,10 @@ const Survey = {
 
   // To remove a conditional question from the flow if the condition that it depends on has changed.
   resetConditionalGroupChildren(conditionalGroup) {
-    const { children, currentAnswers } = conditionalGroup;
+    const { children } = conditionalGroup;
 
-    if ((typeof currentAnswers !== 'undefined' && currentAnswers !== null) && currentAnswers.length) {
-      const excludeFromReset = [];
-      currentAnswers.forEach((a) => { excludeFromReset.push(a); });
-      children.forEach((question) => {
-        const $question = $(question);
-        let string;
-        if ($question.data('conditional-question')) {
-          string = $question.data('conditional-question');
-        } else {
-          string = $question.find('[data-conditional-question]').data('conditional-question');
-        }
-        const { value } = Utils.parseConditionalString(string);
-        if (excludeFromReset.indexOf(value) === -1) {
-          this.resetConditionalQuestion($question);
-        } else {
-          $question.removeClass('hidden');
-        }
-      });
-    } else {
+    // Reset all conditional children - they will be re-activated if needed
+    if (children && children.length) {
       children.forEach((question) => {
         this.resetConditionalQuestion($(question));
         if ($(question).hasClass('survey__question-row')) {


### PR DESCRIPTION
### Fixes: Conditional Questions Persisting When Parent Selection Changes
Fixes issue https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6216

### Problem
When users changed their selection on a parent question with conditional logic, previously shown conditional questions would remain visible alongside the new conditional questions. For example:

User selects Option A → Conditional Question A appears
User changes to Option B → Both Conditional Question A and B are visible (BUG)

### Root Cause
The handleParentConditionalChange() function used complex logic to selectively reset conditional questions, which failed to properly hide previously shown conditionals when the parent selection changed.

### Solution
Simplified the conditional reset logic with a "reset-first" approach

### Key Changes:
Always reset all conditionals first before showing new ones
Simplified resetConditionalGroupChildren() to always reset all children instead of selective exclusion

### Files Modified:
app/assets/javascripts/surveys/modules/Survey.js
Modified handleParentConditionalChange() method
Simplified resetConditionalGroupChildren() method

### Before

https://github.com/user-attachments/assets/9b26849c-acbc-4752-8abc-5e08218a364f

### After

https://github.com/user-attachments/assets/8401eb41-cd82-4cfd-84c5-c17395a48bff

