### PR TITLE
Enable RuboCop rules: HashEach, YodaCondition, ZeroLength, spacing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -235,8 +235,6 @@ Rails/CompactBlank:
   Enabled: false
 Layout/FirstHashElementIndentation:
   Enabled: false
-Performance/StringIdentifierArgument:
-  Enabled: false
 Lint/UselessConstantScoping:
   Enabled: false
 Style/RedundantParentheses:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -251,8 +251,6 @@ Style/RedundantInterpolationUnfreeze:
   Enabled: false
 Naming/PredicateMethod:
   Enabled: false
-Style/YodaCondition:
-  Enabled: false
 Style/YAMLFileRead:
   Enabled: false
 Style/EmptyStringInsideInterpolation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -253,8 +253,6 @@ Naming/PredicateMethod:
   Enabled: false
 Style/YAMLFileRead:
   Enabled: false
-Style/EmptyStringInsideInterpolation:
-  Enabled: false
 Style/ZeroLengthPredicate:
   Enabled: false
 Style/SuperArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -257,8 +257,6 @@ Style/YAMLFileRead:
   Enabled: false
 Style/EmptyStringInsideInterpolation:
   Enabled: false
-Style/HashEachMethods:
-  Enabled: false
 Style/ZeroLengthPredicate:
   Enabled: false
 Style/SuperArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -249,8 +249,6 @@ Naming/PredicateMethod:
   Enabled: false
 Style/YAMLFileRead:
   Enabled: false
-Style/ZeroLengthPredicate:
-  Enabled: false
 Style/SuperArguments:
   Enabled: false
 Metrics/CollectionLiteralLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -241,8 +241,6 @@ Style/RedundantParentheses:
   Enabled: false
 Layout/EmptyLinesAfterModuleInclusion:
   Enabled: false
-Layout/SpaceAroundOperators:
-  Enabled: false
 Style/ArrayIntersect:
   Enabled: false
 Style/RedundantInterpolationUnfreeze:

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -18,7 +18,7 @@ class AssignmentsController < ApplicationController
     @flags = @assignment.flags
     assignment_id = params[:assignment_id]
     user_id = params[:user_id]
-    if assignment_id &&  user_id.present? && @assignment.flags[:available_article]
+    if assignment_id && user_id.present? && @assignment.flags[:available_article]
       @assignment.update(user_id: nil)
       render partial: 'updated_assignment', locals: { assignment: @assignment }
     else

--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -68,7 +68,7 @@ class TrainingModulesUsersController < ApplicationController
   def instructor_orientation_module?
     return false unless Features.wiki_ed?
     @training_module_user.completed_at.present? &&
-      (HOW_TO_TEACH_WITH_WIKIPEDIA_TRAINING_MODULE_ID == @training_module.id)
+      (@training_module.id == HOW_TO_TEACH_WITH_WIKIPEDIA_TRAINING_MODULE_ID)
   end
 
   def last_slide?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   end
 
   def dashboard_stylesheet_tag(filename)
-    filename = "#{rtl? ? 'rtl-' : nil}#{filename}.css"
+    filename = "#{'rtl-' if rtl?}#{filename}.css"
     filename = css_fingerprinted(filename) unless Features.hot_loading?
     stylesheet_link_tag "/assets/stylesheets/#{filename}", media: 'all'
   end

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -30,7 +30,7 @@ module CourseHelper
   end
 
   def format_course_stats(course_stats)
-    course_stats.each do |wiki_ns_key, _wiki_ns_stats|
+    course_stats.each_key do |wiki_ns_key|
       if wiki_ns_key == 'www.wikidata.org'
         # Not all course stats have the 'other updates' field
         if course_stats[wiki_ns_key]['other updates']

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -329,7 +329,7 @@ class Course < ApplicationRecord
     courses_wikis.map do |course_wiki|
       wiki = course_wiki.wiki
       wiki_namespaces = course_wiki.course_wiki_namespaces
-      if wiki_namespaces.length.zero?
+      if wiki_namespaces.empty?
         { wiki:, namespace: 0 }
       else
         wiki_namespaces.map do |wiki_ns|

--- a/app/services/get_revision_plaintext.rb
+++ b/app/services/get_revision_plaintext.rb
@@ -61,7 +61,7 @@ class GetRevisionPlaintext
   def fetch_revision_html
     # https://en.wikipedia.org/w/api.php?action=parse&oldid=952185129
     params = { oldid: @mw_rev_id }
-    resp = @wiki_api.send(:api_client).send('action', 'parse', params)
+    resp = @wiki_api.send(:api_client).send(:action, 'parse', params)
     @rev_html = resp.data.dig('text', '*')
     @article_title = resp.data.dig('title')
     @mw_page_id = resp.data.dig('pageid')
@@ -71,7 +71,7 @@ class GetRevisionPlaintext
   # https://en.wikipedia.org/w/api.php?action=compare&torev=1315427810&fromrev=1315426424&difftype=table
   def fetch_diff_table
     diff_params = { torev: @mw_rev_id, fromrev: @from_rev, difftype: 'table' }
-    resp = @wiki_api.send(:api_client).send('action', 'compare', diff_params)
+    resp = @wiki_api.send(:api_client).send(:action, 'compare', diff_params)
     @article_title = resp.data.dig('totitle')
     @mw_page_id = resp.data.dig('toid')
     @diff_table = resp.data['*']
@@ -200,7 +200,7 @@ class GetRevisionPlaintext
 
   def fetch_parsed_changed_wikitext
     parse_params = { text: @changed_wikitext, contentmodel: 'wikitext' }
-    resp = @wiki_api.send(:api_client).send('action', 'parse', parse_params)
+    resp = @wiki_api.send(:api_client).send(:action, 'parse', parse_params)
     @diff_html = resp.data.dig('text', '*')
   end
 

--- a/lib/analytics/course_students_csv_builder.rb
+++ b/lib/analytics/course_students_csv_builder.rb
@@ -62,9 +62,11 @@ class CourseStudentsCsvBuilder
   def populate_edited_articles
     # A user has edited an article if the user is in the user_ids list of edited_articles_courses
     @course.edited_articles_courses.in_batches do |batch|
+      # rubocop:disable Style/HashEachMethods -- pluck results in an Array of pairs
       batch.pluck(:article_id, :user_ids).each do |_article_id, user_ids|
         user_ids.each { |user_id| @edited_articles[user_id] += 1 }
       end
+      # rubocop:enable Style/HashEachMethods
     end
   end
 

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -59,14 +59,14 @@ class CourseRevisionUpdater
     ArticlesCourses.update_from_course_revisions(@course, revisions)
   end
 
-  def format_revision_response(wiki, timeslice_start, timeslice_end, revision_data)
-    new_revisions = new_revisions?(revision_data, wiki, timeslice_start)
+  def format_revision_response(wiki, timeslice_start, timeslice_end, revisions_array)
+    new_revisions = new_revisions?(revisions_array, wiki, timeslice_start)
     results = {}
     revisions = {}
     revisions[:start] = timeslice_start
     revisions[:end] = timeslice_end
     revisions[:new_data] = new_revisions
-    revisions[:revisions] = revision_data
+    revisions[:revisions] = revisions_array
     results[wiki] = revisions
     results
   end

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -75,7 +75,7 @@ class RevisionScoreImporter
 
   def extract_revisions(pages_data)
     revisions = {}
-    pages_data.each do |_page_id, page_data|
+    pages_data.each_value do |page_data|
       rev_data = page_data['revisions']
       next unless rev_data
       rev_data.each do |rev_datum|

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -152,6 +152,7 @@ class RevisionDataManager
   # Updates the revision data with a new 'scoped' field inside the article data.
   # This field indicates if the article is scoped based on the course type.
   def mark_scoped_articles(wiki, revisions)
+    # rubocop:disable Style/HashEachMethods -- revisions is an Array of pairs
     revisions.each do |_, details|
       article_title = details['article']['title']
       formatted_article_title = ArticleUtils.format_article_title(article_title, wiki)
@@ -159,6 +160,7 @@ class RevisionDataManager
       details['article']['scoped'] =
         @course.scoped_article?(wiki, formatted_article_title, mw_page_id)
     end
+    # rubocop:enable Style/HashEachMethods
   end
 
   # Creates a revision record for the given revision data.

--- a/spec/controllers/system/backups_controller_spec.rb
+++ b/spec/controllers/system/backups_controller_spec.rb
@@ -6,11 +6,11 @@ describe System::BackupsController, type: :request do
   let(:work) do
     ['server-15ALC6:390735:407ff4a2b287',
      '81ib',
-     { 'queue'=>'medium_update',
-     'payload'=>
-       { 'class'=>'CourseDataUpdateWorker',
-       'jid'=>'e118d576de83c8e44526bba7' },
-     'run_at'=>1769012340 }]
+     { 'queue' => 'medium_update',
+     'payload' =>
+       { 'class' => 'CourseDataUpdateWorker',
+       'jid' => 'e118d576de83c8e44526bba7' },
+     'run_at' => 1769012340 }]
   end
 
   describe '#can_start_backup' do

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -263,7 +263,7 @@ describe CopyCourse do
       expect(User.exists?(username: 'Diqi Yan')).to eq(true)
 
       # Update logs were correctly created
-      course.flags['update_logs'].each do |key, _value|
+      course.flags['update_logs'].each_key do |key|
         expect(key).to be_a(Integer)
       end
     end


### PR DESCRIPTION
fixes part of #5297 

This PR enabled 6 RuboCop rules :
- `Style/HashEachMethods`
- `Style/YodaCondition`
- `Style/EmptyStringInsideInterpolation`
- `Performance/StringIdentifierArgument`
- `Layout/SpaceAroundOperators`
- `Style/ZeroLengthPredicate`

### Verification
bundle exec rspec (modified files) → 124 examples, 0 failures
@ragesoss please review it.