### PR TITLE
Skip stale Backup rows so course updates don't hang

### DIFF
--- a/app/models/system/backup.rb
+++ b/app/models/system/backup.rb
@@ -14,12 +14,20 @@
 #
 class Backup < ApplicationRecord
   IN_PROCESS = %w[waiting running].freeze
+  # A healthy backup run touches its row within minutes. Anything older is an
+  # orphaned row left behind by a crashed backup.sh (e.g., host restart), and
+  # must not indefinitely block CourseDataUpdateWorker via
+  # LogSidekiqStatus#pause_until_no_backup.
+  FRESH_WINDOW = 2.hours
 
   def self.current_backup
     # Force uncaching because otherwise pause_until_no_backup may sleep more
     # than necessary since it doesn't detect the backup finished.
     ActiveRecord::Base.uncached do
-      Backup.find_by(status: IN_PROCESS)
+      Backup.where(status: IN_PROCESS)
+            .where('updated_at >= ?', FRESH_WINDOW.ago)
+            .order(id: :desc)
+            .first
     end
   end
 end

--- a/spec/models/system/backup_spec.rb
+++ b/spec/models/system/backup_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: backups
+#
+#  id           :bigint           not null, primary key
+#  scheduled_at :datetime
+#  start        :datetime
+#  end          :datetime
+#  status       :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+require 'rails_helper'
+
+describe Backup do
+  describe '.current_backup' do
+    it 'returns a fresh waiting backup' do
+      backup = create(:backup, status: 'waiting')
+      expect(described_class.current_backup).to eq(backup)
+    end
+
+    it 'returns a fresh running backup' do
+      backup = create(:backup, status: 'running')
+      expect(described_class.current_backup).to eq(backup)
+    end
+
+    it 'ignores a waiting backup older than FRESH_WINDOW' do
+      create(:backup, status: 'waiting',
+                      created_at: 3.hours.ago, updated_at: 3.hours.ago)
+      expect(described_class.current_backup).to be_nil
+    end
+
+    it 'ignores a running backup older than FRESH_WINDOW' do
+      create(:backup, status: 'running',
+                      created_at: 3.hours.ago, updated_at: 3.hours.ago)
+      expect(described_class.current_backup).to be_nil
+    end
+
+    it 'returns the fresh backup when a stale one is also present' do
+      create(:backup, status: 'waiting',
+                      created_at: 3.hours.ago, updated_at: 3.hours.ago)
+      fresh = create(:backup, status: 'waiting')
+      expect(described_class.current_backup).to eq(fresh)
+    end
+
+    it 'ignores terminal-status backups regardless of age' do
+      create(:backup, status: 'finished')
+      create(:backup, status: 'failed')
+      expect(described_class.current_backup).to be_nil
+    end
+
+    it 'returns nil when there are no backup rows' do
+      expect(described_class.current_backup).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
It looks like something went wrong with the backup system this week.

A possible cause was a stalled (or simply very long-running) course update, which was running for several days straight without finishing. I think this left the status as 'waiting' so long that when I finally killed the stuck job as part of a deployment, the script on the database server that was supposed to handle starting the backup when the active jobs are done had died. (That's just a guess.)

The end result was backlog of about 5 days for the course update queues. (Thanks for flagging the problem @Formasitchijoh !). I updated the last 'backup' record to mark it as a failed update, and that got the queues unstuck — except for course 35819 (https://outreachdashboard.wmflabs.org/courses/Wiki_Update/From_Continet_To_Cup) which still has not completed a successful update. I'm working on getting to the bottom of why that course is stuck, but meanwhile, this is Claude's solution to make sure the backup system doesn't cause the whole update queue to stop working.

@gabina I'm going to merge this now, but feel free propose a different solution if you don't like this.