### PR TITLE
Fix NotSignedInError to redirect with UI instead of plain text

### DIFF
--- a/app/assets/stylesheets/modules/_error_messages.styl
+++ b/app/assets/stylesheets/modules/_error_messages.styl
@@ -7,5 +7,48 @@ div.warning
   &.slim
     margin 1em 2em
 
+
 .warning-background
   background-color $warning-light !important
+
+.unauthorized-error
+  margin-top 100px
+  margin-bottom 100px
+  .error-card
+    background white
+    padding 50px
+    border 1px solid $border_lt
+    border-radius 6px
+    box-shadow 0 4px 15px rgba(0,0,0,0.05)
+    text-align center
+    
+    .icon-wiki-purple
+      background-size 60px
+      height 80px
+      width 80px
+      margin 0 auto 20px
+      display block
+      padding 0
+      
+    p.explanation
+      font-size 1.2em
+      color $text
+      margin-bottom 40px
+      line-height 1.6
+      max-width 500px 
+      margin-left auto
+      margin-right auto
+      
+    .actions
+      display flex
+      justify-content center
+      flex-wrap wrap
+      gap 20px
+      
+      .button
+        margin-top 0 // Override default button margins
+        &.big
+          padding 12px 30px
+          font-size 1.1em
+          height auto
+          line-height inherit

--- a/app/views/errors/unauthorized.html.haml
+++ b/app/views/errors/unauthorized.html.haml
@@ -1,0 +1,15 @@
+- content_for :after_title, " - #{t('home.log_in')}"
+
+%section.unauthorized-error
+  .container.narrow
+    .error-card
+      %i.icon.icon-wiki-purple
+      %p.explanation= flash[:alert] || t('error_401.explanation')
+      
+      .actions
+        = link_to user_mediawiki_omniauth_authorize_path, method: :post, class: 'button dark auth big' do
+          %i.icon.icon-wiki-white
+          = t('home.log_in')
+        
+        %a.button.border.big(href="/")
+          = t('application.home')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1832,9 +1832,10 @@ en:
         site works well on recent versions of Chrome, Firefox, Edge, and other modern browsers.
     ip_blocked: >
       You cannot currently create an account from this device. This my happen if your IP address is blocked by Wikipedia or has already reached the daily limit for new accounts. Try connecting from a different network.
+    login_success_download_html: "Successfully signed in! %{link}."
+    download_here: Click here to download your file
 
   error_401:
-    header: "Unauthorized. >:-("
     explanation: >
       You are not authorized to execute this request. If you believe you have
       reached this notice in error, please contact the maintainers of this

--- a/lib/errors/rescue_errors.rb
+++ b/lib/errors/rescue_errors.rb
@@ -36,8 +36,9 @@ module Errors
         if json?(request)
           render json: { message: e.message }, status: :unauthorized
         else
-          # TODO: need more user friendly error handling for html
-          render plain: e.message, status: :unauthorized
+          flash.now[:alert] = e.message
+          session[:return_to] = request.fullpath
+          render 'errors/unauthorized', status: :unauthorized, layout: 'application'
         end
       end
     end
@@ -47,8 +48,8 @@ module Errors
         if json?(request)
           render json: { message: e.message }, status: :unauthorized
         else
-          # TODO: need more user friendly error handling for html
-          render plain: e.message, status: :unauthorized
+          flash.now[:alert] = e.message
+          render 'errors/unauthorized', status: :unauthorized, layout: 'application'
         end
       end
     end
@@ -58,8 +59,8 @@ module Errors
         if json?(request)
           render json: { message: e.message }, status: :unauthorized
         else
-          # TODO: need more user friendly error handling for html
-          render plain: e.message, status: :unauthorized
+          flash.now[:alert] = e.message
+          render 'errors/unauthorized', status: :unauthorized, layout: 'application'
         end
       end
     end
@@ -69,8 +70,8 @@ module Errors
         if json?(request)
           render json: { message: e.message }, status: :unauthorized
         else
-          # TODO: need more user friendly error handling for html
-          render plain: e.message, status: :unauthorized
+          flash.now[:alert] = e.message
+          render 'errors/unauthorized', status: :unauthorized, layout: 'application'
         end
       end
     end


### PR DESCRIPTION
Fixes #6658



### What this PR does

This PR improves the experience when a signed-out user visits a protected page.

- Replaces the plain text **“Please sign in”** response with a proper **401 Unauthorized** page.
- Stores the intended destination in the session and automatically returns the user to that page after a successful Wikipedia login.
- Download Safety: Detects if the return path is a download-only endpoint (like /ungreeted) and redirects the user to the home page with a clear download link. This prevents the browser from getting stuck on the Wikipedia "Allow" page during silent file downloads.
- Security: Validates redirection paths to prevent open-redirect vulnerabilities.
- Tests: Adds unit tests for the redirection and security logic in ApplicationController.

### Screenshots

**Before**  
<img width="692" height="469" alt="Screenshot 2026-02-05 at 3 58 15 AM" src="https://github.com/user-attachments/assets/3961b9cb-91c3-4800-9e59-8ab2ff7881b9" />


**After**  
<img width="920" height="635" alt="Screenshot 2026-02-13 at 9 47 25 PM" src="https://github.com/user-attachments/assets/3ed7f66c-2e0f-4e3b-a64d-5359ebdad813" />



@ragesoss 
