### PR TITLE
Handle Wikimedia rate-limiting better, with `Retry-After` handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,8 +56,13 @@ gem 'rapidfire', git: 'https://github.com/WikiEducationFoundation/rapidfire', br
 
 ### HTTP and API tools
 gem 'faraday' # Standard HTTP library
-gem 'mediawiki_api' # Library for querying mediawiki API'
-# gem 'mediawiki_api', git: 'https://github.com/ragesoss/mediawiki-ruby-api', branch: 'master'
+# Pointing at our fork so we get HttpError#response — needed to honor
+# Retry-After on 429s. Switch back to plain `gem 'mediawiki_api'` once
+# https://gerrit.wikimedia.org/r/admin/repos/mediawiki/ruby/api releases
+# the upstream merge.
+gem 'mediawiki_api',
+    git: 'https://github.com/WikiEducationFoundation/mediawiki-ruby-api',
+    branch: 'expose-response-on-http-error'
 gem 'restforce' # Salesforce API access
 gem 'oj' # JSON Parsing library
 gem 'rss' # Standard RSS library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/WikiEducationFoundation/wikidata-diff-analyzer
-  revision: 5a8f785bf62ab58e65e8140c1e8d87dd47b4d028
+  revision: a8a725529df95560e3c911ab58103817423a3bc2
   specs:
     wikidata-diff-analyzer (2.1.0)
       json (~> 2.1)
@@ -213,8 +213,7 @@ GEM
     diff-lcs (1.5.0)
     digest (3.2.1)
     docile (1.4.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    domain_name (0.6.20240107)
     drb (2.2.3)
     erb (4.0.4)
       cgi (>= 0.3.3)
@@ -228,7 +227,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.23.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -237,11 +236,12 @@ GEM
       http-cookie (>= 1.0.0)
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    faraday-retry (1.0.3)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.17.3)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -298,7 +298,7 @@ GEM
     hashugar (1.0.1)
     htmlentities (4.3.4)
     http-accept (1.7.0)
-    http-cookie (1.0.5)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
     i18n (1.14.8)
@@ -314,7 +314,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.3)
+    json (2.19.4)
     jwt (2.5.0)
     kt-paperclip (7.2.2)
       activemodel (>= 4.2.0)
@@ -359,7 +359,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.5.4)
-    multipart-post (2.2.3)
+    multipart-post (2.4.1)
     mysql2 (0.5.4)
     nenv (0.3.0)
     net-http (0.9.1)
@@ -665,9 +665,6 @@ GEM
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
     unicode (0.4.4.5)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,18 @@ GIT
       rails
 
 GIT
+  remote: https://github.com/WikiEducationFoundation/mediawiki-ruby-api
+  revision: 3eebf48ff49ba9ee116a4c6df889b49a09271758
+  branch: expose-response-on-http-error
+  specs:
+    mediawiki_api (0.9.0)
+      faraday (>= 2.7.0)
+      faraday-cookie_jar
+      faraday-follow_redirects
+      faraday-multipart
+      faraday-retry
+
+GIT
   remote: https://github.com/WikiEducationFoundation/rapidfire
   revision: 02dcb1723a28ef1872b62e60dabc5e7d98247957
   branch: master
@@ -335,12 +347,6 @@ GEM
       rest-client (>= 2.0.2)
     marcel (1.0.4)
     matrix (0.4.3)
-    mediawiki_api (0.9.0)
-      faraday (>= 2.7.0)
-      faraday-cookie_jar
-      faraday-follow_redirects
-      faraday-multipart
-      faraday-retry
     memory_profiler (1.0.0)
     method_source (1.1.0)
     mime-types (3.6.0)
@@ -730,7 +736,7 @@ DEPENDENCIES
   jbuilder
   kt-paperclip
   mailgun-ruby
-  mediawiki_api
+  mediawiki_api!
   memory_profiler
   mysql2
   newrelic_rpm

--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -125,6 +125,7 @@ class UpdateCourseStats
                                'sentry_tag_uuid' => sentry_tag_uuid,
                                'error_count' => error_count,
                                'reference_counter_403_count' => reference_counter_403_count,
+                               'too_many_requests_count' => too_many_requests_count,
                                'processed' => @processed,
                                'reprocessed' => @reprocessed)
   end

--- a/lib/errors/api_error_handling.rb
+++ b/lib/errors/api_error_handling.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
 module ApiErrorHandling
-  def log_error(error, update_service: nil, sentry_extra: nil)
+  def log_error(error, update_service: nil, sentry_extra: nil, sentry_tags: nil)
     Rails.logger.info "Caught #{error}"
-    sentry_tags = nil
+    base_tags = nil
     if update_service.present?
       new_errors_count = sentry_extra&.dig(:new_errors_count) || 1
       update_service.update_error_stats(new_errors_count)
-      sentry_tags = update_service.sentry_tags
+      base_tags = update_service.sentry_tags
     end
+    merged_tags = merge_sentry_tags(base_tags, sentry_tags)
     Sentry.capture_exception(error,
                              level: error_level(error),
                              extra: sentry_extra,
-                             tags: sentry_tags)
+                             tags: merged_tags)
     return nil
+  end
+
+  def merge_sentry_tags(base_tags, extra_tags)
+    return base_tags if extra_tags.blank?
+    (base_tags || {}).merge(extra_tags)
   end
 
   def error_level(error)

--- a/lib/errors/update_service_error_helper.rb
+++ b/lib/errors/update_service_error_helper.rb
@@ -21,6 +21,14 @@ module UpdateServiceErrorHelper
     @reference_counter_403_count = reference_counter_403_count + count
   end
 
+  def too_many_requests_count
+    @too_many_requests_count ||= 0
+  end
+
+  def record_too_many_requests(count = 1)
+    @too_many_requests_count = too_many_requests_count + count
+  end
+
   def sentry_tags
     { update_service_id: sentry_tag_uuid, course: @course.slug }
   end

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -124,8 +124,14 @@ class WikiApi
     end
     retry unless tries.zero?
     log_error(e, update_service: @update_service,
-              sentry_extra: { action:, query:, api_url: @api_url })
+              sentry_extra: { action:, query:, api_url: @api_url },
+              sentry_tags: rate_limit_sentry_tags(e))
     return nil
+  end
+
+  def rate_limit_sentry_tags(error)
+    return unless too_many_requests?(error)
+    { http_status: 429, host: URI(@api_url).host }
   end
 
   def api_client

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -116,15 +116,13 @@ class WikiApi
   rescue StandardError => e
     raise if caller_handles&.call(e)
     tries -= 1
-    # Continue for typical errors so that the request can be retried, but wait
-    # a short bit in the case of 429 — too many request — errors.
     if too_many_requests?(e)
       @update_service&.record_too_many_requests
-      sleep 1
+      sleep retry_delay_for(e)
     end
     retry unless tries.zero?
     log_error(e, update_service: @update_service,
-              sentry_extra: { action:, query:, api_url: @api_url },
+              sentry_extra: rate_limit_sentry_extra(e).merge(action:, query:, api_url: @api_url),
               sentry_tags: rate_limit_sentry_tags(e))
     return nil
   end
@@ -132,6 +130,34 @@ class WikiApi
   def rate_limit_sentry_tags(error)
     return unless too_many_requests?(error)
     { http_status: 429, host: URI(@api_url).host }
+  end
+
+  # Per Wikimedia's rate-limit policy: honor Retry-After when present, else
+  # back off ≥5 s. https://www.mediawiki.org/wiki/Wikimedia_APIs/Rate_limits
+  DEFAULT_RETRY_AFTER_SECONDS = 5
+  # Cap to prevent a misbehaving server from hanging a worker for hours.
+  MAX_RETRY_AFTER_SECONDS = 60
+
+  def retry_delay_for(error)
+    seconds = retry_after_seconds(error) || DEFAULT_RETRY_AFTER_SECONDS
+    seconds.clamp(0, MAX_RETRY_AFTER_SECONDS)
+  end
+
+  # Returns the integer seconds requested by the server's Retry-After header,
+  # or nil if the header is absent / unparseable / the gem version in use
+  # doesn't expose the response on HttpError. Wikimedia uses delay-seconds;
+  # HTTP-date form (RFC 7231) is not parsed.
+  def retry_after_seconds(error)
+    return nil unless error.respond_to?(:response) && error.response
+    raw = error.response.headers['Retry-After']
+    Integer(raw) if raw.present?
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def rate_limit_sentry_extra(error)
+    raw = retry_after_seconds(error)
+    raw ? { retry_after: raw } : {}
   end
 
   def api_client

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -118,7 +118,10 @@ class WikiApi
     tries -= 1
     # Continue for typical errors so that the request can be retried, but wait
     # a short bit in the case of 429 — too many request — errors.
-    sleep 1 if too_many_requests?(e)
+    if too_many_requests?(e)
+      @update_service&.record_too_many_requests
+      sleep 1
+    end
     retry unless tries.zero?
     log_error(e, update_service: @update_service,
               sentry_extra: { action:, query:, api_url: @api_url })

--- a/spec/helpers/update_service_error_helper_spec.rb
+++ b/spec/helpers/update_service_error_helper_spec.rb
@@ -27,4 +27,20 @@ RSpec.describe UpdateServiceErrorHelper do
       expect(subject.error_count).to eq(5)
     end
   end
+
+  describe '#record_too_many_requests' do
+    it 'starts at 0' do
+      expect(subject.too_many_requests_count).to eq(0)
+    end
+
+    it 'increments too_many_requests_count by 1 when no argument is given' do
+      expect { subject.record_too_many_requests }
+        .to change(subject, :too_many_requests_count).by(1)
+    end
+
+    it 'increments too_many_requests_count by the given count' do
+      expect { subject.record_too_many_requests(4) }
+        .to change(subject, :too_many_requests_count).by(4)
+    end
+  end
 end

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -84,6 +84,29 @@ describe WikiApi do
       expect(update_service).to receive(:record_too_many_requests).exactly(3).times
       described_class.new(nil, update_service).query(titles: 'X')
     end
+
+    it 'tags Sentry with http_status and host when the final error is a 429' do
+      allow(Sentry).to receive(:capture_exception)
+      allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+        .and_raise(MediawikiApi::HttpError.new(429))
+      allow_any_instance_of(described_class).to receive(:sleep)
+      described_class.new.query(titles: 'X')
+      expect(Sentry).to have_received(:capture_exception).with(
+        anything,
+        hash_including(tags: hash_including(http_status: 429, host: 'en.wikipedia.org'))
+      )
+    end
+
+    it 'does not add http_status tag when the final error is not a 429' do
+      allow(Sentry).to receive(:capture_exception)
+      allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+        .and_raise(MediawikiApi::ApiError)
+      described_class.new.query(titles: 'X')
+      expect(Sentry).to have_received(:capture_exception).with(
+        anything,
+        hash_excluding(tags: hash_including(:http_status))
+      )
+    end
   end
 
   describe '#get_page_content' do

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -73,6 +73,17 @@ describe WikiApi do
       expect(result).to be_nil
       expect(call_count).to eq(3)
     end
+
+    it 'ticks update_service.record_too_many_requests for each 429 observed' do
+      update_service = double('UpdateService', record_too_many_requests: nil)
+      allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+        .and_raise(MediawikiApi::HttpError.new(429))
+      allow_any_instance_of(described_class).to receive(:sleep)
+      expect_any_instance_of(described_class).to receive(:log_error).once
+      # 3 tries → 3 observed 429s
+      expect(update_service).to receive(:record_too_many_requests).exactly(3).times
+      described_class.new(nil, update_service).query(titles: 'X')
+    end
   end
 
   describe '#get_page_content' do

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -107,6 +107,68 @@ describe WikiApi do
         hash_excluding(tags: hash_including(:http_status))
       )
     end
+
+    context 'Retry-After handling on 429' do
+      def http_error_with_retry_after(value)
+        response = instance_double('Faraday::Response',
+                                   status: 429, headers: { 'Retry-After' => value })
+        MediawikiApi::HttpError.new(response)
+      end
+
+      it 'sleeps the integer seconds the server requested' do
+        allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+          .and_raise(http_error_with_retry_after('12'))
+        expect_any_instance_of(described_class).to receive(:sleep).with(12).at_least(:once)
+        described_class.new.query(titles: 'X')
+      end
+
+      it 'falls back to a 5-second default when Retry-After is absent' do
+        response = instance_double('Faraday::Response', status: 429, headers: {})
+        allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+          .and_raise(MediawikiApi::HttpError.new(response))
+        expect_any_instance_of(described_class).to receive(:sleep).with(5).at_least(:once)
+        described_class.new.query(titles: 'X')
+      end
+
+      it 'falls back to 5 s when the header is unparseable' do
+        allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+          .and_raise(http_error_with_retry_after('Wed, 21 Oct 2026 07:28:00 GMT'))
+        expect_any_instance_of(described_class).to receive(:sleep).with(5).at_least(:once)
+        described_class.new.query(titles: 'X')
+      end
+
+      it 'caps absurdly long Retry-After values at 60 s' do
+        allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+          .and_raise(http_error_with_retry_after('3600'))
+        expect_any_instance_of(described_class).to receive(:sleep).with(60).at_least(:once)
+        described_class.new.query(titles: 'X')
+      end
+
+      it 'puts the requested Retry-After value in Sentry extra' do
+        allow(Sentry).to receive(:capture_exception)
+        allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+          .and_raise(http_error_with_retry_after('30'))
+        allow_any_instance_of(described_class).to receive(:sleep)
+        described_class.new.query(titles: 'X')
+        expect(Sentry).to have_received(:capture_exception).with(
+          anything,
+          hash_including(extra: hash_including(retry_after: 30))
+        )
+      end
+
+      it 'omits retry_after from Sentry extra when no header was sent' do
+        allow(Sentry).to receive(:capture_exception)
+        response = instance_double('Faraday::Response', status: 429, headers: {})
+        allow_any_instance_of(MediawikiApi::Client).to receive(:send)
+          .and_raise(MediawikiApi::HttpError.new(response))
+        allow_any_instance_of(described_class).to receive(:sleep)
+        described_class.new.query(titles: 'X')
+        expect(Sentry).to have_received(:capture_exception).with(
+          anything,
+          hash_excluding(extra: hash_including(:retry_after))
+        )
+      end
+    end
   end
 
   describe '#get_page_content' do


### PR DESCRIPTION
Wikimedia is rolling out global rate limiting for much of its infrastructure: https://www.mediawiki.org/wiki/Wikimedia_APIs/Rate_limits

This set of changes improves how the Dashboard handles 429 errors, using the `Retry-After` response headers where applicable, and improves our ability to see how often 429 errors are occurring via Sentry logging.