### PR TITLE
fix: added link for each alert in alert list

### DIFF
--- a/app/assets/javascripts/components/alerts/alert.jsx
+++ b/app/assets/javascripts/components/alerts/alert.jsx
@@ -29,7 +29,7 @@ const Alert = ({ alert, adminAlert, resolveAlert }) => {
       </td>
     );
   } else {
-    alertTypeCell = <td className="alert-type">{alert.type}</td>;
+    alertTypeCell = <td className="alert-type"><a href={`/alerts_list/${alert.id}`} >{alert.type}</a></td>;
   }
 
   return (


### PR DESCRIPTION
## What this PR does
This PR adds a link to the alerts list on a course page. The link navigates to the individual view of an alert in /alert_list/{alert_id}
It addresses the issue in #6528 

## Screenshots
Before:
<img width="1920" height="1020" alt="Screenshot 2025-11-01 183023" src="https://github.com/user-attachments/assets/b54d665f-baf2-4771-a96c-024d7b9ff23a" />


After:
<img width="1920" height="1020" alt="Screenshot 2025-11-01 182312" src="https://github.com/user-attachments/assets/5338f1af-98c9-46b3-a1d1-5a720e0d8d70" />