### PR TITLE
Modify button to include type

### DIFF
--- a/app/assets/javascripts/components/admin_notes/notes_modal_trigger.jsx
+++ b/app/assets/javascripts/components/admin_notes/notes_modal_trigger.jsx
@@ -33,6 +33,7 @@ const NotesModalTrigger = ({ setIsModalOpen, notesList, setNoteFetchTimestamp })
   return (
     <div className="admin-notes-modal-trigger">
       <button
+        type="button"
         onClick={onClickAdminButton}
         className="button admin-focus-highlight admin-action-button"
         aria-haspopup="dialog"

--- a/app/assets/javascripts/components/admin_notes/notes_panel.jsx
+++ b/app/assets/javascripts/components/admin_notes/notes_panel.jsx
@@ -110,6 +110,7 @@ const NotesPanel = () => {
       <div className="basic-modal">
         {/* Add a close button to the modal */}
         <button
+          type="button"
           onClick={closeModalAndHandleNoteCreation}
           aria-label={I18n.t('notes.admin.aria_label.close_admin')}
           className="pull-right article-viewer-button icon-close admin-focus-highlight"
@@ -122,6 +123,7 @@ const NotesPanel = () => {
             {/* Render the "Create Note" functionality */}
             {!isNoteCreationActive && (
               <button
+                type="button"
                 className="tooltip-trigger admin--note--creator admin-focus-highlight"
                 onClick={() => setIsNoteCreationActive(true)}
                 aria-label={I18n.t('notes.admin.aria_label.create_note')}
@@ -137,6 +139,7 @@ const NotesPanel = () => {
             {isNoteCreationActive && (
               <div role="group" aria-label={I18n.t('notes.admin.aria_label.note_action_button')}>
                 <button
+                  type="button"
                   className="tooltip-trigger cancel--note admin-focus-highlight"
                   onClick={() => setIsNoteCreationActive(false)}
                   aria-label={I18n.t('notes.admin.aria_label.cancel_note_creation')}
@@ -147,6 +150,7 @@ const NotesPanel = () => {
                   </span>
                 </button>
                 <button
+                  type="button"
                   className="tooltip-trigger post--note admin-focus-highlight"
                   onClick={() => onClickPostNotesHandler(course.id)}
                   aria-label={I18n.t('notes.admin.aria_label.post_created_note')}

--- a/app/assets/javascripts/components/admin_notes/notes_row.jsx
+++ b/app/assets/javascripts/components/admin_notes/notes_row.jsx
@@ -91,6 +91,7 @@ const NotesRow = ({ notesList }) => {
         // Render the edit button or cancel button based on the editing state
         const notesEditButton = !isEditing ? (
           <button
+            type="button"
             className="tooltip-trigger admin-focus-highlight"
             aria-label={I18n.t('notes.admin.aria_label.note_edit_button_focused', { title: note.title })}
             onClick={() => onNotesEditButtonClickHandler(note.id, note.title, note.text)}
@@ -102,6 +103,7 @@ const NotesRow = ({ notesList }) => {
           </button>
         ) : (
           <button
+            type="button"
             className="tooltip-trigger cancel--note admin-focus-highlight"
             aria-label={I18n.t('notes.admin.aria_label.note_edit_cancel_button_focused', { title: note.title })}
             onClick={() => onNotesEditCancelButtonClickHandler()}
@@ -116,6 +118,7 @@ const NotesRow = ({ notesList }) => {
         // Render the save button
         const notesEditSaveButton = (
           <button
+            type="button"
             className="tooltip-trigger post--note admin-focus-highlight"
             onClick={() => onNotesEditSaveButtonClickHandler(note.id)}
             aria-label={I18n.t('notes.admin.aria_label.note_edit_save_button_focused', { title: noteTitle })}
@@ -159,6 +162,7 @@ const NotesRow = ({ notesList }) => {
               <td className={`${rowClassName} admin-note__delete`} onClick={e => e.stopPropagation()}>
                 {!isEditing ? (
                   <button
+                    type="button"
                     className="tooltip-trigger admin-focus-highlight"
                     aria-label={I18n.t('notes.admin.aria_label.note_delete_button_focused', { title: note.title })}
                     onClick={() => deleteNote(note.id)}

--- a/app/assets/javascripts/components/article_finder/article_finder_row.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_row.jsx
@@ -125,7 +125,7 @@ const ArticleFinderRow = (props) => {
         const className = `button small add-available-article ${isLoading ? 'disabled' : 'dark'}`;
         button = (
           <td>
-            <button className={className} onClick={() => assignArticle()}>{I18n.t(`article_finder.${ArticleUtils.projectSuffix(props.selectedWiki.project, 'add_available_article')}`)}</button>
+            <button type="button" className={className} onClick={() => assignArticle()}>{I18n.t(`article_finder.${ArticleUtils.projectSuffix(props.selectedWiki.project, 'add_available_article')}`)}</button>
           </td>
         );
       }
@@ -134,14 +134,14 @@ const ArticleFinderRow = (props) => {
         const className = `button small add-available-article ${isLoading ? 'disabled' : ''}`;
         button = (
           <td>
-            <button className={className} onClick={() => unassignArticle(props.current_user.id)}>{I18n.t(`article_finder.${ArticleUtils.projectSuffix(props.selectedWiki.project, 'unassign_article_self')}`)}</button>
+            <button type="button" className={className} onClick={() => unassignArticle(props.current_user.id)}>{I18n.t(`article_finder.${ArticleUtils.projectSuffix(props.selectedWiki.project, 'unassign_article_self')}`)}</button>
           </td>
         );
       } else {
       const className = `button small add-available-article ${isLoading ? 'disabled' : 'dark'}`;
       button = (
         <td>
-          <button className={className} onClick={() => assignArticle(props.current_user.id)}>{I18n.t('article_finder.assign_article_self')}</button>
+          <button type="button" className={className} onClick={() => assignArticle(props.current_user.id)}>{I18n.t('article_finder.assign_article_self')}</button>
         </td>
       );
       }

--- a/app/assets/javascripts/components/article_finder/article_finder_search_bar.jsx
+++ b/app/assets/javascripts/components/article_finder/article_finder_search_bar.jsx
@@ -79,7 +79,7 @@ function ArticleFinderSearchBar({ value, onChange, onSearch, disabled, wiki }) {
         isAutocompleteLoading && <div className="loader"><div className="loading__spinner" /></div>
       }
 
-      <button onClick={searchHandler} disabled={disabled}>
+      <button type="button" onClick={searchHandler} disabled={disabled}>
         {I18n.t('article_finder.search')}
       </button>
 

--- a/app/assets/javascripts/components/articles/add_available_articles.jsx
+++ b/app/assets/javascripts/components/articles/add_available_articles.jsx
@@ -70,7 +70,7 @@ const AddAvailableArticles = ({
         editable
         placeholder={inputPlaceholder}
       />
-      <button className="button border pull-right" onClick={submit}>
+      <button type="button" className="button border pull-right" onClick={submit}>
         {I18n.t(`assignments.${ArticleUtils.projectSuffix(project, 'add_available_submit')}`)}
       </button>
     </div>

--- a/app/assets/javascripts/components/tickets/tickets_handler.jsx
+++ b/app/assets/javascripts/components/tickets/tickets_handler.jsx
@@ -159,6 +159,7 @@ const TicketsHandler = () => {
         </div>
         <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 10 }}>
           <button
+            type="button"
             onClick={doSearch}
             className="button dark"
             name="search_tickets"
@@ -167,6 +168,7 @@ const TicketsHandler = () => {
             {I18n.t('tickets.search_bar_placeholder')}
           </button>
           <button
+            type="button"
             onClick={clearSearch}
             className="button"
             name="clear_search"

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -65,7 +65,7 @@ const updateBlock = (valueKey, value) => {
     if (isEditable) {
       blockActions = (
         <div className="float-container block__block-actions">
-          <button onClick={props.saveBlockChanges.bind(null, block.id)} className="button dark pull-right no-clear">Save</button>
+          <button type="button" onClick={props.saveBlockChanges.bind(null, block.id)} className="button dark pull-right no-clear">Save</button>
           <span role="button" tabIndex={0} onClick={props.cancelBlockEditable.bind(null, block.id)} className="span-link pull-right no-clear">Cancel</span>
         </div>
       );
@@ -97,7 +97,7 @@ const updateBlock = (valueKey, value) => {
     // let graded;
     if (isEditable) {
       if (!block.is_new) {
-        deleteBlock = (<div className="delete-block-container"><button className="danger" onClick={deleteBlocks}>Delete Block</button></div>);
+        deleteBlock = (<div className="delete-block-container"><button type="button" className="danger" onClick={deleteBlocks}>Delete Block</button></div>);
       }
       className += ' editable';
       if (props.isDragging) { className += ' dragging'; }
@@ -163,7 +163,7 @@ const updateBlock = (valueKey, value) => {
 
     const editButton = props.editPermissions ? (
       <div className="block__edit-button-container">
-        <button className="pull-right button ghost-button block__edit-block" onClick={_setEditable}>Edit</button>
+        <button type="button" className="pull-right button ghost-button block__edit-block" onClick={_setEditable}>Edit</button>
       </div>
     ) : undefined;
 

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -293,17 +293,17 @@ const Timeline = createReactClass({
     }
 
     const saveChangesButton = (
-      <button className="button dark button--block" onClick={this.props.saveGlobalChanges}>
+      <button type="button" className="button dark button--block" onClick={this.props.saveGlobalChanges}>
         {I18n.t('timeline.save_all_changes')}
       </button>
     );
     const cancelChangesButton = (
-      <button className="button button--clear button--block" onClick={this.props.cancelGlobalChanges}>
+      <button type="button" className="button button--clear button--block" onClick={this.props.cancelGlobalChanges}>
         {I18n.t('timeline.discard_all_changes')}
       </button>
     );
     const resetTitlesButton = (
-      <button className="button button--clear button--block" onClick={this.props.resetTitles}>
+      <button type="button" className="button button--clear button--block" onClick={this.props.resetTitles}>
         {I18n.t('timeline.reset_titles')}
       </button>
     );
@@ -336,7 +336,7 @@ const Timeline = createReactClass({
       } else if (this.props.editableBlockIds.length === 0) {
         reorderableControls = (
           <div className="reorderable-controls">
-            <button className="button border button--block" onClick={this.props.enableReorderable}>{I18n.t('timeline.arrange_timeline')}</button>
+            <button type="button" className="button border button--block" onClick={this.props.enableReorderable}>{I18n.t('timeline.arrange_timeline')}</button>
           </div>
         );
       }
@@ -352,7 +352,7 @@ const Timeline = createReactClass({
       } else {
         editWeekTitles = (
           <div className="edit-week-titles">
-            <button className="button border button--block" onClick={this.props.enableEditTitles}>{I18n.t('timeline.edit_titles')}</button>
+            <button type="button" className="button border button--block" onClick={this.props.enableEditTitles}>{I18n.t('timeline.edit_titles')}</button>
           </div>
         );
       }
@@ -377,7 +377,7 @@ const Timeline = createReactClass({
         </li>
       ) : (
         <li>
-          <button className="week-nav__add-week" onClick={this.addWeek}>Add Week</button>
+          <button type="button" className="week-nav__add-week" onClick={this.addWeek}>Add Week</button>
         </li>
       );
     }
@@ -423,7 +423,7 @@ const Timeline = createReactClass({
     // and the timeline is not already empty.
     if (this.props.edit_permissions && !this.props.course.submitted && this.hasTimeline()) {
       restartTimeline = (
-        <button className="button border danger button--block" onClick={this.deleteAllWeeks}>
+        <button type="button" className="button border danger button--block" onClick={this.deleteAllWeeks}>
           {I18n.t('timeline.delete_timeline_and_start_over')}
         </button>
       );

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -141,11 +141,11 @@ const Week = createReactClass({
     });
 
     const addBlock = !this.props.reorderable ? (
-      <button className="pull-right week__add-block" href="" onClick={this.addBlock}>Add Block <span className="icon-plus-blue" /></button>
+      <button type="button" className="pull-right week__add-block" href="" onClick={this.addBlock}>Add Block <span className="icon-plus-blue" /></button>
     ) : undefined;
 
     const deleteWeek = !this.props.reorderable && !this.props.week.is_new ? (
-      <button onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} className="pull-right week__delete-week" href="" onClick={this.props.deleteWeek}>Delete Week <span className={`${this.state.isHover ? 'icon-trash_can-hover' : 'icon-trash_can'}`}/></button>
+      <button type="button" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} className="pull-right week__delete-week" href="" onClick={this.props.deleteWeek}>Delete Week <span className={`${this.state.isHover ? 'icon-trash_can-hover' : 'icon-trash_can'}`}/></button>
     ) : undefined;
 
     const weekAddDelete = this.props.edit_permissions ? (

--- a/app/assets/javascripts/components/uploads/upload_viewer.jsx
+++ b/app/assets/javascripts/components/uploads/upload_viewer.jsx
@@ -109,7 +109,7 @@ const UploadViewer = ({ closeUploadViewer, upload, imageFile }) => {
   return (
     <div className="module upload-viewer" ref={ref}>
       <div className="modal-header">
-        <button className="pull-right icon-close" onClick={handleClickOutside} />
+        <button type="button" className="pull-right icon-close" onClick={handleClickOutside} />
         <h3>{upload.file_name}</h3>
       </div>
       <div className="modal-body">

--- a/app/assets/javascripts/components/uploads/uploads_handler.jsx
+++ b/app/assets/javascripts/components/uploads/uploads_handler.jsx
@@ -116,13 +116,13 @@ const UploadsHandler = createReactClass({
         <div className="section-header">
           <h3>{I18n.t('uploads.header')}</h3>
           <div className="view-buttons">
-            <button id="gallery-view" className={galleryClass} onClick={() => { this.setView(GALLERY_VIEW); }}>
+            <button type="button" id="gallery-view" className={galleryClass} onClick={() => { this.setView(GALLERY_VIEW); }}>
               <p className="tooltip dark">{I18n.t('uploads.gallery_view')}</p>
             </button>
-            <button id="list-view" className={listClass} onClick={() => { this.setView(LIST_VIEW); }}>
+            <button type="button" id="list-view" className={listClass} onClick={() => { this.setView(LIST_VIEW); }}>
               <p className="tooltip dark">{I18n.t('uploads.list_view')}</p>
             </button>
-            <button id="tile-view" className={tileClass} onClick={() => { this.setView(TILE_VIEW); }}>
+            <button type="button" id="tile-view" className={tileClass} onClick={() => { this.setView(TILE_VIEW); }}>
               <p className="tooltip dark">{I18n.t('uploads.tile_view')}</p>
             </button>
           </div>

--- a/app/assets/javascripts/components/wizard/option.jsx
+++ b/app/assets/javascripts/components/wizard/option.jsx
@@ -75,7 +75,7 @@ const Option = ({
 
   return (
     <div className={className}>
-      <button onClick={onClick} role="checkbox" aria-checked={option.selected || false}>
+      <button type="buton" onClick={onClick} role="checkbox" aria-checked={option.selected || false}>
         {checkbox}
         {notice}
         <h3>{option.title}</h3>

--- a/app/assets/javascripts/styleguide/styleguide.jsx
+++ b/app/assets/javascripts/styleguide/styleguide.jsx
@@ -93,7 +93,7 @@ const StyleguideExamples = {
 
         return (
           <div className="pop__container">
-            <button className="button dark" onClick={this.toggleOpen}>Toggle popover</button>
+            <button type="button" className="button dark" onClick={this.toggleOpen}>Toggle popover</button>
             <Popover
               is_open={this.state.open}
               edit_row={editRow}

--- a/app/assets/javascripts/training/components/quiz.jsx
+++ b/app/assets/javascripts/training/components/quiz.jsx
@@ -74,7 +74,7 @@ const Quiz = (props) => {
             {answers}
           </ul>
         </fieldset>
-        <button className="btn btn-primary ghost-button capitalize btn-med" onClick={verifyAnswer}> {I18n.t('training.check_answer')} </button>
+        <button type="button" className="btn btn-primary ghost-button capitalize btn-med" onClick={verifyAnswer}> {I18n.t('training.check_answer')} </button>
       </form>
     );
   };


### PR DESCRIPTION
This pull request address this: https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/1408 by enabling and setting an explicit type for every button.
I tried to modify this PR https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6474 which has too much by breaking it into smaller pieces and without touching many files kindly.
