### PR TITLE
Enable ```Rails/ContentTag``` in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -172,8 +172,6 @@ RSpec/ExpectInHook:
   Enabled: false
 Style/DateTime:
   Enabled: false
-Rails/ContentTag:
-  Enabled: false
 Style/OptionalBooleanParameter:
   Enabled: false
 Style/ExplicitBlockArgument:


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >
Enables ```Rails/ContentTag``` in .rubocop.yml
## Screenshots
<img width="1014" height="618" alt="Screenshot From 2025-10-28 21-52-56" src="https://github.com/user-attachments/assets/133e6083-932e-4423-ae3a-c752fbc04237" />

< anything you learned that you want to share, or questions you're wondering about related to this PR >
