### PR TITLE
[WIP]: Add stub for French category search in category scopes spec

### DIFF
--- a/spec/features/category_scopes_spec.rb
+++ b/spec/features/category_scopes_spec.rb
@@ -6,6 +6,38 @@ describe 'Tracked categories and templates', js: true do
   let(:course) { create(:course, type: 'ArticleScopedProgram') }
   let(:user) { create(:user) }
 
+  def stub_fr_category_search_for_materiel_apple
+    page.execute_script(<<~JS)
+      (function() {
+        if (window.__stubFrCategorySearchInstalled) return;
+        window.__stubFrCategorySearchInstalled = true;
+        const originalFetch = window.fetch.bind(window);
+        window.fetch = function(input, init) {
+          const url = (typeof input === 'string') ? input : input.url;
+          const isFrCategorySearch = url.includes('fr.wikipedia.org/w/api.php') &&
+            url.includes('list=search') &&
+            url.includes('srnamespace=14') &&
+            url.includes('Mat%C3%A9riel%20Apple');
+
+          if (isFrCategorySearch) {
+            return Promise.resolve(
+              new Response(JSON.stringify({
+                query: {
+                  search: [{ title: 'Category:Matériel Apple' }]
+                }
+              }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+              })
+            );
+          }
+
+          return originalFetch(input, init);
+        };
+      })();
+    JS
+  end
+
   before do
     JoinCourse.new(course:, user:, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     login_as user
@@ -62,14 +94,20 @@ describe 'Tracked categories and templates', js: true do
 
   it 'lets a facilitator add multiple categories from different wikis at once' do
     visit "/courses/#{course.slug}/articles"
+    stub_fr_category_search_for_materiel_apple
     click_button 'Add category'
     find(:css, '#categories input').set('Earth ')
     find(:css, '#categories div[class*="option"]', text: 'Earth sciences').click
 
     find(:css, '.multi-wiki-selector input').set('fr')
     find(:css, '.multi-wiki-selector div[class*="option"]', text: 'fr.wikipedia.org').click
+    expect(page).to have_css('.multi-wiki-selector', text: 'fr.wikipedia.org')
 
     find(:css, '#categories input').set('Matériel Apple ')
+    expect(page).to have_css('#categories div[class*="option"]',
+                             text: 'fr:Matériel Apple',
+                             exact_text: true,
+                             wait: 20)
     find(:css, '#categories div[class*="option"]', text: 'fr:Matériel Apple', exact_text: true).click # rubocop:disable Layout/LineLength
 
     click_button 'Add categories'


### PR DESCRIPTION
## Changes

Resolves - https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6726

- Added `stub_fr_category_search_for_materiel_apple` in `spec/features/category_scopes_spec.rb` to stub the browser-side French category lookup for `Matériel Apple`.
- Updated the flaky example (`adds multiple categories from different wikis`) to use this stub before interacting with the category autocomplete.
- Added explicit synchronization around wiki/category option rendering so the test waits for the expected UI state before clicking.

This makes the spec deterministic in CI by removing dependence on live Wikipedia search responses and reducing timing-related flakiness in async `AsyncSelect` interactions.

## What this PR does

This PR fixes an intermittent CI failure in:

- `spec/features/category_scopes_spec.rb:63`
- `Tracked categories and templates lets a facilitator add multiple categories from different wikis at once`

Previously, the test depended on a real network-backed category search (`fr:Matériel Apple`) and could fail when the async option list did not render in time or the external request behaved inconsistently. The PR replaces that external dependency with a targeted in-test stub and adds explicit waiting for the expected option, making the test reliable.

## AI usage

I used AI assistance to:
- analyze the likely cause of the flaky failure (async UI timing + external fetch dependency),
- inspect related frontend/spec code paths,
- propose and implement a targeted stubbing strategy for the French category search,

## Screenshots

Before:
- N/A (test/spec reliability change only; no user-facing UI change)

After:
- N/A (test/spec reliability change only; no user-facing UI change)

## Open questions and concerns

- The current fix stubs the specific French category search in this spec to keep behavior deterministic; this is intentionally narrow to avoid affecting unrelated requests.
- If similar flakes appear in other autocomplete feature specs, we may want a shared helper for deterministic search stubs.
