### PR TITLE
[WIP] Update timeslices marked as `needs_update` when changing timeslice duration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Metrics/ClassLength:
     - 'lib/training/wiki_slide_parser.rb'
     - 'lib/wiki_assignment_output.rb'
     - 'lib/course_training_progress_manager.rb'
+    - 'lib/timeslice_cleaner.rb'
     - 'lib/timeslice_manager.rb'
 
 Metrics/AbcSize:

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -36,6 +36,13 @@ class TimesliceManager
                                         needs_update: true)
   end
 
+  # Creates course wiki timeslices records for missing timeslices in the period [start, end]
+  def create_wiki_timeslices_for_period(wiki, start_period, end_period)
+    create_empty_course_wiki_timeslices(start_dates_for_period(wiki, start_period, end_period),
+                                        wiki,
+                                        needs_update: true)
+  end
+
   # Returns a datetime with the date to start getting revisions.
   def get_ingestion_start_time_for_wiki(wiki)
     non_empty_timeslices = @course.course_wiki_timeslices.where(wiki:).reject do |ts|
@@ -114,17 +121,23 @@ class TimesliceManager
     end
   end
 
-  # Returns start dates from the course start to the course end,
+  # Returns start dates for the period [start, end],
   # ensuring they align with the timeslice duration for the given wiki.
-  def start_dates(wiki)
+  def start_dates_for_period(wiki, start_period, end_period)
     start_dates = []
-    current_start = @course.start
-    while current_start <= @course.end
+    current_start = start_period
+    while current_start <= end_period
       start_dates << current_start
       current_start += timeslice_duration(wiki)
     end
 
     start_dates
+  end
+
+  # Returns start dates from the course start to the course end,
+  # ensuring they align with the timeslice duration for the given wiki.
+  def start_dates(wiki)
+    start_dates_for_period(wiki, @course.start, @course.end)
   end
 
   # Returns start dates from the old course start up to the new (previous) course start,

--- a/spec/lib/timeslice_manager_spec.rb
+++ b/spec/lib/timeslice_manager_spec.rb
@@ -105,6 +105,29 @@ describe TimesliceManager do
     end
   end
 
+  describe '#create_wiki_timeslices_for_period' do
+    let(:start_period) { DateTime.new(2024, 3, 22) }
+    let(:end_period) { DateTime.new(2024, 3, 23) }
+
+    before do
+      create(:courses_wikis, wiki: wikibooks, course:)
+      timeslice_manager.create_timeslices_for_new_course_wiki_records([wikibooks])
+      # Delete a random timeslice
+      CourseWikiTimeslice.where(course:, wiki: wikibooks, start: start_period,
+                                end: end_period).delete_all
+    end
+
+    it 'creates timeslices for the period' do
+      expect(course.course_wiki_timeslices.size).to eq(110)
+
+      timeslice_manager.create_wiki_timeslices_for_period(wikibooks, start_period, end_period)
+      course.reload
+      # Create missing course wiki timeslice
+      expect(course.course_wiki_timeslices.size).to eq(111)
+      expect(course.course_wiki_timeslices.where(needs_update: true).size).to eq(1)
+    end
+  end
+
   describe '#get_ingestion_start_time_for_wiki' do
     context 'when no course wiki timeslices' do
       it 'returns course start date' do


### PR DESCRIPTION
## What this PR does
This PR updates the behavior of `UpdateTimeslicesCourseWiki`.
Previously, `UpdateTimeslicesCourseWiki.update_timeslices_durations` deleted and recreated unprocessed timeslices if their duration had changed, but it ignored timeslices marked as `needs_update`.
With this PR, timeslices marked as `needs_update` are also deleted and recreated with the new duration.

This matters because timeslices with a large number of revisions (e.g., more than 100K) are often marked as `needs_update` due to transient API failures when fetching scores. Having such large timeslices repeatedly reprocessed in every course update involves a lot of latency in the queue. By splitting them into smaller timeslices, we increase the likelihood that they are successfully updated.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
