### PR TITLE
Simplify methods to update timeslices to handle a single timeslice

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -46,40 +46,40 @@ class ArticleCourseTimeslice < ApplicationRecord
   end
 
   # Given a course, an article, and a hash of revisions like the following:
-  # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
-  # updates the article course timeslices based on the revisions.
-  def self.update_article_course_timeslices(course, article_id, revisions) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-    rev_start = revisions[:start]
-    rev_end = revisions[:end]
+  # {:start=>"20160320000000", :end=>"20160320235959", :revisions=>[...]},
+  # where start and end span a single timeslice period (end is 1 second
+  # before the next timeslice boundary), updates the article course timeslice.
+  def self.update_article_course_timeslices(course, article_id, revisions)
     wiki_id = revisions[:revisions].first.wiki_id
-    # For debugging purposes only. TODO: delete this sentry message
-    if article_id.nil?
-      Sentry.capture_message "Article id nil for course #{course.id}",
-                             level: 'error',
-                             extra: {
-                               wiki_id:,
-                               mw_page_ids: revisions[:revisions].map(&:mw_page_id),
-                               revision_ids: revisions[:revisions].map(&:mw_rev_id)
-                             }
-    end
-    # Timeslice dates to update are determined based on course wiki timeslices
+
+    # For debugging purposes only. TODO: delete this sentry message log
+    log_nil_article_id(course, article_id, wiki_id, revisions) if article_id.nil?
+
     timeslices = course.course_wiki_timeslices.where(wiki_id:)
-                       .for_revisions_between(rev_start, rev_end)
-    timeslices.each do |timeslice|
-      # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select do |revision|
-        timeslice.start <= revision.date && revision.date < timeslice.end
-      end
-      # Get or create article course timeslice based on course, article_id,
-      # timeslice.start and timeslice.end
-      ac_timeslice = ArticleCourseTimeslice.find_or_create_by(course:,
-                                                              article_id:,
-                                                              start: timeslice.start,
-                                                              end: timeslice.end)
-      # Update cache for ArticleCourseTimeslice
-      ac_timeslice.update_cache_from_revisions revisions_in_timeslice
+                       .for_revisions_between(revisions[:start], revisions[:end])
+    if timeslices.size > 1
+      message = "Multiple article course timeslices matched for course #{course.slug}"
+      Sentry.capture_message message,
+                             level: 'error',
+                             extra: { course_id: course.id, wiki_id:, article_id:,
+                                      start: revisions[:start], end: revisions[:end] }
     end
+    timeslice = timeslices.first
+    ac_timeslice = find_or_create_by(course:, article_id:,
+                                     start: timeslice.start, end: timeslice.end)
+    ac_timeslice.update_cache_from_revisions revisions[:revisions]
   end
+
+  def self.log_nil_article_id(course, article_id, wiki_id, revisions)
+    Sentry.capture_message "Article id nil for course #{course.id}",
+                           level: 'error',
+                           extra: {
+                             wiki_id:,
+                             mw_page_ids: revisions[:revisions].map(&:mw_page_id),
+                             revision_ids: revisions[:revisions].map(&:mw_rev_id)
+                           }
+  end
+  private_class_method :log_nil_article_id
 
   ####################
   # Instance methods #

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -40,29 +40,23 @@ class CourseUserWikiTimeslice < ApplicationRecord
   #################
 
   # Given a course, a user_id, a wiki and a hash of revisions like the following:
-  # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
-  # updates the article course timeslices based on the revisions.
+  # {:start=>"20160320000000", :end=>"20160320235959", :revisions=>[...]},
+  # where start and end span a single timeslice period (end is 1 second
+  # before the next timeslice boundary), updates the course user wiki timeslice.
   def self.update_course_user_wiki_timeslices(course, user_id, wiki, revisions)
-    rev_start = revisions[:start]
-    rev_end = revisions[:end]
-    # Timeslice dates to update are determined based on course wiki timeslices
     timeslices = course.course_wiki_timeslices.where(wiki:)
-                       .for_revisions_between(rev_start, rev_end)
-    timeslices.each do |timeslice|
-      # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select do |revision|
-        timeslice.start <= revision.date && revision.date < timeslice.end
-      end
-      # Get or create article course timeslice based on course, article_id,
-      # timeslice.start and timeslice.end
-      cu_timeslice = CourseUserWikiTimeslice.find_or_create_by(course:,
-                                                               user_id:,
-                                                               wiki:,
-                                                               start: timeslice.start,
-                                                               end: timeslice.end)
-      # Update cache for CourseUserWikiTimeslice
-      cu_timeslice.update_cache_from_revisions revisions_in_timeslice
+                       .for_revisions_between(revisions[:start], revisions[:end])
+    if timeslices.size > 1
+      message = "Multiple course user wiki timeslices matched for course #{course.slug}"
+      Sentry.capture_message message,
+                             level: 'error',
+                             extra: { course_id: course.id, wiki_id: wiki.id, user_id:,
+                                      start: revisions[:start], end: revisions[:end] }
     end
+    timeslice = timeslices.first
+    cu_timeslice = find_or_create_by(course:, user_id:, wiki:,
+                                     start: timeslice.start, end: timeslice.end)
+    cu_timeslice.update_cache_from_revisions revisions[:revisions]
   end
 
   ####################

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -42,23 +42,19 @@ class CourseWikiTimeslice < ApplicationRecord
   #################
 
   # Given a course, a wiki, and a hash of revisions like the following:
-  # {:start=>"20160320", :end=>"20160401", :revisions=>[...]},
-  # updates the course wiki timeslices based on the revisions.
+  # {:start=>"20160320000000", :end=>"20160320235959", :revisions=>[...]},
+  # where start and end span a single timeslice period (end is 1 second
+  # before the next timeslice boundary), updates the course wiki timeslice.
   def self.update_course_wiki_timeslices(course, wiki, revisions)
-    rev_start = revisions[:start]
-    rev_end = revisions[:end]
-    # Course wiki timeslices to update
-    course_wiki_timeslices = CourseWikiTimeslice.for_course_and_wiki(course,
-                                                                     wiki)
-                                                .for_revisions_between(rev_start, rev_end)
-    course_wiki_timeslices.each do |timeslice|
-      # Group revisions that belong to the timeslice
-      revisions_in_timeslice = revisions[:revisions].select do |revision|
-        timeslice.start <= revision.date && revision.date < timeslice.end
-      end
-      # Update cache for CourseWikiTimeslice
-      timeslice.update_cache_from_revisions revisions_in_timeslice
+    timeslices = for_course_and_wiki(course, wiki)
+                 .for_revisions_between(revisions[:start], revisions[:end])
+    if timeslices.size > 1
+      Sentry.capture_message "Multiple timeslices matched for course #{course.slug}",
+                             level: 'error',
+                             extra: { course_id: course.id, wiki_id: wiki.id,
+                                      start: revisions[:start], end: revisions[:end] }
     end
+    timeslices.first.update_cache_from_revisions revisions[:revisions]
   end
 
   ####################

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -86,10 +86,6 @@ describe ArticleCourseTimeslice, type: :model do
 
   describe '.update_article_course_timeslices' do
     before do
-      revisions << build(:revision_on_memory, article_id:, user_id: 1, date: start + 26.hours)
-      revisions << build(:revision_on_memory, article_id:, user_id: 3, date: start + 50.hours)
-      revisions << build(:revision_on_memory, article_id:, user_id: 7, date: start + 51.hours)
-
       create(:course_wiki_timeslice, course:, wiki:, start:, end: start + 1.day)
       create(:course_wiki_timeslice, course:, wiki:, start: start + 1.day,
              end: start + 2.days)
@@ -97,30 +93,22 @@ describe ArticleCourseTimeslice, type: :model do
             end: start + 3.days)
     end
 
-    it 'creates the right article timeslices based on the revisions' do
+    it 'creates the right article timeslice based on the revisions' do
       article_course_timeslice_0 = described_class.find_by(course:, article:, start:)
-      article_course_timeslice_1 = described_class.find_by(course:, article:, start: start + 1.day)
-      article_course_timeslice_2 = described_class.find_by(course:, article:, start: start + 2.days)
 
       expect(article_course_timeslice_0).to be_nil
-      expect(article_course_timeslice_1).to be_nil
-      expect(article_course_timeslice_2).to be_nil
 
       start_period = start.strftime('%Y%m%d%H%M%S')
-      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      end_period = (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')
       revision_data = { start: start_period, end: end_period, revisions: }
       described_class.update_article_course_timeslices(course, article.id, revision_data)
 
+      expect(described_class.where(course:, article:).count).to eq(1)
       article_course_timeslice_0 = described_class.find_by(course:, article:, start:)
-      article_course_timeslice_1 = described_class.find_by(course:, article:, start: start + 1.day)
-      article_course_timeslice_2 = described_class.find_by(course:, article:, start: start + 2.days)
-
       expect(article_course_timeslice_0.user_ids).to eq([25, 1])
-      expect(article_course_timeslice_1.user_ids).to eq([1])
-      expect(article_course_timeslice_2.user_ids).to eq([3, 7])
     end
 
-    it 'updates the right article timeslices based on the revisions' do
+    it 'updates the right article timeslice based on the revisions' do
       create(:article_course_timeslice, course:, article:, start:, end: start + 1.day)
       create(:article_course_timeslice, course:, article:, start: start + 1.day,
              end: start + 2.days)
@@ -136,7 +124,7 @@ describe ArticleCourseTimeslice, type: :model do
       expect(article_course_timeslice_2.user_ids).to eq([])
 
       start_period = start.strftime('%Y%m%d%H%M%S')
-      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      end_period = (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')
       revision_data = { start: start_period, end: end_period, revisions: }
       described_class.update_article_course_timeslices(course, article.id, revision_data)
 
@@ -147,8 +135,22 @@ describe ArticleCourseTimeslice, type: :model do
       article_course_timeslice_2 = described_class.find_by(course:, article:, start: start + 2.days)
 
       expect(article_course_timeslice_0.user_ids).to eq([25, 1])
-      expect(article_course_timeslice_1.user_ids).to eq([1])
-      expect(article_course_timeslice_2.user_ids).to eq([3, 7])
+      expect(article_course_timeslice_1.user_ids).to eq([])
+      expect(article_course_timeslice_2.user_ids).to eq([])
+    end
+
+    it 'sends a Sentry error when multiple timeslices are matched' do
+      start_period = start.strftime('%Y%m%d%H%M%S')
+      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+
+      expect(Sentry).to receive(:capture_message)
+        .with("Multiple article course timeslices matched for course #{course.slug}",
+              level: 'error',
+              extra: hash_including(course_id: course.id, wiki_id: wiki.id,
+                                    article_id:, start: start_period, end: end_period))
+
+      revision_data = { start: start_period, end: end_period, revisions: }
+      described_class.update_article_course_timeslices(course, article.id, revision_data)
     end
   end
 

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -116,35 +116,23 @@ describe CourseUserWikiTimeslice, type: :model do
   describe '.update_course_user_wiki_timeslices' do
     before do
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
-      revisions << build(:revision_on_memory, article_id:, user_id: user.id, date: start + 26.hours,
-                         scoped: true)
-      revisions << build(:revision_on_memory, article_id:, user_id: user.id, date: start + 50.hours,
-                         scoped: true)
-      revisions << build(:revision_on_memory, article_id:, user_id: user.id, date: start + 51.hours,
-                         scoped: true)
     end
 
-    it 'creates the right article timeslices based on the revisions' do
+    it 'creates the right course user wiki timeslice based on the revisions' do
       expect(course.course_user_wiki_timeslices.count).to eq(0)
 
       start_period = start.strftime('%Y%m%d%H%M%S')
-      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      end_period = (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')
       revision_data = { start: start_period, end: end_period, revisions: }
       described_class.update_course_user_wiki_timeslices(course, user.id, wiki, revision_data)
 
       course_user_wiki_timeslice_0 = described_class.find_by(course:, wiki:, user:, start:)
-      course_user_wiki_timeslice_1 = described_class.find_by(course:, wiki:, user:,
-                                                             start: start + 1.day)
-      course_user_wiki_timeslice_2 = described_class.find_by(course:, wiki:, user:,
-                                                             start: start + 2.days)
 
       expect(course_user_wiki_timeslice_0.revision_count).to eq(4)
-      expect(course_user_wiki_timeslice_1.revision_count).to eq(1)
-      expect(course_user_wiki_timeslice_2.revision_count).to eq(2)
-      expect(course.course_user_wiki_timeslices.count).to eq(3)
+      expect(course.course_user_wiki_timeslices.count).to eq(1)
     end
 
-    it 'updates the right article timeslices based on the revisions' do
+    it 'updates the right course user wiki timeslice based on the revisions' do
       # Timeslices are already created
       create(:course_user_wiki_timeslice, course:, wiki:, user:, start:, end: start + 1.day)
       create(:course_user_wiki_timeslice, course:, wiki:, user:, start: start + 1.day,
@@ -163,7 +151,7 @@ describe CourseUserWikiTimeslice, type: :model do
       expect(course_user_wiki_timeslice_2.revision_count).to eq(0)
 
       start_period = start.strftime('%Y%m%d%H%M%S')
-      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      end_period = (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')
       revision_data = { start: start_period, end: end_period, revisions: }
       described_class.update_course_user_wiki_timeslices(course, user.id, wiki, revision_data)
 
@@ -174,9 +162,23 @@ describe CourseUserWikiTimeslice, type: :model do
                                                              start: start + 2.days)
 
       expect(course_user_wiki_timeslice_0.revision_count).to eq(4)
-      expect(course_user_wiki_timeslice_1.revision_count).to eq(1)
-      expect(course_user_wiki_timeslice_2.revision_count).to eq(2)
+      expect(course_user_wiki_timeslice_1.revision_count).to eq(0)
+      expect(course_user_wiki_timeslice_2.revision_count).to eq(0)
       expect(course.course_user_wiki_timeslices.count).to eq(3)
+    end
+
+    it 'sends a Sentry error when multiple timeslices are matched' do
+      start_period = start.strftime('%Y%m%d%H%M%S')
+      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+
+      expect(Sentry).to receive(:capture_message)
+        .with("Multiple course user wiki timeslices matched for course #{course.slug}",
+              level: 'error',
+              extra: hash_including(course_id: course.id, wiki_id: wiki.id, user_id: user.id,
+                                    start: start_period, end: end_period))
+
+      revision_data = { start: start_period, end: end_period, revisions: }
+      described_class.update_course_user_wiki_timeslices(course, user.id, wiki, revision_data)
     end
   end
 

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -96,40 +96,26 @@ scoped: true)
   describe '.update_course_wiki_timeslices' do
     before do
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wiki])
-      array_revisions << build(:revision_on_memory, article_id:, user_id: 1, date: start + 26.hours,
-                               scoped: true)
-      array_revisions << build(:revision_on_memory, article_id:, user_id: 1, date: start + 50.hours,
-                               scoped: true)
-      array_revisions << build(:revision_on_memory, article_id:, user_id: 1, date: start + 51.hours,
-                               scoped: true)
     end
 
-    it 'updates the right course wiki timeslices based on the revisions' do
+    it 'updates the right course wiki timeslice based on the revisions' do
       course_wiki_timeslice_0 = described_class.find_by(course:, wiki:, start:)
-      course_wiki_timeslice_1 = described_class.find_by(course:, wiki:, start: start + 1.day)
-      course_wiki_timeslice_2 = described_class.find_by(course:, wiki:, start: start + 2.days)
 
       expect(course_wiki_timeslice_0.revision_count).to eq(0)
-      expect(course_wiki_timeslice_1.revision_count).to eq(0)
-      expect(course_wiki_timeslice_2.revision_count).to eq(0)
 
       start_period = start.strftime('%Y%m%d%H%M%S')
-      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      end_period = (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')
       revisions = { start: start_period, end: end_period, revisions: array_revisions }
       described_class.update_course_wiki_timeslices(course, wiki, revisions)
 
       course_wiki_timeslice_0 = described_class.find_by(course:, wiki:, start:)
-      course_wiki_timeslice_1 = described_class.find_by(course:, wiki:, start: start + 1.day)
-      course_wiki_timeslice_2 = described_class.find_by(course:, wiki:, start: start + 2.days)
 
       expect(course_wiki_timeslice_0.revision_count).to eq(3)
-      expect(course_wiki_timeslice_1.revision_count).to eq(1)
-      expect(course_wiki_timeslice_2.revision_count).to eq(2)
     end
 
     it 'sets mw_rev_count to the non-system count, including deleted revs' do
       start_period = start.strftime('%Y%m%d%H%M%S')
-      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+      end_period = (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')
       revisions = { start: start_period, end: end_period, revisions: array_revisions }
       described_class.update_course_wiki_timeslices(course, wiki, revisions)
 
@@ -138,6 +124,20 @@ scoped: true)
       slice_0 = described_class.find_by(course:, wiki:, start:)
       expect(slice_0.revision_count).to eq(3)
       expect(slice_0.mw_rev_count).to eq(4)
+    end
+
+    it 'sends a Sentry error when multiple timeslices are matched' do
+      start_period = start.strftime('%Y%m%d%H%M%S')
+      end_period = (start + 55.hours).strftime('%Y%m%d%H%M%S')
+
+      expect(Sentry).to receive(:capture_message)
+        .with("Multiple timeslices matched for course #{course.slug}",
+              level: 'error',
+              extra: hash_including(course_id: course.id, wiki_id: wiki.id,
+                                    start: start_period, end: end_period))
+
+      revisions = { start: start_period, end: end_period, revisions: array_revisions }
+      described_class.update_course_wiki_timeslices(course, wiki, revisions)
     end
   end
 
@@ -192,7 +192,7 @@ scoped: true)
       before do
         TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([wiki])
         array_revisions << build(:revision_on_memory, article_id:, user_id: 1,
-                                 date: start + 51.hours, scoped: true,
+                                 date: start + 1.hour, scoped: true,
                                  error: true) # add revision with error
       end
 

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -86,7 +86,7 @@ scoped: true)
     array_revisions << build(:revision_on_memory, article_id:, user_id: 1, date: start + 2.hours,
 scoped: true)
     array_revisions << build(:revision_on_memory, article_id:, user_id: 2, date: start + 3.hours,
-scoped: true)
+scoped: false)
     array_revisions << build(:revision_on_memory, article_id:, user_id: 2, date: start + 3.hours,
                              system: true, scoped: true)
     array_revisions << build(:revision_on_memory, article_id:, deleted: true, user_id: 1,
@@ -110,7 +110,7 @@ scoped: true)
 
       course_wiki_timeslice_0 = described_class.find_by(course:, wiki:, start:)
 
-      expect(course_wiki_timeslice_0.revision_count).to eq(3)
+      expect(course_wiki_timeslice_0.revision_count).to eq(2)
     end
 
     it 'sets mw_rev_count to the non-system count, including deleted revs' do
@@ -119,11 +119,13 @@ scoped: true)
       revisions = { start: start_period, end: end_period, revisions: array_revisions }
       described_class.update_course_wiki_timeslices(course, wiki, revisions)
 
-      # First slice has 3 normal + 1 system + 1 deleted = 4 non-system revs.
-      # revision_count excludes the deleted one (3); mw_rev_count keeps it (4).
+      # First slice has 2 normal + 1 non-scoped + 1 system + 1 deleted =
+      # 3 scoped non-system revs.
+      # revision_count excludes the deleted one and the non-scoped one (2);
+      # mw_rev_count keeps the deleted one (3).
       slice_0 = described_class.find_by(course:, wiki:, start:)
-      expect(slice_0.revision_count).to eq(3)
-      expect(slice_0.mw_rev_count).to eq(4)
+      expect(slice_0.revision_count).to eq(2)
+      expect(slice_0.mw_rev_count).to eq(3)
     end
 
     it 'sends a Sentry error when multiple timeslices are matched' do
@@ -156,7 +158,7 @@ scoped: true)
 
         expect(course_wiki_timeslice.character_sum).to eq(9010)
         expect(course_wiki_timeslice.references_count).to eq(7)
-        expect(course_wiki_timeslice.revision_count).to eq(3)
+        expect(course_wiki_timeslice.revision_count).to eq(2)
         expect(course_wiki_timeslice.needs_update).to eq(false)
       end
 
@@ -173,7 +175,7 @@ scoped: true)
         expect(course_wiki_timeslice.revision_count).to eq(0)
       end
 
-      it 'mw_rev_count ignores tracked status and deleted, excludes only system' do
+      it 'mw_rev_count ignores tracked status and deleted, excludes system and non-scoped' do
         # Even when the only article is untracked, mw_rev_count counts every
         # non-system rev — it must mirror what CourseRevisionUpdater#new_revisions?
         # computes from the live fetched revisions.
@@ -183,8 +185,8 @@ scoped: true)
         course_wiki_timeslice.update_cache_from_revisions array_revisions
 
         expect(course_wiki_timeslice.revision_count).to eq(0)
-        # 3 normal + 1 deleted, minus the 1 system = 4
-        expect(course_wiki_timeslice.mw_rev_count).to eq(4)
+        # 2 normal + 1 deleted, minus the 1 system and the 1 non-scoped = 3
+        expect(course_wiki_timeslice.mw_rev_count).to eq(3)
       end
     end
 


### PR DESCRIPTION
## What this PR does

Simplifies the three timeslice update methods —
`CourseWikiTimeslice.update_course_wiki_timeslices`,
`CourseUserWikiTimeslice.update_course_user_wiki_timeslices`, and
`ArticleCourseTimeslice.update_article_course_timeslices` — by removing an
unnecessary loop-and-filter pattern. All three are always called with a period
that spans exactly one timeslice (the service layer sets `real_end =
timeslice_end - 1.second` to guarantee this), so the loop was dead
complexity. Each method now calls `.first` directly on the matched timeslices,
and the method comments document the single-timeslice contract.

A Sentry invariant guard was added to each method to log an error if more than
one timeslice is ever matched, making the assumption explicit and alerting us
if it is ever violated in production.

A separate commit also clarifies the spec coverage for `mw_rev_count` vs
`revision_count` in `course_wiki_timeslice_spec.rb`, introducing a non-scoped
revision to the fixture to make the difference between the two counters
explicit.

## AI usage

Claude Code (claude-sonnet-4-6) was used throughout this PR. The overall
approach and goal were defined by the human; Claude drafted the model changes
and Sentry guard patterns, iterated on RuboCop violations (extracting
`log_nil_article_id` into a private class method to avoid
`rubocop:disable`), and wrote all commit messages. The spec changes were
written by the human, with Claude adding the Sentry specs. Claude Code also
drafted this PR description using the `/prepare-pr` skill.

This was developed across 4 commits over roughly 25 hours (2026-05-14 to
2026-05-15), across two conversation sessions (the first ran out of context).
The human sent approximately 30–40 short messages across both sessions,
directing each step and confirming specs passed before each commit.

## Screenshots

No UI changes.

## Open questions and concerns

None.
