### PR TITLE
Add missing wikidataLabel prop to EditedUnassignedArticleRow component

### DIFF
--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticleRow.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticleRow.jsx
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import ArticleViewer from '@components/common/ArticleViewer/containers/ArticleViewer.jsx';
 
 export const EditedUnassignedArticleRow = ({
-  article, course, current_user, fetchArticleDetails, showArticleId, user
+  article, course, current_user, fetchArticleDetails, showArticleId, user, wikidataLabel
 }) => (
   <tr className="article-row">
-    <td className="article-title">{article.title}</td>
+    <td className="article-title">{wikidataLabel ?? article.title}</td>
     <td>
       <p className="assignment-links">
         <a href={article.url} target="_blank">

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/EditedUnassignedArticles/EditedUnassignedArticles.jsx
@@ -11,7 +11,7 @@ import withRouter from '../../../../../util/withRouter.jsx';
 
 const EditedUnassignedArticles = ({
   articles, course, current_user, showArticleId, title, user,
-  fetchArticleDetails, ...props
+  fetchArticleDetails, wikidataLabels, ...props
 }) => {
   const rows = articles.map(article => (
     <EditedUnassignedArticleRow
@@ -20,6 +20,7 @@ const EditedUnassignedArticles = ({
       course={course}
       current_user={current_user}
       fetchArticleDetails={fetchArticleDetails}
+      wikidataLabel={wikidataLabels[article.title]}
       showArticleId={showArticleId}
       user={user}
     />

--- a/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
+++ b/app/assets/javascripts/components/students/components/Articles/SelectedStudent/SelectedStudent.jsx
@@ -96,6 +96,7 @@ export const SelectedStudent = ({
             showArticleId={showArticleId}
             fetchArticleDetails={fetchArticleDetails}
             title="Other Edited Articles"
+            wikidataLabels={wikidataLabels}
           />
         )
       }


### PR DESCRIPTION
## What this PR does
- Issue - https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6368
- Adds missing `wikidataLabel` prop to the `EditedUnassignedArticleRow` component

## Screenshots
Before:
<img width="1257" height="1054" alt="Screenshot 2025-10-04 at 1 06 46 PM" src="https://github.com/user-attachments/assets/28b136a0-dd64-45a2-a519-e56f7f8dc455" />

After:
<img width="1278" height="1161" alt="Screenshot 2025-10-04 at 1 07 46 PM" src="https://github.com/user-attachments/assets/df393ec2-2f5a-4f8b-a822-bb9a526ff26f" />

## Open questions and concerns
TODO: Fill out after double checking my changes
