### PR TITLE
refactor: use constant for URL in specs

### DIFF
--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -260,35 +260,35 @@ describe Replica do
     let(:subject) { described_class.new(en_wiki).get_revisions(all_users, rev_start, rev_end) }
 
     it 'handles timeout errors' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_raise(Errno::ECONNREFUSED)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles failed queries' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles server errors' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 500, body: '', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(subject).to be_empty
     end
 
     it 'handles successful empty responses' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
       expect_any_instance_of(described_class).not_to receive(:log_error)
       expect(subject).to be_empty
@@ -300,35 +300,35 @@ describe Replica do
     let(:result) { described_class.new(en_wiki).post_existing_articles_by_title(article_titles) }
 
     it 'handles timeout errors' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_raise(Errno::ETIMEDOUT)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles connection refused errors' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_raise(Errno::ECONNREFUSED)
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles failed queries' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 200, body: '{ "success": false, "data": [] }', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles server errors' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 500, body: '', headers: {})
       expect_any_instance_of(described_class).to receive(:log_error).once
       expect(result).to be_nil
     end
 
     it 'handles successful empty responses' do
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*})
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 200, body: '{ "success": true, "data": [] }', headers: {})
       expect(result).to be_empty
     end

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -171,7 +171,7 @@ describe UpdateCourseStats do
       allow(Sentry).to receive(:capture_exception)
 
       # Raising errors only in Replica
-      stub_request(:any, %r{https://replica-revision-tools.wmcloud.org/.*}).to_raise(Errno::ECONNREFUSED)
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*}).to_raise(Errno::ECONNREFUSED)
       VCR.use_cassette 'course_update/replica' do
         subject
       end


### PR DESCRIPTION
## What this PR does
This pull request refactors the Replica API tests to improve maintainability and ensure compatibility with the updated Toolforge endpoint. 

Key changes include:
- **Test Refactoring**: Updated `spec/lib/replica_spec.rb` and `spec/services/update_course_stats_spec.rb` to use the `Replica::REPLICA_TOOL_URL` constant instead of hardcoded URL strings.


## Screenshots
N/A (Backend only change. All tests passed successfully on local.)

