### PR TITLE
Improve card styling and layout on /usage page (#2637)

### DIFF
--- a/app/assets/stylesheets/modules/_usage.styl
+++ b/app/assets/stylesheets/modules/_usage.styl
@@ -16,21 +16,25 @@
       border-bottom 2px solid #e0e0e0
 
   .stats-grid
-    display grid
-    grid-template-columns repeat(3, 1fr)
-    gap 15px
+    display flex
+    flex-wrap wrap
+    justify-content center
+    gap 16px
     margin 20px 0
-    max-width 800px
+    max-width 850px
 
   .stats-card
     text-align center
-    padding 15px
+    padding 20px 16px
     margin 0
+    flex 1 1 calc(33.33% - 16px)
+    max-width calc(33.33% - 16px)
+    min-width 160px
     
     h3
       font-size 1.8em
-      font-weight 700
-      color #2c5aa0
+      font-weight 300
+      color $brand_primary
       margin 0 0 8px 0
       
     p
@@ -139,11 +143,12 @@
 
   @media (max-width: 768px)
     .stats-grid
-      grid-template-columns repeat(2, 1fr)
       gap 12px
       
     .stats-card
-      padding 12px
+      flex 1 1 calc(50% - 12px)
+      max-width calc(50% - 12px)
+      padding 16px 12px
       
       h3
         font-size 1.6em
@@ -152,18 +157,18 @@
       columns 1
 
   @media (max-width: 480px)
-    .stats-grid
-      grid-template-columns 1fr
-      
     .stats-card
-      padding 12px
+      flex 1 1 100%
+      max-width 100%
+      padding 14px 12px
       
       h3
         font-size 1.4em
-
+        
   h3
     margin 0
 
   ul
     margin 0
     padding 0
+    


### PR DESCRIPTION

## What this PR does

This PR improves the card styling and layout of the overview stats section on the /usage page, as discussed in #2637. @ragesoss asked for design and layout changes that draw from the course page design language.

The following updates were made:
- Switched from CSS grid to flexbox so the bottom row of 2 cards centers instead of left-aligning
- Changed font-weight from 700 to 300 to match the course page `.stat-display__value` style
- Replaced hardcoded color `#2c5aa0` with `$brand_primary` for consistency
- Improved responsive breakpoints: 3 columns to 2 columns to 1 column on mobile

Only styling changes in `_usage.styl`. No new data, no new statistics.

Fixes #2637

AI usage: No AI was used for this change. The styling was based on reviewing the existing course page styles in `_stats.styl` and `_modules.styl`.

Screenshots:
Before:
<img width="1203" height="412" alt="Screenshot 2026-04-10 at 10 30 29 PM" src="https://github.com/user-attachments/assets/bc716703-00aa-4dac-b601-ff7f7f8e1d5f" />

After:
<img width="1156" height="380" alt="Screenshot 2026-04-10 at 10 52 21 PM" src="https://github.com/user-attachments/assets/e5ce96cc-4d55-4da9-8678-ae2e77d887cf" />
