### PR TITLE
Exclude non-scoped revisions from new_revisions? count

### DIFF
--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -50,7 +50,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
                        .for_revisions_between(rev_start, rev_end)
     timeslices.each do |timeslice|
       # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select(&:scoped).select do |revision|
+      revisions_in_timeslice = revisions[:revisions].select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
       # Get or create article course timeslice based on course, article_id,
@@ -71,7 +71,8 @@ class CourseUserWikiTimeslice < ApplicationRecord
 
   # Assumes that the revisions are for their own course user wiki
   def update_cache_from_revisions(revisions)
-    @revisions = revisions
+    # Only work with scoped revisions
+    @revisions = revisions.select(&:scoped)
     @liverevisions = live_revisions
     tracked_namespace_revisions = live_revisions_in_tracked_namespaces
     update_character_sum(@liverevisions, tracked_namespace_revisions)

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -53,7 +53,7 @@ class CourseWikiTimeslice < ApplicationRecord
                                                 .for_revisions_between(rev_start, rev_end)
     course_wiki_timeslices.each do |timeslice|
       # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select(&:scoped).select do |revision|
+      revisions_in_timeslice = revisions[:revisions].select do |revision|
         timeslice.start <= revision.date && revision.date < timeslice.end
       end
       # Update cache for CourseWikiTimeslice
@@ -67,7 +67,8 @@ class CourseWikiTimeslice < ApplicationRecord
 
   # Assumes that the revisions are for their own course wiki
   def update_cache_from_revisions(revisions)
-    @revisions = revisions
+    # Only work with scoped revisions
+    @revisions = revisions.select(&:scoped)
     @students = course.courses_users.where(role: CoursesUsers::Roles::STUDENT_ROLE)
 
     update_character_sum

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -117,9 +117,9 @@ class CourseWikiTimeslice < ApplicationRecord
     self.revision_count = tracked_revisions.count { |rev| !rev.deleted && !rev.system }
   end
 
-  # Count of revisions as fetched from MediaWiki, excluding only system edits.
   # Must mirror the same filter that CourseRevisionUpdater#new_revisions? applies
   # to the live fetched revisions, so the two counts are comparable.
+  # Exclude non-scoped (pre-filtered in @revisions) and system edits.
   def update_mw_rev_count
     self.mw_rev_count = @revisions.count { |rev| !rev.system }
   end

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -91,12 +91,13 @@ class CourseRevisionUpdater
   # The count comparison is against `timeslice.mw_rev_count`, NOT
   # `timeslice.revision_count`. The two columns apply different filters:
   # `revision_count` excludes deleted revs and revs in `articles_courses.not_tracked`
-  # in addition to system revs, while this method (and `mw_rev_count`) excludes only
-  # system revs. Comparing against `revision_count` would falsely report new data
-  # every cycle for any timeslice that contains a deleted or not-tracked rev.
+  # in addition to system revs and non-scoped revisions, while this method (and `mw_rev_count`)
+  # excludes only system revs and non-scoped revisions. Comparing against `revision_count` would
+  # falsely report new data every cycle for any timeslice that contains a deleted or not-tracked
+  # rev. Note that we have to fetch scores to determine if a revision is deleted.
   # See CourseWikiTimeslice#update_mw_rev_count.
   def new_revisions?(revisions, wiki, timeslice_start)
-    live_revisions = revisions.reject(&:system)
+    live_revisions = revisions.reject { |rev| rev.system || !rev.scoped }
     revision_count = live_revisions.count
     timeslice = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
                                    .for_datetime(timeslice_start)

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -288,6 +288,39 @@ describe CourseRevisionUpdater do
         response = scoped_instance_class.fetch_revisions_for_course_wiki(wiki, start_date, end_date)
         expect(response[wiki][:revisions]).to eq([])
       end
+
+      context 'when fetched revisions include non-scoped ones' do
+        let(:rev_date) { '2016-03-25'.to_datetime }
+        let(:scoped_revision) { RevisionOnMemory.new(scoped: true, system: false, date: rev_date) }
+        let(:non_scoped_revision) do
+          RevisionOnMemory.new(scoped: false, system: false, date: rev_date - 1.day)
+        end
+
+        before do
+          create(:course_wiki_timeslice, course: scoped_course, wiki:,
+                                         start: start_date, end: end_date.to_datetime + 1.day,
+                                         mw_rev_count: 1, last_mw_rev_datetime: rev_date)
+          allow(scoped_instance_class).to receive(:no_point_in_importing_revisions?)
+            .and_return(false)
+          allow(scoped_instance_class).to receive(:fetch_revisions)
+            .and_return([scoped_revision, non_scoped_revision])
+        end
+
+        it 'does not report new data when non-scoped revisions do not change the scoped count' do
+          response = scoped_instance_class.fetch_revisions_for_course_wiki(wiki, start_date,
+                                                                           end_date)
+          expect(response[wiki][:new_data]).to eq(false)
+        end
+
+        it 'reports new data when scoped revision count increases' do
+          extra_scoped = RevisionOnMemory.new(scoped: true, system: false, date: rev_date)
+          allow(scoped_instance_class).to receive(:fetch_revisions)
+            .and_return([scoped_revision, non_scoped_revision, extra_scoped])
+          response = scoped_instance_class.fetch_revisions_for_course_wiki(wiki, start_date,
+                                                                           end_date)
+          expect(response[wiki][:new_data]).to eq(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What this PR does

`CourseRevisionUpdater#new_revisions?` compares a live count of fetched revisions
against `timeslice.mw_rev_count` to decide whether a timeslice has new data. Before
this PR, the live count included non-scoped revisions, while `mw_rev_count` was
always built from scoped-only revisions. This asymmetry caused `new_revisions?` to
return `true` spuriously whenever non-scoped MediaWiki activity appeared in the
response, triggering unnecessary update cycles for `ArticleScopedProgram` courses.

The fix has two parts:

1. `CourseRevisionUpdater#new_revisions?` now excludes non-scoped revisions from
   the live count (in addition to system revisions), so both sides of the comparison
   apply the same filter.
2. `CourseWikiTimeslice#update_cache_from_revisions` and
   `CourseUserWikiTimeslice#update_cache_from_revisions` now filter `@revisions` to
   scoped-only internally, making the scoped filter self-contained in the model
   rather than at the call site. This is a readability improvement with no behaviour
   change for `mw_rev_count`.

New specs cover the fixed behaviour: `new_data` is false when only non-scoped
revisions differ, and true when the scoped count genuinely increases.

See PR #6816 and PR #6868
## AI usage

This PR was developed with Claude Code (Anthropic). The `new_revisions?` filter
change was authored by the human; Claude assisted with planning the approach,
proposed moving the `select(&:scoped)` filter into `update_cache_from_revisions`,
and wrote the new specs in `course_revision_updater_spec.rb`. Commit messages were
drafted by Claude Code. The work involved one planning session with back-and-forth
(~20 messages), resulting in 2 commits made within a single day (2026-05-11). This
PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes.

## Open questions and concerns

None.

(PR description written by Claude Code.)