### PR TITLE
Update Article Views documentation to reflect new calculation method

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1224,8 +1224,8 @@ en:
       other: total usages across languages
     view_count_description: Article Views
     view_count_description_wikidata: Item Views
-    view_count_doc: This is the estimated number of views based on a 30-day average for each article, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
-    view_count_doc_wikidata: This is the estimated number of views based on a 30-day average for each item, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
+    view_count_doc: This is the estimated number of views based on the daily average from the article's first revision during the course up to the most recent stats update.
+    view_count_doc_wikidata: This is the estimated number of views based on the daily average from the item's first revision during the course up to the most recent stats update.
     view_data_unavailable: No view data available
     view: Views
     wiki_ed_help: Use the 'Get Help' button to report a problem.


### PR DESCRIPTION
- Changed from '30-day average' to 'daily average from first revision during course to present'
- Updated both view_count_doc and view_count_doc_wikidata entries
- Addresses issue #6548 following implementation changes in PR #6456


## What this PR does
Updates the tooltip documentation for Article Views metrics to reflect the new calculation method implemented in PR #6456.

## Changes Made

- Updated `view_count_doc` from "30-day average" to "daily average from first revision during course to present"
- Updated `view_count_doc_wikidata` with the same change for Wikidata items  
- Both changes reflect the new implementation that calculates views from the article's first revision during the course period up to the present

## Code Changes
**Before:**
`
view_count_doc: This is the estimated number of views based on a 30-day average for each article, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
`
**After:**
`
view_count_doc: This is the estimated number of views based on daily average from the article's first revision during the course up to the present, through the most recent stats update. Views may decrease if the updated average is lower than previous counts.
`

## Screenshots
No before/after screenshots are provided for the following reasons:
- Testing the tooltip requires Wikipedia OAuth authentication, which requires setting up a Wikipedia account and configuring OAuth credentials in the development environment, but in my case , i am not able to made the account, due to account errors from wikipedia side.
- The change can be verified by reviewing the locale file modifications shown in the code diff above

Closes #6548
