### PR TITLE
Fix sorting bug in AI stats view

### DIFF
--- a/app/assets/javascripts/components/alerts/courses_with_ai_alerts_list.jsx
+++ b/app/assets/javascripts/components/alerts/courses_with_ai_alerts_list.jsx
@@ -39,7 +39,7 @@ const CoursesWithAiAlertsList = ({ stats }) => {
   };
 
   const elements = sortedCourses.map(data => (
-    <tr key={data.course}>
+    <tr key={data.course_slug}>
       <td><a target="_blank" href={`/courses/${data.course_slug}`}>{data.course}</a></td>
       <td>{data.mainspace_count}</td>
       <td>{data.users_count}</td>


### PR DESCRIPTION
## What this PR does
This PR fixes a bug in sorting functionality  (reported by Sage [here](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6559#issuecomment-3513010210)) when two or more courses have the same title. Now we use course slug as key, since it's always unique.

## AI usage
No AI this time.

## Screenshots
Before:
[Screencast from 2025-11-10 15-02-58.webm](https://github.com/user-attachments/assets/93e8a10c-eba4-48cc-a68a-3226be1be29e)

After:
[Screencast from 2025-11-10 15-08-42.webm](https://github.com/user-attachments/assets/7d9830a4-b8de-46bb-8bf8-ad371f0abecb)


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
