### PR TITLE
Fix backup script when previous backup has no dump file

### DIFF
--- a/config/backup/backup.sh
+++ b/config/backup/backup.sh
@@ -51,20 +51,30 @@ exec >>"$LOG_FILE" 2>&1
 
 log "Starting"
 
-# Calculate min free space in bytes based on last backup
-LATEST_DIR=$(ls -1d "$BACKUP_ROUTE"/*/ | sort | tail -2 | head -1)
-LAST_BACKUP=$(ls "$LATEST_DIR"/*.sql.gz | head -1)
+# Calculate min free space in bytes based on last successful backup
+LAST_BACKUP=""
+while IFS= read -r dir; do
+  candidate=$(find "$dir" -maxdepth 1 -name "*.sql.gz" | head -1)
+  if [ -n "$candidate" ]; then
+    LAST_BACKUP="$candidate"
+    break
+  fi
+done < <(ls -1d "$BACKUP_ROUTE"/*/ | sort -r | tail -n +2)
 
-LAST_BACKUP_SIZE=$(stat -c%s "$LAST_BACKUP")
-# Backups are stored in compressed form. We require 30x the size of the previous backup,
-# assuming the compressed version is about 10 times smaller 
-MIN_FREE_SPACE=$(( LAST_BACKUP_SIZE * 30 ))
+if [ -n "$LAST_BACKUP" ]; then
+  LAST_BACKUP_SIZE=$(stat -c%s "$LAST_BACKUP")
+  # Backups are stored in compressed form. We require 30x the size of the previous backup,
+  # assuming the compressed version is about 10 times smaller
+  MIN_FREE_SPACE=$(( LAST_BACKUP_SIZE * 30 ))
 
-# Calculate free space in bytes
-FREE_SPACE=$(df -B 1 --output=avail $BACKUP_DIR | tail -1 | tr -dc '0-9')
-if [ $FREE_SPACE -lt $MIN_FREE_SPACE ]; then
-  log "Not enough free space. Aborting"
-  exit 1
+  # Calculate free space in bytes
+  FREE_SPACE=$(df -B 1 --output=avail $BACKUP_DIR | tail -1 | tr -dc '0-9')
+  if [ $FREE_SPACE -lt $MIN_FREE_SPACE ]; then
+    log "Not enough free space. Aborting"
+    exit 1
+  fi
+else
+  log "No previous successful backup found, skipping free space check"
 fi
 
 # Create waiting backup record


### PR DESCRIPTION
## What this PR does

Fixes a bug where the backup script would crash when the most recent previous backup
directory exists but contains no `.sql.gz` file (because that prior run failed before
reaching the dump step). With `set -euo pipefail` active, the failing `ls *.sql.gz` glob
exited with code 2, causing the current run to abort too — compounding the outage.

The fix replaces the two-line directory lookup with a loop that walks backup directories
from newest to oldest, skips the just-created current directory, and finds the first
directory that actually contains a `.sql.gz` file. If no previous successful backup exists,
it logs a message and skips the free-space check rather than crashing.

Addresses #6861.

## AI usage

Claude Code was used throughout: it traced the root cause, designed and implemented the
fix, wrote the commit message, and drafted this PR description. The user identified the
issue, linked issue #6861, directed the work, and performed all manual testing.

The fix required two iterations: the first attempt was caught as incorrect through manual
testing of the failure scenario (a previous backup directory with no dump file). Claude Code
explained the root cause of the regression and implemented a corrected fix. An unrelated
accidental change was also caught during review and reverted.

This was a single session across two days (May 4–5, 2026). This PR description was drafted
using the Claude Code `/prepare-pr` skill.

## Screenshots

No UI changes.

## Open questions and concerns

None.

(PR description written by Claude Code.)