### PR TITLE
[WIP] LTIAAS Integration - Persist LTI context and Send results to Canvas

### DIFF
--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -10,23 +10,75 @@ class LtiLaunchController < ApplicationController
   # LtiGradingServiceUnavailable: Raised if the grading service is
   #   unavailable for the current LTI context.
 
+  def init_lti_session
+    # Starting LTI Session
+    @ltik = params[:ltik]
+    ltiaas_domain = ENV['LTIAAS_DOMAIN']
+    api_key = ENV['LTIAAS_API_KEY']
+    @lti_session = LtiSession.new(ltiaas_domain, api_key, @ltik)
+    # Clearing ltik from session after successful processing
+    # session.delete(:ltik)
+    true
+  end
+
   def launch
     unless current_user
       # Redirecting user to page requiring them to log in
       # You might want to append the ltik here, depending on whether or not
       # you want the user to remain in the iframe for the login process (if it's even possible)
+      session['ltik'] = params[:ltik]
       redirect_to root_path
       return
     end
-    # Starting LTI Session
-    ltik = params[:ltik]
-    ltiaas_domain = ENV['LTIAAS_DOMAIN']
-    api_key = ENV['LTIAAS_API_KEY']
-    lti_session = LtiSession.new(ltiaas_domain, api_key, ltik)
+
+    init_lti_session
+
     # Linking LTI User
-    lti_session.link_lti_user(current_user)
-    # Redirecting user to page confirming their account has been linked
-    redirect_to root_path
+    @lti_session.link_lti_user(current_user)
+    # Redirecting user to page confirming their account has been linked, training for now
+    redirect_to "/training"
+  end
+
+  def deep_link_launch
+    init_lti_session
+    render "lti_launch/deep_link"
+  end
+
+  def deep_link_search
+    @search = params[:query].present?
+    @results = search_resources(params[:query])
+    render "lti_launch/deep_link"
+  end
+
+  def deep_link_submit
+    selection = params[:selection]
+    raise "No selection" if selection.blank?
+    type, id = selection.split(":")
+    resource = type.constantize.find(id)
+
+    form_html = @lti_session.build_and_submit_deep_link(resource)
+    render html: form_html.html_safe
+  end
+
+  def search_resources(query)
+    results = []
+
+    TrainingModule.where("name LIKE :q OR slug LIKE :q OR description LIKE :q", q: "%#{query}%")
+                  .limit(5).each do |t|
+      results << { id: t.id, title: t.name, resource_type: "TrainingModule" }
+    end
+
+    Course.where("title LIKE :q OR slug LIKE :q OR description LIKE :q", q: "%#{query}%")
+          .limit(5).each do |c|
+      results << { id: c.id, title: c.title, resource_type: "Course" }
+    end
+
+    Campaign.where("title LIKE :q OR slug LIKE :q OR description LIKE :q", q: "%#{query}%")
+            .limit(5).each do |c|
+      results << { id: c.id, title: c.title, resource_type: "Campaign" }
+    end
+
+    results
   end
 
   private

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -18,6 +18,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in @user
       redirect_to "/courses/#{session['course_slug']}/enroll/#{session['enroll_code']}"
     else
+      returning_from_lti_launch
       sign_in_and_redirect @user
     end
   end
@@ -66,5 +67,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def session_enroll_code
     session['enroll_code']
+  end
+
+  def returning_from_lti_launch
+    if session['ltik']
+      request.env['omniauth.origin'] = "/lti?ltik=#{session['ltik']}"
+    end
   end
 end

--- a/app/services/lti_session.rb
+++ b/app/services/lti_session.rb
@@ -62,16 +62,22 @@ class LtiSession
     @cached_line_item_id ||= determine_line_item_id
   end
 
+  def resolve_user_from_lti_identity
+    return nil if @user_lti_id.blank?
+    LtiContext.find_by(user_lti_id: @user_lti_id)&.user
+  end
+
   def link_lti_user(current_user)
     # Checking if LTI User already exists.
     return unless LtiContext.find_by(user: current_user, user_lti_id:, lms_id:, context_id:).nil?
-    # Sending account created signal if user is a student.
-    # You can pass the User Wikipedia ID as parameter to this method to
-    #  generate a comment in the grade.
-    # Example: lti_session.send_account_created_signal(123)
-    send_account_created_signal(current_user.username) unless user_is_teacher?
     # Creating LTI User
-    LtiContext.create(user: current_user, user_lti_id:, lms_id:, lms_family:, context_id:)
+    @lti_record = LtiContext.create!(user: current_user, user_lti_id:, lms_id:, lms_family:,
+context_id:)
+      # Sending account created signal if user is a student.
+      # You can pass the User Wikipedia ID as parameter to this method to
+      #  generate a comment in the grade.
+      # Example: lti_session.send_account_created_signal(123)
+    send_account_created_signal(current_user.username) unless user_is_teacher?
   end
 
   private
@@ -109,7 +115,7 @@ class LtiSession
     return line_item_id unless line_item_id.nil? || line_item_id.empty?
 
     resource_link_id = @idtoken['launch']['resourceLink']['id']
-    line_items = make_get_request("/api/lineitems?resourceLinkId#{resource_link_id}")['lineItems']
+    line_items = make_get_request("/api/lineitems?resourceLinkId=#{resource_link_id}")['lineItems']
     return line_items.first['id'] unless line_items.empty?
 
     line_item = {
@@ -118,6 +124,35 @@ class LtiSession
       'scoreMaximum' => SCORE_MAXIMUM
     }
     return make_post_request('/api/lineitems', line_item)['id']
+  end
+
+  def build_and_submit_deep_link(resource)
+    content_item = build_content_item(resource)
+    create_deep_linking_form([content_item])
+  end
+
+  def build_content_item(resource)
+    {
+      type: "ltiResourceLink",
+      url: "#{ltiaas_launch_url}?resource_type=#{resource.class.name}&resource_id=#{resource.id}",
+      title: resource.title
+    }
+  end
+
+  def create_deep_linking_form(content_items)
+    unless @idtoken['services']['deepLinking']['available']
+      raise LtiDeepLinkingServiceUnavailable
+    end
+    unless user_is_teacher?
+      render status: :forbidden
+      raise LtiaasClientError
+    end
+
+    body = {
+      contentItems: content_items
+    }
+    response = make_post_request("/api/deeplinking/form", body)
+    response['form']
   end
 
   class LtiaasClientError < StandardError
@@ -131,4 +166,5 @@ class LtiSession
   end
 
   class LtiGradingServiceUnavailable < StandardError; end
+  class LtiDeepLinkingServiceUnavailable < StandardError; end
 end

--- a/app/views/lti_launch/_search_results.html.haml
+++ b/app/views/lti_launch/_search_results.html.haml
@@ -1,0 +1,17 @@
+= form_with url: "/lti/deep_link/submit", method: :post do
+
+  %ul.training-libraries.no-bullets.no-margin.action-card-text
+    - if @results.present?
+      - @results.each do |item|
+        %li
+          = radio_button_tag :selection, "#{item[:resource_type]}:#{item[:id]}"
+
+          %span
+            #{item[:resource_type]}:
+            %strong= item[:title]
+
+    - else
+      No results found
+
+  %br
+  %button{ type: "submit", class: ["button"]} Add to Canvas

--- a/app/views/lti_launch/deep_link.html.haml
+++ b/app/views/lti_launch/deep_link.html.haml
@@ -1,0 +1,14 @@
+.container.training
+  .module
+    .section-header
+      %h3 Select Content for Canvas
+    .container
+      .search-bar{ style: 'position:relative'}
+        = form_tag("/lti/deep_link/search", method: :get) do
+          = text_field_tag(:query, params[:query], placeholder: "Search training modules, courses, campaigns", style: 'width: 100%; height: 3rem; font-size: 15px')
+          %button{ type: 'submit', style: 'position:absolute; right:20px; top:10px' }
+            %i.icon.icon-search
+
+      - if @search
+        = render 'search_results'
+      - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -414,6 +414,9 @@ Rails.application.routes.draw do
 
     # LTI
   get 'lti' => 'lti_launch#launch'
+  get 'lti/deep_link' => 'lti_launch#deep_link_launch'
+  get 'lti/deep_link/search' => 'lti_launch#deep_link_search'
+  post 'lti/deep_link/submit' => 'lti_launch#deep_link_submit'
 
   # frequenty asked questions
   resources :faq do


### PR DESCRIPTION
## What this PR does
- Stores ltik in session so after redirection to login, lti flow can continue
- Changes lti link user flow to create user before sending score signal
- Refactors lti launch controller to accomodate deeplinking + creates base views
- Adds methods to send deep linking form in lti session

## AI usage
ChatGPT to understand LTI flow, to debug

## Screenshots
<img width="1231" height="659" alt="base deep link views WIP" src="https://github.com/user-attachments/assets/fae54e15-143e-4eae-9f5e-1d3f1b8cc65e" />

more screenshots to be added

## Open questions and concerns

Current goal is to verify deep linking flow working then more work can be done to extend the views and content selection search to use the existing search functionalities already used by like training modules, courses, campaigns etc.

Error when trying to select content via deep linking in google chrome: 
Text: "You're probably using Safari with 'Prevent cross site tracking' enabled. This may cause your login information to not be properly sent with the LTI Launch. Let's try to fix this."

<img width="931" height="537" alt="iframe error" src="https://github.com/user-attachments/assets/95723e19-92a8-4581-883c-fa7bd58c53cd" />

For starters I am not using safari / a mac so yeah.

I have tried a lot of fixes like:
1. Trying to detect the iframe and open a new tab
2. removing the login requirement and need for a current_user for deep linking ( so ltik not stored in session) 
3. trying to render a plain html ok page from the controller method instead of a full on view
4. not initializing an lti session 
and restarting the app but still the same error. So it's not a code issue but more of a browser setting one.

- Tried using firefox on my laptop, the error text does not appear but the iframe remains blank (although firefox also blocks cross-site cookies by default too)
- Tried with chrome on my mobile and still same error
- Tried with tor browser on my mobile and it works (although a NoScript XSS Warning popup displays first asking whether to allow the OIDC login request)

<img width="1080" height="2015" alt="Tor browser no script xss warning" src="https://github.com/user-attachments/assets/8e17a3b7-2636-47e9-8d67-af55ac9fa208" />

This occurs at the OIDC login initiation step when Canvas initiates OAuth with LTIAAS, before the dashboard is involved (which makes sense the error in chrome says 'This may cause your login information to not be properly sent with the LTI Launch'.

-  before the iframe loads:

https://github.com/user-attachments/assets/1fcf0ff1-d19d-4950-b753-6bca8919d85c

LTIAAS lists possible workarounds for such issues here : https://docs.ltiaas.com/guides/resources/cookies-and-lti

