### PR TITLE
Update slack CTA from gmail specific to generic mailto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Overview:
 
 This project welcomes contributions, and we try to be as newbie-friendly as possible. Check out [the CONTRIBUTING file](CONTRIBUTING.md) for more details.
 
-[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
+[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/u/1?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
 
 ### Setup
 - [Setting up a development environment](docs/setup.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Overview:
 
 This project welcomes contributions, and we try to be as newbie-friendly as possible. Check out [the CONTRIBUTING file](CONTRIBUTING.md) for more details.
 
-[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](https://mail.google.com/mail/u/1?view=cm&fs=1&to=sage@wikiedu.org&su=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
+[![🚀 Join Slack Now](https://img.shields.io/badge/🚀%20Join%20Slack%20Now-Click%20Here-ff6b6b?style=for-the-badge&logo=slack&logoColor=white)](mailto:sage@wikiedu.org?subject=Request%20to%20join%20Slack%20Community&body=Hey%20Sage%2C%0AI%20hope%20you're%20doing%20well.%0AI%20would%20like%20to%20join%20the%20Slack%20community.%20Kindly%20send%20me%20an%20invite%20at%20your%20convenience.%0AThank%20you!)
 
 ### Setup
 - [Setting up a development environment](docs/setup.md)


### PR DESCRIPTION
## What this PR does
- Issue - https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6468
- Updates the slack call to action link to be a generic `mailto` link as opposed to a gmail specific link
