### PR TITLE
Refactor serialization syntax across multiple models 

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -28,7 +28,7 @@ class Alert < ApplicationRecord
 
   include ArticleHelper
 
-  serialize :details, Hash
+  serialize :details, type: Hash
 
   ALERT_TYPES = %w[
     ActiveCourseAlert

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -34,7 +34,7 @@ class ArticleCourseTimeslice < ApplicationRecord
     in_period(period_start, period_end).or(for_datetime(period_start)).or(for_datetime(period_end))
   }
 
-  serialize :user_ids, Array # This text field only stores user ids as text
+  serialize :user_ids, type: Array # This text field only stores user ids as text
 
   #################
   # Class methods #

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -120,7 +120,7 @@ class Course < ApplicationRecord
     distinct.sandbox
   }, source: :article, through: :article_course_timeslices
 
-  serialize :flags, Hash
+  serialize :flags, type: Hash
 
   module ClonedStatus
     NOT_A_CLONE = 0

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -38,7 +38,7 @@ class ArticlesCourses < ApplicationRecord
   scope :tracked, -> { where(tracked: true).distinct }
   scope :not_tracked, -> { where(tracked: false).distinct }
 
-  serialize :user_ids, Array # This text field only stores user ids as text
+  serialize :user_ids, type: Array # This text field only stores user ids as text
 
   ####################
   # Instance methods #

--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -47,7 +47,7 @@ class Assignment < ApplicationRecord
   before_validation :set_defaults_and_normalize
   before_save :set_sandbox_url
 
-  serialize :flags, Hash
+  serialize :flags, type: Hash
 
   delegate :status, to: :assignment_pipeline
   delegate :update_status, to: :assignment_pipeline

--- a/app/models/course_data/block.rb
+++ b/app/models/course_data/block.rb
@@ -22,7 +22,7 @@ require_dependency "#{Rails.root}/lib/block_date_manager"
 class Block < ApplicationRecord
   belongs_to :week
   has_one :course, through: :week
-  serialize :training_module_ids, Array
+  serialize :training_module_ids, type: Array
   default_scope { includes(:week, :course) }
 
   KINDS = {

--- a/app/models/course_data/course_stat.rb
+++ b/app/models/course_data/course_stat.rb
@@ -12,5 +12,5 @@
 
 class CourseStat < ApplicationRecord
   belongs_to :course
-  serialize :stats_hash, Hash
+  serialize :stats_hash, type: Hash
 end

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -33,7 +33,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
     in_period(period_start, period_end).or(for_datetime(period_start)).or(for_datetime(period_end))
   }
 
-  serialize :user_ids, Array # This text field only stores user ids as text
+  serialize :user_ids, type: Array # This text field only stores user ids as text
 
   #################
   # Class methods #

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -22,7 +22,7 @@ class CourseWikiTimeslice < ApplicationRecord
   belongs_to :course
   belongs_to :wiki
 
-  serialize :stats, Hash
+  serialize :stats, type: Hash
 
   scope :for_course_and_wiki, ->(course, wiki) { where(course:, wiki:) }
   # Returns the timeslice to which a datetime belongs (it should be a single timeslice)

--- a/app/models/revision_ai_score.rb
+++ b/app/models/revision_ai_score.rb
@@ -23,5 +23,5 @@ class RevisionAiScore < ApplicationRecord
   belongs_to :course
   belongs_to :user
 
-  serialize :details, Hash
+  serialize :details, type: Hash
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -12,7 +12,7 @@
 
 #= Generic store of global settings, with a key mapping to a hash of associated data.
 class Setting < ApplicationRecord
-  serialize :value, Hash
+  serialize :value, type: Hash
   def self.set_hash(property, key, value)
     setting = find_or_create_by(key: property)
     setting.value = (setting.value || {}).merge(key => value)

--- a/app/models/surveys/survey_assignment.rb
+++ b/app/models/surveys/survey_assignment.rb
@@ -42,7 +42,7 @@ class SurveyAssignment < ApplicationRecord
   ###########################
   # Custom email attributes #
   ###########################
-  serialize :custom_email, Hash
+  serialize :custom_email, type: Hash
 
   def custom_email_subject
     custom_email[:subject]

--- a/app/models/training_library.rb
+++ b/app/models/training_library.rb
@@ -19,8 +19,8 @@ require_dependency "#{Rails.root}/lib/training/training_base"
 
 #= Class representing an individual training module
 class TrainingLibrary < ApplicationRecord
-  serialize :categories, Array
-  serialize :translations, Hash
+  serialize :categories, type: Array
+  serialize :translations, type: Hash
 
   validates_uniqueness_of :slug, case_sensitive: false
 

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -23,9 +23,9 @@ require_dependency "#{Rails.root}/lib/training/training_base"
 class TrainingModule < ApplicationRecord
   attr_accessor :status
 
-  serialize :slide_slugs, Array
-  serialize :translations, Hash
-  serialize :settings, Hash
+  serialize :slide_slugs, type: Array
+  serialize :translations, type: Hash
+  serialize :settings, type: Hash
 
   validates_uniqueness_of :slug, case_sensitive: false
 

--- a/app/models/training_slide.rb
+++ b/app/models/training_slide.rb
@@ -22,8 +22,8 @@ require_dependency "#{Rails.root}/lib/training/training_base"
 #= Class representing an individual training slide
 class TrainingSlide < ApplicationRecord
   validates_presence_of :id, :slug, :title
-  serialize :assessment, Hash
-  serialize :translations, Hash
+  serialize :assessment, type: Hash
+  serialize :translations, type: Hash
 
   #################
   # Class Methods #

--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -18,7 +18,7 @@ class TrainingModulesUsers < ApplicationRecord
   belongs_to :user
   belongs_to :training_module
 
-  serialize :flags, Hash
+  serialize :flags, type: Hash
 
   def furthest_slide?(slide_slug)
     return true if last_slide_completed.nil?

--- a/app/models/user_data/user_profile.rb
+++ b/app/models/user_data/user_profile.rb
@@ -20,7 +20,7 @@ class UserProfile < ApplicationRecord
   belongs_to :user
   has_attached_file :image, styles: { thumb: '150x150>' }
   validates_attachment_content_type :image, content_type: %r{\Aimage/.*\z}
-  serialize :email_preferences, Hash
+  serialize :email_preferences, type: Hash
 
   def email_preferences_token
     set_email_preferences_token unless email_preferences.key?(:token)

--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -26,7 +26,7 @@ class Category < ApplicationRecord
   has_many :categories_courses, class_name: 'CategoriesCourses', dependent: :destroy
   has_many :courses, through: :categories_courses
 
-  serialize :article_titles, Array
+  serialize :article_titles, type: Array
 
   validates :name, presence: true, length: { minimum: 1 }
   validates :name, numericality: { only_integer: true }, on: :create,

--- a/app/models/wiki_content/revision.rb
+++ b/app/models/wiki_content/revision.rb
@@ -36,6 +36,6 @@ class Revision < ApplicationRecord
   validates :mw_page_id, presence: true
   validates :mw_rev_id, presence: true
 
-  serialize :features, Hash
-  serialize :features_previous, Hash
+  serialize :features, type: Hash
+  serialize :features_previous, type: Hash
 end

--- a/config/initializers/surveys.rb
+++ b/config/initializers/surveys.rb
@@ -124,7 +124,7 @@ Rails.application.config.to_prepare do
   Rapidfire::Question.class_eval do
     has_paper_trail
     scope :course_data_questions, ->{where("course_data_type <> ''")}
-    serialize :alert_conditions, Hash
+    serialize :alert_conditions, type: Hash
 
     def self.for_conditionals(question_id)
       where.not(id: question_id).where("conditionals IS NULL OR conditionals = ''")

--- a/config/initializers/ticket_dispenser.rb
+++ b/config/initializers/ticket_dispenser.rb
@@ -21,6 +21,9 @@ Rails.application.config.to_prepare do
   end
 
   TicketDispenser::Message.class_eval do
+    # Fix Rails 7.2 serialize syntax for TicketDispenser gem
+    serialize :details, type: Hash
+
     def serialized_sender
       return {} if sender.nil?
       {


### PR DESCRIPTION
## What this PR does

This PR updates all `serialize` method calls throughout the codebase to use the new Rails 7.2 syntax. In Rails 7.2, the `serialize` method signature changed, requiring the use of the `type:` keyword argument instead of passing Hash or Array as a positional argument.

### Changes Made:

- Updated 20+ `serialize` calls across models and initializers from the old syntax (`serialize :attribute, Hash`) to the new syntax (`serialize :attribute, type: Hash`)
- This includes updates to:
  - Model files in `app/models/` (including subdirectories like `course_data/`, `user_data/`, `wiki_content/`)
  - Initializer files in `config/initializers/` (surveys.rb and ticket_dispenser.rb)

### Files Modified:

**Models:**
- `app/models/alert.rb`
- `app/models/article_course_timeslice.rb`
- `app/models/course.rb`
- `app/models/course_data/assignment.rb`
- `app/models/course_data/articles_courses.rb`
- `app/models/course_data/block.rb`
- `app/models/course_data/course_stat.rb`
- `app/models/course_user_wiki_timeslice.rb`
- `app/models/course_wiki_timeslice.rb`
- `app/models/revision_ai_score.rb`
- `app/models/setting.rb`
- `app/models/surveys/survey_assignment.rb`
- `app/models/training_library.rb`
- `app/models/training_module.rb`
- `app/models/training_slide.rb`
- `app/models/user_data/training_modules_users.rb`
- `app/models/user_data/user_profile.rb`
- `app/models/wiki_content/category.rb`
- `app/models/wiki_content/revision.rb`

**Initializers:**
- `config/initializers/surveys.rb`
- `config/initializers/ticket_dispenser.rb`

### Syntax Changes:

**Before (Rails 7.0 and earlier):**
```ruby
serialize :details, Hash
serialize :user_ids, Array
```

**After (Rails 7.2):**
```ruby
serialize :details, type: Hash
serialize :user_ids, type: Array
```

## Why these changes were made

Rails 7.2 introduced breaking changes to the `serialize` method API. The old syntax where Hash or Array could be passed as a positional second argument is no longer supported. The new API requires using the `type:` keyword argument to specify the serialization type.

This change ensures compatibility with Rails 7.2 and prevents `ArgumentError: wrong number of arguments` errors when the application runs.

## AI usage

I used Cursor AI (Claude Sonnet 4.5) to:
- Identify all `serialize` calls in the codebase that needed updating
- Understand the Rails 7.2 `serialize` API changes and correct syntax
- Update all occurrences systematically across models and initializers
- Verify the changes were applied correctly

The AI helped me understand:
- The breaking change in Rails 7.2's `serialize` method signature
- The difference between the old positional argument syntax and the new keyword argument syntax
- How to systematically find and update all occurrences

## Screenshots

Before:
N/A - These are backend code changes with no UI impact.

After:
N/A - These are backend code changes with no UI impact.



