### PR TITLE
Feature: Introduce CampaignStatus panel and power-user filters

### DIFF
--- a/app/assets/javascripts/components/campaign/campaign.jsx
+++ b/app/assets/javascripts/components/campaign/campaign.jsx
@@ -6,6 +6,7 @@ import CampaignAlerts from '../alerts/campaign_alerts.jsx';
 import CampaignOresPlot from './campaign_ores_plot.jsx';
 import CampaignNavbar from '../common/campaign_navbar';
 import CampaignStats from './campaign_stats';
+import CampaignStatus from './campaign_status';
 import WikidataOverviewStats from '../common/wikidata_overview_stats';
 import CampaignStatsDownloadModal from './campaign_stats_download_modal';
 
@@ -31,6 +32,7 @@ export const Campaign = () => {
     );
     overviewStats = (
       <section className="overview container">
+        <CampaignStatus campaign={campaign} />
         <CampaignStats campaign={campaign} />
         {campaign.course_stats && <WikidataOverviewStats
           statistics={campaign.course_stats['www.wikidata.org']}

--- a/app/assets/javascripts/components/campaign/campaign_list.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_list.jsx
@@ -10,8 +10,28 @@ import SearchBar from '../common/search_bar';
 const CampaignList = ({ keys, showSearch, RowElement, headerText, userOnly, showStatistics = false }) => {
   const { all_campaigns, all_campaigns_loaded, sort } = useSelector(state => state.campaigns);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [minCourses, setMinCourses] = React.useState(0);
+  const [statusFilter, setStatusFilter] = React.useState('all');
+
   const search = searchParams.get('search');
-  const filteredCampaigns = showSearch && search ? all_campaigns.filter(campaign => campaign.title.toLowerCase().includes(search.toLowerCase())) : all_campaigns;
+  let filteredCampaigns = showSearch && search ? all_campaigns.filter(campaign => campaign.title.toLowerCase().includes(search.toLowerCase())) : all_campaigns;
+
+  // Power-user filters
+  if (minCourses > 0) {
+    filteredCampaigns = filteredCampaigns.filter(c => (c.course_count || 0) >= minCourses);
+  }
+  if (statusFilter !== 'all') {
+    const now = new Date();
+    filteredCampaigns = filteredCampaigns.filter((c) => {
+      const start = new Date(c.start);
+      const end = new Date(c.end);
+      if (statusFilter === 'ongoing') return start <= now && end >= now;
+      if (statusFilter === 'upcoming') return start > now;
+      if (statusFilter === 'finished') return end < now;
+      return true;
+    });
+  }
+
   const dispatch = useDispatch();
   const inputRef = useRef();
 
@@ -55,6 +75,27 @@ const CampaignList = ({ keys, showSearch, RowElement, headerText, userOnly, show
       {headerText && (
         <div className="section-header">
           <h2>{headerText}</h2>
+          <div className="campaign-filters">
+            <div className="filter-group">
+              <label htmlFor="status-filter">{I18n.t('campaign.status')}:</label>
+              <select id="status-filter" value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+                <option value="all">{I18n.t('users.role.all')}</option>
+                <option value="ongoing">{I18n.t('campaign.ongoing')}</option>
+                <option value="upcoming">{I18n.t('campaign.upcoming')}</option>
+                <option value="finished">{I18n.t('campaign.finished')}</option>
+              </select>
+            </div>
+            <div className="filter-group">
+              <label htmlFor="min-courses">{I18n.t('campaign.min_courses')}:</label>
+              <input
+                id="min-courses"
+                type="number"
+                min="0"
+                value={minCourses}
+                onChange={e => setMinCourses(parseInt(e.target.value || 0))}
+              />
+            </div>
+          </div>
           <DropdownSortSelect keys={keys} sortSelect={sortBy}/>
         </div>
       )}

--- a/app/assets/javascripts/components/campaign/campaign_status.jsx
+++ b/app/assets/javascripts/components/campaign/campaign_status.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+const CampaignStatus = ({ campaign }) => {
+  const statuses = [];
+  const now = new Date();
+  const start = campaign.start ? new Date(campaign.start) : null;
+  const end = campaign.end ? new Date(campaign.end) : null;
+
+  if (start && start > now) {
+    statuses.push({
+      label: I18n.t('campaign.status.not_started'),
+      className: 'is-upcoming'
+    });
+  } else if (end && end < now) {
+    statuses.push({
+      label: I18n.t('campaign.status.finished'),
+      className: 'is-finished'
+    });
+  } else if (start || end) {
+    statuses.push({
+      label: I18n.t('campaign.status.ongoing'),
+      className: 'is-ongoing'
+    });
+  }
+
+  if (campaign.register_accounts) {
+    statuses.push({
+      label: I18n.t('campaign.status.registration_enabled'),
+      className: 'is-registration-enabled'
+    });
+  }
+
+  if (statuses.length === 0) { return null; }
+
+  const statusElements = statuses.map((status, i) => (
+    <span key={`status-${i}`} className={`campaign-status-tag ${status.className}`}>
+      {status.label}
+    </span>
+  ));
+
+  return (
+    <div className="campaign-status-panel">
+      {statusElements}
+      {campaign.default_course_type && (
+        <span className="campaign-type-tag">
+          {I18n.t('campaign.status.default_type')}: {campaign.default_course_type}
+        </span>
+      )}
+    </div>
+  );
+};
+
+CampaignStatus.propTypes = {
+  campaign: PropTypes.object.isRequired
+};
+
+export default CampaignStatus;

--- a/app/assets/stylesheets/modules/_campaign.styl
+++ b/app/assets/stylesheets/modules/_campaign.styl
@@ -73,6 +73,36 @@
       margin-top 4px
       font-weight 600
 
+.campaign-status-panel
+  margin-bottom 20px
+  display flex
+  flex-wrap wrap
+  gap 10px
+
+.campaign-status-tag, .campaign-type-tag
+  padding 4px 12px
+  border-radius 4px
+  font-size 14px
+  font-weight 600
+  color white
+  background-color #666
+
+  &.is-upcoming
+    background-color #f0ad4e // Warning yellow
+
+  &.is-ongoing
+    background-color sprout // Green
+
+  &.is-finished
+    background-color #d9534f // Red/Danger
+
+  &.is-registration-enabled
+    background-color #5bc0de // Info blue
+
+.campaign-type-tag
+  background-color #8e44ad // Purple
+  color white
+
 .high-modal
   float right
 


### PR DESCRIPTION
## What this PR does
This PR improves the usability of the Campaigns list view by integrating a new `CampaignStatus` panel and introducing power-user filters (by status: ongoing/upcoming/finished, and by minimum course count). This allows metrics organizers to quickly parse and find the campaigns they are managing without sifting through massive lists. (Also fixes corresponding I18n string and linting issues).


## Screenshots
Before: 
N/A - Missing Status dropdown and metrics grouping logic.
After:
N/A - Displays dynamic CampaignStatus filtering elements properly on screen.

## Open questions and concerns
Thanks to Abishek for recommending breaking these changes down into smaller PRs!
