### PR TITLE
AI edit alerts stats: prevent alert list rows from colliding with the sidebar

### DIFF
--- a/app/assets/javascripts/components/alerts/ai_alert.jsx
+++ b/app/assets/javascripts/components/alerts/ai_alert.jsx
@@ -8,9 +8,9 @@ const AiAlert = ({ alert }) => {
     <tr className="alert">
       <td className="desktop-only-tc"><a target="_blank" href={`/alerts_list/${alert.id}`}>{alert.id}</a></td>
       <td className="desktop-only-tc">{formatDateWithTime(alert.timestamp)}</td>
-      <td className="desktop-only-tc"><a target="_blank" href={`/courses/${alert.course_slug}`}>{alert.course}</a></td>
+      <td className="desktop-only-tc"><a style={{ wordBreak: 'break-all' }} target="_blank" href={`/courses/${alert.course_slug}`}>{alert.course}</a></td>
       <td className="desktop-only-tc"><a target="_blank" href={`/users/${alert.user}`}>{alert.user}</a></td>
-      <td className="desktop-only-tc"><a target="_blank" href={`${alert.diff_url}`}>{alert.article}</a></td>
+      <td className="desktop-only-tc"><a style={{ wordBreak: 'break-all' }} target="_blank" href={`${alert.diff_url}`}>{alert.article}</a></td>
       <td className="desktop-only-tc"><button className="button small" onClick={redirectToPangram}>{I18n.t('alerts.ai_stats.go_to_pangram')}</button></td>
     </tr>
   );


### PR DESCRIPTION
## What this PR does
This PR adds word break style to course slug and article title in `AiAlert` component to prevent the table from expanding until it visually collides with the sidebar.

I tried to fix this in PR #6685 by adding `humanize` to the texts, but it wasn't enough for production data.
## AI usage
No AI usage.

## Screenshots
Before:
<img width="1383" height="992" alt="Screenshot from 2026-03-11 16-45-15" src="https://github.com/user-attachments/assets/7838f90b-1df8-4261-891a-cf659025d238" />

After:
<img width="1383" height="992" alt="Screenshot from 2026-03-11 16-53-16" src="https://github.com/user-attachments/assets/e45816ec-e8e8-45ff-90f7-a539345f2a3a" />



## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
