### PR TITLE
Skip rescoring on warm updates with no actual new revisions

### DIFF
--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -17,6 +17,7 @@
 #  needs_update         :boolean          default(FALSE)
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  mw_rev_count         :integer          default(0)
 #
 class CourseWikiTimeslice < ApplicationRecord
   belongs_to :course
@@ -72,6 +73,7 @@ class CourseWikiTimeslice < ApplicationRecord
     update_character_sum
     update_references_count
     update_revision_count
+    update_mw_rev_count
     update_stats
     update_needs_update
     save
@@ -112,6 +114,13 @@ class CourseWikiTimeslice < ApplicationRecord
     end
 
     self.revision_count = tracked_revisions.count { |rev| !rev.deleted && !rev.system }
+  end
+
+  # Count of revisions as fetched from MediaWiki, excluding only system edits.
+  # Must mirror the same filter that CourseRevisionUpdater#new_revisions? applies
+  # to the live fetched revisions, so the two counts are comparable.
+  def update_mw_rev_count
+    self.mw_rev_count = @revisions.count { |rev| !rev.system }
   end
 
   def update_stats

--- a/db/migrate/20260428223445_add_mw_rev_count_to_course_wiki_timeslices.rb
+++ b/db/migrate/20260428223445_add_mw_rev_count_to_course_wiki_timeslices.rb
@@ -1,0 +1,5 @@
+class AddMwRevCountToCourseWikiTimeslices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :course_wiki_timeslices, :mw_rev_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_23_212149) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_28_223445) do
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "courses_id"
     t.string "title"
@@ -268,6 +268,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_23_212149) do
     t.boolean "needs_update", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "mw_rev_count", default: 0
     t.index ["course_id", "wiki_id", "start", "end"], name: "course_wiki_timeslice_by_course_wiki_start_and_end", unique: true
   end
 

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -87,6 +87,14 @@ class CourseRevisionUpdater
 
   # Determines if there are new revisions, based on the number of revisions and the
   # last revision datetime.
+  #
+  # The count comparison is against `timeslice.mw_rev_count`, NOT
+  # `timeslice.revision_count`. The two columns apply different filters:
+  # `revision_count` excludes deleted revs and revs in `articles_courses.not_tracked`
+  # in addition to system revs, while this method (and `mw_rev_count`) excludes only
+  # system revs. Comparing against `revision_count` would falsely report new data
+  # every cycle for any timeslice that contains a deleted or not-tracked rev.
+  # See CourseWikiTimeslice#update_mw_rev_count.
   def new_revisions?(revisions, wiki, timeslice_start)
     live_revisions = revisions.reject(&:system)
     revision_count = live_revisions.count
@@ -104,6 +112,6 @@ class CourseRevisionUpdater
     end
 
     latest_revision = revisions.maximum(:date)
-    revision_count != timeslice.revision_count || latest_revision != timeslice.last_mw_rev_datetime
+    revision_count != timeslice.mw_rev_count || latest_revision != timeslice.last_mw_rev_datetime
   end
 end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -79,6 +79,7 @@ describe CourseRevisionUpdater do
         # complete the timeslice
         last_mw_rev_datetime = '2016-03-31 19:50:54'.to_datetime
         course.course_wiki_timeslices.update(revision_count: 3,
+                                             mw_rev_count: 3,
                                              last_mw_rev_datetime:)
         VCR.use_cassette 'course_revision_updater' do
           revisions = instance_class.fetch_revisions_for_course_wiki(wiki, start_date, end_date)
@@ -105,10 +106,52 @@ describe CourseRevisionUpdater do
         end
       end
 
+      it 'compares against mw_rev_count, not revision_count' do
+        # Repro for the warm-update reprocessing bug: the cassette returns 3
+        # live (non-system) revisions. If the timeslice's revision_count is
+        # less than the live count (e.g. because some revs are in not_tracked
+        # articles or are deleted) but mw_rev_count matches the live count,
+        # the gate should still report no new data. Pre-fix this returned
+        # `new_data: true` and triggered re-scoring on every update cycle.
+        last_mw_rev_datetime = '2016-03-31 19:50:54'.to_datetime
+        course.course_wiki_timeslices.update(revision_count: 0,
+                                             mw_rev_count: 3,
+                                             last_mw_rev_datetime:)
+        VCR.use_cassette 'course_revision_updater' do
+          revisions = instance_class.fetch_revisions_for_course_wiki(wiki, start_date, end_date)
+          revisions_with_scores = instance_class.fetch_scores_for_revisions(revisions,
+                                                                            only_new: true)
+          expect(revisions_with_scores[wiki][:new_data]).to eq(false)
+          revs = revisions_with_scores.values.flat_map { |data| data[:revisions] }.flatten
+          expect(revs.count).to eq(3)
+          # No scores fetched — proves we skipped the scoring path.
+          expect(revs.last.features).to be_empty
+          expect(revs.last.features_previous).to be_empty
+        end
+      end
+
+      it 'reports new data when live count exceeds mw_rev_count' do
+        # Regression guard: when actual new revisions arrive (live > cached),
+        # new_data must still flip to true and scoring must run.
+        last_mw_rev_datetime = '2016-03-31 19:50:54'.to_datetime
+        course.course_wiki_timeslices.update(revision_count: 2,
+                                             mw_rev_count: 2,
+                                             last_mw_rev_datetime:)
+        VCR.use_cassette 'course_revision_updater' do
+          revisions = instance_class.fetch_revisions_for_course_wiki(wiki, start_date, end_date)
+          revisions_with_scores = instance_class.fetch_scores_for_revisions(revisions,
+                                                                            only_new: true)
+          expect(revisions_with_scores[wiki][:new_data]).to eq(true)
+          revs = revisions_with_scores.values.flat_map { |data| data[:revisions] }.flatten
+          expect(revs.last.features).to eq({ 'num_ref' => 19 })
+        end
+      end
+
       it 'does not fail when fetching data for partial timeslice' do
         # complete the timeslice
         last_mw_rev_datetime = '2016-03-31 19:50:54'.to_datetime
         course.course_wiki_timeslices.update(revision_count: 3,
+                                             mw_rev_count: 3,
                                              last_mw_rev_datetime:)
         VCR.use_cassette 'course_revision_updater' do
           expect(Sentry).not_to receive(:capture_message)
@@ -203,6 +246,7 @@ describe CourseRevisionUpdater do
         # complete the timeslice
         last_mw_rev_datetime = '2016-03-31 19:50:54'.to_datetime
         course.course_wiki_timeslices.update(revision_count: 3,
+                                             mw_rev_count: 3,
                                              last_mw_rev_datetime:)
         VCR.use_cassette 'course_revision_updater' do
           expect(Sentry).not_to receive(:capture_message)

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -17,6 +17,7 @@
 #  needs_update         :boolean          default(FALSE)
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  mw_rev_count         :integer          default(0)
 #
 require 'rails_helper'
 require "#{Rails.root}/lib/timeslice_manager"
@@ -125,6 +126,19 @@ scoped: true)
       expect(course_wiki_timeslice_1.revision_count).to eq(1)
       expect(course_wiki_timeslice_2.revision_count).to eq(2)
     end
+
+    it 'sets mw_rev_count to the non-system count, including deleted revs' do
+      start_period = start.strftime('%Y%m%d%H%M%S')
+      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      revisions = { start: start_period, end: end_period, revisions: array_revisions }
+      described_class.update_course_wiki_timeslices(course, wiki, revisions)
+
+      # First slice has 3 normal + 1 system + 1 deleted = 4 non-system revs.
+      # revision_count excludes the deleted one (3); mw_rev_count keeps it (4).
+      slice_0 = described_class.find_by(course:, wiki:, start:)
+      expect(slice_0.revision_count).to eq(3)
+      expect(slice_0.mw_rev_count).to eq(4)
+    end
   end
 
   describe '#update_cache_from_revisions' do
@@ -157,6 +171,20 @@ scoped: true)
         expect(course_wiki_timeslice.references_count).to eq(7)
         # Don't add any new revision count
         expect(course_wiki_timeslice.revision_count).to eq(0)
+      end
+
+      it 'mw_rev_count ignores tracked status and deleted, excludes only system' do
+        # Even when the only article is untracked, mw_rev_count counts every
+        # non-system rev — it must mirror what CourseRevisionUpdater#new_revisions?
+        # computes from the live fetched revisions.
+        ArticlesCourses.find(1).update(tracked: 0)
+
+        course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+        course_wiki_timeslice.update_cache_from_revisions array_revisions
+
+        expect(course_wiki_timeslice.revision_count).to eq(0)
+        # 3 normal + 1 deleted, minus the 1 system = 4
+        expect(course_wiki_timeslice.mw_rev_count).to eq(4)
       end
     end
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -256,10 +256,12 @@ describe UpdateCourseWikiTimeslices do
         # Set timeslices to reprocess
         course.course_wiki_timeslices.where(wiki: enwiki)
               .first.update(revision_count: 15,
+                            mw_rev_count: 15,
                             last_mw_rev_datetime: '2018-11-24 10:25:00',
                             needs_update: true)
         course.course_wiki_timeslices.where(wiki: wikidata)
               .first.update(revision_count: 15,
+                            mw_rev_count: 15,
                             last_mw_rev_datetime: '2018-11-24 10:25:00',
                             stats: { 'total revisions:': 15 },
                             needs_update: true)


### PR DESCRIPTION
This addresses what I think is the main source of update slowness in current courses, like many of the `long_update` courses on Peony.

I used Claude Code to benchmark some courses, particularly this one that was clogging the system until recent optimizations (skipping requests for unused LiftWing data, and making revision-counter handle batched requests): https://outreachdashboard.wmflabs.org/courses/Wiki_Update/From_Continet_To_Cup

Even when fully up-to-date with already-processed timeslices, this course still takes a while to update. This seems to be because of the mismatch between the `revision_count` we store on the CourseWikiTimeslice record and the revision count available to CourseRevisionUpdater when checking if there are any new revisions for a timeslice. Because there are some revisions that don't (and will never) get included in the `revision_count` in some timeslices — deleted or non-tracked ones — those timeslices get reprocessed every update without changing the result.