### PR TITLE
fix: post instructor userpage template on course approval

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -279,8 +279,9 @@ class CoursesController < ApplicationController
   end
 
   def handle_course_announcement(instructor)
-    # Course announcements aren't particularly necessary, but we'll keep them on
-    # for Wiki Ed for now.
+    # Only send submission emails at submission time.
+    # Instructor userpage templates are now posted when the course is approved
+    # (via ListCourseManager) instead of at submission time.
     return unless Features.wiki_ed?
     newly_submitted = !@course.submitted? && course_params[:submitted] == true
     return unless newly_submitted

--- a/app/workers/list_course_worker.rb
+++ b/app/workers/list_course_worker.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/wiki_course_edits"
+
+class ListCourseWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  def self.schedule_edits(course:, editing_user:, instructor:)
+    perform_async(course.id, editing_user.id, instructor.id)
+  end
+
+  def perform(course_id, editing_user_id, instructor_id)
+    course = Course.find(course_id)
+    editing_user = User.find(editing_user_id)
+    instructor = User.find(instructor_id)
+    WikiCourseEdits.new(action: 'add_course_template_to_instructor_userpage',
+                        course:,
+                        current_user: editing_user,
+                        instructor:)
+  end
+end

--- a/lib/wiki_course_edits.rb
+++ b/lib/wiki_course_edits.rb
@@ -50,9 +50,8 @@ class WikiCourseEdits
     return unless @course.wiki_title # Don't post for courses that lack a wiki course page
 
     instructor ||= @current_user
-    add_course_template_to_instructor_userpage(instructor)
     # Announce the course on the Education Noticeboard or equivalent.
-    announce_course_on_announcement_page(instructor)
+    announce_course_on_announcement_page(instructor:)
   end
 
   # Adds a template to the enrolling student's userpage, and also
@@ -202,7 +201,7 @@ class WikiCourseEdits
     @wiki_editor.post_whole_page(@current_user, wiki_title, safe_wiki_text, summary)
   end
 
-  def add_course_template_to_instructor_userpage(instructor)
+  def add_course_template_to_instructor_userpage(instructor:)
     user_page = "User:#{instructor.username}"
     template = "{{#{template_name(@templates, 'instructor')}" \
                " | course = [[#{@course.wiki_title}]] }}\n"
@@ -211,7 +210,7 @@ class WikiCourseEdits
     @wiki_editor.add_to_page_top(user_page, @current_user, template, summary)
   end
 
-  def announce_course_on_announcement_page(instructor)
+  def announce_course_on_announcement_page(instructor:)
     announcement_page = ENV['course_announcement_page']
     # rubocop:disable Layout/LineLength
     announcement = "I have created a new course — #{@course.title} — at #{@dashboard_url}/courses/#{@course.slug}. If you'd like to see more details about my course, check out my course page.--~~~~"

--- a/spec/lib/wiki_course_edits_spec.rb
+++ b/spec/lib/wiki_course_edits_spec.rb
@@ -64,13 +64,24 @@ describe WikiCourseEdits do
 
   describe '#announce_course' do
     # Posts to the Wiki Education dashboard by default in tests
-    it 'posts to the userpage of the instructor and a noticeboard' do
-      expect_any_instance_of(WikiEdits).to receive(:add_to_page_top) # userpage edit
+    it 'posts to a noticeboard' do
       expect_any_instance_of(WikiEdits).to receive(:add_new_section) # noticeboard edit
+      expect_any_instance_of(WikiEdits).not_to receive(:add_to_page_top) # userpage edit
       described_class.new(action: :announce_course,
                           course:,
                           current_user: user,
                           instructor: nil) # defaults to current user
+    end
+  end
+
+  describe '#add_course_template_to_instructor_userpage' do
+    it 'posts to the userpage of the instructor' do
+      expect_any_instance_of(WikiEdits).to receive(:add_to_page_top) # userpage edit
+      expect_any_instance_of(WikiEdits).not_to receive(:add_new_section) # noticeboard edit
+      described_class.new(action: :add_course_template_to_instructor_userpage,
+                          course:,
+                          current_user: user,
+                          instructor: user)
     end
 
     context 'makes correct edits on the Wiki Education Dashboard' do
@@ -80,10 +91,10 @@ describe WikiCourseEdits do
                 user,
                 "{{course instructor | course = [[#{course.wiki_title}]] }}\n",
                 "New course announcement: [[#{course.wiki_title}]].")
-        described_class.new(action: :announce_course,
+        described_class.new(action: :add_course_template_to_instructor_userpage,
                             course:,
                             current_user: user,
-                            instructor: nil)
+                            instructor: user)
       end
     end
 
@@ -111,8 +122,8 @@ describe WikiCourseEdits do
 
       context 'for enabled projects' do
         it 'posts to P&E Dashboard' do
-          expect_any_instance_of(WikiEdits).to receive(:add_to_page_top)
           expect_any_instance_of(WikiEdits).to receive(:add_new_section)
+          expect_any_instance_of(WikiEdits).not_to receive(:add_to_page_top)
           described_class.new(action: :announce_course,
                               course:,
                               current_user: user,
@@ -125,10 +136,10 @@ describe WikiCourseEdits do
                   user,
                   "{{program instructor | course = [[#{course.wiki_title}]] }}\n",
                   "New course announcement: [[#{course.wiki_title}]].")
-          described_class.new(action: :announce_course,
+          described_class.new(action: :add_course_template_to_instructor_userpage,
                               course:,
                               current_user: user,
-                              instructor: nil)
+                              instructor: user)
         end
       end
 


### PR DESCRIPTION
## What this PR does
Fix #6589 :  changed the announcement timing from instructor course submission to course approval.

## AI usage
to verify the correctness of logic and writing tests to verify the changes.

## Open questions and concerns
I've verified the changes by running tests which executed successfully.
