### PR TITLE
Add global_id to users JSON response and corresponding tests

### DIFF
--- a/app/views/courses/_users.json.jbuilder
+++ b/app/views/courses/_users.json.jbuilder
@@ -7,7 +7,7 @@ json.users course.courses_users.eager_load(:user, :course) do |cu|
   json.call(cu, :character_sum_ms, :character_sum_us, :character_sum_draft, :references_count,
             :role, :role_description, :recent_revisions, :content_expert, :program_manager,
             :contribution_url, :sandbox_url, :global_contribution_url, :total_uploads)
-  json.call(cu.user, :id, :username)
+  json.call(cu.user, :id, :username, :global_id)
   json.enrolled_at cu.created_at
   json.admin cu.user.admin?
   json.registered_at cu.user.registered_at

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -31,6 +31,27 @@ describe CoursesController, type: :request do
     end
   end
 
+  describe '#users' do
+    let(:course) { create(:course, slug: slug_params) }
+    let(:student) { create(:user, username: 'Global Student', global_id: 12_345) }
+
+    before do
+      create(:courses_user,
+             course_id: course.id,
+             user_id: student.id,
+             role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
+
+    it 'includes each user global_id in the json payload' do
+      get "/courses/#{course.slug}/users.json"
+
+      body = JSON.parse(response.body)
+      user = body.dig('course', 'users')&.find { |course_user| course_user['id'] == student.id }
+
+      expect(user['global_id']).to eq(student.global_id)
+    end
+  end
+
   describe '#destroy' do
     let!(:course)           { create(:course, submitted: true, slug: slug_params) }
     let!(:user)             { create(:test_user) }


### PR DESCRIPTION
## What this PR does
- Adds user global_id to the course users JSON payload at /courses/:slug/users.json, aligning JSON output with course_students_csv.
- This change is needed because global_id had already been added to the CSV in https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/5232 (requested by me), but a later change in https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/3f347aefb69c67cc380295d3d698ae09a2dfc07f now requires login before accessing that CSV.
- I've updated my downstream integration to consume JSON instead of CSV. This PR restores parity by exposing global_id in the JSON response as well.
- Adds request-spec coverage to ensure global_id remains present in the users JSON payload.

## AI usage
I used GitHub Copilot (GPT-5.3-Codex) to:
- Locate where /courses/:slug/users.json is serialized.
- Add global_id to the users JSON payload.
- Draft and validate a focused request spec for this behavior.

I reviewed the changes and test result manually.

## Screenshots
Before:
- Not applicable (no UI change).

After:
- Not applicable (no UI change).
