### PR TITLE
fix: Add VCR cassettes for wiki_pageviews specs to prevent intermittent CI failures

### DIFF
--- a/fixtures/vcr_cassettes/wiki_pageviews/article_with_apostrophe.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/article_with_apostrophe.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/Broussard's/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - s-maxage=14400, max-age=14400
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:54 GMT
+      Content-Length:
+      - '737'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '451'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - 94ad3f55-2d93-4dcf-82f5-13421da9cedb
+      X-Analytics:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"project":"en.wikipedia","article":"Broussard''s","granularity":"daily","timestamp":"2025081500","access":"all-access","agent":"user","views":9},{"project":"en.wikipedia","article":"Broussard''s","granularity":"daily","timestamp":"2025081600","access":"all-access","agent":"user","views":6},{"project":"en.wikipedia","article":"Broussard''s","granularity":"daily","timestamp":"2025081700","access":"all-access","agent":"user","views":6},{"project":"en.wikipedia","article":"Broussard''s","granularity":"daily","timestamp":"2025081800","access":"all-access","agent":"user","views":7},{"project":"en.wikipedia","article":"Broussard''s","granularity":"daily","timestamp":"2025081900","access":"all-access","agent":"user","views":11}]}'
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/article_with_no_view_data.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/article_with_no_view_data.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fr.wikisource.org/w/api.php?action=query&format=json&meta=siteinfo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Nov 2025 16:57:28 GMT
+      Server:
+      - mw-api-ext.codfw.main-566cc8887c-gj2q8
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      X-Cache:
+      - cp5022 miss, cp5022 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikisource.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikisource.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      - WMF-Uniq=FuHCcbJpnmUoaNS66FaCNwKiAAAAAFvdklritv33-dcRYuHf0la0IaNx5Cn21Dai;Domain=.wikisource.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Thu,
+        05 Nov 2026 00:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Transfer-Encoding:
+      - chunked
+      X-Request-Id:
+      - 85238789-c74d-4ae4-b28a-d2ce41601b8c
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"general":{"mainpage":"Wikisource:Accueil","base":"https://fr.wikisource.org/wiki/Wikisource:Accueil","sitename":"Wikisource","logo":"//fr.wikisource.org/static/images/project-logos/frwikisource.png","generator":"MediaWiki
+        1.45.0-wmf.25","phpversion":"8.1.33","phpsapi":"fpm-fcgi","dbtype":"mysql","dbversion":"10.11.13-MariaDB-log","langconversion":"","linkconversion":"","titleconversion":"","linkprefixcharset":"","linkprefix":"","linktrail":"/^([a-z\u00e0\u00e2\u00e7\u00e9\u00e8\u00ea\u00ee\u00f4\u00fb\u00e4\u00eb\u00ef\u00f6\u00fc\u00f9\u00c7\u00c9\u00c2\u00ca\u00ce\u00d4\u00db\u00c4\u00cb\u00cf\u00d6\u00dc\u00c0\u00c8\u00d9]+)(.*)$/sDu","legaltitlechars":"
+        %!\"$&''()*,\\-.\\/0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+","invalidusernamechars":"@:>=","git-hash":"1a3d44e348291179dbda7219b8b9e6b0c75a8690","git-branch":"wmf/1.45.0-wmf.25","case":"first-letter","lang":"fr","fallback":[{"code":"en"}],"fallback8bitEncoding":"windows-1252","writeapi":"","maxarticlesize":2097152,"timezone":"UTC","timeoffset":0,"articlepath":"/wiki/$1","scriptpath":"/w","script":"/w/index.php","variantarticlepath":false,"server":"//fr.wikisource.org","servername":"fr.wikisource.org","wikiid":"frwikisource","time":"2025-11-05T16:57:28Z","misermode":"","uploadsenabled":"","maxuploadsize":5368709120,"minuploadchunksize":1024,"galleryoptions":{"imagesPerRow":0,"imageWidth":120,"imageHeight":120,"captionLength":"","showBytes":"","mode":"traditional","showDimensions":""},"thumblimits":[120,150,180,200,220,250,300,400],"imagelimits":[{"width":320,"height":240},{"width":640,"height":480},{"width":800,"height":600},{"width":1024,"height":768},{"width":1280,"height":1024},{"width":2560,"height":2048}],"favicon":"https://fr.wikisource.org/static/favicon/wikisource.ico","centralidlookupprovider":"CentralAuth","allcentralidlookupproviders":["CentralAuth","local"],"interwikimagic":"","magiclinks":{"ISBN":"","PMID":"","RFC":""},"categorycollation":"uppercase","nofollowlinks":"","nofollownsexceptions":[],"nofollowdomainexceptions":["mediawiki.org","wikibooks.org","wikimedia.com","wikimedia.org","wikinews.org","wikipedia.org","wikiquote.org","wikisource.org","wikiversity.org","wiktionary.org","wikivoyage.org","wikidata.org","wikifunctions.org","tools.wmflabs.org","toolforge.org","etherpad.wmflabs.org"],"wmf-config":{"wmfMasterDatacenter":"codfw","wmfEtcdLastModifiedIndex":6116476},"max-page-id":4729856,"linter":{"high":["deletable-table-tag","duplicate-ids","html5-misnesting","misc-tidy-replacement-issues","multiline-html-table-in-list","multiple-unclosed-formatting-tags","pwrap-bug-workaround","self-closed-tag","tidy-font-bug","tidy-whitespace-bug","unclosed-quotes-in-heading"],"medium":["bogus-image-options","fostered","misnested-tag","multi-colon-escape","wikilink-in-extlink"],"low":["empty-heading","missing-end-tag","missing-end-tag-in-heading","night-mode-unaware-background-color","obsolete-tag","stripped-tag"]},"mobileserver":"https://fr.wikisource.org","pageviewservice-supported-metrics":{"pageviews":{"pageviews":""},"siteviews":{"pageviews":"","uniques":""},"mostviewed":{"pageviews":""}},"readinglists-config":{"maxListsPerUser":100,"maxEntriesPerList":5000,"deletedRetentionDays":30}}}}'
+  recorded_at: Wed, 18 Oct 2023 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/article_with_quote_marks.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/article_with_quote_marks.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/%22Weird_Al%22_Yankovic/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - s-maxage=14400, max-age=14400
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:54 GMT
+      Content-Length:
+      - '803'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '451'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - d3e30681-d575-4b22-9571-086fcf9b1357
+      X-Analytics:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"project":"en.wikipedia","article":"\"Weird_Al\"_Yankovic","granularity":"daily","timestamp":"2025081500","access":"all-access","agent":"user","views":5572},{"project":"en.wikipedia","article":"\"Weird_Al\"_Yankovic","granularity":"daily","timestamp":"2025081600","access":"all-access","agent":"user","views":37991},{"project":"en.wikipedia","article":"\"Weird_Al\"_Yankovic","granularity":"daily","timestamp":"2025081700","access":"all-access","agent":"user","views":49374},{"project":"en.wikipedia","article":"\"Weird_Al\"_Yankovic","granularity":"daily","timestamp":"2025081800","access":"all-access","agent":"user","views":6691},{"project":"en.wikipedia","article":"\"Weird_Al\"_Yankovic","granularity":"daily","timestamp":"2025081900","access":"all-access","agent":"user","views":4869}]}'
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/article_with_slash.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/article_with_slash.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/HIV%2FAIDS/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - s-maxage=14400, max-age=14400
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:53 GMT
+      Content-Length:
+      - '736'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '452'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - 0aa1cb29-7dc1-4f24-9854-1e5a95c70f11
+      X-Analytics:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"project":"en.wikipedia","article":"HIV/AIDS","granularity":"daily","timestamp":"2025081500","access":"all-access","agent":"user","views":2097},{"project":"en.wikipedia","article":"HIV/AIDS","granularity":"daily","timestamp":"2025081600","access":"all-access","agent":"user","views":2016},{"project":"en.wikipedia","article":"HIV/AIDS","granularity":"daily","timestamp":"2025081700","access":"all-access","agent":"user","views":2071},{"project":"en.wikipedia","article":"HIV/AIDS","granularity":"daily","timestamp":"2025081800","access":"all-access","agent":"user","views":2255},{"project":"en.wikipedia","article":"HIV/AIDS","granularity":"daily","timestamp":"2025081900","access":"all-access","agent":"user","views":2303}]}'
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/article_with_unicode.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/article_with_unicode.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/Andr%C3%A9_the_Giant/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - s-maxage=14400, max-age=14400
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:55 GMT
+      Content-Length:
+      - '776'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '451'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - 201fc4ad-4462-44aa-8ec0-9e2ae337dbd7
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpdGVtcyI6W3sicHJvamVjdCI6ImVuLndpa2lwZWRpYSIsImFydGljbGUiOiJBbmRyw6lfdGhlX0dpYW50IiwiZ3JhbnVsYXJpdHkiOiJkYWlseSIsInRpbWVzdGFtcCI6IjIwMjUwODE1MDAiLCJhY2Nlc3MiOiJhbGwtYWNjZXNzIiwiYWdlbnQiOiJ1c2VyIiwidmlld3MiOjYxNjJ9LHsicHJvamVjdCI6ImVuLndpa2lwZWRpYSIsImFydGljbGUiOiJBbmRyw6lfdGhlX0dpYW50IiwiZ3JhbnVsYXJpdHkiOiJkYWlseSIsInRpbWVzdGFtcCI6IjIwMjUwODE2MDAiLCJhY2Nlc3MiOiJhbGwtYWNjZXNzIiwiYWdlbnQiOiJ1c2VyIiwidmlld3MiOjY1NDN9LHsicHJvamVjdCI6ImVuLndpa2lwZWRpYSIsImFydGljbGUiOiJBbmRyw6lfdGhlX0dpYW50IiwiZ3JhbnVsYXJpdHkiOiJkYWlseSIsInRpbWVzdGFtcCI6IjIwMjUwODE3MDAiLCJhY2Nlc3MiOiJhbGwtYWNjZXNzIiwiYWdlbnQiOiJ1c2VyIiwidmlld3MiOjYzMjl9LHsicHJvamVjdCI6ImVuLndpa2lwZWRpYSIsImFydGljbGUiOiJBbmRyw6lfdGhlX0dpYW50IiwiZ3JhbnVsYXJpdHkiOiJkYWlseSIsInRpbWVzdGFtcCI6IjIwMjUwODE4MDAiLCJhY2Nlc3MiOiJhbGwtYWNjZXNzIiwiYWdlbnQiOiJ1c2VyIiwidmlld3MiOjU2MzJ9LHsicHJvamVjdCI6ImVuLndpa2lwZWRpYSIsImFydGljbGUiOiJBbmRyw6lfdGhlX0dpYW50IiwiZ3JhbnVsYXJpdHkiOiJkYWlseSIsInRpbWVzdGFtcCI6IjIwMjUwODE5MDAiLCJhY2Nlc3MiOiJhbGwtYWNjZXNzIiwiYWdlbnQiOiJ1c2VyIiwidmlld3MiOjQ5ODh9XX0=
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/facebook_popular_article.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/facebook_popular_article.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/Facebook/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - s-maxage=14400, max-age=14400
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:53 GMT
+      Content-Length:
+      - '741'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '452'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - f6135248-e07f-429b-b1f1-00569795532b
+      X-Analytics:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"project":"en.wikipedia","article":"Facebook","granularity":"daily","timestamp":"2025081500","access":"all-access","agent":"user","views":19225},{"project":"en.wikipedia","article":"Facebook","granularity":"daily","timestamp":"2025081600","access":"all-access","agent":"user","views":19328},{"project":"en.wikipedia","article":"Facebook","granularity":"daily","timestamp":"2025081700","access":"all-access","agent":"user","views":18155},{"project":"en.wikipedia","article":"Facebook","granularity":"daily","timestamp":"2025081800","access":"all-access","agent":"user","views":20395},{"project":"en.wikipedia","article":"Facebook","granularity":"daily","timestamp":"2025081900","access":"all-access","agent":"user","views":22844}]}'
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/nonexistent_article.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/nonexistent_article.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/THIS_IS_NOT_A_REAL_ARTICLE/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - s-maxage=600
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/problem+json
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:56 GMT
+      Content-Length:
+      - '382'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '452'
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - 67c27788-076b-4395-a73c-0431495d4d96
+      X-Analytics:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"detail":"The date(s) you used are valid, but we either do not have
+        data for those date(s), or the project you asked for is not loaded yet. Please
+        check documentation for more information","method":"get","status":404,"title":"Not
+        Found","type":"about:blank","uri":"/metrics/pageviews/per-article/en.wikipedia/all-access/user/THIS_IS_NOT_A_REAL_ARTICLE/daily/2025081500/2025081900"}'
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/wiki_pageviews/wikidata_item.yml
+++ b/fixtures/vcr_cassettes/wiki_pageviews/wikidata_item.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/wikidata/all-access/user/Q42/daily/2025081500/2025081900
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - wikimedia.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - s-maxage=14400, max-age=14400
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"20-da39a3ee5e6b4b0d3255bfef95601890afd80709"
+      Date:
+      - Wed, 05 Nov 2025 16:49:56 GMT
+      Content-Length:
+      - '682'
+      Server:
+      - main-tls
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,HEAD
+      Access-Control-Allow-Headers:
+      - accept, content-type, content-length, cache-control, accept-language, api-user-agent,
+        if-match, if-modified-since, if-none-match, dnt, accept-encoding
+      Access-Control-Expose-Headers:
+      - etag
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Referrer-Policy:
+      - origin-when-cross-origin
+      X-Xss-Protection:
+      - 1; mode=block
+      Age:
+      - '451'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp5022 miss, cp5022 hit/1
+      X-Cache-Status:
+      - hit-front
+      Server-Timing:
+      - cache;desc="hit-front", host;desc="cp5022"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=IN:UP:Bareilly:28.37:79.43:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=05-Nov-2025;Path=/;Domain=.wikimedia.org;HttpOnly;secure;Expires=Sun,
+        07 Dec 2025 12:00:00 GMT
+      - WMF-Last-Access=05-Nov-2025;Path=/;HttpOnly;secure;Expires=Sun, 07 Dec 2025
+        12:00:00 GMT
+      X-Client-Ip:
+      - 137.97.131.26
+      X-Request-Id:
+      - 4809e0d0-e99d-48ba-93ed-b2aa37e6ee87
+      X-Analytics:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"project":"wikidata","article":"Q42","granularity":"daily","timestamp":"2025081500","access":"all-access","agent":"user","views":71},{"project":"wikidata","article":"Q42","granularity":"daily","timestamp":"2025081600","access":"all-access","agent":"user","views":78},{"project":"wikidata","article":"Q42","granularity":"daily","timestamp":"2025081700","access":"all-access","agent":"user","views":80},{"project":"wikidata","article":"Q42","granularity":"daily","timestamp":"2025081800","access":"all-access","agent":"user","views":87},{"project":"wikidata","article":"Q42","granularity":"daily","timestamp":"2025081900","access":"all-access","agent":"user","views":129}]}'
+  recorded_at: Wed, 20 Aug 2025 00:00:00 GMT
+recorded_with: VCR 6.1.0

--- a/spec/lib/wiki_pageviews_spec.rb
+++ b/spec/lib/wiki_pageviews_spec.rb
@@ -17,7 +17,7 @@ describe WikiPageviews do
       let(:title) { 'Facebook' }
 
       it 'returns the average page views' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/facebook_popular_article' do
           expect(subject).to be_within(2000).of(19989.4)
         end
       end
@@ -27,7 +27,7 @@ describe WikiPageviews do
       let(:title) { 'HIV/AIDS' }
 
       it 'returns the average page views' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/article_with_slash' do
           expect(subject).to be_within(200).of(2148.4)
         end
       end
@@ -37,7 +37,7 @@ describe WikiPageviews do
       let(:title) { "Broussard's" }
 
       it 'returns the average page views' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/article_with_apostrophe' do
           expect(subject).to be_within(2).of(7.8)
         end
       end
@@ -47,7 +47,7 @@ describe WikiPageviews do
       let(:title) { '"Weird_Al"_Yankovic' }
 
       it 'returns the average page views' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/article_with_quote_marks' do
           expect(subject).to be_within(2000).of(20899.4)
         end
       end
@@ -57,7 +57,7 @@ describe WikiPageviews do
       let(:title) { 'André_the_Giant' }
 
       it 'returns the average page views' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/article_with_unicode' do
           expect(subject).to be_within(500).of(5930.8)
         end
       end
@@ -70,7 +70,7 @@ describe WikiPageviews do
       before { stub_wiki_validation }
 
       it 'returns the average page views' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/wikidata_item' do
           expect(subject).to be_within(15).of(89.0)
         end
       end
@@ -80,7 +80,7 @@ describe WikiPageviews do
       let(:title) { 'THIS_IS_NOT_A_REAL_ARTICLE' }
 
       it 'returns 0' do
-        VCR.use_cassette 'wiki_pageviews/average_views_from_date' do
+        VCR.use_cassette 'wiki_pageviews/nonexistent_article' do
           expect(subject).to eq(0)
         end
       end
@@ -99,7 +99,7 @@ describe WikiPageviews do
       end
 
       it 'returns 0' do
-        VCR.use_cassette 'wiki_pageviews/404_handling' do
+        VCR.use_cassette 'wiki_pageviews/article_with_no_view_data' do
           expect(subject).to eq(0)
         end
       end


### PR DESCRIPTION
## What this PR does
This PR fixes intermittent CI failures in wiki_pageviews specs by adding VCR cassettes to record and replay Wikimedia API responses instead of making live HTTP requests during tests.

## Changes Made
- Added 8 VCR cassettes in `wiki_pageviews` covering all test scenarios

### Fixes #6542
