### PR TITLE
Fix new_editors CSV column for course stats

### DIFF
--- a/lib/analytics/course_csv_builder.rb
+++ b/lib/analytics/course_csv_builder.rb
@@ -97,7 +97,8 @@ class CourseCsvBuilder
 
   def new_editors
     # A user counts as a new editor if they registered during the course.
-    @course.students.where(registered_at: @course.start..@course.end)
+    # Return the count rather than the relation so CSV displays a number.
+    @course.students.where(registered_at: @course.start..@course.end).count
   end
 
   def revisions_by_namespace(namespace)


### PR DESCRIPTION
**What i did in this  PR**  fixes #6672

i fix the `new_editors` column in course overview / campaign “course data” CSVs so it outputs a numeric count instead of the `#<User::ActiveRecord_AssociationRelation...>` string in course_csv_builder.rb file.

 **AI usage**
I used an AI coding assistant to:
- Locate the CSV builder logic.
- Help with local testing instructions Rails console and Docker 

i reviewed all code changes and tested locally via the Rails console.

## Screenshots
Before:
- 
<img width="1437" height="339" alt="Screenshot 2026-02-12 at 10 15 52" src="https://github.com/user-attachments/assets/56accf70-3bc3-412a-956e-77ac80ef2100" />



After:
- <img width="1440" height="361" alt="Screenshot 2026-02-12 at 10 20 09" src="https://github.com/user-attachments/assets/fef38834-68c0-464e-b6f8-f743996daeba" />


## Open questions and concerns
- None at this time. If there are other CSVs that rely on relations in a similar way, I’m happy to extend this fix in a follow-up PR.