### PR TITLE
Fix error when initializing WikiApi with a wrong keyword argument

### DIFF
--- a/lib/importers/category_importer.rb
+++ b/lib/importers/category_importer.rb
@@ -47,7 +47,7 @@ class CategoryImporter
     pages = []
     continue = true
     until continue.nil?
-      cat_response = WikiApi.new(@wiki, update_service: @update_service).query query
+      cat_response = WikiApi.new(@wiki, @update_service).query query
       pages_batch = cat_response.data['categorymembers']
       pages += pages_batch
       continue = cat_response['continue']

--- a/lib/importers/transclusion_importer.rb
+++ b/lib/importers/transclusion_importer.rb
@@ -19,7 +19,7 @@ class TransclusionImporter
   private
 
   def all_transcluded_pages
-    wiki_api = WikiApi.new(@wiki, update_service: @update_service)
+    wiki_api = WikiApi.new(@wiki, @update_service)
     @query = transclusion_query
     @transcluded_in = []
     until @continue == 'done'


### PR DESCRIPTION
## What this PR does
`WikiApi.new` takes two positional arguments: `wiki` and `update_service`.

```
class WikiApi

  def initialize(wiki = nil, update_service = nil)
    wiki ||= Wiki.default_wiki
    @api_url = wiki.api_url
    @update_service = update_service
  end
```

This PR updates `WikiApi.new` calls to ensure we're sending `update_service` argument as a positional one.

See [Sentry issue](https://wiki-education.sentry.io/issues/7291472719/?project=6269916&query=is%3Aunresolved&referrer=issue-stream) related to erroneously sending `update_service` as  a keyword argument:

```
NoMethodError
undefined method `update_error_stats' for {:update_service=>nil}:Hash

      update_service.update_error_stats(new_errors_count)
```

## AI usage
No AI usage

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
