### PR TITLE
Fix: Reduce frequent Article Viewer requests

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/containers/ArticleViewer.jsx
@@ -266,8 +266,17 @@ const ArticleViewer = ({ showOnMount, users, showArticleFinder, showButtonLabel,
       }).catch((error) => {
         setWhoColorFailed(true);
         setFailureMessage(error.message);
-        // Set flag to verify and fetch the article title if the fetch failed, possibly due to the article being moved
-        setCheckArticleTitle(true);
+        // Only trigger title verification for failures that may be caused by title changes.
+        // If WhoColor is simply not ready/available (our API throws a specific message),
+        // do NOT re-verify the title to avoid infinite re-requests.
+        const unavailablePattern = /^Request failed after \d+ attempts/;
+        const cooldownPattern = /WhoColor temporarily unavailable; retry later/;
+        if (unavailablePattern.test(error.message) || cooldownPattern.test(error.message)) {
+          setCheckArticleTitle(false);
+        } else {
+          // For other errors (eg, 404s after redirects), allow one title verification pass
+          setCheckArticleTitle(true);
+        }
       });
   };
 


### PR DESCRIPTION
# What this PR does

This PR fixes **“Article Viewer makes too many requests too frequently when wikiwho data is not available”** by adding proper retry/backoff and a cooldown, and by preventing a verify-and-refetch loop that caused repeated WhoColor requests even after failures.

**Addresses:** Article Viewer re-requesting WhoColor indefinitely when the API reports data is not yet available.

**Scope:** `ArticleViewerAPI.js` and a small guard in `ArticleViewer.jsx`.

---

## Impact

- ✅ Fewer network calls  
- ✅ Capped retries  
- ✅ No infinite loops  
- ✅ User sees a clear failure state if data isn’t ready  

---

## Background

When the WhoColor endpoint returns a `200` with `success: false` (data not yet prepared), the viewer kept trying again quickly and could be re-triggered by the “verify title” path in the container, causing repeated requests.  
This PR restores and strengthens the intended failure handling.

---

## Changes in Detail

### 1. Exponential Backoff with Jitter and Hard Cap

**Location:** `ArticleViewerAPI.fetchWhocolorHtml`

**Behavior:**
- Retries now use exponential delays with a small jitter:  
  `~0s → ~1s → ~2s → ~4s → ~8s` (capped per-attempt delay ≤ 30s)
- Attempts are capped at **5** (configurable in the function).
- On terminal failure, preserves the existing error message format:


---

### 2. Cooldown to Avoid Re-Hammering the API When Not Ready

**Location:** `ArticleViewerAPI.js`

**Behavior:**
- Adds an **in-memory cooldown cache** keyed by `language|title|revision`.
- After a terminal failure, subsequent calls for the same article+revision within **5 minutes** are **short-circuited locally** and do not hit the network.
- Returns a friendly error:

---

### 3. Stop the Verify-and-Refetch Loop in the Container

**Location:** `ArticleViewer.jsx` (catch handler for `fetchWhocolorHtml`)

**Behavior:**
- On WhoColor unavailability errors (either “Request failed after N attempts …” or the cooldown message), we **no longer set** `checkArticleTitle = true`.
- This prevents the cross-check-and-refetch path from re-triggering WhoColor during a not-ready window.
- Other error types (like real 404/redirect issues) still allow a **one-time title verification**.

---
