### PR TITLE
Refactoring: Standardize absolute date formats in DateCalculator

### DIFF
--- a/app/assets/javascripts/utils/date_calculator.js
+++ b/app/assets/javascripts/utils/date_calculator.js
@@ -15,7 +15,7 @@ class DateCalculator {
   }
 
   start() {
-    return format(this.startDate(), 'MM/dd');
+    return format(this.startDate(), 'MMM dd');
   }
 
   endDate() {
@@ -23,7 +23,7 @@ class DateCalculator {
   }
 
   end() {
-    return format(this.endDate(), 'MM/dd');
+    return format(this.endDate(), 'MMM dd');
   }
 }
 

--- a/test/utils/date_calculator.spec.js
+++ b/test/utils/date_calculator.spec.js
@@ -8,7 +8,7 @@ describe('DateCalculator', () => {
         'returns the formatted start of the nth week (as provided to the constructor)',
         () => {
           const calculator = new DateCalculator('2016-01-01', '2016-12-31', 1, { zeroIndexed: true });
-          expect(calculator.start()).toBe('01/03');
+          expect(calculator.start()).toBe('Jan 03');
         }
       );
     });
@@ -17,7 +17,7 @@ describe('DateCalculator', () => {
         'returns the formatted start of the n - 1 week (as provided to the constructor)',
         () => {
           const calculator = new DateCalculator('2016-01-01', '2016-12-31', 1, { zeroIndexed: false });
-          expect(calculator.start()).toBe('12/27');
+          expect(calculator.start()).toBe('Dec 27');
         }
       );
     });
@@ -28,14 +28,14 @@ describe('DateCalculator', () => {
         'returns the formatted start of the nth week (as provided to the constructor)',
         () => {
           const calculator = new DateCalculator('2016-01-01', '2016-12-31', 1, { zeroIndexed: false });
-          expect(calculator.end()).toBe('01/02');
+          expect(calculator.end()).toBe('Jan 02');
         }
       );
     });
     describe('last day of the week we started on is after course end', () => {
       test('returns the formatted course end', () => {
         const calculator = new DateCalculator('2016-01-01', '2016-12-31', 60, { zeroIndexed: false });
-        expect(calculator.end()).toBe('12/31');
+        expect(calculator.end()).toBe('Dec 31');
       });
     });
   });


### PR DESCRIPTION
## What this PR does
This PR standardizes the absolute date formats used by the `DateCalculator` module (updating them to `MMM dd`). Previously, raw formats were inconsistently generated, causing visual jarring in the timelines because some views used `MM/dd` while others used localized formats.


## Screenshots
Before: 
(Timelines rendered dates like `01/03` and `12/31` generically)
After: 
(Timelines now render readable dates like `Jan 03` and `Dec 31`)

## Open questions and concerns
*(Addressed maintainer feedback: I have excluded the unrelated `CourseUtils` change that accidentally shipped with the first commit, and fixed the broken tests in `date_calculator.spec.js` that were strictly checking for the old format strings!)*
