### PR TITLE
Feat: Filter pageviews to count created articles only

### DIFF
--- a/app/assets/javascripts/components/overview/overview_stats.jsx
+++ b/app/assets/javascripts/components/overview/overview_stats.jsx
@@ -13,6 +13,34 @@ const OverviewStats = ({ course }) => {
     return course.newStats[stat] ? 'stat-display__value stat-change' : 'stat-display__value';
   };
 
+  const buildPageviewsBreakdown = (courseData) => {
+    // Check if breakdown data is available
+    const hasBreakdown = (courseData.view_count_created !== undefined
+      && courseData.view_count_created !== null
+      && courseData.view_count_existing !== undefined
+      && courseData.view_count_existing !== null);
+
+    // If breakdown data is not available, fall back to simple doc
+    if (!hasBreakdown) {
+      return I18n.t(`metrics.${ArticleUtils.projectSuffix(courseData.home_wiki.project, 'view_count_doc')}`);
+    }
+
+    // Build breakdown array using the readable values from backend
+    const breakdown = [
+      [
+        courseData.view_count_created,
+        I18n.t('metrics.pageviews_breakdown.new_articles')
+      ],
+      [
+        courseData.view_count_existing,
+        I18n.t('metrics.pageviews_breakdown.existing_articles')
+      ]
+    ];
+
+    // Return breakdown array (OverviewStatInfo will handle rendering)
+    return breakdown;
+  };
+
   let editedLabel;
   let createdLabel;
   if (isWikidata) {
@@ -140,7 +168,7 @@ const OverviewStats = ({ course }) => {
         stat={course.view_count}
         statMsg={I18n.t(`metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'view_count_description')}`)}
         renderZero={false}
-        info={I18n.t(`metrics.${ArticleUtils.projectSuffix(course.home_wiki.project, 'view_count_doc')}`)}
+        info={buildPageviewsBreakdown(course)}
         infoId="view-count-info"
       />
       {uploadCount}

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -13,6 +13,7 @@
 #  term                  :string(255)
 #  character_sum         :integer          default(0)
 #  view_sum              :bigint           default(0)
+#  view_sum_created      :bigint           default(0)
 #  user_count            :integer          default(0)
 #  article_count         :integer          default(0)
 #  revision_count        :integer          default(0)
@@ -612,6 +613,27 @@ class Course < ApplicationRecord
 
   def update_cache_from_timeslices
     CourseCacheManager.new(self).update_cache_from_timeslices course_wiki_timeslices
+  end
+
+  # Returns the cached estimate of cumulative pageviews for articles that were
+  # created by participants in this course. This value is updated by
+  # CourseCacheManager during course cache updates, not calculated on-the-fly
+  # for performance reasons (courses can have up to 100K articles).
+  # The calculation mirrors view_sum but filters for tracked, live, created articles only.
+  #
+  # For courses that have been updated but view_sum_created is still 0 (likely
+  # because it wasn't populated during the first update after migration), we calculate
+  # on-the-fly. For historical courses that haven't been updated, we return the cached
+  # value to avoid performance issues.
+  def view_sum_created
+    cached_value = self[:view_sum_created] || 0
+    # If course has been updated but view_sum_created is 0 and we have new articles,
+    # calculate on-the-fly (this handles courses updated before view_sum_created was added)
+    if cached_value.zero? && was_course_ever_updated? && new_article_count.positive?
+      CourseCacheManager.calculate_view_sum_created_for_course(self)
+    else
+      cached_value
+    end
   end
 
   # Ensures weeks for a course have order 1..weeks.count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1211,8 +1211,11 @@ en:
       other: total usages across languages
     view_count_description: Article Views
     view_count_description_wikidata: Item Views
-    view_count_doc: This is the estimated number of views based on a 30-day average for each article, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
-    view_count_doc_wikidata: This is the estimated number of views based on a 30-day average for each item, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
+    view_count_doc: Estimated total views calculated from each article's first revision during this course up to the present. The daily average is computed from all daily view counts during this period, and the total is estimated as (days from first revision to present) × daily average. Each course calculates its own average for the same article based on when it was first edited in that course.
+    view_count_doc_wikidata: Estimated total views calculated from each item's first revision during this course up to the present. The daily average is computed from all daily view counts during this period, and the total is estimated as (days from first revision to present) × daily average. Each course calculates its own average for the same item based on when it was first edited in that course.
+    pageviews_breakdown:
+      new_articles: "from new articles"
+      existing_articles: "from existing articles"
     view_data_unavailable: No view data available
     view: Views
     wiki_ed_help: Use the 'Get Help' button to report a problem.

--- a/db/migrate/20251105112928_add_view_sum_created_to_courses.rb
+++ b/db/migrate/20251105112928_add_view_sum_created_to_courses.rb
@@ -1,0 +1,6 @@
+class AddViewSumCreatedToCourses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :courses, :view_sum_created, :bigint, default: 0
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
-  create_table "alerts", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2025_11_05_112928) do
+  create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "courses_id"
+    t.string "title"
+    t.text "text"
+    t.string "edited_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["courses_id"], name: "index_admin_course_notes_on_courses_id"
+  end
+
+  create_table "alerts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id"
     t.integer "user_id"
     t.integer "article_id"
     t.integer "revision_id"
     t.string "type"
-    t.datetime "email_sent_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "email_sent_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "message"
     t.integer "target_user_id"
     t.integer "subject_id"
@@ -32,7 +42,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["user_id"], name: "index_alerts_on_user_id"
   end
 
-  create_table "article_course_timeslices", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "article_course_timeslices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "article_id", null: false
     t.datetime "start"
@@ -50,39 +60,29 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["course_id", "updated_at", "article_id"], name: "article_course_timeslice_by_updated_at"
   end
 
-  create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.integer "courses_id"
+  create_table "articles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
-    t.text "text"
-    t.string "edited_by"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["courses_id"], name: "index_admin_course_notes_on_courses_id"
-  end
-  
-  create_table "articles", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.string "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.date "views_updated_at"
     t.integer "namespace"
     t.string "rating"
-    t.datetime "rating_updated_at"
+    t.datetime "rating_updated_at", precision: nil
     t.boolean "deleted", default: false
     t.string "language", limit: 10
     t.float "average_views"
     t.date "average_views_updated_at"
     t.integer "wiki_id"
     t.integer "mw_page_id"
-    t.virtual "index_hash", type: :string, as: "if(`deleted`,NULL,concat(`mw_page_id`,'-',`wiki_id`))", stored: true
+    t.virtual "index_hash", type: :string, as: "if(`deleted`,NULL,concat(`mw_page_id`,_utf8mb4'-',`wiki_id`))", stored: true
     t.index ["index_hash"], name: "index_articles_on_index_hash", unique: true
     t.index ["mw_page_id"], name: "index_articles_on_mw_page_id"
     t.index ["namespace", "wiki_id", "title"], name: "index_articles_on_namespace_and_wiki_id_and_title"
   end
 
-  create_table "articles_courses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "articles_courses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "article_id"
     t.integer "course_id"
     t.bigint "view_count", default: 0
@@ -98,18 +98,18 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["course_id", "article_id"], name: "index_articles_courses_on_course_id_and_article_id", unique: true
   end
 
-  create_table "assignment_suggestions", charset: "utf8mb4", force: :cascade do |t|
+  create_table "assignment_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "text"
     t.bigint "assignment_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
     t.index ["assignment_id"], name: "index_assignment_suggestions_on_assignment_id"
   end
 
-  create_table "assignments", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "assignments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.integer "course_id"
     t.integer "article_id"
@@ -122,12 +122,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
-  create_table "blocks", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "blocks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "kind"
     t.text "content"
     t.integer "week_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "title"
     t.integer "order"
     t.date "due_date"
@@ -136,77 +136,77 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["week_id"], name: "index_blocks_on_week_id"
   end
 
-  create_table "campaigns", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.string "slug"
     t.string "url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "description"
-    t.datetime "start"
-    t.datetime "end"
+    t.datetime "start", precision: nil
+    t.datetime "end", precision: nil
     t.text "template_description"
     t.string "default_course_type"
     t.string "default_passcode"
     t.boolean "register_accounts", default: false
   end
 
-  create_table "campaigns_courses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns_courses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "campaign_id"
     t.integer "course_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["campaign_id"], name: "index_campaigns_courses_on_campaign_id"
     t.index ["course_id", "campaign_id"], name: "index_campaigns_courses_on_course_id_and_campaign_id", unique: true
   end
 
-  create_table "campaigns_survey_assignments", id: false, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns_survey_assignments", id: false, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "survey_assignment_id"
     t.integer "campaign_id"
     t.index ["campaign_id"], name: "index_campaigns_survey_assignments_on_campaign_id"
     t.index ["survey_assignment_id"], name: "index_campaigns_survey_assignments_on_survey_assignment_id"
   end
 
-  create_table "campaigns_users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "campaigns_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "campaign_id"
     t.integer "user_id"
     t.integer "role", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["campaign_id"], name: "index_campaigns_users_on_campaign_id"
     t.index ["user_id"], name: "index_campaigns_users_on_user_id"
   end
 
-  create_table "categories", charset: "utf8mb4", force: :cascade do |t|
+  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "wiki_id"
     t.text "article_titles", size: :medium
     t.string "name"
     t.integer "depth", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "source", default: "category"
     t.index ["name"], name: "index_categories_on_name"
     t.index ["wiki_id", "name", "depth", "source"], name: "index_categories_on_wiki_id_and_name_and_depth_and_source", unique: true
     t.index ["wiki_id"], name: "index_categories_on_wiki_id"
   end
 
-  create_table "categories_courses", charset: "utf8mb4", force: :cascade do |t|
+  create_table "categories_courses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "category_id"
     t.integer "course_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["category_id"], name: "index_categories_courses_on_category_id"
     t.index ["course_id", "category_id"], name: "index_categories_courses_on_course_id_and_category_id", unique: true
     t.index ["course_id"], name: "index_categories_courses_on_course_id"
   end
 
-  create_table "commons_uploads", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "commons_uploads", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "file_name", limit: 2000
-    t.datetime "uploaded_at"
+    t.datetime "uploaded_at", precision: nil
     t.integer "usage_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "thumburl", limit: 2000
     t.string "thumbwidth"
     t.string "thumbheight"
@@ -214,8 +214,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["user_id"], name: "index_commons_uploads_on_user_id"
   end
 
-
-  create_table "course_stats", charset: "utf8mb4", force: :cascade do |t|
+  create_table "course_stats", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "stats_hash"
     t.integer "course_id"
     t.datetime "created_at", null: false
@@ -223,7 +222,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["course_id"], name: "index_course_stats_on_course_id"
   end
 
-  create_table "course_user_wiki_timeslices", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "course_user_wiki_timeslices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "user_id", null: false
     t.integer "wiki_id", null: false
@@ -239,7 +238,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["course_id", "user_id", "wiki_id", "start", "end"], name: "course_user_wiki_timeslice_by_course_user_wiki_start_and_end", unique: true
   end
 
-  create_table "course_wiki_namespaces", charset: "utf8mb4", force: :cascade do |t|
+  create_table "course_wiki_namespaces", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "namespace"
     t.bigint "courses_wikis_id"
     t.datetime "created_at", null: false
@@ -247,7 +246,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["courses_wikis_id"], name: "index_course_wiki_namespaces_on_courses_wikis_id"
   end
 
-  create_table "course_wiki_timeslices", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "course_wiki_timeslices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "wiki_id", null: false
     t.datetime "start"
@@ -263,10 +262,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["course_id", "wiki_id", "start", "end"], name: "course_wiki_timeslice_by_course_wiki_start_and_end", unique: true
   end
 
-  create_table "courses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "courses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.datetime "start"
     t.datetime "end"
     t.string "school"
@@ -297,7 +296,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.string "syllabus_file_name"
     t.string "syllabus_content_type"
     t.bigint "syllabus_file_size"
-    t.datetime "syllabus_updated_at"
+    t.datetime "syllabus_updated_at", precision: nil
     t.integer "home_wiki_id"
     t.integer "recent_revision_count", default: 0
     t.boolean "needs_update", default: false
@@ -307,12 +306,13 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.boolean "private", default: false
     t.boolean "withdrawn", default: false
     t.integer "references_count", default: 0
+    t.bigint "view_sum_created", default: 0
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 
-  create_table "courses_users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "courses_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "course_id"
     t.integer "user_id"
     t.integer "character_sum_ms", default: 0
@@ -331,77 +331,88 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["user_id"], name: "index_courses_users_on_user_id"
   end
 
-  create_table "courses_wikis", charset: "utf8mb4", force: :cascade do |t|
+  create_table "courses_wikis", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id"
     t.integer "wiki_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["course_id", "wiki_id"], name: "index_courses_wikis_on_course_id_and_wiki_id", unique: true
     t.index ["course_id"], name: "index_courses_wikis_on_course_id"
     t.index ["wiki_id"], name: "index_courses_wikis_on_wiki_id"
   end
 
-  create_table "faqs", charset: "utf8mb4", force: :cascade do |t|
+  create_table "faqs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
     t.text "content"
   end
 
-  create_table "feedback_form_responses", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "feedback_form_responses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "subject"
     t.text "body"
     t.integer "user_id"
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
   end
 
-  create_table "question_group_conditionals", id: :integer, charset: "utf8mb4", force: :cascade do |t|
-    t.integer "rapidfire_question_group_id"
-    t.integer "campaign_id"
+  create_table "lti_contexts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "user_lti_id", null: false
+    t.string "context_id", null: false
+    t.string "lms_id", null: false
+    t.string "lms_family"
+    t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_lti_contexts_on_user_id"
+  end
+
+  create_table "question_group_conditionals", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "rapidfire_question_group_id"
+    t.integer "campaign_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["campaign_id"], name: "index_question_group_conditionals_on_campaign_id"
     t.index ["rapidfire_question_group_id"], name: "index_question_group_conditionals_on_rapidfire_question_group_id"
   end
 
-  create_table "rapidfire_answer_groups", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_answer_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "question_group_id"
     t.string "user_type"
     t.integer "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "course_id"
     t.index ["question_group_id"], name: "index_rapidfire_answer_groups_on_question_group_id"
     t.index ["user_id", "user_type"], name: "index_rapidfire_answer_groups_on_user_id_and_user_type"
   end
 
-  create_table "rapidfire_answers", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_answers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "answer_group_id"
     t.integer "question_id"
     t.text "answer_text"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "follow_up_answer_text"
     t.index ["answer_group_id"], name: "index_rapidfire_answers_on_answer_group_id"
     t.index ["question_id"], name: "index_rapidfire_answers_on_question_id"
   end
 
-  create_table "rapidfire_question_groups", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_question_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "tags"
   end
 
-  create_table "rapidfire_questions", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "rapidfire_questions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "question_group_id"
     t.string "type"
     t.text "question_text"
     t.integer "position"
     t.text "answer_options"
     t.text "validation_rules"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "follow_up_question_text"
     t.text "conditionals"
     t.boolean "multiple", default: false
@@ -412,12 +423,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["question_group_id"], name: "index_rapidfire_questions_on_question_group_id"
   end
 
-  create_table "requested_accounts", charset: "utf8mb4", force: :cascade do |t|
+  create_table "requested_accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "username"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "revision_ai_scores", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -436,14 +447,14 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["wiki_id", "revision_id"], name: "revision_ai_scores_by_wiki_rev"
   end
 
-  create_table "revisions", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "revisions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "characters", default: 0
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.integer "article_id"
     t.bigint "views", default: 0
-    t.datetime "date"
+    t.datetime "date", precision: nil
     t.boolean "new_article", default: false
     t.boolean "deleted", default: false
     t.float "wp10"
@@ -462,18 +473,18 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["wiki_id", "mw_rev_id"], name: "index_revisions_on_wiki_id_and_mw_rev_id", unique: true
   end
 
-  create_table "settings", charset: "utf8mb4", force: :cascade do |t|
+  create_table "settings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "key"
     t.text "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["key"], name: "index_settings_on_key", unique: true
   end
 
-  create_table "survey_assignments", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "survey_assignments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "courses_user_role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "send_date_days"
     t.integer "survey_id"
     t.boolean "send_before", default: true
@@ -487,26 +498,26 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["survey_id"], name: "index_survey_assignments_on_survey_id"
   end
 
-  create_table "survey_notifications", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "survey_notifications", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "courses_users_id"
     t.integer "course_id"
     t.integer "survey_assignment_id"
     t.boolean "dismissed", default: false
-    t.datetime "email_sent_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "email_sent_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "completed", default: false
-    t.datetime "last_follow_up_sent_at"
+    t.datetime "last_follow_up_sent_at", precision: nil
     t.integer "follow_up_count", default: 0
     t.index ["course_id"], name: "index_survey_notifications_on_course_id"
     t.index ["courses_users_id"], name: "index_survey_notifications_on_courses_users_id"
     t.index ["survey_assignment_id"], name: "index_survey_notifications_on_survey_assignment_id"
   end
 
-  create_table "surveys", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "surveys", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "intro"
     t.text "thanks"
     t.boolean "open", default: false
@@ -515,48 +526,48 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.text "optout"
   end
 
-  create_table "surveys_question_groups", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "surveys_question_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "survey_id"
     t.integer "rapidfire_question_group_id"
     t.integer "position"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["rapidfire_question_group_id"], name: "index_surveys_question_groups_on_rapidfire_question_group_id"
     t.index ["survey_id"], name: "index_surveys_question_groups_on_survey_id"
   end
 
-  create_table "tags", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "tag"
     t.string "key"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["course_id", "key"], name: "index_tags_on_course_id_and_key", unique: true
   end
 
-  create_table "ticket_dispenser_messages", charset: "utf8mb4", force: :cascade do |t|
+  create_table "ticket_dispenser_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "kind", limit: 1, default: 0
     t.integer "sender_id"
     t.bigint "ticket_id"
     t.boolean "read", default: false, null: false
     t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "details"
     t.index ["ticket_id"], name: "index_ticket_dispenser_messages_on_ticket_id"
   end
 
-  create_table "ticket_dispenser_tickets", charset: "utf8mb4", force: :cascade do |t|
+  create_table "ticket_dispenser_tickets", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "project_id"
     t.integer "owner_id"
     t.integer "status", limit: 1, default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["owner_id"], name: "index_ticket_dispenser_tickets_on_owner_id"
     t.index ["project_id"], name: "index_ticket_dispenser_tickets_on_project_id"
   end
 
-  create_table "training_libraries", charset: "utf8mb4", force: :cascade do |t|
+  create_table "training_libraries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "wiki_page"
     t.string "slug"
@@ -564,12 +575,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.text "categories", size: :medium
     t.text "translations", size: :medium
     t.boolean "exclude_from_index", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["slug"], name: "index_training_libraries_on_slug", unique: true
   end
 
-  create_table "training_modules", charset: "utf8mb4", force: :cascade do |t|
+  create_table "training_modules", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "estimated_ttc"
     t.string "wiki_page"
@@ -577,20 +588,20 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.text "slide_slugs"
     t.text "description"
     t.text "translations", size: :medium
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "kind", limit: 1, default: 0
     t.text "settings"
     t.index ["slug"], name: "index_training_modules_on_slug", unique: true
   end
 
-  create_table "training_modules_users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "training_modules_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "training_module_id"
     t.string "last_slide_completed"
-    t.datetime "completed_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "completed_at", precision: nil
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.text "flags"
     t.index ["user_id", "training_module_id"], name: "index_training_modules_users_on_user_id_and_training_module_id", unique: true
   end
@@ -605,12 +616,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.text "content"
     t.text "translations", size: :medium
     t.string "slug"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["slug"], name: "index_training_slides_on_slug", unique: true, length: 191
   end
 
-  create_table "trigrams", charset: "utf8mb4", force: :cascade do |t|
+  create_table "trigrams", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "trigram", limit: 3
     t.integer "score", limit: 2
     t.integer "owner_id"
@@ -620,26 +631,26 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.index ["owner_id", "owner_type"], name: "index_by_owner"
   end
 
-  create_table "user_profiles", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_profiles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "bio"
     t.integer "user_id"
     t.string "image_file_name"
     t.string "image_content_type"
     t.bigint "image_file_size"
-    t.datetime "image_updated_at"
+    t.datetime "image_updated_at", precision: nil
     t.string "location"
     t.string "institution"
     t.text "email_preferences"
     t.string "image_file_link"
   end
 
-  create_table "users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "username"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.boolean "trained", default: false
     t.integer "global_id"
-    t.datetime "remember_created_at"
+    t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
     t.string "wiki_token"
     t.string "wiki_secret"
@@ -652,31 +663,31 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
     t.string "locale"
     t.string "chat_password"
     t.string "chat_id"
-    t.datetime "registered_at"
-    t.datetime "first_login"
+    t.datetime "registered_at", precision: nil
+    t.datetime "first_login", precision: nil
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "versions", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object", size: :long
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "weeks", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "weeks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.integer "course_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "order", default: 1, null: false
     t.index ["course_id"], name: "index_weeks_on_course_id"
   end
 
-  create_table "wikis", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "wikis", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "language", limit: 16
     t.string "project", limit: 16
     t.index ["language", "project"], name: "index_wikis_on_language_and_project", unique: true
@@ -685,4 +696,5 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_28_182700) do
   add_foreign_key "admin_course_notes", "courses", column: "courses_id"
   add_foreign_key "course_stats", "courses"
   add_foreign_key "course_wiki_namespaces", "courses_wikis", column: "courses_wikis_id", on_delete: :cascade
+  add_foreign_key "lti_contexts", "users", on_delete: :cascade
 end

--- a/spec/lib/course_cache_manager_spec.rb
+++ b/spec/lib/course_cache_manager_spec.rb
@@ -68,6 +68,22 @@ describe CourseCacheManager do
       expect(course.new_article_count).to eq(1)
     end
 
+    it 'updates view_sum_created for newly created articles only' do
+      # article1 is new_article: true, created 10 days ago, average_views: 10
+      # Expected: 10 days * 10 views = 100
+      described_class.new(course).update_cache_from_timeslices []
+      expect(course.view_sum_created).to eq(100)
+    end
+
+    it 'does not include existing articles in view_sum_created' do
+      # article2 is new_article: false (default), created 8 days ago, average_views: 5
+      # Should not be included in view_sum_created
+      described_class.new(course).update_cache_from_timeslices []
+      # view_sum_created should only include article1 (100), not article2
+      expect(course.view_sum_created).to eq(100)
+      expect(course.view_sum).to eq(140) # Both articles: 100 + 40 = 140
+    end
+
     it 'updates user_count based on existing course students' do
       described_class.new(course).update_cache_from_timeslices []
       expect(course.user_count).to eq(2)


### PR DESCRIPTION
Closes #6534 

## What this PR does
This Pull Request modifies the main pageview statistics calculation. It filters the results to only include pageviews from articles newly created by program participants.

This changes the previous behavior, which included views from all edited articles (both new and existing).

## Screenshots
Before:
<img width="1169" height="404" alt="screenshot-2025-11-01_19-24-33" src="https://github.com/user-attachments/assets/a5477ee0-447d-4dec-a7d7-f1fa7df8cbdf" />


After:
<img width="941" height="891" alt="image" src="https://github.com/user-attachments/assets/b4f70432-38af-454e-bef5-debc1b551bf0" />

