### PR TITLE
[Backup]: automatically remove oldest backup

### DIFF
--- a/config/backup/backup.sh
+++ b/config/backup/backup.sh
@@ -85,3 +85,12 @@ mariadb-dump --single-transaction --routines --databases dashboard | gzip > $BAC
 log "Finishing"
 # Update running backup record to 'finished'
 mysql < $QUERY_ROUTE/finished.sql
+
+# Remove oldest backup if there are more than three
+MIN_BACKUPS_NUMBER=3
+CURRENT_BACKUPS_NUMBER=$(ls -1d "$BACKUP_ROUTE"/*/ | wc -l)
+if [ $CURRENT_BACKUPS_NUMBER -gt $MIN_BACKUPS_NUMBER ]; then
+  OLDEST_BACKUP=$(ls -1d "$BACKUP_ROUTE"/*/ | sort | head -1)
+  log "Removing $OLDEST_BACKUP"
+  rm -r $OLDEST_BACKUP
+fi


### PR DESCRIPTION
## What this PR does
This PR is the last step for issue #6579: updates the `backup.sh` script to automatically remove the oldest backup after the new one was created if there are more than three backups.

Closes #6579

### Notes
In peony server, we currently have 4 backups:
- 2026-01-28-00:00:00 
- 2026-02-04-22:10:01 
- 2026-02-08-20:00:01
- 2026-02-15-20:00:01

In wiki edu server, we also have 4 backups:
- 2026-01-30-17:53:22
- 2026-02-04-21:45:01
- 2026-02-08-20:00:01
- 2026-02-15-20:00:01

If we add automatic removal to the script, then the next time the cron job runs, only the oldest backup will be removed and we will keep four backups per server. I would wait until we had something like 10 backups before adding this to the script. That way, we would always have backups from two months ago. Compressed backups don't take up much space, so having 10 is totally feasible (about 15 GB in total).

No sanity check is performed on the newly created backup, so it is possible that we remove a valid older backup even if the new one is corrupted. However, this would be an unusual scenario. If something goes wrong during backup creation, the process exits immediately. Therefore, if a backup is removed, it means the script completed without errors.

## AI usage
No AI usage.

## Open questions and concerns
Originally, the issue says:
> Automatically curate a set of database dumps (eg, keep one that is about 6 months old, one that is about a month old, and one that is at most a week old) to keep, and delete old ones as new ones get created.

That requirement is not satisfied with this approach, since the implemented logic is considerable simpler than that.

## TODO
Add documentation