### PR TITLE
Fix singular/plural for image usage count (#6738)

### DIFF
--- a/app/assets/javascripts/components/uploads/upload.jsx
+++ b/app/assets/javascripts/components/uploads/upload.jsx
@@ -51,7 +51,7 @@ const Upload = ({ upload, view, linkUsername }) => {
 
   let usage = '';
   if (upload.usage_count) {
-    usage = `${I18n.t('uploads.usage_count_gallery_tile', { usage_count: upload.usage_count })}`;
+    usage = I18n.t('uploads.usage_count_gallery_tile', { count: upload.usage_count });
   }
 
   let uploadDivStyle;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1647,7 +1647,9 @@ en:
     uploaded_on: Uploaded On
     usage_count: Usage Count
     usage_doc: Number of Wikipedia articles that this image appears in.
-    usage_count_gallery_tile: Used in %{usage_count} articles
+    usage_count_gallery_tile:
+      one: "Used in %{count} article"
+      other: "Used in %{count} articles"
     usages: Usages
     gallery_view: Gallery View
     list_view: List View


### PR DESCRIPTION
## What this PR does

Fixes the grammar issue reported in #6738. When an image is used in only 1 article, the tooltip says "Used in 1 articles" should be "Used in 1 article".

## Changes

- Updated `usage_count_gallery_tile` in `en.yml` to use I18n pluralization (`one`/`other`) instead of a single string
- Changed `upload.jsx` to pass `count` instead of `usage_count` so I18n picks the right form automatically

Same pattern already used elsewhere in the codebase (e.g. `search_results`).

## AI usage

Used AI for finding the right files in the codebase. Fix and testing done by me.