### PR TITLE
chore: upgrade mediawiki_api gem to 0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'rapidfire', git: 'https://github.com/WikiEducationFoundation/rapidfire', br
 
 ### HTTP and API tools
 gem 'faraday' # Standard HTTP library
-gem 'mediawiki_api' # Library for querying mediawiki API'
+gem 'mediawiki_api', '~> 0.9.0' # Library for querying mediawiki API'
 # gem 'mediawiki_api', git: 'https://github.com/ragesoss/mediawiki-ruby-api', branch: 'master'
 gem 'restforce' # Salesforce API access
 gem 'oj' # JSON Parsing library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -648,7 +648,7 @@ DEPENDENCIES
   jbuilder
   kt-paperclip
   mailgun-ruby
-  mediawiki_api
+  mediawiki_api (~> 0.9.0)
   memory_profiler
   mysql2
   newrelic_rpm


### PR DESCRIPTION
Required For #6627

## What this PR does

Upgrades `mediawiki_api` gem from 0.7.1 to 0.9.0 to add support for the `oauth_access_token` method, which is required for OAuth 2.0 authentication with Wikimedia's API.

