### PR TITLE
Fix bug when default timeslice duration changes

### DIFF
--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -49,8 +49,8 @@ class UpdateTimeslicesCourseWiki
   end
 
   def update_timeslices_durations
-    recreate_unprocessed_timeslices
     recreate_timeslices_needing_update
+    recreate_unprocessed_timeslices
   end
 
   def recreate_unprocessed_timeslices


### PR DESCRIPTION
## What this PR does
Fix a bug introduced in PR #6457. Once that PR was deployed, I changed the timeslice duration for course [32963](https://outreachdashboard.wmflabs.org/courses/Wikimedia_Indonesia/Geodatathon_Agustus_2025/home) to two hours. There were three timeslices for the course, two of them having `needs_update` to 1.

<img width="1339" height="94" alt="image" src="https://github.com/user-attachments/assets/55d31ca5-10d3-4bd3-8d4b-8b02bb08fc73" />

When `UpdateTimeslicesCourseWiki` ran during the pre-update, it recreated both timeslices set as `needs_update`, but didn't touch the first timeslice (already completed). However, after that, when new revisions were fetched, `get_ingestion_start_time_for_wiki` returned `2025-08-26 17:00:00`. As timeslice duration at that point was 2 hours, we processed a non-existing timeslice from  `2025-08-26 17:00:00` to  `2025-08-26 19:00:00` and overwrote the daily timeslice. Then, another non-existing timeslice from  `2025-08-26 19:00:00` to  `2025-08-26 21:00:00` was processed, etc.  Thus, the timeslice from  `2025-08-26 17:00:00` to  `2025-08-27 17:00:00` ended with data associated only with the last 2 hours of its actual period.

