### PR TITLE
Fix tooltip icons mobile responsive

### DIFF
--- a/app/assets/stylesheets/modules/_stats.styl
+++ b/app/assets/stylesheets/modules/_stats.styl
@@ -206,5 +206,5 @@
 @media only screen and (max-width: 919px)
   .stat-display
     .stat-display__value
-      img
+      img:not([src*="info.svg"])
         display none


### PR DESCRIPTION


This PR fixes tooltip icons (info icons) disappearing on mobile devices and responsive views. The issue was caused by an overly broad CSS rule that hid ALL images on screens smaller than 919px, including important tooltip icons that provide contextual information about statistics.

The fix modifies the CSS selector to exclude tooltip icons from being hidden while preserving the original intent of hiding decorative images on mobile.

Closes #6654


## Screenshots

Before:
<img width="333" height="604" alt="Screenshot 2026-01-30 at 10 37 18 PM" src="https://github.com/user-attachments/assets/0e8b8755-29b4-4a53-8b5a-a182804f8ada" />

After:
<img width="334" height="740" alt="Screenshot 2026-02-01 at 6 12 23 PM" src="https://github.com/user-attachments/assets/cd6dcddd-cd13-4dba-9ee3-068ed53f7f5d" />

@ragesoss 