### PR TITLE
Propagate deleted flag from ReferenceCounterApi to RevisionScoreApiHandler

### DIFF
--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -74,13 +74,7 @@ class ReferenceCounterApi
     return normalize_batch_results(rev_ids, parsed_response) if status == 200
 
     batch_non_200_response_log(status, { rev_ids:, content: parsed_response })
-
-    default = if non_transient_error?(status)
-                { 'num_ref' => nil }
-              else
-                { 'num_ref' => nil, 'error' => parsed_response }
-              end
-    rev_ids.to_h { |id| [id.to_s, default] }
+    rev_ids.to_h { |id| [id.to_s, { 'num_ref' => nil, 'error' => parsed_response }] }
   end
 
   def normalize_batch_results(rev_ids, parsed_response)
@@ -177,16 +171,6 @@ class ReferenceCounterApi
       },
       request: { open_timeout: OPEN_TIMEOUT, timeout: REQUEST_TIMEOUT }
     )
-  end
-
-  BAD_REQUEST = 400
-  FORBIDDEN = 403
-  NOT_FOUND = 404
-  # A bad request response indicates that the language and/or project is not supported.
-  # A forbidden response likely means we lack permission to access the revision,
-  # possibly because it was deleted or hidden.
-  def non_transient_error?(status)
-    [BAD_REQUEST, FORBIDDEN, NOT_FOUND].include? status
   end
 
   TYPICAL_ERRORS = [Faraday::TimeoutError,

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -84,10 +84,14 @@ class ReferenceCounterApi
     end
   end
 
-  # Per-rev entry shape from the batch endpoint:
+  # Per-rev entry shape from the batch endpoint (input):
   #   { 'num_ref' => N }                                  # normal
   #   { 'num_ref' => nil, 'error' => 'no content' }       # suppressed/deleted
   #   nil                                                 # missing from response
+  # Transformed output:
+  #   { 'num_ref' => N }                                  # normal
+  #   { 'num_ref' => nil, 'deleted' => true }             # suppressed/deleted
+  #   { 'num_ref' => nil }                                # missing from response
   def transform_entry(entry)
     return { 'num_ref' => nil } if entry.nil?
     return handle_forbidden if suppressed_content?(entry)
@@ -103,7 +107,7 @@ class ReferenceCounterApi
   # surface a total per course update, and skip Sentry reporting.
   def handle_forbidden
     @update_service&.record_reference_counter_403
-    { 'num_ref' => nil }
+    { 'num_ref' => nil, 'deleted' => true }
   end
 
   def error_key(status)

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -54,25 +54,16 @@ class RevisionScoreApiHandler
   def complete_score(score)
     completed_score = {}
 
-    # If the score already has error is key is because some API request failed some way
+    # If the score already has error key is because some API request failed some way
     completed_score['error'] = score.key?('error')
 
-    # Fetch the value for 'wp10' and 'prediction', or default to nil if not present.
-    completed_score['wp10'] = score.fetch('wp10', nil)
-    completed_score['prediction'] = score.fetch('prediction', nil)
     # Fetch the value for 'deleted, or default to 'false if not present.
     completed_score['deleted'] = score.fetch('deleted', false)
 
-    # Ensure 'features' has the correct value (a hash).
-    # For Wikidata, 'features' has to contain the LiftWing features.
+    # features field has to contain the reference-counter scores if
+    # different from nil. Otherwise, it should be the empty hash.
     completed_score['features'] =
-      if @wiki.project == 'wikidata'
-        score.fetch('features', {})
-      else
-        # For other wikis, 'features' has to contain the reference-counter scores if
-        # different from nil. Otherwise, it should be the empty hash.
-        score.fetch('num_ref').nil? ? {} : { 'num_ref' => score['num_ref'] }
-      end
+      score.fetch('num_ref').nil? ? {} : { 'num_ref' => score['num_ref'] }
 
     completed_score
   end

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -40,8 +40,10 @@ describe ReferenceCounterApi do
       expect(response.dig('5006942').key?('error')).to eq(false)
       expect(response.dig('5006946', 'num_ref')).to eq(2)
       expect(response.dig('5006946').key?('error')).to eq(false)
+      # Indicates if a revision was deleted
       expect(response.dig('6115106', 'num_ref')).to be_nil
       expect(response.dig('6115106').key?('error')).to eq(false)
+      expect(response.dig('6115106', 'deleted')).to eq(true)
     end
 
     it 'records suppressed-content revs on the update service and does not send them to Sentry' do

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -55,48 +55,6 @@ describe ReferenceCounterApi do
     end
   end
 
-  context 'fails silently' do
-    before do
-      stub_wiki_validation
-    end
-
-    it 'if response is 400 bad request' do
-      stub_400_wiki_reference_counter_response
-      ref_counter_api = described_class.new(en_wikipedia)
-      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
-      expect(response.dig('5006940', 'num_ref')).to be_nil
-      expect(response.dig('5006940').key?('error')).to eq(false)
-      expect(response.dig('5006942', 'num_ref')).to be_nil
-      expect(response.dig('5006942').key?('error')).to eq(false)
-      expect(response.dig('5006946', 'num_ref')).to be_nil
-      expect(response.dig('5006946').key?('error')).to eq(false)
-    end
-
-    it 'if response is 403 forbidden' do
-      stub_403_wiki_reference_counter_response
-      ref_counter_api = described_class.new(en_wikipedia)
-      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
-      expect(response.dig('5006940', 'num_ref')).to be_nil
-      expect(response.dig('5006940').key?('error')).to eq(false)
-      expect(response.dig('5006942', 'num_ref')).to be_nil
-      expect(response.dig('5006942').key?('error')).to eq(false)
-      expect(response.dig('5006946', 'num_ref')).to be_nil
-      expect(response.dig('5006946').key?('error')).to eq(false)
-    end
-
-    it 'if response is 404 not found' do
-      stub_404_wiki_reference_counter_response
-      ref_counter_api = described_class.new(en_wikipedia)
-      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
-      expect(response.dig('5006940', 'num_ref')).to be_nil
-      expect(response.dig('5006940').key?('error')).to eq(false)
-      expect(response.dig('5006942', 'num_ref')).to be_nil
-      expect(response.dig('5006942').key?('error')).to eq(false)
-      expect(response.dig('5006946', 'num_ref')).to be_nil
-      expect(response.dig('5006946').key?('error')).to eq(false)
-    end
-  end
-
   it 'logs the error once if an unexpected error raises several times' do
     reference_counter_api = described_class.new(es_wiktionary)
 
@@ -122,29 +80,35 @@ describe ReferenceCounterApi do
     expect(response.dig('5006940', 'error')).not_to be_nil
   end
 
+  # The batch endpoint returns 400 for invalid inputs (bad JSON, non-integer rev_ids,
+  # too many rev_ids, invalid project/language). Per-revision errors such as
+  # deleted/suppressed revisions are returned inline within a 200 response.
   context 'when the API returns non-200 responses' do
-    let(:failing_ids) {
-      [708326238, 123456789, 987654321, 111222333, 444555666, 777888999, 408326238] }
-
-    # Mock the update service to provide the tags the test expects
-    let(:update_service) do
-      instance_double('UpdateService',
-        update_error_stats: true,
-        record_reference_counter_403: true,
-        sentry_tags: { update_service_id: 'tag1', course: '/UBA/Mongolia_(second_semester_2026)' }
-      )
+    before do
+      stub_wiki_validation
+      stub_400_wiki_reference_counter_response
     end
 
-    let(:subject) { described_class.new(en_wikipedia, update_service) }
+    it 'returns nil num_ref with the error body for all revisions' do
+      ref_counter_api = described_class.new(en_wikipedia)
+      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
+      expected_error = { 'code' => 400, 'name' => 'Bad Request',
+                         'description' => "Request body must be JSON with a 'rev_ids' array." }
+      expect(response.dig('5006940', 'num_ref')).to be_nil
+      expect(response.dig('5006940', 'error')).to eq(expected_error)
+      expect(response.dig('5006942', 'num_ref')).to be_nil
+      expect(response.dig('5006942', 'error')).to eq(expected_error)
+      expect(response.dig('5006946', 'num_ref')).to be_nil
+      expect(response.dig('5006946', 'error')).to eq(expected_error)
+    end
 
-    it 'sends separate Sentry logs for each unique non-403 status code' do
-      subject.send(:batch_non_200_response_log, 404, { rev_id: 987654321, content: {} })
-      subject.send(:batch_non_200_response_log, 400, { rev_id: 111222333, content: {} })
-      subject.send(:batch_non_200_response_log, 400, { rev_id: 111222333, content: {} })
-
-      # Expecting two different exceptions to be captured
-      expect(Sentry).to receive(:capture_exception).twice
-      subject.send(:report_reference_counter_error_to_sentry)
+    it 'reports non-200 responses to Sentry' do
+      update_service = instance_double('UpdateService', record_reference_counter_403: true,
+                                                        update_error_stats: true,
+                                                        sentry_tags: {})
+      ref_counter_api = described_class.new(en_wikipedia, update_service)
+      expect(Sentry).to receive(:capture_exception).once
+      ref_counter_api.get_number_of_references_from_revision_ids rev_ids
     end
   end
 

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -10,7 +10,7 @@ describe ReferenceCounterApi do
   let(:es_wiktionary) { Wiki.get_or_create(language: 'es', project: 'wiktionary') }
   let(:commons) { Wiki.get_or_create(language: 'commons', project: 'wikimedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
-  let(:deleted_rev_ids) { [708326238] }
+  let(:deleted_rev_id) { [6115106] }
   let(:rev_ids) { [5006940, 5006942, 5006946] }
 
   it 'raises InvalidProjectError for wikidata' do
@@ -25,22 +25,33 @@ describe ReferenceCounterApi do
     end.to raise_error(described_class::InvalidProjectError)
   end
 
-  context 'returns the number of references' do
+  context 'when the API returns 200 responses' do
     before do
       stub_wiki_validation
       stub_es_wiktionary_reference_counter_response
     end
 
-    # Get revision data for valid rev ids for Wikidata
-    it 'if response is 200 OK', vcr: true do
+    it 'returns the number of references' do
       ref_counter_api = described_class.new(es_wiktionary)
-      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids
+      response = ref_counter_api.get_number_of_references_from_revision_ids rev_ids + deleted_rev_id
       expect(response.dig('5006940', 'num_ref')).to eq(10)
       expect(response.dig('5006940').key?('error')).to eq(false)
       expect(response.dig('5006942', 'num_ref')).to eq(4)
       expect(response.dig('5006942').key?('error')).to eq(false)
       expect(response.dig('5006946', 'num_ref')).to eq(2)
       expect(response.dig('5006946').key?('error')).to eq(false)
+      expect(response.dig('6115106', 'num_ref')).to be_nil
+      expect(response.dig('6115106').key?('error')).to eq(false)
+    end
+
+    it 'records suppressed-content revs on the update service and does not send them to Sentry' do
+      update_service = instance_double('UpdateService', record_reference_counter_403: true)
+      ref_counter_api = described_class.new(es_wiktionary, update_service)
+
+      expect(update_service).to receive(:record_reference_counter_403).once
+      expect(Sentry).not_to receive(:capture_exception)
+
+      ref_counter_api.get_number_of_references_from_revision_ids(rev_ids + deleted_rev_id)
     end
   end
 
@@ -86,7 +97,7 @@ describe ReferenceCounterApi do
     end
   end
 
-  it 'logs the error once if an unexpected error raises several times', vcr: true do
+  it 'logs the error once if an unexpected error raises several times' do
     reference_counter_api = described_class.new(es_wiktionary)
 
     stub_request(:any, /.*reference-counter.toolforge.org*/)
@@ -125,26 +136,6 @@ describe ReferenceCounterApi do
     end
 
     let(:subject) { described_class.new(en_wikipedia, update_service) }
-
-    it 'records suppressed-content revs on the update service and does not send them to Sentry' do
-      stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikipedia/en')
-        .to_return(
-          status: 200,
-          body: lambda do |request|
-            rev_ids = JSON.parse(request.body).fetch('rev_ids', [])
-            rev_ids.to_h { |id| [id.to_s, { 'num_ref' => nil, 'error' => 'no content' }] }.to_json
-          end,
-          headers: { 'Content-Type': 'application/json' }
-        )
-
-      expect(update_service).to receive(:record_reference_counter_403)
-        .exactly(failing_ids.size).times
-      expect(Sentry).not_to receive(:capture_exception)
-
-      results = subject.get_number_of_references_from_revision_ids(failing_ids)
-      expect(results.length).to eq(failing_ids.size)
-      expect(results.values.all? { |v| v['num_ref'].nil? }).to be true
-    end
 
     it 'sends separate Sentry logs for each unique non-403 status code' do
       subject.send(:batch_non_200_response_log, 404, { rev_id: 987654321, content: {} })

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -18,10 +18,10 @@ describe RevisionScoreApiHandler do
 
       it 'returns completed scores if data is retrieved without errors' do
         expect(subject).to be_a(Hash)
-        expect(subject.dig('829840090')).to eq({ 'wp10' => nil, 'error' => false,
-        'features' => { 'num_ref' => 132 }, 'deleted' => false, 'prediction' => nil })
-        expect(subject.dig('829840091')).to eq({ 'wp10' => nil, 'error' => false,
-        'features' => { 'num_ref' => 1 }, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('829840090')).to eq({ 'error' => false,
+        'features' => { 'num_ref' => 132 }, 'deleted' => false })
+        expect(subject.dig('829840091')).to eq({ 'error' => false,
+        'features' => { 'num_ref' => 1 }, 'deleted' => false })
       end
 
       it 'returns completed scores if there is an error hitting ReferenceCounterApi' do
@@ -29,10 +29,10 @@ describe RevisionScoreApiHandler do
           .to_raise(Errno::ETIMEDOUT)
 
         expect(subject).to be_a(Hash)
-        expect(subject.dig('829840090')).to eq({ 'wp10' => nil, 'error' => true,
-        'features' => {}, 'deleted' => false, 'prediction' => nil })
-        expect(subject.dig('829840091')).to eq({ 'wp10' => nil, 'error' => true,
-        'features' => {}, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('829840090')).to eq({ 'error' => true,
+        'features' => {}, 'deleted' => false })
+        expect(subject.dig('829840091')).to eq({ 'error' => true,
+        'features' => {}, 'deleted' => false })
       end
     end
   end
@@ -50,9 +50,8 @@ describe RevisionScoreApiHandler do
 
     it 'returns deleted: true and empty features' do
       result = handler.get_revision_data [829840092]
-      expect(result.dig('829840092')).to eq({ 'wp10' => nil, 'error' => false,
-                                              'features' => {}, 'deleted' => true,
-                                              'prediction' => nil })
+      expect(result.dig('829840092')).to eq({ 'error' => false,
+                                              'features' => {}, 'deleted' => true })
     end
   end
 
@@ -87,20 +86,20 @@ describe RevisionScoreApiHandler do
     describe '#get_revision_data' do
       it 'returns completed scores if retrieves data without errors' do
         expect(subject).to be_a(Hash)
-        expect(subject.dig('157412237')).to eq({ 'wp10' => nil, 'error' => false,
-        'features' => { 'num_ref' => 111 }, 'deleted' => false, 'prediction' => nil })
-        expect(subject.dig('157417768')).to eq({ 'wp10' => nil, 'error' => false,
-        'features' => { 'num_ref' => 42 }, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('157412237')).to eq({ 'error' => false,
+        'features' => { 'num_ref' => 111 }, 'deleted' => false })
+        expect(subject.dig('157417768')).to eq({ 'error' => false,
+        'features' => { 'num_ref' => 42 }, 'deleted' => false })
       end
 
       it 'returns completed scores if there is an error hitting reference-counter api' do
         stub_request(:any, /.*reference-counter.toolforge.org*/)
           .to_raise(Errno::ETIMEDOUT)
         expect(subject).to be_a(Hash)
-        expect(subject.dig('157412237')).to eq({ 'wp10' => nil, 'error' => true,
-        'features' => {}, 'deleted' => false, 'prediction' => nil })
-        expect(subject.dig('157417768')).to eq({ 'wp10' => nil, 'error' => true,
-        'features' => {}, 'deleted' => false, 'prediction' => nil })
+        expect(subject.dig('157412237')).to eq({ 'error' => true,
+        'features' => {}, 'deleted' => false })
+        expect(subject.dig('157417768')).to eq({ 'error' => true,
+        'features' => {}, 'deleted' => false })
       end
     end
   end

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -37,6 +37,25 @@ describe RevisionScoreApiHandler do
     end
   end
 
+  context 'when a revision is suppressed or deleted' do
+    before do
+      stub_wiki_validation
+      stub_reference_counter_batch_response(
+        project: 'wikipedia', language: 'en',
+        num_refs: { '829840092' => nil }
+      )
+    end
+
+    let(:handler) { described_class.new(wiki: Wiki.find(1)) }
+
+    it 'returns deleted: true and empty features' do
+      result = handler.get_revision_data [829840092]
+      expect(result.dig('829840092')).to eq({ 'wp10' => nil, 'error' => false,
+                                              'features' => {}, 'deleted' => true,
+                                              'prediction' => nil })
+    end
+  end
+
   context 'when the wiki is wikidata' do
     before { stub_wiki_validation }
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -581,7 +581,14 @@ module RequestHelpers
         body: lambda do |request|
           rev_ids = JSON.parse(request.body).fetch('rev_ids', [])
           rev_ids.to_h do |rev_id|
-            [rev_id.to_s, { 'num_ref' => num_refs[rev_id.to_s] }]
+            num_ref = num_refs[rev_id.to_s]
+            # nil signals a deleted/suppressed revision; real API returns 'error' => 'no content'
+            entry = if num_ref.nil?
+                      { 'num_ref' => nil, 'error' => 'no content' }
+                    else
+                      { 'num_ref' => num_ref }
+                    end
+            [rev_id.to_s, entry]
           end.to_json
         end,
         headers: { 'Content-Type' => 'application/json' }
@@ -591,7 +598,7 @@ module RequestHelpers
   def stub_es_wiktionary_reference_counter_response
     stub_reference_counter_batch_response(
       project: 'wiktionary', language: 'es',
-      num_refs: { '5006940' => 10, '5006942' => 4, '5006946' => 2 }
+      num_refs: { '5006940' => 10, '5006942' => 4, '5006946' => 2, '6115106' => nil }
     )
   end
 

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -620,27 +620,8 @@ module RequestHelpers
     stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikipedia/en')
       .to_return(
         status: 400,
-        body: { 'description' => 'Bad request.' }.to_json,
-        headers: { 'Content-Type' => 'application/json' }
-      )
-  end
-
-  def stub_403_wiki_reference_counter_response
-    stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikipedia/en')
-      .to_return(
-        status: 403,
-        body: { 'description' => "mwapi error: permissiondenied - You don't have permission to view\
-        deleted text or changes between deleted revisions." }.to_json,
-        headers: { 'Content-Type' => 'application/json' }
-      )
-  end
-
-  def stub_404_wiki_reference_counter_response
-    stub_request(:post, 'https://reference-counter.toolforge.org/api/v1/references/wikipedia/en')
-      .to_return(
-        status: 404,
-        body: { 'description' => 'rest-nonexistent-revision -\
-        The specified revision does not exist' }.to_json,
+        body: { 'code' => 400, 'name' => 'Bad Request',
+                'description' => "Request body must be JSON with a 'rev_ids' array." }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
   end


### PR DESCRIPTION
## What this PR does

Fixes how `rev.deleted` is populated for non-Wikidata wikis by surfacing
the suppressed/deleted signal from `ReferenceCounterApi` all the way through
to `RevisionScoreApiHandler`, so that `update_revision_count` correctly
excludes deleted revisions.

**Commit 1 — spec improvements (`ReferenceCounterApi`):**
Adds a real deleted `es.wiktionary` revision (`6115106`) to the stub and
spec, so the test suite exercises the `{"num_ref": null, "error": "no
content"}` path the batch API returns for suppressed/deleted revisions.
Fixes `stub_reference_counter_batch_response` to emit that shape when
`num_ref` is `nil`, matching real API behaviour.

**Commit 2 — dead-code removal:**
Removes `non_transient_error?` and the `BAD_REQUEST`/`FORBIDDEN`/`NOT_FOUND`
constants. Those codes belonged to the old per-revision GET endpoint; the
batch POST endpoint returns only 200 (per-rev errors inline) or 400 for
malformed input. Removes the corresponding 403/404 stubs and consolidates
the non-200 specs into a single context that goes through the public
interface.

**Commit 3 — propagate `deleted` flag:**
`handle_forbidden` now returns `{ 'num_ref' => nil, 'deleted' => true }`
instead of `{ 'num_ref' => nil }`. This distinguishes suppressed/deleted
revisions from revisions missing from the response, and lets the flag flow
through `RevisionScoreApiHandler#complete_score` (which already calls
`score.fetch('deleted', false)`) so `rev.deleted` is correctly set for
non-Wikidata wikis.

**Commit 4 — remove unused fields from `RevisionScoreApiHandler`:**
Removes `wp10` and `prediction` from `complete_score` — both were always
nil since LiftWing was removed from the update path, and nothing downstream
reads them. Also removes the now-dead Wikidata branch from the `features`
construction, since `complete_score` is never reached for Wikidata revisions.

## AI usage

Developed with Claude Code (Sonnet 4.6) under the direction of @gabina.
The spec cleanup, analysis of the batch endpoint (confirming 403/404 are
impossible), and the `RevisionScoreApiHandler` spec additions were drafted
by Claude Code. The core production fixes (commits 3 and 4) were written
by the human; Claude Code reviewed correctness and verified no downstream
code reads the removed fields. All commit messages were drafted by Claude
Code. Work was done across two sessions on 2026-05-08.

This PR description was drafted using the Claude Code `/prepare-pr` skill.

(PR description written by Claude Code.)

## Screenshots

No UI changes.

## Open questions and concerns

During investigation we discovered the batch API returns two distinct error
strings: `"no content"` for suppressed/texthidden revisions and
`"not_found_or_hidden"` for rev_ids that never existed. The current code
only marks `"no content"` revisions as `deleted: true`, which is correct
semantically. The `"not_found_or_hidden"` case and the defensive `nil`
guard in `transform_entry` (now confirmed unreachable) can be addressed as
a follow-up.