### PR TITLE
Add live preview to site notice settings

### DIFF
--- a/app/assets/javascripts/components/settings/views/configure_site_notice.jsx
+++ b/app/assets/javascripts/components/settings/views/configure_site_notice.jsx
@@ -14,7 +14,14 @@ const ConfigureSiteNotice = (props) => {
   };
 
   const { isOpen, ref, open } = useExpandablePopover(getKey);
-  const form = <SiteNoticeForm handlePopoverClose={open} updateSiteNotice={updateSiteNotice} currentStatus={props.currentSiteNotice.status} />;
+  const form = (
+    <SiteNoticeForm
+      handlePopoverClose={open}
+      updateSiteNotice={updateSiteNotice}
+      currentStatus={props.currentSiteNotice.status}
+      currentSiteNotice={props.currentSiteNotice}
+    />
+  );
 
   const toggleHandler = (e) => {
     e.preventDefault();
@@ -42,6 +49,10 @@ const ConfigureSiteNotice = (props) => {
         is_open={isOpen}
         edit_row={form}
         right
+        styles={{
+          tableLayout: 'fixed',
+          width: 'min(800px, 75vw)',
+        }}
       />
     </div>
   );

--- a/app/assets/javascripts/components/settings/views/site_notice_form.jsx
+++ b/app/assets/javascripts/components/settings/views/site_notice_form.jsx
@@ -1,10 +1,15 @@
-import React, { useState } from 'react';
-import TextInput from '../../common/text_input';
+import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import SiteNoticePreview from './site_notice_preview';
+import TextAreaInput from '../../common/text_area_input';
 
 const SiteNoticeForm = (props) => {
-  const [siteNotice, setSiteNotice] = useState();
+  const [siteNotice, setSiteNotice] = useState(props.currentSiteNotice?.message || '');
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    setSiteNotice(props.currentSiteNotice?.message || '');
+  }, [props.currentSiteNotice]);
 
   const handleChange = (key, value) => {
     setSiteNotice(value);
@@ -20,15 +25,22 @@ const SiteNoticeForm = (props) => {
     <tr>
       <td>
         <form onSubmit={handleSubmit}>
-          <TextInput
+          <TextAreaInput
             id="site_notice"
-            editable
-            onChange={handleChange}
+            editable={true}
             value={siteNotice}
+            onChange={handleChange}
+            placeholder="Enter site notice"
+            autoExpand={true}
+            rows="8"
+            wysiwyg={false}
             value_key="site_notice"
-            type="text"
-            label="Site Notice"
             maxLength="255"
+          />
+
+          <SiteNoticePreview
+            message={siteNotice}
+            enabled={!!props.currentStatus}
           />
           <button className="button border" type="submit" value="Submit">{I18n.t('application.submit')}</button>
         </form>

--- a/app/assets/javascripts/components/settings/views/site_notice_preview.jsx
+++ b/app/assets/javascripts/components/settings/views/site_notice_preview.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const SiteNoticePreview = ({ message, enabled }) => {
+    const hasMessage = !!message && message.trim().length > 0;
+
+    return (
+      <div style={{ marginTop: 10, marginBottom: 10, width: '100%', maxWidth: '100%', boxSizing: 'border-box' }}>
+        <div style={{ fontSize: 12, opacity: 0.8, marginBottom: 6 }}>
+          {I18n.t('settings.common_settings_components.headings.site_notice_preview')}
+        </div>
+
+        {enabled && hasMessage ? (
+          <div
+            style={{
+            border: '1px solid #ddd',
+            padding: '10px 12px',
+            borderRadius: 4,
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            wordBreak: 'break-all',
+            width: '100%',
+            maxWidth: '100%',
+            boxSizing: 'border-box'
+          }}
+          >
+            {message}
+          </div>
+      ) : (
+        <div style={{ fontSize: 12, opacity: 0.7 }}>
+          {!enabled
+            ? 'Preview is hidden because the notice is disabled.'
+            : 'Type a message to see the preview.'}
+        </div>
+      )}
+      </div>
+    );
+};
+
+export default SiteNoticePreview;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1354,6 +1354,7 @@ en:
         course_creation_settings: Course creation
         default_campaign_setting: Default Campaign
         site_notice_setting: Site Notice
+        site_notice_preview: Live Preview
       buttons:
         add_admin_button: Add Admin
         add_special_user_button: Add Special User


### PR DESCRIPTION
## What this PR does
This PR adds a live preview to the Site Notice configuration in /settings to make it easier for admins to create and edit site notices.
Addresses issue: #6646 

## Issue

- The input field was too small to properly view longer notices.
- There was no preview functionality 

## Changes Made
1. Replaced `TextInput `with `TextAreaInput`

- Allows better visibility of longer messages
- Enables auto-expand functionality
- Improves overall user experience when entering site notices
- Supports max length of 255 characters

2. Added `SiteNoticePreview` Component

- Displays a live preview of the site notice message
- Preview updates dynamically as the user types
- Preview is enabled only when the site notice is enabled
- Added break word functionality

3. State Sync Improvement

- Added `useEffect` to sync local state when `currentSiteNotice` changes.

4. Popover
- Set minimum width of popover to `800 px` for desktops and `75vw` for smaller screens

## AI usage
To paraphrase PR

## Screenshots
Before:
<img width="1470" height="245" alt="Screenshot 2026-02-04 at 15 46 46" src="https://github.com/user-attachments/assets/720bc4ae-d49f-412e-bd69-57246ad0ca98" />


After:

<img width="1454" height="261" alt="Screenshot 2026-02-17 at 14 48 42" src="https://github.com/user-attachments/assets/30cb37a4-95d2-41cb-b801-6c1c61479033" />

<img width="1438" height="415" alt="Screenshot 2026-03-03 at 12 29 38" src="https://github.com/user-attachments/assets/a3ed19ac-f861-4615-82b7-1e7ad83873d8" />

<img width="1438" height="333" alt="Screenshot 2026-03-03 at 12 36 15" src="https://github.com/user-attachments/assets/670fba1a-335e-4c84-a81a-fa77b27c99c3" />




