### PR TITLE
PART 2: Remove N+1 queries in IndividualStatisticsTimeslicePresenter#article_course_records

### DIFF
--- a/app/presenters/individual_statistics_timeslice_presenter.rb
+++ b/app/presenters/individual_statistics_timeslice_presenter.rb
@@ -60,10 +60,8 @@ class IndividualStatisticsTimeslicePresenter
 
   def set_data_from_article_course
     @article_course_data = {}
-    individual_courses.each do |course|
-      article_course_records(course).each do |article_course|
-        @article_course_data[article_course.article_id] = 1
-      end
+    article_course_records(individual_courses.pluck(:id)).each do |article_course|
+      @article_course_data[article_course.article_id] = 1
     end
   end
 
@@ -76,12 +74,13 @@ class IndividualStatisticsTimeslicePresenter
     end
   end
 
-  def article_course_records(course)
-    course.articles_courses
-          .where('user_ids LIKE ?', "%- #{@user.id}\n%")
-          .joins(:article)
-          .includes(:article)
-          .where(articles: { namespace: Article::Namespaces::MAINSPACE, deleted: false })
+  def article_course_records(course_id)
+    ArticlesCourses
+      .where('user_ids LIKE ?', "%- #{@user.id}\n%")
+      .where(course_id:)
+      .joins(:article)
+      .where(articles: { namespace: Article::Namespaces::MAINSPACE, deleted: false })
+      .select(:article_id)
   end
 
   def course_user_records(course)


### PR DESCRIPTION
#6441
**Sentry ID:** [2a5efcc6](https://wiki-education.sentry.io/issues/6615860737/?project=6269916&query=%22N%2B1%20Query%22&referrer=issue-stream)

**PART 1:** https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6442
**PART 2:** https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6444
**PART 3:** (FINAL): https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6449

## What this PR does

Removes N+1 queries in IndividualStatisticsTimeslicePresenter#article_course_records


## Where is the N+1 this fixes, and what do the N+1 queries look like

a) **Where is the N+1 this fixes**

<img width="747" height="325" alt="Screenshot from 2025-08-11 20-42-46" src="https://github.com/user-attachments/assets/97124564-4037-4b48-8ae4-70232d8fc5e0" />


b) **what do the N+1 queries look like**


<img width="1360" height="622" alt="Screenshot from 2025-08-11 20-41-04" src="https://github.com/user-attachments/assets/f9b84849-1ab7-476a-be74-4f046b432954" />


## Screenshots

**Before:**

<img width="1353" height="225" alt="Screenshot from 2025-08-11 20-44-37" src="https://github.com/user-attachments/assets/0228a2a9-7058-4bd0-bbec-e81a723b8519" />

```sql
SELECT `articles_courses`.`id` AS t0_r0, `articles_courses`.`created_at` AS t0_r1, `articles_courses`.`updated_at` AS t0_r2, `articles_courses`.`article_id` AS t0_r3, `articles_courses`.`course_id` AS t0_r4, `articles_courses`.`view_count` AS t0_r5, `articles_courses`.`character_sum` AS t0_r6, `articles_courses`.`new_article` AS t0_r7, `articles_courses`.`references_count` AS t0_r8, `articles_courses`.`tracked` AS t0_r9, `articles_courses`.`user_ids` AS t0_r10, `articles_courses`.`first_revision` AS t0_r11, `articles`.`id` AS t1_r0, `articles`.`title` AS t1_r1, `articles`.`created_at` AS t1_r2, `articles`.`updated_at` AS t1_r3, `articles`.`views_updated_at` AS t1_r4, `articles`.`namespace` AS t1_r5, `articles`.`rating` AS t1_r6, `articles`.`rating_updated_at` AS t1_r7, `articles`.`deleted` AS t1_r8, `articles`.`language` AS t1_r9, `articles`.`average_views` AS t1_r10, `articles`.`average_views_updated_at` AS t1_r11, `articles`.`wiki_id` AS t1_r12, `articles`.`mw_page_id` AS t1_r13, `articles`.`index_hash` AS t1_r14 
FROM `articles_courses` 
INNER JOIN `articles` 
ON `articles`.`id` = `articles_courses`.`article_id` 
WHERE `articles_courses`.`course_id` = 10027 
AND (user_ids LIKE '%- 364\n%') 
AND `articles`.`namespace` = 0 
AND `articles`.`deleted` = FALSE;
```


<img width="525" height="238" alt="Screenshot from 2025-08-11 20-57-48" src="https://github.com/user-attachments/assets/1b0375af-0791-449f-adde-fed832bf7e2e" />


---

**After:**

<img width="525" height="238" alt="Screenshot from 2025-08-11 20-56-48" src="https://github.com/user-attachments/assets/898b4aa2-f0f0-48fd-aac2-bd67861b1f8e" />


<img width="1353" height="70" alt="Screenshot from 2025-08-11 20-48-45" src="https://github.com/user-attachments/assets/e746c450-1200-4c86-a25a-8c8bcd7bf84d" />


```sql
SELECT `articles_courses`.`article_id` 
FROM `articles_courses` 
INNER JOIN `articles` 
ON `articles`.`id` = `articles_courses`.`article_id` 
WHERE (user_ids LIKE '%- 364\n%') 
AND `articles_courses`.`course_id` 
IN (10021, 10027) 
AND `articles`.`namespace` = 0 
AND `articles`.`deleted` = FALSE;
```
