### PR TITLE
Set finite timeouts on Replica, Lift Wing, ref-counter HTTP calls

### DIFF
--- a/lib/lift_wing_api.rb
+++ b/lib/lift_wing_api.rb
@@ -98,12 +98,20 @@ class LiftWingApi
     "/service/lw/inference/v1/models/#{wiki_key}-#{model_key}:predict"
   end
 
+  # Without these timeouts, a silent Lift Wing server leaves the worker blocked
+  # in IO#wait_readable indefinitely. With them, Faraday::TimeoutError raises
+  # and the caller's rescue loop can retry or fall through to per-revision
+  # error handling instead of hanging the whole job.
+  OPEN_TIMEOUT = 30
+  REQUEST_TIMEOUT = 60
+
   def lift_wing_server
     Faraday.new(
       url: LIFT_WING_SERVER_URL,
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      request: { open_timeout: OPEN_TIMEOUT, timeout: REQUEST_TIMEOUT }
     )
     # connection.headers['User-Agent'] = ENV['visualizer_url'] + ' ' + Rails.env
   end

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -137,12 +137,20 @@ class ReferenceCounterApi
     "/api/v1/references/#{@project_code}/#{@language_code}/#{rev_id}"
   end
 
+  # A single-revision lookup has no reason to take longer than this. Without
+  # timeouts, a silent server leaves the worker blocked in IO#wait_readable
+  # indefinitely — Faraday::TimeoutError is already in TYPICAL_ERRORS and the
+  # 5-retry rescue below will handle transient failures gracefully.
+  OPEN_TIMEOUT = 30
+  REQUEST_TIMEOUT = 60
+
   def toolforge_server
     Faraday.new(
       url: TOOLFORGE_SERVER_URL,
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      request: { open_timeout: OPEN_TIMEOUT, timeout: REQUEST_TIMEOUT }
     )
   end
 

--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -8,7 +8,7 @@ require_dependency "#{Rails.root}/lib/errors/api_error_handling"
 #=   https://replica-revision-tools.wmcloud.org/
 #= For what's going on at the other end, see:
 #=   https://github.com/WikiEducationFoundation/WikiEduDashboardTools
-class Replica
+class Replica # rubocop:disable Metrics/ClassLength
   include ApiErrorHandling
 
   def initialize(wiki, update_service = nil)
@@ -157,11 +157,19 @@ class Replica
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
 
+  # Finite timeouts on the Replica HTTP call: without them, a silent server
+  # leaves the worker blocked in IO#wait_readable forever (holding its
+  # sidekiq-unique-jobs lock for up to 30 days). api_get's rescue loop will
+  # retry on Net::ReadTimeout / Net::OpenTimeout via StandardError.
+  OPEN_TIMEOUT = 30
+  READ_TIMEOUT = 180
+
   def do_query(endpoint, query)
     url = URI.parse compile_query_url(endpoint, query)
     req = Net::HTTP::Get.new(url)
     req.add_field('User-Agent', ENV['user_agent'])
-    Net::HTTP.start(url.host, url.port, use_ssl: true) { |http| http.request(req) }
+    Net::HTTP.start(url.host, url.port, use_ssl: true, open_timeout: OPEN_TIMEOUT,
+                    read_timeout: READ_TIMEOUT) { |http| http.request(req) }
   end
 
   REPLICA_TOOL_URL = 'https://replica-revision-tools.wmcloud.org/'
@@ -179,7 +187,8 @@ class Replica
     req.content_type = 'application/x-www-form-urlencoded'
     req.body = URI.encode_www_form(form_data)
 
-    Net::HTTP.start(url.host, url.port, use_ssl: true) { |http| http.request(req) }
+    Net::HTTP.start(url.host, url.port, use_ssl: true, open_timeout: OPEN_TIMEOUT,
+                    read_timeout: READ_TIMEOUT) { |http| http.request(req) }
   end
 
   # Query URL for the WikiEduDashboardTools repository

--- a/spec/lib/lift_wing_api_spec.rb
+++ b/spec/lib/lift_wing_api_spec.rb
@@ -84,4 +84,22 @@ describe LiftWingApi do
       end
     end
   end
+
+  # Without these, a silent Lift Wing server blocks the worker indefinitely.
+  describe 'lift_wing_server connection' do
+    before { stub_wiki_validation }
+
+    let(:en_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:conn) { described_class.new(en_wiki).send(:lift_wing_server) }
+
+    it 'has a finite request timeout' do
+      expect(conn.options.timeout).to eq(described_class::REQUEST_TIMEOUT)
+      expect(conn.options.timeout).to be > 0
+    end
+
+    it 'has a finite open_timeout' do
+      expect(conn.options.open_timeout).to eq(described_class::OPEN_TIMEOUT)
+      expect(conn.options.open_timeout).to be > 0
+    end
+  end
 end

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -146,4 +146,18 @@ describe ReferenceCounterApi do
     end
   end
 
+  # Without these, a silent toolforge server blocks the worker indefinitely.
+  describe 'toolforge_server connection' do
+    let(:conn) { described_class.new(en_wikipedia).send(:toolforge_server) }
+
+    it 'has a finite request timeout' do
+      expect(conn.options.timeout).to eq(described_class::REQUEST_TIMEOUT)
+      expect(conn.options.timeout).to be > 0
+    end
+
+    it 'has a finite open_timeout' do
+      expect(conn.options.open_timeout).to eq(described_class::OPEN_TIMEOUT)
+      expect(conn.options.open_timeout).to be > 0
+    end
+  end
 end

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -348,6 +348,30 @@ describe Replica do
       end
     end
   end
+
+  # Without these, a silent Replica endpoint blocks the worker indefinitely.
+  describe 'HTTP timeouts' do
+    before do
+      allow(Net::HTTP).to receive(:start).and_return(
+        instance_double(Net::HTTPResponse, code: '200',
+                                           body: '{"success":true,"data":[]}')
+      )
+    end
+
+    it 'passes finite open_timeout and read_timeout to Net::HTTP.start for do_query' do
+      described_class.new(en_wiki).send(:do_query, 'revisions.php', 'foo=bar')
+      expect(Net::HTTP).to have_received(:start).with(
+        anything, anything,
+        hash_including(open_timeout: described_class::OPEN_TIMEOUT,
+                       read_timeout: described_class::READ_TIMEOUT)
+      )
+    end
+
+    it 'has positive, finite timeout constants' do
+      expect(described_class::OPEN_TIMEOUT).to be > 0
+      expect(described_class::READ_TIMEOUT).to be > 0
+    end
+  end
 end
 
 


### PR DESCRIPTION
Adds timeouts to prevent some API requests to cause an update to hand indefinitely.

This is Claude Code's guess at the proximate cause of the stalled update for https://outreachdashboard.wmflabs.org/courses/Wiki_Update/From_Continet_To_Cup that may have interacted with the Backup system to stall all course updates this week.

See https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6809
