### PR TITLE
Display the merged from stat in the wikidata course overview stats

### DIFF
--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -31,6 +31,13 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
               renderZero={true}
             />
             <OverviewStat
+              id="merged-from"
+              className="stat-display__value-small"
+              stat={statistics['merged from']}
+              statMsg={I18n.t('metrics.merged_from')}
+              renderZero={true}
+            />
+            <OverviewStat
               id="interwiki-links"
               className="stat-display__value-small"
               stat={statistics['interwiki links added']}

--- a/app/services/update_wikidata_stats_timeslice.rb
+++ b/app/services/update_wikidata_stats_timeslice.rb
@@ -12,6 +12,7 @@ class UpdateWikidataStatsTimeslice
   STATS_CLASSIFICATION = {
     # UI section: General
     'merge_to' => 'merged to',
+    'merge_from' => 'merged from',
     'added_sitelinks' => 'interwiki links added',
     # UI section: Claims
     'added_claims' => 'claims created',
@@ -45,7 +46,6 @@ class UpdateWikidataStatsTimeslice
     'changed_qualifiers' => 'qualifiers changed',
     'removed_sitelinks' => 'interwiki links removed',
     'changed_sitelinks' => 'interwiki links updated',
-    'merge_from' => 'merged from',
     'added_lemmas' => 'lemmas added',
     'removed_lemmas' => 'lemmas removed',
     'changed_lemmas' => 'lemmas changed',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1260,7 +1260,8 @@ en:
     total_revisions: Total revisions
     claims: Claims
     aliases: Aliases
-    merged: Merged
+    merged: Merged to
+    merged_from: Merged from
     created: Created
     changed: Changed
     removed: Removed

--- a/spec/services/update_wikidata_stats_timeslice_spec.rb
+++ b/spec/services/update_wikidata_stats_timeslice_spec.rb
@@ -37,6 +37,13 @@ describe UpdateWikidataStatsTimeslice do
       expect(unscoped_revision.summary).to be_nil
     end
 
+    it 'counts merge_from in built stats' do
+      revision = build(:revision_on_memory, wiki_id: wikidata.id, scoped: true)
+      revision.summary = { 'merge_from' => 1 }.to_json
+      stats = updater.build_stats_from_revisions([revision])
+      expect(stats['merged from']).to eq(1)
+    end
+
     it 'creates record in CourseStat table', :vcr do
       expect(CourseStat.count).to eq(0)
       updater.update_revisions_with_stats(revisions)


### PR DESCRIPTION
## What this PR does
This PR is a follow-up to #6813 and [PR #6838](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/6838), surfacing the merged from stat in the Wikidata course overview stats. The merge_from key was already computed but sat in the # Not added yet section of STATS_CLASSIFICATION and was never displayed.

## AI usage
Used AI to understand why ArticleScoped programs that track wikidata items are not copied

## Screenshots
Before:
<img width="1438" height="847" alt="Screenshot 2026-05-02 at 13 53 22" src="https://github.com/user-attachments/assets/7ec612cc-c3c1-458b-86b6-df4d4ebb9ff6" />

After:
<img width="1438" height="847" alt="Screenshot 2026-05-02 at 13 51 13" src="https://github.com/user-attachments/assets/e2de92a6-89d5-4527-b291-01dda6d6778e" />

## Open questions and concerns
Copying a Wikidata course via the UI does not preserve the course type , it creates a standard Wikipedia-tracking course instead of an ArticleScopedProgram with Wikidata as the home wiki. This should probably be prevented or fixed separately, but is out of scope for this PR.

