### PR TITLE
hamburger menu disappearance fix

### DIFF
--- a/app/assets/javascripts/components/common/list.jsx
+++ b/app/assets/javascripts/components/common/list.jsx
@@ -137,9 +137,9 @@ const List = ({
     );
   }
   let fixedHeader;
-  let fixedArea;
+  let fixedArea = 'table-responsive';
   if (stickyHeader) {
-    fixedArea = 'persist-area';
+    fixedArea += ' persist-area';
     const fixheader = fixHeader === true ? 'floatingHeader' : '';
     fixedHeader = 'persist-header';
     fixedHeader += ` ${fixheader}`;

--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -196,6 +196,11 @@
   +below(tablet)
     width max-content
 
+.table-responsive
+  display block
+  overflow-x auto
+  -webkit-overflow-scrolling touch
+
 .revision-list-container
   +below(tablet)
     overflow-y: scroll

--- a/app/views/campaigns/articles.html.haml
+++ b/app/views/campaigns/articles.html.haml
@@ -25,7 +25,7 @@
           %option{rel: 'asc', value: 'course_title'}
             = t("#{@presenter.course_string_prefix}.courses")
 
-    %table.table.table--hoverable.table--sortable
+    %table.table.table--hoverable.table--sortable.table-responsive
       %thead
         %tr
           %th.sort.sortable{'data-default-order' => 'asc', 'data-sort' => 'title'}

--- a/app/views/campaigns/programs.html.haml
+++ b/app/views/campaigns/programs.html.haml
@@ -33,7 +33,7 @@
           %option{rel: 'asc', value: 'start-date'}
             = t("courses.start_date")
 
-    %table.table.table--hoverable.table--sortable
+    %table.table.table--hoverable.table--sortable.table-responsive
       %thead
         %tr
           %th.sort.sortable{'data-default-order' => 'asc', 'data-sort' => 'title'}


### PR DESCRIPTION
This PR resolves an issue where the mobile hamburger menu disappears on certain campaign tabs (`Courses/Programs` and `Articles`). Instead of the mobile menu, the desktop navigation links are squeezed into the header, causing layout overlapping.

Closes #6714

## Screenshots

### (i) Outreach Dashboard

#### 1. Before (Program Page)

| | |
|---|---|
| <img src="https://github.com/user-attachments/assets/6a1b48cf-656c-4568-b8d6-fd69b7ed26e4" width="300"> | <img src="https://github.com/user-attachments/assets/e11c8a36-c0c8-490a-bdfc-8dab40d6645d" width="300"> |

#### 2. Article Page

| Before | After Fix |
|---|---|
| <img src="https://github.com/user-attachments/assets/aaf2892e-d8af-415c-82d3-d34d799714ca" width="300"> | <img src="https://github.com/user-attachments/assets/b9d27514-f4d8-44d9-89c9-fd6069e949b9" width="300"> |

### (ii) Wiki Dashboard

#### 3. Before (Courses Tab)

| Before | After Fix |
|---|---|
| <img width="332" height="736" alt="Screenshot 2026-03-12 at 8 35 52 PM" src="https://github.com/user-attachments/assets/89413c76-43fd-4296-867a-419747905cc9" /> | <img src="https://github.com/user-attachments/assets/ee781ab6-a564-471b-87e5-d79785a871d1" width="300"> |




@ragesoss please review it