### PR TITLE
[ACUWT] Fix discrepancies between default and ACUWT course-update paths

### DIFF
--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -62,6 +62,8 @@ class CourseUserWikiTimeslice < ApplicationRecord
   def self.update_from_acuwt(course, user_id, wiki, start, finish)
     acuwt_records = ArticleCourseUserWikiTimeslice
                       .where(course:, user_id:, wiki:, start:, end: finish)
+    acuwt_records = acuwt_records.where(article_id: course.scoped_article_ids) if
+      course.only_scoped_articles_course?
     cu_timeslice = find_or_create_by(course:, user_id:, wiki:, start:, end: finish)
     cu_timeslice.update_cache_from_acuwt(acuwt_records)
   end

--- a/app/models/course_user_wiki_timeslice.rb
+++ b/app/models/course_user_wiki_timeslice.rb
@@ -91,7 +91,7 @@ class CourseUserWikiTimeslice < ApplicationRecord
     tracked_records = records.reject { |r| excluded_article_ids.include?(r.article_id) }
     by_ns = records_by_namespace(tracked_records)
     update_character_sum_from_acuwt(by_ns)
-    self.revision_count = by_ns.except(nil).values.flatten.sum(&:revision_count)
+    self.revision_count = filtered_live_acuwt_records(tracked_records).sum(&:revision_count)
     save
   end
 
@@ -130,6 +130,12 @@ class CourseUserWikiTimeslice < ApplicationRecord
     @liverevisions.select do |rev|
       live_article_ids.include?(rev.article_id)
     end
+  end
+
+  def filtered_live_acuwt_records(records)
+    article_ids = records.map(&:article_id)
+    live_article_ids = Article.where(id: article_ids, deleted: false).pluck(:id)
+    records.select { |r| live_article_ids.include?(r.article_id) }
   end
 
   def update_character_sum(revisions, tracked_namespace_revisions)

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -131,11 +131,14 @@ class CourseWikiTimeslice < ApplicationRecord
   def acuwt_mainspace_tracked_student_records
     @acuwt_mainspace_tracked_student_records ||= begin
       student_user_ids = @students.pluck(:user_id)
-      ArticleCourseUserWikiTimeslice
-        .joins(:article)
-        .where(course:, wiki:, start:, user_id: student_user_ids)
-        .where.not(article_id: not_tracked_article_ids)
-        .where(articles: { namespace: Article::Namespaces::MAINSPACE, deleted: false })
+      query = ArticleCourseUserWikiTimeslice
+                .joins(:article)
+                .where(course:, wiki:, start:, user_id: student_user_ids)
+                .where.not(article_id: not_tracked_article_ids)
+                .where(articles: { namespace: Article::Namespaces::MAINSPACE, deleted: false })
+      query = query.where(article_id: course.scoped_article_ids) if
+        course.only_scoped_articles_course?
+      query
     end
   end
 

--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -120,10 +120,12 @@ class CourseWikiTimeslice < ApplicationRecord
   end
 
   def update_revision_count_from_acuwt
-    self.revision_count = ArticleCourseUserWikiTimeslice
-                            .where(course:, wiki:, start:)
-                            .where.not(article_id: not_tracked_article_ids)
-                            .sum(:revision_count)
+    query = ArticleCourseUserWikiTimeslice
+              .where(course:, wiki:, start:)
+              .where.not(article_id: not_tracked_article_ids)
+    query = query.where(article_id: course.scoped_article_ids) if
+      course.only_scoped_articles_course?
+    self.revision_count = query.sum(:revision_count)
   end
 
   def acuwt_mainspace_tracked_student_records
@@ -163,9 +165,10 @@ class CourseWikiTimeslice < ApplicationRecord
 
   def update_stats_from_acuwt
     return unless wiki.project == 'wikidata'
-    individual_stats = ArticleCourseUserWikiTimeslice
-                         .where(course:, wiki:, start:)
-                         .map(&:stats).compact
+    query = ArticleCourseUserWikiTimeslice.where(course:, wiki:, start:)
+    query = query.where(article_id: course.scoped_article_ids) if
+      course.only_scoped_articles_course?
+    individual_stats = query.map(&:stats).compact
     self.stats = UpdateWikidataStatsTimeslice.new(course).sum_up_stats(individual_stats)
   end
 

--- a/app/models/wiki_content/category.rb
+++ b/app/models/wiki_content/category.rb
@@ -101,7 +101,11 @@ class Category < ApplicationRecord
 
     @article_ids = []
     article_titles.each_slice(5000) do |titles_batch|
-      @article_ids.concat(Article.where(namespace: 0, wiki_id:, title: titles_batch).pluck(:id))
+      titles_set = titles_batch.to_set
+      # Pluck id+title and filter in Ruby: MySQL's accent-insensitive collation would otherwise
+      # return articles whose titles differ only in diacritics from the requested titles.
+      results = Article.where(namespace: 0, wiki_id:, title: titles_batch).pluck(:id, :title)
+      @article_ids.concat(results.filter_map { |id, title| id if titles_set.include?(title) })
     end
 
     @article_ids

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -225,6 +225,16 @@ RSpec.describe Category, type: :model do
     end
   end
 
+  describe '#article_ids' do
+    it 'excludes articles whose titles differ only in diacritics from the category titles' do
+      accented   = create(:article, title: 'Orgullo_de_Hanói', wiki_id: 1)
+      unaccented = create(:article, title: 'Orgullo_de_Hanoi', wiki_id: 1)
+      category = create(:category, wiki_id: 1, article_titles: ['Orgullo_de_Hanói'])
+      expect(category.article_ids).to     include(accented.id)
+      expect(category.article_ids).not_to include(unaccented.id)
+    end
+  end
+
   describe '.refresh_titles' do
     let(:pt_wiki) { create(:wiki, language: 'pt', project: 'wikipedia') }
     # Portuguese language category with 'Discussão:' in prefixes

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -261,6 +261,30 @@ describe CourseUserWikiTimeslice, type: :model do
       expect(described_class.where(course:, user:, wiki:).count).to eq(1)
       expect(described_class.find_by(course:, user:, wiki:, start:).revision_count).to eq(3)
     end
+
+    context 'when course is article-scoped' do
+      let(:unscoped_article) { create(:article, title: 'Unscoped') }
+
+      before do
+        course.add_flag(key: :article_scoped)
+        create(:assignment, course_id: course.id, article_id: article.id,
+               article_title: article.title, wiki_id: wiki.id)
+        create(:articles_course, article: unscoped_article, course:)
+        create(:article_course_user_wiki_timeslice, course:, article: unscoped_article, wiki:,
+               user:, start:, end: start + 1.day, revision_count: 5,
+               character_sum: 999, references_count: 50)
+      end
+
+      it 'excludes out-of-scope articles' do
+        described_class.update_from_acuwt(course, user.id, wiki, start, start + 1.day)
+        cuwt = described_class.find_by(course:, wiki:, user:, start:)
+        # Only `article` (mainspace) is in scoped_article_ids.
+        # `sandbox` (userspace, no assignment) and `unscoped_article` are excluded.
+        expect(cuwt.revision_count).to eq(2)
+        expect(cuwt.character_sum_ms).to eq(100)
+        expect(cuwt.references_count).to eq(3)
+      end
+    end
   end
 
   describe '#update_cache_from_acuwt' do

--- a/spec/models/course_user_wiki_timeslice_spec.rb
+++ b/spec/models/course_user_wiki_timeslice_spec.rb
@@ -284,6 +284,55 @@ describe CourseUserWikiTimeslice, type: :model do
         expect(cuwt.character_sum_ms).to eq(100)
         expect(cuwt.references_count).to eq(3)
       end
+
+      describe 'known discrepancy: talk-page revisions counted by default path, ' \
+               'excluded by ACUWT path' do
+        # article (mainspace, title: 'Selfie') and talk_page (TALK namespace, title: 'Selfie')
+        # share a title. scoped_article? checks titles only — no namespace filter — so a
+        # Talk:Selfie revision can be marked scoped: true when 'Selfie' appears in
+        # category_article_titles. Category#article_ids queries with namespace: 0, so
+        # talk_page.id never enters scoped_article_ids, while the default path still counts
+        # the talk revision because it trusts the pre-set revision.scoped flag.
+        let(:category) do
+          create(:category, wiki:, name: 'Photography', article_titles: ['Selfie'])
+        end
+        let(:revision_ms_1) do
+          build(:revision_on_memory, article_id: article.id, date: start,
+                 characters: 100, user_id: user.id, scoped: true)
+        end
+        let(:revision_ms_2) do
+          build(:revision_on_memory, article_id: article.id, date: start,
+                 characters: 100, user_id: user.id, scoped: true)
+        end
+        # scoped: true simulates scoped_article? matching 'Selfie' via category_article_titles
+        # without checking whether the revision's article is in mainspace.
+        let(:revision_talk) do
+          build(:revision_on_memory, article_id: talk_page.id, date: start,
+                 characters: 50, user_id: user.id, scoped: true)
+        end
+
+        before do
+          category.courses << course
+          create(:articles_course, article: talk_page, course:)
+          courses_user
+          create(:article_course_user_wiki_timeslice, course:, article: talk_page, wiki:, user:,
+                 start:, end: start + 1.day, revision_count: 1, character_sum: 50,
+                 references_count: 0)
+        end
+
+        it 'counts the talk-page revision in the default path but not in the ACUWT path' do
+          cuwt = create(:course_user_wiki_timeslice, course:, user:, wiki:, start:,
+                        end: start + 1.day)
+          cuwt.update_cache_from_revisions([revision_ms_1, revision_ms_2, revision_talk])
+          # Default path: all three revisions pass (scoped: true, none deleted) → 3
+          expect(cuwt.revision_count).to eq(3)
+
+          described_class.update_from_acuwt(course, user.id, wiki, start, start + 1.day)
+          # Category#article_ids(namespace: 0) → talk_page.id excluded from scoped_article_ids
+          # → only article ACUWT (revision_count: 2) contributes → 2
+          expect(described_class.find_by(course:, wiki:, user:, start:).revision_count).to eq(2)
+        end
+      end
     end
   end
 

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -301,6 +301,27 @@ scoped: false)
         end
       end
 
+      context 'when course is article-scoped' do
+        let(:unscoped_article) { create(:article, id: 10, namespace: 0) }
+
+        before do
+          course.add_flag(key: :article_scoped)
+          create(:assignment, course_id: course.id, article_id: article.id,
+                 article_title: article.title, wiki_id: wiki.id)
+          create(:articles_course, article: unscoped_article, course:)
+          create(:article_course_user_wiki_timeslice, course:, wiki:, article: unscoped_article,
+                 user_id: 1, start:, end: timeslice_end, revision_count: 7)
+        end
+
+        it 'excludes out-of-scope articles from revision_count' do
+          course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+          course_wiki_timeslice.update_cache_from_revisions(array_revisions)
+
+          # Only scoped article ACUWT: 3 + 2 = 5; unscoped article (7) is excluded
+          expect(course_wiki_timeslice.revision_count).to eq(5)
+        end
+      end
+
       context 'when wiki is wikidata' do
         let(:wikidata_wiki) { Wiki.get_or_create(language: nil, project: 'wikidata') }
 
@@ -330,6 +351,29 @@ scoped: false)
           cuwt.update_cache_from_revisions(array_revisions)
 
           expect(cuwt.stats['descriptions added']).to eq(0)
+        end
+
+        context 'when course is article-scoped' do
+          let(:unscoped_article) { create(:article, id: 10, namespace: 0) }
+
+          before do
+            course.add_flag(key: :article_scoped)
+            create(:assignment, course_id: course.id, article_id: article.id,
+                   article_title: article.title, wiki_id: wikidata_wiki.id)
+            create(:articles_course, article: unscoped_article, course:)
+            create(:article_course_user_wiki_timeslice, course:, wiki: wikidata_wiki,
+                   article: unscoped_article, user_id: 1, start:, end: timeslice_end,
+                   stats: { 'claims created' => 99, 'total revisions' => 50 })
+          end
+
+          it 'excludes out-of-scope articles from wikidata stats' do
+            cuwt = described_class.find_by(course:, wiki: wikidata_wiki, start:)
+            cuwt.update_cache_from_revisions(array_revisions)
+
+            # Only scoped article ACUWT: claims created 3+1=4; unscoped (99) excluded
+            expect(cuwt.stats['claims created']).to eq(4)
+            expect(cuwt.stats['total revisions']).to eq(7)
+          end
         end
       end
     end

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -310,7 +310,8 @@ scoped: false)
                  article_title: article.title, wiki_id: wiki.id)
           create(:articles_course, article: unscoped_article, course:)
           create(:article_course_user_wiki_timeslice, course:, wiki:, article: unscoped_article,
-                 user_id: 1, start:, end: timeslice_end, revision_count: 7)
+                 user_id: 1, start:, end: timeslice_end, revision_count: 7,
+                 character_sum: 999, references_count: 50)
         end
 
         it 'excludes out-of-scope articles from revision_count' do
@@ -319,6 +320,22 @@ scoped: false)
 
           # Only scoped article ACUWT: 3 + 2 = 5; unscoped article (7) is excluded
           expect(course_wiki_timeslice.revision_count).to eq(5)
+        end
+
+        it 'excludes out-of-scope articles from character_sum' do
+          course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+          course_wiki_timeslice.update_cache_from_revisions(array_revisions)
+
+          # Only scoped article ACUWT: 500 + 200 = 700; unscoped (999) is excluded
+          expect(course_wiki_timeslice.character_sum).to eq(700)
+        end
+
+        it 'excludes out-of-scope articles from references_count' do
+          course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+          course_wiki_timeslice.update_cache_from_revisions(array_revisions)
+
+          # Only scoped article ACUWT: 3 + 1 = 4; unscoped (50) is excluded
+          expect(course_wiki_timeslice.references_count).to eq(4)
         end
       end
 


### PR DESCRIPTION
## What this PR does

Fixes several discrepancies between the default (revision-based) course-update path and the newer ACUWT-based path introduced for `CourseUserWikiTimeslice` and `CourseWikiTimeslice`.

**Discrepancies fixed:**

- **Missing scoped-article filter on ACUWT aggregation** (`course_wiki_timeslice.rb`, `course_user_wiki_timeslice.rb`): For article-scoped courses (`only_scoped_articles_course?`), the ACUWT-based methods were summing contributions from all articles instead of limiting to `scoped_article_ids`, producing counts higher than the revision-based path.

- **`Category#article_ids` returning diacritic-variant articles** (`category.rb`): The method used a plain SQL `WHERE title IN (...)` query. MySQL's `utf8_unicode_ci` collation is accent-insensitive, so a title like `'Orgullo_de_Hanói'` in the scoped set would also match an unrelated article `'Orgullo_de_Hanoi'`, leaking a spurious ID into `scoped_article_ids`. Fixed by plucking `[:id, :title]` pairs and filtering in Ruby with exact string equality.

- **Missing deleted-article guard on `revision_count`** (`course_user_wiki_timeslice.rb`): `update_cache_from_acuwt` was summing `revision_count` across all namespace-grouped ACUWT records without first filtering out records for soft-deleted articles, unlike the parallel `filtered_live_revisions` check in the default path. Extracted into a `filtered_live_acuwt_records` helper that mirrors that guard.

**Known remaining discrepancy (documented in spec, not fixed):**

The default path marks a revision as scoped via `scoped_article?(wiki, title, mw_page_id)`, which checks article titles with no namespace constraint. A revision on Talk:Selfie can therefore receive `scoped: true` if `'Selfie'` appears in `category_article_titles`, even though it is not a mainspace article.

The ACUWT path cannot replicate this behaviour: it determines scope from `article_id` alone, using `scoped_article_ids`, which is built via `Category#article_ids`. That method queries with `namespace: 0`, so talk-page article IDs never appear in the scoped set. Because scoping decisions are embedded in ACUWT rows at ingestion time (when the revision is processed and `scoped_article?` is called), there is no straightforward way to apply the same title-based, namespace-agnostic logic at aggregation time. A spec at `spec/models/course_user_wiki_timeslice_spec.rb` pins the current behaviour of both paths to make the discrepancy visible.

No UI changes.

## AI usage

Claude Code (`claude-sonnet-4-6`) was used throughout this branch for writing and iterating on model changes and specs. In most sessions the user provided the diagnosis and direction; Claude drafted the code and commit messages. Several fixes were written entirely by Claude under user guidance (the scoped-article filter, the diacritic fix, the deleted-article guard); others were pre-written by the user and brought to Claude for spec coverage and committing.

Commit messages were written by Claude Code using the `/commit` skill, and this PR description was drafted using the `/prepare-pr` skill. All Claude-authored commits carry a `Co-Authored-By: Claude Sonnet 4.6` trailer.

The branch spans roughly 4 days (2026-05-22 to 2026-05-26) across several short focused sessions.

## Screenshots

No UI changes.

## Open questions and concerns

- The talk-page title-match discrepancy is a structural limitation of the ACUWT path: scoped-article decisions for the ACUWT path are made per-article-id at write time, not per-revision-title at read time. Closing the gap would require either (a) propagating namespace information into the ACUWT row, or (b) post-filtering ACUWT records by article namespace when aggregating. Neither is attempted here.

(PR description written by Claude Code.)