### PR TITLE
[WIP]: Part 2: Improve performance of PerWikiCourseStats#stats

### DIFF
--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -110,6 +110,7 @@ class CourseCsvBuilder
   end
 
   def per_wiki_counts
-    @per_wiki_counts ||= PerWikiCourseStats.new(@course).stats
+    namespace = [Article::Namespaces::MAINSPACE]
+    @per_wiki_counts ||= PerWikiCourseStats.new(@course, namespace).stats
   end
 end

--- a/lib/analytics/per_wiki_course_stats.rb
+++ b/lib/analytics/per_wiki_course_stats.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class PerWikiCourseStats
-  def initialize(course)
+  def initialize(course, namespace)
     @course = course
     @wikis = @course.wikis
+    @namespace = namespace
   end
 
   def stats
@@ -22,7 +23,8 @@ class PerWikiCourseStats
                                        .joins(:article)
                                        .where(articles: { wiki: })
                                        .sum(&:revision_count),
-      "#{wiki.domain}_articles_edited" => @course.articles.where(wiki:).count,
+      "#{wiki.domain}_articles_edited" => @course.articles.where(wiki:,
+                                                                 namespace: @namespace).count,
       "#{wiki.domain}_articles_created" => @course.new_articles_on(wiki).count
     }
   end


### PR DESCRIPTION
Part 1: #6434
Part 2: #6438
Part 3(Final): #6439

## NOTE (IMPORTANT)

The optimization in this PR is based on the assumption that the `(course_id, article_id)` pair is **unique** in the `articles_courses` join table. This ensures that counting records through `.where(wiki:, namespace: @namespace).count` gives an accurate result without requiring `DISTINCT`.

**Before merging this PR**, we must **ensure that uniqueness is enforced** to avoid inflated counts. For more context, please refer to this discussion:

[Issue comment detailing the uniqueness constraint concern](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6401#issuecomment-3138058094)

## What this PR does

Updates the logic for calculating the number of articles edited in a course to:

* Explicitly filter by `namespace: 0` (main article namespace).


* **Improved accuracy**: Articles outside of the main namespace (e.g., Talk, User pages) was not be included in the count of course-edited articles.

* **Performance optimization**: The revised query leverages a more efficient index (`index_articles_on_namespace_and_wiki_id_and_title`) and avoids the overhead of `COUNT(DISTINCT ...)`.
* **Query plan improvement**: EXPLAIN output shows lower estimated rows and faster execution times.



* Query time for only running SQL reduced (from \~0.033s to \~0.013s in testing) and for AR around 30ms dropped to 13ms.
* Output for my local data remains consistent for using namespace 0 filtered data (339 articles before and after).

---
## Performance Comparions [(Using benchmark/ips)](https://github.com/evanphx/benchmark-ips):

- **BENCHMARK/ips CODE**

```ruby


def benchmark_ips(wiki)
  require 'benchmark/ips'
  puts "\n== Benchmark for Wiki: #{wiki} =="

  Benchmark.ips do |x|
    x.report('With Namespace') do
      @course.all_articles.where(namespace: 0, wiki:).count
    end

    x.report('Without Namespace') do
      @course.articles.where(wiki:).count
    end

    x.compare!
  end
end

```

In terms of iteration per seconds for before and after code  there is only an improvment of only 3.28x 

```
Comparison:
      With Namespace:       88.5 i/s
   Without Namespace:       27.0 i/s - 3.28x  slower

```


---

## Performance Comparsion (Using Benchmark)

- BENCHMARK CODE:

```ruby

# Without namespace
def run_benchmarks_measure
  without_namesapce = Benchmark.measure do
    @course.articles.where(wiki: 2).count
  end
  
  puts without_namesapce
end

```

```sql

SELECT COUNT(DISTINCT `articles`.`id`) 
FROM `articles` 
INNER JOIN `articles_courses` 
ON `articles`.`id` = `articles_courses`.`article_id` 
WHERE `articles_courses`.`course_id` = 10000 
AND `articles`.`wiki_id` = 2

```

```ruby

# With namespace
def run_benchmarks_measure
  with_namesapce = Benchmark.measure do
    @course.all_articles.where(namespace: 0, wiki: 2).count
  end
  
  puts with_namesapce
end

```

```sql


SELECT COUNT(*) 
FROM `articles` 
INNER JOIN `articles_courses` 
ON `articles`.`id` = `articles_courses`.`article_id` 
WHERE `articles_courses`.`course_id` = 10000 
AND `articles`.`namespace` = 0 
AND `articles`.`wiki_id` = 2


```

- **BENCHMARK RESULT**

```
Before (Without namespace)

1) 0.016956   0.001216   0.018172  (0.067842)
2) 0.002350   0.000851   0.003201  (0.061892)
3) 0.003089   0.000020   0.003109  (0.040130)
4) 0.003342   0.000000   0.003342  (0.061255)
5) 0.002082   0.000019   0.002101  (0.095167) 
6) 0.002720   0.000167   0.002887  (0.056613)
7) 0.002470   0.000000   0.002470  (0.096032)
8) 0.002470   0.000000   0.002470  (0.096032)
9) 0.002915   0.000212   0.003127  (0.056804)
10)0.003022   0.000004   0.003026 (0.066021)


After (With namespace)

1) 0.002171   0.001037   0.003208 (0.022167)
2) 0.002619   0.000923   0.003542 (0.022202)
3) 0.002088   0.000017   0.002105 (0.011344)
4) 0.002204   0.001042   0.003246 (0.027661)
5) 0.001720   0.000146   0.001866 (0.011181)
6) 0.001962   0.000000   0.001962 (0.015093)
7) 0.001325   0.000863   0.002188 (0.011902)
8) 0.001721   0.000147   0.001868 (0.010709)
9) 0.001530   0.000313   0.001843 (0.011427)
10) 0.003326   0.000066   0.003392 (0.025358)


```

| Run     | Ruby User (s) | Ruby Sys (s) | Ruby Total (s) | Ruby Real (s) | AR User (s)  | AR Sys (s)   | AR Total (s) | AR Real (s)  | Speedup (×) |
| ------- | ------------- | ------------ | -------------- | ------------- | ------------ | ------------ | ------------ | ------------ | ----------- |
| 1       | 0.016956      | 0.001216     | 0.018172       | 0.067842      | 0.002171     | 0.001037     | 0.003208     | 0.022167     | 3.06×       |
| 2       | 0.002350      | 0.000851     | 0.003201       | 0.061892      | 0.002619     | 0.000923     | 0.003542     | 0.022202     | 2.79×       |
| 3       | 0.003089      | 0.000020     | 0.003109       | 0.040130      | 0.002088     | 0.000017     | 0.002105     | 0.011344     | 3.54×       |
| 4       | 0.003342      | 0.000000     | 0.003342       | 0.061255      | 0.002204     | 0.001042     | 0.003246     | 0.027661     | 2.22×       |
| 5       | 0.002082      | 0.000019     | 0.002101       | 0.095167      | 0.001720     | 0.000146     | 0.001866     | 0.011181     | 8.51×       |
| 6       | 0.002720      | 0.000167     | 0.002887       | 0.056613      | 0.001962     | 0.000000     | 0.001962     | 0.015093     | 3.75×       |
| 7       | 0.002470      | 0.000000     | 0.002470       | 0.096032      | 0.001325     | 0.000863     | 0.002188     | 0.011902     | 8.07×       |
| 8       | 0.002470      | 0.000000     | 0.002470       | 0.096032      | 0.001721     | 0.000147     | 0.001868     | 0.010709     | 8.97×       |
| 9       | 0.002915      | 0.000212     | 0.003127       | 0.056804      | 0.001530     | 0.000313     | 0.001843     | 0.011427     | 4.97×       |
| 10      | 0.003022      | 0.000004     | 0.003026       | 0.066021      | 0.003326     | 0.000066     | 0.003392     | 0.025358     | 2.60×       |
| **Avg** | **0.004642**  | **0.000249** | **0.004891**   | **0.070779**  | **0.002367** | **0.000455** | **0.002822** | **0.016605** | **4.26×**   |


This shows an average **\~4.26× speedup**


---

## Screenshots `(SQL Query)`

**The updated query removes unnecessary `DISTINCT`, avoids `WHERE` filtering by using only indexes, leading to constant-time index lookups and reduced row scans for faster, more efficient execution.**



- **BEFORE**

<img width="1359" height="53" alt="Screenshot from 2025-08-02 22-07-56" src="https://github.com/user-attachments/assets/1f723bf4-a233-4b51-b511-13545ccb5d42" />

```

MariaDB [dashboard]> SELECT COUNT(DISTINCT `articles`.`id`) 
    -> FROM `articles` 
    -> INNER JOIN `articles_courses` 
    -> ON `articles`.`id` = `articles_courses`.`article_id` 
    -> WHERE `articles_courses`.`course_id` = 10000 
    -> AND `articles`.`wiki_id` = 2;
+---------------------------------+
| COUNT(DISTINCT `articles`.`id`) |
+---------------------------------+
|                             339 |
+---------------------------------+
1 row in set (0.033 sec)

MariaDB [dashboard]> EXPLAIN EXTENDED SELECT COUNT(DISTINCT `articles`.`id`) 
    -> FROM `articles` 
    -> INNER JOIN `articles_courses` 
    -> ON `articles`.`id` = `articles_courses`.`article_id` 
    -> WHERE `articles_courses`.`course_id` = 10000 
    -> AND `articles`.`wiki_id` = 2 \G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles_courses
         type: ref
possible_keys: index_articles_on_course_id_and_article_id,index_articles_courses_on_article_id
          key: index_articles_on_course_id_and_article_id
      key_len: 5
          ref: const
         rows: 35500
     filtered: 100.00
        Extra: Using where; Using index
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles
         type: eq_ref
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: dashboard.articles_courses.article_id
         rows: 1
     filtered: 100.00
        Extra: Using where



```


 - **AFTER**

<img width="1359" height="67" alt="Screenshot from 2025-08-02 22-07-18" src="https://github.com/user-attachments/assets/ee6b6033-e686-4603-8aea-4edd717bb7d2" />

```

MariaDB [dashboard]> SELECT COUNT(*) 
    -> FROM `articles` 
    -> INNER JOIN `articles_courses` 
    -> ON `articles`.`id` = `articles_courses`.`article_id` 
    -> WHERE `articles_courses`.`course_id` = 10000 
    -> AND `articles`.`namespace` = 0 
    -> AND `articles`.`wiki_id` = 2;
+----------+
| COUNT(*) |
+----------+
|      339 |
+----------+
1 row in set (0.013 sec)

MariaDB [dashboard]> EXPLAIN EXTENDED SELECT COUNT(*) 
    -> FROM `articles` 
    -> INNER JOIN `articles_courses` 
    -> ON `articles`.`id` = `articles_courses`.`article_id` 
    -> WHERE `articles_courses`.`course_id` = 10000 
    -> AND `articles`.`namespace` = 0 
    -> AND `articles`.`wiki_id` = 2 \G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles
         type: ref
possible_keys: PRIMARY,index_articles_on_namespace_and_wiki_id_and_title
          key: index_articles_on_namespace_and_wiki_id_and_title
      key_len: 10
          ref: const,const
         rows: 10356
     filtered: 100.00
        Extra: Using index
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles_courses
         type: ref
possible_keys: index_articles_on_course_id_and_article_id,index_articles_courses_on_article_id
          key: index_articles_on_course_id_and_article_id
      key_len: 10
          ref: const,dashboard.articles.id
         rows: 1
     filtered: 100.00
        Extra: Using index
2 rows in set, 1 warning (0.001 sec)


```