### PR TITLE
Add global contribution url to User Profile

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,11 @@
 module UsersHelper
   def contribution_link(courses_user, text = nil, css_class = nil)
     options = { target: '_blank', class: css_class }
-    link_to((text || courses_user.user.username), courses_user.contribution_url, options)
+    link_to(
+      (text || courses_user.user.username),
+      contribution_link_redirect(courses_user),
+      options
+    )
   end
 
   COURSE_ROLE_MESSAGE_STRINGS = {
@@ -16,5 +20,11 @@ module UsersHelper
   }.freeze
   def course_role_name(courses_users_role)
     t("users.role.#{COURSE_ROLE_MESSAGE_STRINGS[courses_users_role]}")
+  end
+
+  private
+
+  def contribution_link_redirect(courses_user)
+    Features.wiki_ed? ? courses_user.contribution_url : courses_user.global_contribution_url
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -9,8 +9,15 @@ describe UsersHelper, type: :helper do
     let(:courses_user) { create(:courses_user, course_id: course.id, user_id: user.id) }
 
     it 'returns a link to a user\'s contributions page' do
+      allow(Features).to receive(:wiki_ed?).and_return(true)
       link = contribution_link(courses_user)
-      expect(link).to match(/<a.*href=/)
+      expect(link).to match(/Special:Contributions/)
+    end
+
+    it 'returns a link to a user\'s global contributions page' do
+      allow(Features).to receive(:wiki_ed?).and_return(false)
+      link = contribution_link(courses_user)
+      expect(link).to match(/guc.toolforge.org/)
     end
   end
 end


### PR DESCRIPTION
Add global contribution to user profile on dashboard

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## What this PR does
1. Add a parameter to contribution_link on users_helper to identify which request wants global user contribution.
2. Add a condition to call global_contribution_link
3. Modify Rspec according to current changes

## Screenshots
Before:
[Screencast from 11-11-25 16:35:31.webm](https://github.com/user-attachments/assets/d499ab68-625b-48ca-9030-fba1fafa55d7)

After:
[Screencast from 11-11-25 16:36:35.webm](https://github.com/user-attachments/assets/3af2febd-5c36-4200-8eb0-160ca4f9d3be)

Fixes: #6554
