### PR TITLE
Add tests for bad_work_alert, need_help_alert, and new_account reducers

### DIFF
--- a/test/reducers/bad_work_alert.spec.js
+++ b/test/reducers/bad_work_alert.spec.js
@@ -1,0 +1,49 @@
+import deepFreeze from 'deep-freeze';
+import badWorkAlert from '../../app/assets/javascripts/reducers/bad_work_alert';
+import {
+  BAD_WORK_ALERT_SUBMITTED,
+  BAD_WORK_ALERT_CREATED,
+  RESET_BAD_WORK_ALERT
+} from '../../app/assets/javascripts/constants';
+import '../testHelper';
+
+const initialState = {
+  submitting: false,
+  created: false
+};
+
+describe('bad_work_alert reducer', () => {
+  test('should return the initial state', () => {
+    expect(badWorkAlert(undefined, {})).toEqual(initialState);
+  });
+
+  test('should set submitting to true on BAD_WORK_ALERT_SUBMITTED', () => {
+    deepFreeze(initialState);
+    const action = { type: BAD_WORK_ALERT_SUBMITTED };
+    const newState = badWorkAlert(initialState, action);
+    expect(newState).toEqual({ submitting: true, created: false });
+  });
+
+  test('should set created to true and submitting to false on BAD_WORK_ALERT_CREATED', () => {
+    const submittingState = { submitting: true, created: false };
+    deepFreeze(submittingState);
+    const action = { type: BAD_WORK_ALERT_CREATED };
+    const newState = badWorkAlert(submittingState, action);
+    expect(newState).toEqual({ submitting: false, created: true });
+  });
+
+  test('should reset submitting and created on RESET_BAD_WORK_ALERT', () => {
+    const createdState = { submitting: false, created: true };
+    deepFreeze(createdState);
+    const action = { type: RESET_BAD_WORK_ALERT };
+    const newState = badWorkAlert(createdState, action);
+    expect(newState).toEqual({ submitting: false, created: false });
+  });
+
+  test('should return the current state for unknown action types', () => {
+    deepFreeze(initialState);
+    const action = { type: 'UNKNOWN_ACTION' };
+    const newState = badWorkAlert(initialState, action);
+    expect(newState).toEqual(initialState);
+  });
+});

--- a/test/reducers/need_help_alert.spec.js
+++ b/test/reducers/need_help_alert.spec.js
@@ -1,0 +1,49 @@
+import deepFreeze from 'deep-freeze';
+import needHelpAlert from '../../app/assets/javascripts/reducers/need_help_alert';
+import {
+  NEED_HELP_ALERT_SUBMITTED,
+  NEED_HELP_ALERT_CREATED,
+  RESET_NEED_HELP_ALERT
+} from '../../app/assets/javascripts/constants';
+import '../testHelper';
+
+const initialState = {
+  submitting: false,
+  created: false
+};
+
+describe('need_help_alert reducer', () => {
+  test('should return the initial state', () => {
+    expect(needHelpAlert(undefined, {})).toEqual(initialState);
+  });
+
+  test('should set submitting to true on NEED_HELP_ALERT_SUBMITTED', () => {
+    deepFreeze(initialState);
+    const action = { type: NEED_HELP_ALERT_SUBMITTED };
+    const newState = needHelpAlert(initialState, action);
+    expect(newState).toEqual({ submitting: true, created: false });
+  });
+
+  test('should set created to true and submitting to false on NEED_HELP_ALERT_CREATED', () => {
+    const submittingState = { submitting: true, created: false };
+    deepFreeze(submittingState);
+    const action = { type: NEED_HELP_ALERT_CREATED };
+    const newState = needHelpAlert(submittingState, action);
+    expect(newState).toEqual({ submitting: false, created: true });
+  });
+
+  test('should reset submitting and created on RESET_NEED_HELP_ALERT', () => {
+    const createdState = { submitting: false, created: true };
+    deepFreeze(createdState);
+    const action = { type: RESET_NEED_HELP_ALERT };
+    const newState = needHelpAlert(createdState, action);
+    expect(newState).toEqual({ submitting: false, created: false });
+  });
+
+  test('should return the current state for unknown action types', () => {
+    deepFreeze(initialState);
+    const action = { type: 'UNKNOWN_ACTION' };
+    const newState = needHelpAlert(initialState, action);
+    expect(newState).toEqual(initialState);
+  });
+});

--- a/test/reducers/new_account.spec.js
+++ b/test/reducers/new_account.spec.js
@@ -1,0 +1,88 @@
+import deepFreeze from 'deep-freeze';
+import newAccount from '../../app/assets/javascripts/reducers/new_account';
+import {
+  SET_NEW_ACCOUNT_EMAIL,
+  SET_NEW_ACCOUNT_USERNAME,
+  NEW_ACCOUNT_VALIDATING_USERNAME,
+  NEW_ACCOUNT_USERNAME_VALID,
+  NEW_ACCOUNT_USERNAME_INVALID,
+  NEW_ACCOUNT_REQUEST_SUBMITTED
+} from '../../app/assets/javascripts/constants';
+import '../testHelper';
+
+const initialState = {
+  username: '',
+  email: ''
+};
+
+describe('new_account reducer', () => {
+  test('should return the initial state', () => {
+    expect(newAccount(undefined, {})).toEqual(initialState);
+  });
+
+  test('should set email and emailValid to true for a valid email on SET_NEW_ACCOUNT_EMAIL', () => {
+    deepFreeze(initialState);
+    const action = { type: SET_NEW_ACCOUNT_EMAIL, email: 'user@example.com' };
+    const newState = newAccount(initialState, action);
+    expect(newState.email).toBe('user@example.com');
+    expect(newState.emailValid).toBe(true);
+  });
+
+  test('should set emailValid to false for an invalid email on SET_NEW_ACCOUNT_EMAIL', () => {
+    deepFreeze(initialState);
+    const action = { type: SET_NEW_ACCOUNT_EMAIL, email: 'notanemail' };
+    const newState = newAccount(initialState, action);
+    expect(newState.email).toBe('notanemail');
+    expect(newState.emailValid).toBe(false);
+  });
+
+  test('should set username and clear usernameValid on SET_NEW_ACCOUNT_USERNAME', () => {
+    const validatedState = { ...initialState, username: 'old', usernameValid: true };
+    deepFreeze(validatedState);
+    const action = { type: SET_NEW_ACCOUNT_USERNAME, username: 'newuser' };
+    const newState = newAccount(validatedState, action);
+    expect(newState.username).toBe('newuser');
+    expect(newState.usernameValid).toBeUndefined();
+  });
+
+  test('should set checking to true and clear error on NEW_ACCOUNT_VALIDATING_USERNAME', () => {
+    const errorState = { ...initialState, error: 'some error' };
+    deepFreeze(errorState);
+    const action = { type: NEW_ACCOUNT_VALIDATING_USERNAME };
+    const newState = newAccount(errorState, action);
+    expect(newState.checking).toBe(true);
+    expect(newState.error).toBeUndefined();
+  });
+
+  test('should set usernameValid to true and checking to false on NEW_ACCOUNT_USERNAME_VALID', () => {
+    const checkingState = { ...initialState, checking: true };
+    deepFreeze(checkingState);
+    const action = { type: NEW_ACCOUNT_USERNAME_VALID };
+    const newState = newAccount(checkingState, action);
+    expect(newState.usernameValid).toBe(true);
+    expect(newState.checking).toBe(false);
+  });
+
+  test('should set error and checking to false on NEW_ACCOUNT_USERNAME_INVALID', () => {
+    const checkingState = { ...initialState, checking: true };
+    deepFreeze(checkingState);
+    const action = { type: NEW_ACCOUNT_USERNAME_INVALID, error: 'Username taken' };
+    const newState = newAccount(checkingState, action);
+    expect(newState.error).toBe('Username taken');
+    expect(newState.checking).toBe(false);
+  });
+
+  test('should set submitted to true on NEW_ACCOUNT_REQUEST_SUBMITTED', () => {
+    deepFreeze(initialState);
+    const action = { type: NEW_ACCOUNT_REQUEST_SUBMITTED };
+    const newState = newAccount(initialState, action);
+    expect(newState.submitted).toBe(true);
+  });
+
+  test('should return the current state for unknown action types', () => {
+    deepFreeze(initialState);
+    const action = { type: 'UNKNOWN_ACTION' };
+    const newState = newAccount(initialState, action);
+    expect(newState).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
Addresses #2082

## Summary

Adds test coverage for three untested Redux reducers:

- **bad_work_alert** — tests the submit → create → reset lifecycle (5 tests)
- **need_help_alert** — tests the submit → create → reset lifecycle (5 tests)
- **new_account** — tests email validation, username validation flow, and form submission (8 tests)

All tests follow the established `deepFreeze` pattern to verify state immutability. Each test file covers:
- Initial state
- All action types handled by the reducer
- Unknown action type (returns current state unchanged)

## Test plan

- [x] All 18 new tests pass locally (`npm test`)
- [x] Tests follow existing patterns from `alerts.spec.js`, `refreshing.spec.js`
- [x] Uses `deepFreeze` to verify immutability