### PR TITLE
Mark timeslices as needs update if rolling back

### DIFF
--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -61,12 +61,14 @@ class UpdateCourseWikiTimeslices
       # If the timeslice was reprocessed in this update, then skip it
       next if timeslice_reprocessed?(wiki.id, t.start)
 
-      ActiveRecord::Base.transaction do
-        processed = @splitter.handle(wiki, t.start, t.end, only_new: true)
-        @processed_timeslices_count += processed.count
+      begin
+        ActiveRecord::Base.transaction do
+          processed = @splitter.handle(wiki, t.start, t.end, only_new: true)
+          @processed_timeslices_count += processed.count
+        end
       rescue StandardError => e
         log_error(e)
-        raise ActiveRecord::Rollback
+        t.update(needs_update: true)
       end
     end
   end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -142,8 +142,30 @@ describe UpdateCourseWikiTimeslices do
 
       # last_mw_rev_datetime wasn't updated
       timeslice = course.course_wiki_timeslices.where(wiki: enwiki, start: '2018-11-29').first
-
       expect(timeslice.last_mw_rev_datetime).to be_nil
+      # timeslice was set as needs_update
+      expect(timeslice.needs_update).to eq(true)
+      # course user wiki timeslice was rolled backed
+      cuw_timeslice = course.course_user_wiki_timeslices.where(wiki: enwiki, start: '2018-11-29')
+      expect(cuw_timeslice.size).to eq(0)
+
+      # last_mw_rev_datetime wasn't updated
+      timeslice = course.course_wiki_timeslices.where(wiki: enwiki, start: '2018-11-24').first
+      expect(timeslice.last_mw_rev_datetime).to be_nil
+      # timeslice was set as needs_update
+      expect(timeslice.needs_update).to eq(true)
+      # course user wiki timeslice was rolled backed
+      cuw_timeslice = course.course_user_wiki_timeslices.where(wiki: enwiki, start: '2018-11-24')
+      expect(cuw_timeslice.size).to eq(0)
+
+      # last_mw_rev_datetime wasn't updated
+      timeslice = course.course_wiki_timeslices.where(wiki: wikidata, start: '2018-11-24').first
+      expect(timeslice.last_mw_rev_datetime).to be_nil
+      # timeslice was set as needs_update
+      expect(timeslice.needs_update).to eq(true)
+      # course user wiki timeslice was rolled backed
+      cuw_timeslice = course.course_user_wiki_timeslices.where(wiki: wikidata, start: '2018-11-24')
+      expect(cuw_timeslice.size).to eq(0)
     end
 
     it 'fetches revisions up to end date' do

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -166,7 +166,8 @@ describe UpdateCourseWikiTimeslices do
         # timeslice was set as needs_update
         expect(timeslice.needs_update).to eq(true)
         # course user wiki timeslice was rolled backed
-        cuw_timeslice = course.course_user_wiki_timeslices.where(wiki: wikidata, start: '2018-11-24')
+        cuw_timeslice = course.course_user_wiki_timeslices
+                              .where(wiki: wikidata, start: '2018-11-24')
         expect(cuw_timeslice.size).to eq(0)
       end
 


### PR DESCRIPTION
## What this PR does
This PR starts from #6461. Only the last two commits are relevant to this PR:

- 3248978afe2adc27893a9ceaef02285491005511
- 9cbe98a521a30550a1edf14c6adeb9f8e0b06a1d

The basic idea is to mark timeslices as `needs_update` if something goes wrong during the update and the db transaction needs to be roll-backed. 

After analyzing `Mysql2::Error: Field 'article_id' doesn't have a default value` sentry [log](https://wiki-education.sentry.io/issues/6382949119/events/?project=6269916&query=&referrer=issue-stream), I noticed that we need to explicitly mark a failed timeslice as `needs_update`, otherwise it may not be retried for processing.

The improvement on the log (including start and end dates) would also help to better understand the error and reproduce it.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
