### PR TITLE
 Fix glitches while copying course from another server

### DIFF
--- a/app/controllers/copy_course_controller.rb
+++ b/app/controllers/copy_course_controller.rb
@@ -14,8 +14,8 @@ class CopyCourseController < ApplicationController
                   flash: { error: "Course not created: #{response[:error]}" })
     else
       course = response[:course]
+      course.flags = course.flags.merge(timeline_enabled: true)
       course.update(
-        flags: { timeline_enabled: true },
         cloned_status: 3,
         expected_students: course.expected_students || 0,
         term: ''

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -499,6 +499,14 @@ class Course < ApplicationRecord
     edit_settings['enrollment_edits_enabled']
   end
 
+  FEATURE_FLAG_KEYS = %w[
+    wiki_edits_enabled event_sync peer_review_count timeline_enabled
+    online_volunteers_enabled stay_in_sandbox no_sandboxes
+    retain_available_articles disable_student_emails review_bibliography
+    declined very_long_update max_group_size article_scoped
+    closed_date register_accounts
+  ].freeze
+
   def controlled_by_event_center?
     flags[:event_sync].present?
   end

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -78,15 +78,7 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
   def symbolize_feature_flags(flags_hash)
     return unless flags_hash.is_a?(Hash)
 
-    feature_flag_keys = %w[
-      wiki_edits_enabled event_sync peer_review_count timeline_enabled
-      online_volunteers_enabled stay_in_sandbox no_sandboxes
-      retain_available_articles disable_student_emails review_bibliography
-      declined very_long_update max_group_size article_scoped
-      closed_date register_accounts
-    ]
-
-    feature_flag_keys.each do |key|
+    Course::FEATURE_FLAG_KEYS.each do |key|
       if flags_hash.key?(key)
         flags_hash[key.to_sym] = flags_hash.delete(key)
       end

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -41,6 +41,10 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
       copied_data['flags']['update_logs'] =
         fix_update_logs_parsing(copied_data['flags']['update_logs'])
     end
+    # The flags hash is copied via JSON so all keys are strings.
+    # We must convert known feature flags to symbols because Course model
+    # readers (e.g. peer_review_count) look for symbol keys.
+    symbolize_feature_flags(copied_data['flags'])
     # Create the course
     @course = Course.create!(copied_data)
   end
@@ -69,6 +73,24 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
   # This causes problems, so we need to force the keys to be integers.
   def fix_update_logs_parsing(update_logs)
     update_logs.transform_keys(&:to_i)
+  end
+
+  def symbolize_feature_flags(flags_hash)
+    return unless flags_hash.is_a?(Hash)
+
+    feature_flag_keys = %w[
+      wiki_edits_enabled event_sync peer_review_count timeline_enabled
+      online_volunteers_enabled stay_in_sandbox no_sandboxes
+      retain_available_articles disable_student_emails review_bibliography
+      declined very_long_update max_group_size article_scoped
+      closed_date register_accounts
+    ]
+
+    feature_flag_keys.each do |key|
+      if flags_hash.key?(key)
+        flags_hash[key.to_sym] = flags_hash.delete(key)
+      end
+    end
   end
 
   def add_tracked_wikis

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -160,7 +160,8 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
   def copy_blocks(week, blocks)
     blocks.each do |block_data|
       block = Block.create!(content: block_data['content'], title: block_data['title'],
-                            week_id: week.id, order: block_data['order'], kind: block_data['kind'])
+                            week_id: week.id, order: block_data['order'], kind: block_data['kind'],
+                            due_date: block_data['due_date'], points: block_data['points'])
       update_block_content(block, block_data)
     end
   end
@@ -180,6 +181,8 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
     content_additions.reverse_each do |kind, addition|
       final_content = headings[kind] + addition + final_content unless addition.empty?
     end
+
+    final_content.gsub!('href="/', "href=\"#{@host}/") if final_content.present?
 
     block.update!(content: final_content)
   end

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -291,4 +291,117 @@ describe CopyCourse do
       expect(block.content).to include('<h4 class="timeline-exercise">Exercise</h4>')
     end
   end
+
+  describe 'additional copy features' do
+    let(:slug) { 'University_of_South_Carolina/Invertebrate_Zoology_(COPIED_FROM_Spring_2022)' }
+    let(:course_url) { url_base + slug + '/course.json' }
+    let(:categories_url) { url_base + slug + '/categories.json' }
+    let(:users_url) { url_base + slug + '/users.json' }
+    let(:timeline_url) { url_base + slug + '/timeline.json' }
+    let(:training_modules_url) { @selected_dashboard + '/training_modules.json' }
+
+    let(:course_response_body) do
+      {
+        course: {
+          id: 15_907,
+          slug: 'University_of_South_Carolina/Invertebrate_Zoology_(Spring_2022)',
+          school: 'University of South Carolina',
+          title: 'Invertebrate Zoology',
+          term: 'Spring 2022',
+          start: '2022-01-11T00:00:00.000Z',
+          end: '2022-04-30T23:59:59.000Z',
+          type: 'ClassroomProgramCourse',
+          home_wiki: { id: 1, language: 'en', project: 'wikipedia' },
+          flags: { 'peer_review_count' => 2, 'online_volunteers_enabled' => true },
+          training_library_slug: 'students',
+          wikis: [{ language: 'en', project: 'wikipedia' }]
+        }
+      }.to_json
+    end
+
+    let(:categories_response_body) { { course: { categories: [] } }.to_json }
+    let(:users_response_body) { { course: { users: [] } }.to_json }
+
+    let(:timeline_response_body) do
+      {
+        course: {
+          weeks: [
+            {
+              id: 57_366, order: 1, title: 'Week 1',
+              blocks: [
+                {
+                  id: 1, kind: 0, week_id: 57_366, order: 1,
+                  title: 'Journal',
+                  content: 'See <a href="/training/students/' \
+                           'keeping-a-research-journal">the journal</a> ' \
+                           'and <a href="https://en.wikipedia.org/wiki/Foo">Foo</a>.',
+                  due_date: nil, points: nil, training_module_ids: []
+                },
+                {
+                  id: 2, kind: 1, week_id: 57_366, order: 2,
+                  title: 'Custom assignment',
+                  content: 'Do the thing.',
+                  due_date: '2022-03-15', points: 25, training_module_ids: []
+                }
+              ]
+            }
+          ]
+        }
+      }.to_json
+    end
+
+    def stub_all_requests
+      stub_request(:get, course_url).to_return(status: 200, body: course_response_body)
+      stub_request(:get, categories_url).to_return(status: 200, body: categories_response_body)
+      stub_request(:get, users_url).to_return(status: 200, body: users_response_body)
+      stub_request(:get, timeline_url).to_return(status: 200, body: timeline_response_body)
+      stub_request(:get, training_modules_url)
+        .to_return(status: 200, body: { training_modules: [] }.to_json)
+    end
+
+    let(:copied_course) do
+      described_class.new(url: url_base + slug, user_data: '0').make_copy
+      Course.find_by(slug: slug)
+    end
+
+    describe 'flag preservation' do
+      before { stub_all_requests }
+
+      it 'keeps the raw flags hash from the source course' do
+        expect(copied_course.flags).to include(peer_review_count: 2)
+      end
+
+      it 'exposes peer_review_count through the model reader after copy' do
+        expect(copied_course.peer_review_count).to eq(2)
+      end
+
+      it 'exposes online_volunteers_enabled? through the model reader after copy' do
+        expect(copied_course.online_volunteers_enabled?).to eq(true)
+      end
+    end
+
+    describe 'relative link rewriting' do
+      before { stub_all_requests }
+
+      it 'rewrites relative hrefs to absolute against the source host' do
+        block = copied_course.weeks.first.blocks.find_by(title: 'Journal')
+        expect(block.content).to include('href="https://dashboard.wikiedu.org/training/students/')
+      end
+
+      it 'leaves already-absolute hrefs untouched' do
+        block = copied_course.weeks.first.blocks.find_by(title: 'Journal')
+        expect(block.content).to include('href="https://en.wikipedia.org/wiki/Foo"')
+      end
+    end
+
+    describe 'custom assignment fields' do
+      before { stub_all_requests }
+
+      it 'preserves due_date and points' do
+        block = copied_course.weeks.first.blocks.find_by(title: 'Custom assignment')
+        expect(block.due_date).to eq(Date.parse('2022-03-15'))
+        expect(block.points).to eq(25)
+      end
+    end
+  end
 end


### PR DESCRIPTION

#### What this PR does
This PR addresses three data-loss and formatting glitches that occur when copying a course from another server (e.g., from WikiEdu to Outreach Dashboard):
1. **Preserve `flags` when copying:**  The code now uses `.merge(timeline_enabled: true)` to ensure existing flags are safely preserved.
2. **Convert relative links to absolute links in timeline content:** The `CopyCourse` service now checks the block content and prepends the original server's `@host` to any relative `href="/..."` paths.
3. **Preserve custom assignment `due_date` and `points`:** When creating new blocks from the copied timeline data, the previous code mapped the title and content but ignored the `due_date` and `points` properties. These attributes are now explicitly mapped and saved on the new `Block` record to prevent data loss for custom assignments.

addresses #6550 
