### PR TITLE
Replace hardcoded strings with I18n in ArticleViewer components (#6727)

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlert/SubmitIssuePanel.jsx
@@ -31,7 +31,7 @@ export const SubmitIssuePanel = ({ handleChange, handleSubmit, isSubmitting, mes
           value_key="message"
         />
         <button className="button danger" type="submit" disabled={isSubmitting}>
-          Notify Wiki Expert
+          {I18n.t('instructor_view.bad_work.notify_wiki_expert')}
         </button>
       </form>
     </article>

--- a/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlertButton.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/BadWorkAlertButton.jsx
@@ -6,7 +6,7 @@ export const BadWorkAlertButton = ({ showBadArticleAlert }) => (
     className="button small pull-right article-viewer-button"
     onClick={showBadArticleAlert}
   >
-    Quality Problems?
+    {I18n.t('instructor_view.bad_work.quality_problems_button')}
   </a>
 );
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1149,6 +1149,8 @@ en:
       submit_issue_wikidata: "What are the significant problems with this item?"
       submit_issue_placeholder: "The more expert perspective and detail you can provide, the better."
       thank_you: "Thank you! Contact your Wiki Expert if you have additional questions."
+      quality_problems_button: "Quality Problems?"
+      notify_wiki_expert: "Notify Wiki Expert"
     exercises_and_trainings: "%{prefix} Exercises & Trainings"
     no_assignments: "This student currently has no assigned articles."
     can_assign_assignments: "You can assign an article by using the buttons above."


### PR DESCRIPTION
## What this PR does

This PR fixes two i18next/no-literal-string warnings that were showing up during `yarn lint`. The issue was caused by hardcoded English strings in the ArticleViewer components.

The following updates were made:
- Replaced "Quality Problems?" in `BadWorkAlertButton.jsx` with `I18n.t('instructor_view.bad_work.quality_problems_button')`
- Replaced "Notify Wiki Expert" in `SubmitIssuePanel.jsx` with `I18n.t('instructor_view.bad_work.notify_wiki_expert')`
- Added both keys to `config/locales/en.yml` under the existing `instructor_view.bad_work` section

The UI looks the same, but the text now comes from localization files and can be translated into other languages.

Addresses #6727

AI usage:
 I used AI to understand how I18n.t() works in the project and to check the correct key path format under instructor_view.bad_work. The actual changes and file edits were done by me after running yarn lint locally to find the warnings.

Screenshots:
These buttons appear inside the Article Viewer when an instructor reviews a student's article. The UI looks identical before and after  the only change is that the text now comes from I18n localization files instead of hardcoded strings, enabling proper translation when the Dashboard is used in other languages.