### PR TITLE
Skip unreachable replica DBs instead of flooding Sentry

### DIFF
--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -122,11 +122,10 @@ class Replica # rubocop:disable Metrics/ClassLength
   def api_get(endpoint, query = '')
     tries ||= 3
     response = do_query(endpoint, query)
-    raise unless response.code == '200'
-    response_body = response.body
-    parsed = Oj.load(response_body)
-    raise unless parsed['success']
-    parsed['data']
+    parsed = parse_replica_body(response.body)
+    return parsed['data'] if parsed && parsed['success']
+    return skip_replica_failure(endpoint, parsed) if replica_connection_failure?(parsed)
+    raise "Replica #{endpoint} request failed (HTTP #{response.code})"
   rescue StandardError => e
     tries -= 1
     sleep 2 && retry unless tries.zero?
@@ -135,16 +134,14 @@ class Replica # rubocop:disable Metrics/ClassLength
                               language: @wiki.language, project: @wiki.project })
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def api_post(endpoint, key, data)
     tries ||= 3
     response = do_post(endpoint, key, data)
-    raise unless response.code == '200'
-    return if response.body.empty?
-    parsed = Oj.load(response.body)
-    raise unless parsed['success']
-    parsed['data']
+    return if response.code == '200' && response.body.empty?
+    parsed = parse_replica_body(response.body)
+    return parsed['data'] if parsed && parsed['success']
+    return skip_replica_failure(endpoint, parsed) if replica_connection_failure?(parsed)
+    raise "Replica #{endpoint} request failed (HTTP #{response.code})"
   rescue StandardError => e
     tries -= 1
     sleep 2 && retry unless tries.zero?
@@ -154,8 +151,34 @@ class Replica # rubocop:disable Metrics/ClassLength
                               language: @wiki.language,
                               project: @wiki.project })
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
+
+  # Parse a replica response body into a Hash, or nil when there is no parseable
+  # JSON (an empty body, an HTML error page, etc.).
+  def parse_replica_body(body)
+    return nil if body.blank?
+    Oj.load(body)
+  rescue Oj::ParseError
+    nil
+  end
+
+  # A replica DB *connection* failure, as opposed to a query-level failure.
+  # As of WikiEduDashboardTools PR #22 these return HTTP 502 with a JSON body
+  # carrying an "error" message — e.g. a newly created wiki whose wikireplica
+  # views don't exist yet (see Wikimedia T415977). It is a known, non-transient
+  # per-wiki condition, so we skip the wiki rather than retrying and reporting
+  # every call to Sentry. Query-level failures ({ "success": false } with no
+  # "error" key) still fall through to the hard-error path so they stay visible.
+  def replica_connection_failure?(parsed)
+    parsed.is_a?(Hash) && parsed['success'] == false && parsed['error'].present?
+  end
+
+  def skip_replica_failure(endpoint, parsed)
+    Rails.logger.warn(
+      "Replica #{endpoint} cannot reach #{@wiki.language}.#{@wiki.project}: " \
+      "#{parsed['error']} — skipping this wiki for this update cycle"
+    )
+    nil
+  end
 
   # Finite timeouts on the Replica HTTP call: without them, a silent server
   # leaves the worker blocked in IO#wait_readable forever (holding its

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -280,6 +280,16 @@ describe Replica do
       expect(subject).to be_empty
     end
 
+    it 'skips a wiki whose replica DB is unreachable without reporting to Sentry' do
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
+        .to_return(status: 502,
+                   body: '{ "success": false, "error": "Cannot connect to database" }',
+                   headers: {})
+      expect_any_instance_of(described_class).not_to receive(:log_error)
+      expect(Rails.logger).to receive(:warn).at_least(:once)
+      expect(subject).to be_empty
+    end
+
     it 'handles server errors' do
       stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 500, body: '', headers: {})

--- a/spec/lib/replica_spec.rb
+++ b/spec/lib/replica_spec.rb
@@ -330,6 +330,16 @@ describe Replica do
       expect(result).to be_nil
     end
 
+    it 'skips a wiki whose replica DB is unreachable without reporting to Sentry' do
+      stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
+        .to_return(status: 502,
+                   body: '{ "success": false, "error": "Cannot connect to database" }',
+                   headers: {})
+      expect_any_instance_of(described_class).not_to receive(:log_error)
+      expect(Rails.logger).to receive(:warn).at_least(:once)
+      expect(result).to be_nil
+    end
+
     it 'handles server errors' do
       stub_request(:any, %r{#{Replica::REPLICA_TOOL_URL}.*})
         .to_return(status: 500, body: '', headers: {})


### PR DESCRIPTION
## What this PR does

`Replica#api_get` / `#api_post` used bare `raise unless response.code == '200'`
(and `raise unless parsed['success']`) to handle endpoint failures. A failed
call threw a `RuntimeError` with no message — which Sentry labels "unhandled
exception" — then retried 3× and reported to Sentry at error level.

This became a quota problem. One active P&E Dashboard course (OKI Summer
Internship 2026) tracks 17 wikis including **ur.wikisource**, a newly-created
wiki on replica section s5 whose wikireplica views aren't provisioned yet
(Wikimedia [T415977](https://phabricator.wikimedia.org/T415977), still open).
The replica tool fails on every query for it — ~392 times per ~75-minute update
cycle, **~7,800 Sentry events/day, ~79% of all org error events** — which
exhausted the monthly Sentry error quota.

The replica tool side is already fixed/deployed
([WikiEduDashboardTools #21](https://github.com/WikiEducationFoundation/WikiEduDashboardTools/issues/21),
PR #22): a DB connection failure now returns HTTP 502 with a JSON
`{ "success": false, "error": ... }` body instead of an empty 500. This PR is
the consumer-side half. `api_get` / `api_post` now:

- parse the body once, and return data on `{ "success": true }`;
- on a replica **connection** failure (a `{ "success": false }` body carrying
  an `error` key), log a single `warn` and skip that wiki for the cycle — no
  retry, no Sentry report;
- otherwise raise a **descriptive** error (`"Replica <endpoint> request failed
  (HTTP <code>)"`) so genuine hard failures still retry and report to Sentry,
  and group by a real message instead of "unhandled exception".

Query-level failures (`{ "success": false }` with no `error` key) deliberately
still report to Sentry, so only the known, non-transient connection failure is
suppressed. The result: the ~7,800 Sentry events/day from this course become
~7,800 `warn` logs/day in the Sidekiq log, and stop entirely once T415977 lands
upstream — with no further Dashboard change needed. It also future-proofs
against the next newly-created wiki hitting the same provisioning window.

Addresses the Dashboard side of WikiEduDashboardTools #21.

## AI usage

This change was written by **Claude Code** (`claude-opus-4-8`) under
step-by-step human direction in a single focused session on 2026-06-05 (one
commit). The work began as a Sentry quota investigation: Claude Code triaged
org-wide event volume via the Sentry MCP, drilled into the top issue
(PEONY-2M0), probed the replica endpoint directly with `curl` to isolate
`ur.wikisource` as the sole failing wiki, reproduced the failure locally
against live data with a rails-runner harness, filed the upstream issue
(WikiEduDashboardTools #21), and then wrote this consumer-side fix and its spec.

The human (Sage) directed each phase in short prompts, made the call on which
mitigation to pursue (the durable code fix over a one-off course edit), and
reviewed the result. One correction happened mid-fix: Claude's first attempt
suppressed *all* `{ success: false }` responses, which broke two existing specs
that expect query-level failures to still reach Sentry; it was narrowed to the
connection-failure signature. Final state is `replica_spec` green (30 examples)
and rubocop clean. The commit message and this PR description were also drafted
by Claude Code (via the `/commit` and `/prepare-pr` skills) and, like the rest
of this analysis, may contain errors worth checking against the diff.

## Screenshots

No UI changes — this is a backend change to the replica API client.

## Open questions and concerns

- **The fix keys on the `error` key, not the 502 status**, to track the
  WikiEduDashboardTools response-body contract rather than a transport code. If
  a future tool change moves the connection error into a different shape, the
  skip would silently stop applying (failures would revert to Sentry-reported
  hard errors — noisy, but not data loss).
- **A transient 502 on an otherwise-healthy wiki is now skipped for that
  cycle** rather than retried within the call. The next scheduled update (~75
  min later) recovers it, so the cost is at most one cycle of staleness; this
  is an intentional tradeoff to kill the persistent-failure spam.
- **Volume moves rather than disappears**: expect ~7,800 `warn`/day in the
  `peony-sidekiq-medium` log for this course until T415977 resolves. Not
  Sentry-metered, but worth knowing if anyone watches log volume.
- Scope is intentionally limited to the connection-failure case; broader
  suppression of query-level `{ success: false }` was considered and left out
  to preserve existing Sentry visibility.
