### PR TITLE
Fix/image tooltip pluralization 6738

### DIFF
--- a/app/assets/javascripts/components/uploads/upload.jsx
+++ b/app/assets/javascripts/components/uploads/upload.jsx
@@ -51,7 +51,7 @@ const Upload = ({ upload, view, linkUsername }) => {
 
   let usage = '';
   if (upload.usage_count) {
-    usage = `${I18n.t('uploads.usage_count_gallery_tile', { usage_count: upload.usage_count })}`;
+    usage = `${I18n.t('uploads.usage_count_gallery_tile', { count: upload.usage_count })}`;
   }
 
   let uploadDivStyle;
@@ -68,7 +68,7 @@ const Upload = ({ upload, view, linkUsername }) => {
       <p className="tablet-only">
         <span>{upload.uploader}</span>
         <span>&nbsp;|&nbsp;</span>
-        <span>Usages: {upload.usage_count}</span>
+        <span>{I18n.t('uploads.usages')}: {upload.usage_count}</span>
       </p>
     );
   } else {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1647,7 +1647,9 @@ en:
     uploaded_on: Uploaded On
     usage_count: Usage Count
     usage_doc: Number of Wikipedia articles that this image appears in.
-    usage_count_gallery_tile: Used in %{usage_count} articles
+    usage_count_gallery_tile:
+      one: "Used in 1 article"
+      other: "Used in %{count} articles"
     usages: Usages
     gallery_view: Gallery View
     list_view: List View

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -696,8 +696,10 @@ qqq:
       only)
     show_courses: Checkbox for option to show user courses only (Wiki Ed only)
     uploaded_by: Label for the user who uploaded a file
-    usage_count: Label for the number of global usages of a file across Wikimedia
-      sites
+    usage_count: Label for the number of global usages of a file across Wikimedia projects
+    usage_count_gallery_tile:
+      one: "Label for when the media file is used in exactly one article"
+      other: "Label for when the media file is used in many articles. {{PLURAL:%1$d|1=Used in 1 article|Used in %1$d articles}}"
   revisions:
     chars_added: Label for counter of added chars
     class: |-

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -411,13 +411,39 @@ describe 'the course page', type: :feature, js: true do
         user_id: 1,
         file_name: 'File:Example.jpg',
         uploaded_at: '2015-06-01',
-        thumburl: 'https://upload.wikimedia.org/wikipedia/commons/a/af/Grottolella.jpg'
+        thumburl: 'https://upload.wikimedia.org/wikipedia/commons/a/af/Grottolella.jpg',
+        usage_count: 1
       )
     end
 
     it 'displays a list of uploads' do
+      @commons_upload_plural = create(
+        :commons_upload,
+        user_id: 1,
+        file_name: 'File:Example_2.jpg',
+        uploaded_at: '2015-06-02',
+        thumburl: 'https://upload.wikimedia.org/wikipedia/commons/a/af/Grottolella.jpg',
+        usage_count: 2
+      )
+
       js_visit "/courses/#{slug}/uploads"
-      expect(page).to have_selector('div.upload')
+      expect(page).to have_selector('div.upload', count: 2)
+
+      # Wait for the images and containers to be ready
+      expect(page).to have_selector('img[alt$="Example.jpg"]')
+      expect(page).to have_selector('img[alt$="Example_2.jpg"]')
+
+      # Hover singular
+      # Find the upload container that contains the specific image and hover it
+      find('img[alt$="Example.jpg"]').ancestor('.upload').hover
+      # Verify correct singular pluralization
+      expect(page).to have_css('.usage', text: 'Used in 1 article', wait: 5)
+
+      # Hover plural
+      find('img[alt$="Example_2.jpg"]').ancestor('.upload').hover
+      # Verify correct plural pluralization
+      expect(page).to have_css('.usage', text: 'Used in 2 articles', wait: 5)
+
       expect(page).not_to have_content I18n.t('courses_generic.uploads_none')
     end
 


### PR DESCRIPTION
What this PR does:

This PR fixes a pluralization issue in the image usage count displayed on the Uploads tab.
Previously, when an image was used in a single article, it incorrectly displayed:
"Used in 1 articles"
This PR ensures correct grammatical handling by updating the implementation to display:
"Used in 1 article" (singular)
"Used in X articles" (plural)

Changes made:
Updated translation keys in config/locales/en.yml to support proper pluralization.
Modified upload.jsx to use I18n.t with the count parameter for automatic plural handling.
Ensured compatibility with existing i18n conventions in the codebase.

AI usage :
I used an AI tool only to identify the source of the warnings. The actual implementation, code changes, and verification were done manually.

Screenshots:
Before
Incorrect pluralization for singular case
<img width="1846" height="1001" alt="Screenshot from 2026-03-26 22-15-45" src="https://github.com/user-attachments/assets/a38ffc3d-b00d-46fb-a1ca-f357be208f5f" />

After:
Correct singular and plural display
<img width="1843" height="979" alt="Screenshot from 2026-03-26 23-36-55" src="https://github.com/user-attachments/assets/4cfd3a99-80f2-47da-a3d1-787c3c2b2284" />

Open questions / concerns:
None. The change is scoped, minimal, and does not affect other parts of the system.