### PR TITLE
Fix i18n(t) errors in training slide handler

### DIFF
--- a/app/assets/javascripts/training/components/training_slide_handler.jsx
+++ b/app/assets/javascripts/training/components/training_slide_handler.jsx
@@ -136,7 +136,7 @@ const TrainingSlideHandler = () => {
   if (training.loading === true) {
     return (
       <div className="training-loader">
-        <h1 className="h2">Loading…</h1>
+        <h1 className="h2">{I18n.t('training.loading')}</h1>
         <div className="training-loader__spinner" />
       </div>
     );
@@ -239,7 +239,7 @@ const TrainingSlideHandler = () => {
 
  let sourceLink;
  if (training.currentSlide.wiki_page) {
-   sourceLink = <span><a href={`https://meta.wikimedia.org/wiki/${training.currentSlide.wiki_page}`} target="_blank">wiki source</a></span>;
+   sourceLink = <span><a href={`https://meta.wikimedia.org/wiki/${training.currentSlide.wiki_page}`} target="_blank">{I18n.t('training.wiki_source')}</a></span>;
  }
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1590,6 +1590,8 @@ en:
     exercise_sandbox: Exercise Sandbox
     remaining_exercise: "%{count} additional exercises remaining."
     view_all: View all exercises
+    loading: "Loading…"
+    wiki_source: "wiki source"
 
   update_username:
     header: Update a changed username


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## Instructions

Convert the PR to a draft unless/until:
* The tests are all passing (ie, the CI build is green)
* All feedback has been addressed. (Reviewers will convert it back to a draft if changes need to be made. Mark it ready for review when it's ready again.)
* The git history is tidy. (Each commit should be self-contained, with a clear description in the commit message. In most cases, there should be no merge commits.)
* The PR description template is complete, with a clear indication of the purpose, links to related issues, links to relevant external documentation, an AI usage statement, up-to-date screenshots or demo videos (if applicable). This "Instructions" section can be removed.

If your PR is ready but has been ignored for a week or more, feel free to leave a comment reminding us.

## What this PR does
Replaces string literals in training_slide_handler.jsx to I18n(t) translation.

## AI usage
none

## Screenshots
Before:
<img width="1366" height="768" alt="Screenshot From 2026-03-22 16-21-09" src="https://github.com/user-attachments/assets/137facb3-e8cb-4446-a419-7143911d2f08" />


After:
<img width="1366" height="768" alt="Screenshot From 2026-03-24 15-26-15" src="https://github.com/user-attachments/assets/a22af8ea-d545-4bf1-842a-3eafd8473e2c" />
<img width="1366" height="768" alt="Screenshot From 2026-03-24 15-08-13" src="https://github.com/user-attachments/assets/3aee7efb-0306-4a1f-8eae-dcc8305ee185" />
<img width="1366" height="768" alt="Screenshot From 2026-03-24 15-09-33" src="https://github.com/user-attachments/assets/ce3e1d50-777d-4d9b-bef8-a82f9e83adff" />


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
