### PR TITLE
Refactor CoursesPresenter to use shared campaign_articles_count helper

### DIFF
--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -85,14 +85,9 @@ class CoursesPresenter
 
   # Create paginated collection for articles_courses data
   def paginated_articles_courses
-    WillPaginate::Collection.create(current_page, PER_PAGE, total_articles_count) do |pager|
+    WillPaginate::Collection.create(current_page, PER_PAGE, campaign_articles_count) do |pager|
       pager.replace(articles_courses_scope)
     end
-  end
-
-  # Count total articles for pagination metadata
-  def total_articles_count
-    ArticlesCourses.where(course_id: course_ids_and_slugs.map(&:id), tracked: true).count
   end
 
   # Current page number with fallback to 1
@@ -108,7 +103,11 @@ class CoursesPresenter
   # If there are too many articles, rendering a page of them can take a very long time.
   ARTICLE_LIMIT = 50000
   def too_many_articles?
-    @too_many ||= campaign.articles_courses.count > ARTICLE_LIMIT
+    @too_many ||= campaign_articles_count > ARTICLE_LIMIT
+  end
+
+  def campaign_articles_count
+    @campaign_articles_count ||= campaign.articles_courses.where(tracked: true).count
   end
 
   def tag_articles


### PR DESCRIPTION
Found in Sentry Transaction Summary [#a480922522d3 ](https://wiki-education.sentry.io/insights/summary/trace/a480922522d340f38599e585f62a405c/?breakdown=none&fov=0%2C503.5791015625&node=span-ae33988a45739df5&project=6269916&query=&showTransactions=p95&sort=-transaction.duration&source=performance_transaction_summary&tab=events&timestamp=1754953168&transaction=CampaignsController%23articles)of **CampaignsController#articles**

## What this PR does

Refactors `CoursesPresenter` to introduce a new `campaign_articles_count` method that:
- Centralizes logic for counting tracked campaign articles
- Uses memoization to avoid repeated queries within a request
- Ensures both `too_many_articles?` and pagination metadata use the same count logic

### Changes
- Removed `total_articles_count` method
- Added `campaign_articles_count` with `tracked: true` filter
- Updated `paginated_articles_courses` and `too_many_articles?` to use the new helper

### Benefits
- Keeps counting logic DRY and consistent
- Ensures the tracked filter is applied consistently
- Reduces duplicate query overhead with memoization

No change to end-user behavior, Except for reducing Query time to count the number of articles which was required for pagination.


## Screenshots

<img width="677" height="330" alt="Screenshot from 2025-08-13 01-52-25" src="https://github.com/user-attachments/assets/9546d203-dd2c-4f8e-9cba-368404403fc3" />


**Before:**



<img width="1366" height="404" alt="SCR 1" src="https://github.com/user-attachments/assets/9da8401d-1038-40f2-aa0e-2f699ff9b9f8" />


---
**After:**

<img width="1359" height="71" alt="Screenshot from 2025-08-13 01-44-13" src="https://github.com/user-attachments/assets/e93a73ce-abc6-4dcc-91a8-64d0d9da703f" />

