### PR TITLE
Escalate courses with consecutive unfinished updates to long_update queue

### DIFF
--- a/lib/data_cycle/course_queue_sorting.rb
+++ b/lib/data_cycle/course_queue_sorting.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 module CourseQueueSorting
+  # Number of consecutive unfinished updates that triggers escalation to long_update queue
+  UNFINISHED_UPDATES_LONG_QUEUE_THRESHOLD = 2
+
   def queue_for(course)
     update_longest_update_time(course)
     return 'very_long_update' if course.very_long_update?
+    return 'long_update' if too_many_consecutive_unfinished_updates?(course)
 
     case longest_recent_update_time(course)
     when nil
@@ -15,6 +19,22 @@ module CourseQueueSorting
     when (601..) # more than 10 minutes
       'long_update'
     end
+  end
+
+  def too_many_consecutive_unfinished_updates?(course)
+    consecutive_unfinished_updates(course) >= UNFINISHED_UPDATES_LONG_QUEUE_THRESHOLD
+  end
+
+  # Returns the number of consecutive update failures since the last success.
+  # Old unfinished entries that predate the last successful end_time are excluded,
+  # since they're not evidence of a current problem.
+  def consecutive_unfinished_updates(course)
+    unfinished_logs = course.flags['unfinished_update_logs']
+    return 0 unless unfinished_logs.present?
+
+    finished_logs = course.flags['update_logs']
+    latest_end = finished_logs&.values&.filter_map { |log| log['end_time'].to_f }&.max || 0
+    unfinished_logs.values.count { |log| log['start_time'].to_f > latest_end }
   end
 
   def longest_recent_update_time(course)

--- a/spec/lib/data_cycle/course_queue_sorting_spec.rb
+++ b/spec/lib/data_cycle/course_queue_sorting_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/data_cycle/course_queue_sorting"
+
+describe CourseQueueSorting do
+  let(:including_class) { Class.new { include CourseQueueSorting } }
+  let(:subject) { including_class.new }
+
+  let(:fast_finished_log) do
+    { 1 => { 'start_time' => 10.seconds.ago, 'end_time' => 5.seconds.ago } }
+  end
+
+  describe '#queue_for' do
+    context 'when there are 2 or more consecutive unfinished updates' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: {
+                          'update_logs' => fast_finished_log,
+                          'unfinished_update_logs' => {
+                            1 => { 'start_time' => 4.seconds.ago },
+                            2 => { 'start_time' => 3.seconds.ago }
+                          }
+                        })
+      end
+
+      it 'queues in long_update' do
+        expect(subject.queue_for(course)).to eq 'long_update'
+      end
+    end
+
+    context 'when there is only 1 consecutive unfinished update' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: {
+                          'update_logs' => fast_finished_log,
+                          'unfinished_update_logs' => {
+                            1 => { 'start_time' => 4.seconds.ago }
+                          }
+                        })
+      end
+
+      it 'queues according to the last successful update time' do
+        expect(subject.queue_for(course)).to eq 'short_update'
+      end
+    end
+
+    context 'when there are old unfinished entries that predate the last success' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: {
+                          'update_logs' => fast_finished_log,
+                          'unfinished_update_logs' => {
+                            1 => { 'start_time' => 2.hours.ago },
+                            2 => { 'start_time' => 1.hour.ago }
+                          }
+                        })
+      end
+
+      it 'ignores old entries and queues according to the last successful update time' do
+        expect(subject.queue_for(course)).to eq 'short_update'
+      end
+    end
+  end
+
+  describe '#consecutive_unfinished_updates' do
+    context 'when there are no unfinished logs' do
+      let(:course) { create(:course, start: 1.day.ago, end: 2.months.from_now) }
+
+      it 'returns 0' do
+        expect(subject.consecutive_unfinished_updates(course)).to eq 0
+      end
+    end
+
+    context 'when all unfinished logs are newer than the last successful end_time' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: {
+                          'update_logs' => fast_finished_log,
+                          'unfinished_update_logs' => {
+                            1 => { 'start_time' => 4.seconds.ago },
+                            2 => { 'start_time' => 3.seconds.ago }
+                          }
+                        })
+      end
+
+      it 'counts all of them' do
+        expect(subject.consecutive_unfinished_updates(course)).to eq 2
+      end
+    end
+
+    context 'when unfinished logs predate the last successful end_time' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: {
+                          'update_logs' => fast_finished_log,
+                          'unfinished_update_logs' => {
+                            1 => { 'start_time' => 2.hours.ago },
+                            2 => { 'start_time' => 1.hour.ago }
+                          }
+                        })
+      end
+
+      it 'returns 0' do
+        expect(subject.consecutive_unfinished_updates(course)).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does

`CourseQueueSorting#queue_for` previously determined a course's Sidekiq queue
solely from the timing of its most recent *completed* updates (`update_logs`).
A course stuck on a heavy timeslice would keep accumulating entries in
`unfinished_update_logs` while remaining in `short_update` based on its past
fast completions — tying up short-queue workers and starving other courses.

This was observed in production with course 36303 [Campaña mujeres en tiempos
de guerra 2026](https://outreachdashboard.wmflabs.org/courses/Wikiesfera/Campa%C3%B1a_mujeres_en_tiempos_de_guerra_2026/home) (an article-scoped program):
three consecutive updates started but never finished. While the course seems to be
a small course, it has now 79,272 ACTs, which means at least 79,272 revisions.
The short queue was
restarted once, and it died again apparently because the same course was
re-enqueued into the same short queue.

This PR adds a heuristic: if a course has 2 or more consecutive unfinished
updates since its last successful `end_time`, it is escalated to `long_update`.
Once an update succeeds the counter resets and normal queue-assignment logic
(based on completed-update timings) resumes.

Old `unfinished_update_logs` entries that predate the last successful `end_time`
are excluded, so stale entries from prior incidents don't cause false positives.

## AI usage

Claude Code (claude-sonnet-4-6) was used to implement this change under the
author's direction. The author diagnosed the production incident and proposed the
heuristic; Claude Code translated it into code, wrote the spec, and drafted the
commit message. Iterations included: extracting the threshold into a named
constant (`UNFINISHED_UPDATES_LONG_QUEUE_THRESHOLD`) and refactoring an
overly-long guard line into a `too_many_consecutive_unfinished_updates?`
predicate. The author ran the specs and manually verified the behavior before
committing.

This was a single focused session resulting in one commit. This PR description
was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes.

## Open questions and concerns


(PR description written by Claude Code.)
