### PR TITLE
Enhance FAQ editor with live Markdown preview and improved styling

### DIFF
--- a/app/assets/javascripts/faq_editor.js
+++ b/app/assets/javascripts/faq_editor.js
@@ -1,0 +1,38 @@
+// Live Markdown preview for FAQ editor
+import markdownIt from './utils/markdown_it';
+
+const md = markdownIt({ html: true, linkify: true });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('faq_content');
+  const preview = document.getElementById('faq_preview');
+
+  if (!textarea || !preview) return;
+
+  // Debounce function to avoid excessive re-renders
+  let debounceTimer;
+  const debounce = (callback, delay) => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(callback, delay);
+  };
+
+  // Update preview function
+  const updatePreview = () => {
+    const markdown = textarea.value;
+    if (markdown.trim() === '') {
+      preview.innerHTML = '<em>Start typing to see a live preview…</em>';
+  } else {
+      preview.innerHTML = md.render(markdown);
+    }
+  };
+
+  // Listen to input events with debouncing
+  textarea.addEventListener('input', () => {
+    debounce(updatePreview, 300);
+  });
+
+  // Initial render if there's existing content
+  if (textarea.value.trim() !== '') {
+    updatePreview();
+  }
+});

--- a/app/assets/stylesheets/modules/_faq.styl
+++ b/app/assets/stylesheets/modules/_faq.styl
@@ -18,6 +18,7 @@
 
   .faq-list
     width 70%
+    
 
   .faq-topic-list
     width 20%
@@ -77,3 +78,79 @@
       transform rotate(180deg)
     .faq-content
       padding-bottom 20px
+
+.faq-editor
+  display: flex
+  gap: 30px
+  margin-top: 20px
+  @media only screen and (max-width: 768px)
+    flex-direction: column
+
+  .editor-pane
+    flex 1
+    min-width 0
+
+    form
+      .string, .text
+        margin-bottom 5px
+
+      .faq-editor__title
+        width 100%
+        border-radius 4px
+
+        &:focus
+          outline none
+          border-color #676eb4
+
+      .faq-editor__textarea
+        width 100%
+        padding 12px
+        font-size 14px
+        font-family 'Monaco', 'Menlo', 'Ubuntu Mono', monospace
+        line-height 1.6
+        border 1px solid #ddd
+        border-radius 4px
+        box-sizing border-box
+        resize vertical
+        min-height 400px
+
+        &:focus
+          outline none
+          border-color #676eb4
+          box-shadow 0 0 0 3px rgba(103, 110, 180, 0.1)
+
+      .button, input[type="submit"]
+        display inline-block
+        padding 10px 20px
+        background-color #676eb4
+        color white
+        border none
+        border-radius 4px
+        font-size 14px
+        font-weight 600
+        cursor pointer
+        text-decoration none
+        transition background-color 0.2s
+
+        &:hover
+          background-color #5558a0
+
+        &:active
+          background-color #4a4d8a
+
+  .preview-pane
+    flex: 1
+    min-width: 0
+    h3
+      margin-bottom: 15px
+    .faq-preview
+        padding: 20px
+        background-color: rgba(0,0,0,0.03)
+        border: 1px solid $border
+        border-radius: 4px
+        overflow-y: auto
+        max-height: 50vh 
+        min-height: 400px
+        overflow-wrap: break-word
+        scrollbar-color: #8e8e8eff #8f8f8fff
+        scrollbar-width: thin

--- a/app/views/faq/edit.html.haml
+++ b/app/views/faq/edit.html.haml
@@ -1,9 +1,18 @@
+= hot_javascript_tag 'faq_editor'
 - content_for :before_title, "Edit FAQ - #{@faq.title}"
-.container
-  = simple_form_for @faq do |f|
-    = f.input :title
-    = f.input :content
-    = f.button :submit
+.container.faq-editor
+  .editor-pane
+    = simple_form_for @faq do |f|
+      = f.input :title, input_html: { class: 'faq-editor__title' }
+      = f.input :content, as: :text,
+                 input_html: { id: 'faq_content', class: 'faq-editor__textarea', rows: 16, 'data-preview-target': '#faq_preview' }
+      = f.button :submit, class: 'button'        
 
-  %hr
-  = button_to 'delete', @faq, method: :delete, data: { confirm: "Are you sure you want to delete this?" }
+    %hr
+    = button_to 'Delete', @faq, method: :delete,
+      data: { confirm: "Are you sure you want to delete this?" }, class: 'button'
+
+  .preview-pane
+    %h3 Preview
+    .faq-preview.markdown#faq_preview
+      = raw @faq.html_content

--- a/app/views/faq/new.html.haml
+++ b/app/views/faq/new.html.haml
@@ -1,7 +1,15 @@
+= hot_javascript_tag 'faq_editor'
 - content_for :before_title, "New FAQ"
-.container
-  %h1 Add new FAQ
-  = simple_form_for @faq, url: '/faq' do |f|
-    = f.input :title
-    = f.input :content
-    = f.button :submit
+.container.faq-editor
+  .editor-pane
+    %h1 Add new FAQ
+    = simple_form_for @faq, url: '/faq' do |f|
+      = f.input :title, input_html: { class: 'faq-editor__title' }
+      = f.input :content, as: :text,
+                 input_html: { id: 'faq_content', class: 'faq-editor__textarea', rows: 16, 'data-preview-target': '#faq_preview' }
+      = f.button :submit, class: 'button'
+
+  .preview-pane
+    %h3 Preview
+    .faq-preview.markdown#faq_preview
+      %em Start typing to see a live preview…

--- a/spec/features/faq_spec.rb
+++ b/spec/features/faq_spec.rb
@@ -44,7 +44,7 @@ describe 'FAQs', type: :feature, js: true do
     it 'redirects to FAQ INDEX after deleting' do
       visit "/faq/#{faq.id}/edit"
       accept_confirm do
-        click_button 'delete'
+        click_button 'Delete'
       end
       expect(page).to have_current_path('/faq')
       expect(Faq.count).to eq(0)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = (env) => {
     charts: [`${jsSource}/charts.js`],
     accordian: [`${jsSource}/accordian.js`],
     editable: [`${jsSource}/utils/editable.js`],
+    faq_editor: [`${jsSource}/faq_editor.js`],
     i18n: [`${jsSource}/i18n.js`],
 
     surveys: [`${cssSource}/surveys.styl`],


### PR DESCRIPTION
## What this PR does
This PR solves #6530 by cleaning up #6537 

## AI usage
 No AI usage

## Screenshots
Here is a video of the current implementation

https://www.loom.com/share/2434b0b2b8f443b3bc953dfc7f53b554


## Open Questions

I have some suggestions for the look of the FAQ section

- Currently if you do not click on the `All questions`  the list of the questions does not show. I think by default this list should be displayed and on filtering based on topic this should cause the content of the questions to get filtered or updated

<img width="1440" height="818" alt="Screenshot 2026-01-20 at 11 20 00" src="https://github.com/user-attachments/assets/353f572c-61a2-46bc-9957-2cd3ce20599e" />

- Can we have an icon to replace the `edit` text and also give some spacing to the content on the page


<img width="1440" height="818" alt="Screenshot 2026-01-20 at 11 21 57" src="https://github.com/user-attachments/assets/e29c8e2d-f858-48e9-8ce9-a59c3050e779" />

- For the text area in the FAQ form, it is not a rich text field and hence most of the content might not be formatted appropriately,  like bolding text or putting content in bullet form. Could the input field be replaced with a rich text input field


<img width="1440" height="818" alt="Screenshot 2026-01-20 at 11 24 56" src="https://github.com/user-attachments/assets/7a2ebdd2-af3e-465b-aa56-7739cae288e7" />


