### PR TITLE
feat: add cumulative_diff_url method to ArticlesCourses

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -20,6 +20,7 @@
 #
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/cumulative_diff_url_builder"
 
 #= ArticlesCourses is a join model between Article and Course.
 #= It represents a mainspace Wikipedia article that has been worked on by a
@@ -45,6 +46,10 @@ class ArticlesCourses < ApplicationRecord
   ####################
   # Instance methods #
   ####################
+  def cumulative_diff_url
+    CumulativeDiffUrlBuilder.new(self).url
+  end
+
   def update_cache_from_timeslices
     self.character_sum = article_course_timeslices.sum(&:character_sum)
     self.references_count = article_course_timeslices.sum(&:references_count)

--- a/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/both_editors.yml
+++ b/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/both_editors.yml
@@ -1,0 +1,327 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=newer&rvend=2025-12-10T23:59:59Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-08-18T00:00:00Z&rvuser=Kfase&titles=Media_multiplexity_theory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:37 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-mk6f4
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=zktkz5dFEoWSeHQVyd-obANWAAAAAFvd598kGiQ4CPg6sr5q9zday_nKQDE9HLcT;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '306'
+      X-Request-Id:
+      - 6e9c7b9f-3f80-4d3a-83a1-dd3c4eb22fb0
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Media_multiplexity_theory","to":"Media
+        multiplexity theory"}],"pages":{"75215900":{"pageid":75215900,"ns":0,"title":"Media
+        multiplexity theory","revisions":[{"revid":1310268231,"parentid":1291883584,"user":"Kfase","timestamp":"2025-09-08T16:41:19Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:37 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=newer&rvend=2025-12-10T23:59:59Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-08-18T00:00:00Z&rvuser=JakeZim16&titles=Media_multiplexity_theory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:37 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-85prl
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=KcBALd0zh7ALS4LFwvugnwNWAAAAAFvdwnR6dz4rMLaYeb2dIh_yujsa2QJWgVHt;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '310'
+      X-Request-Id:
+      - 35124658-e33a-4ff0-a56b-720d4bf2ec63
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Media_multiplexity_theory","to":"Media
+        multiplexity theory"}],"pages":{"75215900":{"pageid":75215900,"ns":0,"title":"Media
+        multiplexity theory","revisions":[{"revid":1322934870,"parentid":1310268231,"user":"JakeZim16","timestamp":"2025-11-18T18:08:11Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:37 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=older&rvend=2025-08-18T00:00:00Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-12-10T23:59:59Z&rvuser=Kfase&titles=Media_multiplexity_theory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:38 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-kd7gm
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=XtBpCZn7zqAh7oghQoUm_gNWAAAAAFvdDzoYuiS728552q4y5zbVHo-0guprAEJs;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '306'
+      X-Request-Id:
+      - 2b06793c-b487-4757-90c4-ad877ad5e933
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Media_multiplexity_theory","to":"Media
+        multiplexity theory"}],"pages":{"75215900":{"pageid":75215900,"ns":0,"title":"Media
+        multiplexity theory","revisions":[{"revid":1310268231,"parentid":1291883584,"user":"Kfase","timestamp":"2025-09-08T16:41:19Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:38 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=older&rvend=2025-08-18T00:00:00Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-12-10T23:59:59Z&rvuser=JakeZim16&titles=Media_multiplexity_theory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:38 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-cd5hg
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=SvJ4Y9qzTjD7Gb5hxAhlrQNWAAAAAFvdeAtBBa-rz0oBbswJRfPr1FB032MfSAXj;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '310'
+      X-Request-Id:
+      - 47b15f03-0798-4247-bf67-b0a34b6bf649
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Media_multiplexity_theory","to":"Media
+        multiplexity theory"}],"pages":{"75215900":{"pageid":75215900,"ns":0,"title":"Media
+        multiplexity theory","revisions":[{"revid":1322934870,"parentid":1310268231,"user":"JakeZim16","timestamp":"2025-11-18T18:08:11Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:38 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/new_article.yml
+++ b/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/new_article.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=newer&rvend=2025-12-10T23:59:59Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-08-18T00:00:00Z&rvuser=JakeZim16&titles=User:JakeZim16/Media_multiplexity_theory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:39 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-8c282
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '2'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=8SaDrP9uGKvBamC1HoYCAwNWAAAAAFvde-CzhD33I5kWXNSu1xjqdR17wac3qp4P;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '397'
+      X-Request-Id:
+      - 2fa5d194-dc99-4368-a891-7fd559feb5a0
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"continue":{"rvcontinue":"20251019160215|1317710847","continue":"||"},"query":{"normalized":[{"from":"User:JakeZim16/Media_multiplexity_theory","to":"User:JakeZim16/Media
+        multiplexity theory"}],"pages":{"81377672":{"pageid":81377672,"ns":2,"title":"User:JakeZim16/Media
+        multiplexity theory","revisions":[{"revid":1317703640,"parentid":0,"user":"JakeZim16","timestamp":"2025-10-19T15:09:45Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:39 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=older&rvend=2025-08-18T00:00:00Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-12-10T23:59:59Z&rvuser=JakeZim16&titles=User:JakeZim16/Media_multiplexity_theory
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:40 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-p74cv
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=kQLJ7EFOHMvr_WMOwnO4SQNWAAAAAFvd3-mA2AG1a9mcge9C20YT67QSo4C31zRI;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '406'
+      X-Request-Id:
+      - 0d76f29c-8bca-4e28-b52d-65f1c8656849
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"continue":{"rvcontinue":"20251106181302|1320774157","continue":"||"},"query":{"normalized":[{"from":"User:JakeZim16/Media_multiplexity_theory","to":"User:JakeZim16/Media
+        multiplexity theory"}],"pages":{"81377672":{"pageid":81377672,"ns":2,"title":"User:JakeZim16/Media
+        multiplexity theory","revisions":[{"revid":1322930411,"parentid":1320774157,"user":"JakeZim16","timestamp":"2025-11-18T17:37:20Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:40 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/no_revisions.yml
+++ b/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/no_revisions.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=newer&rvend=2025-12-10T23:59:59Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-08-18T00:00:00Z&rvuser=Julia.kennedy2004&titles=Social_constructionism
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 3d17135eb2444987b18e201a72ca0406-ba07bd0360984568
+      Baggage:
+      - sentry-trace_id=3d17135eb2444987b18e201a72ca0406,sentry-sample_rand=0.773291,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:29:26 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-k5dhf
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '2'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=lDFSkXfRMcCTfQE3Eq_qXgNWAAAAAFvdNx1xzHY4pV06KuQcWSkwaBLv00SIXJqG;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '186'
+      X-Request-Id:
+      - 0ddce988-61ce-4374-a6f6-043c4c7bbd65
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Social_constructionism","to":"Social
+        constructionism"}],"pages":{"203510":{"pageid":203510,"ns":0,"title":"Social
+        constructionism"}}}}'
+  recorded_at: Mon, 04 May 2026 05:29:26 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=older&rvend=2025-08-18T00:00:00Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-12-10T23:59:59Z&rvuser=Julia.kennedy2004&titles=Social_constructionism
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 3d17135eb2444987b18e201a72ca0406-ba07bd0360984568
+      Baggage:
+      - sentry-trace_id=3d17135eb2444987b18e201a72ca0406,sentry-sample_rand=0.773291,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:29:27 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-grfsx
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=ABIm-HdExK47zLQJIHvpzwNWAAAAAFvdBQ3tUFYOTbYRTjVrg3f0yGa6NjM0MJfG;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '186'
+      X-Request-Id:
+      - d40ab5f5-1076-4391-a172-3a1d749cde35
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Social_constructionism","to":"Social
+        constructionism"}],"pages":{"203510":{"pageid":203510,"ns":0,"title":"Social
+        constructionism"}}}}'
+  recorded_at: Mon, 04 May 2026 05:29:27 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/single_editor.yml
+++ b/fixtures/vcr_cassettes/cached/cumulative_diff_url_builder/single_editor.yml
@@ -1,0 +1,327 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=newer&rvend=2025-12-10T23:59:59Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-08-18T00:00:00Z&rvuser=Nateiac7&titles=Social_constructionism
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:38 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-4v698
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=4_HG-eCALEYVHzAu6BiO6ANWAAAAAFvdhNjLJ0B5PKcxnz3kK9OuM-db3UykG_j3;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '347'
+      X-Request-Id:
+      - d498d264-b944-415d-99ce-0a9273649022
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"continue":{"rvcontinue":"20251117005104|1322581156","continue":"||"},"query":{"normalized":[{"from":"Social_constructionism","to":"Social
+        constructionism"}],"pages":{"203510":{"pageid":203510,"ns":0,"title":"Social
+        constructionism","revisions":[{"revid":1322578885,"parentid":1316523874,"user":"Nateiac7","timestamp":"2025-11-17T00:36:59Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:38 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=newer&rvend=2025-12-10T23:59:59Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-08-18T00:00:00Z&rvuser=Julia.kennedy2004&titles=Social_constructionism
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:39 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-pvn97
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=YF8Dgtrp-5up2SuMG7HCVQNWAAAAAFvdQcw2xyS2zbGkclvUn8KaK4nPkQhtDp2L;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '186'
+      X-Request-Id:
+      - 8beae212-9704-480c-a011-7a96ee4b11d9
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Social_constructionism","to":"Social
+        constructionism"}],"pages":{"203510":{"pageid":203510,"ns":0,"title":"Social
+        constructionism"}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:39 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=older&rvend=2025-08-18T00:00:00Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-12-10T23:59:59Z&rvuser=Nateiac7&titles=Social_constructionism
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:39 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-fdcrn
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=XRrRb1VcEjR3MQj0UFnr0wNWAAAAAFvdWu0QdGrh-M1gSZ3d3gq0iH3hpf1ddBNR;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '347'
+      X-Request-Id:
+      - 441f6842-3882-4f22-9c1e-6b8ca5c1fe3c
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"continue":{"rvcontinue":"20251118171303|1322926164","continue":"||"},"query":{"normalized":[{"from":"Social_constructionism","to":"Social
+        constructionism"}],"pages":{"203510":{"pageid":203510,"ns":0,"title":"Social
+        constructionism","revisions":[{"revid":1323073695,"parentid":1322926164,"user":"Nateiac7","timestamp":"2025-11-19T14:56:35Z"}]}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:39 GMT
+- request:
+    method: get
+    uri: https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvdir=older&rvend=2025-08-18T00:00:00Z&rvlimit=1&rvprop=timestamp%7Cuser%7Cids&rvstart=2025-12-10T23:59:59Z&rvuser=Julia.kennedy2004&titles=Social_constructionism
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Sentry-Trace:
+      - 9dee93985bcd42c6add82bb58d1f20d4-3a6ec0fa4c734329
+      Baggage:
+      - sentry-trace_id=9dee93985bcd42c6add82bb58d1f20d4,sentry-sample_rand=0.431405,sentry-environment=test
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2026 05:16:39 GMT
+      Server:
+      - mw-api-ext.codfw.main-fc5885ff4-6n6wn
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      X-Frame-Options:
+      - DENY
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+      Age:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      X-Cache:
+      - cp4037 miss, cp4037 pass
+      X-Cache-Status:
+      - pass
+      Server-Timing:
+      - cache;desc="pass", host;desc="cp4037"
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Report-To:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      Nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      Set-Cookie:
+      - GeoIP=US:HI:Honolulu:21.31:-157.82:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Last-Access-Global=04-May-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Fri,
+        05 Jun 2026 00:00:00 GMT
+      - WMF-Last-Access=04-May-2026;Path=/;HttpOnly;secure;Expires=Fri, 05 Jun 2026
+        00:00:00 GMT
+      - WMF-Uniq=bUQqH_xgFpSGiRvA3wUEJANWAAAAAFvd8ExyWP0RInGqCs0MLCBzHBfF1m1wkj05;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Tue,
+        04 May 2027 00:00:00 GMT
+      X-Client-Ip:
+      - 4.43.228.235
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      Content-Length:
+      - '186'
+      X-Request-Id:
+      - cafc151e-ca3b-4fd2-a194-44a4646fd4c6
+      X-Analytics:
+      - ''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"normalized":[{"from":"Social_constructionism","to":"Social
+        constructionism"}],"pages":{"203510":{"pageid":203510,"ns":0,"title":"Social
+        constructionism"}}}}'
+  recorded_at: Mon, 04 May 2026 05:16:39 GMT
+recorded_with: VCR 6.1.0

--- a/lib/cumulative_diff_url_builder.rb
+++ b/lib/cumulative_diff_url_builder.rb
@@ -3,6 +3,9 @@
 #= Builds a cumulative diff URL for an ArticlesCourses record by querying
 #= the MediaWiki API to find the earliest and latest revisions made by the
 #= course's editors within the course date range.
+#=
+#= Makes 2 API requests per editor (earliest + latest revision), so for an
+#= article with N editors this issues 2N sequential requests.
 class CumulativeDiffUrlBuilder
   def initialize(articles_course)
     @articles_course = articles_course
@@ -24,12 +27,18 @@ class CumulativeDiffUrlBuilder
     last_rev = latest_revision(article_title, usernames, start_date, end_date)
     return nil unless first_rev && last_rev
 
-    parent_id = first_rev['parentid']
-    last_id = last_rev['revid']
-    "#{@wiki.base_url}/w/index.php?oldid=#{parent_id}&diff=#{last_id}"
+    build_diff_url(first_rev, last_rev)
   end
 
   private
+
+  def build_diff_url(first_rev, last_rev)
+    parent_id = first_rev['parentid']
+    last_id = last_rev['revid']
+    # parentid is 0 when the student created the article; use revid instead
+    old_id = parent_id.zero? ? first_rev['revid'] : parent_id
+    "#{@wiki.base_url}/w/index.php?oldid=#{old_id}&diff=#{last_id}"
+  end
 
   def earliest_revision(title, usernames, start_date, end_date)
     revisions = usernames.filter_map do |username|
@@ -46,24 +55,24 @@ class CumulativeDiffUrlBuilder
   end
 
   def fetch_revision(title, username, start_date, end_date, direction:)
-    params = {
-      prop: 'revisions',
-      titles: title,
-      rvprop: 'timestamp|user|ids',
-      rvuser: username,
-      rvdir: direction,
-      rvlimit: 1
-    }
-
-    if direction == 'newer'
-      params[:rvstart] = start_date
-      params[:rvend] = end_date
-    else
-      params[:rvstart] = end_date
-      params[:rvend] = start_date
-    end
-
+    params = revision_query_params(title, username, start_date, end_date, direction)
     response = @wiki_api.query(params)
+    parse_revision(response)
+  end
+
+  def revision_query_params(title, username, start_date, end_date, direction)
+    params = {
+      prop: 'revisions', titles: title, rvprop: 'timestamp|user|ids',
+      rvuser: username, rvdir: direction, rvlimit: 1
+    }
+    if direction == 'newer'
+      params.merge(rvstart: start_date, rvend: end_date)
+    else
+      params.merge(rvstart: end_date, rvend: start_date)
+    end
+  end
+
+  def parse_revision(response)
     return nil unless response&.data
     pages = response.data['pages']
     return nil unless pages

--- a/lib/cumulative_diff_url_builder.rb
+++ b/lib/cumulative_diff_url_builder.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#= Builds a cumulative diff URL for an ArticlesCourses record by querying
+#= the MediaWiki API to find the earliest and latest revisions made by the
+#= course's editors within the course date range.
+class CumulativeDiffUrlBuilder
+  def initialize(articles_course)
+    @articles_course = articles_course
+    @article = articles_course.article
+    @course = articles_course.course
+    @wiki = @article.wiki
+    @wiki_api = WikiApi.new(@wiki)
+  end
+
+  def url
+    usernames = User.where(id: @articles_course.user_ids).pluck(:username)
+    return nil if usernames.empty?
+
+    article_title = @article.escaped_full_title
+    start_date = @course.start.iso8601
+    end_date = @course.end.iso8601
+
+    first_rev = earliest_revision(article_title, usernames, start_date, end_date)
+    last_rev = latest_revision(article_title, usernames, start_date, end_date)
+    return nil unless first_rev && last_rev
+
+    parent_id = first_rev['parentid']
+    last_id = last_rev['revid']
+    "#{@wiki.base_url}/w/index.php?oldid=#{parent_id}&diff=#{last_id}"
+  end
+
+  private
+
+  def earliest_revision(title, usernames, start_date, end_date)
+    revisions = usernames.filter_map do |username|
+      fetch_revision(title, username, start_date, end_date, direction: 'newer')
+    end
+    revisions.min_by { |rev| rev['timestamp'] }
+  end
+
+  def latest_revision(title, usernames, start_date, end_date)
+    revisions = usernames.filter_map do |username|
+      fetch_revision(title, username, start_date, end_date, direction: 'older')
+    end
+    revisions.max_by { |rev| rev['timestamp'] }
+  end
+
+  def fetch_revision(title, username, start_date, end_date, direction:)
+    params = {
+      prop: 'revisions',
+      titles: title,
+      rvprop: 'timestamp|user|ids',
+      rvuser: username,
+      rvdir: direction,
+      rvlimit: 1
+    }
+
+    if direction == 'newer'
+      params[:rvstart] = start_date
+      params[:rvend] = end_date
+    else
+      params[:rvstart] = end_date
+      params[:rvend] = start_date
+    end
+
+    response = @wiki_api.query(params)
+    return nil unless response&.data
+    pages = response.data['pages']
+    return nil unless pages
+    page = pages.values.first
+    page&.dig('revisions', 0)
+  end
+end

--- a/spec/lib/cumulative_diff_url_builder_spec.rb
+++ b/spec/lib/cumulative_diff_url_builder_spec.rb
@@ -3,61 +3,112 @@
 require 'rails_helper'
 require "#{Rails.root}/lib/cumulative_diff_url_builder"
 
+# Examples in this spec use real users, articles, and dates from this ended course:
+# https://dashboard.wikiedu.org/courses/Aquinas_College/Advanced_Communication_Theory_(Fall_2025)
+# (start: 2025-08-18, end: 2025-12-10)
 describe CumulativeDiffUrlBuilder do
-  let(:article) { create(:article) }
-  let(:course) { create(:course, start: '2024-06-16', end: '2024-08-16') }
-  let(:user1) { create(:user, username: 'StudentA') }
-  let(:user2) { create(:user, username: 'StudentB') }
-  let(:articles_course) do
-    create(:articles_course, article:, course:, user_ids: [user1.id, user2.id])
-  end
-
-  before do
-    travel_to Date.new(2024, 7, 16)
-  end
-
-  after do
-    travel_back
-  end
+  let(:course) { create(:course, start: '2025-08-18', end: '2025-12-10') }
 
   describe '#url' do
-    context 'when both users have revisions' do
-      before do
-        allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
-          response = instance_double(MediawikiApi::Response)
-          allow(response).to receive(:data).and_return(
-            build_response(params[:rvuser], params[:rvdir])
-          )
-          response
-        end
+    context 'when both editors contributed to the article' do
+      # "Media multiplexity theory" was edited by two students from the course:
+      # - Kfase   (earliest, 2025-09-08, revid 1310268231 / parentid 1291883584)
+      # - JakeZim16 (latest, 2025-11-18, revid 1322934870 / parentid 1310268231)
+      let(:article) { create(:article, title: 'Media_multiplexity_theory') }
+      let(:kfase) { create(:user, username: 'Kfase') }
+      let(:jakezim) { create(:user, username: 'JakeZim16') }
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [kfase.id, jakezim.id])
       end
 
       it 'returns a diff URL from the earliest first revision to the latest last revision' do
-        url = articles_course.cumulative_diff_url
-        # StudentA's earliest has parentid 99, StudentB's latest has revid 504
-        expect(url).to eq("https://en.wikipedia.org/w/index.php?oldid=99&diff=504")
+        VCR.use_cassette 'cached/cumulative_diff_url_builder/both_editors' do
+          expect(articles_course.cumulative_diff_url)
+            .to eq('https://en.wikipedia.org/w/index.php?oldid=1291883584&diff=1322934870')
+        end
+      end
+    end
+
+    context 'when only one user has revisions' do
+      # "Social constructionism" was edited only by Nateiac7 in the course window
+      # (earliest 2025-11-17 parentid 1316523874, latest 2025-11-19 revid 1323073695).
+      # Julia.kennedy2004 is in the course but did not edit this article.
+      let(:article) { create(:article, title: 'Social_constructionism') }
+      let(:editor) { create(:user, username: 'Nateiac7') }
+      let(:non_editor) { create(:user, username: 'Julia.kennedy2004') }
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [editor.id, non_editor.id])
+      end
+
+      it 'returns a diff URL using that single user revisions' do
+        VCR.use_cassette 'cached/cumulative_diff_url_builder/single_editor' do
+          expect(articles_course.cumulative_diff_url)
+            .to eq('https://en.wikipedia.org/w/index.php?oldid=1316523874&diff=1323073695')
+        end
       end
     end
 
     context 'when the first revision created the article (parentid 0)' do
-      before do
-        allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
-          response = instance_double(MediawikiApi::Response)
-          allow(response).to receive(:data).and_return(
-            build_new_article_response(params[:rvdir])
-          )
-          response
-        end
+      # "User:JakeZim16/Media multiplexity theory" was created by JakeZim16
+      # on 2025-10-19 (revid 1317703640, parentid 0). The latest revision in
+      # the course window is revid 1322930411.
+      let(:article) do
+        create(:article,
+               title: 'JakeZim16/Media_multiplexity_theory',
+               namespace: Article::Namespaces::USER)
+      end
+      let(:user) { create(:user, username: 'JakeZim16') }
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [user.id])
       end
 
       it 'uses the first revid instead of parentid 0' do
-        url = articles_course.cumulative_diff_url
-        # parentid is 0, so oldid should be the first revid (100) not 0
-        expect(url).to eq("https://en.wikipedia.org/w/index.php?oldid=100&diff=102")
+        VCR.use_cassette 'cached/cumulative_diff_url_builder/new_article' do
+          expect(articles_course.cumulative_diff_url)
+            .to eq('https://en.wikipedia.org/w/index.php?oldid=1317703640&diff=1322930411')
+        end
       end
     end
 
-    context 'when no users have revisions' do
+    context 'when user_ids is empty' do
+      let(:article) { create(:article, title: 'Social_constructionism') }
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [])
+      end
+
+      it 'returns nil without making any API calls' do
+        # No cassette needed: the builder short-circuits when user_ids is empty.
+        expect(articles_course.cumulative_diff_url).to be_nil
+      end
+    end
+
+    context 'when none of the users have revisions to the article in the course window' do
+      # "Social constructionism" was not edited by Julia.kennedy2004 in the
+      # course window, so the API returns the page with no revisions key.
+      let(:article) { create(:article, title: 'Social_constructionism') }
+      let(:non_editor) { create(:user, username: 'Julia.kennedy2004') }
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [non_editor.id])
+      end
+
+      it 'returns nil' do
+        VCR.use_cassette 'cached/cumulative_diff_url_builder/no_revisions' do
+          expect(articles_course.cumulative_diff_url).to be_nil
+        end
+      end
+    end
+
+    context 'when the WikiApi request fails (returns nil after retries)' do
+      # Stubbed rather than recorded: WikiApi#query returns nil when its
+      # underlying retries are exhausted on a network error. That path is
+      # awkward to capture cleanly with VCR, so this one context keeps a
+      # small stub for the failure case.
+      let(:article) { create(:article, title: 'Social_constructionism') }
+      let(:user) { create(:user, username: 'Nateiac7') }
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [user.id])
+      end
+
       before do
         allow_any_instance_of(WikiApi).to receive(:query).and_return(nil)
       end
@@ -66,96 +117,5 @@ describe CumulativeDiffUrlBuilder do
         expect(articles_course.cumulative_diff_url).to be_nil
       end
     end
-
-    context 'when only one user has revisions' do
-      before do
-        allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
-          next unless params[:rvuser] == 'StudentA'
-          response = instance_double(MediawikiApi::Response)
-          allow(response).to receive(:data).and_return(
-            build_single_user_response(params[:rvdir])
-          )
-          response
-        end
-      end
-
-      it 'returns a diff URL using that single user revisions' do
-        url = articles_course.cumulative_diff_url
-        expect(url).to eq("https://en.wikipedia.org/w/index.php?oldid=99&diff=102")
-      end
-    end
-
-    context 'when user_ids is empty' do
-      let(:articles_course) do
-        create(:articles_course, article:, course:, user_ids: [])
-      end
-
-      it 'returns nil' do
-        expect(articles_course.cumulative_diff_url).to be_nil
-      end
-    end
-
-    context 'when the API returns a page with no revisions' do
-      before do
-        allow_any_instance_of(WikiApi).to receive(:query) do
-          response = instance_double(MediawikiApi::Response)
-          allow(response).to receive(:data).and_return(
-            { 'pages' => { '-1' => { 'ns' => 0, 'title' => 'Nonexistent', 'missing' => '' } } }
-          )
-          response
-        end
-      end
-
-      it 'returns nil' do
-        expect(articles_course.cumulative_diff_url).to be_nil
-      end
-    end
-  end
-
-  # StudentA: earliest rev at July 1 (parentid 99, revid 100), latest at July 10 (revid 102)
-  # StudentB: earliest rev at July 5 (parentid 200, revid 201), latest at July 15 (revid 504)
-  def build_response(username, direction)
-    revisions = {
-      'StudentA' => {
-        'newer' => { 'revid' => 100, 'parentid' => 99, 'timestamp' => '2024-07-01T12:00:00Z',
-                     'user' => 'StudentA' },
-        'older' => { 'revid' => 102, 'parentid' => 101, 'timestamp' => '2024-07-10T12:00:00Z',
-                     'user' => 'StudentA' }
-      },
-      'StudentB' => {
-        'newer' => { 'revid' => 201, 'parentid' => 200, 'timestamp' => '2024-07-05T12:00:00Z',
-                     'user' => 'StudentB' },
-        'older' => { 'revid' => 504, 'parentid' => 503, 'timestamp' => '2024-07-15T12:00:00Z',
-                     'user' => 'StudentB' }
-      }
-    }
-
-    rev = revisions.dig(username, direction)
-    { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
-  end
-
-  # New article: parentid is 0 (student created the page)
-  def build_new_article_response(direction)
-    revisions = {
-      'newer' => { 'revid' => 100, 'parentid' => 0, 'timestamp' => '2024-07-01T12:00:00Z',
-                   'user' => 'StudentA' },
-      'older' => { 'revid' => 102, 'parentid' => 101, 'timestamp' => '2024-07-10T12:00:00Z',
-                   'user' => 'StudentA' }
-    }
-
-    rev = revisions[direction]
-    { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
-  end
-
-  def build_single_user_response(direction)
-    revisions = {
-      'newer' => { 'revid' => 100, 'parentid' => 99, 'timestamp' => '2024-07-01T12:00:00Z',
-                   'user' => 'StudentA' },
-      'older' => { 'revid' => 102, 'parentid' => 101, 'timestamp' => '2024-07-10T12:00:00Z',
-                   'user' => 'StudentA' }
-    }
-
-    rev = revisions[direction]
-    { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
   end
 end

--- a/spec/lib/cumulative_diff_url_builder_spec.rb
+++ b/spec/lib/cumulative_diff_url_builder_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require "#{Rails.root}/lib/cumulative_diff_url_builder"
 
 describe CumulativeDiffUrlBuilder do
-  let(:wiki) { create(:wiki) }
-  let(:article) { create(:article, wiki:) }
+  let(:article) { create(:article) }
   let(:course) { create(:course, start: '2024-06-16', end: '2024-08-16') }
   let(:user1) { create(:user, username: 'StudentA') }
   let(:user2) { create(:user, username: 'StudentB') }

--- a/spec/lib/cumulative_diff_url_builder_spec.rb
+++ b/spec/lib/cumulative_diff_url_builder_spec.rb
@@ -39,6 +39,24 @@ describe CumulativeDiffUrlBuilder do
       end
     end
 
+    context 'when the first revision created the article (parentid 0)' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
+          response = instance_double(MediawikiApi::Response)
+          allow(response).to receive(:data).and_return(
+            build_new_article_response(params[:rvdir])
+          )
+          response
+        end
+      end
+
+      it 'uses the first revid instead of parentid 0' do
+        url = articles_course.cumulative_diff_url
+        # parentid is 0, so oldid should be the first revid (100) not 0
+        expect(url).to eq("https://en.wikipedia.org/w/index.php?oldid=100&diff=102")
+      end
+    end
+
     context 'when no users have revisions' do
       before do
         allow_any_instance_of(WikiApi).to receive(:query).and_return(nil)
@@ -52,13 +70,12 @@ describe CumulativeDiffUrlBuilder do
     context 'when only one user has revisions' do
       before do
         allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
-          if params[:rvuser] == 'StudentA'
-            response = instance_double(MediawikiApi::Response)
-            allow(response).to receive(:data).and_return(
-              build_single_user_response(params[:rvdir])
-            )
-            response
-          end
+          next unless params[:rvuser] == 'StudentA'
+          response = instance_double(MediawikiApi::Response)
+          allow(response).to receive(:data).and_return(
+            build_single_user_response(params[:rvdir])
+          )
+          response
         end
       end
 
@@ -95,8 +112,6 @@ describe CumulativeDiffUrlBuilder do
     end
   end
 
-  private
-
   # StudentA: earliest rev at July 1 (parentid 99, revid 100), latest at July 10 (revid 102)
   # StudentB: earliest rev at July 5 (parentid 200, revid 201), latest at July 15 (revid 504)
   def build_response(username, direction)
@@ -116,6 +131,19 @@ describe CumulativeDiffUrlBuilder do
     }
 
     rev = revisions.dig(username, direction)
+    { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
+  end
+
+  # New article: parentid is 0 (student created the page)
+  def build_new_article_response(direction)
+    revisions = {
+      'newer' => { 'revid' => 100, 'parentid' => 0, 'timestamp' => '2024-07-01T12:00:00Z',
+                   'user' => 'StudentA' },
+      'older' => { 'revid' => 102, 'parentid' => 101, 'timestamp' => '2024-07-10T12:00:00Z',
+                   'user' => 'StudentA' }
+    }
+
+    rev = revisions[direction]
     { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
   end
 

--- a/spec/lib/cumulative_diff_url_builder_spec.rb
+++ b/spec/lib/cumulative_diff_url_builder_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CumulativeDiffUrlBuilder do
+  let(:wiki) { create(:wiki) }
+  let(:article) { create(:article, wiki:) }
+  let(:course) { create(:course, start: '2024-06-16', end: '2024-08-16') }
+  let(:user1) { create(:user, username: 'StudentA') }
+  let(:user2) { create(:user, username: 'StudentB') }
+  let(:articles_course) do
+    create(:articles_course, article:, course:, user_ids: [user1.id, user2.id])
+  end
+
+  before do
+    travel_to Date.new(2024, 7, 16)
+  end
+
+  after do
+    travel_back
+  end
+
+  describe '#url' do
+    context 'when both users have revisions' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
+          response = instance_double(MediawikiApi::Response)
+          allow(response).to receive(:data).and_return(
+            build_response(params[:rvuser], params[:rvdir])
+          )
+          response
+        end
+      end
+
+      it 'returns a diff URL from the earliest first revision to the latest last revision' do
+        url = articles_course.cumulative_diff_url
+        # StudentA's earliest has parentid 99, StudentB's latest has revid 504
+        expect(url).to eq("https://en.wikipedia.org/w/index.php?oldid=99&diff=504")
+      end
+    end
+
+    context 'when no users have revisions' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:query).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(articles_course.cumulative_diff_url).to be_nil
+      end
+    end
+
+    context 'when only one user has revisions' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:query).and_wrap_original do |_m, params|
+          if params[:rvuser] == 'StudentA'
+            response = instance_double(MediawikiApi::Response)
+            allow(response).to receive(:data).and_return(
+              build_single_user_response(params[:rvdir])
+            )
+            response
+          end
+        end
+      end
+
+      it 'returns a diff URL using that single user revisions' do
+        url = articles_course.cumulative_diff_url
+        expect(url).to eq("https://en.wikipedia.org/w/index.php?oldid=99&diff=102")
+      end
+    end
+
+    context 'when user_ids is empty' do
+      let(:articles_course) do
+        create(:articles_course, article:, course:, user_ids: [])
+      end
+
+      it 'returns nil' do
+        expect(articles_course.cumulative_diff_url).to be_nil
+      end
+    end
+
+    context 'when the API returns a page with no revisions' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:query) do
+          response = instance_double(MediawikiApi::Response)
+          allow(response).to receive(:data).and_return(
+            { 'pages' => { '-1' => { 'ns' => 0, 'title' => 'Nonexistent', 'missing' => '' } } }
+          )
+          response
+        end
+      end
+
+      it 'returns nil' do
+        expect(articles_course.cumulative_diff_url).to be_nil
+      end
+    end
+  end
+
+  private
+
+  # StudentA: earliest rev at July 1 (parentid 99, revid 100), latest at July 10 (revid 102)
+  # StudentB: earliest rev at July 5 (parentid 200, revid 201), latest at July 15 (revid 504)
+  def build_response(username, direction)
+    revisions = {
+      'StudentA' => {
+        'newer' => { 'revid' => 100, 'parentid' => 99, 'timestamp' => '2024-07-01T12:00:00Z',
+                     'user' => 'StudentA' },
+        'older' => { 'revid' => 102, 'parentid' => 101, 'timestamp' => '2024-07-10T12:00:00Z',
+                     'user' => 'StudentA' }
+      },
+      'StudentB' => {
+        'newer' => { 'revid' => 201, 'parentid' => 200, 'timestamp' => '2024-07-05T12:00:00Z',
+                     'user' => 'StudentB' },
+        'older' => { 'revid' => 504, 'parentid' => 503, 'timestamp' => '2024-07-15T12:00:00Z',
+                     'user' => 'StudentB' }
+      }
+    }
+
+    rev = revisions.dig(username, direction)
+    { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
+  end
+
+  def build_single_user_response(direction)
+    revisions = {
+      'newer' => { 'revid' => 100, 'parentid' => 99, 'timestamp' => '2024-07-01T12:00:00Z',
+                   'user' => 'StudentA' },
+      'older' => { 'revid' => 102, 'parentid' => 101, 'timestamp' => '2024-07-10T12:00:00Z',
+                   'user' => 'StudentA' }
+    }
+
+    rev = revisions[direction]
+    { 'pages' => { '1' => { 'pageid' => 1, 'revisions' => [rev] } } }
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `CumulativeDiffUrlBuilder` service that queries the MediaWiki API to find the earliest and latest revisions made by a course's editors within the course date range
- Adds a `cumulative_diff_url` instance method to `ArticlesCourses` that delegates to the builder
- Includes specs covering multi-user, single-user, empty users, missing page, nil API response, and new-article (parentid=0) cases

This enables cumulative diff URLs to be generated server-side for use in alert emails and batch scripting, without relying on the frontend `DiffViewer` component.

## Test plan

- [x] Verify `ArticlesCourses#cumulative_diff_url` returns a valid diff URL for a record with multiple editors
- [x] Verify it returns `nil` gracefully when there are no editors or the article has no revisions
- [x] Run `bundle exec rspec spec/lib/cumulative_diff_url_builder_spec.rb` (6/6 passing)

Closes #6749