### PR TITLE
Fix MySQL datetime comparison bug in CourseAiAlertManager

### DIFF
--- a/lib/alerts/course_ai_alert_manager.rb
+++ b/lib/alerts/course_ai_alert_manager.rb
@@ -52,6 +52,6 @@ class CourseAiAlertManager
   # alert for the same course would cover a non-overlapping window.
   def recent_unresolved_alert_exists?(course)
     AiSpikeAlert.where(course_id: course.id, resolved: false)
-                .exists?(['created_at > ?', RECENT_DAYS])
+                .exists?(['created_at > ?', RECENT_DAYS.days.ago])
   end
 end

--- a/spec/lib/alerts/course_ai_alert_manager_spec.rb
+++ b/spec/lib/alerts/course_ai_alert_manager_spec.rb
@@ -47,4 +47,43 @@ describe CourseAiAlertManager do
       expect(AiSpikeAlert.last.email_sent_at).not_to be_nil
     end
   end
+
+  context 'when checking for recent unresolved alerts' do
+    before do
+      # Create an unresolved alert to trigger the date comparison query
+      AiSpikeAlert.create(course: course, resolved: false, created_at: 5.days.ago, details: {})
+      # Create recent AiEditAlerts that would trigger a new alert
+      3.times do
+        create(:ai_edit_alert, course: course, details: mainspace_details)
+      end
+    end
+
+    it 'correctly compares created_at with a datetime value, not an integer' do
+      # This test will fail with MySQL error "Incorrect DATETIME value: '14'"
+      # if RECENT_DAYS (integer) is used instead of RECENT_DAYS.days.ago (datetime)
+      expect { subject.create_alerts }.not_to raise_error
+      # A recent unresolved alert exists, so no new alert should be created
+      expect(AiSpikeAlert.count).to eq(1)
+    end
+  end
+
+  context 'when checking for old unresolved alerts' do
+    before do
+      # Create an old unresolved alert (outside the recent window)
+      AiSpikeAlert.create(course: course, resolved: false, created_at: 15.days.ago, details: {})
+      # Create recent AiEditAlerts that would trigger a new alert
+      3.times do
+        create(:ai_edit_alert, course: course, details: mainspace_details)
+      end
+    end
+
+    it 'correctly handles date comparison for old alerts' do
+      # This test will fail with MySQL error "Incorrect DATETIME value: '14'"
+      # if RECENT_DAYS (integer) is used instead of RECENT_DAYS.days.ago (datetime)
+      expect(AlertMailer).to receive(:send_alert_email).and_call_original
+      expect { subject.create_alerts }.not_to raise_error
+      # Old alert is outside recent window, so a new alert should be created
+      expect(AiSpikeAlert.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does

This PR fixes a bug in `CourseAiAlertManager#recent_unresolved_alert_exists?` where `RECENT_DAYS` (an integer value of 14) was being used directly in a SQL query instead of `RECENT_DAYS.days.ago` (a datetime value). 

The bug caused a MySQL error: **"Incorrect DATETIME value: '14'"** when trying to compare the `created_at` datetime column with an integer value. When the `mysql2 `gem was updated to 0.5.7 This would prevent the alert manager from correctly checking whether a recent unresolved alert exists for a course.

**Changes made:**
- Fixed the date comparison in `recent_unresolved_alert_exists?` method to use `RECENT_DAYS.days.ago` instead of `RECENT_DAYS`
- Added comprehensive test cases to verify the date comparison works correctly for both recent and old unresolved alerts
- Tests include comments documenting the specific MySQL error that would occur if the bug is reintroduced

**Issue addressed:** The method was throwing a MySQL error when checking for recent unresolved alerts, preventing the alert system from functioning correctly.

## AI usage

I used Cursor AI to:
- Understand the bug by analyzing the error message and code context

The AI helped identify that the issue was a type mismatch between an integer (14) and a datetime column

## Screenshots

Before:
N/A - This is a backend bug fix that doesn't affect the UI. The error would occur in the application logs when the alert manager tried to check for recent unresolved alerts.

After:
N/A - This is a backend bug fix. The fix ensures the alert manager can successfully query the database without throwing MySQL errors.

## Open questions and concerns

- The fix ensures that the date comparison works correctly, but I'm wondering if there are other places in the codebase where similar patterns might exist (using integer day values directly in datetime comparisons)
