### PR TITLE
Count only real backups when enforcing minimum backup retention

### DIFF
--- a/config/backup/backup.sh
+++ b/config/backup/backup.sh
@@ -97,11 +97,19 @@ log "Finishing"
 # Update running backup record to 'finished'
 mysql < $QUERY_ROUTE/finished.sql
 
-# Remove oldest backup if there are more than three
+# Remove oldest backup if there are more than MIN_BACKUPS_NUMBER real backups.
+# A real backup is a folder that contains a .sql.gz file; empty or failed
+# folders are excluded from the count so they never block deletion.
 MIN_BACKUPS_NUMBER=3
-CURRENT_BACKUPS_NUMBER=$(ls -1d "$BACKUP_ROUTE"/*/ | wc -l)
-if [ $CURRENT_BACKUPS_NUMBER -gt $MIN_BACKUPS_NUMBER ]; then
-  OLDEST_BACKUP=$(ls -1d "$BACKUP_ROUTE"/*/ | sort | head -1)
+REAL_BACKUPS=()
+while IFS= read -r dir; do
+  if find "$dir" -maxdepth 1 -name "*.sql.gz" | grep -q .; then
+    REAL_BACKUPS+=("$dir")
+  fi
+done < <(ls -1d "$BACKUP_ROUTE"/*/ | sort)
+
+if [ ${#REAL_BACKUPS[@]} -gt $MIN_BACKUPS_NUMBER ]; then
+  OLDEST_BACKUP="${REAL_BACKUPS[0]}"
   log "Removing $OLDEST_BACKUP"
-  rm -r $OLDEST_BACKUP
+  rm -r "$OLDEST_BACKUP"
 fi


### PR DESCRIPTION
## What this PR does

The backup cleanup step in `config/backup/backup.sh` previously counted every
subdirectory under `BACKUP_ROUTE` to determine how many backups exist. Folders
left behind by failed runs (no `.sql.gz` inside) were counted as real backups.
The worst-case consequence: if most folders were empty and only one contained
an actual dump, the old code would still see the total exceed `MIN_BACKUPS_NUMBER`
and delete the oldest folder — potentially destroying the only recoverable backup
and leaving the system with zero real backups. It could also prevent deletion of
genuinely old backups, or pick an empty folder as the deletion target.

This PR replaces the simple folder count with a loop that collects only
directories containing a `.sql.gz` file into a `REAL_BACKUPS` array. The
`MIN_BACKUPS_NUMBER` guard is now applied to that count, and deletion targets
the oldest folder with a real dump — empty/failed folders are ignored entirely.

## AI usage

Claude Code (Sonnet 4.6) drafted the fix and commit message. The user
identified the problem, directed the approach, and tested the change manually
before asking for the commit. The session was a single short exchange (~5
messages, one sitting, May 12 2026). This PR description was drafted using the
Claude Code `/prepare-pr` skill; the user then corrected the description to
highlight the worst-case scenario (deleting the only real backup) that the
initial draft had understated.

## Screenshots

No UI changes.

## Open questions and concerns

None.

(PR description written by Claude Code.)