### PR TITLE
Refactor redirect methods in account request controllers

### DIFF
--- a/app/controllers/requested_accounts_campaigns_controller.rb
+++ b/app/controllers/requested_accounts_campaigns_controller.rb
@@ -11,12 +11,12 @@ class RequestedAccountsCampaignsController < ApplicationController
   # modal instead of redirecting to the mediawiki account creation flow.
   def enable_account_requests
     @campaign.update(register_accounts: true)
-    redirect_back(fallback_location: root_path)
+    redirect_back_or_to(root_path)
   end
 
   def disable_account_requests
     @campaign.update(register_accounts: false)
-    redirect_back(fallback_location: root_path)
+    redirect_back_or_to(root_path)
   end
 
   # List of requested accounts for a course.

--- a/app/controllers/requested_accounts_controller.rb
+++ b/app/controllers/requested_accounts_controller.rb
@@ -60,7 +60,7 @@ class RequestedAccountsController < ApplicationController
     requested_account = RequestedAccount.find_by(id: params[:id])
     raise_unauthorized_exception unless @course.id == requested_account.course_id
     requested_account.delete
-    redirect_back fallback_location: '/'
+    redirect_back_or_to('/')
   end
 
   # Try to create each of the requested accounts for a course, and show the


### PR DESCRIPTION

# PR 2: Rails 7.1 API Deprecations - Update redirect_back calls

## What this PR does
This PR updates deprecated `redirect_back` method calls to use the new `redirect_back_or_to` method, which is the recommended approach in Rails 7.1.

**Changes:**
- `app/controllers/requested_accounts_campaigns_controller.rb`: Replaces `redirect_back(fallback_location: root_path)` with `redirect_back_or_to(root_path)` in both `enable_account_requests` and `disable_account_requests` methods
- `app/controllers/requested_accounts_controller.rb`: Replaces `redirect_back fallback_location: '/'` with `redirect_back_or_to('/')` in the delete action

The `redirect_back` method was deprecated in Rails 7.0 and `redirect_back_or_to` is the recommended replacement. This change ensures compatibility with Rails 7.1 and removes deprecation warnings.

Ref -
https://github.com/rails/rails/releases/tag/v7.1.0
https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back_or_to


## Screenshots
Before:
N/A - Backend changes only, no visible UI changes (redirect behavior remains the same)

After:
N/A - Backend changes only, no visible UI changes (redirect behavior remains the same)



