### PR TITLE
Fix AI stats graphs

### DIFF
--- a/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_graph.jsx
+++ b/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_graph.jsx
@@ -162,7 +162,7 @@ const ScoresTrendsGraph = (props) => {
   });
 
   // Calculate number of days in the period
-  const days = props.statsData.map(s => new Date(s.created_at).getTime());
+  const days = [...new Set(props.statsData.map(s => new Date(s.created_at).getTime()))];
   const minDay = Math.min(...days);
   const maxDay = Math.max(...days);
   const numberOfdays = Math.round((maxDay - minDay) / (1000 * 60 * 60 * 24));

--- a/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_in_bins_graph.jsx
+++ b/app/assets/javascripts/components/revision_ai_scores/graphs/scores_trends_in_bins_graph.jsx
@@ -210,7 +210,7 @@ const ScoresTrendsInBinsGraph = (props) => {
   const legendLabels = Array.from({ length: bins }, (_, i) => i).map(e => formatLabel(e));
 
   // Calculate number of days in the period
-  const days = props.statsData.map(s => new Date(s.created_at).getTime());
+  const days = [...new Set(props.statsData.map(s => new Date(s.created_at).getTime()))];
   const minDay = Math.min(...days);
   const maxDay = Math.max(...days);
   const numberOfdays = Math.round((maxDay - minDay) / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
## What this PR does
Closes #6712

This PR fixes the graphs in `/revision_ai_scores_stats` that fails with:
```
instrument.js:109 RangeError: Maximum call stack size exceeded
    at d (scores_trends_graph.jsx:166:18)
    at _a (react-dom.production.min.js:167:137)
    at wu (react-dom.production.min.js:290:337)
    at gl (react-dom.production.min.js:280:389)
    at hl (react-dom.production.min.js:280:320)
    at pl (react-dom.production.min.js:280:180)
    at rl (react-dom.production.min.js:271:88)
    at tl (react-dom.production.min.js:268:429)
    at x (scheduler.production.min.js:13:203)
    at D (scheduler.production.min.js:14:128)
    at O.<computed> (task.js:61:7)
    at T (task.js:35:5)
    at MessagePort.D (task.js:46:3)
(anonymous) @ instrument.js:109
instrument.js:109 RangeError: Maximum call stack size exceeded
    at h (scores_trends_in_bins_graph.jsx:214:18)
    at _a (react-dom.production.min.js:167:137)
    at wu (react-dom.production.min.js:290:337)
    at gl (react-dom.production.min.js:280:389)
    at hl (react-dom.production.min.js:280:320)
    at pl (react-dom.production.min.js:280:180)
    at rl (react-dom.production.min.js:271:88)
    at tl (react-dom.production.min.js:268:429)
    at x (scheduler.production.min.js:13:203)
    at D (scheduler.production.min.js:14:128)
    at O.<computed> (task.js:61:7)
    at T (task.js:35:5)
    at MessagePort.D (task.js:46:3)
(anonymous) @ instrument.js:109
instrument.js:109 RangeError: Maximum call stack size exceeded
    at h (scores_trends_in_bins_graph.jsx:214:18)
    at _a (react-dom.production.min.js:167:137)
    at wu (react-dom.production.min.js:290:337)
    at gl (react-dom.production.min.js:280:389)
    at hl (react-dom.production.min.js:280:320)
    at pl (react-dom.production.min.js:280:180)
    at rl (react-dom.production.min.js:271:88)
    at tl (react-dom.production.min.js:268:429)
    at x (scheduler.production.min.js:13:203)
    at D (scheduler.production.min.js:14:128)
    at O.<computed> (task.js:61:7)
    at T (task.js:35:5)
    at MessagePort.D (task.js:46:3)
(anonymous) @ instrument.js:109
react-dom.production.min.js:283 Uncaught RangeError: Maximum call stack size exceeded
    at d (scores_trends_graph.jsx:166:18)
    at _a (react-dom.production.min.js:167:137)
    at wu (react-dom.production.min.js:290:337)
    at gl (react-dom.production.min.js:280:389)
    at hl (react-dom.production.min.js:280:320)
    at pl (react-dom.production.min.js:280:180)
    at rl (react-dom.production.min.js:271:88)
    at tl (react-dom.production.min.js:268:429)
    at x (scheduler.production.min.js:13:203)
    at D (scheduler.production.min.js:14:128)
    at O.<computed> (task.js:61:7)
    at T (task.js:35:5)
    at MessagePort.D (task.js:46:3)
```

The error lines point to:
scores_trends_in_bins_graph.jsx:214:   `const minDay = Math.min(...days);`
scores_trends_graph.jsx:166: `const minDay = Math.min(...days);`

While the error doesn’t occur naturally in my local environment, I printed `days` and noticed that it has 8,118 elements with many duplicate values. When I replaced the `days` definition with one that keeps only unique values, it printed only 123 values.

## AI usage
No AI usage.

## Screenshots
Before: (forcing the days array to be huge)
<img width="1088" height="654" alt="Screenshot from 2026-03-09 11-05-40" src="https://github.com/user-attachments/assets/dc99b33e-1403-4195-9a99-8425ad0e9c7f" />

After: (using unique version of the huge array)
<img width="1554" height="1003" alt="image" src="https://github.com/user-attachments/assets/d2da6f2f-2b8f-4ff2-a45e-07ec7f073cc9" />

## Open questions and concerns
At some point we may need to apply a period cutoff to show only data from the most recent period (for example, the last three months). But even with that strategy, I think the first step is to avoid duplicates.