### PR TITLE
Update form elements in campaign edit and overview views to include unique IDs 

### DIFF
--- a/app/views/campaigns/edit.html.haml
+++ b/app/views/campaigns/edit.html.haml
@@ -18,7 +18,7 @@
   %section.overview.container
     = render 'courses/header_stats', presenter: @presenter
     .primary
-      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-description rails_editable' }) do
+      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { id: 'edit_campaign_description', class: 'module campaign-description rails_editable' }) do
         .section-header
           %h3
             = succeed ':' do
@@ -54,7 +54,7 @@
                     %tbody
                       %tr.edit
                         %td
-                          = form_for(@campaign, url: add_organizer_campaign_path(@campaign.slug), method: :put) do
+                          = form_for(@campaign, url: add_organizer_campaign_path(@campaign.slug), method: :put, html: { id: 'add_organizer_form' }) do
                             = text_field_tag(:username, '', { required: true, placeholder: t('users.username_placeholder') })
                             %button.button.border.add-organizer-button Add organizer
                       - @campaign.organizers.each do |organizer|
@@ -64,7 +64,7 @@
                               %span
                                 = organizer.username
                             - else
-                              = form_for(@campaign, url: remove_organizer_campaign_path(@campaign.slug, id: organizer.id), html: { method: :put, class: 'remove-organizer-form', 'data-username' => organizer.username }) do
+                              = form_for(@campaign, url: remove_organizer_campaign_path(@campaign.slug, id: organizer.id), html: { id: "remove_organizer_#{organizer.id}", method: :put, class: 'remove-organizer-form', 'data-username' => organizer.username }) do
                                 %span
                                   = organizer.username
                                 %button.button.border.plus -
@@ -126,7 +126,7 @@
                   = @campaign.end.try(:strftime, '%Y-%m-%d')
                 = date_field(:campaign, :end, placeholder: '2016-12-31', class: 'rails_editable-input')
 
-      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
+      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { id: 'edit_campaign_template', class: 'module campaign-template-description rails_editable' }) do
         .section-header
           %span.tooltip-trigger
             %h3
@@ -150,6 +150,6 @@
           = form_tag("/requested_accounts_campaigns/#{@campaign.slug}/disable_account_requests", method: :put, class: 'campaign-create') do
             %button.button.dark
               = t('campaign.disable_account_requests')    
-      = form_for(@campaign, url: campaign_path(@campaign.slug), method: :delete, html: { class: 'campaign-delete', 'data-title' => @campaign.title }) do
+      = form_for(@campaign, url: campaign_path(@campaign.slug), method: :delete, html: { id: 'delete_campaign_form', class: 'campaign-delete', 'data-title' => @campaign.title }) do
         %button.button.danger
           = t('campaign.delete_campaign')

--- a/app/views/campaigns/overview.html.haml
+++ b/app/views/campaigns/overview.html.haml
@@ -17,7 +17,7 @@
 .container
   %section.overview.container#overview-campaign-details
     .primary
-      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-description rails_editable' }) do
+      = form_for(@campaign, url: campaign_path(@campaign.slug), html: { id: 'edit_campaign_description', class: 'module campaign-description rails_editable' }) do
         .section-header
           %h3
             = succeed ':' do
@@ -85,7 +85,7 @@
                       %tbody
                         %tr.edit
                           %td
-                            = form_for(@campaign, url: add_organizer_campaign_path(@campaign.slug), method: :put) do
+                            = form_for(@campaign, url: add_organizer_campaign_path(@campaign.slug), method: :put, html: { id: 'add_organizer_form' }) do
                               = text_field_tag(:username, '', { required: true, placeholder: t('users.username_placeholder') })
                               %button.button.border.add-organizer-button Add organizer
                         - @campaign.organizers.each do |organizer|
@@ -95,7 +95,7 @@
                                 %span
                                   = organizer.username
                               - else
-                                = form_for(@campaign, url: remove_organizer_campaign_path(@campaign.slug, id: organizer.id), html: { method: :put, class: 'remove-organizer-form', 'data-username' => organizer.username }) do
+                                = form_for(@campaign, url: remove_organizer_campaign_path(@campaign.slug, id: organizer.id), html: { id: "remove_organizer_#{organizer.id}", method: :put, class: 'remove-organizer-form', 'data-username' => organizer.username }) do
                                   %span
                                     = organizer.username
                                   %button.button.border.plus -
@@ -144,7 +144,7 @@
                   = @campaign.default_passcode
       %section#campaign_stats
       - if @campaign.template_description.present?
-        = form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-template-description rails_editable' }) do
+        = form_for(@campaign, url: campaign_path(@campaign.slug), html: { id: 'edit_campaign_template', class: 'module campaign-template-description rails_editable' }) do
           .section-header
             %span.tooltip-trigger
               %h3


### PR DESCRIPTION


## What this PR does

This PR improves the maintainability and testability of campaign view templates by adding explicit id attributes to key form elements in the campaign edit and overview pages. These changes make the forms easier to reference in JavaScript and automated tests, and reduce ambiguity when interacting with the DOM.



###  View Template Improvements

**Files**:
- `app/views/campaigns/edit.html.haml`
- `app/views/campaigns/overview.html.haml`

**Changes**: Added explicit `id` attributes to form elements for better JavaScript/DOM manipulation and testing.

**Example**:
```haml
# Before
= form_for(@campaign, url: campaign_path(@campaign.slug), html: { class: 'module campaign-description rails_editable' }) do

# After
= form_for(@campaign, url: campaign_path(@campaign.slug), html: { id: 'edit_campaign_description', class: 'module campaign-description rails_editable' }) do
```

**Why**: Adding explicit IDs makes it easier to:
- Target forms in JavaScript/jQuery
- Write more reliable tests
- Debug and maintain the codebase





