### PR TITLE
Fix: Article development plot (ArticleGraphs) is empty in timeslice system

### DIFF
--- a/app/assets/javascripts/components/articles/article.jsx
+++ b/app/assets/javascripts/components/articles/article.jsx
@@ -7,6 +7,7 @@ import DiffViewer from '../revisions/diff_viewer.jsx';
 import Switch from 'react-switch';
 import { toWikiDomain } from '../../utils/wiki_utils.js';
 import { stringify } from 'query-string';
+import ArticleGraphs from './article_graphs.jsx';
 
 const Article = ({ article, index, course, fetchArticleDetails, updateArticleTrackedStatus, articleDetails, wikidataLabel,
   showOnMount, setSelectedIndex, lastIndex, selectedIndex, pageLogsMessage, deletedMessage, current_user }) => {
@@ -94,9 +95,7 @@ const Article = ({ article, index, course, fetchArticleDetails, updateArticleTra
           {!isDeleted
             ? (
               <small>
-                {/* Disabling article development plot feature until re-implementing. See issue #6337 */}
-                {/* <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a> | <ArticleGraphs article={article} /> */}
-                <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a>
+                <a href={historyUrl} target="_blank" className="inline">{I18n.t('articles.history')}</a> | <ArticleGraphs article={article} course_id={course.id}/>
               </small>
             )
             : (

--- a/app/assets/javascripts/components/articles/article_graphs.jsx
+++ b/app/assets/javascripts/components/articles/article_graphs.jsx
@@ -4,7 +4,7 @@ import EditSizeGraph from './edit_size_graph.jsx';
 import Loading from '../common/loading.jsx';
 import request from '../../utils/request.js';
 
-const ArticleGraphs = ({ article }) => {
+const ArticleGraphs = ({ article, course_id }) => {
   const { id: article_id } = article;
 
   const [showGraph, setShowGraph] = useState(false);
@@ -39,7 +39,7 @@ const ArticleGraphs = ({ article }) => {
     if (articleData) {
       return;
     }
-    const articledataUrl = `/articles/article_data.json?article_id=${article_id}`;
+    const articledataUrl = `/articles/${article_id}/revision_score?course_id=${course_id}`;
     request(articledataUrl)
       .then(resp => resp.json())
       .then((data) => {

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
+require_dependency "#{Rails.root}/lib/revision_score_manager"
 
 class ArticlesController < ApplicationController
   respond_to :json
-  before_action :set_course, except: :article_data
+  before_action :set_course
 
   # returns revision score data for vega graphs
-  def article_data
+  #  { rev_id: 123, characters: 1000, wp10: 0.5, date: '2021-01-01', username: 'Example' }
+  def revision_score
     @article = Article.find(params[:article_id])
+    rev_manager = RevisionScoreManager.new(@article, @course)
+    enrolled_usernames = @course.users.pluck(:username)
+    # root: false prevents wrap_parameters from wrapping the array under the
+    # controller name ("articles"), which would leak into the response.
+    render json: rev_manager.fetch_scored_revisions(enrolled_usernames), root: false
   end
 
   # returns details about how an article changed during a course
@@ -28,4 +35,5 @@ class ArticlesController < ApplicationController
   def set_course
     @course = Course.find(params[:course_id])
   end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -246,7 +246,7 @@ Rails.application.routes.draw do
   post 'courses/:course_id/disable_timeline' => 'timeline#disable_timeline',
        constraints: { course_id: /.*/ }
 
-  get 'articles/article_data' => 'articles#article_data'
+  get 'articles/:article_id/revision_score' => 'articles#revision_score'
   get 'articles/details' => 'articles#details'
   post 'articles/status' => 'articles#update_tracked_status'
 

--- a/lib/revision_score_manager.rb
+++ b/lib/revision_score_manager.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+require_dependency "#{Rails.root}/lib/lift_wing_api"
+
+# Handles fetching and scoring article revisions for course-specific graphs.
+class RevisionScoreManager
+  def initialize(article, course)
+    @article = article
+    @course = course
+    @wiki = article.wiki
+  end
+
+  MAX_REVISION_COUNT = 50
+
+  def fetch_scored_revisions(enrolled_usernames)
+    revisions = get_student_revisions(enrolled_usernames)
+    return [] if revisions.empty?
+    cached_scored_revisions(revisions.first(MAX_REVISION_COUNT))
+  end
+
+  private
+
+  # Use the ID of the most recent revision as the cache key
+  # If this ID changes, the cache automatically invalidates.
+  def cache_key(recent_revision_id)
+    "article_#{@course.id}_#{@article.mw_page_id}_#{recent_revision_id}"
+  end
+
+  # Caches scored revisions to avoid hitting LiftWing API repeatedly for the same data
+  def cached_scored_revisions(target_revisions)
+    Rails.cache.fetch(cache_key(target_revisions.first[:revid]), expires_in: 1.day) do
+      rev_ids = target_revisions.map { |r| r[:revid] }
+      scores = score_revisions(rev_ids)
+
+      target_revisions.map do |rev|
+        {
+          rev_id: rev[:revid],
+          characters: rev[:size],
+          wp10: scores.dig(rev[:revid].to_s, 'wp10'),
+          date: rev[:timestamp],
+          username: rev[:user]
+        }
+      end
+    end
+  end
+
+  # Filters the total revision to a manageable number for plotting.
+  # We explicitly take the most recent revisions (up to MAX_REVISION_COUNT)
+  # to ensure the graph remains performant and readable.
+  def get_student_revisions(enrolled_usernames)
+    params = query_params
+    student_revisions = []
+
+    loop do
+      response = WikiApi.new(@wiki).query(params)
+      page_data = response['query']['pages'][@article.mw_page_id.to_s]
+
+      process_revisions(page_data['revisions'], enrolled_usernames, student_revisions)
+
+      # Exits loop if there is no continue parameter in response or
+      # Stop immediately if we found 50 student revisions
+      break if student_revisions.size >= MAX_REVISION_COUNT || !response['continue']
+
+      # When the API returns a continue hash, pull out its
+      # `rvcontinue`/`continue` tokens and merge them into `params`.
+      # That mutates the query parameters so the next loop iteration
+      # will request the next page of revisions.
+      params.merge!(response['continue'].slice('rvcontinue', 'continue'))
+    end
+    student_revisions
+  end
+
+  def process_revisions(revisions, usernames, results)
+    (revisions || []).each do |r|
+      next unless usernames.include?(r['user'])
+
+      results << {
+        revid: r['revid'],
+        user: r['user'],
+        timestamp: r['timestamp'],
+        size: r['size']
+      }
+    end
+  end
+
+  def score_revisions(rev_ids)
+    LiftWingApi.new(@wiki).get_revision_data(rev_ids)
+  end
+
+  # Queries for revisions made within the course period
+  # [course.start, course.end]
+  def query_params
+    {
+      action: 'query',
+      prop: 'revisions',
+      pageids: @article.mw_page_id,
+      rvprop: 'user|ids|timestamp|size',
+      rvstart: @course.end.strftime('%Y%m%d%H%M%S'),
+      rvend: @course.start.strftime('%Y%m%d%H%M%S'),
+      rvdir: 'older', # List newest first. rvstart has to be later than rvend.
+      rvlimit: 500
+    }
+  end
+end

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -6,7 +6,7 @@ describe ArticlesController, type: :request do
   let(:article) { create(:article) }
   let(:user) { create(:user) }
   let(:second_user) { create(:user, username: 'SecondUser') }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, start: Time.zone.now, end: Time.zone.now + 1.week) }
 
   before do
     create(:courses_user, user_id: user.id, course_id: course.id)
@@ -15,9 +15,9 @@ describe ArticlesController, type: :request do
                              user_ids: [user.id, second_user.id])
   end
 
-  describe '#article_data' do
+  describe '#revision_score' do
     it 'sets the article from the id' do
-      get '/articles/article_data', params: { article_id: article.id, format: :json }
+      get "/articles/#{article.id}/revision_score", params: { course_id: course.id, format: :json }
       expect(assigns(:article)).to eq(article)
     end
   end

--- a/spec/lib/revision_score_manager_spec.rb
+++ b/spec/lib/revision_score_manager_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_dependency "#{Rails.root}/lib/revision_score_manager"
+
+describe RevisionScoreManager do
+  let(:article) { create(:article, mw_page_id: 46721259) }
+  let(:course) { create(:course, start: '2023-01-01', end: '2023-02-01') }
+  let(:manager) { described_class.new(article, course) }
+
+  describe '#fetch_scored_revisions' do
+    let(:wiki_api_response) do
+      {
+        'query' => {
+          'pages' => {
+            '46721259' => {
+              'revisions' => [
+                { 'revid' => 1189_344_512, 'user' => 'RageSock',
+                  'timestamp' => '2023-01-10T12:00:00Z', 'size' => 42_100 },
+                { 'revid' => 1189_201_347, 'user' => 'WikiedStaff',
+                  'timestamp' => '2023-01-09T08:30:00Z', 'size' => 41_800 }
+              ]
+            }
+          }
+        }
+      }
+    end
+
+    let(:lift_wing_scores) do
+      {
+        '1189344512' => { 'wp10' => 0.5 }
+      }
+    end
+
+    before do
+      allow_any_instance_of(WikiApi).to receive(:query).and_return(wiki_api_response)
+      allow_any_instance_of(LiftWingApi).to receive(:get_revision_data).and_return(lift_wing_scores)
+    end
+
+    it 'returns formatted data only for enrolled users' do
+      enrolled_usernames = ['RageSock', 'MillerWon']
+      result = manager.fetch_scored_revisions(enrolled_usernames)
+
+      expect(result.length).to eq(1)
+      expect(result.first[:rev_id]).to eq(1189_344_512)
+      expect(result.first[:username]).to eq('RageSock')
+      expect(result.first[:wp10]).to eq(0.5)
+    end
+
+    it 'returns an empty array if no revisions match enrolled users' do
+      enrolled_usernames = ['MillerWon']
+      result = manager.fetch_scored_revisions(enrolled_usernames)
+      expect(result).to eq([])
+    end
+
+    it 'handles cases where LiftWing scores are missing' do
+      allow_any_instance_of(LiftWingApi).to receive(:get_revision_data).and_return({})
+      enrolled_usernames = ['RageSock']
+      result = manager.fetch_scored_revisions(enrolled_usernames)
+
+      expect(result.first[:wp10]).to be_nil
+    end
+
+    context 'when the API response spans multiple pages' do
+      let(:first_page_response) do
+        {
+          'query' => {
+            'pages' => {
+              '46721259' => {
+                'revisions' => [
+                  { 'revid' => 1189_344_512, 'user' => 'RageSock',
+                    'timestamp' => '2023-01-15T12:00:00Z', 'size' => 42_100 },
+                  { 'revid' => 1189_344_345, 'user' => 'WikiEdStaff',
+                    'timestamp' => '2023-02-15T12:00:00Z', 'size' => 42_400 }
+                ]
+              }
+            }
+          },
+          'continue' => { 'rvcontinue' => '20230115120000|1189344512', 'continue' => '-||' }
+        }
+      end
+
+      let(:second_page_response) do
+        {
+          'query' => {
+            'pages' => {
+              '46721259' => {
+                'revisions' => [
+                  { 'revid' => 1189_201_347, 'user' => 'RageSock',
+                    'timestamp' => '2023-01-10T08:30:00Z', 'size' => 41_800 },
+                  { 'revid' => 1189_201_346, 'user' => 'WikiEdStaff',
+                    'timestamp' => '2023-04-10T08:30:00Z', 'size' => 41_800 }
+                ]
+              }
+            }
+          }
+        }
+      end
+
+      let(:wiki_api) { instance_double(WikiApi) }
+
+      before do
+        allow(WikiApi).to receive(:new).and_return(wiki_api)
+        allow(wiki_api).to receive(:query).and_return(first_page_response, second_page_response)
+        allow_any_instance_of(LiftWingApi).to receive(:get_revision_data)
+          .and_return('1189344512' => { 'wp10' => 0.62 }, '1189201347' => { 'wp10' => 0.58 })
+      end
+
+      it 'collects revisions across all pages until no continue token remains' do
+        result = manager.fetch_scored_revisions(['RageSock'])
+
+        expect(result.length).to eq(2)
+        expect(result.map { |r| r[:rev_id] }).to contain_exactly(1189_344_512, 1189_201_347)
+      end
+
+      it 'makes one API call per page' do
+        expect(wiki_api).to receive(:query).twice
+        manager.fetch_scored_revisions(['RageSock'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR resolves #6337  by implementing a `revision_score` controller method. The new method accepts an article_id, looks up the associated course, fetches all revisions on that article between the course’s start and end dates and retrieves the `wp10` score for each revision using the `LiftWingApi`. The data is returned in the exact format that the `article_graph` requires for `plotting` revision scores. This functionality was moved to the server to prevent bloating the frontend in case of too many revisions and also ensure the data can be cached to reduce round trip time for the same resource. 

## AI usage

## Screenshots
Before: 

<img width="1210" height="772" alt="image" src="https://github.com/user-attachments/assets/c11e2d65-0a7b-4732-a050-14eccdf5713c" />


After:
https://www.loom.com/share/aeace9f1105d40758de474cbdc4859f1




@gabina Could you take a look when you are chanced