### PR TITLE
Bug Fix: duplicate campaign article rows by updating fragment cache keys

### DIFF
--- a/app/views/campaigns/articles.html.haml
+++ b/app/views/campaigns/articles.html.haml
@@ -75,7 +75,7 @@
           - articles_courses.each do |ac|
             - course = courses[ac.course_id]
             - article = articles[ac.article_id]
-            - cache [ac, locale] do
+            - cache ["article_row", ac.article_id, ac.course_id, ac.updated_at, locale] do
               = render 'campaigns/article_row', article:, article_course: ac, course:
 
     = will_paginate articles_courses


### PR DESCRIPTION
Issue: https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6430#issuecomment-3268557154

## To reproduce the Bug locally:

Set in **(config/environments/development.rb):**
a) `config.action_controller.perform_caching = true`
b) `config.cache_store = :redis_cache_store, { url: 'redis://localhost:6379/0' }` (make sure your localhost for redis in devlopment.rb matches with the one shown in redis local server) and redis server should be running

## What this PR does

In production, the *Campaign Articles* page was showing **duplicate rows** for the same `(article_id, course_id)` pair, even though the database query returned unique results.

This issue only appeared with **fragment caching enabled** under Puma’s multi-threaded environment.
The root cause was that the HAML partial used:

```haml
- cache [ac, locale] do
  = render 'campaigns/article_row', article:, article_course: ac, course:
```

Here `ac` was a partially-selected `ArticlesCourse` record from the new `RankedArticlesCoursesQuery`.
Because of this:

* Rails could not always generate a consistent cache key across threads.
* Multiple threads ended up writing different Redis fragments for the same logical row.
* When rendering, duplicates appeared even though the DB results were correct.

Replace the unstable object-based cache key with an **explicit deterministic key**:

```haml
- cache ["article_row", ac.article_id, ac.course_id, ac.updated_at, locale] do
  = render 'campaigns/article_row', article:, article_course: ac, course:
```

This ensures:

* Each `(article_id, course_id)` pair always maps to one fragment.
* Cache invalidation happens automatically when the record changes (`updated_at`).

## Screenshots

Before:


https://github.com/user-attachments/assets/d27350ed-352b-4ccf-944c-df8f82d3c0ae



After:


https://github.com/user-attachments/assets/1ca87649-26bd-405a-9cad-4cb77077a037


