### PR TITLE
[WIP] Remove N+1 queries in WikiCourseOutput

### DIFF
--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -90,6 +90,10 @@ class Assignment < ApplicationRecord
     role == Roles::ASSIGNED_ROLE
   end
 
+  def reviewing?
+    role == Roles::REVIEWING_ROLE
+  end
+
   def sandbox_pagename
     URI.decode_www_form_component sandbox_url.gsub("#{wiki.base_url}/wiki/", '')
   # Fallback for cases where the URL doesn't match URI's requirements

--- a/lib/wiki_course_output.rb
+++ b/lib/wiki_course_output.rb
@@ -114,7 +114,7 @@ class WikiCourseOutput
   end
 
   def students_table
-    students = @course.students
+    students = @course.students.includes(:assignments)
     return '' if students.blank?
     table = "{{#{template_name(@templates, 'table')}}}\r"
     students.each do |student|
@@ -126,9 +126,11 @@ class WikiCourseOutput
 
   def student_row(student)
     username = student.username
-    assignments = student.assignments.where(course_id: @course.id)
-    assigned = Wikitext.assignments_to_wikilinks(assignments.assigned, @course.home_wiki)
-    reviewing = Wikitext.assignments_to_wikilinks(assignments.reviewing, @course.home_wiki)
+    assignments = student.assignments.select { |a| a.course_id == @course.id }
+    assigned = Wikitext.assignments_to_wikilinks(assignments.select(&:editing?),
+                                                 @course.home_wiki)
+    reviewing = Wikitext.assignments_to_wikilinks(assignments.select(&:reviewing?),
+                                                  @course.home_wiki)
 
     "{{#{template_name(@templates, 'table_row')}|#{username}|#{assigned}|#{reviewing}}}\r"
   end


### PR DESCRIPTION
## What this PR does
This PR fixes N+1 queries during `EnrollInCourseWorker`. `EnrollInCourseWorker` currently runs on `default` queue which lives in the web-server, so it would be nice to fix.

Note the max number of assignments for a course in production is 3K (course 31078), most of them having less than 1k.
In addition, the max number of users for an ongoing course in production is 752, most of them having less than 200.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
