### PR TITLE
Refactor RevisionDataManager for clarity and readability

### DIFF
--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -8,6 +8,14 @@ require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
 
 #= Fetches revision data from API
+# This class is intended to be used in two main ways:
+# 1. To fetch revisions and scores for a given course over a period:
+#    - First, fetch the revisions using `fetch_revision_data_for_course`.
+#    - Then, fetch the scores by calling `fetch_score_data_for_course`, passing the array
+#      of revisions obtained earlier. These are done in separate steps for performance reasons,
+#      since fetching scores can be expensive.
+# 2. To fetch revisions (without scores) for a given set of users over a period:
+#    - Use `fetch_revision_data_for_users` as the entry point.
 class RevisionDataManager
   include EncodingHelper
 


### PR DESCRIPTION
## What this PR does
This PR makes minor refactors to `RevisionDataManager`:
- Remove `@revisions`
- Remove `@articles`

I think having instance variables in this case was confusing and prone to errors.

This is to address the [review](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6461#discussion_r2399709484) in PR #6461:

> I think it's worth clarifying in comments at the top about how this class is supposed to be used, in terms of the life cycle of a single instance, and how @revisions and @articles are used over that lifecycle (which may involve calls to each of the three non-private instance methods). It's confusing that one method fetches data to populate @revisions, and another takes revisions as an argument and sets @revisions based on that. Similarly, it's not clear from the code what the difference is between @articles and articles right here. (You addressed the reason for this change in the PR description, but perhaps more specific variable names help.)

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
