### PR TITLE
Clean up outdated LiftWing comments

### DIFF
--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -3,9 +3,8 @@
 require_dependency "#{Rails.root}/lib/revision_score_api_handler"
 require_dependency "#{Rails.root}/lib/wiki_api/article_content"
 
-#= Imports revision scoring data from Lift Wing and reference-counter APIs.
-#= This class populates wp10, wp10_previous, features, features_previous and
-#= deleted fields.
+#= Imports revision scoring data from the reference-counter API.
+#= This class populates features, features_previous, deleted and error fields.
 class RevisionScoreImporter
   BATCH_SIZE = 50
 

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -18,8 +18,7 @@ class RevisionScoreImporter
     @api_handler = RevisionScoreApiHandler.new(wiki: @wiki, update_service:)
   end
 
-  # Takes an array of Revision records, and returns an array of Revisions records
-  # with scores completed.
+  # Takes an array of RevisionOnMemory records, and returns them with scores completed.
   def get_revision_scores(new_revisions)
     scores = {}
     parent_scores = {}

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -3,9 +3,8 @@
 require_dependency "#{Rails.root}/lib/reference_counter_api"
 
 #= Handles the logic to decide how to retrieve revision data for a given wiki.
-# This involves to determine if the given wiki is supported for both Lift Wing API and
-# reference-counter API (e.g en.wikipedia), only for Lift Wing API (wikidata),
-# or only for reference-counter API (e.g es.wikipedia).
+# Determines whether the wiki is supported by the reference-counter API
+# (e.g. en.wikipedia, es.wikipedia).
 class RevisionScoreApiHandler
   def initialize(language: 'en', project: 'wikipedia', wiki: nil, update_service: nil)
     @update_service = update_service
@@ -15,25 +14,18 @@ class RevisionScoreApiHandler
     @reference_counter_api = ReferenceCounterApi.new(@wiki, @update_service)
   end
 
-  # Returns data from LiftWing API and/or reference-counter API.
+  # Returns data from the reference-counter API.
   # The response has the following format:
   # { "rev_0"=>
-  #     { "wp10"=>0.296976285416441736e2,
-  #       "features"=> { "num_ref"=>0 },
+  #     { "features"=> { "num_ref"=>0 },
   #       "deleted"=>false,
-  #       "prediction"=>"Start",
-  #       "start" => false },
+  #       "error"=>false },
   #   ...,
   #   "rev_n"=>
-  #     { "wp10"=>0.2929458626376752846e2,
-  #       "features"=> {},
+  #     { "features"=> {},
   #       "deleted"=>false,
-  #       "prediction"=>"Start",
-  #       "start" => false }
+  #       "error"=>false }
   # }
-  #
-  # For wikidata, "features" key contains Liftwing features. For other wikis, "features"
-  # key contains reference-counter response (or empty hash).
   def get_revision_data(rev_batch)
     scores = maybe_get_reference_data(rev_batch)
     ensure_complete_scores scores


### PR DESCRIPTION
## What this PR does

Removes outdated comments in `lib/revision_score_api_handler.rb` and
`lib/importers/revision_score_importer.rb` that referred to LiftWing API
fields (`wp10`, `prediction`, `start`) and a wikidata-only code path that no
longer exist. The comments were left over from before LiftWing was removed and
no longer reflected what the code actually does.

Addresses #6871.

Changes:
- `RevisionScoreApiHandler` class comment: removed references to the LiftWing
  API and the wikidata-only path; the class now only coordinates the
  reference-counter API.
- `RevisionScoreApiHandler#get_revision_data` comment: replaced the example
  response (which showed `wp10`, `prediction`, `start`) with the actual current
  format (`features`, `deleted`, `error`); removed an inaccurate note about
  unsupported wikis (they return `{}` entirely, not per-revision entries with
  `features: {}`).
- `RevisionScoreImporter` class comment: removed "Lift Wing" from the API list
  and replaced `wp10`/`wp10_previous` with the fields actually populated
  (`features`, `features_previous`, `deleted`, `error`).
- `RevisionScoreImporter#get_revision_scores` comment: corrected "Revision
  records" to `RevisionOnMemory`, which is what all callers actually pass.

## AI usage

Claude Code (claude-sonnet-4-6) drafted all comment changes under the user's
direction. The user identified the files and the nature of the staleness; Claude
Code proposed and applied the edits. One inaccuracy was caught by the user
mid-session — a comment claiming that unsupported wikis return per-revision
entries with `features: {}`, when in fact the entire response is `{}`; this was
corrected before committing. The `RevisionOnMemory` correction was also
user-initiated after Claude Code had already committed the first batch.

Both commits were made within a single ~6-minute session on 2026-05-11. Claude
Code also wrote the commit messages and this PR description using the `/commit`
and `/prepare-pr` skills.

## Screenshots

No UI changes.

## Open questions and concerns

The comment in `RevisionDataManager#fetch_score_data_for_course` (line 58) also
says "Revision records" where it should say `RevisionOnMemory`, but the user
chose to leave that for a follow-up.

(PR description written by Claude Code.)