### PR TITLE
Create an alert when a mainspace article is edited after AI alert

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -51,6 +51,7 @@ class Alert < ApplicationRecord
     GANominationAlert
     HighQualityArticleAssignmentAlert
     HighQualityArticleEditAlert
+    MainspaceAiFollowupAlert
     NeedHelpAlert
     NoTaEnrolledAlert
     NoEnrolledStudentsAlert

--- a/app/models/alert_types/ai_edit_alert.rb
+++ b/app/models/alert_types/ai_edit_alert.rb
@@ -203,6 +203,10 @@ class AiEditAlert < Alert
     details[:prior_alert_for_user]
   end
 
+  def mainspace?
+    page_type == :mainspace
+  end
+
   def page_type # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
     case article_title
     when /Choose an Article/
@@ -230,6 +234,14 @@ class AiEditAlert < Alert
     else
       :unknown
     end
+  end
+
+  # This will only work for mainspace, and might exclude
+  # revisions that happened after the alert but during the same timeslice.
+  def characters_added_after_alert
+    @chars_added_after ||= ArticleCourseTimeslice.where(course_id:, article_id:)
+                                                 .where('start > ?', created_at)
+                                                 .sum(:character_sum)
   end
 
   def to_partial_path

--- a/app/models/alert_types/mainspace_ai_followup_alert.rb
+++ b/app/models/alert_types/mainspace_ai_followup_alert.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: alerts
+#
+#  id             :integer          not null, primary key
+#  course_id      :integer
+#  user_id        :integer
+#  article_id     :integer
+#  revision_id    :integer
+#  type           :string(255)
+#  email_sent_at  :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  message        :text(65535)
+#  target_user_id :integer
+#  subject_id     :integer
+#  resolved       :boolean          default(FALSE)
+#  details        :text(65535)
+
+# Alert for Wiki Experts to follow up on later edits to an article
+# that had a mainspace AI alert
+class MainspaceAiFollowupAlert < Alert
+  def main_subject
+    "Mainspace AI follow-up: #{article.title}"
+  end
+
+  def url
+    course_url
+  end
+
+  def resolvable?
+    false
+  end
+
+  def send_email
+    email_content_expert
+  end
+end

--- a/app/workers/daily_update/mainspace_ai_followup_worker.rb
+++ b/app/workers/daily_update/mainspace_ai_followup_worker.rb
@@ -1,0 +1,10 @@
+require_dependency "#{Rails.root}/lib/alerts/mainspace_ai_followup_manager"
+
+class MainspaceAiFollowupWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  def perform
+    MainspaceAiFollowupManager.new(Course.current).generate_followup_alerts
+  end
+end

--- a/lib/alerts/mainspace_ai_followup_manager.rb
+++ b/lib/alerts/mainspace_ai_followup_manager.rb
@@ -1,0 +1,43 @@
+require_dependency "#{Rails.root}/lib/revision_scanner"
+
+# Identifies articles that had mainspace AI alerts where
+# the student made significant additions afterwards,
+# and creates alerts for Wiki Experts to check that later work
+class MainspaceAiFollowupManager
+  def initialize(courses)
+    @wiki = Wiki.find_by(language: 'en', project: 'wikipedia')
+    @courses = courses
+  end
+
+  def generate_followup_alerts
+    course_ids = @courses.map(&:id)
+    mainspace_ai_alerts = AiEditAlert.where(course_id: course_ids).filter(&:mainspace?)
+    mainspace_ai_alerts.each do |ai_alert|
+      next if followup_alert_already_exists?(ai_alert)
+      next unless significant_additions_after_ai_alert?(ai_alert)
+      
+      MainspaceAiFollowupAlert.create!(
+        course_id: ai_alert.course_id,
+        article_id: ai_alert.article_id,
+        user_id: ai_alert.user_id,
+        details: {
+          ai_alert_id: ai_alert.id,
+          characters_added_after_alert: ai_alert.characters_added_after_alert
+        }
+      )
+    end
+  end
+
+  private
+
+  def followup_alert_already_exists?(ai_alert)
+    MainspaceAiFollowupAlert.exists?(course_id: ai_alert.course_id, article_id: ai_alert.article_id)
+  end
+
+  # Use the same threshold as RevisionScanner uses for determining which revisions to check for AI.
+  CHARACTERS_ADDED_THRESHOLD = RevisionScanner::TEXT_DUMP_CHARACTERS
+  def significant_additions_after_ai_alert?(ai_alert)
+    ai_alert.characters_added_after_alert > CHARACTERS_ADDED_THRESHOLD
+  end
+end
+  

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -7,6 +7,7 @@ require_dependency "#{Rails.root}/app/workers/daily_update/import_ratings_worker
 require_dependency "#{Rails.root}/app/workers/daily_update/overdue_training_alert_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/salesforce_sync_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/wiki_discouraged_article_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/mainspace_ai_followup_worker"
 
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 require_dependency "#{Rails.root}/lib/automated_emails/term_recap_email_scheduler"
@@ -35,6 +36,7 @@ class DailyUpdate
     update_wiki_discouraged_article if Features.wiki_ed?
     send_term_recap_emails if Features.wiki_ed?
     generate_overdue_training_alerts if Features.wiki_ed?
+    generate_mainspace_ai_followup_alerts if Features.wiki_ed?
     push_course_data_to_salesforce if Features.wiki_ed?
     log_end_of_update 'Daily update finished.'
   # rubocop:disable Lint/RescueException
@@ -85,6 +87,11 @@ class DailyUpdate
   def generate_overdue_training_alerts
     log_message 'Generating alerts for overdue trainings'
     OverdueTrainingAlertWorker.set(queue: QUEUE).perform_async
+  end
+
+  def generate_mainspace_ai_followup_alerts
+    log_message 'Generating followup alerts for mainspace AI edits'
+    MainspaceAiFollowupWorker.set(queue: QUEUE).perform_async
   end
 
   ###############

--- a/spec/lib/alerts/mainspace_ai_followup_manager_spec.rb
+++ b/spec/lib/alerts/mainspace_ai_followup_manager_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require "#{Rails.root}/lib/alerts/mainspace_ai_followup_manager"
+
+describe MainspaceAiFollowupManager do
+  describe '#generate_followup_alerts_for_current_courses' do
+    let(:course) { create(:course, start: 2.weeks.ago, end: 2.weeks.from_now) }
+    let(:student) { create(:user, username: 'student') }
+    let(:courses_user) do
+      create(:courses_user, user_id: student.id,
+                            course_id: course.id,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
+    let(:article) { create(:article, title: 'Test Article', namespace: 0) }
+
+    before do
+      courses_user
+      course.campaigns << Campaign.default_campaign
+      create(:ai_edit_alert, course_id: course.id, article_id: article.id,
+                             user_id: student.id, created_at: 1.week.ago,
+                             details: { article_title: article.title })
+    end
+
+    let(:small_addition) { 50 }
+    let(:large_addition) { 5000 }
+
+    let(:subject) { MainspaceAiFollowupManager.new([course]) }
+
+    it 'creates a followup alert for major additions after the AI alert' do
+      expect(MainspaceAiFollowupAlert.count).to eq(0)
+      # Simulate significant additions after the AI alert
+      ArticleCourseTimeslice.create!(course_id: course.id, article_id: article.id,
+                                     start: 2.days.ago, character_sum: large_addition)
+
+
+      subject.generate_followup_alerts
+      expect(MainspaceAiFollowupAlert.count).to eq(1)
+
+      followup_alert = MainspaceAiFollowupAlert.last
+      expect(followup_alert.course_id).to eq(course.id)
+      expect(followup_alert.article_id).to eq(article.id)
+      expect(followup_alert.user_id).to eq(student.id)
+      expect(followup_alert.details[:characters_added_after_alert]).to eq(5000)
+    end
+
+    it 'does not create a followup alert for only small additions' do
+      expect(MainspaceAiFollowupAlert.count).to eq(0)
+      # Simulate minor additions after the AI alert
+      ArticleCourseTimeslice.create!(course_id: course.id, article_id: article.id,
+                                     start: 2.days.ago, character_sum: small_addition)
+      subject.generate_followup_alerts
+      expect(MainspaceAiFollowupAlert.count).to eq(0)
+    end
+  end
+end

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -22,6 +22,7 @@ describe DailyUpdate do
       expect(RatingImporter).to receive(:update_all_ratings)
       expect(UploadImporter).to receive(:find_deleted_files)
       expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
+      expect_any_instance_of(MainspaceAiFollowupManager).to receive(:generate_followup_alerts)
       expect(PushCourseToSalesforce).to receive(:new)
       expect(UpdateCourseFromSalesforce).to receive(:new)
       expect(Sentry).to receive(:capture_message).and_call_original


### PR DESCRIPTION
## What this PR does
This is an initial implementation of alerts to follow up when an article that was subject to an AI alert is later edited significantly by students in the same course.

It runs daily, and detects post-alert additions based on ArticleCourseTimeslice records, so it may miss edits that happen during the same day as the alert.

## AI usage
I used some of the spec code suggested by GitHub Copilot. It didn't work initially, but seemed reasonable enough as a starting point, so I cleaned it up enough to be keepable.
