### PR TITLE
Pangram check stats view: calculate bar width dynamically based on the days in the period

### DIFF
--- a/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_graph.jsx
+++ b/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_graph.jsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ArticleUtils from '../../../utils/article_utils';
 
-const renderGraph = (id, statsData, pageTypes, labels) => {
+const renderGraph = (id, statsData, pageTypes, labels, days) => {
   const vegaSpec = {
     width: 800,
     height: 250,
@@ -91,7 +91,6 @@ const renderGraph = (id, statsData, pageTypes, labels) => {
         title: 'Revision creation date',
         format: '%b %d %Y',
         tickCount: 'day',
-        tickOffset: -5,
         labelAngle: -20,
         labelOverlap: 'greedy',
         labelPadding: 10
@@ -124,7 +123,7 @@ const renderGraph = (id, statsData, pageTypes, labels) => {
               enter: {
                 interpolate: { value: 'monotone' },
                 x: { scale: 'x', field: 'created_at' },
-                x2: { scale: 'x', field: 'created_at', offset: 30 },
+                x2: { scale: 'x', field: 'created_at', offset: 800 / days },
                 y: { scale: 'y', field: 'y0' },
                 y2: { scale: 'y', field: 'y1' },
                 fill: { scale: 'color', field: 'value' }
@@ -154,7 +153,14 @@ const ScoresTrendsGraph = (props) => {
       };
     });
 
-    renderGraph(id, props.statsData, legendLabels.map(e => e.value), legendLabels.map(e => e.label));
+    // Calculate number of days in the period
+    const days = props.statsData.map(s => new Date(s.created_at).getTime());
+    const minDay = Math.min(...days);
+    const maxDay = Math.max(...days);
+    const numberOfdays = Math.round((maxDay - minDay) / (1000 * 60 * 60 * 24));
+
+
+    renderGraph(id, props.statsData, legendLabels.map(e => e.value), legendLabels.map(e => e.label), numberOfdays);
   }, []);
     return (
       <div id={id} />

--- a/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_in_bins_graph.jsx
+++ b/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_in_bins_graph.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-const renderGraph = (id, statsData, bins, labels) => {
+const renderGraph = (id, statsData, bins, labels, days) => {
   const vegaSpec = {
     width: 800,
     height: 250,
@@ -101,7 +101,6 @@ const renderGraph = (id, statsData, bins, labels) => {
         title: 'Revision creation date',
         format: '%b %d %Y',
         tickCount: 'day',
-        tickOffset: -5,
         labelAngle: -20,
         labelOverlap: 'greedy',
         labelPadding: 10
@@ -134,7 +133,7 @@ const renderGraph = (id, statsData, bins, labels) => {
               enter: {
                 interpolate: { value: 'monotone' },
                 x: { scale: 'x', field: 'created_at' },
-                x2: { scale: 'x', field: 'created_at', offset: 30 },
+                x2: { scale: 'x', field: 'created_at', offset: 800 / days },
                 y: { scale: 'y', field: 'y0' },
                 y2: { scale: 'y', field: 'y1' },
                 fill: { scale: 'color', field: 'value' }
@@ -173,7 +172,13 @@ const ScoresTrendsGraph = (props) => {
       };
     });
 
-    renderGraph(id, props.statsData, bins, legendLabels);
+    // Calculate number of days in the period
+    const days = props.statsData.map(s => new Date(s.created_at).getTime());
+    const minDay = Math.min(...days);
+    const maxDay = Math.max(...days);
+    const numberOfdays = Math.round((maxDay - minDay) / (1000 * 60 * 60 * 24));
+
+    renderGraph(id, props.statsData, bins, legendLabels, numberOfdays);
   }, []);
     return (
       <div id={id} />


### PR DESCRIPTION
## What this PR does
This PR makes a small update to the pangram check admin view graphs to calculate bar width dynamically (instead of use a hard-coded number).

## Screenshots
Before:  bars can overlap
<img width="1022" height="831" alt="Screenshot from 2025-12-10 16-38-12" src="https://github.com/user-attachments/assets/bcc2258f-3a10-4713-bcc1-dea0747e82ff" />

After: bars width gets adjusted dynamically based on the number of days in the period to be displayed
<img width="1022" height="831" alt="Screenshot from 2025-12-10 16-41-31" src="https://github.com/user-attachments/assets/4f29be01-698b-4d7f-a32b-0a2a1b603c96" />
 
<img width="1022" height="831" alt="Screenshot from 2025-12-10 16-42-05" src="https://github.com/user-attachments/assets/8e06283b-37ec-46fd-bca0-652960d0f659" />

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
