### PR TITLE
Enable ```Layout/LineContinuationLeadingSpace``` in rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -214,8 +214,6 @@ RSpec/BeEq:
   Enabled: false
 Style/OpenStructUse:
   Enabled: false
-Layout/LineContinuationLeadingSpace:
-  Enabled: false
 RSpec/VerifiedDoubleReference:
   Enabled: false
 RSpec/ChangeByZero:

--- a/app/controllers/experiments/fall2017_cmu_experiment_controller.rb
+++ b/app/controllers/experiments/fall2017_cmu_experiment_controller.rb
@@ -10,8 +10,8 @@ module Experiments
     def opt_in
       Fall2017CmuExperiment.new(@course).opt_in
       flash[:notice] = 'Thank you for opting in. We will add the video sessions'\
-                       ' to the relevant assignments on the timeline for your'\
-                       ' WikiEd dashboard and send you an email about next steps.'
+                       'to the relevant assignments on the timeline for your'\
+                       'WikiEd dashboard and send you an email about next steps.'
       redirect_to course_slug_path(@course.slug)
     end
 

--- a/app/controllers/experiments/spring2018_cmu_experiment_controller.rb
+++ b/app/controllers/experiments/spring2018_cmu_experiment_controller.rb
@@ -10,8 +10,8 @@ module Experiments
     def opt_in
       Spring2018CmuExperiment.new(@course).opt_in
       flash[:notice] = 'Thank you for opting in. We will add the video sessions'\
-                       ' to the relevant assignments on the timeline for your'\
-                       ' WikiEd dashboard and send you an email about next steps.'
+                       'to the relevant assignments on the timeline for your'\
+                       'WikiEd dashboard and send you an email about next steps.'
       redirect_to course_slug_path(@course.slug)
     end
 

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -205,7 +205,7 @@ class WikiCourseEdits
   def add_course_template_to_instructor_userpage(instructor)
     user_page = "User:#{instructor.username}"
     template = "{{#{template_name(@templates, 'instructor')}"\
-               " | course = [[#{@course.wiki_title}]] }}\n"
+               "| course = [[#{@course.wiki_title}]] }}\n"
     summary = "New course announcement: [[#{@course.wiki_title}]]."
 
     @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)

--- a/lib/wiki_userpage_output.rb
+++ b/lib/wiki_userpage_output.rb
@@ -15,7 +15,7 @@ class WikiUserpageOutput
       "#{course_page_param}"\
       "#{course_slug_param}"\
       "#{course_type_param}"\
-      ' }}'
+      '}}'
   end
 
   def enrollment_summary
@@ -32,7 +32,7 @@ class WikiUserpageOutput
       "#{course_page_param}"\
       "#{course_slug_param}"\
       "#{course_type_param}"\
-      ' }}'
+      '}}'
   end
 
   def sandbox_template(dashboard_url)

--- a/spec/lib/alerts/blocked_edits_reporter_spec.rb
+++ b/spec/lib/alerts/blocked_edits_reporter_spec.rb
@@ -29,7 +29,7 @@ describe BlockedEditsReporter do
               },
             '*' =>
               'See https://en.wikipedia.org/w/api.php for API usage.'\
-              ' Subscribe to the mediawiki-api-announce mailing list at '\
+              'Subscribe to the mediawiki-api-announce mailing list at '\
               '&lt;https://lists.wikimedia.org/mailman/listinfo/'\
               'mediawiki-api-announce&gt; '\
               'for notice of API deprecations and breaking changes.',

--- a/spec/lib/wiki_assignment_output_spec.rb
+++ b/spec/lib/wiki_assignment_output_spec.rb
@@ -99,9 +99,9 @@ describe WikiAssignmentOutput do
 
         it 'removes the existing assignment template if the new tag is blank' do
           old_content = '{{dashboard.wikiedu.org assignment'\
-                        ' | course = Wikipedia:Wiki_Ed/University_of_Hawaiʻi_at_Mānoa/'\
+                        '| course = Wikipedia:Wiki_Ed/University_of_Hawaiʻi_at_Mānoa/'\
                         'Language_in_Hawaiʻi_and_the_Pacific_(Fall_2016)'\
-                        ' | assignments = [[User:Keï|Keï]] }}
+                        '| assignments = [[User:Keï|Keï]] }}
 
   {{WP Languages|class=Stub}}
   {{WikiProject Melanesia|class=Stub|Vanuatu=yes}}
@@ -192,7 +192,7 @@ describe WikiAssignmentOutput do
       it 'does not mess things up when the talk page content is not a simple template line' do
         assignment_tag = '{{template|foo=bar}}'
         initial_talk_page_content = '{{ping|Johnjes6}} Greetings! Good start on an article!'\
-                                    ' I had some concrete feedback.\n'
+                                    'I had some concrete feedback.\n'
 
         output = wiki_assignment_output
                  .build_assignment_page_content(assignment_tag,

--- a/spec/lib/wiki_course_output_spec.rb
+++ b/spec/lib/wiki_course_output_spec.rb
@@ -34,8 +34,8 @@ describe WikiCourseOutput do
              content: 'block 1 content',
              week: week1)
       html_with_link = '<ul>\n  <li>Overview of the course</li>\n  <li>Introduction'\
-                       ' to how Wikipedia will be used in the course</li>\n  <li>Understanding'\
-                       ' Wikipedia as a community, we\'ll discuss its expectations and etiquette.'\
+                       'to how Wikipedia will be used in the course</li>\n  <li>Understanding'\
+                       'Wikipedia as a community, we\'ll discuss its expectations and etiquette.'\
                        '</li>\n</ul>\n<hr />\n<p>Handout: <a href="http://wikiedu.org/editingwikipedia">'\
                        'Editing Wikipedia</a></p>\n'
       create(:block,

--- a/spec/models/rapidfire/question_spec.rb
+++ b/spec/models/rapidfire/question_spec.rb
@@ -15,7 +15,7 @@ describe Rapidfire::Question do
     end
 
     it 'does not raise an error if the question type has changed to'\
-       " one that doesn't require answer options" do
+       "one that doesn't require answer options" do
       valid_question = build(:q_radio, course_data_type: 'Students')
       valid_question.type = 'Rapidfire::Questions::RangeInput'
       valid_question.answer_options = ''


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >
This PR enables ```Layout/LineContinuationLeadingSpace``` in ```.rubocop.yml``` file.

## Screenshots
Before:
< add a screenshot of the UI before your change >

After:
< add a screenshot of the UI after your change >
## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
