### PR TITLE
Improve wiki list 2637

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -7,7 +7,7 @@ Chartkick.addAdapter(Chart);
 
 // Usage page JavaScript functionality
 const initUsage = () => {
-    initWikiDropdown();
+    initWikiList();
     initCsvButton();
 };
 
@@ -17,26 +17,244 @@ if (document.readyState === 'loading') {
     initUsage();
 }
 
-function initWikiDropdown() {
-    const dropdown = document.getElementById('wiki-view-dropdown');
-    if (!dropdown) return;
+function initWikiList() {
+    const container = document.getElementById('wiki-list-container');
+    if (!container) return;
 
-    const sortSections = document.querySelectorAll('.wiki-sort-section');
+    const wikis = JSON.parse(container.dataset.wikis);
+    const maxCount = wikis.length > 0 ? wikis[0].course_count : 0;
+    const INITIAL_SHOW = 20;
 
-    dropdown.addEventListener('change', function () {
-        const selectedView = this.value;
+    let currentTab = 'all';
+    let searchQuery = '';
+    let showAll = false;
 
-        // Hide all sections
-        sortSections.forEach((section) => {
-            section.style.display = 'none';
+    // Build the controls and table container
+    container.innerHTML = `${buildControls()}<div id="wiki-table-area" role="tabpanel" aria-labelledby="wiki-tab-all" tabindex="0"></div>`;
+
+    // Bind events
+    bindSearchEvent();
+    bindTabEvents();
+
+    // Initial render
+    renderTable();
+
+    function buildControls() {
+        return `
+            <div class="wiki-controls">
+                <input type="text" class="wiki-search" id="wiki-search" placeholder="Search wikis..." aria-label="Search wikis" />
+                <div class="wiki-tabs" id="wiki-tabs" role="tablist">
+                    <button class="wiki-tab active" data-tab="all" role="tab" id="wiki-tab-all" aria-selected="true" aria-controls="wiki-table-area" tabindex="0">All wikis</button>
+                    <button class="wiki-tab" data-tab="top10" role="tab" id="wiki-tab-top10" aria-selected="false" aria-controls="wiki-table-area" tabindex="-1">Top 10</button>
+                    <button class="wiki-tab" data-tab="project" role="tab" id="wiki-tab-project" aria-selected="false" aria-controls="wiki-table-area" tabindex="-1">By project</button>
+                    <button class="wiki-tab" data-tab="language" role="tab" id="wiki-tab-language" aria-selected="false" aria-controls="wiki-table-area" tabindex="-1">By language</button>
+                </div>
+            </div>
+        `;
+    }
+
+    function bindSearchEvent() {
+        const searchInput = document.getElementById('wiki-search');
+        searchInput.addEventListener('input', function () {
+            searchQuery = this.value.toLowerCase();
+            showAll = false;
+            renderTable();
+        });
+    }
+
+    function bindTabEvents() {
+        const tabContainer = document.getElementById('wiki-tabs');
+        const tabs = Array.from(tabContainer.querySelectorAll('.wiki-tab'));
+
+        const activate = (tab) => {
+            tabs.forEach((t) => {
+                t.classList.remove('active');
+                t.setAttribute('aria-selected', 'false');
+                t.setAttribute('tabindex', '-1');
+            });
+            tab.classList.add('active');
+            tab.setAttribute('aria-selected', 'true');
+            tab.setAttribute('tabindex', '0');
+            currentTab = tab.dataset.tab;
+            showAll = false;
+            renderTable();
+        };
+
+        tabContainer.addEventListener('click', (e) => {
+            const tab = e.target.closest('.wiki-tab');
+            if (!tab) return;
+            activate(tab);
         });
 
-        // Show selected section
-        const selectedSection = document.getElementById(`wiki-list-${selectedView}`);
-        if (selectedSection) {
-            selectedSection.style.display = 'block';
+        tabContainer.addEventListener('keydown', (e) => {
+            if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+            const i = tabs.indexOf(document.activeElement);
+            if (i === -1) return;
+            e.preventDefault();
+            const next = e.key === 'ArrowRight' ? (i + 1) % tabs.length : (i - 1 + tabs.length) % tabs.length;
+            tabs[next].focus();
+            activate(tabs[next]);
+        });
+    }
+
+    function getFilteredWikis() {
+        let filtered = wikis;
+
+        if (searchQuery) {
+            filtered = filtered.filter(w =>
+                w.domain.toLowerCase().includes(searchQuery)
+                || w.project.toLowerCase().includes(searchQuery)
+                || (w.language && w.language.toLowerCase().includes(searchQuery))
+            );
         }
-    });
+
+        if (currentTab === 'top10') {
+            filtered = filtered.slice(0, 10);
+        }
+
+        return filtered;
+    }
+
+    function renderTable() {
+        const area = document.getElementById('wiki-table-area');
+
+        if (currentTab === 'project') {
+            renderGroupedView(area, 'project');
+            return;
+        }
+
+        if (currentTab === 'language') {
+            renderGroupedView(area, 'language');
+            return;
+        }
+
+        const filtered = getFilteredWikis();
+        const displayWikis = showAll ? filtered : filtered.slice(0, INITIAL_SHOW);
+        const remaining = filtered.length - displayWikis.length;
+
+        let html = buildTableHeader();
+        html += '<tbody>';
+        displayWikis.forEach((w) => {
+            html += buildTableRow(w);
+        });
+        html += '</tbody></table>';
+
+        if (remaining > 0) {
+            html += `
+                <div class="wiki-table-footer">
+                    <span class="wiki-table-info">Showing ${displayWikis.length} of ${filtered.length} wikis</span>
+                    <button class="wiki-show-all-btn" id="wiki-show-all">Show all</button>
+                </div>
+            `;
+        } else if (filtered.length > INITIAL_SHOW) {
+            html += `
+                <div class="wiki-table-footer">
+                    <span class="wiki-table-info">Showing all ${filtered.length} wikis</span>
+                </div>
+            `;
+        } else if (filtered.length === 0) {
+            html += '<div class="wiki-no-results">No wikis found matching your search.</div>';
+        }
+
+        area.innerHTML = html;
+
+        // Bind show all button
+        const showAllBtn = document.getElementById('wiki-show-all');
+        if (showAllBtn) {
+            showAllBtn.addEventListener('click', () => {
+                showAll = true;
+                renderTable();
+            });
+        }
+    }
+
+    function renderGroupedView(area, groupBy) {
+        const filtered = getFilteredWikis();
+        const groups = {};
+
+        filtered.forEach((w) => {
+            const key = groupBy === 'project' ? w.project : (w.language || 'Other');
+            if (!groups[key]) groups[key] = [];
+            groups[key].push(w);
+        });
+
+        // Sort groups by total course count
+        const sortedGroups = Object.entries(groups).sort((a, b) => {
+            const totalA = a[1].reduce((sum, w) => sum + w.course_count, 0);
+            const totalB = b[1].reduce((sum, w) => sum + w.course_count, 0);
+            return totalB - totalA;
+        });
+
+        let html = '';
+
+        if (sortedGroups.length === 0) {
+            html = '<div class="wiki-no-results">No wikis found matching your search.</div>';
+            area.innerHTML = html;
+            return;
+        }
+
+        sortedGroups.forEach(([groupName, groupWikis]) => {
+            const totalCourses = groupWikis.reduce((sum, w) => sum + w.course_count, 0);
+            const label = groupBy === 'project'
+                ? `${groupWikis.length} wikis, ${totalCourses.toLocaleString()} courses`
+                : `${groupWikis.length} projects, ${totalCourses.toLocaleString()} courses`;
+
+            html += `
+                <div class="wiki-group">
+                    <div class="wiki-group-header">
+                        <h3 class="wiki-group-name">${capitalize(groupName)}</h3>
+                        <span class="wiki-group-count">(${label})</span>
+                    </div>
+                    ${buildTableHeader()}
+                    <tbody>
+            `;
+            groupWikis.forEach((w) => {
+                html += buildTableRow(w);
+            });
+            html += '</tbody></table></div>';
+        });
+
+        area.innerHTML = html;
+    }
+
+    function buildTableHeader() {
+        return `
+            <table class="wiki-table">
+                <thead>
+                    <tr>
+                        <th>Wiki</th>
+                        <th>Project</th>
+                        <th>Courses</th>
+                        <th class="wiki-bar-col">Activity</th>
+                    </tr>
+                </thead>
+        `;
+    }
+
+    function buildTableRow(wiki) {
+        const barWidth = maxCount > 0 ? Math.max(1, Math.round((wiki.course_count / maxCount) * 100)) : 0;
+        let barClass = 'wiki-bar-low';
+        if (barWidth > 25) barClass = 'wiki-bar-high';
+        else if (barWidth > 8) barClass = 'wiki-bar-mid';
+
+        return `
+            <tr>
+                <td><a href="/courses_by_wiki/${wiki.domain}" class="wiki-domain-link">${wiki.domain}</a></td>
+                <td><span class="wiki-project-tag">${capitalize(wiki.project)}</span></td>
+                <td class="wiki-course-count">${wiki.course_count.toLocaleString()}</td>
+                <td class="wiki-bar-col">
+                    <div class="wiki-bar-bg">
+                        <div class="wiki-bar-fill ${barClass}" style="width: ${barWidth}%"></div>
+                    </div>
+                </td>
+            </tr>
+        `;
+    }
+
+    function capitalize(str) {
+        if (!str) return '';
+        return str.charAt(0).toUpperCase() + str.slice(1);
+    }
 }
 
 function initCsvButton() {

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -7,7 +7,7 @@ Chartkick.addAdapter(Chart);
 
 // Usage page JavaScript functionality
 const initUsage = () => {
-    initWikiDropdown();
+    initWikiList();
     initCsvButton();
 };
 
@@ -17,26 +17,223 @@ if (document.readyState === 'loading') {
     initUsage();
 }
 
-function initWikiDropdown() {
-    const dropdown = document.getElementById('wiki-view-dropdown');
-    if (!dropdown) return;
+function initWikiList() {
+    const container = document.getElementById('wiki-list-container');
+    if (!container) return;
 
-    const sortSections = document.querySelectorAll('.wiki-sort-section');
+    const wikis = JSON.parse(container.dataset.wikis);
+    const maxCount = wikis.length > 0 ? wikis[0].course_count : 0;
+    const INITIAL_SHOW = 20;
 
-    dropdown.addEventListener('change', function () {
-        const selectedView = this.value;
+    let currentTab = 'all';
+    let searchQuery = '';
+    let showAll = false;
 
-        // Hide all sections
-        sortSections.forEach((section) => {
-            section.style.display = 'none';
+    // Build the controls and table container
+    container.innerHTML = `${buildControls()}<div id="wiki-table-area"></div>`;
+
+    // Bind events
+    bindSearchEvent();
+    bindTabEvents();
+
+    // Initial render
+    renderTable();
+
+    function buildControls() {
+        return `
+            <div class="wiki-controls">
+                <input type="text" class="wiki-search" id="wiki-search" placeholder="Search wikis..." />
+                <div class="wiki-tabs" id="wiki-tabs">
+                    <button class="wiki-tab active" data-tab="all">All wikis</button>
+                    <button class="wiki-tab" data-tab="top10">Top 10</button>
+                    <button class="wiki-tab" data-tab="project">By project</button>
+                    <button class="wiki-tab" data-tab="language">By language</button>
+                </div>
+            </div>
+        `;
+    }
+
+    function bindSearchEvent() {
+        const searchInput = document.getElementById('wiki-search');
+        searchInput.addEventListener('input', function () {
+            searchQuery = this.value.toLowerCase();
+            showAll = false;
+            renderTable();
+        });
+    }
+
+    function bindTabEvents() {
+        const tabContainer = document.getElementById('wiki-tabs');
+        tabContainer.addEventListener('click', (e) => {
+            const tab = e.target.closest('.wiki-tab');
+            if (!tab) return;
+
+            tabContainer.querySelectorAll('.wiki-tab').forEach(t => t.classList.remove('active'));
+            tab.classList.add('active');
+            currentTab = tab.dataset.tab;
+            showAll = false;
+            renderTable();
+        });
+    }
+
+    function getFilteredWikis() {
+        let filtered = wikis;
+
+        if (searchQuery) {
+            filtered = filtered.filter(w =>
+                w.domain.toLowerCase().includes(searchQuery)
+                || w.project.toLowerCase().includes(searchQuery)
+                || (w.language && w.language.toLowerCase().includes(searchQuery))
+            );
+        }
+
+        if (currentTab === 'top10') {
+            filtered = filtered.slice(0, 10);
+        }
+
+        return filtered;
+    }
+
+    function renderTable() {
+        const area = document.getElementById('wiki-table-area');
+
+        if (currentTab === 'project') {
+            renderGroupedView(area, 'project');
+            return;
+        }
+
+        if (currentTab === 'language') {
+            renderGroupedView(area, 'language');
+            return;
+        }
+
+        const filtered = getFilteredWikis();
+        const displayWikis = showAll ? filtered : filtered.slice(0, INITIAL_SHOW);
+        const remaining = filtered.length - displayWikis.length;
+
+        let html = buildTableHeader();
+        html += '<tbody>';
+        displayWikis.forEach((w) => {
+            html += buildTableRow(w);
+        });
+        html += '</tbody></table>';
+
+        if (remaining > 0) {
+            html += `
+                <div class="wiki-table-footer">
+                    <span class="wiki-table-info">Showing ${displayWikis.length} of ${filtered.length} wikis</span>
+                    <button class="wiki-show-all-btn" id="wiki-show-all">Show all</button>
+                </div>
+            `;
+        } else if (filtered.length > INITIAL_SHOW) {
+            html += `
+                <div class="wiki-table-footer">
+                    <span class="wiki-table-info">Showing all ${filtered.length} wikis</span>
+                </div>
+            `;
+        } else if (filtered.length === 0) {
+            html += '<div class="wiki-no-results">No wikis found matching your search.</div>';
+        }
+
+        area.innerHTML = html;
+
+        // Bind show all button
+        const showAllBtn = document.getElementById('wiki-show-all');
+        if (showAllBtn) {
+            showAllBtn.addEventListener('click', () => {
+                showAll = true;
+                renderTable();
+            });
+        }
+    }
+
+    function renderGroupedView(area, groupBy) {
+        const filtered = getFilteredWikis();
+        const groups = {};
+
+        filtered.forEach((w) => {
+            const key = groupBy === 'project' ? w.project : (w.language || 'Other');
+            if (!groups[key]) groups[key] = [];
+            groups[key].push(w);
         });
 
-        // Show selected section
-        const selectedSection = document.getElementById(`wiki-list-${selectedView}`);
-        if (selectedSection) {
-            selectedSection.style.display = 'block';
+        // Sort groups by total course count
+        const sortedGroups = Object.entries(groups).sort((a, b) => {
+            const totalA = a[1].reduce((sum, w) => sum + w.course_count, 0);
+            const totalB = b[1].reduce((sum, w) => sum + w.course_count, 0);
+            return totalB - totalA;
+        });
+
+        let html = '';
+
+        if (sortedGroups.length === 0) {
+            html = '<div class="wiki-no-results">No wikis found matching your search.</div>';
+            area.innerHTML = html;
+            return;
         }
-    });
+
+        sortedGroups.forEach(([groupName, groupWikis]) => {
+            const totalCourses = groupWikis.reduce((sum, w) => sum + w.course_count, 0);
+            const label = groupBy === 'project'
+                ? `${groupWikis.length} wikis, ${totalCourses.toLocaleString()} courses`
+                : `${groupWikis.length} projects, ${totalCourses.toLocaleString()} courses`;
+
+            html += `
+                <div class="wiki-group">
+                    <div class="wiki-group-header">
+                        <span class="wiki-group-name">${capitalize(groupName)}</span>
+                        <span class="wiki-group-count">(${label})</span>
+                    </div>
+                    ${buildTableHeader()}
+                    <tbody>
+            `;
+            groupWikis.forEach((w) => {
+                html += buildTableRow(w);
+            });
+            html += '</tbody></table></div>';
+        });
+
+        area.innerHTML = html;
+    }
+
+    function buildTableHeader() {
+        return `
+            <table class="wiki-table">
+                <thead>
+                    <tr>
+                        <th>Wiki</th>
+                        <th>Project</th>
+                        <th>Courses</th>
+                        <th class="wiki-bar-col">Activity</th>
+                    </tr>
+                </thead>
+        `;
+    }
+
+    function buildTableRow(wiki) {
+        const barWidth = maxCount > 0 ? Math.max(1, Math.round((wiki.course_count / maxCount) * 100)) : 0;
+        let barClass = 'wiki-bar-low';
+        if (barWidth > 25) barClass = 'wiki-bar-high';
+        else if (barWidth > 8) barClass = 'wiki-bar-mid';
+
+        return `
+            <tr>
+                <td><a href="/courses_by_wiki/${wiki.domain}" class="wiki-domain-link">${wiki.domain}</a></td>
+                <td><span class="wiki-project-tag">${capitalize(wiki.project)}</span></td>
+                <td class="wiki-course-count">${wiki.course_count.toLocaleString()}</td>
+                <td class="wiki-bar-col">
+                    <div class="wiki-bar-bg">
+                        <div class="wiki-bar-fill ${barClass}" style="width: ${barWidth}%"></div>
+                    </div>
+                </td>
+            </tr>
+        `;
+    }
+
+    function capitalize(str) {
+        if (!str) return '';
+        return str.charAt(0).toUpperCase() + str.slice(1);
+    }
 }
 
 function initCsvButton() {

--- a/app/assets/stylesheets/modules/_usage.styl
+++ b/app/assets/stylesheets/modules/_usage.styl
@@ -16,21 +16,25 @@
       border-bottom 2px solid #e0e0e0
 
   .stats-grid
-    display grid
-    grid-template-columns repeat(3, 1fr)
-    gap 15px
+    display flex
+    flex-wrap wrap
+    justify-content center
+    gap 16px
     margin 20px 0
-    max-width 800px
+    max-width 850px
 
   .stats-card
     text-align center
-    padding 15px
+    padding 20px 16px
     margin 0
+    flex 1 1 calc(33.33% - 16px)
+    max-width calc(33.33% - 16px)
+    min-width 160px
 
     h3
       font-size 1.8em
-      font-weight 700
-      color #2c5aa0
+      font-weight 300
+      color $brand_primary
       margin 0 0 8px 0
 
     p
@@ -54,109 +58,213 @@
       margin 5px 0 0 0
       font-style italic
 
-  .wiki-list
-    padding 0
-    margin 0
-    list-style-type disc
-    padding-left 20px
+  // Wiki list controls
+  .wiki-controls
+    display flex
+    gap 10px
+    margin-bottom 16px
+    flex-wrap wrap
+    align-items center
 
-    li
-      margin-bottom 8px
-
-      a
-        color #007bff
-        text-decoration none
-
-        &:hover
-          text-decoration underline
-
-      .count
-        color #666
-        font-size 0.9em
-        margin-left 5px
-
-    &.all-wikis
-      li
-        font-size 0.95em
-
-    &.top-wikis
-      list-style-type decimal
-
-      li
-        .rank
-          font-weight 700
-          color #2c5aa0
-          margin-right 8px
-
-  .project-group, .language-group
-    margin 0
-    padding 0
-
-  h3.project-title, h3.language-title
-    margin 0
-    margin-bottom 0
-    padding 0
+  .wiki-search
+    flex 1
+    min-width 180px
+    padding 8px 12px
+    border 1px solid #d1d5db
+    border-radius 3px
+    font-size 14px
     color #333
+    background #fff
+    outline none
+
+    &:focus
+      border-color $brand_primary
+
+    &::placeholder
+      color #aaa
+
+  .wiki-tabs
+    display flex
+    border 1px solid #d1d5db
+    border-radius 3px
+    overflow hidden
+
+  .wiki-tab
+    padding 8px 14px
+    font-size 13px
+    background #fff
+    color #666
+    border none
+    border-right 1px solid #d1d5db
+    cursor pointer
+    font-family inherit
+    transition background 0.15s, color 0.15s
+
+    &:last-child
+      border-right none
+
+    &:hover
+      background #f9f9fb
+
+    &.active
+      background $brand_primary
+      color #fff
+
+  // Wiki list table
+  .wiki-table
+    width 100%
+    border-collapse collapse
+    font-size 14px
+
+    thead th
+      text-align left
+      font-size 12px
+      font-weight 400
+      color #888
+      text-transform uppercase
+      letter-spacing 0.3px
+      padding 10px 12px
+      border-bottom 2px solid #e8e8e8
+
+    tbody td
+      padding 11px 12px
+      border-bottom 1px solid #f2f2f2
+      vertical-align middle
+
+    tbody tr
+      &:hover
+        background #fafbfc
+
+      &:last-child td
+        border-bottom none
+
+  .wiki-domain-link
+    color $brand_primary
+    text-decoration none
+
+    &:hover
+      text-decoration underline
+
+  .wiki-project-tag
+    display inline-block
+    font-size 11px
+    padding 2px 8px
+    border-radius 3px
+    background #f3f4f6
+    color #555
+
+  .wiki-course-count
+    font-variant-numeric tabular-nums
+
+  .wiki-bar-col
+    width 110px
+
+  .wiki-bar-bg
+    width 100px
+    height 5px
+    background #f0f0f0
+    border-radius 3px
+    overflow hidden
+
+  .wiki-bar-fill
+    height 100%
+    border-radius 3px
+
+  .wiki-bar-high
+    background $brand_primary
+
+  .wiki-bar-mid
+    background lighten($brand_primary, 30%)
+
+  .wiki-bar-low
+    background lighten($brand_primary, 55%)
+
+  // Table footer
+  .wiki-table-footer
+    display flex
+    align-items center
+    justify-content space-between
+    margin-top 14px
+    padding-top 12px
+    border-top 1px solid #f0f0f0
+
+  .wiki-table-info
+    font-size 13px
+    color #888
+
+  .wiki-show-all-btn
+    font-size 13px
+    padding 6px 16px
+    background #fff
+    border 1px solid #d1d5db
+    border-radius 3px
+    color $brand_primary
+    cursor pointer
+    font-family inherit
+    transition background 0.15s, border-color 0.15s
+
+    &:hover
+      background #f9f9fb
+      border-color $brand_primary
+
+  .wiki-no-results
+    color #666
+    font-style italic
+    padding 20px
+    text-align center
+
+  // Grouped view (By project / By language)
+  .wiki-group
+    margin-bottom 24px
+
+  .wiki-group-header
+    margin-bottom 8px
+
+  .wiki-group-name
     font-size 1.1em
     font-weight 600
+    color #333
 
-    .project-count, .language-count
-      color #666
-      font-size 0.85em
-      font-weight 400
-      margin-left 8px
+  .wiki-group-count
+    color #666
+    font-size 0.85em
+    font-weight 400
+    margin-left 8px
 
-  h3.project-title + ul.wiki-list,
-  h3.language-title + ul.wiki-list
-    margin 0
-    margin-top 0
-    margin-bottom 24px
-    padding 0
-
-    li
-      margin-bottom 4px
-      padding 0
-      font-size 0.95em
-
-  .wiki-view-selector
-    margin-bottom 20px
-
-    label
-      margin-right 10px
-
-    .wiki-dropdown
-      padding 5px 10px
-      border 1px solid #ccc
-      background white
-      font-size 1em
-
-  .wiki-sort-section
-    .no-data
-      color #666
-      font-style italic
-      padding 20px
-      text-align center
-
+  // Responsive
   @media (max-width: 768px)
     .stats-grid
-      grid-template-columns repeat(2, 1fr)
       gap 12px
 
     .stats-card
-      padding 12px
+      flex 1 1 calc(50% - 12px)
+      max-width calc(50% - 12px)
+      padding 16px 12px
 
       h3
         font-size 1.6em
 
-    .wiki-list
-      columns 1
+    .wiki-controls
+      flex-direction column
+
+    .wiki-search
+      min-width 100%
+
+    .wiki-tabs
+      width 100%
+
+    .wiki-tab
+      flex 1
+      text-align center
+
+    .wiki-bar-col
+      display none
 
   @media (max-width: 480px)
-    .stats-grid
-      grid-template-columns 1fr
-
     .stats-card
-      padding 12px
+      flex 1 1 100%
+      max-width 100%
+      padding 14px 12px
 
       h3
         font-size 1.4em

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -85,9 +85,6 @@ class AnalyticsController < ApplicationController
 
     {
       all: wikis_with_counts,
-      by_project: wikis_with_counts.group_by { |w| w[:project] },
-      by_language: group_by_language(wikis_with_counts),
-      top_wikis: wikis_with_counts.first(10),
       summary: build_wiki_summary(wikis_with_counts)
     }
   end
@@ -98,11 +95,6 @@ class AnalyticsController < ApplicationController
       { wiki: wiki, domain: wiki.domain, language: wiki.language,
         project: wiki.project, course_count: course_counts[wiki.id] || 0 }
     end
-  end
-
-  def group_by_language(wikis_with_counts)
-    wikis_with_counts.group_by { |w| w[:language] }
-                     .select { |lang, wikis| lang.present? && wikis.size > 1 }
   end
 
   def build_wiki_summary(wikis_with_counts)

--- a/app/views/analytics/_wiki_list.html.haml
+++ b/app/views/analytics/_wiki_list.html.haml
@@ -1,51 +1,6 @@
-.wiki-view-selector
-  %label{for: 'wiki-view-dropdown'} View:
-  %select#wiki-view-dropdown.wiki-dropdown
-    %option{value: 'all', selected: true} All Wikis (by Activity)
-    %option{value: 'top10'} Top 10 Most Active Wikis
-    %option{value: 'project'} Sort by Project Type
-    %option{value: 'language'} Sort by Language
+-# Wiki data is passed as JSON for client-side rendering
+-# This enables search, filtering, and sorting without page reloads
+- wiki_json = @wiki_data[:all].map { |w|
+-     w.slice(:domain, :project, :language, :course_count) }.to_json
 
-#wiki-list-all.wiki-sort-section{style: 'display: block;'}
-  %ul.wiki-list.all-wikis
-    - @wiki_data[:all].each do |item|
-      %li
-        %a{href: "/courses_by_wiki/#{item[:domain]}"}
-          = "#{item[:domain]}"
-        %span.count= "(#{item[:course_count]} courses)"
-
-#wiki-list-top10.wiki-sort-section{style: 'display: none;'}
-  %ol.wiki-list.top-wikis
-    - @wiki_data[:top_wikis].each_with_index do |item, index|
-      %li
-        %a{href: "/courses_by_wiki/#{item[:domain]}"}
-          = "#{item[:domain]}"
-        %span.count= "(#{item[:course_count]} courses)"
-
-#wiki-list-project.wiki-sort-section{style: 'display: none;'}
-  - @wiki_data[:by_project].each do |project, wikis|
-    .project-group
-      %h3.project-title
-        = "#{project.capitalize}"
-        %span.project-count= "(#{wikis.size} wikis, #{wikis.sum { |w| w[:course_count] }} courses)"
-      %ul.wiki-list
-        - wikis.each do |item|
-          %li
-            %a{href: "/courses_by_wiki/#{item[:domain]}"}
-              = "#{item[:domain]}"
-            %span.count= "(#{item[:course_count]})"
-
-#wiki-list-language.wiki-sort-section{style: 'display: none;'}
-  - @wiki_data[:by_language].each do |language, wikis|
-    .language-group
-      %h3.language-title
-        = "#{language}"
-        %span.language-count= "(#{wikis.size} projects, #{wikis.sum { |w| w[:course_count] }} courses)"
-      %ul.wiki-list
-        - wikis.each do |item|
-          %li
-            %a{href: "/courses_by_wiki/#{item[:domain]}"}
-              = "#{item[:domain]}"
-            %span.count= "(#{item[:course_count]})"
-  - if @wiki_data[:by_language].empty?
-    %p.no-data No languages with multiple projects found.
+#wiki-list-container{'data-wikis' => wiki_json}

--- a/app/views/analytics/_wiki_list.html.haml
+++ b/app/views/analytics/_wiki_list.html.haml
@@ -1,51 +1,5 @@
-.wiki-view-selector
-  %label{for: 'wiki-view-dropdown'} View:
-  %select#wiki-view-dropdown.wiki-dropdown
-    %option{value: 'all', selected: true} All Wikis (by Activity)
-    %option{value: 'top10'} Top 10 Most Active Wikis
-    %option{value: 'project'} Sort by Project Type
-    %option{value: 'language'} Sort by Language
+-# Wiki data is passed as JSON for client-side rendering
+-# This enables search, filtering, and sorting without page reloads
+- wiki_json = @wiki_data[:all].map { |w| { domain: w[:domain], project: w[:project], language: w[:language], course_count: w[:course_count] } }.to_json
 
-#wiki-list-all.wiki-sort-section{style: 'display: block;'}
-  %ul.wiki-list.all-wikis
-    - @wiki_data[:all].each do |item|
-      %li
-        %a{href: "/courses_by_wiki/#{item[:domain]}"}
-          = "#{item[:domain]}"
-        %span.count= "(#{item[:course_count]} courses)"
-
-#wiki-list-top10.wiki-sort-section{style: 'display: none;'}
-  %ol.wiki-list.top-wikis
-    - @wiki_data[:top_wikis].each_with_index do |item, index|
-      %li
-        %a{href: "/courses_by_wiki/#{item[:domain]}"}
-          = "#{item[:domain]}"
-        %span.count= "(#{item[:course_count]} courses)"
-
-#wiki-list-project.wiki-sort-section{style: 'display: none;'}
-  - @wiki_data[:by_project].each do |project, wikis|
-    .project-group
-      %h3.project-title
-        = "#{project.capitalize}"
-        %span.project-count= "(#{wikis.size} wikis, #{wikis.sum { |w| w[:course_count] }} courses)"
-      %ul.wiki-list
-        - wikis.each do |item|
-          %li
-            %a{href: "/courses_by_wiki/#{item[:domain]}"}
-              = "#{item[:domain]}"
-            %span.count= "(#{item[:course_count]})"
-
-#wiki-list-language.wiki-sort-section{style: 'display: none;'}
-  - @wiki_data[:by_language].each do |language, wikis|
-    .language-group
-      %h3.language-title
-        = "#{language}"
-        %span.language-count= "(#{wikis.size} projects, #{wikis.sum { |w| w[:course_count] }} courses)"
-      %ul.wiki-list
-        - wikis.each do |item|
-          %li
-            %a{href: "/courses_by_wiki/#{item[:domain]}"}
-              = "#{item[:domain]}"
-            %span.count= "(#{item[:course_count]})"
-  - if @wiki_data[:by_language].empty?
-    %p.no-data No languages with multiple projects found.
+#wiki-list-container{'data-wikis' => wiki_json}

--- a/spec/features/usage_page_spec.rb
+++ b/spec/features/usage_page_spec.rb
@@ -1,59 +1,98 @@
 require 'rails_helper'
 
-describe 'usage page', type: :feature, js: true, js_error_expected: true do
-  let(:en_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-  let(:fr_wiki) { Wiki.get_or_create(language: 'fr', project: 'wikipedia') }
+describe 'wiki list on /usage page', type: :feature, js: true, js_error_expected: true do
+  # 25 valid Wikipedia language codes — used to exercise show-all
+  # (threshold is 20), top-10, search, and grouped views.
+  langs = %w[
+    en fr de es it nl pt ru ja zh ar pl uk sv no fi da cs hu el tr he th vi id
+  ]
 
   before do
-    # Create some courses to have data on the page
-    Course.create!(
-      title: 'English Wiki Course',
-      school: 'School',
-      term: 'Term',
-      slug: 'School/English_Wiki_Course',
-      start: 1.month.ago,
-      end: 1.month.from_now,
-      home_wiki: en_wiki,
-      passcode: 'pizza'
-    )
+    # Bypass the live MediaWiki sanity check that fires on Wiki creation.
+    allow_any_instance_of(Wiki).to receive(:ensure_wiki_exists).and_return(true)
 
+    langs.each_with_index do |lang, i|
+      wiki = Wiki.get_or_create(language: lang, project: 'wikipedia')
+      (i + 1).times do |j|
+        Course.create!(
+          title: "#{lang} Course #{j}",
+          school: 'School',
+          term: 'Term',
+          slug: "School/#{lang}_course_#{j}",
+          start: 1.month.ago,
+          end: 1.month.from_now,
+          home_wiki: wiki,
+          passcode: 'pizza'
+        )
+      end
+    end
+    # Also include a wikidata wiki (no language), to verify the
+    # "language || 'Other'" fallback doesn't blow up.
+    wd = Wiki.get_or_create(language: nil, project: 'wikidata')
     Course.create!(
-      title: 'French Wiki Course',
+      title: 'Wikidata Course',
       school: 'School',
       term: 'Term',
-      slug: 'School/French_Wiki_Course',
+      slug: 'School/wd_course',
       start: 1.month.ago,
       end: 1.month.from_now,
-      home_wiki: fr_wiki,
+      home_wiki: wd,
       passcode: 'pizza'
     )
   end
 
-  it 'shows usage data and toggles wiki lists' do
+  it 'renders 20 rows by default with a Show all button' do
     visit '/usage'
-    expect(page).to have_text('Usage Stats')
+    expect(page).to have_css('.wiki-table tbody tr', count: 20)
+    expect(page).to have_css('#wiki-show-all', text: 'Show all')
+    expect(page).to have_text('Showing 20 of 26 wikis')
+  end
 
-    # Initially, "All Wikis" should be visible
-    expect(page).to have_css('#wiki-list-all', visible: true)
-    expect(page).to have_css('#wiki-list-top10', visible: false)
+  it 'expands to all rows when Show all is clicked' do
+    visit '/usage'
+    find('#wiki-show-all').click
+    expect(page).to have_css('.wiki-table tbody tr', count: 26)
+    expect(page).to have_no_css('#wiki-show-all')
+  end
 
-    # Change to "Top 10"
-    find('#wiki-view-dropdown').select('Top 10 Most Active Wikis')
-    expect(page).to have_css('#wiki-list-top10', visible: true)
-    expect(page).to have_css('#wiki-list-all', visible: false)
+  it 'limits Top 10 view to 10 rows' do
+    visit '/usage'
+    find('.wiki-tab', text: 'Top 10').click
+    expect(page).to have_css('.wiki-table tbody tr', count: 10)
+  end
 
-    # Change to "Project Type"
-    find('#wiki-view-dropdown').select('Sort by Project Type')
-    expect(page).to have_css('#wiki-list-project', visible: true)
-    expect(page).to have_css('#wiki-list-top10', visible: false)
+  it 'filters rows by domain when typing in search' do
+    visit '/usage'
+    fill_in 'wiki-search', with: 'th.wikipedia'
+    expect(page).to have_css('.wiki-table tbody tr', count: 1)
+    expect(page).to have_text('th.wikipedia.org')
+    expect(page).to have_no_text('vi.wikipedia.org')
+  end
 
-    # Change to "Language"
-    find('#wiki-view-dropdown').select('Sort by Language')
-    expect(page).to have_css('#wiki-list-language', visible: true)
-    expect(page).to have_css('#wiki-list-project', visible: false)
+  it 'shows a no-results message when search has no matches' do
+    visit '/usage'
+    fill_in 'wiki-search', with: 'no_such_wiki'
+    expect(page).to have_text('No wikis found matching your search')
+  end
 
-    # Save a screenshot so the user can see the result
-    page.save_screenshot('tmp/screenshots/usage_page_test_result.png')
-    puts "\nScreenshot saved to: tmp/screenshots/usage_page_test_result.png"
+  it 'groups wikis by project in the By project view' do
+    visit '/usage'
+    find('.wiki-tab', text: 'By project').click
+    expect(page).to have_css('.wiki-group')
+    expect(page).to have_text('Wikipedia')
+    expect(page).to have_text('Wikidata')
+  end
+
+  it 'shows wikis without a language under "Other" in By language view' do
+    visit '/usage'
+    find('.wiki-tab', text: 'By language').click
+    expect(page).to have_text('Other')
+  end
+
+  it 'has working anchor links to courses_by_wiki' do
+    visit '/usage'
+    # `id` is last in the langs list, so it has the most courses
+    # and appears in the default top-20 view.
+    expect(page).to have_link(href: '/courses_by_wiki/id.wikipedia.org')
   end
 end

--- a/spec/features/usage_page_spec.rb
+++ b/spec/features/usage_page_spec.rb
@@ -5,7 +5,6 @@ describe 'usage page', type: :feature, js: true, js_error_expected: true do
   let(:fr_wiki) { Wiki.get_or_create(language: 'fr', project: 'wikipedia') }
 
   before do
-    # Create some courses to have data on the page
     Course.create!(
       title: 'English Wiki Course',
       school: 'School',
@@ -29,31 +28,34 @@ describe 'usage page', type: :feature, js: true, js_error_expected: true do
     )
   end
 
-  it 'shows usage data and toggles wiki lists' do
+  it 'shows usage data and wiki list table' do
     visit '/usage'
     expect(page).to have_text('Usage Stats')
 
-    # Initially, "All Wikis" should be visible
-    expect(page).to have_css('#wiki-list-all', visible: true)
-    expect(page).to have_css('#wiki-list-top10', visible: false)
+    # Wiki list table should be visible with search and tabs
+    expect(page).to have_css('.wiki-search')
+    expect(page).to have_css('.wiki-tabs')
+    expect(page).to have_css('.wiki-table')
 
-    # Change to "Top 10"
-    find('#wiki-view-dropdown').select('Top 10 Most Active Wikis')
-    expect(page).to have_css('#wiki-list-top10', visible: true)
-    expect(page).to have_css('#wiki-list-all', visible: false)
+    # Should show wiki data in the table
+    expect(page).to have_text('en.wikipedia.org')
+    expect(page).to have_text('fr.wikipedia.org')
 
-    # Change to "Project Type"
-    find('#wiki-view-dropdown').select('Sort by Project Type')
-    expect(page).to have_css('#wiki-list-project', visible: true)
-    expect(page).to have_css('#wiki-list-top10', visible: false)
+    # Switch to Top 10 tab
+    find('.wiki-tab', text: 'Top 10').click
+    expect(page).to have_css('.wiki-table')
 
-    # Change to "Language"
-    find('#wiki-view-dropdown').select('Sort by Language')
-    expect(page).to have_css('#wiki-list-language', visible: true)
-    expect(page).to have_css('#wiki-list-project', visible: false)
+    # Switch to By project tab
+    find('.wiki-tab', text: 'By project').click
+    expect(page).to have_css('.wiki-group')
 
-    # Save a screenshot so the user can see the result
-    page.save_screenshot('tmp/screenshots/usage_page_test_result.png')
-    puts "\nScreenshot saved to: tmp/screenshots/usage_page_test_result.png"
+    # Switch to By language tab
+    find('.wiki-tab', text: 'By language').click
+    expect(page).to have_css('.wiki-group')
+
+    # Search functionality
+    find('.wiki-tab', text: 'All wikis').click
+    fill_in 'wiki-search', with: 'en'
+    expect(page).to have_text('en.wikipedia.org')
   end
 end


### PR DESCRIPTION
## What this PR does

Redesigns the Wiki List section on the /usage page. Right now it dumps all 255 wikis as a flat bullet list with a dropdown to switch views  hard to scan or find anything specific. This replaces it with a searchable table.
Follows up on the design I shared in #2637 that @ragesoss approved.

## Changes

- Replaced the bullet list with a table (wiki name, project type, course count, activity bar)
- Added a search box so you can filter wikis by name/project/language
- Swapped the dropdown for inline tabs (All wikis / Top 10 / By project / By language)
- Activity bars next to each row show relative course count at a glance
- Shows first 20 wikis with a "Show all" button to reveal the rest (no pagination — per Sage's feedback)
- By project and By language views group wikis under headers with totals
- All colors use `$brand_primary`, matches course page design language
- Activity bars hidden on mobile for cleaner responsive layout

## Files changed

- `app/views/analytics/_wiki_list.html.haml` — now passes wiki data as JSON for client-side rendering
- `app/assets/javascripts/charts.js` — builds the table with search/tabs/show all
- `app/assets/stylesheets/modules/_usage.styl` — replaced old list styles with table styles
- `spec/features/usage_page_spec.rb` — updated test to match new table structure

## AI usage

Design and layout were decided by me. Used AI for tips on implementing the design logic, navigating the codebase to find the right files, and understanding the existing code flow across folders to prevent errors. Tested and debugged on my local setup.


### Screenshots

**Before:**
<img width="517" height="765" alt="Screenshot 2026-04-15 at 12 37 51 AM" src="https://github.com/user-attachments/assets/01a550c5-a23e-466f-8fbf-0abcf28631fe" />

**After:**
<img width="504" height="766" alt="Screenshot 2026-04-15 at 12 36 44 AM" src="https://github.com/user-attachments/assets/cb4749cd-6bf1-40e4-a46c-c17cc57a6404" />
