### PR TITLE
AI Detector comparison tool improvements

### DIFF
--- a/app/controllers/ai_tools_controller.rb
+++ b/app/controllers/ai_tools_controller.rb
@@ -17,14 +17,21 @@ class AiToolsController < ApplicationController
     render 'show'
   end
 
-  private
-
-  MAX_CONCURRENCY = 4
-
   PANGRAM_V2_KEY = 'pangram_v2'
   PANGRAM_V3_KEY = 'pangram_v3'
   ORIGINALITY_TURBO_KEY = 'originality_turbo'
   ORIGINALITY_ACADEMIC_KEY = 'originality_academic'
+
+  MODELS_KEY = [
+    PANGRAM_V2_KEY,
+    PANGRAM_V3_KEY,
+    ORIGINALITY_TURBO_KEY,
+    ORIGINALITY_ACADEMIC_KEY
+  ].freeze
+
+  private
+
+  MAX_CONCURRENCY = 4
 
   DETECTORS = {
     PANGRAM_V2_KEY => PangramApi.v2,
@@ -38,7 +45,7 @@ class AiToolsController < ApplicationController
     results = Concurrent::Hash.new
 
     DETECTORS.each do |key, detector|
-      pool.post { detect_ai(key, detector, text, results) }
+      pool.post { detect_ai(key, detector, text, results) } if params[key.to_sym]
     end
     pool.shutdown && pool.wait_for_termination
 

--- a/app/views/ai_tools/show.html.haml
+++ b/app/views/ai_tools/show.html.haml
@@ -10,6 +10,13 @@
         = label_tag :article_or_diff_url, 'Diff URL:'
         = text_field_tag :article_or_diff_url 
         = hidden_field_tag :diff_mode, 'true'
+        %hr
+        %h4 Models
+        - AiToolsController::MODELS_KEY.each do |key|
+          %div.checkbox-group
+            = check_box_tag(key.to_sym, '1', true)
+            %label{for: key}= key
+        %br
         .button= submit_tag 'Submit'
       %hr
     - if @url


### PR DESCRIPTION
## What this PR does
This PR is part of issue #6710.

It implements two improvements:
- Run API requests to different tools and models in parallel, so that response time for the results doesn't get longer and longer as we add more reports. This is implemented through `Concurrent::FixedThreadPool`, with `MAX_CONCURRENCY` set to 4 because we have currently 4 models. This reduced the request time from 9.25 s to  5.20 s.  Note that we're using `wait_for_termination`, so the total time is bounded by the longest request. Commit bc28ff712a29a14fe6f98c2cf8a4badaf07c0588
- Add functionality to select/unselect each supported model. Commit 6a47326e6986d24d6aa3c4b979df91f4e7018f93


## AI usage
No AI usage.

## Screenshots
Before:
<img width="1546" height="691" alt="image" src="https://github.com/user-attachments/assets/a5c5bae1-cafb-4609-8385-664a62a0febd" />

After:
[Screencast from 2026-03-09 17-49-45.webm](https://github.com/user-attachments/assets/59df2542-430c-429b-83f3-389533d969ad)

## Open questions and concerns
Note that blocking until all requests finish is not compatible with the following requirement:

_Ideally, when requesting multiple reports, results would appear for each one as soon as it's available, rather than needing to wait until all reports are generated. (That will require moving away from simple HAML views, so it might be more trouble than it's worth at the moment, but it's worth keeping in mind while making other architectural decisions.)_