### PR TITLE
Rename  `UpdateCourseStatsTimeslices` class to `UpdateCourseStats`

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -231,7 +231,7 @@ class CoursesController < ApplicationController
   def manual_update
     require_super_admin_permissions
     @course = find_course_by_slug(params[:id])
-    UpdateCourseStatsTimeslice.new(@course)
+    UpdateCourseStats.new(@course)
     redirect_to "/courses/#{@course.slug}"
   end
 

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -13,8 +13,10 @@ require_dependency "#{Rails.root}/lib/data_cycle/course_queue_sorting"
 require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 require_dependency "#{Rails.root}/app/services/update_course_wiki_timeslices"
 
-#= Pulls in new revisions for a single course wiki timeslice and updates the corresponding records
-class UpdateCourseStatsTimeslice
+#= Updates stats for a specific course. This includes importing data (revisions, uploads,
+# Wikidata stats, categories, article views), processing it (mostly through timeslices
+# records), and updating cached stats.
+class UpdateCourseStats
   include UpdateServiceErrorHelper
   include CourseQueueSorting
 

--- a/app/workers/course_data_update_worker.rb
+++ b/app/workers/course_data_update_worker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_dependency "#{Rails.root}/app/services/update_course_stats_timeslice"
+require_dependency "#{Rails.root}/app/services/update_course_stats"
 
 class CourseDataUpdateWorker
   THIRTY_DAYS = 60 * 60 * 24 * 30
@@ -18,7 +18,7 @@ class CourseDataUpdateWorker
     return if course.very_long_update?
 
     logger.info "Updating course timeslice version: #{course.slug}"
-    UpdateCourseStatsTimeslice.new(course)
+    UpdateCourseStats.new(course)
   rescue StandardError => e
     Sentry.capture_exception e
   end

--- a/benchmarks/cuwbench.rb
+++ b/benchmarks/cuwbench.rb
@@ -16,7 +16,7 @@ make_copy_of 'https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wik
 puts 'Warmup...'
 ActiveRecord::Base.transaction do
   # Warmup
-  UpdateCourseStatsTimeslice.new(@course)
+  UpdateCourseStats.new(@course)
   raise ActiveRecord::Rollback
 end
 
@@ -31,7 +31,7 @@ result = Benchmark.measure do
   10.times do
     printf('.')
     ActiveRecord::Base.transaction do
-      UpdateCourseStatsTimeslice.new(@course)
+      UpdateCourseStats.new(@course)
       raise ActiveRecord::Rollback
     end
   end
@@ -43,12 +43,12 @@ raise unless Article.count.zero?
 puts '### Hot Database'
 
 ActiveRecord::Base.transaction do
-  UpdateCourseStatsTimeslice.new(@course)
+  UpdateCourseStats.new(@course)
 
   result = Benchmark.measure do
     10.times do
       printf('.')
-      UpdateCourseStatsTimeslice.new(@course)
+      UpdateCourseStats.new(@course)
     end
   end
   puts result

--- a/benchmarks/cuwprofile.rb
+++ b/benchmarks/cuwprofile.rb
@@ -14,7 +14,7 @@ make_copy_of 'https://outreachdashboard.wmflabs.org/courses/CodeTheCity/WODD-Wik
 @course = Course.first
 
 profile = StackProf.run(mode: :wall, raw: true, interval: 10000) do
-  UpdateCourseStatsTimeslice.new(@course)
+  UpdateCourseStats.new(@course)
 end
 
 # Drag this file into https://speedscope.app

--- a/docs/user_roles.md
+++ b/docs/user_roles.md
@@ -103,7 +103,7 @@ To reproduce a working course with active editors, complete the following:
 1. For populating the Uploads, find users [who have recently uploaded files](https://en.wikipedia.org/wiki/Special:Log/upload).
 1. As an instructor or admin, create a course with dates _that encompass the dates of the changes_. For example, if the editor you're looking to add made changes on February 1st, 2019. Start your course in January and end it after February.
 1. Then, go to the "Students" tab of the course and add those students. (Note: If you do not see the students tab, you may need to approve the course. You can do so by clicking "Edit Details" on the course's home page and adding it to a campaign.)
-4. Import course data by triggering a manual update. Either add `/manual_update` to the end of the base course URL, or use a console to load the Course record (e.g., `course = Course.last`) and then run `UpdateCourseStatsTimeslice.new(course)`.
+4. Import course data by triggering a manual update. Either add `/manual_update` to the end of the base course URL, or use a console to load the Course record (e.g., `course = Course.last`) and then run `UpdateCourseStats.new(course)`.
 5. Optionally, load additional metadata by running a `ConstantUpdate` in a console:
     * `require "#{Rails.root}/lib/data_cycle/constant_update`
     * `ConstantUpdate.new`

--- a/setup/populate_dashboard.rb
+++ b/setup/populate_dashboard.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'net/http'
 require_dependency "#{Rails.root}/lib/importers/user_importer"
-require_dependency "#{Rails.root}/app/services/update_course_stats_timeslice"
+require_dependency "#{Rails.root}/app/services/update_course_stats"
 require_dependency "#{Rails.root}/lib/timeslice_manager"
 
 def make_copy_of(url)
@@ -79,7 +79,7 @@ def populate_dashboard
         # Add the course to the campaign if it doesn't already exist
         default_campaign.courses << course
         puts "Getting data for #{course.slug}..."
-        UpdateCourseStatsTimeslice.new(course)
+        UpdateCourseStats.new(course)
       end
     rescue ActiveRecord::RecordInvalid => e
       # Handle specific error when record creation fails

--- a/spec/features/namespace_stats_spec.rb
+++ b/spec/features/namespace_stats_spec.rb
@@ -22,7 +22,7 @@ describe 'Namespace-specific stats', type: :feature, js: true do
     JoinCourse.new(course:, user: user1, role: 0)
     JoinCourse.new(course:, user: user2, role: 0)
     login_as superadmin
-    allow(UpdateCourseStatsTimeslice).to receive(:new)
+    allow(UpdateCourseStats).to receive(:new)
     create(:course_stats,
            stats_hash: { 'en.wikibooks.org-namespace-0':
     { edited_count: 1, new_count: 2, revision_count: 3,

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -47,7 +47,7 @@ describe ScheduleCourseUpdates do
     end
 
     it 'calls the revisions and articles updates on courses currently taking place' do
-      expect(UpdateCourseStatsTimeslice).to receive(:new).exactly(7).times
+      expect(UpdateCourseStats).to receive(:new).exactly(7).times
       update = described_class.new
       sentry_logs = update.instance_variable_get(:@sentry_logs)
       expect(sentry_logs.grep(/Short update latency/).any?).to eq(true)

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -65,7 +65,7 @@ describe ArticleScopedProgram, type: :model do
       allow(Replica).to receive(:new).and_return(replica_instance)
       allow(replica_instance).to receive(:get_revisions).and_return(revisions)
       VCR.use_cassette 'article_scoped_update' do
-        UpdateCourseStatsTimeslice.new(asp)
+        UpdateCourseStats.new(asp)
       end
     end
 

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -65,7 +65,7 @@ describe VisitingScholarship, type: :model do
       allow(Replica).to receive(:new).and_return(replica_instance)
       allow(replica_instance).to receive(:get_revisions).and_return(revisions)
       VCR.use_cassette 'visiting_scholarship_update' do
-        UpdateCourseStatsTimeslice.new(vs)
+        UpdateCourseStats.new(vs)
       end
     end
 

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require "#{Rails.root}/lib/timeslice_manager"
 
-describe UpdateCourseStatsTimeslice do
+describe UpdateCourseStats do
   before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
 
   let(:course) { create(:course, start: '2018-11-24', end: '2018-11-30', flags:) }

--- a/spec/services/update_wiki_namespace_stats_timeslice_spec.rb
+++ b/spec/services/update_wiki_namespace_stats_timeslice_spec.rb
@@ -15,7 +15,7 @@ describe UpdateWikiNamespaceStatsTimeslice do
   let(:enwiki_course_wiki) { course.courses_wikis.find_by(wiki: enwiki) }
 
   before do
-    skip('Skipping this test due to failures in UpdateCourseStatsTimeslice. TODO: fix me')
+    skip('Skipping this test due to failures in UpdateCourseStats. TODO: fix me')
     stub_wiki_validation
     course.campaigns << Campaign.first
 
@@ -26,7 +26,7 @@ describe UpdateWikiNamespaceStatsTimeslice do
     JoinCourse.new(course:, user: user2, role: 0)
     course.reload
     VCR.use_cassette 'course_update_timeslices' do
-      UpdateCourseStatsTimeslice.new(course)
+      UpdateCourseStats.new(course)
     end
   end
 


### PR DESCRIPTION
Rename `UpdateCourseStatsTimeslices` class to `UpdateCourseStats`, since the purpose of the class is to update course statistics (regardless of whether this is done through timeslices or not).

