### PR TITLE
Part 2(#6568) Final: Add Require authentication for all CSV report generation

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,7 +7,10 @@ require_dependency "#{Rails.root}/app/workers/report_csv_worker"
 class ReportsController < ApplicationController
   include CourseHelper
   before_action :require_signed_in,
-                only: %i[campaign_instructors_csv campaign_courses_csv campaign_articles_csv]
+                only: %i[campaign_instructors_csv campaign_courses_csv campaign_articles_csv
+                         campaign_students_csv campaign_wikidata_csv course_csv
+                         course_uploads_csv course_students_csv course_articles_csv
+                         course_wikidata_csv]
   before_action :set_campaign, only: %i[campaign_courses_csv campaign_articles_csv
                                         campaign_students_csv campaign_instructors_csv
                                         campaign_wikidata_csv]

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -15,61 +15,67 @@ describe ReportsController, type: :request do
     FileUtils.remove_dir('public/system/analytics')
   end
 
-  it '#course_csv returns a CSV' do
-    expect(CsvCleanupWorker).to receive(:perform_at)
-    get '/course_csv', params: { course: course.slug }
-    expect(response.body).to include('file is being generated')
-    get '/course_csv', params: { course: course.slug }
-    follow_redirect!
-    csv = response.body.force_encoding('utf-8')
-    expect(csv).to include(course.title)
-  end
+  describe 'authenticated course CSV endpoints' do
+    before do
+      login_as user
+    end
 
-  it '#course_uploads_csv returns a CSV' do
-    expect(CsvCleanupWorker).to receive(:perform_at)
-    get '/course_uploads_csv', params: { course: course.slug }
-    expect(response.body).to include('file is being generated')
-    get '/course_uploads_csv', params: { course: course.slug }
-    follow_redirect!
-    csv = response.body.force_encoding('utf-8')
-    expect(csv).to include('filename')
-  end
+    it '#course_csv returns a CSV' do
+      expect(CsvCleanupWorker).to receive(:perform_at)
+      get '/course_csv', params: { course: course.slug }
+      expect(response.body).to include('file is being generated')
+      get '/course_csv', params: { course: course.slug }
+      follow_redirect!
+      csv = response.body.force_encoding('utf-8')
+      expect(csv).to include(course.title)
+    end
 
-  it '#course_students_csv returns a CSV' do
-    expect(CsvCleanupWorker).to receive(:perform_at)
-    get '/course_students_csv', params: { course: course.slug }
-    expect(response.body).to include('file is being generated')
-    get '/course_students_csv', params: { course: course.slug }
-    follow_redirect!
-    csv = response.body.force_encoding('utf-8')
-    expect(csv).to include('username')
-  end
+    it '#course_uploads_csv returns a CSV' do
+      expect(CsvCleanupWorker).to receive(:perform_at)
+      get '/course_uploads_csv', params: { course: course.slug }
+      expect(response.body).to include('file is being generated')
+      get '/course_uploads_csv', params: { course: course.slug }
+      follow_redirect!
+      csv = response.body.force_encoding('utf-8')
+      expect(csv).to include('filename')
+    end
 
-  it '#course_articles_csv returns a CSV' do
-    expect(CsvCleanupWorker).to receive(:perform_at)
-    get '/course_articles_csv', params: { course: course.slug }
-    expect(response.body).to include('file is being generated')
-    get '/course_articles_csv', params: { course: course.slug }
-    follow_redirect!
-    csv = response.body.force_encoding('utf-8')
-    expect(csv).to include('pageviews_link')
-  end
+    it '#course_students_csv returns a CSV' do
+      expect(CsvCleanupWorker).to receive(:perform_at)
+      get '/course_students_csv', params: { course: course.slug }
+      expect(response.body).to include('file is being generated')
+      get '/course_students_csv', params: { course: course.slug }
+      follow_redirect!
+      csv = response.body.force_encoding('utf-8')
+      expect(csv).to include('username')
+    end
 
-  it '#course_wikidata_csv returns a CSV' do
-    expect(CsvCleanupWorker).to receive(:perform_at)
-    get '/course_wikidata_csv', params: { course: course.slug }
-    expect(response.body).to include('file is being generated')
-    get '/course_wikidata_csv', params: { course: course.slug }
-    follow_redirect!
-    csv = response.body.force_encoding('utf-8')
-    expect(csv).to include('total revisions')
+    it '#course_articles_csv returns a CSV' do
+      expect(CsvCleanupWorker).to receive(:perform_at)
+      get '/course_articles_csv', params: { course: course.slug }
+      expect(response.body).to include('file is being generated')
+      get '/course_articles_csv', params: { course: course.slug }
+      follow_redirect!
+      csv = response.body.force_encoding('utf-8')
+      expect(csv).to include('pageviews_link')
+    end
+
+    it '#course_wikidata_csv returns a CSV' do
+      expect(CsvCleanupWorker).to receive(:perform_at)
+      get '/course_wikidata_csv', params: { course: course.slug }
+      expect(response.body).to include('file is being generated')
+      get '/course_wikidata_csv', params: { course: course.slug }
+      follow_redirect!
+      csv = response.body.force_encoding('utf-8')
+      expect(csv).to include('total revisions')
+    end
   end
 
   describe '#campaign_students_csv' do
     let(:student) { create(:user) }
 
     before do
-      login_as build(:user)
+      login_as student
       create(:courses_user, course_id: course.id, user_id: student.id,
                             role: CoursesUsers::Roles::STUDENT_ROLE)
     end


### PR DESCRIPTION
Closes: #6568

Part 1 - #6591

## What this PR does

**Implements**: `Require the user to be logged in for every CSV generation request (which we currently do only for campaign data, not course data).` - From #6568

**Authentication added for:**

- campaign_students_csv 
- campaign_wikidata_csv 
- course_csv
- course_uploads_csv 
- course_students_csv 
- course_articles_csv
- course_wikidata_csv

## AI usage

No AI usage.

## Screenshots

**Before:**


https://github.com/user-attachments/assets/4c9b02fe-4578-4a0f-9ace-f018c9cc2358



**After:**


https://github.com/user-attachments/assets/cf3e4dcd-4000-4ad1-936c-f7809ed9040a


