### PR TITLE
Implementing sticky privacy notice banner on Activity tab

### DIFF
--- a/app/assets/javascripts/components/activity/activity_handler.jsx
+++ b/app/assets/javascripts/components/activity/activity_handler.jsx
@@ -5,6 +5,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import SubNavigation from '../common/sub_navigation.jsx';
 import CourseAlertsList from '../alerts/course_alerts_list';
 import RevisionHandler from '../revisions/revisions_handler';
+import CourseDateUtils from '../../utils/course_date_utils';
 
 const ActivityHandler = (props) => {
   const { course, current_user } = props;
@@ -22,8 +23,35 @@ const ActivityHandler = (props) => {
     });
   }
 
+  const showEndedNotification = props.usersLoaded && CourseDateUtils.isEndedTenDaysAgo(course);
+
+  const endedNotification = showEndedNotification ? (
+    <div
+      className="notification"
+      style={{
+        position: 'sticky',
+        top: '55px',
+        zIndex: 98,
+        textAlign: 'left',
+        backgroundColor: '#40AD90',
+        color: 'white',
+        padding: '15px 0',
+        marginLeft: 'calc(-50vw + 50%)',
+        marginRight: 'calc(-50vw + 50%)',
+        marginTop: '-30px',
+        marginBottom: '30px',
+        width: '100vw'
+      }}
+    >
+      <div className="container" style={{ margin: '0 auto', maxWidth: '1200px', padding: '0 15px' }}>
+        <p style={{ margin: 0, fontWeight: 'bold' }}>{I18n.t('revisions.course_ended_notification')}</p>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div className="activity-handler">
+      {endedNotification}
       <SubNavigation links={links} />
       <Routes>
         {props.usersLoaded && <Route path="recent" element={<RevisionHandler {...props} />} />}

--- a/app/assets/javascripts/components/activity/activity_handler.jsx
+++ b/app/assets/javascripts/components/activity/activity_handler.jsx
@@ -23,28 +23,12 @@ const ActivityHandler = (props) => {
     });
   }
 
-  const showEndedNotification = props.usersLoaded && CourseDateUtils.isEndedTenDaysAgo(course);
+  const showEndedNotification = props.usersLoaded && CourseDateUtils.isEnded(course);
 
   const endedNotification = showEndedNotification ? (
-    <div
-      className="notification"
-      style={{
-        position: 'sticky',
-        top: '55px',
-        zIndex: 98,
-        textAlign: 'left',
-        backgroundColor: '#40AD90',
-        color: 'white',
-        padding: '15px 0',
-        marginLeft: 'calc(-50vw + 50%)',
-        marginRight: 'calc(-50vw + 50%)',
-        marginTop: '-30px',
-        marginBottom: '30px',
-        width: '100vw'
-      }}
-    >
-      <div className="container" style={{ margin: '0 auto', maxWidth: '1200px', padding: '0 15px' }}>
-        <p style={{ margin: 0, fontWeight: 'bold' }}>{I18n.t('revisions.course_ended_notification')}</p>
+    <div className="notification notification--course-ended">
+      <div className="container">
+        <p>{I18n.t('revisions.course_ended_notification')}</p>
       </div>
     </div>
   ) : null;

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -218,6 +218,11 @@ const CourseDateUtils = {
     return openWeekCount;
   },
 
+  isEndedTenDaysAgo(course) {
+    const tenDaysAfterEnd = addDays(toDate(course.end), 10);
+    return isAfter(new Date(), tenDaysAfterEnd);
+  },
+
   isEnded(course) {
     return isBefore(toDate(course.end), new Date());
   },

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -218,10 +218,6 @@ const CourseDateUtils = {
     return openWeekCount;
   },
 
-  isEndedTenDaysAgo(course) {
-    const tenDaysAfterEnd = addDays(toDate(course.end), 10);
-    return isAfter(new Date(), tenDaysAfterEnd);
-  },
 
   isEnded(course) {
     return isBefore(toDate(course.end), new Date());

--- a/app/assets/stylesheets/modules/_notifications.styl
+++ b/app/assets/stylesheets/modules/_notifications.styl
@@ -51,3 +51,15 @@
 .notice--error
   @extends .notice
   text-align center
+
+.notification--course-ended
+  position sticky
+  top 55px
+  z-index 98
+  text-align left
+  margin-left calc(-50vw + 50%)
+  margin-right calc(-50vw + 50%)
+  margin-top -30px
+  margin-bottom 30px
+  width 100vw
+  padding 15px 0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1359,6 +1359,8 @@ en:
     see_more: See more
     show_all: Show All
     show_course_specific: Show Course Specific
+    course_ended_notification: "This course due date has been passed, but the Recent Activity tab continues to show recent edits by enrolled users. You can use the 'Show Course Specific' filter to limit the view to activity that occurred during the course."
+    filter_for_course_edits: "Filter for Course Edits Only"
     show_only_new_editors: Show Only New Editors
 
   resources:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1359,8 +1359,7 @@ en:
     see_more: See more
     show_all: Show All
     show_course_specific: Show Course Specific
-    course_ended_notification: "This course due date has been passed, but the Recent Activity tab continues to show recent edits by enrolled users. You can use the 'Show Course Specific' filter to limit the view to activity that occurred during the course."
-    filter_for_course_edits: "Filter for Course Edits Only"
+    course_ended_notification: "This shows recent edits by enrolled users, but any edits after the 'end date' are not counted toward the stats or reflected on the Articles tab. You can use the 'Show Course Specific' filter to limit the view to activity that occurred before the end date."
     show_only_new_editors: Show Only New Editors
 
   resources:


### PR DESCRIPTION
fixes #6689 
### What this PR does
This PR addresses privacy concerns on the Activity tab for courses that have ended. It implements a sticky, full-width notification banner that informs users about the continued visibility of post-course edits and guides them toward the "Course Specific" filter for a restricted view

### AI usage
used to populate the data to understand the tracking behaviour of Contributions, yet the scope of this pr touches the UI

### Screenshots
Before:
<img width="1247" height="716" alt="Screenshot 2026-04-17 at 2 06 18 AM" src="https://github.com/user-attachments/assets/16da48bd-f08b-4a43-8af4-56e554b28fce" />


After:
<img width="1301" height="640" alt="Screenshot 2026-06-06 at 11 51 53 AM" src="https://github.com/user-attachments/assets/fdcbacb3-3bd1-4149-9967-c31016be64a4" />


### Learnings
Got to know about the how tracking of contributions work

@ragesoss please review it and @Formasitchijoh any feedback welcome.