### PR TITLE
Remove deprecated @babel/plugin-proposal-object-rest-spread

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,6 @@ module.exports = {
     }]
   ],
   plugins: [
-    '@babel/plugin-proposal-object-rest-spread',
     [
       'babel-plugin-root-import',
       {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.17.5",
-    "@babel/plugin-proposal-object-rest-spread": "^7.17.3",
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,7 +672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.17.3, @babel/plugin-proposal-object-rest-spread@npm:^7.18.6":
+"@babel/plugin-proposal-object-rest-spread@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.18.6"
   dependencies:
@@ -3420,7 +3420,6 @@ __metadata:
   dependencies:
     "@babel/core": ^7.17.5
     "@babel/eslint-parser": ^7.17.0
-    "@babel/plugin-proposal-object-rest-spread": ^7.17.3
     "@babel/plugin-transform-modules-commonjs": ^7.16.8
     "@babel/plugin-transform-runtime": ^7.9.0
     "@babel/preset-env": ^7.16.11


### PR DESCRIPTION
Addresses #6727

## Summary

Removes the deprecated `@babel/plugin-proposal-object-rest-spread` Babel plugin, which was renamed to `@babel/plugin-transform-object-rest-spread` in Babel 7.22 and emits a deprecation warning when used.

Since `@babel/preset-env` already includes the object rest spread transform for ES2018+ targets, the explicit plugin in `babel.config.js` is redundant.

## Changes

- Removed `@babel/plugin-proposal-object-rest-spread` from `babel.config.js` plugins
- Removed the corresponding dependency from `package.json`
- Updated `yarn.lock`