### PR TITLE
Enabled RuboCop rules UnfreezeString, CompactBlank, RedundantCurrentDirectory, SpaceInsideHashLiteralBraces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -259,8 +259,6 @@ Style/RedundantEach:
   Enabled: false
 Style/ComparableBetween:
   Enabled: false
-Style/RedundantCurrentDirectoryInPath:
-  Enabled: false
 Style/ClassEqualityComparison:
   Enabled: false
 Style/MapIntoArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,8 +133,6 @@ Style/RedundantParentheses:
 
 Rails/FilePath:
   Enabled: false
-Performance/UnfreezeString:
-  Enabled: false
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/InverseOf:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -271,8 +271,6 @@ Style/SafeNavigationChainLength:
   Enabled: false
 Lint/AmbiguousRange:
   Enabled: false
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
 Style/SafeNavigation:
   Enabled: false
 Style/RedundantRegexpArgument:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -231,8 +231,6 @@ RSpecRails/HaveHttpStatus:
   Enabled: false
 FactoryBot/SyntaxMethods:
   Enabled: false
-Rails/CompactBlank:
-  Enabled: false
 Layout/FirstHashElementIndentation:
   Enabled: false
 Lint/UselessConstantScoping:

--- a/app/controllers/wikimedia_event_center_controller.rb
+++ b/app/controllers/wikimedia_event_center_controller.rb
@@ -146,7 +146,7 @@ class WikimediaEventCenterController < ApplicationController
   def add_or_remove_participants
     return if params[:dry_run]
 
-    synced_participants = params[:participant_usernames].reject(&:blank?)
+    synced_participants = params[:participant_usernames].compact_blank
     current_participants = @course.students.pluck(:username)
 
     new_participants = synced_participants - current_participants

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,8 +58,8 @@ module ApplicationHelper
 
   def class_for_path(req, path)
     return 'active' if req.path == '/' && path == '/'
-    current_path_segments = req.path.split('/').reject(&:blank?)
-    active_path = path.split('/').reject(&:blank?).last
+    current_path_segments = req.path.split('/').compact_blank
+    active_path = path.split('/').compact_blank.last
     current_path_segments.include?(active_path) ? 'active' : nil
   end
 

--- a/app/helpers/question_results_helper.rb
+++ b/app/helpers/question_results_helper.rb
@@ -42,7 +42,7 @@ module QuestionResultsHelper
     answers
       .filter_map(&:answer_text)
       .flat_map { |text| text.to_s.split(Rapidfire.answers_delimiter) }
-      .reject(&:blank?)
+      .compact_blank
   end
 
   # Builds answer data with user/course info, caching expensive course lookups

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -344,8 +344,8 @@ module SurveysHelper
   end
 
   def survey_class_for_path(req, path)
-    current_path_segments = req.path.split('/').reject(&:blank?)
-    active_path = path.split('/').reject(&:blank?).last
+    current_path_segments = req.path.split('/').compact_blank
+    active_path = path.split('/').compact_blank.last
     current_path_segments.include?(active_path) ? 'active' : nil
   end
 

--- a/lib/alerts/survey_response_alert_manager.rb
+++ b/lib/alerts/survey_response_alert_manager.rb
@@ -70,7 +70,7 @@ class SurveyResponseAlertManager
   end
 
   def alert_message(answer)
-    message = String.new("Question: #{answer.question.question_text}")
+    message = +"Question: #{answer.question.question_text}"
     message += "\r\n"
     message += "Answer: #{answer.answer_text}"
     message

--- a/lib/content_evaluation/unreliable_source_detector.rb
+++ b/lib/content_evaluation/unreliable_source_detector.rb
@@ -3,7 +3,7 @@
 # Detects sources that are unreliable or possibly unreliable
 # Based on https://en.wikipedia.org/wiki/User:Headbomb/unreliable.js
 
-require_relative './unreliable_js_rules'
+require_relative 'unreliable_js_rules'
 
 class UnreliableSourcesDetector
   def initialize(content)

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -65,7 +65,7 @@ class ReferenceCounterApi
     return handle_forbidden if response.status == FORBIDDEN
 
     if response.status != 200
-      error_response = { rev_id: rev_id, content: parsed_response}
+      error_response = { rev_id: rev_id, content: parsed_response }
       batch_non_200_response_log(response.status, error_response)
     end
     # Leave the error empty if it is not a transient error.

--- a/spec/controllers/ai_tools_controller_spec.rb
+++ b/spec/controllers/ai_tools_controller_spec.rb
@@ -18,14 +18,14 @@ describe AiToolsController, type: :request do
         'ai' => {
           'aiModel' => 'academic',
           'classification' => { 'AI' => 1, 'Original' => 0 },
-          'confidence' =>  {'AI' => 1, 'Original' => 0 },
+          'confidence' =>  { 'AI' => 1, 'Original' => 0 },
           'blocks' =>
             [{ 'result' => { 'fake' => 0.6722026056164665,
                              'real' => 0.3277973943835335,
-                             'status' => 'success' }},
+                             'status' => 'success' } },
              { 'result' => { 'fake' => 0.18571670712174604,
                              'real' => 0.814283292878254,
-                             'status' => 'success' }}]},
+                             'status' => 'success' } }] },
         'plagiarism' => { 'error' => 'not selected' }
         }
       }

--- a/spec/controllers/timeline_controller_spec.rb
+++ b/spec/controllers/timeline_controller_spec.rb
@@ -12,8 +12,7 @@ describe TimelineController, type: :request do
     let(:first_ids)   { [1] }
     let(:ids)         { [1] }
     let(:prams) do
-      {
-      }
+      {}
     end
     let(:post_params) do
       {

--- a/spec/controllers/user_profiles_controller_spec.rb
+++ b/spec/controllers/user_profiles_controller_spec.rb
@@ -281,8 +281,8 @@ describe UserProfilesController, type: :request do
       it 'when updating with an invalid email' do
         post route, params: {
           username: user.username,
-          email: { email: 'email'},
-          user_profile: {bio: 'Bio'}
+          email: { email: 'email' },
+          user_profile: { bio: 'Bio' }
         }
         expect(response).to redirect_to("/users/#{user.username}")
         expect(flash[:error]).to be_nil

--- a/spec/lib/training/wiki_slide_parser_spec.rb
+++ b/spec/lib/training/wiki_slide_parser_spec.rb
@@ -399,7 +399,7 @@ describe WikiSlideParser do
     end
 
     it 'handles nil input' do
-      output = described_class.new(''.dup).content
+      output = described_class.new((+'')).content
       expect(output).to eq('')
     end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -214,7 +214,7 @@ module RequestHelpers
   # MediaWiki query requests #
   ############################
   def stub_contributors_query
-    response = String.new '{"continue":{"pccontinue":"2169951|5094","continue":"||"},
+    response = +'{"continue":{"pccontinue":"2169951|5094","continue":"||"},
                  "query":{"normalized":[{"from":"User_talk:Ragesoss","to":"User talk:Ragesoss"}],
                  "pages":{"2169951":{"pageid":2169951,"ns":3,"title":"User talk:Ragesoss",
                  "anoncontributors":17,"contributors":[{"userid":584,"name":"Danny"}]}}}}'
@@ -225,7 +225,7 @@ module RequestHelpers
 
   def stub_raw_action
     stub_request(:get, %r{.*wikipedia.org/w/index.php\?action=raw.*})
-      .to_return(status: 200, body: String.new('[[wikitext]]'), headers: {})
+      .to_return(status: 200, body: +'[[wikitext]]', headers: {})
   end
 
   def stub_info_query


### PR DESCRIPTION
This PR enables and fixes offenses for four previously disabled RuboCop rules :
- Performance/UnfreezeString
- Rails/CompactBlank
- Style/RedundantCurrentDirectoryInPath
- Layout/SpaceInsideHashLiteralBraces

addresses #5297 
@ragesoss please review it