### PR TITLE
Fix incorrect pluralization for uploads_in _use_count

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign_stats.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_stats.jsx
@@ -6,7 +6,7 @@ import OverviewStat from '../common/OverviewStats/overview_stat.jsx';
 const CampaignStats = ({ campaign }) => {
   const studentsInfo = [[`${campaign.trained_percent_human}%`, I18n.t('users.up_to_date_with_training')]];
   const campaignUploadsInfo = [
-    [`${campaign.uploads_in_use_count_human}`, I18n.t('metrics.uploads_in_use_count', { count: campaign.uploads_in_use_count })],
+    [`${campaign.uploads_in_use_count}`, I18n.t('metrics.uploads_in_use_count', { count: campaign.uploads_in_use_count })],
     [`${campaign.upload_usage_count_human}`, I18n.t('metrics.upload_usages_count', { count: campaign.upload_usage_count })]];
 
   return (


### PR DESCRIPTION
## What this PR does
This PR fixes incorrect pluralization for uploads_in_use_count.

## Issue
The text shows "used in 1 articles", which is grammatically incorrect.

## Fix
Updated the pluralization logic to correctly display:
- "used in 1 article"
- "used in X articles"

## AI usage
I did not use any AI tools for this PR.

## Screenshots
Before:
<img width="1422" height="807" alt="image" src="https://github.com/user-attachments/assets/81dd218f-d93b-4523-a7af-9c711842b44f" />

After: 
<img width="1352" height="768" alt="image" src="https://github.com/user-attachments/assets/478baeab-bea7-44a8-abf8-dddf2badf7df" />




## Open questions and concerns
None.

## Related Issue
Fixes #6738