### PR TITLE
Add Sentry message to debug mysql error due to 'article_id' being null

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -48,10 +48,20 @@ class ArticleCourseTimeslice < ApplicationRecord
   # Given a course, an article, and a hash of revisions like the following:
   # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
   # updates the article course timeslices based on the revisions.
-  def self.update_article_course_timeslices(course, article_id, revisions)
+  def self.update_article_course_timeslices(course, article_id, revisions) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
     rev_start = revisions[:start]
     rev_end = revisions[:end]
     wiki_id = revisions[:revisions].first.wiki_id
+    # For debugging purposes only. TODO: delete this sentry message
+    if article_id.nil?
+      Sentry.capture_message "Article id nil for course #{course.id}",
+                             level: 'error',
+                             extra: {
+                               wiki_id:,
+                               mw_page_ids: revisions[:revisions].map(&:mw_page_id),
+                               revision_ids: revisions[:revisions].map(&:mw_rev_id)
+                             }
+    end
     # Timeslice dates to update are determined based on course wiki timeslices
     timeslices = course.course_wiki_timeslices.where(wiki_id:)
                        .for_revisions_between(rev_start, rev_end)


### PR DESCRIPTION
## What this PR does
This is to research issue #6470.
It adds a Sentry message to log `mw_page_ids` and `mw_rev_ids` when `article_id` is null in `update_article_course_timeslices`. According to what I understand, that's the function where the `Mysql2::Error: Field 'article_id' doesn't have a default value
` comes from.
## AI usage
No AI usage.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
