### PR TITLE
[WIP] Disable update timeslices durations during `UpdateTimeslicesCourseWiki`

### DIFF
--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -24,9 +24,6 @@ class UpdateTimeslicesCourseWiki
 
     new_wiki_ids = current_course_wiki_ids - processed_courses_wikis
     add_courses_wikis(new_wiki_ids)
-
-    # Check if some wiki changes timeslice duration
-    update_timeslices_durations
   end
 
   private
@@ -46,53 +43,5 @@ class UpdateTimeslicesCourseWiki
     Rails.logger.info { "UpdateTimeslicesCourseWiki: Adding wikis: #{wiki_ids}" }
     # Create course wiki timeslice records for new wikis
     @timeslice_manager.create_timeslices_for_new_course_wiki_records(wikis)
-  end
-
-  def update_timeslices_durations
-    recreate_timeslices_needing_update
-    recreate_unprocessed_timeslices
-  end
-
-  def recreate_unprocessed_timeslices
-    @course.wikis.each do |wiki|
-      start = @timeslice_manager.get_ingestion_start_time_for_wiki wiki
-      timeslice = @course.course_wiki_timeslices.where(wiki:, start:).first
-      next unless timeslice && needs_recreate?(timeslice,
-                                               @timeslice_manager.timeslice_duration(wiki))
-
-      @timeslice_cleaner.delete_course_wiki_timeslices_after_date([wiki], start - 1.second)
-      @timeslice_cleaner.delete_course_user_wiki_timeslices_after_date([wiki], start - 1.second)
-      @timeslice_cleaner.delete_article_course_timeslices_after_date([wiki], start - 1.second)
-      @timeslice_manager.create_wiki_timeslices_up_to_new_course_end_date(wiki)
-    end
-  end
-
-  def recreate_timeslices_needing_update
-    @course.wikis.each do |wiki|
-      CourseWikiTimeslice.for_course_and_wiki(@course, wiki).needs_update.find_each do |timeslice|
-        next unless needs_recreate?(timeslice,
-                                    @timeslice_manager.timeslice_duration(wiki),
-                                    needs_update: true)
-
-        @timeslice_cleaner.delete_timeslices_for_period([wiki], timeslice.start, timeslice.end)
-        @timeslice_manager.create_wiki_timeslices_for_period(wiki, timeslice.start,
-                                                             timeslice.end - 1.second)
-      end
-    end
-  end
-
-  # Determines whether a timeslice should be recreated.
-  # The criteria is:
-  # - For current or future timeslices: recreate if the new duration differs
-  #   from the effective duration.
-  # - For timeslices marked as needs_update:
-  #   recreate only if the new duration differs and evenly divides the effective duration.
-  def needs_recreate?(timeslice, new_duration, needs_update: false)
-    effective_duration = timeslice.end - timeslice.start
-    # No need to recreate if duration didn't change
-    return false if effective_duration == new_duration
-    return true unless needs_update
-    # Recreate only if the new duration evenly divides the effective duration
-    (effective_duration % new_duration).zero?
   end
 end

--- a/lib/timeslice_manager.rb
+++ b/lib/timeslice_manager.rb
@@ -36,16 +36,6 @@ class TimesliceManager
                                         needs_update: true)
   end
 
-  # Creates course wiki timeslice records for the period [start_period, end_period].
-  # In other words, it creates all timeslices whose start date falls within that range,
-  # using the configured timeslice duration for the given course and wiki.
-  # Note that this may include a timeslice starting exactly at end_period.
-  def create_wiki_timeslices_for_period(wiki, start_period, end_period)
-    create_empty_course_wiki_timeslices(start_dates_for_period(wiki, start_period, end_period),
-                                        wiki,
-                                        needs_update: true)
-  end
-
   # Returns a datetime with the date to start getting revisions.
   def get_ingestion_start_time_for_wiki(wiki)
     # Timeslices may have changed, so we need to ensure we return the actual


### PR DESCRIPTION
## What this PR does
This PR removes the code that dynamically updated timeslice durations when the duration setting changed. After implementing that, we decided instead to use the strategy of automatically splitting timeslices when they exceed `REVISION_THRESHOLD`. Supporting both approaches at once adds unnecessary complexity and doesn’t make much sense, so this PR deletes the duration-based update logic in favor of the automatic split timeslice algorithm.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
