### PR TITLE
Don't use LiftWingApi during course updates; batch revision-counter requests

### DIFF
--- a/app/models/wiki_content/revision_on_memory.rb
+++ b/app/models/wiki_content/revision_on_memory.rb
@@ -15,8 +15,7 @@ class RevisionOnMemory
   attribute :characters, :integer, default: 0
 
   attr_accessor :date, :article_id, :mw_page_id, :user_id, :new_article,
-                :system, :wiki_id, :scoped, :error, :summary,
-                :wp10, :wp10_previous, :deleted
+                :system, :wiki_id, :scoped, :error, :summary, :deleted
 
   ####################
   # Instance methods #

--- a/lib/analytics/ores_diff_csv_builder.rb
+++ b/lib/analytics/ores_diff_csv_builder.rb
@@ -51,8 +51,12 @@ class OresDiffCsvBuilder
     ]
   end
 
+  # Historically the wikis where Lift Wing provided ORES quality scores. The
+  # wp10 fields are TODO/disabled now, but the wiki filter still scopes the
+  # CSV to the same set of Wikipedias.
+  ORES_SUPPORTED_WIKIPEDIAS = %w[en eu fa fr gl nl pt ru sv tr uk].freeze
   def supported_wiki_ids
-    @ids ||= Wiki.where(language: LiftWingApi::AVAILABLE_WIKIPEDIAS,
+    @ids ||= Wiki.where(language: ORES_SUPPORTED_WIKIPEDIAS,
                         project: 'wikipedia').pluck(:id)
   end
 end

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -89,13 +89,11 @@ class RevisionScoreImporter
 
   def update_scores(rev, rev_scores)
     rev.features = rev_scores['features']
-    rev.wp10 = rev_scores['wp10']
     rev.deleted = rev_scores['deleted'] # double check if this is a boolean
     rev.error = rev_scores['error']
   end
 
   def update_previous_scores(rev, parent_rev_scores)
-    rev.wp10_previous = parent_rev_scores['wp10']
     rev.features_previous = parent_rev_scores['features']
     # turn on error if there was an error fetching parent scores
     rev.error = true if parent_rev_scores['error']

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -4,6 +4,11 @@ require_dependency "#{Rails.root}/lib/errors/api_error_handling"
 
 # Gets data from reference-counter Toolforge tool
 # https://toolsadmin.wikimedia.org/tools/id/reference-counter
+#
+# Uses the batch endpoint (POST /api/v1/references/{project}/{language}) so a
+# group of revisions costs one HTTP round-trip instead of N. Suppressed/deleted
+# revisions surface as per-rev `{ "num_ref": null, "error": "no content" }`
+# entries inside an otherwise-200 response.
 class ReferenceCounterApi
   include ApiErrorHandling
 
@@ -28,59 +33,74 @@ class ReferenceCounterApi
     @non_200_errors = {}
   end
 
-  # This is the main entry point.
-  # Given an array of revision ids, it returns a hash with the number of references
-  # for those revision ids.
-  # Format result example:
-  # { 'rev_id0' => { 'num_ref' => 10 }
-  #   ...
-  #   'rev_idn' => { "num_ref" => 0 }
-  # }
+  # Given an array of revision ids, returns a hash:
+  #   { 'rev_id0' => { 'num_ref' => 10 }, ... 'rev_idn' => { 'num_ref' => 0 } }
+  # Suppressed/deleted revisions return { 'num_ref' => nil } (with no 'error'
+  # key, matching the prior 403 path) and tick record_reference_counter_403 on
+  # the update service so we surface a per-update count.
   def get_number_of_references_from_revision_ids(rev_ids)
-    # Restart errors array
     @errors = []
-    results = {}
-    rev_ids.each do |rev_id|
-      results.deep_merge!({ rev_id.to_s => get_number_of_references_from_revision_id(rev_id) })
-    end
+    return {} if rev_ids.empty?
+
+    results = fetch_batch(rev_ids)
 
     log_error_batch(rev_ids)
     report_reference_counter_error_to_sentry
-    return results
+    results
   end
 
   private
 
-  # Given a revision ID, it retrieves a hash containing the reference count from the
-  # reference-counter Toolforge API.
-  # If the API response is not 200 or an error occurs, it returns nil.
-  # Any encountered errors are logged in Sentry at the batch level.
-  def get_number_of_references_from_revision_id(rev_id)
+  def fetch_batch(rev_ids)
     tries ||= RETRY_COUNT
-    response = toolforge_server.get(references_query_url(rev_id))
-    parsed_response = Oj.load(response.body)
-
-    return { 'num_ref' => parsed_response['num_ref'] } if response.status == 200
-
-    return handle_forbidden if response.status == FORBIDDEN
-
-    if response.status != 200
-      error_response = { rev_id: rev_id, content: parsed_response}
-      batch_non_200_response_log(response.status, error_response)
+    response = toolforge_server.post(batch_query_url) do |req|
+      req.body = { 'rev_ids' => rev_ids }.to_json
     end
-    # Leave the error empty if it is not a transient error.
-    return { 'num_ref' => nil } if non_transient_error? response.status
-    # Log the error and return empty hash
-    return { 'num_ref' => nil, 'error' => parsed_response }
+    parsed_response = Oj.load(response.body)
+    handle_batch_response(rev_ids, response.status, parsed_response)
   rescue StandardError => e
     tries -= 1
     retry unless tries.zero?
     @errors << e
-    return { 'num_ref' => nil, 'error' => e }
+    rev_ids.to_h { |id| [id.to_s, { 'num_ref' => nil, 'error' => e }] }
   end
 
-  # 403 responses are expected for revisions whose content has been suppressed
-  # (texthidden / revdeleted). Count them on the update service so we can
+  def handle_batch_response(rev_ids, status, parsed_response)
+    return normalize_batch_results(rev_ids, parsed_response) if status == 200
+
+    batch_non_200_response_log(status, { rev_ids:, content: parsed_response })
+
+    default = if non_transient_error?(status)
+                { 'num_ref' => nil }
+              else
+                { 'num_ref' => nil, 'error' => parsed_response }
+              end
+    rev_ids.to_h { |id| [id.to_s, default] }
+  end
+
+  def normalize_batch_results(rev_ids, parsed_response)
+    rev_ids.each_with_object({}) do |rev_id, results|
+      entry = parsed_response[rev_id.to_s]
+      results[rev_id.to_s] = transform_entry(entry)
+    end
+  end
+
+  # Per-rev entry shape from the batch endpoint:
+  #   { 'num_ref' => N }                                  # normal
+  #   { 'num_ref' => nil, 'error' => 'no content' }       # suppressed/deleted
+  #   nil                                                 # missing from response
+  def transform_entry(entry)
+    return { 'num_ref' => nil } if entry.nil?
+    return handle_forbidden if suppressed_content?(entry)
+    { 'num_ref' => entry['num_ref'] }
+  end
+
+  def suppressed_content?(entry)
+    entry['num_ref'].nil? && entry['error'] == 'no content'
+  end
+
+  # Suppressed-content revs are expected for revisions whose content has been
+  # hidden (texthidden / revdeleted). Count them on the update service so we
   # surface a total per course update, and skip Sentry reporting.
   def handle_forbidden
     @update_service&.record_reference_counter_403
@@ -133,14 +153,14 @@ class ReferenceCounterApi
   class InvalidProjectError < StandardError
   end
 
-  def references_query_url(rev_id)
-    "/api/v1/references/#{@project_code}/#{@language_code}/#{rev_id}"
+  def batch_query_url
+    "/api/v1/references/#{@project_code}/#{@language_code}"
   end
 
-  # A single-revision lookup has no reason to take longer than this. Without
-  # timeouts, a silent server leaves the worker blocked in IO#wait_readable
-  # indefinitely — Faraday::TimeoutError is already in TYPICAL_ERRORS and the
-  # 5-retry rescue below will handle transient failures gracefully.
+  # A batch lookup has no reason to take longer than this. Without timeouts,
+  # a silent server leaves the worker blocked in IO#wait_readable indefinitely
+  # — Faraday::TimeoutError is already in TYPICAL_ERRORS and the 5-retry
+  # rescue below will handle transient failures gracefully.
   OPEN_TIMEOUT = 30
   REQUEST_TIMEOUT = 60
 

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency "#{Rails.root}/lib/lift_wing_api"
 require_dependency "#{Rails.root}/lib/reference_counter_api"
 
 #= Handles the logic to decide how to retrieve revision data for a given wiki.
@@ -11,8 +10,6 @@ class RevisionScoreApiHandler
   def initialize(language: 'en', project: 'wikipedia', wiki: nil, update_service: nil)
     @update_service = update_service
     @wiki = wiki || Wiki.get_or_create(language:, project:)
-    # Initialize LiftWingApi if the wiki is valid for it
-    @lift_wing_api = LiftWingApi.new(@wiki, @update_service) if LiftWingApi.valid_wiki?(@wiki)
     # Initialize ReferenceCounterApi if the wiki is valid for it
     return unless ReferenceCounterApi.valid_wiki?(@wiki)
     @reference_counter_api = ReferenceCounterApi.new(@wiki, @update_service)
@@ -38,8 +35,7 @@ class RevisionScoreApiHandler
   # For wikidata, "features" key contains Liftwing features. For other wikis, "features"
   # key contains reference-counter response (or empty hash).
   def get_revision_data(rev_batch)
-    scores = maybe_get_lift_wing_data rev_batch
-    scores.deep_merge!(maybe_get_reference_data(rev_batch))
+    scores = maybe_get_reference_data(rev_batch)
     ensure_complete_scores scores
   end
 
@@ -47,14 +43,6 @@ class RevisionScoreApiHandler
   # Helper methods #
   ##################
   private
-
-  # Lift Wing is not called during course updates. Its outputs were either
-  # unused downstream (wp10, prediction) or redundant with ReferenceCounterApi /
-  # WikidataDiffAnalyzer (features, deleted). LiftWingApi is still available
-  # for on-demand admin use (revision feedback controller).
-  def maybe_get_lift_wing_data(_rev_batch)
-    {}
-  end
 
   def maybe_get_reference_data(rev_batch)
     if ReferenceCounterApi.valid_wiki?(@wiki)

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -48,8 +48,11 @@ class RevisionScoreApiHandler
   ##################
   private
 
-  def maybe_get_lift_wing_data(rev_batch)
-    return @lift_wing_api.get_revision_data rev_batch if LiftWingApi.valid_wiki?(@wiki)
+  # Lift Wing is not called during course updates. Its outputs were either
+  # unused downstream (wp10, prediction) or redundant with ReferenceCounterApi /
+  # WikidataDiffAnalyzer (features, deleted). LiftWingApi is still available
+  # for on-demand admin use (revision feedback controller).
+  def maybe_get_lift_wing_data(_rev_batch)
     {}
   end
 

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -102,8 +102,6 @@ describe CourseRevisionUpdater do
           # no fetched scores
           expect(revisions.last.features).to be_empty
           expect(revisions.last.features_previous).to be_empty
-          expect(revisions.last.wp10).to be_nil
-          expect(revisions.last.wp10_previous).to be_nil
         end
       end
 
@@ -136,8 +134,6 @@ describe CourseRevisionUpdater do
           # no fetched scores
           expect(revisions.last.features).to be_empty
           expect(revisions.last.features_previous).to be_empty
-          expect(revisions.last.wp10).to be_nil
-          expect(revisions.last.wp10_previous).to be_nil
         end
       end
     end
@@ -200,8 +196,6 @@ describe CourseRevisionUpdater do
           # no fetched scores
           expect(revisions.last.features).to be_empty
           expect(revisions.last.features_previous).to be_empty
-          expect(revisions.last.wp10).to be_nil
-          expect(revisions.last.wp10_previous).to be_nil
         end
       end
 
@@ -232,8 +226,6 @@ describe CourseRevisionUpdater do
           # no fetched scores
           expect(revisions.last.features).to be_empty
           expect(revisions.last.features_previous).to be_empty
-          expect(revisions.last.wp10).to be_nil
-          expect(revisions.last.wp10_previous).to be_nil
         end
       end
     end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -46,8 +46,6 @@ describe CourseRevisionUpdater do
           # fetched scores
           expect(revisions.last.features).to eq({ 'num_ref' => 19 })
           expect(revisions.last.features_previous).to eq({ 'num_ref' => 18 })
-          expect(revisions.last.wp10.to_f).to be_within(0.01).of(47.03)
-          expect(revisions.last.wp10_previous.to_f).to be_within(0.01).of(46.94)
         end
       end
 
@@ -74,8 +72,6 @@ describe CourseRevisionUpdater do
           # fetched scores
           expect(revisions.last.features).to eq({ 'num_ref' => 19 })
           expect(revisions.last.features_previous).to eq({ 'num_ref' => 18 })
-          expect(revisions.last.wp10.to_f).to be_within(0.01).of(47.03)
-          expect(revisions.last.wp10_previous.to_f).to be_within(0.01).of(46.94)
         end
       end
 

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -78,12 +78,9 @@ describe RevisionScoreImporter do
       expect(revisions).to eq([662106477, 708326238, 753277075])
     end
 
-    it 'wp10 previous scores and features previous is nil for first revisions' do
+    it 'features previous is empty for first revisions' do
       VCR.use_cassette 'revision_scores/get_revision_scores' do
         revisions = described_class.new.get_revision_scores(array_revisions)
-
-        # wp10 previous keeps being nil
-        expect(revisions[0].wp10_previous).to be_nil
 
         # features previous keep being nil
         expect(revisions[0].features_previous).to eq({})

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -87,29 +87,33 @@ describe RevisionScoreImporter do
       end
     end
 
-    it 'propagates error if fetching revision scores fails' do
+    it 'propagates error to all revs when scoring batch fails' do
       VCR.use_cassette 'revision_scores/revision_score_fails' do
-        stub_request(:any, /reference-counter\.toolforge\.org.*662106477/)
+        stub_request(:post, %r{reference-counter\.toolforge\.org/api/v1/references/wikipedia/en})
           .to_raise(Errno::ECONNREFUSED)
 
         revisions = described_class.new.get_revision_scores(array_revisions)
-        expect(revisions[0].error).to eq(false)
-        expect(revisions[1].error).to eq(true)
-        expect(revisions[2].error).to eq(false)
-        expect(revisions[3].error).to eq(false)
+        expect(revisions.all?(&:error)).to be true
       end
     end
 
-    it 'propagates error if fetching parent revision scores fails' do
+    it 'propagates error to revs whose parent-revision-score batch fails' do
       VCR.use_cassette 'revision_scores/parent_revision_score_fails' do
-        stub_request(:any, /reference-counter\.toolforge\.org.*708291784/)
+        # Distinguish the parent-revision-score batch by a parent rev_id
+        # appearing in the POST body.
+        stub_request(:post, %r{reference-counter\.toolforge\.org/api/v1/references/wikipedia/en})
+          .with(body: hash_including('rev_ids' => array_including(708291784)))
           .to_raise(Errno::ECONNREFUSED)
 
         revisions = described_class.new.get_revision_scores(array_revisions)
+        # rev[0] is a new article (no parent fetch); rev[3]'s parent isn't
+        # returned by the wiki API (it's a deleted revision), so it has no
+        # parent fetch either.
         expect(revisions[0].error).to eq(false)
-        expect(revisions[1].error).to eq(false)
-        expect(revisions[2].error).to eq(true)
         expect(revisions[3].error).to eq(false)
+        # rev[1] and rev[2] each had their parent in the failing batch.
+        expect(revisions[1].error).to eq(true)
+        expect(revisions[2].error).to eq(true)
       end
     end
 

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -53,28 +53,19 @@ describe RevisionScoreImporter do
       expect(revisions).to eq([])
     end
 
-    it 'updates wp10 scores and features for revisions' do
+    it 'updates reference counts on revisions' do
       VCR.use_cassette 'revision_scores/get_revision_scores' do
         revisions = described_class.new.get_revision_scores(array_revisions)
 
-        # updates wp10
         expect(revisions[0].features['num_ref']).to eq(0)
         expect(revisions[1].features['num_ref']).to eq(9)
-
-        # updates features
-        expect(revisions[0].wp10.to_f).to be >= 11
-        expect(revisions[1].wp10.to_f).to be >= 36
       end
     end
 
-    it 'updates wp10 previous scores and features previous for non-first revisions' do
+    it 'updates previous-revision reference counts on non-first revisions' do
       VCR.use_cassette 'revision_scores/get_revision_scores' do
         revisions = described_class.new.get_revision_scores(array_revisions)
 
-        # updates wp10 previous
-        expect(revisions[1].wp10_previous).to be >= 46
-
-        # updates features previous
         expect(revisions[1].features_previous['num_ref']).to eq(9)
       end
     end
@@ -96,28 +87,6 @@ describe RevisionScoreImporter do
 
         # features previous keep being nil
         expect(revisions[0].features_previous).to eq({})
-      end
-    end
-
-    it 'marks TextDeleted revisions as deleted' do
-      VCR.use_cassette 'revision_scores/deleted_revision' do
-        # See https://ores.wikimedia.org/v2/scores/enwiki/wp10/708326238?features
-        # https://en.wikipedia.org/wiki/Philip_James_Rutledge?diff=708326238
-        revisions = described_class.new.get_revision_scores(array_revisions)
-        expect(revisions[2].deleted).to eq(true)
-        expect(revisions[2].wp10).to be_nil
-        expect(revisions[2].features).to eq({})
-        expect(revisions[2].error).to eq(false)
-      end
-    end
-
-    it 'marks RevisionNotFound revisions as deleted' do
-      VCR.use_cassette 'revision_scores/notfound_revision' do
-        revisions = described_class.new.get_revision_scores(array_revisions)
-        expect(revisions[3].deleted).to eq(true)
-        expect(revisions[3].wp10).to be_nil
-        expect(revisions[3].features).to eq({})
-        expect(revisions[3].error).to eq(false)
       end
     end
 

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -93,7 +93,7 @@ describe ReferenceCounterApi do
          project_code: 'wiktionary',
          language_code: 'es',
          rev_ids: [5006940, 5006942, 5006946],
-         error_count: 3
+         error_count: 1
      }
     )
     response = reference_counter_api.get_number_of_references_from_revision_ids rev_ids
@@ -120,11 +120,16 @@ describe ReferenceCounterApi do
 
     let(:subject) { described_class.new(en_wikipedia, update_service) }
 
-    it 'records 403s on the update service and does not send them to Sentry' do
-      stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/en/\d+})
-        .to_return(status: 403,
-                   body: '{"description":"mwapi error: permissiondenied"}',
-                   headers: { 'Content-Type': 'application/json' })
+    it 'records suppressed-content revs on the update service and does not send them to Sentry' do
+      stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikipedia/en')
+        .to_return(
+          status: 200,
+          body: lambda do |request|
+            rev_ids = JSON.parse(request.body).fetch('rev_ids', [])
+            rev_ids.to_h { |id| [id.to_s, { 'num_ref' => nil, 'error' => 'no content' }] }.to_json
+          end,
+          headers: { 'Content-Type': 'application/json' }
+        )
 
       expect(update_service).to receive(:record_reference_counter_403)
         .exactly(failing_ids.size).times

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -117,7 +117,7 @@ describe RevisionDataManager do
     end
 
     it 'fetches all the revisions that occurred during the given period of time' do
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         revisions = subject
         expect(revisions.length).to eq(4)
         # Fetches the right revision ids
@@ -133,7 +133,7 @@ describe RevisionDataManager do
         .once
         .with(revision_data)
 
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         subject
       end
     end
@@ -153,7 +153,7 @@ describe RevisionDataManager do
     end
 
     it 'ensures all revisions have a non-nil character field' do
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         # Revisions retrieved from the replica may have a nil characters field.
         # This spec ensures that the created Revision record always has a non-nil
         # characters value, defaulting to zero if nil.
@@ -248,7 +248,7 @@ describe RevisionDataManager do
     end
 
     it 'fetches all the revisions scores' do
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         revisions = subject
         expect(revisions.length).to eq(4)
         # Fetches the reference counts and deletion status. wp10 / prediction
@@ -273,7 +273,7 @@ describe RevisionDataManager do
 
     it 'does not calculate scores for revisions out mainspace/userspace/draftspace' do
       allow(instance_class).to receive(:get_revisions).and_return([data1, data2, data3])
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         revisions = subject
         # Returns all revisions
         expect(revisions.length).to eq(3)
@@ -298,7 +298,7 @@ describe RevisionDataManager do
       scoped_instance_class = described_class.new(home_wiki, scoped_course)
       allow(scoped_instance_class).to receive(:get_revisions).and_return([data1, data2, data3])
       allow(scoped_course).to receive(:scoped_article_titles).and_return(['Scoped_article'])
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         revisions = scoped_instance_class.fetch_revision_data_for_course('20180706', '20180707')
         revisions = scoped_instance_class.fetch_score_data_for_course(revisions)
         # Returns all revisions
@@ -331,7 +331,7 @@ describe RevisionDataManager do
     end
 
     it 'fetches all the revisions for the specific users during the given period of time' do
-      VCR.use_cassette 'revision_importer/all' do
+      VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
         revisions = subject
         expect(revisions.length).to eq(10)
         # Revisions don't have scores

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -335,7 +335,6 @@ describe RevisionDataManager do
         revisions = subject
         expect(revisions.length).to eq(10)
         # Revisions don't have scores
-        expect(revisions[0].wp10).to eq(nil)
         expect(revisions[0].features).to eq({})
       end
     end

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -251,27 +251,20 @@ describe RevisionDataManager do
       VCR.use_cassette 'revision_importer/all' do
         revisions = subject
         expect(revisions.length).to eq(4)
-        # Fetches the scores
-        expect(revisions[0].wp10).to be_within(0.01).of(18.29)
-        expect(revisions[0].wp10_previous).to be_within(0.01).of(11.96)
+        # Fetches the reference counts and deletion status. wp10 / prediction
+        # are no longer populated during updates (Lift Wing is not called).
         expect(revisions[0].features).to eq({ 'num_ref' => 2 })
         expect(revisions[0].features_previous).to eq({ 'num_ref' => 2 })
         expect(revisions[0].deleted).to eq(false)
 
-        expect(revisions[1].wp10).to be_within(0.01).of(20.09)
-        expect(revisions[1].wp10_previous).to be_within(0.01).of(18.29)
         expect(revisions[1].features).to eq({ 'num_ref' => 3 })
         expect(revisions[1].features_previous).to eq({ 'num_ref' => 2 })
         expect(revisions[1].deleted).to eq(false)
 
-        expect(revisions[2].wp10).to be_within(0.01).of(21.37)
-        expect(revisions[2].wp10_previous).to be_within(0.01).of(20.09)
         expect(revisions[2].features).to eq({ 'num_ref' => 3 })
         expect(revisions[2].features_previous).to eq({ 'num_ref' => 3 })
         expect(revisions[2].deleted).to eq(false)
 
-        expect(revisions[3].wp10).to be_within(0.01).of(21.34)
-        expect(revisions[3].wp10_previous).to be_within(0.01).of(21.37)
         expect(revisions[3].features).to eq({ 'num_ref' => 3 })
         expect(revisions[3].features_previous).to eq({ 'num_ref' => 3 })
         expect(revisions[3].deleted).to eq(false)

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 require "#{Rails.root}/lib/revision_score_api_handler"
 
 describe RevisionScoreApiHandler do
-  context 'when the wiki works for both lift wing and reference-counter APIs' do
+  context 'when the wiki is en.wikipedia (uses reference-counter only)' do
+    # LiftWing is no longer called during updates. wp10 / prediction are always nil;
+    # features comes solely from ReferenceCounterApi (num_ref).
     before do
       stub_en_wikipedia_reference_counter_reponse
     end
@@ -15,65 +17,17 @@ describe RevisionScoreApiHandler do
       let(:subject) { handler.get_revision_data [829840090, 829840091] }
 
       it 'returns completed scores if data is retrieved without errors' do
-        VCR.use_cassette 'revision_score_api_handler/en_wikipedia' do
-          expect(subject).to be_a(Hash)
-          expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.81)
-          expect(subject.dig('829840090', 'features')).to be_a(Hash)
-          # Only num_ref feature is stored. LiftWing features are discarded.
-          expect(subject.dig('829840090', 'features')).to eq({ 'num_ref' => 132 })
-          expect(subject.dig('829840090', 'deleted')).to eq(false)
-          expect(subject.dig('829840090', 'prediction')).to eq('B')
-          expect(subject.dig('829840090', 'error')).to eq(false)
-
-          expect(subject.dig('829840091', 'wp10').to_f).to be_within(0.01).of(39.51)
-          expect(subject.dig('829840091', 'features')).to be_a(Hash)
-          # Only num_ref feature is stored. LiftWing features are discarded.
-          expect(subject.dig('829840091', 'features')).to eq({ 'num_ref' => 1 })
-          expect(subject.dig('829840091', 'deleted')).to eq(false)
-          expect(subject.dig('829840091', 'prediction')).to eq('C')
-          expect(subject.dig('829840091', 'error')).to eq(false)
-        end
-      end
-
-      it 'returns completed scores if there is an error hitting LiftWingApi' do
-        VCR.use_cassette 'revision_score_api_handler/en_wikipedia_liftwing_error' do
-          stub_request(:any, /.*api.wikimedia.org.*/).to_raise(Errno::ETIMEDOUT)
-          expect(subject).to be_a(Hash)
-          expect(subject.dig('829840090')).to eq({ 'wp10' => nil, 'error' => true,
-          'features' => { 'num_ref' => 132 }, 'deleted' => false, 'prediction' => nil })
-          expect(subject.dig('829840091')).to eq({ 'wp10' => nil, 'error' => true,
-          'features' => { 'num_ref' => 1 }, 'deleted' => false, 'prediction' => nil })
-        end
+        expect(subject).to be_a(Hash)
+        expect(subject.dig('829840090')).to eq({ 'wp10' => nil, 'error' => false,
+        'features' => { 'num_ref' => 132 }, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('829840091')).to eq({ 'wp10' => nil, 'error' => false,
+        'features' => { 'num_ref' => 1 }, 'deleted' => false, 'prediction' => nil })
       end
 
       it 'returns completed scores if there is an error hitting ReferenceCounterApi' do
-        VCR.use_cassette 'revision_score_api_handler/en_wikipedia_reference_counter_error' do
-          stub_request(:any, /.*reference-counter.toolforge.org*/)
-            .to_raise(Errno::ETIMEDOUT)
-
-          expect(subject).to be_a(Hash)
-
-          expect(subject.dig('829840090', 'wp10').to_f).to be_within(0.01).of(62.81)
-          expect(subject.dig('829840090')).to have_key('features')
-          expect(subject.dig('829840090', 'features')).to eq({})
-          expect(subject.dig('829840090', 'deleted')).to eq(false)
-          expect(subject.dig('829840090', 'prediction')).to eq('B')
-          expect(subject.dig('829840090', 'error')).to eq(true)
-
-          expect(subject.dig('829840091', 'wp10').to_f).to be_within(0.01).of(39.51)
-          expect(subject.dig('829840091')).to have_key('features')
-          expect(subject.dig('829840091', 'features')).to eq({})
-          expect(subject.dig('829840091', 'deleted')).to eq(false)
-          expect(subject.dig('829840091', 'prediction')).to eq('C')
-          expect(subject.dig('829840091', 'error')).to eq(true)
-        end
-      end
-
-      it 'returns completed scores if there is an error hitting both apis' do
-        stub_request(:any, /.*api.wikimedia.org.*/)
-          .to_raise(Errno::ETIMEDOUT)
         stub_request(:any, /.*reference-counter.toolforge.org*/)
           .to_raise(Errno::ETIMEDOUT)
+
         expect(subject).to be_a(Hash)
         expect(subject.dig('829840090')).to eq({ 'wp10' => nil, 'error' => true,
         'features' => {}, 'deleted' => false, 'prediction' => nil })

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -181,19 +181,6 @@ describe UpdateCourseStats do
       expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
     end
 
-    it 'tracks update errors properly in LiftWing' do
-      allow(Sentry).to receive(:capture_exception)
-
-      # Raising errors only in LiftWing
-      stub_request(:any, %r{https://api.wikimedia.org/service/lw.*}).to_raise(Faraday::ConnectionFailed)
-      VCR.use_cassette 'course_update/lift_wing_api' do
-        subject
-      end
-      sentry_tag_uuid = subject.sentry_tag_uuid
-      expect(course.flags['update_logs'][1]['error_count']).to eq 2
-      expect(course.flags['update_logs'][1]['sentry_tag_uuid']).to eq sentry_tag_uuid
-    end
-
     it 'tracks update errors properly in WikiApi' do
       allow(Sentry).to receive(:capture_exception)
       allow_any_instance_of(described_class).to receive(:update_article_status).and_return(nil)

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -573,76 +573,44 @@ module RequestHelpers
     stub_users
   end
 
-  def stub_es_wiktionary_reference_counter_response
-    # Define the response body in a hash with revision IDs as keys
-    request_body = {
-      '5006940' => { 'num_ref' => 10, 'lang' => 'es', 'project' => 'wiktionary',
-      'revid' => 5006940 },
-      '5006942' => { 'num_ref' => 4, 'lang' => 'es', 'project' => 'wiktionary',
-      'revid' => 5006942 },
-      '5006946' => { 'num_ref' => 2, 'lang' => 'es', 'project' => 'wiktionary', 'revid' => 5006946 }
-    }
-
-    # Stub the request to match the revision ID in the URL
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wiktionary/es/\d+})
+  def stub_reference_counter_batch_response(project:, language:, num_refs:)
+    url = "https://reference-counter.toolforge.org/api/v1/references/#{project}/#{language}"
+    stub_request(:post, url)
       .to_return(
         status: 200,
         body: lambda do |request|
-          # Extract revision ID from the URL
-          rev_id = request.uri.path.split('/').last
-          # Return the appropriate response based on the revision ID
-          { 'num_ref' => request_body[rev_id.to_s]['num_ref'] }.to_json
+          rev_ids = JSON.parse(request.body).fetch('rev_ids', [])
+          rev_ids.to_h do |rev_id|
+            [rev_id.to_s, { 'num_ref' => num_refs[rev_id.to_s] }]
+          end.to_json
         end,
         headers: { 'Content-Type' => 'application/json' }
       )
+  end
+
+  def stub_es_wiktionary_reference_counter_response
+    stub_reference_counter_batch_response(
+      project: 'wiktionary', language: 'es',
+      num_refs: { '5006940' => 10, '5006942' => 4, '5006946' => 2 }
+    )
   end
 
   def stub_es_wikipedia_reference_counter_reponse
-    request_body = {
-      '157412237' => { 'num_ref' => 111, 'lang' => 'es', 'project' => 'wikipedia',
-      'revid' => 157412237 },
-      '157417768' => { 'num_ref' => 42, 'lang' => 'es', 'project' => 'wikipedia',
-      'revid' => 157417768 }
-    }
-
-    # Stub the request to match the revision ID in the URL
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/es/\d+})
-      .to_return(
-        status: 200,
-        body: lambda do |request|
-          # Extract revision ID from the URL
-          rev_id = request.uri.path.split('/').last
-          # Return the appropriate response based on the revision ID
-          { 'num_ref' => request_body[rev_id.to_s]['num_ref'] }.to_json
-        end,
-        headers: { 'Content-Type' => 'application/json' }
-      )
+    stub_reference_counter_batch_response(
+      project: 'wikipedia', language: 'es',
+      num_refs: { '157412237' => 111, '157417768' => 42 }
+    )
   end
 
   def stub_en_wikipedia_reference_counter_reponse
-    request_body = {
-      '829840090' => { 'num_ref' => 132, 'lang' => 'es', 'project' => 'wikipedia',
-      'revid' => 829840090 },
-      '829840091' => { 'num_ref' => 1, 'lang' => 'es', 'project' => 'wikipedia',
-      'revid' => 829840091 }
-    }
-
-    # Stub the request to match the revision ID in the URL
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikipedia/en/\d+})
-      .to_return(
-        status: 200,
-        body: lambda do |request|
-          # Extract revision ID from the URL
-          rev_id = request.uri.path.split('/').last
-          # Return the appropriate response based on the revision ID
-          { 'num_ref' => request_body[rev_id.to_s]['num_ref'] }.to_json
-        end,
-        headers: { 'Content-Type' => 'application/json' }
-      )
+    stub_reference_counter_batch_response(
+      project: 'wikipedia', language: 'en',
+      num_refs: { '829840090' => 132, '829840091' => 1 }
+    )
   end
 
   def stub_400_wiki_reference_counter_response
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator/\d+})
+    stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator')
       .to_return(
         status: 400,
         body: { 'description' => 'Language incubator is not a valid language. ' }.to_json,
@@ -651,7 +619,7 @@ module RequestHelpers
   end
 
   def stub_403_wiki_reference_counter_response
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator/\d+})
+    stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator')
       .to_return(
         status: 403,
         body: { 'description' => "mwapi error: permissiondenied - You don't have permission to view\
@@ -661,7 +629,7 @@ module RequestHelpers
   end
 
   def stub_404_wiki_reference_counter_response
-    stub_request(:get, %r{https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator/\d+})
+    stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikimedia/incubator')
       .to_return(
         status: 404,
         body: { 'description' => 'rest-nonexistent-revision -\


### PR DESCRIPTION
LiftWing is by far the slowest part of the course update cycle for Wikipedia courses. Since deprecating the Revisions table, it looks like we don't actually use any of the data we were getting from LiftWing, except theoretically it could indicate a deleted revision... but that's redundant from Replica and the revision counter API, so we don't need that either.

This should dramatically speed up updates on the wikis where we were using it.

This also adds a switch to batching requests to the new batch-capable version of reference-counter, which is another major speedup to course updates.

@gabina am I missing something? I think this just slipped through the cracks as we gradually replaced or removed all the things we previously did with LiftWing data during the update cycle, and just never noticed that we no longer needed it.