### PR TITLE
Scope .table-responsive CSS to mobile only

### DIFF
--- a/app/assets/stylesheets/modules/_tables.styl
+++ b/app/assets/stylesheets/modules/_tables.styl
@@ -197,9 +197,10 @@
     width max-content
 
 .table-responsive
-  display block
-  overflow-x auto
-  -webkit-overflow-scrolling touch
+  +below(tablet)
+    display block
+    overflow-x auto
+    -webkit-overflow-scrolling touch
 
 .revision-list-container
   +below(tablet)


### PR DESCRIPTION
Fixes desktop UI scroll bug and broken table layouts caused by unscoped overflow-x: auto.

related to the pr #6715 



## Screenshots
Before:
(HomePage)
<img width="832" height="350" alt="Screenshot 2026-03-25 at 1 40 48 AM" src="https://github.com/user-attachments/assets/6c735527-403f-4006-aa0e-fedf9620b66f" />
(Articles Tab)
<img width="1181" height="611" alt="Screenshot 2026-03-25 at 2 16 06 AM" src="https://github.com/user-attachments/assets/aec486e6-9849-451f-bdd6-227966161ec2" />


After:
(HomePage)
<img width="885" height="258" alt="Screenshot 2026-03-25 at 2 19 25 AM" src="https://github.com/user-attachments/assets/f5f1e110-7cd8-4293-bb4c-c857479651e0" />

(Articles Tab)

<img width="967" height="425" alt="Screenshot 2026-03-25 at 2 15 46 AM" src="https://github.com/user-attachments/assets/de229399-3ae1-47a4-a152-9bde407b8d4b" />


