### PR TITLE
Fix I18n warnings in Week component

### DIFF
--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -141,11 +141,11 @@ const Week = createReactClass({
     });
 
     const addBlock = !this.props.reorderable ? (
-      <button type="button" className="pull-right week__add-block" href="" onClick={this.addBlock}>Add Block <span className="icon-plus-blue" /></button>
+      <button type="button" className="pull-right week__add-block" href="" onClick={this.addBlock}>{I18n.t('timeline.add_block')}<span className="icon-plus-blue" /></button>
     ) : undefined;
 
     const deleteWeek = !this.props.reorderable && !this.props.week.is_new ? (
-      <button type="button" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} className="pull-right week__delete-week" href="" onClick={this.props.deleteWeek}>Delete Week <span className={`${this.state.isHover ? 'icon-trash_can-hover' : 'icon-trash_can'}`}/></button>
+      <button type="button" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} className="pull-right week__delete-week" href="" onClick={this.props.deleteWeek}>{I18n.t('timeline.delete_week')} <span className={`${this.state.isHover ? 'icon-trash_can-hover' : 'icon-trash_can'}`}/></button>
     ) : undefined;
 
     const weekAddDelete = this.props.edit_permissions ? (

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1571,6 +1571,9 @@ en:
       week or change your assignment dates to make room for a new one.
     view_full_timeline: View Full Timeline
     week_number: "Week %{number}"
+    add_block: Add Block
+    delete_week: Delete Week
+    
 
   training:
     continue: Continue (%{progress})


### PR DESCRIPTION
NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## Instructions

Convert the PR to a draft unless/until:
* The tests are all passing (ie, the CI build is green)
* All feedback has been addressed. (Reviewers will convert it back to a draft if changes need to be made. Mark it ready for review when it's ready again.)
* The git history is tidy. (Each commit should be self-contained, with a clear description in the commit message. In most cases, there should be no merge commits.)
* The PR description template is complete, with a clear indication of the purpose, links to related issues, links to relevant external documentation, an AI usage statement, up-to-date screenshots or demo videos (if applicable). This "Instructions" section can be removed.

If your PR is ready but has been ignored for a week or more, feel free to leave a comment reminding us.

## What this PR does
This PR replaces the hard coded string literals i.e Add block and Delete week to I18n translations.

## AI usage
No
## Screenshots
Before:
<img width="1366" height="768" alt="Screenshot From 2026-04-02 14-19-47" src="https://github.com/user-attachments/assets/560f8d35-4fd4-4d7a-a2be-c3a4e371bd8b" />


After:
<img width="1366" height="768" alt="Screenshot From 2026-04-02 15-47-46" src="https://github.com/user-attachments/assets/50e5bca3-18b4-45bb-96d3-ef7842a115c9" />


## Open questions and concerns
None
