### PR TITLE
Count Wikidata merges into in-scope items (issue #6813)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,9 +31,9 @@ GIT
 
 GIT
   remote: https://github.com/WikiEducationFoundation/wikidata-diff-analyzer
-  revision: a8a725529df95560e3c911ab58103817423a3bc2
+  revision: 683c88e6744f6c95cc4653dd4a0df4e32a092c65
   specs:
-    wikidata-diff-analyzer (2.1.0)
+    wikidata-diff-analyzer (2.2.0)
       json (~> 2.1)
       mediawiki_api
 

--- a/app/services/update_wikidata_stats_timeslice.rb
+++ b/app/services/update_wikidata_stats_timeslice.rb
@@ -75,48 +75,30 @@ class UpdateWikidataStatsTimeslice
     @course = course
   end
 
-  # Given an array of revisions, it updates the summary field for each one with
-  # the wikidata stats. wikidata-diff-analyzer gem is used to fetch the stats.
-  # Also marks revisions as `deleted` when the analyzer couldn't retrieve their content
-  # (suppressed revisions, missing rev IDs, deleted pages) — this replaces Lift Wing as
-  # the source of truth for deletion detection on Wikidata.
-  # Returns the updated array.
+  # Updates the summary field of each revision with its wikidata diff stats,
+  # and marks revisions as `deleted` when the analyzer couldn't retrieve their
+  # content (suppressed/missing/deleted) — this replaces Lift Wing as the
+  # source of truth for deletion detection on Wikidata. Scoped revisions get
+  # the full diff; non-scoped revisions admit only merge_to into an in-scope
+  # target (see issue #6813).
   def update_revisions_with_stats(revisions)
-    # We will only use the diff stats for in-scope revisions, and this is very slow.
-    scoped_revisions = revisions.select(&:scoped)
-    result = analyze_revisions(scoped_revisions.map(&:mw_rev_id))
-    diffs = result[:diffs]
+    result = analyze_revisions(revisions.map(&:mw_rev_id))
     not_analyzed = result[:diffs_not_analyzed].to_set
-    scoped_revisions.each do |revision|
-      rev_id = revision.mw_rev_id
-      if not_analyzed.include?(rev_id)
-        revision.deleted = true
-      else
-        revision.summary = diffs[rev_id].to_json
-      end
-    end
+    revisions.each { |rev| apply_diff(rev, result[:diffs], not_analyzed) }
     revisions
   rescue WikidataDiffAnalyzerError
-    # If the request to WikidataDiffAnalyzer failed, mark scoped revisions with error
-    scoped_revisions.each { |rev| rev.error = true }
+    revisions.each { |rev| rev.error = true }
     revisions
   end
 
   # Given an array of revisions, it builds the stats for those revisions
   def build_stats_from_revisions(revisions)
-    stats = {}
-    STATS_CLASSIFICATION.each_key do |key|
-      stats[STATS_CLASSIFICATION[key]] = 0
-    end
-
-    # create a sum of stats after deserializing the stats for each revision object
+    stats = STATS_CLASSIFICATION.values.to_h { |label| [label, 0] }
     revisions.each do |revision|
-      # Deserialize the summary field to get the stats
-      deserialized_stat = revision.diff_stats
-      next if deserialized_stat.nil?
-      # create a stats which sums up each field of the deserialized_stat and create a stats hash
-      deserialized_stat.each do |key, value|
-        stats[STATS_CLASSIFICATION[key]] += value
+      revision.diff_stats&.each do |key, value|
+        # Skip non-counter fields the analyzer may include (e.g. merge_target).
+        ui_label = STATS_CLASSIFICATION[key] or next
+        stats[ui_label] += value
       end
     end
     stats['total revisions'] = revisions.count
@@ -135,6 +117,28 @@ class UpdateWikidataStatsTimeslice
 
   private
 
+  def apply_diff(revision, diffs, not_analyzed)
+    if not_analyzed.include?(revision.mw_rev_id)
+      revision.deleted = true
+      return
+    end
+    diff = diffs[revision.mw_rev_id]
+    if revision.scoped
+      revision.summary = diff.to_json
+    elsif merge_into_in_scope_target?(diff)
+      revision.summary = { 'merge_to' => 1 }.to_json
+    end
+  end
+
+  # Admit a non-scoped revision's merge_to contribution iff the merge target
+  # parsed from the edit comment is itself a scoped article on this course.
+  def merge_into_in_scope_target?(diff)
+    return false unless diff && diff[:merge_to] == 1
+    target = diff[:merge_target]
+    return false unless target
+    @course.scoped_article?(wikidata, target, nil)
+  end
+
   TYPICAL_ERRORS = [].freeze
 
   RETRY_COUNT = 3
@@ -150,18 +154,10 @@ class UpdateWikidataStatsTimeslice
   end
 
   def sum_up_stats(individual_stats)
-    total_stats = {}
-    STATS_CLASSIFICATION.each_key do |key|
-      total_stats[STATS_CLASSIFICATION[key]] = 0
-    end
-    # Add total revisions
+    total_stats = STATS_CLASSIFICATION.values.to_h { |label| [label, 0] }
     total_stats['total revisions'] = 0
-
-    # Iterate over each individual stat and sum up the values
     individual_stats.each do |hash|
-      hash.each do |key, value|
-        total_stats[key] += value
-      end
+      hash.each { |key, value| total_stats[key] += value }
     end
     total_stats
   end

--- a/spec/lib/revision_data_manager_merge_scoping_spec.rb
+++ b/spec/lib/revision_data_manager_merge_scoping_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Regression test for issue #6813: Wikidata merge operations not counted in
+# course stats. After a Wikidata item is merged into another, the source item
+# becomes a redirect and drops out of the PetScan-driven category article list.
+# RevisionDataManager#mark_scoped_articles correctly marks the resulting merge
+# revision as scoped=false. The fix is in UpdateWikidataStatsTimeslice: it
+# still analyzes non-scoped revisions and admits a merge_to contribution iff
+# the merge target (parsed from the edit comment by the gem) is itself an
+# in-scope article.
+
+require 'rails_helper'
+require "#{Rails.root}/lib/revision_data_manager"
+
+describe 'issue #6813 Wikidata merge scoping' do
+  let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
+  let(:course) do
+    create(:article_scoped_program, start: '2026-04-01', end: '2026-04-30',
+                                    home_wiki: wikidata)
+  end
+  let(:user) { create(:user, username: 'Epidosis') }
+
+  # Q3350322 is a tracked Wikidata item still present in PetScan output.
+  # Q112434841 was merged INTO Q3350322 on 2026-04-03 (rev 2477846959 has
+  # comment "wbmergeitems-to:0||Q3350322"); its title is no longer in the
+  # PetScan-refreshed list because PetScan excludes redirects.
+  let(:tracked_target_title) { 'Q3350322' }
+  let(:redirected_source_title) { 'Q112434841' }
+  let(:merge_rev_id) { 2_477_846_959 }
+  let(:normal_rev_id) { 2_479_212_246 }
+
+  let(:tracked_target_revision) do
+    [tracked_target_title, {
+      'article' => { 'mw_page_id' => '3193529', 'title' => tracked_target_title,
+                     'namespace' => '0', 'wiki_id' => wikidata.id },
+      'revisions' => [
+        { 'mw_rev_id' => normal_rev_id.to_s, 'date' => '20260407', 'characters' => '0',
+          'mw_page_id' => '3193529', 'username' => 'Epidosis', 'new_article' => 'false',
+          'system' => 'false', 'wiki_id' => wikidata.id }
+      ]
+    }]
+  end
+  let(:merge_source_revision) do
+    [redirected_source_title, {
+      'article' => { 'mw_page_id' => '107326531', 'title' => redirected_source_title,
+                     'namespace' => '0', 'wiki_id' => wikidata.id },
+      'revisions' => [
+        { 'mw_rev_id' => merge_rev_id.to_s, 'date' => '20260403', 'characters' => '0',
+          'mw_page_id' => '107326531', 'username' => 'Epidosis', 'new_article' => 'false',
+          'system' => 'false', 'wiki_id' => wikidata.id }
+      ]
+    }]
+  end
+
+  let(:unrelated_merge_rev_id) { 9_999_999_999 }
+  let(:unrelated_source_title) { 'Q987654321' }
+  let(:unrelated_merge_revision) do
+    [unrelated_source_title, {
+      'article' => { 'mw_page_id' => '999999', 'title' => unrelated_source_title,
+                     'namespace' => '0', 'wiki_id' => wikidata.id },
+      'revisions' => [
+        { 'mw_rev_id' => unrelated_merge_rev_id.to_s, 'date' => '20260415',
+          'characters' => '0', 'mw_page_id' => '999999', 'username' => 'Epidosis',
+          'new_article' => 'false', 'system' => 'false', 'wiki_id' => wikidata.id }
+      ]
+    }]
+  end
+
+  before do
+    stub_wiki_validation
+    create(:courses_user, course:, user:)
+    # Simulate the post-PetScan-refresh state: the merge target is tracked,
+    # the now-redirected merge source is not.
+    allow(course).to receive(:scoped_article_titles)
+      .and_return([tracked_target_title])
+  end
+
+  it 'admits merge_to from a non-scoped revision when the target is in scope' do
+    manager = RevisionDataManager.new(wikidata, course)
+    allow(manager).to receive(:get_revisions)
+      .and_return([tracked_target_revision, merge_source_revision, unrelated_merge_revision])
+
+    revisions = manager.fetch_revision_data_for_course('20260401', '20260430')
+
+    target_rev    = revisions.find { |r| r.mw_rev_id == normal_rev_id }
+    merge_rev     = revisions.find { |r| r.mw_rev_id == merge_rev_id }
+    unrelated_rev = revisions.find { |r| r.mw_rev_id == unrelated_merge_rev_id }
+
+    # mark_scoped_articles still drops the redirected source items.
+    expect(target_rev.scoped).to eq(true)
+    expect(merge_rev.scoped).to eq(false)
+    expect(unrelated_rev.scoped).to eq(false)
+
+    # All revisions reach the analyzer now (not just scoped ones), so merges
+    # on now-redirected source pages get a chance to be classified.
+    expect(WikidataDiffAnalyzer).to receive(:analyze)
+      .with([normal_rev_id, merge_rev_id, unrelated_merge_rev_id])
+      .and_return(
+        diffs_analyzed_count: 3,
+        diffs_not_analyzed: [],
+        diffs: {
+          normal_rev_id => { merge_to: 0, added_claims: 1 },
+          merge_rev_id => { merge_to: 1, merge_target: tracked_target_title },
+          unrelated_merge_rev_id => { merge_to: 1, merge_target: 'Q987654' }
+        },
+        total: {}
+      )
+
+    UpdateWikidataStatsTimeslice.new(course).update_revisions_with_stats(revisions)
+
+    # Scoped rev keeps its full diff.
+    expect(JSON.parse(target_rev.summary)).to include('added_claims' => 1)
+
+    # Non-scoped merge into a scoped target → minimal merge_to summary admitted.
+    expect(JSON.parse(merge_rev.summary)).to eq('merge_to' => 1)
+
+    # Non-scoped merge into an unrelated target → still excluded.
+    expect(unrelated_rev.summary).to be_nil
+
+    # And the per-timeslice stats roll-up reflects the admitted merge.
+    stats = UpdateWikidataStatsTimeslice.new(course).build_stats_from_revisions(revisions)
+    expect(stats['merged to']).to eq(1)
+    expect(stats['claims created']).to eq(1)
+  end
+end

--- a/spec/services/update_wikidata_stats_timeslice_spec.rb
+++ b/spec/services/update_wikidata_stats_timeslice_spec.rb
@@ -72,12 +72,13 @@ describe UpdateWikidataStatsTimeslice do
           .and_raise(MediawikiApi::HttpError, '')
         expect(updater).to receive(:log_error).once
         updater.update_revisions_with_stats(revisions)
-        expect(revision1.summary).to be_nil
-        expect(revision1.error).to eq(true)
-        expect(revision2.summary).to be_nil
-        expect(revision2.error).to eq(true)
-        expect(unscoped_revision.summary).to be_nil
-        expect(unscoped_revision.error).to be_nil
+        # Non-scoped revisions are now also analyzed (so merge_to on
+        # now-redirected source items can still be classified — see #6813),
+        # so an analyzer outage marks them all with error.
+        revisions.each do |rev|
+          expect(rev.summary).to be_nil
+          expect(rev.error).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
## What this PR does

Fixes the bug reported in #6813: on Wikidata-tracking courses, merge operations performed by participants are not counted in course stats. The "merged" count fluctuates over time and is consistently lower than the number of merges that demonstrably occurred.

**Mechanism (confirmed via a focused replication spec using real revision IDs from the reported course, Q112434841 → Q3350322 at rev 2477846959):** when a Wikidata item is merged into another, the source item becomes a redirect. PetScan excludes redirects, so on the next category refresh the source title disappears from `category.article_titles`. From that point on, `RevisionDataManager#mark_scoped_articles` marks every revision on that source page (including the merge revision itself) as `scoped=false`, and `UpdateWikidataStatsTimeslice#update_revisions_with_stats` filters non-scoped revisions out before passing anything to `WikidataDiffAnalyzer`. The `merge_to` revision — which the analyzer would correctly classify from its `wbmergeitems-to:…` edit comment — is silently dropped. The analyzer itself handles redirected source pages fine: `WikidataDiffAnalyzer.analyze([2477846959])` returns `merge_to: 1` for that rev id even though Q112434841 is now a redirect, ruling out the issue's "root cause # 1" and isolating scope filtering as the only failure point. The diagnosis tracks @Formasitchijoh's [analysis comment](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6813#issuecomment-4332930331) on the issue.

**The fix in `app/services/update_wikidata_stats_timeslice.rb`:**

- `update_revisions_with_stats` now sends every non-deleted revision to the analyzer, not just `scoped` ones. A new `apply_diff` helper dispatches per revision: scoped → full diff in `summary` (unchanged behavior); non-scoped → minimal `{merge_to: 1}` summary admitted only when `merge_into_in_scope_target?` returns true.
- `merge_into_in_scope_target?` requires `diff[:merge_to] == 1` and `course.scoped_article?(wikidata, diff[:merge_target], nil)`. The `merge_target` Q-id is parsed out of the edit comment by the gem (paired PR: WikiEducationFoundation/wikidata-diff-analyzer#35); this gates admittance precisely on "merged into a tracked item", preserving the article-scoping policy for everything else and avoiding over-counting unrelated merges by participants.
- The rescue path now marks all revisions with `error` on analyzer failure (since all revs go through the analyzer now). The existing spec at `spec/services/update_wikidata_stats_timeslice_spec.rb` was updated to match.
- `build_stats_from_revisions` skips unknown keys defensively, so the new `merge_target` / `merge_source` strings carried inside scoped revisions' summaries don't blow up the sum loop. `build_stats_from_revisions` and `sum_up_stats` were compacted in passing to keep the class under the 130-line RuboCop limit after adding the new helpers.

A regression spec at `spec/lib/revision_data_manager_merge_scoping_spec.rb` asserts all three branches: scoped revs get the full diff, non-scoped merges into in-scope targets get the minimal `merge_to` summary, non-scoped merges into unrelated targets are still excluded, and the per-timeslice stats roll-up reflects the admitted merge.

**Approach.** This implements [Option 2 from @Formasitchijoh's analysis](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6813#issuecomment-4332930331) ("admit `merge_to` from non-scoped revisions") with a tighter gate: rather than counting every merge any participant performs on any item, the dashboard admits a `merge_to` contribution from a non-scoped revision iff the *merge target* (i.e. the item that survives the merge) is itself in the course's scoped article list. To make that gate possible without a second API round-trip per revision, the `merge_target` Q-id is parsed out of the edit comment by the paired gem change. Both branches were [reviewed by @Formasitchijoh](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6813#issuecomment-4340688790) before opening as PRs.

**Gem dependency.** Bumps `wikidata-diff-analyzer` to 2.2.0 (commit 683c88e on `main`, merged from WikiEducationFoundation/wikidata-diff-analyzer#35).

**Not addressed in this PR:**
- `merge_from` is still not displayed in the UI (issue's root cause # 3). The gem now exposes `:merge_source`, so the remaining work is a separate frontend change moving `'merge_from' => 'merged from'` out of the `STATS_CLASSIFICATION` "Not added yet" section. Worth doing as a follow-up rather than bundling into this fix.

Addresses #6813.

## AI usage

This PR was drafted by Claude Code (Anthropic's CLI for Claude) under human direction. Claude:

- Read through the relevant slice of the pipeline (`UpdateWikidataStatsTimeslice`, `RevisionDataManager#mark_scoped_articles`, `Course#scoped_article?`, `Category#refresh_titles`, `UpdateCourseStats` ordering) and confirmed @Formasitchijoh's mechanism end-to-end.
- Probed the actual on-wiki state of the items in the issue. Three of the five Q-ids the issue named are merge *targets*, not sources — Claude followed those to the corresponding source items (Q112434841, Q112499989, …), confirmed they're now redirects with `wbmergeitems-to` revisions sitting at the top of their histories, and ran `WikidataDiffAnalyzer.analyze` against two of those merge_to rev IDs to confirm the analyzer returns `merge_to: 1` for both — ruling out "root cause # 1" and isolating scope filtering as the only failure point.
- Wrote a focused replication spec using the real rev IDs and the real `mark_scoped_articles` / `update_revisions_with_stats` codepath, with `scoped_article_titles` stubbed to simulate the post-PetScan-refresh state. The bug-demonstrating version of the spec passed on the first run after adding the missing `stub_wiki_validation` call; that became the proof of mechanism that justified the fix direction.
- Drafted the service refactor (`apply_diff` dispatch, `merge_into_in_scope_target?`, defensive `build_stats_from_revisions`) and the paired gem change to expose `merge_target` / `merge_source` from `CommentAnalyzer`, then iterated to keep the class under the 130-line RuboCop limit by compacting `build_stats_from_revisions` and `sum_up_stats` (using `to_h` for the zero-init step in both, removing redundant comments).
- Wrote the commit message and this PR description.

The human contributed: the initial pointer to the issue and the request to replicate the bug before discussing fixes; the choice to refine "Option 2" into "admit when merge target is in scope" rather than "admit when source had a prior in-scope edit"; the decision to do this as a paired gem + dashboard change rather than re-fetching comments dashboard-side; review and approval of the approach. The session was a single focused thread with six user messages — the first paragraph-length, the rest mostly terse approvals or short corrections ("amend it"). All dashboard code in this PR was authored during that session; no pre-existing changes were brought in.

A second AI-assisted session (also Claude Code) opened this PR: rebased both branches onto current master, regenerated `Gemfile.lock` against current master to pick up intervening gem updates, ran the regression spec and RuboCop on the rebased state to confirm clean, opened the paired gem PR (#35), and drafted this description via the project's `/prepare-pr` skill.

The "What this PR does" summary above and the description of mechanism / code changes were drafted by Claude Code and may contain errors — please review against the diff and the linked issue analysis. Reviewer @Formasitchijoh has already [signed off on both branches](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6813#issuecomment-4340688790) before this PR was opened.

This PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes. This is a backend-only change to the Wikidata stats pipeline; the visible effect (a non-zero "merged" count on courses where merges previously dropped to zero) is a data-level change, not a UI change.

## Open questions and concerns

- **Rescue-path behavior change.** Previously, an analyzer failure marked only `scoped` revisions with `error`; non-scoped revisions were never sent to the analyzer at all. Now all non-deleted revisions go through the analyzer, so the rescue path marks all of them with `error` on failure. The updated spec at `spec/services/update_wikidata_stats_timeslice_spec.rb` covers this. Worth a second look that the broader error-marking is the right behavior — there's a case for marking only scoped revisions with `error` on failure (since that's what the previous timeslice-retry contract relied on), but in practice the timeslice retry path should re-analyze all of them anyway.
- **Follow-up: `merge_from` UI.** Listed in the issue as root cause # 3 and intentionally not bundled into this fix. The gem now exposes `:merge_source`, so the remaining work is moving `'merge_from' => 'merged from'` out of the `STATS_CLASSIFICATION` "Not added yet" section and the corresponding frontend filtering. Worth a separate small PR.

(PR description written by Claude Code.)

