### PR TITLE
Improve layout of subject-specific guides block in Timeline

### DIFF
--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -569,10 +569,12 @@ a.training-module
 
 a.handout-link
   margin-right 8px
+  margin-bottom 8px
   color #6a6a6a
   border solid 1px #ddd
   border-radius 3px
   text-decoration none
   padding 5px
+  display inline-block
   &:hover, &:focus
     border solid 1px $brand_primary

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -177,9 +177,7 @@ class WizardTimelineManager
     link_text = HANDOUTS[logic_key][0]
     url = HANDOUTS[logic_key][1]
     <<~LINK
-      <p>
-        <a class="handout-link" href="#{url}" target="_blank">#{link_text}</a>
-      </p>
+      <a class="handout-link" href="#{url}" target="_blank">#{link_text}</a>
     LINK
   end
 


### PR DESCRIPTION
### **What this PR does?**

- Remove "< p >" wrapper from handout links in wizard_timeline_manager.rb
- Add margin-bottom and display inline-block to a.handout-link in _timeline.styl

Fixes #5707

### **Note:**
This works only for the new courses. 


### **Screenshots:**

**Before:**
![before](https://github.com/user-attachments/assets/c0d976af-18b5-4490-9e35-7cad8c8aa21d)


**After:**
![after](https://github.com/user-attachments/assets/2bfb8ed8-34b6-42c9-a7cd-ba94139b6515)


