### PR TITLE
Add regression test for suppressed parent revision bug

### DIFF
--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -333,4 +333,21 @@ describe Replica do
       expect(result).to be_empty
     end
   end
+
+  # Regression test for the suppressed parent revision bug.
+  describe 'suppressed parent revision' do
+    it 'returns correct characters for a revision with a suppressed parent revision' do
+      VCR.use_cassette 'replica/suppressed_parent_revision' do
+        user = build(:user, username: 'Rhitorical')
+        response = described_class.new(en_wiki)
+                                  .get_revisions([user], 2025_02_01_000000,
+                                                 2025_06_01_000000)
+        rev = response['9171866']['revisions'].find { |r| r['mw_rev_id'] == '1278154303' }
+
+        expect(rev['characters'].to_i).to eq(1842)
+      end
+    end
+  end
 end
+
+


### PR DESCRIPTION
## What this PR does
This PR addresses the issue of inflated character count statistics on the dashboard (#6331 ). This typically occurs for edits where the parent revision has been suppressed. In these cases, the standard replica queries at `replica-revision-tools.wmcloud.org` fail to obtain the parent revision's size, leading to the entire page size being reported as the edit's character count.

Changes include:
- A new regression test in `spec/lib/replica_spec.rb` that verifies correct character count retrieval for a known problematic revision (mw_rev_id: 1278154303).

## AI usage
- Identify the bug behind failing test cases.

## Screenshots
N/A(backend only test)

##Open questions and concerns
The tests in `replica_spec.rb` and `article_status_manager_timeslice_spec.rb` are  failing when I am testing on my local and also in my previous PR. The root cause seems to be that POST requests to the replica API endpoint  are returning `nil` instead of the expected article data.

I've found that adding the following line to the request in `lib/replica.rb` fixes the failures:
```ruby
req.add_field('Content-Type', 'application/x-www-form-urlencoded')
```
This line explicitly tells the server that we're sending a standard HTML form body, which allows it to correctly parse the article titles we're sending. Without it, the server doesn't understand the request and returns `nil`.

So I have a doubt, how these tests were passing previously successfully without adding this.

