### PR TITLE
Fix early `average view` updates for articles

### DIFF
--- a/lib/importers/average_views_importer.rb
+++ b/lib/importers/average_views_importer.rb
@@ -42,13 +42,12 @@ class AverageViewsImporter
   def self.update_average_views_for_article(article_course, average_views, time)
     can_update = (1.day.ago - article_course.first_revision) > 1.day
 
+    # If not enough time has passed since first revision, return
     return unless can_update
 
-    views_since_revision = WikiPageviews.new(article_course.article)
-                                        .average_views_from_date(article_course.first_revision)
-
     average_views[article_course.id] = {
-      average_views: views_since_revision,
+      average_views: WikiPageviews.new(article_course.article)
+                                  .average_views_from_date(article_course.first_revision),
       average_views_updated_at: time
     }
   end

--- a/spec/lib/importers/average_views_importer_spec.rb
+++ b/spec/lib/importers/average_views_importer_spec.rb
@@ -14,8 +14,8 @@ describe AverageViewsImporter do
   end
 
   let(:article_course_with_insufficient_rev_time) do
-    create(:articles_course, course:, article_id: article4.id, average_views: 10,
-           average_views_updated_at: 1.day.ago, first_revision: 1.day.ago)
+    create(:articles_course, course:, article_id: article4.id, average_views: nil,
+           average_views_updated_at: nil, first_revision: 1.day.ago)
   end
 
   before do
@@ -40,7 +40,7 @@ describe AverageViewsImporter do
       VCR.use_cassette 'average_views' do
         described_class.update_average_views(ArticlesCourses.all)
       end
-      expect(article_course_with_insufficient_rev_time.reload.average_views).to eq(10)
+      expect(article_course_with_insufficient_rev_time.reload.average_views).to eq(nil)
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR fixes the issue with courses having 0 views when their articles may have had views. This fix skips updating the `average_views_updated_at` when the `views_from_date` is 0. This makes it possible for views to be updated when they happen.

Closes #6476

## Open questions and concerns