### PR TITLE
disable sandbox link for non-mainspace assignment

### DIFF
--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -153,10 +153,17 @@ class Assignment < ApplicationRecord
   def set_sandbox_url
     return unless user
     return if sandbox_url.present?
+    return unless mainspace_article?
     # If the sandbox already exists, use that URL instead
     existing = Assignment.where(course:, article_title:, wiki:)
                          .where.not(user:).first
 
     self.sandbox_url = existing&.sandbox_url || default_sandbox_url
+  end
+
+  def mainspace_article?
+    return false if article_title.blank?
+
+    article_title.exclude?(':')
   end
 end


### PR DESCRIPTION
## What this PR does
This PR fixes the issue of bad sandbox links that are generated for non mainspace assignments. it Fixes #6551 by disabling sandbox link for non mainspace assignments.
## AI usage
No AI tools were used in this PR.

## Screenshots

https://github.com/user-attachments/assets/b834884f-5bbc-4a72-b611-82966e9b7d6f



After:

https://github.com/user-attachments/assets/a0fa2d51-b0a0-4659-91e7-a6f748fc4e13


## Open questions and concerns
I'm not sure if the behavior seen in the screen record of the after fix is the expected behavior. It seems that even after stopping the sandbox link from being generated during assignment creation, it still shows a link on the table which is probably a default link. 
I also wanted to ask if it's okay a write a test for the new function I wrote to fix this issue.