### PR TITLE
Update cache store configuration and upgrade cache format version 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,10 @@ module WikiEduDashboard
     config.exceptions_app = self.routes
 
     # Rails cache with Dalli/memcached
-    config.cache_store = :mem_cache_store, 'localhost', { pool_size: 5, expires_in: 7.days, compress: false, value_max_bytes: 1024 * 1024 * 4 }
+    config.cache_store = :mem_cache_store, 'localhost', { pool: { size: 5 }, expires_in: 7.days, compress: false, value_max_bytes: 1024 * 1024 * 4 }
+    
+    # Upgrade cache format version from deprecated 6.1 to 7.1
+    config.active_support.cache_format_version = 7.1
 
     # Handle YAML safe loading of serialized Ruby objects
     config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal, DateTime, Date, Time, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone]


### PR DESCRIPTION
### What this PR does

This PR updates `config/application.rb` to resolve Rails 7.2 deprecation warnings related to cache store configuration and cache format version.

### Changes Made:

1. **Cache Store Pool Configuration**: Updated the `pool_size` parameter to use the new `pool: { size: }` syntax
   - **Before**: `pool_size: 5`
   - **After**: `pool: { size: 5 }`

2. **Cache Format Version**: Upgraded the cache format version from the deprecated 6.1 to 7.1
   - Added: `config.active_support.cache_format_version = 7.1`

### Files Modified:

- `config/application.rb`

### Specific Changes:

**Line 57** - Cache store configuration:
```ruby
# Before:
config.cache_store = :mem_cache_store, 'localhost', { pool_size: 5, expires_in: 7.days, compress: false, value_max_bytes: 1024 * 1024 * 4 }

# After:
config.cache_store = :mem_cache_store, 'localhost', { pool: { size: 5 }, expires_in: 7.days, compress: false, value_max_bytes: 1024 * 1024 * 4 }
```

**Lines 59-60** - Cache format version:
```ruby
# Added:
# Upgrade cache format version from deprecated 6.1 to 7.1
config.active_support.cache_format_version = 7.1
```

## Why these changes were made

Rails 7.2 introduced breaking changes that require updates to cache configuration:

1. **`pool_size` deprecation**: The `pool_size` parameter in cache store configuration is deprecated in favor of the nested `pool: { size: }` syntax. This change is required for Rails 7.2 compatibility and will be removed in Rails 7.2.

2. **Cache format version deprecation**: Rails 7.1 defaulted to cache format version 6.1, which is deprecated. Rails 7.2 requires upgrading to format version 7.1. This ensures compatibility with the new cache serialization format and prevents deprecation warnings.

These changes ensure the application is compatible with Rails 7.2 and eliminates deprecation warnings related to cache configuration.

## AI usage

I used Cursor AI (Claude Sonnet 4.5) to:
- Identify the deprecation warnings in the test output
- Understand the Rails 7.2 API changes for cache store configuration
- Determine the correct syntax for `pool` configuration
- Research the correct cache format version for Rails 7.2 compatibility

The AI helped me understand:
- The deprecation of `pool_size` in favor of `pool: { size: }` syntax
- The requirement to explicitly set `cache_format_version` to 7.1 for Rails 7.2


## Screenshots

Before:
N/A - These are backend configuration changes with no UI impact.

After:
N/A - These are backend configuration changes with no UI impact.



