### PR TITLE
Fix: disable sandbox url and update button for userspace page

### DIFF
--- a/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/AssignmentLinks.jsx
@@ -11,7 +11,7 @@ import PeerReviewLink from './PeerReviewLink';
 import AllPeerReviewLinks from './AllPeerReviewLinks';
 import Separator from '@components/overview/my_articles/common/Separator.jsx';
 import ArticleUtils from '../../../utils/article_utils';
-
+import { isUserSandbox } from '@components/overview/my_articles/utils/processAssignments';
 // constants
 import { ASSIGNED_ROLE, REVIEWING_ROLE } from '~/app/assets/javascripts/constants/assignments';
 
@@ -27,7 +27,7 @@ const AssignmentLinks = ({ assignment, courseType, user, course, project, editMo
   const { article_url, id, role, editors } = assignment;
   const actions = [];
 
-  if ((editors && editors.length) || assignment.role === ASSIGNED_ROLE) {
+  if (((editors && editors.length) || assignment.role === ASSIGNED_ROLE) && !isUserSandbox(assignment)) {
     // Exclude sandbox link for 'no_sandboxes' courses for existing articles.
     // New articles will still use sandboxes for drafting in 'no_sandboxes' courses.
     if (!assignment.article_id || !course?.no_sandboxes) {
@@ -53,7 +53,7 @@ const AssignmentLinks = ({ assignment, courseType, user, course, project, editMo
   }
 
   // Only show mainspace article link if the article already exists.
-  if (assignment.article_id) {
+  if (assignment.article_id || isUserSandbox(assignment)) {
     const articleLink = (
       <a key={`article-${id}`} href={article_url} target="_blank">{I18n.t(`assignments.${ArticleUtils.projectSuffix(project, 'article_link')}`)}</a>
     );

--- a/app/assets/javascripts/components/common/AssignmentLinks/SandboxLink.jsx
+++ b/app/assets/javascripts/components/common/AssignmentLinks/SandboxLink.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isUserSandbox } from '@components/overview/my_articles/utils/processAssignments';
 
 export const SandboxLink = ({ assignment, editMode }) => {
   const sandboxExists = assignment.draft_sandbox_status !== 'does_not_exist';
@@ -12,11 +11,6 @@ export const SandboxLink = ({ assignment, editMode }) => {
     if (editMode) { url += '?veaction=edit&preload=Template:Dashboard.wikiedu.org_draft_template'; }
     linkClass += 'redlink';
     mouseoverText = I18n.t('assignments.sandbox_redlink_info');
-  }
-
-  if (isUserSandbox(assignment)) {
-    linkClass += ' disabled-link';
-    mouseoverText = I18n.t('assignments.sandbox_link_disabled_tooltip');
   }
 
   return (

--- a/app/assets/stylesheets/modules/_students.styl
+++ b/app/assets/stylesheets/modules/_students.styl
@@ -4,22 +4,6 @@
 .sandbox-link
   font-size: 80%
 
-.disabled-link,
-.disabled-link:hover,
-.disabled-link:active,
-.disabled-link:focus {
-  cursor: not-allowed;
-  opacity: 0.6;
-  color: #9ca3af;
-  text-decoration: none;
-  border-color: #9ca3af;
-}
-
-.disabled-link:active,
-.disabled-link:focus {
-  pointer-events: none;
-}
-
 .users-control
   text-align right
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,7 +397,6 @@ en:
     review_tooltip_wikidata: This is for item(s) you plan to peer review or provide feedback on.
     sandbox_draft_link: Sandbox Draft
     sandbox_redlink_info: This link is red because the page has not been created yet. (If it was created recently, the Dashboard will update its data soon.)
-    sandbox_link_disabled_tooltip: This link is disabled because this is a user sandbox.
     select: Select
     submit: Submit
     invalid_url: Cannot update sandbox url. The URL %{url} is not a valid Wikipedia URL.


### PR DESCRIPTION
## What this PR does
This PR resolves https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6551 by disabling sandbox url and update button for userspace page.

## AI usage
No AI usage

## Screenshots

https://github.com/user-attachments/assets/8b8b872e-acf2-4bfb-beb2-9fcb985155c4




