### PR TITLE
Fix wikidata stats wiped when reprocessing timeslice with no new revisions

### DIFF
--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -112,7 +112,7 @@ class UpdateCourseWikiTimeslices
     else
       log_processing(wiki, start_date, end_date, only_new)
       add_scores(only_new:)
-      maybe_fetch_wikidata_stats(wiki)
+      maybe_fetch_wikidata_stats(wiki, only_new:)
       process_timeslices(wiki) if !only_new | new_data?(wiki)
       [start_date]
     end
@@ -143,8 +143,8 @@ class UpdateCourseWikiTimeslices
     [timeslice_end - 1.second, @course.end].min
   end
 
-  def maybe_fetch_wikidata_stats(wiki)
-    fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && new_data?(wiki)
+  def maybe_fetch_wikidata_stats(wiki, only_new:)
+    fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && (!only_new || new_data?(wiki))
   end
 
   def new_data?(wiki)

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -104,18 +104,22 @@ class UpdateCourseWikiTimeslices
     fetch_only_revisions(wiki, start_date, end_date)
     split, dates = @splitter.maybe_split(wiki, start_date, end_date, @revisions)
     if split
-      new_start = dates[0]
-      midpoint = dates[1]
-      new_end = dates[2]
-      handle_timeslice(wiki, new_start, midpoint,
-                       only_new:) + handle_timeslice(wiki, midpoint, new_end, only_new:)
+      new_start, midpoint, new_end = dates
+      handle_timeslice(wiki, new_start, midpoint, only_new:) +
+        handle_timeslice(wiki, midpoint, new_end, only_new:)
     else
-      log_processing(wiki, start_date, end_date, only_new)
-      add_scores(only_new:)
-      maybe_fetch_wikidata_stats(wiki, only_new:)
-      process_timeslices(wiki) if !only_new | new_data?(wiki)
-      [start_date]
+      process_leaf_timeslice(wiki, start_date, end_date, only_new:)
     end
+  end
+
+  def process_leaf_timeslice(wiki, start_date, end_date, only_new:)
+    log_processing(wiki, start_date, end_date, only_new)
+    add_scores(only_new:)
+    if should_update_timeslice?(wiki, only_new:)
+      fetch_wikidata_stats(wiki) if wiki.project == 'wikidata'
+      process_timeslices(wiki)
+    end
+    [start_date]
   end
 
   def timeslice_reprocessed?(wiki_id, start_date)
@@ -143,8 +147,8 @@ class UpdateCourseWikiTimeslices
     [timeslice_end - 1.second, @course.end].min
   end
 
-  def maybe_fetch_wikidata_stats(wiki, only_new:)
-    fetch_wikidata_stats(wiki) if wiki.project == 'wikidata' && (!only_new || new_data?(wiki))
+  def should_update_timeslice?(wiki, only_new:)
+    !only_new || new_data?(wiki)
   end
 
   def new_data?(wiki)

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -248,6 +248,27 @@ describe UpdateCourseWikiTimeslices do
       end
     end
 
+    context 'when reprocessing a wikidata timeslice with no new revisions' do
+      before do
+        TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
+        # Mark the first wikidata timeslice for reprocessing
+        course.course_wiki_timeslices.where(wiki: wikidata).first
+              .update(needs_update: true)
+        # Simulate no new revisions for any wiki or timeslice
+        allow_any_instance_of(CourseRevisionUpdater)
+          .to receive(:fetch_revisions_for_course_wiki) do |_instance, wiki, ts_start, ts_end|
+            { wiki => { start: ts_start, end: ts_end, new_data: false, revisions: [] } }
+          end
+      end
+
+      it 'fetches wikidata stats even when there are no new revisions' do
+        expect_any_instance_of(UpdateWikidataStatsTimeslice)
+          .to receive(:update_revisions_with_stats)
+          .and_return([])
+        subject
+      end
+    end
+
     context 'when there is no point in importing revisions' do
       before do
         CoursesUsers.find_by(course:, user:).destroy


### PR DESCRIPTION
## What this PR does

Fixes a bug where Wikidata stats were wiped when a timeslice was reprocessed
with no new revisions. Closes #6860.

When a `CourseWikiTimeslice` with `needs_update: true` was reprocessed
(`only_new: false`) and no new revisions had been added since the last
processing, `process_timeslices` would run (clearing the stored stats) but
`maybe_fetch_wikidata_stats` would skip — because it only checked
`new_data?(wiki)` rather than the same condition used by `process_timeslices`:
`!only_new || new_data?(wiki)`. The result was a timeslice reprocessed with
empty Wikidata stats.

The fix aligns the guard condition in both places. A failing spec was written
first to demonstrate the bug, then the fix was applied.

The PR also includes a follow-up readability refactor of
`UpdateCourseWikiTimeslices#handle_timeslice`: its non-split branch is
extracted into `process_leaf_timeslice`, turning `handle_timeslice` into a
clean recursive dispatcher. The shared guard condition is also extracted into a
named predicate `should_update_timeslice?`, making it clear that the Wikidata
stats fetch and the timeslice cache update share the same criterion.

## AI usage

This PR was developed entirely with Claude Code (Anthropic) under the author's
direction. Claude Code read the relevant service and spec files, identified the
root cause, wrote the failing spec, proposed and applied the fix, and proposed
the refactor. The author directed each step, chose between design options (e.g.
which extraction approach to use for the refactor), and reviewed all changes
before committing. Both commit messages and this PR description were drafted by
Claude Code using the `/commit` and `/prepare-pr` skills.

Both commits were made within a single ~20-minute session. All work was driven
by the author; Claude Code produced no code autonomously.

## Screenshots

To reproduce, use the course https://dashboard.wikiedu.org/courses/Wiki_Education/NYDCLC_Wikidata_Institute_(Fall_2021)/home,
run a manual update, set one non-empty timeslice as `needs_update`, and run
the update again.

**Before (bug): Wikidata stats after setting a timeslice as `needs_update` and re-running the update — stats are empty.**

<img width="1284" height="726" alt="image" src="https://github.com/user-attachments/assets/f66a4712-34ca-4ff4-b9d2-4fbc16f45d62" />

**After (fix): Wikidata stats are preserved after reprocessing.**

<img width="1345" height="802" alt="image" src="https://github.com/user-attachments/assets/05b26949-7cad-4635-a422-c267c8112ca9" />

## Open questions and concerns

None.

(PR description written by Claude Code.)