### PR TITLE
Improve page_type classifier: add draft and mainspace

### DIFF
--- a/app/models/alert_types/ai_edit_alert.rb
+++ b/app/models/alert_types/ai_edit_alert.rb
@@ -168,7 +168,7 @@ class AiEditAlert < Alert
     details[:prior_alert_for_user]
   end
 
-  def page_type
+  def page_type # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
     case article_title
     when /Choose an Article/
       :choose_an_article
@@ -182,6 +182,10 @@ class AiEditAlert < Alert
       :peer_review
     when /^User:/ # catchall for other sandboxes
       :sandbox
+    when /^Draft:/
+      :draft
+    when /^[^:]+$/ # match titles without ':'
+      :mainspace
     else
       :unknown
     end


### PR DESCRIPTION
## What this PR does
This PR adds draft and mainspace as new page types:

- If the article title starts with "Draft:", then it's classified as draft
- If the article title does not contain a colon (:), is classified as mainspace

## Screenshots
Before:
<img width="1414" height="452" alt="image" src="https://github.com/user-attachments/assets/78df9e63-2fdb-4e69-9d61-16ad33a8ba58" />


After:
<img width="1441" height="568" alt="image" src="https://github.com/user-attachments/assets/1dbc3f1f-8263-4156-ac5e-e37358e10438" />

## Open questions and concerns
Namespace classifications like draft, mainspace, userspace may be implemented through the Article record associated to the alert `article_id`. That strategy should be 100% accurate.