### PR TITLE
Fix database connection error by adding MySQL user setup instructions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -122,6 +122,11 @@ If you know your way around Rails, here's the very short version. Some additiona
         - Windows: `C:\xampp\mysql\bin\mysql -u root`
     - `CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
     - `CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
+    - `CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';`
+    - `GRANT ALL PRIVILEGES ON dashboard.* TO 'wiki'@'localhost';`
+    - `GRANT ALL PRIVILEGES ON dashboard_testing.* TO 'wiki'@'localhost';`
+    - `FLUSH PRIVILEGES;` # reload privilege tables so the new user/permissions take effect
+    - `SELECT User, Host FROM mysql.user WHERE User = 'wiki';`
     - `exit`
 
 - Install Gems:


### PR DESCRIPTION
This PR updates the `manual setup documentation` to include instructions for creating the default MySQL user (`wiki`) and
granting it privileges on the `dashboard` and `dashboard_testing` databases.

Without this step,  may encounter the following error during `rake db:migrate`:

```
WikiEduDashboard master ❯ rake db:migrate
rake aborted!
ActiveRecord::DatabaseConnectionError: There is an issue connecting to your database with your username/password, username: wiki.

Please check your database configuration to ensure the username/password are valid. ...

Caused by:
Mysql2::Error::ConnectionError: Access denied for user 'wiki'@'localhost' (using password: YES)

```