### PR TITLE
Fix text overflow in Milestones sidebar and Timeline blocks

### DIFF
--- a/app/assets/stylesheets/modules/_overview.styl
+++ b/app/assets/stylesheets/modules/_overview.styl
@@ -32,6 +32,7 @@
       opacity 0.5
   .markdown
     color body-color
+    word-break break-word
   .section-header:last-child
     margin-bottom 0
     hr

--- a/app/assets/stylesheets/modules/_overview.styl
+++ b/app/assets/stylesheets/modules/_overview.styl
@@ -32,7 +32,7 @@
       opacity 0.5
   .markdown
     color body-color
-    word-break break-word
+    overflow-wrap anywhere
   .section-header:last-child
     margin-bottom 0
     hr

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -87,7 +87,7 @@
 
 .block__block-content
   color $text_dk
-  word-break break-word
+  overflow-wrap anywhere
 
 .block.block--orderable
   display flex

--- a/app/assets/stylesheets/modules/_timeline.styl
+++ b/app/assets/stylesheets/modules/_timeline.styl
@@ -87,6 +87,7 @@
 
 .block__block-content
   color $text_dk
+  word-break break-word
 
 .block.block--orderable
   display flex


### PR DESCRIPTION
#### Problem
While reproducing the bug #6550 during copying the course https://dashboard.wikiedu.org/courses/University_of_California_Santa_Cruz/Antarctic_Ecology,_Geology,_History,_and_Policy_(Spring_2026)/home , we can see the text overflow in Milestones section.

#### what does PR do
Added the `word-break: break-word` CSS property directly to the `.markdown` container inside `.milestones` (`_overview.styl`) and the `.block__block-content` container (`_timeline.styl`). 


## Screenshots
Before:
<img width="1297" height="814" alt="Screenshot 2026-06-06 at 4 02 24 PM" src="https://github.com/user-attachments/assets/8cf413cf-0cc5-4a93-b6e6-b513defff602" />


After:
<img width="1057" height="474" alt="Screenshot 2026-06-06 at 5 25 54 PM" src="https://github.com/user-attachments/assets/c033e602-73e8-48ee-88ae-ec2e2aa58951" />

