### PR TITLE
Fix assorted interactions between specs and other sources of flakiness

### DIFF
--- a/app/assets/javascripts/components/common/ScopingMethods/autocomplete_categories_input.jsx
+++ b/app/assets/javascripts/components/common/ScopingMethods/autocomplete_categories_input.jsx
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash';
-import React from 'react';
+import React, { useRef, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import AsyncSelect from 'react-select/async';
 import API from '../../../utils/api';
@@ -7,15 +7,15 @@ import API from '../../../utils/api';
 const CategoryAutoCompleteInput = ({ label, actionType, initial, wiki, depth }) => {
   const dispatch = useDispatch();
 
-  const search = async (query) => {
-    const data = await API.getCategoriesWithPrefix(wiki, query, depth);
-    return data;
-  };
+  const searchRef = useRef();
+  searchRef.current = query => API.getCategoriesWithPrefix(wiki, query, depth);
 
-  const _loadOptions = (query, callback) => {
-    search(query).then(resp => callback(resp));
-  };
-  const loadOptions = debounce(_loadOptions, 300);
+  const loadOptions = useMemo(
+    () => debounce((query, callback) => {
+      searchRef.current(query).then(resp => callback(resp));
+    }, 300),
+    []
+  );
 
   const updateCategories = (categories) => {
     dispatch({

--- a/app/assets/javascripts/components/common/ScopingMethods/autocomplete_templates_input.jsx
+++ b/app/assets/javascripts/components/common/ScopingMethods/autocomplete_templates_input.jsx
@@ -1,23 +1,21 @@
 import { debounce } from 'lodash';
-import React from 'react';
-import { useDispatch, } from 'react-redux';
+import React, { useRef, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
 import AsyncSelect from 'react-select/async';
 import API from '../../../utils/api';
 
 const TemplatesAutoCompleteInput = ({ label, actionType, initial, wiki }) => {
   const dispatch = useDispatch();
 
-  const search = async (query) => {
-    const data = await API.getTemplatesWithPrefix(wiki, query);
-    return data;
-  };
+  const searchRef = useRef();
+  searchRef.current = query => API.getTemplatesWithPrefix(wiki, query);
 
-  const _loadOptions = (query, callback) => {
-    search(query).then(resp => callback(resp));
-  };
-
-
-  const loadOptions = debounce(_loadOptions, 300);
+  const loadOptions = useMemo(
+    () => debounce((query, callback) => {
+      searchRef.current(query).then(resp => callback(resp));
+    }, 300),
+    []
+  );
 
   const updateTemplates = (templates) => {
     dispatch({

--- a/app/helpers/surveys_analytics_helper.rb
+++ b/app/helpers/surveys_analytics_helper.rb
@@ -18,13 +18,13 @@ module SurveysAnalyticsHelper
 
   def survey_author(model)
     return '--' if model.versions.empty? || model.versions.last.whodunnit.nil?
-    user = User.find(model.versions.last.whodunnit)
+    user = User.find_by(id: model.versions.last.whodunnit)
     return user.username unless user.nil?
   end
 
   def question_group_survey_author(version)
     return '--' if version.blank? || version.whodunnit.nil?
-    user = User.find(version.whodunnit)
+    user = User.find_by(id: version.whodunnit)
     return user.username unless user.nil?
   end
 

--- a/bin/bisect-flaky
+++ b/bin/bisect-flaky
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Bisect to find which spec(s) poison a victim spec.
+#
+# Usage:
+#   bin/bisect-flaky <victim_spec> [suspect_dir]
+#
+# Examples:
+#   bin/bisect-flaky spec/features/course_overview_spec.rb
+#   bin/bisect-flaky spec/features/course_overview_spec.rb spec/features/
+#   bin/bisect-flaky spec/features/course_overview_spec.rb:58
+#
+# The victim is run alone first (must pass). Then the suspect set is run
+# before the victim, and the set is bisected until the minimal polluter
+# is found.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ $# -lt 1 ]; then
+  echo "Usage: bin/bisect-flaky <victim_spec> [suspect_dir]"
+  exit 1
+fi
+
+victim="$1"
+suspect_dir="${2:-spec/}"
+
+mkdir -p tmp
+
+echo "=== Bisect-flaky ==="
+echo "Victim:    $victim"
+echo "Suspects:  $suspect_dir"
+echo ""
+
+# Step 1: Verify victim passes alone
+echo "--- Checking victim passes alone ---"
+bundle exec rspec "$victim" --format progress > tmp/bisect_solo.log 2>&1
+if [ $? -ne 0 ]; then
+  echo "ABORT: Victim fails when run alone. Fix it first."
+  echo "Log: tmp/bisect_solo.log"
+  cat tmp/bisect_solo.log
+  exit 1
+fi
+echo "OK: victim passes alone."
+echo ""
+
+# Step 2: Collect suspect spec files (excluding the victim itself)
+victim_file="${victim%%:*}"  # strip line number if present
+mapfile -t all_suspects < <(
+  find "$suspect_dir" -name '*_spec.rb' -type f | sort | grep -v "^${victim_file}$"
+)
+
+echo "Found ${#all_suspects[@]} suspect spec files."
+echo ""
+
+# Step 3: Verify the full suspect set actually causes failure
+echo "--- Checking full suspect set causes failure ---"
+bundle exec rspec "${all_suspects[@]}" "$victim" --format progress \
+  > tmp/bisect_full.log 2>&1
+if [ $? -eq 0 ]; then
+  echo "NOTE: Victim passes even with all suspects. Trying with --order rand..."
+  # Try a few random orderings
+  found_failure=false
+  for attempt in 1 2 3 4 5; do
+    echo -n "  Attempt $attempt... "
+    bundle exec rspec "${all_suspects[@]}" "$victim" \
+      --format progress --order rand \
+      > "tmp/bisect_rand_${attempt}.log" 2>&1
+    if [ $? -ne 0 ]; then
+      echo "FAIL (order matters — this is order-dependent)"
+      found_failure=true
+      break
+    else
+      echo "pass"
+    fi
+  done
+  if [ "$found_failure" = false ]; then
+    echo ""
+    echo "Could not reproduce failure with suspects from $suspect_dir."
+    echo "Try a different suspect directory or check if the failure is timing-dependent."
+    exit 1
+  fi
+  echo ""
+  echo "The failure is order-dependent. Bisecting with --order defined to preserve order..."
+  order_flag="--order defined"
+else
+  order_flag="--order defined"
+  echo "OK: victim fails with full suspect set."
+fi
+echo ""
+
+# Step 4: Binary search
+suspects=("${all_suspects[@]}")
+round=0
+
+while [ ${#suspects[@]} -gt 1 ]; do
+  round=$((round + 1))
+  midpoint=$(( ${#suspects[@]} / 2 ))
+  first_half=("${suspects[@]:0:$midpoint}")
+  second_half=("${suspects[@]:$midpoint}")
+
+  echo "--- Round $round: ${#suspects[@]} suspects, splitting at $midpoint ---"
+
+  # Try first half + victim
+  echo -n "  First half (${#first_half[@]} files)... "
+  # shellcheck disable=SC2086
+  bundle exec rspec "${first_half[@]}" "$victim" --format progress $order_flag \
+    > "tmp/bisect_round_${round}_first.log" 2>&1
+  first_rc=$?
+
+  if [ $first_rc -ne 0 ]; then
+    echo "FAIL — polluter is in first half"
+    suspects=("${first_half[@]}")
+    continue
+  else
+    echo "pass"
+  fi
+
+  # Try second half + victim
+  echo -n "  Second half (${#second_half[@]} files)... "
+  # shellcheck disable=SC2086
+  bundle exec rspec "${second_half[@]}" "$victim" --format progress $order_flag \
+    > "tmp/bisect_round_${round}_second.log" 2>&1
+  second_rc=$?
+
+  if [ $second_rc -ne 0 ]; then
+    echo "FAIL — polluter is in second half"
+    suspects=("${second_half[@]}")
+    continue
+  else
+    echo "pass"
+  fi
+
+  # Neither half alone causes failure — interaction between halves
+  echo "  Neither half alone causes failure. Possible multi-file interaction."
+  echo "  Trying to narrow down with both halves..."
+  # Keep the full set and try removing one file at a time from the smaller set
+  break
+done
+
+echo ""
+echo "=== Result ==="
+
+if [ ${#suspects[@]} -eq 1 ]; then
+  echo "Minimal polluter: ${suspects[0]}"
+  echo ""
+  echo "Verify with:"
+  echo "  bundle exec rspec ${suspects[0]} $victim --format documentation"
+  echo ""
+  echo "Polluter: ${suspects[0]}" > tmp/bisect_result.txt
+elif [ ${#suspects[@]} -le 5 ]; then
+  echo "Narrowed to ${#suspects[@]} suspects (multi-file interaction likely):"
+  for s in "${suspects[@]}"; do
+    echo "  $s"
+  done
+  echo ""
+  echo "Try running each individually with the victim:"
+  for s in "${suspects[@]}"; do
+    echo "  bundle exec rspec $s $victim --format documentation"
+  done
+  printf '%s\n' "${suspects[@]}" > tmp/bisect_result.txt
+else
+  echo "Could not narrow below ${#suspects[@]} suspects."
+  echo "The failure may involve complex multi-file state interaction."
+  printf '%s\n' "${suspects[@]}" > tmp/bisect_result.txt
+fi
+
+echo ""
+echo "Logs in tmp/bisect_*.log"

--- a/bin/full-suite
+++ b/bin/full-suite
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Run the full rspec suite and archive the coverage directory with today's date.
+# Run the full rspec suite in parallel and archive the coverage directory
+# with today's date.
 #
 # Usage:
 #   bin/full-suite
-#   bin/full-suite [extra rspec args...]
+#   bin/full-suite [extra parallel_rspec args...]
 
 set -euo pipefail
 
@@ -12,7 +13,7 @@ cd "$(dirname "$0")/.."
 date_stamp=$(date +%Y-%m-%d)
 archive="coverage.all.${date_stamp}"
 
-bundle exec rspec "$@" || rspec_exit=$?
+PARALLEL_TEST_GROUPS=true bundle exec parallel_rspec -n 4 "$@" || rspec_exit=$?
 rspec_exit=${rspec_exit:-0}
 
 if [ -d coverage ]; then

--- a/bin/repeat-spec
+++ b/bin/repeat-spec
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run a spec file N times, reporting pass/fail for each.
+#
+# Usage:
+#   bin/repeat-spec <spec_file> [--runs N] [-- extra_rspec_args...]
+#
+# Examples:
+#   bin/repeat-spec spec/lib/foo_spec.rb --runs 20
+#   bin/repeat-spec spec/lib/foo_spec.rb --runs 10 -- --order rand
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ $# -lt 1 ]; then
+  echo "Usage: bin/repeat-spec <spec_file> [--runs N] [-- extra_rspec_args...]"
+  exit 1
+fi
+
+spec="$1"; shift
+runs=10
+extra_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs)  runs="$2"; shift 2 ;;
+    --)      shift; extra_args=("$@"); break ;;
+    *)       extra_args+=("$1"); shift ;;
+  esac
+done
+
+pass=0
+fail=0
+
+echo "=== Repeating: $spec ($runs runs) ==="
+echo ""
+
+for i in $(seq 1 "$runs"); do
+  echo -n "Run $i/$runs ... "
+  bundle exec rspec "$spec" --format progress "${extra_args[@]:+${extra_args[@]}}" \
+    > "tmp/repeat_run_${i}.log" 2>&1
+  rc=$?
+  if [ $rc -eq 0 ]; then
+    echo "PASS"
+    pass=$((pass + 1))
+  else
+    echo "FAIL (exit $rc)"
+    fail=$((fail + 1))
+  fi
+done
+
+echo ""
+echo "=== Results: $pass passed, $fail failed out of $runs ==="
+[ "$fail" -eq 0 ]

--- a/bin/soak-test
+++ b/bin/soak-test
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Run the parallel test suite N times with random ordering, logging results.
+# Exit 0 only if all runs pass.
+#
+# Usage:
+#   bin/soak-test [--runs N] [--seed SEED] [-- extra_rspec_args...]
+#
+# Examples:
+#   bin/soak-test                       # 3 runs, random seeds
+#   bin/soak-test --runs 10             # 10 runs
+#   bin/soak-test --seed 12345          # fixed seed every run
+#   bin/soak-test -- spec/features/     # only feature specs
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+runs=3
+seed=""
+extra_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs)  runs="$2"; shift 2 ;;
+    --seed)  seed="$2"; shift 2 ;;
+    --)      shift; extra_args=("$@"); break ;;
+    *)       extra_args+=("$1"); shift ;;
+  esac
+done
+
+mkdir -p tmp
+
+pass=0
+fail=0
+summary="tmp/soak_results.txt"
+: > "$summary"
+
+echo "=== Soak test: $runs run(s) ==="
+echo ""
+
+for i in $(seq 1 "$runs"); do
+  log="tmp/soak_run_${i}.log"
+  run_seed="${seed:-$RANDOM}"
+
+  echo -n "Run $i/$runs (seed $run_seed) ... "
+  echo "=== Run $i  seed=$run_seed  $(date -Iseconds) ===" > "$log"
+
+  PARALLEL_TEST_GROUPS=true bundle exec parallel_rspec -n 4 \
+    -o "--order rand:$run_seed" \
+    "${extra_args[@]:+${extra_args[@]}}" \
+    >> "$log" 2>&1
+  rc=$?
+
+  if [ $rc -eq 0 ]; then
+    echo "PASS"
+    echo "Run $i  seed=$run_seed  PASS" >> "$summary"
+    pass=$((pass + 1))
+  else
+    echo "FAIL (exit $rc)"
+    echo "Run $i  seed=$run_seed  FAIL (exit $rc)" >> "$summary"
+    fail=$((fail + 1))
+    # Extract failed examples from log for quick diagnosis
+    if grep -q 'Failed examples:' "$log"; then
+      echo "  Failed examples:" >> "$summary"
+      sed -n '/^Failed examples:/,/^$/p' "$log" | head -20 >> "$summary"
+    fi
+  fi
+done
+
+echo ""
+echo "=== Results: $pass passed, $fail failed out of $runs ==="
+echo "" >> "$summary"
+echo "Total: $pass passed, $fail failed out of $runs" >> "$summary"
+cat "$summary"
+
+[ "$fail" -eq 0 ]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,6 +76,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
+  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/spec/features/course_cloning_spec.rb
+++ b/spec/features/course_cloning_spec.rb
@@ -115,7 +115,6 @@ describe 'cloning a course', js: true do
 
   it 'copies relevant attributes of an existing course with assignments' do
     course.wikis = Wiki.find([1, 3, 4]) # Let the original course have some tracked wikis.
-    visit '/status' # Flush browser state from previous spec
     login_as user
     visit root_path
     click_link 'Create Course'

--- a/spec/features/course_copying_spec.rb
+++ b/spec/features/course_copying_spec.rb
@@ -21,7 +21,6 @@ describe 'course copying', type: :feature, js: true do
   let(:subject) { 'Advanced Foo' }
 
   it 'checks copying of course across server' do
-    visit '/status'
     login_as(user, scope: :user)
     visit root_path
     click_link 'Copy Course from another Server'

--- a/spec/features/js_error_detection_spec.rb
+++ b/spec/features/js_error_detection_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Meta-test: verifies that SEVERE JavaScript console errors are captured in
+# browser logs and detectable after page navigation — the same mechanism the
+# after(:each) hook in rails_helper uses to fail specs on JS errors.
+#
+# Uses js_error_expected: true so the after hook skips its own check; instead
+# we call check_for_severe_js_errors directly (the same method the hook uses)
+# so this test stays in sync with the real detection logic.
+describe 'JS error detection', type: :feature, js: true, js_error_expected: true do
+  let(:course) { create(:course) }
+  let(:admin) { create(:admin) }
+
+  before do
+    stub_token_request
+    login_as(admin, scope: :user)
+  end
+
+  it 'detects SEVERE errors in browser logs after page navigation' do
+    visit "/courses/#{course.slug}"
+    expect(page).to have_content course.title
+
+    page.execute_script(<<~JS)
+      var s = document.createElement('script');
+      s.textContent = 'throw new Error("Intentional test error for JS error detection")';
+      document.head.appendChild(s);
+    JS
+
+    click_link 'Home'
+    expect(page).to have_content 'My Dashboard'
+
+    # Call the same method the after(:each) hook uses. If this stops catching
+    # the injected error, it means the detection mechanism is broken.
+    errors = page.driver.browser.logs.get(:browser)
+    expect { check_for_severe_js_errors(errors) }
+      .to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+end

--- a/spec/lib/training_module_due_date_manager_spec.rb
+++ b/spec/lib/training_module_due_date_manager_spec.rb
@@ -88,9 +88,9 @@ describe TrainingModuleDueDateManager do
                      .overdue?
     end
 
-    before(:all) { travel_to Date.new(2015, 8, 25) }
+    before { travel_to Date.new(2015, 8, 25) }
 
-    after(:all) { travel_back }
+    after { travel_back }
 
     context 'module is not complete' do
       context "today's date is before computed_due_date" do
@@ -100,7 +100,7 @@ describe TrainingModuleDueDateManager do
       end
 
       context "today's date is computed_due_date" do
-        let(:due_date) { Time.zone.now.to_date }
+        let(:due_date) { Date.new(2015, 8, 25) }
 
         it 'returns false' do
           expect(subject).to eq(false)
@@ -108,7 +108,7 @@ describe TrainingModuleDueDateManager do
       end
 
       context "today's date is after computed_due_date" do
-        let(:due_date) { 1.week.ago.to_date }
+        let(:due_date) { Date.new(2015, 8, 18) }
 
         it 'returns true' do
           expect(subject).to eq(true)
@@ -116,7 +116,7 @@ describe TrainingModuleDueDateManager do
       end
 
       context 'training module is not of kind TRAINING' do
-        let(:due_date) { 1.week.ago.to_date }
+        let(:due_date) { Date.new(2015, 8, 18) }
 
         before { t_module.update(kind: TrainingModule::Kinds::EXERCISE) }
 
@@ -129,8 +129,8 @@ describe TrainingModuleDueDateManager do
     end
 
     context 'module is complete' do
-      let(:completed_at) { 10.days.ago.to_date }
-      let(:due_date) { 1.week.ago.to_date }
+      let(:completed_at) { Date.new(2015, 8, 15) }
+      let(:due_date) { Date.new(2015, 8, 18) }
 
       it 'returns false' do
         expect(subject).to eq(false)
@@ -144,11 +144,11 @@ describe TrainingModuleDueDateManager do
                      .deadline_status
     end
 
-    before(:all) { travel_to Date.new(2015, 8, 25) }
+    before { travel_to Date.new(2015, 8, 25) }
 
-    after(:all) { travel_back }
+    after { travel_back }
 
-    let(:completed_at) { 1.day.ago }
+    let(:completed_at) { Date.new(2015, 8, 24) }
 
     context 'user is nil' do
       let(:user) { nil }
@@ -168,7 +168,7 @@ describe TrainingModuleDueDateManager do
       let(:completed_at) { nil }
 
       context 'due date in future' do
-        let(:due_date) { 1.week.from_now }
+        let(:due_date) { Date.new(2015, 9, 1) }
 
         it 'returns nil' do
           expect(subject).to be_nil
@@ -176,7 +176,7 @@ describe TrainingModuleDueDateManager do
       end
 
       context 'overdue' do
-        let(:due_date) { 1.week.ago }
+        let(:due_date) { Date.new(2015, 8, 18) }
 
         it 'returns "overdue"' do
           expect(subject).to eq('overdue')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,6 +106,9 @@ RSpec.configure do |config|
     errors = page.driver.browser.logs.get(:browser)
 
     warn errors
+
+    # Clear persistent browser state from previous spec
+    page.driver.browser.manage.delete_all_cookies
   end
 
   # fail on javascript errors in feature specs
@@ -120,26 +123,22 @@ RSpec.configure do |config|
     # logs in the `before` block above.
     errors = page.driver.browser.logs.get(:browser)
 
+    # Kill all in-flight requests and timers by navigating away.
+    # window.stop() immediately cancels pending fetches so they can't complete
+    # during the next spec and pollute its browser logs with SEVERE entries.
+    # The AbortErrors it generates appear after logs.get above, so they don't
+    # affect this spec — they get cleared by the next spec's before hook.
+    page.execute_script('window.stop()') rescue nil # rubocop:disable Style/RescueModifier
+    visit 'about:blank'
+
     # pass `js_error_expected: true` to skip JS error checking
     next if example.metadata[:js_error_expected]
 
-    if errors.present?
-      aggregate_failures 'javascript errrors' do
-        errors.each do |error|
-          # some specs test behavior for 4xx responses and other errors.
-          # Don't fail on these.
-          next if /Failed to load resource/.match?(error.message)
-
-          warn 'JavaScript warning / error'
-          warn error.level
-          warn error
-          warn error.message
-          expect(error.level).not_to eq('SEVERE'), error.message
-        end
-      end
-    end
+    check_for_severe_js_errors(errors)
   end
   config.after(:each) do
+    travel_back
+    Warden.test_reset!
     I18n.locale = I18n.default_locale
   end
   config.after(:suite) do
@@ -189,6 +188,28 @@ def pass_pending_spec
     print 'P'
   end
   raise 'this test passed — this time'
+end
+
+# Checks browser log entries for SEVERE JavaScript errors and fails the
+# current example if any are found. Filters out "Failed to load resource"
+# entries (expected in specs that test 4xx responses).
+# Also used by spec/features/js_error_detection_spec.rb to verify this
+# mechanism works.
+def check_for_severe_js_errors(browser_log_entries)
+  severe = browser_log_entries.select do |error|
+    error.level == 'SEVERE' && !/Failed to load resource/.match?(error.message)
+  end
+  return if severe.empty?
+
+  aggregate_failures 'javascript errors' do
+    severe.each do |error|
+      warn 'JavaScript warning / error'
+      warn error.level
+      warn error
+      warn error.message
+      expect(error.level).not_to eq('SEVERE'), error.message
+    end
+  end
 end
 
 def format_local_datetime(date)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -124,12 +124,15 @@ RSpec.configure do |config|
     errors = page.driver.browser.logs.get(:browser)
 
     # Kill all in-flight requests and timers by navigating away.
-    # window.stop() immediately cancels pending fetches so they can't complete
-    # during the next spec and pollute its browser logs with SEVERE entries.
-    # The AbortErrors it generates appear after logs.get above, so they don't
-    # affect this spec — they get cleared by the next spec's before hook.
+    # window.stop() cancels pending fetches, and about:blank unloads all JS.
     page.execute_script('window.stop()') rescue nil # rubocop:disable Style/RescueModifier
     visit 'about:blank'
+
+    # Drain stale SEVERE entries generated asynchronously by window.stop()
+    # (e.g. Redux API_FAIL console.error from aborted fetches). These fire
+    # between the first logs.get and now; consuming them here prevents them
+    # from being misattributed to the next spec.
+    page.driver.browser.logs.get(:browser)
 
     # pass `js_error_expected: true` to skip JS error checking
     next if example.metadata[:js_error_expected]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,15 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true # This enables transactions for all tests
   config.global_fixtures = :all
 
+  # Retry examples that hit MySQL deadlocks (InnoDB gap-lock conflicts
+  # between the fixture transaction and SAVEPOINT inserts, especially
+  # under parallel_tests).
+  config.around do |example|
+    example.run
+  rescue ActiveRecord::Deadlocked
+    example.run
+  end
+
   config.include Devise::Test::ControllerHelpers, type: :controller
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/ajax_diagnostics.rb
+++ b/spec/support/ajax_diagnostics.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# AJAX Diagnostics — tracks in-flight fetch/XHR requests at spec boundaries.
+# Activate with AJAX_DIAG=1 environment variable.
+#
+# Before each JS feature spec: injects a monkey-patch on window.fetch and
+# XMLHttpRequest to count pending requests.
+# After each JS feature spec: warns if any requests are still in-flight.
+
+if ENV['AJAX_DIAG'] == '1'
+  AJAX_DIAG_INJECT_JS = <<~JS
+    (function() {
+      if (window.__ajaxDiagInstalled) return;
+      window.__ajaxDiagInstalled = true;
+      window.__pendingRequests = 0;
+      window.__completedRequests = 0;
+      window.__requestLog = [];
+
+      // Monkey-patch fetch
+      var originalFetch = window.fetch;
+      window.fetch = function() {
+        var url = (arguments[0] instanceof Request) ? arguments[0].url : String(arguments[0]);
+        window.__pendingRequests++;
+        window.__requestLog.push({type: 'fetch', url: url, time: Date.now(), state: 'started'});
+        return originalFetch.apply(this, arguments).then(function(response) {
+          window.__pendingRequests--;
+          window.__completedRequests++;
+          return response;
+        }).catch(function(err) {
+          window.__pendingRequests--;
+          window.__completedRequests++;
+          throw err;
+        });
+      };
+
+      // Monkey-patch XMLHttpRequest
+      var originalOpen = XMLHttpRequest.prototype.open;
+      var originalSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function() {
+        this.__ajaxDiagUrl = arguments[1];
+        return originalOpen.apply(this, arguments);
+      };
+      XMLHttpRequest.prototype.send = function() {
+        var xhr = this;
+        window.__pendingRequests++;
+        window.__requestLog.push({type: 'xhr', url: xhr.__ajaxDiagUrl, time: Date.now(), state: 'started'});
+        xhr.addEventListener('loadend', function() {
+          window.__pendingRequests--;
+          window.__completedRequests++;
+        });
+        return originalSend.apply(this, arguments);
+      };
+    })();
+  JS
+
+  RSpec.configure do |config|
+    config.before(:each, type: :feature, js: true) do
+      page.execute_script(AJAX_DIAG_INJECT_JS) rescue nil # rubocop:disable Style/RescueModifier
+    end
+
+    config.after(:each, type: :feature, js: true) do |example|
+      begin
+        pending_count = page.evaluate_script('window.__pendingRequests') || 0
+        completed_count = page.evaluate_script('window.__completedRequests') || 0
+
+        if pending_count > 0
+          request_log = page.evaluate_script(
+            'window.__requestLog.filter(function(r) { return r.state === "started" }).slice(-5)'
+          ) || []
+
+          warn "[AJAX_DIAG] #{example.full_description}"
+          warn "  #{pending_count} pending request(s) at spec end (#{completed_count} completed)"
+          request_log.each do |entry|
+            warn "  in-flight: #{entry['type']} #{entry['url']}"
+          end
+        end
+      rescue StandardError
+        # Page may already be navigated away; ignore
+      end
+    end
+  end
+end


### PR DESCRIPTION
Assorted scripts for debugging flaky specs and adjustments to the testing system that fix or work around some of the causes of spec failures, especially when running specs in parallel.

This didn't fix all the problems, but it should generally make our specs more resilient.

Along the way, also found a debounce-related minor issue in a couple of React components.

## AI usage
This was all driven by Claude Code, as I tried to get the test suite to pass consistently for me locally with 4-process parallelism.