### PR TITLE
[WIP]: Part 3 (FINAL): Improve performance of PerWikiCourseStats#stats

### DIFF
--- a/lib/analytics/per_wiki_course_stats.rb
+++ b/lib/analytics/per_wiki_course_stats.rb
@@ -23,7 +23,10 @@ class PerWikiCourseStats
                                        .where(articles: { wiki: })
                                        .sum(&:revision_count),
       "#{wiki.domain}_articles_edited" => @course.articles.where(wiki:).count,
-      "#{wiki.domain}_articles_created" => @course.new_articles_on(wiki).count
+      "#{wiki.domain}_articles_created" => ArticlesCourses.joins(:article)
+                                                          .where(course_id: 10000, tracked: true, new_article: true) # rubocop:disable Layout/LineLength
+                                                          .where(articles: { namespace: @namespace, wiki:, deleted: false }) # rubocop:disable Layout/LineLength
+                                                          .count
     }
   end
 end


### PR DESCRIPTION
Part 1: #6434
Part 2: #6438
Part 3(Final): #6439

## What this PR does

Improves the performance of the query that counts new tracked articles for a given course and wiki by:

- Removing the need for `DISTINCT` on `articles_courses.id`

- Adding a `namespace = 0` condition on the `articles` table

- Relying on existing indexes (`articles.namespace`, `wiki_id`, and `deleted`) for more efficient filtering


## EXPLAIN EXTENDED 


### BEFORE

```

MariaDB [dashboard]> EXPLAIN EXTENDED SELECT COUNT(DISTINCT `articles_courses`.`id`) 
    -> FROM `articles_courses` 
    -> INNER JOIN `articles` 
    -> ON `articles`.`id` = `articles_courses`.`article_id` 
    -> WHERE `articles_courses`.`course_id` = 10000 
    -> AND `articles_courses`.`tracked` = TRUE 
    -> AND `articles`.`deleted` = FALSE 
    -> AND `articles_courses`.`new_article` = TRUE 
    -> AND (articles.wiki_id = 2) \G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles_courses
         type: ALL
possible_keys: index_articles_on_course_id_and_article_id,index_articles_courses_on_article_id
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 91459
     filtered: 38.82
        Extra: Using where
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles
         type: eq_ref
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: dashboard.articles_courses.article_id
         rows: 1
     filtered: 100.00
        Extra: Using where
2 rows in set, 1 warning (0.001 sec)
```

### AFTER

```
MariaDB [dashboard]> EXPLAIN EXTENDED SELECT COUNT(*) 
    -> FROM `articles_courses` 
    -> INNER JOIN `articles` 
    -> ON `articles`.`id` = `articles_courses`.`article_id` 
    -> WHERE `articles_courses`.`course_id` = 10000 
    -> AND `articles_courses`.`tracked` = TRUE 
    -> AND `articles_courses`.`new_article` = TRUE 
    -> AND `articles`.`namespace` = 0 
    -> AND `articles`.`wiki_id` = 2 
    -> AND `articles`.`deleted` = FALSE \G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles
         type: ref
possible_keys: PRIMARY,index_articles_on_namespace_and_wiki_id_and_title
          key: index_articles_on_namespace_and_wiki_id_and_title
      key_len: 10
          ref: const,const
         rows: 10356
     filtered: 100.00
        Extra: Using where
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: articles_courses
         type: ref
possible_keys: index_articles_on_course_id_and_article_id,index_articles_courses_on_article_id
          key: index_articles_courses_on_article_id
      key_len: 5
          ref: dashboard.articles.id
         rows: 1
     filtered: 38.82
        Extra: Using where
2 rows in set, 1 warning (0.001 sec)
```

### **EXPLAIN Analysis: Before vs. After**

#### **Before** – With `DISTINCT`, No `namespace` Filter

```sql
SELECT COUNT(DISTINCT articles_courses.id) ...
```

| Table              | Type    | Key Used | Rows Scanned | Notes                         |
| ------------------ | ------- | -------- | ------------ | ----------------------------- |
| `articles_courses` | **ALL** | None     | **91,459**   | Full table scan (inefficient) |
| `articles`         | eq\_ref | PRIMARY  | 1            | Good join strategy (1-to-1)   |

* **Key Issues**:

  * **No index used on `articles_courses`**, forcing a full table scan.
  * The use of `DISTINCT` on a **primary key (`id`)** is unnecessary.

---

#### ✅ **After** – With `COUNT(*)`, `namespace = 0`, and No `DISTINCT`

```sql
SELECT COUNT(*) ...
```

| Table              | Type | Key Used                                            | Rows Scanned | Notes                             |
| ------------------ | ---- | --------------------------------------------------- | ------------ | --------------------------------- |
| `articles`         | ref  | `index_articles_on_namespace_and_wiki_id_and_title` | **10,356**   | Efficient filter + indexed access |
| `articles_courses` | ref  | `index_articles_courses_on_article_id`              | 1            | Indexed join via `article_id`     |

* **Key Improvements**:

  * Adds `namespace = 0`, increasing selectivity and enabling use of a compound index on `articles`.
  * **No `DISTINCT` needed** because there's no duplication of `articles_courses.id`.
  * Fewer rows scanned: **\~10,356 vs. \~91,459**

---

### **Conclusion**

The **optimized version is little better**, because:

* It avoids the unnecessary and costly `DISTINCT` on a primary key.
* It leverages **indexes** on both `articles` and `articles_courses`.
* It reduces row scans by **almost 9x** for my local data, drastically improving performance.



## **Peformance Impact:**

Using `Benchmark.ips`, which shows a **2x speed improvement:**



| Method                          | Iterations/sec |
|--------------------------------|----------------|
| Old (`DISTINCT`, no `namespace`) | ~25.2 i/s       |
| New (`no DISTINCT`, `namespace = 0`) | ~51.3 i/s       |

- `Benchmark/ips` code

```ruby
require 'benchmark/ips'
Benchmark.ips do |x|
  x.report('Without Namespace') do
    @course.new_articles_on(wiki).count
  end
  
  x.report('Namespace Added and Distinct Removed') do
    ArticlesCourses.joins(:article)
                   .where(course_id: 10000, tracked: true, new_article: true)
                   .where(articles: { namespace: 0, wiki:, deleted: false })
                   .count
  end
  
  x.compare!
end
```

###  Benchmark.measure Results (10 Iterations)

```ruby

without_namespace = Benchmark.measure do
  @course.new_articles_on(wiki).count
end

puts without_namespace

```

```sql

SELECT COUNT(DISTINCT `articles_courses`.`id`) 
FROM `articles_courses` 
INNER JOIN `articles` 
ON `articles`.`id` = `articles_courses`.`article_id` 
WHERE `articles_courses`.`course_id` = 10000 
AND `articles_courses`.`tracked` = TRUE 
AND `articles`.`deleted` = FALSE 
AND `articles_courses`.`new_article` = TRUE 
AND (articles.wiki_id = 2)


```

#### Without Namespace (`DISTINCT`, no `namespace`)
| Iteration | User     | System   | Total    | Real     |
|-----------|----------|----------|----------|----------|
| 1         | 0.017853 | 0.001177 | 0.019030 | 0.057217 |
| 2         | 0.002163 | 0.000036 | 0.002199 | 0.033369 |
| 3         | 0.004492 | 0.000112 | 0.004604 | 0.061536 |
| 4         | 0.002947 | 0.000990 | 0.003937 | 0.052062 |
| 5         | 0.002853 | 0.000000 | 0.002853 | 0.054078 |
| 6         | 0.004060 | 0.000256 | 0.004316 | 0.063674 |
| 7         | 0.001780 | 0.000000 | 0.001780 | 0.035986 |
| 8         | 0.004479 | 0.000000 | 0.004479 | 0.044534 |
| 9         | 0.003451 | 0.001115 | 0.004566 | 0.063716 |
| 10        | 0.001117 | 0.000786 | 0.001903 | 0.034597 |
| **Avg**   | **0.00412** | **0.000447** | **0.00457** | **0.05008** |


```ruby
with_namespace_and_distinct_removed = Benchmark.measure do
   ArticlesCourses.joins(:article)
                  .where(course_id: 10000, tracked: true, new_article: true)
                  .where(articles: { namespace: 0, wiki:, deleted: false })
                  .count
end
puts with_namespace_and_distinct_removed

```

```sql


SELECT COUNT(*) 
FROM `articles_courses` 
INNER JOIN `articles` 
ON `articles`.`id` = `articles_courses`.`article_id` 
WHERE `articles_courses`.`course_id` = 10000 
AND `articles_courses`.`tracked` = TRUE 
AND `articles_courses`.`new_article` = TRUE 
AND `articles`.`namespace` = 0 
AND `articles`.`wiki_id` = 2 
AND `articles`.`deleted` = FALSE;

```

#### With Namespace and `DISTINCT` Removed (`COUNT(*)`, `namespace = 0`)
| Iteration | User     | System   | Total    | Real     |
|-----------|----------|----------|----------|----------|
| 1         | 0.012656 | 0.002148 | 0.014804 | 0.059724 |
| 2         | 0.002026 | 0.000000 | 0.002026 | 0.022622 |
| 3         | 0.001832 | 0.000000 | 0.001832 | 0.025996 |
| 4         | 0.002113 | 0.001027 | 0.003140 | 0.034152 |
| 5         | 0.002820 | 0.000000 | 0.002820 | 0.031101 |
| 6         | 0.004269 | 0.000062 | 0.004331 | 0.038027 |
| 7         | 0.004083 | 0.000019 | 0.004102 | 0.034069 |
| 8         | 0.003711 | 0.000000 | 0.003711 | 0.020822 |
| 9         | 0.004241 | 0.000000 | 0.004241 | 0.042736 |
| 10        | 0.002726 | 0.000170 | 0.002896 | 0.022827 |
| **Avg**   | **0.00405** | **0.000343** | **0.00440** | **0.03321** |


## Screenshots

Before:

<img width="1359" height="69" alt="Screenshot from 2025-08-05 16-47-31" src="https://github.com/user-attachments/assets/c358093e-b557-478e-94e3-a9c8867591da" />


After:

<img width="1359" height="69" alt="Screenshot from 2025-08-05 16-46-09" src="https://github.com/user-attachments/assets/6d8a53a2-24fc-4e29-ae24-1fecb37a4863" />

