### PR TITLE
Resolving category scope failing test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '3.4.8'
 
 ### Basic Framework
-gem 'rails', '8.1.2'
+gem 'rails', '8.1.2' # Rails 8.1.2 is the latest stable version of Rails
 gem 'jbuilder' # DSL for building JSON view templates
 gem 'haml-rails' # HTML template language, used instead of ERB
 gem 'bootsnap', require: false # Makes rails boot faster via caching


### PR DESCRIPTION

## What this PR does

This PR investigates an intermittent failure in `spec/features/category_scopes_spec.rb`, specifically:

`Tracked categories and templates lets a facilitator add multiple categories from different wikis at once`

I have been trying various approaches to figure out how and why the spec fails sometimes, including:
- Running the specific example repeatedly in isolation
- Running with fixed seeds
- Checking whether the issue reproduces consistently
- Comparing behavior between isolated runs and broader test execution contexts

The immediate goal is to identify whether this is a timing-related/flaky behavior or an ordering/environment-related issue.

## AI usage

I used AI assistance to:
- help reason about potential flaky-test causes
- suggest targeted reproduction strategies (seeded runs, repeated runs, broader-scope runs)
- summarize findings for this PR description

## Screenshots

Before:
- N/A (no UI change was introduced; this PR is focused on test-flake investigation)

After:
- N/A (no UI change was introduced; this PR is focused on test-flake investigation)

## Open questions and concerns

- The spec has passed repeatedly in local isolated runs, but it has been reported as intermittently failing.
- Is the failure reproducible only in CI or only when run with other specs?
- If this is caused by asynchronous UI timing, what is the most reliable and minimal way to stabilize the test without over-waiting?
