### PR TITLE
Handle interwiki link format in assignment titles

### DIFF
--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -145,6 +145,20 @@ class Assignment < ApplicationRecord
   end
 
   def set_defaults_and_normalize
+    # Check if article_title contains interwiki format and update wiki accordingly
+    if article_title.present?
+      interwiki_info = ArticleUtils.parse_interwiki_format(article_title)
+      if interwiki_info
+        # Parse interwiki format and update wiki_id accordingly
+        target_wiki = Wiki.get_or_create(
+          language: interwiki_info[:language],
+          project: interwiki_info[:project]
+        )
+        self.wiki_id = target_wiki.id
+        self.article_title = interwiki_info[:title]
+      end
+    end
+
     self.wiki_id ||= course.home_wiki.id
     return if article_title.nil?
     self.article_title = ArticleUtils.format_article_title(article_title, wiki)

--- a/lib/article_utils.rb
+++ b/lib/article_utils.rb
@@ -1,6 +1,58 @@
 # frozen_string_literal: true
 
 class ArticleUtils
+  # Interwiki prefixes that can appear in article titles
+  INTERWIKI_PREFIXES = {
+    'w' => 'wikipedia',
+    'wikt' => 'wiktionary',
+    'n' => 'wikinews',
+    'b' => 'wikibooks',
+    'q' => 'wikiquote',
+    's' => 'wikisource',
+    'v' => 'wikiversity',
+    'voy' => 'wikivoyage',
+    'c' => 'commons',
+    'wmf' => 'wikimedia',
+    'm' => 'metawikipedia',
+    'species' => 'wikispecies',
+    'mw' => 'mediawiki'
+  }.freeze
+
+  # Valid project names
+  VALID_PROJECTS = ['wikipedia', 'wiktionary', 'wikinews', 'wikibooks', 'wikiquote',
+                    'wikisource', 'wikiversity', 'wikivoyage', 'commons', 'wikimedia',
+                    'wikidata', 'metawikipedia', 'wikispecies', 'mediawiki'].freeze
+
+  # Parse interwiki format from article title like "en:Article" or "en:wiktionary:Article"
+  # Returns a hash with :title, :project, :language, or nil if not interwiki format
+  def self.parse_interwiki_format(article_title)
+    # Pattern: (optional leading colon)(2-3 char language code)(optional :project):title
+    match = article_title.match(/^(:)?([a-z]{2,3}(?:-[a-z]+)?)(?::([a-z]+))?:(.+)$/i)
+    return nil unless match
+
+    _leading_colon, language, project_code, title = match.captures
+
+    # If project is specified, resolve the code or name
+    if project_code
+      project = INTERWIKI_PREFIXES[project_code] || 
+                (VALID_PROJECTS.include?(project_code) ? project_code : nil)
+      # If we can't resolve the project code, it might not be a project code at all,
+      # but part of the title (e.g., "en:User:Example"). Treat it as wikipedia.
+      if project.nil?
+        title = "#{project_code}:#{title}"
+        project = 'wikipedia'
+      end
+    else
+      project = 'wikipedia'
+    end
+
+    {
+      title: title,
+      project: project,
+      language: language
+    }
+  end
+
   # This method takes user input and tries to convert it into a valid article title
   def self.format_article_title(article_title, wiki = nil)
     formatted_title = String.new(article_title)
@@ -8,7 +60,7 @@ class ArticleUtils
     unless wiki&.project == 'wiktionary'
       first_letter = formatted_title[0]
       # Use mb_chars so that we can capitalize unicode letters too.
-      formatted_title[0] = first_letter.mb_chars.capitalize.to_s
+      formatted_title[0] = first_letter.mb_chars.capitalize.to_s if first_letter
     end
     formatted_title = formatted_title.tr(' ', '_')
     formatted_title

--- a/spec/lib/article_utils_spec.rb
+++ b/spec/lib/article_utils_spec.rb
@@ -36,4 +36,67 @@ describe ArticleUtils do
       expect(formatted_title).to eq('derívense')
     end
   end
+
+  # Handle interwiki link format
+  describe '.parse_interwiki_format' do
+    it 'parses simple interwiki format (en:Article)' do
+      result = described_class.parse_interwiki_format('en:Slavonic Library in Prague')
+      expect(result).to eq({
+        title: 'Slavonic Library in Prague',
+        project: 'wikipedia',
+        language: 'en'
+      })
+    end
+
+    it 'parses interwiki format with project (es:wiktionary:palabra)' do
+      result = described_class.parse_interwiki_format('es:wiktionary:palabra')
+      expect(result).to eq({
+        title: 'palabra',
+        project: 'wiktionary',
+        language: 'es'
+      })
+    end
+
+    it 'parses interwiki format with project abbreviation (en:wikt:hello)' do
+      result = described_class.parse_interwiki_format('en:wikt:hello')
+      expect(result).to eq({
+        title: 'hello',
+        project: 'wiktionary',
+        language: 'en'
+      })
+    end
+
+    it 'parses interwiki format with other projects (de:b:Mathematik)' do
+      result = described_class.parse_interwiki_format('de:b:Mathematik')
+      expect(result).to eq({
+        title: 'Mathematik',
+        project: 'wikibooks',
+        language: 'de'
+      })
+    end
+
+    it 'handles titles with colons (en:User:Example)' do
+      result = described_class.parse_interwiki_format('en:User:Example')
+      expect(result).to eq({
+        title: 'User:Example',
+        project: 'wikipedia',
+        language: 'en'
+      })
+    end
+
+    it 'returns nil for non-interwiki format (Engineer:Something)' do
+      result = described_class.parse_interwiki_format('Engineer:Something')
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for regular article titles (Boston Trinity Academy)' do
+      result = described_class.parse_interwiki_format('Boston Trinity Academy')
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for category pages (Category:Photography)' do
+      result = described_class.parse_interwiki_format('Category:Photography')
+      expect(result).to be_nil
+    end
+  end
 end

--- a/test/utils/course_utils.spec.js
+++ b/test/utils/course_utils.spec.js
@@ -222,6 +222,72 @@ describe('courseUtils.articleFromTitleInput', () => {
     expect(output.language).toBe('en');
     expect(output.article_url).toBe(input);
   });
+
+  // Handle interwiki link format
+  test('parses interwiki format with language only (en:Article)', () => {
+    const input = 'en:Slavonic Library in Prague';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Slavonic Library in Prague');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+    expect(output.article_url).toBe(null);
+  });
+
+  test('parses interwiki format with underscores (en:Article_Title)', () => {
+    const input = 'en:Slavonic_Library_in_Prague';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Slavonic Library in Prague');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('en');
+  });
+
+  test('parses interwiki format with language and project (es:wiktionary:Article)', () => {
+    const input = 'es:wiktionary:palabra';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('palabra');
+    expect(output.project).toBe('wiktionary');
+    expect(output.language).toBe('es');
+  });
+
+  test('parses interwiki format with project abbreviation (en:wikt:Article)', () => {
+    const input = 'en:wikt:hello';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('hello');
+    expect(output.project).toBe('wiktionary');
+    expect(output.language).toBe('en');
+  });
+
+  test('parses interwiki format for different wikis (fr:Article)', () => {
+    const input = 'fr:Paris';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Paris');
+    expect(output.project).toBe('wikipedia');
+    expect(output.language).toBe('fr');
+  });
+
+  test('parses interwiki format for wikibooks (de:b:Article)', () => {
+    const input = 'de:b:Mathematik';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Mathematik');
+    expect(output.project).toBe('wikibooks');
+    expect(output.language).toBe('de');
+  });
+
+  test('does not parse article titles with colons that are not interwiki format', () => {
+    const input = 'Engineer:Something';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Engineer:Something');
+    expect(output.project).toBe(null);
+    expect(output.language).toBe(null);
+  });
+
+  test('does not parse Category:Something as interwiki format', () => {
+    const input = 'Category:Photography';
+    const output = courseUtils.articleFromTitleInput(input);
+    expect(output.title).toBe('Category:Photography');
+    expect(output.project).toBe(null);
+    expect(output.language).toBe(null);
+  });
 });
 
 describe('courseUtils.articleFromAssignment', () => {


### PR DESCRIPTION
- Add support for parsing interwiki format (e.g., en:Article, es:wiktionary:palabra)
- Update JavaScript articleFromTitleInput() to parse interwiki format
- Update Ruby ArticleUtils with parse_interwiki_format() method
- Modify Assignment model to handle interwiki format on save
- Add comprehensive test coverage for both JS and Ruby implementations


## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

Fixes #2491 

Pls review @ragesoss @Abishekcs @gabina 