### PR TITLE
Fix activity after end date

### DIFF
--- a/app/assets/javascripts/utils/mediawiki_revisions_utils.js
+++ b/app/assets/javascripts/utils/mediawiki_revisions_utils.js
@@ -51,19 +51,19 @@ export const fetchRevisionsFromUsers = async (course, users, days, last_date, fi
   const usernames = users.map(user => user.username);
   const registered_dates = users.map(user => user.registered_at);
 
-  // setting last_date to course end + 7 days if its present after that
+  // setting last_date to course end + 7 days if it's present after that
   const courseEndBuffer = addDays(toDate(course.end), 7);
   if (isAfter(toDate(last_date), courseEndBuffer)) {
     last_date = formatISO(courseEndBuffer);
   }
 
   let revisions = [];
-  const wikiPromises = [];
 
   // request until we find 50 revisions or the date is outside the course duration
   // the last we fetch is up until 5 years ago
   let keepRunning = true;
   while (revisions.length < 50 && keepRunning) {
+    const wikiPromises = [];
     for (const wiki of course.wikis) {
       wikiPromises.push(fetchRevisionsFromWiki(days, wiki, usernames, course.start, course.end, last_date));
     }


### PR DESCRIPTION


## What this PR does
- Add course end date + 7 day buffer check in fetchRevisionsFromUsers, by introducing a conditional statement. Assigning last_date to course_end date + 7 days buffer for recenet acitivities.
- Add early exit in fetchAllRevisions when past course end buffer
- Pass course_end parameter through the revision fetching chain
- Prevents unnecessary MediaWiki API calls for completed courses

Fixes #6689"

## AI usage
-Understanding the function of "fetchAllRevisions" function in the mediawiki_revisions_utils.js
-Fixing the errors after adding the required changes(conditional statements and adding parameters)

## Screenshots
Before:
![Image 22-02-26 at 7 50 PM](https://github.com/user-attachments/assets/2c883d05-1c14-4662-b0e1-6149957204e6)

After:
![2018](https://github.com/user-attachments/assets/100e5d52-44b5-4e7b-96aa-cb0d8b2c70f8)
