### PR TITLE
Fix article views metric for campaign view.

### DIFF
--- a/app/presenters/courses_presenter.rb
+++ b/app/presenters/courses_presenter.rb
@@ -79,7 +79,7 @@ class CoursesPresenter
     @fetched_articles = Article
                         .includes(:wiki)
                         .where(id: articles_courses_scope.map(&:article_id).uniq)
-                        .select(:id, :title, :deleted, :wiki_id, :namespace)
+                        .select(:id, :title, :deleted, :wiki_id, :namespace, :average_views)
                         .index_by(&:id)
   end
 

--- a/app/presenters/query/ranked_articles_courses_query.rb
+++ b/app/presenters/query/ranked_articles_courses_query.rb
@@ -16,7 +16,8 @@ class Query::RankedArticlesCoursesQuery
   def scope
     ArticlesCourses
       .joins("INNER JOIN (#{subquery.to_sql}) AS ranked_articles USING (id)")
-      .select(:article_id, :course_id, :character_sum, :references_count, :view_count, :updated_at)
+      .select(:article_id, :course_id, :character_sum, :references_count,
+              :first_revision, :average_views, :view_count, :updated_at)
   end
 
   private

--- a/app/views/campaigns/_article_row.html.haml
+++ b/app/views/campaigns/_article_row.html.haml
@@ -7,7 +7,8 @@
   %td.references
     = article_course.references_count
   %td.views
-    = number_to_human article_course.view_count
+    = number_to_human calculate_view_count(article_course.first_revision, article_course.average_views, article.average_views,
+                                         article_course.view_count)
   %td.lang_project
     %small
       = "#{article.wiki.language}.#{article.wiki.project}"

--- a/spec/lib/importers/average_views_importer_spec.rb
+++ b/spec/lib/importers/average_views_importer_spec.rb
@@ -7,13 +7,14 @@ describe AverageViewsImporter do
   let(:article) { create(:article, title: 'Selfie') }
   let(:course) { create(:course) }
 
-  let!(:articles_course) do
+  let(:articles_course) do
     create(:articles_course, course:, article_id: article.id, average_views: 1,
     average_views_updated_at: 1.day.ago, first_revision: 10.days.ago)
   end
 
   before do
     travel_to Date.new(2025, 8, 28)
+    articles_course
   end
 
   after do


### PR DESCRIPTION
## What this PR does
This PR fixes a minor bug related to the article views metric. On the `campaigns/articles` route, we were displaying the raw  `articles_courses.view_count` value. Since the article views metric implementation has changed, we can’t rely on that value anymore. The correct approach is to use the `calculate_view_count` helper (read method docs).

## Screenshots
Before:
<img width="1340" height="998" alt="before_article_views" src="https://github.com/user-attachments/assets/7448cc04-8539-4ed1-bca9-9a452708264f" />

After:
<img width="1340" height="998" alt="after_article_views" src="https://github.com/user-attachments/assets/eba9fedb-de3a-4e12-9bd7-24148a584ed2" />

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
