### PR TITLE
[ACUWT] Add indexes to article_course_user_wiki_timeslices

### DIFF
--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -70,13 +70,6 @@ class ArticleCourseTimeslice < ApplicationRecord
     ac_timeslice.update_cache_from_revisions revisions[:revisions]
   end
 
-  def self.update_from_acuwt(course, article_id, wiki, start, finish)
-    acuwt_records = ArticleCourseUserWikiTimeslice
-                      .where(course:, article_id:, wiki:, start:, end: finish)
-    ac_timeslice = find_or_create_by(course:, article_id:, start:, end: finish)
-    ac_timeslice.update_cache_from_acuwt(acuwt_records)
-  end
-
   # Bulk-update ACT rows for a single timeslice window from stored ACUWT records.
   # Replaces the per-article find_or_create_by + N aggregate queries with one SELECT
   # (all ACUWT for the window) + one upsert_all.
@@ -114,16 +107,6 @@ class ArticleCourseTimeslice < ApplicationRecord
     self.new_article = revisions.any?(&:new_article)
     # first_revision may be nil if revision count is 0
     self.first_revision = live_revisions.minimum(:date)
-    save
-  end
-
-  def update_cache_from_acuwt(acuwt_records)
-    self.revision_count = acuwt_records.sum(:revision_count)
-    self.character_sum = acuwt_records.sum(:character_sum)
-    self.references_count = acuwt_records.sum(:references_count)
-    self.user_ids = acuwt_records.where('revision_count > 0').pluck(:user_id)
-    self.new_article = acuwt_records.where(new_article: true).exists?
-    self.first_revision = acuwt_records.minimum(:first_revision)
     save
   end
 

--- a/app/models/article_course_timeslice.rb
+++ b/app/models/article_course_timeslice.rb
@@ -77,6 +77,17 @@ class ArticleCourseTimeslice < ApplicationRecord
     ac_timeslice.update_cache_from_acuwt(acuwt_records)
   end
 
+  # Bulk-update ACT rows for a single timeslice window from stored ACUWT records.
+  # Replaces the per-article find_or_create_by + N aggregate queries with one SELECT
+  # (all ACUWT for the window) + one upsert_all.
+  def self.bulk_update_from_acuwt(course, wiki, ts_start, ts_end)
+    records = act_records_from_acuwt(course, wiki, ts_start, ts_end)
+    return if records.empty?
+    upsert_all(records,
+               update_only: %i[revision_count character_sum references_count
+                               user_ids new_article first_revision updated_at])
+  end
+
   def self.log_nil_article_id(course, article_id, wiki_id, revisions)
     Sentry.capture_message "Article id nil for course #{course.id}",
                            level: 'error',
@@ -115,6 +126,29 @@ class ArticleCourseTimeslice < ApplicationRecord
     self.first_revision = acuwt_records.minimum(:first_revision)
     save
   end
+
+  def self.act_records_from_acuwt(course, wiki, ts_start, ts_end)
+    now = Time.current
+    base = { course_id: course.id, start: ts_start, end: ts_end }
+    ArticleCourseUserWikiTimeslice
+      .where(course:, wiki:, start: ts_start, end: ts_end)
+      .group_by(&:article_id)
+      .map do |article_id, rows|
+        { **base, article_id:, created_at: now, updated_at: now,
+          **act_stats_from_acuwt(rows) }
+      end
+  end
+  private_class_method :act_records_from_acuwt
+
+  def self.act_stats_from_acuwt(rows)
+    { revision_count: rows.sum(&:revision_count),
+      character_sum: rows.sum(&:character_sum),
+      references_count: rows.sum(&:references_count),
+      user_ids: rows.select { |r| r.revision_count.positive? }.map(&:user_id),
+      new_article: rows.any?(&:new_article),
+      first_revision: rows.map(&:first_revision).compact.min }
+  end
+  private_class_method :act_stats_from_acuwt
 
   private
 

--- a/app/models/article_course_user_wiki_timeslice.rb
+++ b/app/models/article_course_user_wiki_timeslice.rb
@@ -64,6 +64,16 @@ class ArticleCourseUserWikiTimeslice < ApplicationRecord
     acuw_timeslice.update_cache_from_revisions revisions[:revisions]
   end
 
+  # Bulk-upsert ACUWT rows for a single timeslice window from an array of revision objects.
+  # Replaces the per-(article, user) find_or_create_by + save loop with one upsert_all call.
+  def self.bulk_upsert_from_revisions(course, wiki, ts_start, ts_end, revisions)
+    records = acuwt_records_from_revisions(course, wiki, ts_start, ts_end, revisions)
+    return if records.empty?
+    upsert_all(records,
+               update_only: %i[revision_count character_sum references_count new_article
+                               first_revision stats updated_at])
+  end
+
   ####################
   # Instance methods #
   ####################
@@ -88,4 +98,34 @@ class ArticleCourseUserWikiTimeslice < ApplicationRecord
   def update_wikidata_stats(revisions)
     UpdateWikidataStatsTimeslice.new(course).build_stats_from_revisions(revisions)
   end
+
+  def self.acuwt_records_from_revisions(course, wiki, ts_start, ts_end, revisions)
+    now = Time.current
+    base = { course_id: course.id, wiki_id: wiki.id, start: ts_start, end: ts_end }
+    revisions
+      .reject { |r| r.article_id.nil? || r.user_id.nil? }
+      .group_by { |r| [r.article_id, r.user_id] }
+      .map do |(article_id, user_id), revs|
+        live = revs.reject { |r| r.deleted || r.system }
+        { **base, article_id:, user_id:, created_at: now, updated_at: now,
+          **acuwt_revision_stats(course, wiki, revs, live) }
+      end
+  end
+  private_class_method :acuwt_records_from_revisions
+
+  def self.acuwt_revision_stats(course, wiki, revs, live)
+    { revision_count: live.size,
+      character_sum: live.sum { |r| r.characters.to_i.positive? ? r.characters : 0 },
+      references_count: live.sum(&:references_added),
+      new_article: revs.any?(&:new_article),
+      first_revision: live.map(&:date).min,
+      stats: acuwt_wikidata_stats(course, wiki, live) }
+  end
+  private_class_method :acuwt_revision_stats
+
+  def self.acuwt_wikidata_stats(course, wiki, live_revisions)
+    return unless wiki.project == 'wikidata'
+    UpdateWikidataStatsTimeslice.new(course).build_stats_from_revisions(live_revisions)
+  end
+  private_class_method :acuwt_wikidata_stats
 end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -225,10 +225,7 @@ class UpdateCourseWikiTimeslices
 
   def update_article_course_timeslices_from_acuwt_for_wiki(wiki, revisions)
     timeslice = acuwt_timeslice_for(wiki, revisions)
-    revisions[:revisions].map(&:article_id).uniq.each do |article_id|
-      ArticleCourseTimeslice.update_from_acuwt(@course, article_id, wiki,
-                                               timeslice.start, timeslice.end)
-    end
+    ArticleCourseTimeslice.bulk_update_from_acuwt(@course, wiki, timeslice.start, timeslice.end)
   end
 
   def update_course_user_wiki_timeslices_from_acuwt_for_wiki(wiki, revisions)
@@ -254,11 +251,9 @@ class UpdateCourseWikiTimeslices
 
   def reaggregate_timeslice_from_acuwt(cwt)
     wiki = cwt.wiki
-    acuwt = ArticleCourseUserWikiTimeslice.where(course: @course, wiki:, start: cwt.start)
-    acuwt.pluck(:article_id).uniq.each do |article_id|
-      ArticleCourseTimeslice.update_from_acuwt(@course, article_id, wiki, cwt.start, cwt.end)
-    end
-    acuwt.pluck(:user_id).uniq.each do |user_id|
+    ArticleCourseTimeslice.bulk_update_from_acuwt(@course, wiki, cwt.start, cwt.end)
+    ArticleCourseUserWikiTimeslice.where(course: @course, wiki:, start: cwt.start)
+                                  .pluck(:user_id).uniq.each do |user_id|
       CourseUserWikiTimeslice.update_from_acuwt(@course, user_id, wiki, cwt.start, cwt.end)
     end
     CourseWikiTimeslice.update_from_acuwt(@course, wiki, cwt.start, cwt.end)

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -217,16 +217,10 @@ class UpdateCourseWikiTimeslices
   end
 
   def update_article_course_user_wiki_timeslices_for_wiki(wiki, revisions)
-    start_period = revisions[:start]
-    end_period = revisions[:end]
-    revs = revisions[:revisions]
-    revs.group_by { |r| [r.article_id, r.user_id] }.each do |(article_id, user_id), grouped_revs|
-      article_user_wiki_data = { start: start_period, end: end_period,
-                                 revisions: grouped_revs }
-      ArticleCourseUserWikiTimeslice.update_article_course_user_wiki_timeslices(
-        @course, article_id, user_id, wiki, article_user_wiki_data
-      )
-    end
+    timeslice = acuwt_timeslice_for(wiki, revisions)
+    ArticleCourseUserWikiTimeslice.bulk_upsert_from_revisions(
+      @course, wiki, timeslice.start, timeslice.end, revisions[:revisions]
+    )
   end
 
   def update_article_course_timeslices_from_acuwt_for_wiki(wiki, revisions)

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -91,14 +91,9 @@ class UpdateTimeslicesCourseUser
   end
 
   def create_acuwt_records_for_timeslice(wiki, cwt, revisions)
-    revisions.group_by { |r| [r.article_id, r.user_id] }.each do |(article_id, user_id), revs|
-      next if article_id.nil? || user_id.nil?
-
-      article_user_wiki_data = { start: cwt.start, end: cwt.end, revisions: revs }
-      ArticleCourseUserWikiTimeslice.update_article_course_user_wiki_timeslices(
-        @course, article_id, user_id, wiki, article_user_wiki_data
-      )
-    end
+    ArticleCourseUserWikiTimeslice.bulk_upsert_from_revisions(
+      @course, wiki, cwt.start, cwt.end, revisions
+    )
   end
 
   def fetch_users_revisions_for_wiki(wiki, user_ids)

--- a/db/migrate/20260602000001_add_indexes_to_article_course_user_wiki_timeslices.rb
+++ b/db/migrate/20260602000001_add_indexes_to_article_course_user_wiki_timeslices.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexesToArticleCourseUserWikiTimeslices < ActiveRecord::Migration[7.0]
+  def change
+    add_index :article_course_user_wiki_timeslices,
+              %i[course_id article_id user_id wiki_id start end],
+              unique: true,
+              name: 'index_acuwt_unique'
+    add_index :article_course_user_wiki_timeslices, %i[course_id wiki_id],
+              name: 'index_acuwt_on_course_id_and_wiki_id'
+    add_index :article_course_user_wiki_timeslices, %i[course_id user_id],
+              name: 'index_acuwt_on_course_id_and_user_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_000001) do
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "courses_id"
     t.string "title"
@@ -76,6 +76,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_000001) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.integer "wiki_id", null: false
+    t.index ["course_id", "article_id", "user_id", "wiki_id", "start", "end"], name: "index_acuwt_unique", unique: true
+    t.index ["course_id", "user_id"], name: "index_acuwt_on_course_id_and_user_id"
+    t.index ["course_id", "wiki_id"], name: "index_acuwt_on_course_id_and_wiki_id"
   end
 
   create_table "articles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/models/article_course_timeslice_spec.rb
+++ b/spec/models/article_course_timeslice_spec.rb
@@ -204,46 +204,11 @@ describe ArticleCourseTimeslice, type: :model do
     end
   end
 
-  describe '.update_from_acuwt' do
-    let(:user1) { create(:user, username: 'User1') }
-    let(:user2) { create(:user, username: 'User2') }
-    let(:ts_end) { start + 1.day }
-
-    before do
-      create(:article_course_user_wiki_timeslice, course:, article:, wiki:, user: user1,
-             start:, end: ts_end, revision_count: 2, character_sum: 100,
-             references_count: 3, new_article: true, first_revision: start + 1.hour)
-      create(:article_course_user_wiki_timeslice, course:, article:, wiki:, user: user2,
-             start:, end: ts_end, revision_count: 1, character_sum: 50,
-             references_count: 2, new_article: false, first_revision: start + 3.hours)
-    end
-
-    it 'creates an article course timeslice aggregated from ACUWT' do
-      expect(described_class.find_by(course:, article:, start:)).to be_nil
-      described_class.update_from_acuwt(course, article.id, wiki, start, ts_end)
-      act = described_class.find_by(course:, article:, start:)
-      expect(act.revision_count).to eq(3)
-      expect(act.character_sum).to eq(150)
-      expect(act.references_count).to eq(5)
-      expect(act.new_article).to eq(true)
-      expect(act.user_ids).to contain_exactly(user1.id, user2.id)
-      expect(act.first_revision).to eq(start + 1.hour)
-    end
-
-    it 'updates an existing article course timeslice' do
-      create(:article_course_timeslice, course:, article:, start:, end: ts_end)
-      described_class.update_from_acuwt(course, article.id, wiki, start, ts_end)
-      expect(described_class.where(course:, article:).count).to eq(1)
-      expect(described_class.find_by(course:, article:, start:).revision_count).to eq(3)
-    end
-  end
-
-  describe '#update_cache_from_acuwt' do
+  describe '.bulk_update_from_acuwt' do
     let(:user1) { create(:user, username: 'User1') }
     let(:user2) { create(:user, username: 'User2') }
     let(:user3) { create(:user, username: 'User3') }
     let(:ts_end) { start + 1.day }
-    let(:act) { create(:article_course_timeslice, course:, article:, start:, end: ts_end) }
 
     before do
       create(:article_course_user_wiki_timeslice, course:, article:, wiki:, user: user1,
@@ -257,22 +222,29 @@ describe ArticleCourseTimeslice, type: :model do
              references_count: 0, new_article: false, first_revision: nil)
     end
 
-    let(:acuwt_records) do
-      ArticleCourseUserWikiTimeslice.where(course:, article:, wiki:, start:, end: ts_end)
-    end
-
-    it 'aggregates all cache fields from ACUWT records' do
-      act.update_cache_from_acuwt(acuwt_records)
+    it 'creates an article course timeslice aggregated from ACUWT' do
+      expect(described_class.find_by(course:, article:, start:)).to be_nil
+      described_class.bulk_update_from_acuwt(course, wiki, start, ts_end)
+      act = described_class.find_by(course:, article:, start:)
       expect(act.revision_count).to eq(3)
       expect(act.character_sum).to eq(150)
       expect(act.references_count).to eq(5)
       expect(act.new_article).to eq(true)
+      expect(act.user_ids).to contain_exactly(user1.id, user2.id)
       expect(act.first_revision).to eq(start + 1.hour)
     end
 
+    it 'updates an existing article course timeslice' do
+      create(:article_course_timeslice, course:, article:, start:, end: ts_end)
+      described_class.bulk_update_from_acuwt(course, wiki, start, ts_end)
+      expect(described_class.where(course:, article:).count).to eq(1)
+      expect(described_class.find_by(course:, article:, start:).revision_count).to eq(3)
+    end
+
     it 'only includes in user_ids users with at least one revision' do
-      act.update_cache_from_acuwt(acuwt_records)
-      expect(act.user_ids).to contain_exactly(user1.id, user2.id)
+      described_class.bulk_update_from_acuwt(course, wiki, start, ts_end)
+      expect(described_class.find_by(course:, article:, start:).user_ids)
+        .to contain_exactly(user1.id, user2.id)
     end
   end
 end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -374,13 +374,13 @@ describe UpdateCourseWikiTimeslices do
         allow(CourseWikiTimeslice).to receive(:update_course_wiki_timeslices)
         allow(ArticleCourseUserWikiTimeslice)
           .to receive(:update_article_course_user_wiki_timeslices)
-        allow(ArticleCourseTimeslice).to receive(:update_from_acuwt)
+        allow(ArticleCourseTimeslice).to receive(:bulk_update_from_acuwt)
         allow(CourseUserWikiTimeslice).to receive(:update_from_acuwt)
       end
 
-      it 'calls ArticleCourseTimeslice.update_from_acuwt for articles in revised timeslices' do
-        expect(ArticleCourseTimeslice).to receive(:update_from_acuwt)
-          .with(course, article_id, enwiki, anything, anything).at_least(:once)
+      it 'calls ArticleCourseTimeslice.bulk_update_from_acuwt for revised timeslices' do
+        expect(ArticleCourseTimeslice).to receive(:bulk_update_from_acuwt)
+          .with(course, enwiki, anything, anything).at_least(:once)
         subject
       end
 


### PR DESCRIPTION
## What this PR does

Adds three indexes to `article_course_user_wiki_timeslices` and implements
bulk `upsert_all` writes for ACUWT and ACT rows.

- **Indexes**: unique index on `(course_id, article_id, user_id, wiki_id, start, end)`
  for data integrity, plus `(course_id, wiki_id)` and `(course_id, user_id)` for
  deletion and lookup queries.
- **ACUWT bulk write** (`bulk_upsert_from_revisions`): replaces the per-(article, user)
  `find_or_create_by + save` loop with a single `upsert_all`, reducing write overhead
  from N×3 queries to 2 per timeslice window.
- **ACT bulk write** (`bulk_update_from_acuwt`): replaces the per-article
  `find_or_create_by + N aggregate queries + save` loop with a single SELECT and
  `upsert_all`, reducing N×9 queries to 2 per timeslice window.

## Benchmarks

Small article scoped program on wikidata: [Latinoamérica en Wikidata 2024 - Bolivia.](https://outreachdashboard.wmflabs.org/courses/wikidata/Latinoam%C3%A9rica_en_Wikidata_2024_-_Bolivia_(octubre)/home)


<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Full update | Step | ACUWT path (s) | default path (s) | difference (s)
-- | -- | -- | -- | --
  | wikidata_stats_fetched | 1708.7 | 1738.8 |  
  | revisions_fetched | 31.9 | 32.9 |  
  | acuwt_updated | 14.5 | 0 | 14.5
  | scores_fetched | 10.8 | 11 |  
  | cuwt_updated | 4.3 | 4.2 |  
  | uploads_imported | 4 | 3.9 |  
  | act_updated | 3.7 | 234.6 | -230.9
  | articles_courses_updated | 3.6 | 3.6 |  
  | cwt_updated | 2.3 | 3.6 |  
  | timeslices_recreated | 1.3 | 1.4 |  
  | courses_users_updated | 0.2 | 0.2 |  
  | course_cache_updated | 0.1 | 0.1 |  
  | article_namespaces_updated | 0.1 | 0 |  
  | wikidata_stats_updated | 0 | 0 |  
  | average_pageviews_updated | 0 | 0 |  
  | categories_updated | 0 | 0 |  
  | reaggregation | 0 | 0 |  
  | wiki_namespace_stats_updated | 0 | 0 |  
  | timeslices_processed_3 | 0 | 0 |  
  | Total | 1785.5 | 2034.3 | -248.8

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Remove user | Step | ACUWT path (s) | default path (s) | difference (s)
-- | -- | -- | -- | --
  | wikidata_stats_fetched | 45.5 | 949.2 | -903.7
  | revisions_fetched | 0.8 | 19 | -18.2
  | acuwt_updated | 0.3 | 0 | 0.3
  | scores_fetched | 0 | 6.7 | -6.7
  | cuwt_updated | 0.1 | 2.2 | -2.1
  | uploads_imported | 2.1 | 2.1 |  
  | act_updated | 0.1 | 42.8 | -42.7
  | articles_courses_updated | 2.7 | 0 | 2.7
  | cwt_updated | 0 | 2.2 | -2.2
  | timeslices_recreated | 0 | 0 |  
  | courses_users_updated | 0.1 | 0.1 |  
  | course_cache_updated | 0.1 | 0.1 |  
  | article_namespaces_updated | 0 | 0 |  
  | wikidata_stats_updated | 0 | 0 |  
  | average_pageviews_updated | 26.5 | 27.1 |  
  | categories_updated | 0 | 0 |  
  | reaggregation | 5 | 0 | 5
  | wiki_namespace_stats_updated | 0 | 0 |  
  | timeslices_processed_3 | 0 | 0 |  
  | removed_user_cwt_marked | 0.1 | 0.1 |  
  | Total | 83.4 | 1051.6 | -968.2

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Add new user | Step | ACUWT path (s) | default path (s) | difference (s)
-- | -- | -- | -- | --
  | new_user_revisions_fetched | 394 |   | 394
  | wikidata_stats_fetched | 70.9 | 1337 | -1266.1
  | revisions_fetched | 1 | 22.6 | -21.6
  | acuwt_updated | 0.4 |   | 0.4
  | scores_fetched | 0 | 6.8 | -6.8
  | cuwt_updated | 0.1 | 1.9 | -1.8
  | uploads_imported | 3.8 | 3.9 |  
  | act_updated | 0.1 | 84.9 | -84.8
  | articles_courses_updated | 3 | 0.1 | 2.9
  | cwt_updated | 0.1 | 2.5 | -2.4
  | timeslices_recreated | 0 |   |  
  | courses_users_updated | 0.2 | 0.2 |  
  | course_cache_updated | 0.1 | 0.1 |  
  | article_namespaces_updated | 0 |   |  
  | wikidata_stats_updated | 0 |   |  
  | average_pageviews_updated | 12.7 | 22.2 |  
  | categories_updated | 0 |   |  
  | reaggregation | 6.1 |   | 6.1
  | wiki_namespace_stats_updated | 0 |   |  
  | timeslices_processed_3 | 0 |   |  
  | new_user_acuwt_written | 3 |   |  
  | timeslices_course_user_updated | 0 | 1.7 | -1.7
  | Total | 101.5 | 1483.9 | -1382.4


## AI usage

Claude Code (Sonnet 4.6) was used to analyze query patterns across all callers
of the table to inform index choices, draft the bulk write implementations, and
write commit messages. The human directed all decisions on what to build and ran
all benchmarks.

This PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes.

## Open questions and concerns

The `use_acuwt?` flag must currently be set per-course via `flags[:use_acuwt]`
— there is no admin UI to toggle it. Enabling it for production courses requires
a console or direct DB update.

The CUWT reaggregation step still uses a per-user loop rather than `upsert_all`.
A bulk write optimization there would be a natural follow-up.

