### PR TITLE
Implemented a 30-second cache for /requested_accounts.json responses

### DIFF
--- a/app/assets/javascripts/components/nav/notifications_bell.jsx
+++ b/app/assets/javascripts/components/nav/notifications_bell.jsx
@@ -9,6 +9,38 @@ export const shouldSkipNotificationFetch = (pathname) => {
   return SKIP_NOTIFICATION_ROUTES.some(route => pathname.startsWith(route));
 };
 
+// Cache configuration
+const CACHE_KEYS = {
+  REQUESTED_ACCOUNTS: 'notifications_requested_accounts',
+  OPEN_TICKETS: 'notifications_open_tickets',
+  TIMESTAMP: 'notifications_cache_timestamp'
+};
+const CACHE_TTL_MS = 30000; // 30 seconds
+
+// Helper: Check if cache is still valid
+export const isCacheValid = (storage = sessionStorage) => {
+  const timestamp = storage.getItem(CACHE_KEYS.TIMESTAMP);
+  if (!timestamp) return false;
+  return Date.now() - parseInt(timestamp) < CACHE_TTL_MS;
+};
+
+// Helper: Get cached value
+export const getCached = (key, storage = sessionStorage) => {
+  if (!isCacheValid(storage)) return null;
+  const value = storage.getItem(key);
+  if (value === null) return null;
+  return value === 'true';
+};
+
+// Helper: Set cache with timestamp
+export const setCache = (key, value, storage = sessionStorage) => {
+  storage.setItem(key, String(value));
+  storage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now()));
+};
+
+// Export for testing
+export { CACHE_KEYS, CACHE_TTL_MS };
+
 const NotificationsBell = () => {
   const [hasOpenTickets, setHasOpenTickets] = useState(false);
   const [hasRequestedAccounts, setHasRequestedAccounts] = useState(false);
@@ -19,18 +51,40 @@ const NotificationsBell = () => {
       return;
     }
 
+    // Check cache first and use cached values if valid
+    if (isCacheValid()) {
+      const cachedRequestedAccounts = getCached(CACHE_KEYS.REQUESTED_ACCOUNTS);
+      const cachedOpenTickets = getCached(CACHE_KEYS.OPEN_TICKETS);
+
+      if (cachedRequestedAccounts !== null) {
+        setHasRequestedAccounts(cachedRequestedAccounts);
+      }
+      if (cachedOpenTickets !== null) {
+        setHasOpenTickets(cachedOpenTickets);
+      }
+      // Skip API calls since cache is still valid
+      return;
+    }
+
+    // Fetch fresh data and update cache
     const main = document.getElementById('main');
     const userId = main ? main.dataset.userId : null;
     if (Features.wikiEd && userId) {
       request(`/td/open_tickets?owner_id=${userId}`)
         .then(res => res.json())
-        .then(({ open_tickets }) => setHasOpenTickets(open_tickets))
+        .then(({ open_tickets }) => {
+          setHasOpenTickets(open_tickets);
+          setCache(CACHE_KEYS.OPEN_TICKETS, open_tickets);
+        })
         .catch(err => err);
     }
 
     request('/requested_accounts.json')
       .then(res => res.json())
-      .then(({ requested_accounts }) => setHasRequestedAccounts(requested_accounts))
+      .then(({ requested_accounts }) => {
+        setHasRequestedAccounts(requested_accounts);
+        setCache(CACHE_KEYS.REQUESTED_ACCOUNTS, requested_accounts);
+      })
       .catch(err => err); // If this errors, we're going to ignore it
   }, []);
 

--- a/test/components/notifications_bell.spec.js
+++ b/test/components/notifications_bell.spec.js
@@ -1,7 +1,12 @@
 import '../testHelper';
 import {
     SKIP_NOTIFICATION_ROUTES,
-    shouldSkipNotificationFetch
+    shouldSkipNotificationFetch,
+    CACHE_KEYS,
+    CACHE_TTL_MS,
+    isCacheValid,
+    getCached,
+    setCache
 } from '../../app/assets/javascripts/components/nav/notifications_bell';
 
 describe('NotificationsBell', () => {
@@ -91,6 +96,155 @@ describe('NotificationsBell', () => {
             test('/onboarding/step1', () => {
                 expect(shouldSkipNotificationFetch('/onboarding/step1')).toBe(true);
             });
+        });
+    });
+});
+
+describe('NotificationsBell Cache', () => {
+    // Mock sessionStorage
+    let mockStorage;
+
+    beforeEach(() => {
+        mockStorage = {
+            store: {},
+            getItem(key) {
+                return this.store[key] || null;
+            },
+            setItem(key, value) {
+                this.store[key] = value;
+            },
+            removeItem(key) {
+                delete this.store[key];
+            },
+            clear() {
+                this.store = {};
+            }
+        };
+    });
+
+    describe('CACHE_KEYS', () => {
+        test('contains expected keys', () => {
+            expect(CACHE_KEYS.REQUESTED_ACCOUNTS).toBe('notifications_requested_accounts');
+            expect(CACHE_KEYS.OPEN_TICKETS).toBe('notifications_open_tickets');
+            expect(CACHE_KEYS.TIMESTAMP).toBe('notifications_cache_timestamp');
+        });
+    });
+
+    describe('CACHE_TTL_MS', () => {
+        test('is set to 30 seconds', () => {
+            expect(CACHE_TTL_MS).toBe(30000);
+        });
+    });
+
+    describe('isCacheValid', () => {
+        test('returns false when no timestamp exists', () => {
+            expect(isCacheValid(mockStorage)).toBe(false);
+        });
+
+        test('returns true when timestamp is within TTL', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now()));
+            expect(isCacheValid(mockStorage)).toBe(true);
+        });
+
+        test('returns true when timestamp is 10 seconds ago', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now() - 10000));
+            expect(isCacheValid(mockStorage)).toBe(true);
+        });
+
+        test('returns true when timestamp is 29 seconds ago', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now() - 29000));
+            expect(isCacheValid(mockStorage)).toBe(true);
+        });
+
+        test('returns false when timestamp is 31 seconds ago (expired)', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now() - 31000));
+            expect(isCacheValid(mockStorage)).toBe(false);
+        });
+
+        test('returns false when timestamp is 60 seconds ago', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now() - 60000));
+            expect(isCacheValid(mockStorage)).toBe(false);
+        });
+    });
+
+    describe('getCached', () => {
+        test('returns null when cache is not valid', () => {
+            expect(getCached(CACHE_KEYS.REQUESTED_ACCOUNTS, mockStorage)).toBeNull();
+        });
+
+        test('returns null when key does not exist but cache is valid', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now()));
+            expect(getCached(CACHE_KEYS.REQUESTED_ACCOUNTS, mockStorage)).toBeNull();
+        });
+
+        test('returns true when cached value is "true"', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now()));
+            mockStorage.setItem(CACHE_KEYS.REQUESTED_ACCOUNTS, 'true');
+            expect(getCached(CACHE_KEYS.REQUESTED_ACCOUNTS, mockStorage)).toBe(true);
+        });
+
+        test('returns false when cached value is "false"', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now()));
+            mockStorage.setItem(CACHE_KEYS.REQUESTED_ACCOUNTS, 'false');
+            expect(getCached(CACHE_KEYS.REQUESTED_ACCOUNTS, mockStorage)).toBe(false);
+        });
+
+        test('returns null when cache is expired even if value exists', () => {
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now() - 60000));
+            mockStorage.setItem(CACHE_KEYS.REQUESTED_ACCOUNTS, 'true');
+            expect(getCached(CACHE_KEYS.REQUESTED_ACCOUNTS, mockStorage)).toBeNull();
+        });
+    });
+
+    describe('setCache', () => {
+        test('stores value as string', () => {
+            setCache(CACHE_KEYS.REQUESTED_ACCOUNTS, true, mockStorage);
+            expect(mockStorage.getItem(CACHE_KEYS.REQUESTED_ACCOUNTS)).toBe('true');
+        });
+
+        test('stores false value as "false" string', () => {
+            setCache(CACHE_KEYS.REQUESTED_ACCOUNTS, false, mockStorage);
+            expect(mockStorage.getItem(CACHE_KEYS.REQUESTED_ACCOUNTS)).toBe('false');
+        });
+
+        test('updates timestamp when setting cache', () => {
+            const before = Date.now();
+            setCache(CACHE_KEYS.REQUESTED_ACCOUNTS, true, mockStorage);
+            const timestamp = parseInt(mockStorage.getItem(CACHE_KEYS.TIMESTAMP));
+            const after = Date.now();
+            expect(timestamp).toBeGreaterThanOrEqual(before);
+            expect(timestamp).toBeLessThanOrEqual(after);
+        });
+    });
+
+    describe('Performance comparison (before vs after)', () => {
+        test('demonstrates API call savings when cache is valid', () => {
+            // Simulate fresh cache
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now()));
+            mockStorage.setItem(CACHE_KEYS.REQUESTED_ACCOUNTS, 'true');
+
+            // BEFORE: Without caching - always makes API call
+            const beforeApiCalls = 1;
+
+            // AFTER: With caching - skips API call if cache is valid
+            const cacheValid = isCacheValid(mockStorage);
+            const afterApiCalls = cacheValid ? 0 : 1;
+
+            expect(cacheValid).toBe(true);
+            expect(afterApiCalls).toBe(0);
+            expect(beforeApiCalls - afterApiCalls).toBe(1); // Saved 1 API call
+        });
+
+        test('shows API call made when cache is expired', () => {
+            // Simulate expired cache (31 seconds ago)
+            mockStorage.setItem(CACHE_KEYS.TIMESTAMP, String(Date.now() - 31000));
+            mockStorage.setItem(CACHE_KEYS.REQUESTED_ACCOUNTS, 'true');
+
+            const cacheValid = isCacheValid(mockStorage);
+            const apiCalls = cacheValid ? 0 : 1;
+
+            expect(cacheValid).toBe(false);
+            expect(apiCalls).toBe(1); // Fresh data fetched as expected
         });
     });
 });


### PR DESCRIPTION
## What this PR does
Implements a caching mechanism for notification API calls to prevent redundant requests when users switch tabs or navigate the dashboard rapidly.
Solves the 2nd part of #6351 

**Key Changes:**
- Integrated `sessionStorage` caching for `/requested_accounts.json` and `/td/open_tickets` responses.
- Added a **30-second Time-To-Live (TTL)** for the cache to ensure data stays relatively fresh while preventing "request storms" during rapid navigation.
- Added helper functions (`isCacheValid`, `getCached`, `setCache`) for robust cache management.

This optimization significantly reduces the number of duplicate API calls made by the `NotificationsBell` component, leading to a smoother user experience and reduced backend load.

## AI usage
I used AI for:
- Writing unit tests to verify cache expiration and retrieval logic.

Video demonstrating in 30-second interval, there is no duplicate api call for notifications:
[Screencast from 2026-02-10 02-26-41.webm](https://github.com/user-attachments/assets/b32a9db0-7143-4083-a531-6c5cb34b831b)
