### PR TITLE
Populates the registered_at field when a new user Joins a course

### DIFF
--- a/app/workers/fetch_user_registration_worker.rb
+++ b/app/workers/fetch_user_registration_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/importers/user_importer"
+
+class FetchUserRegistrationWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return unless user
+    UserImporter.update_users([user])
+  end
+end

--- a/lib/importers/user_importer.rb
+++ b/lib/importers/user_importer.rb
@@ -15,12 +15,15 @@ class UserImporter
   end
 
   def self.new_from_omniauth(auth)
-    User.create(
+    user = User.create(
       username: auth.info.name,
       global_id: auth.uid,
       wiki_token: auth.credentials.token,
       wiki_secret: auth.credentials.secret
     )
+    # Populates the registered_at field when ever a new user is created via omniauth
+    FetchUserRegistrationWorker.perform_async(user.id)
+    user
   end
 
   LTR_MARK = 8206.chr # left-to-right mark, Ruby character 8206
@@ -43,7 +46,10 @@ class UserImporter
 
     # At this point, if we still can't find a record with this username,
     # we finally create and return it.
-    return User.find_or_create_by(username:)
+    user = User.find_or_create_by(username:)
+    # Populates the registered_at field for any user enrolled or added into the course
+    FetchUserRegistrationWorker.perform_async(user.id) if user.registered_at.nil?
+    user
   end
 
   # There are some users who have a local wiki account, but do not have one

--- a/spec/workers/fetch_user_registration_worker_spec.rb
+++ b/spec/workers/fetch_user_registration_worker_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/app/workers/fetch_user_registration_worker"
+
+describe FetchUserRegistrationWorker do
+  let(:user) { create(:user, registered_at: nil) }
+
+  it 'calls UserImporter.update_users with the user' do
+    expect(UserImporter).to receive(:update_users).with([user])
+    described_class.new.perform(user.id)
+  end
+
+  it 'does nothing when the user does not exist' do
+    expect(UserImporter).not_to receive(:update_users)
+    described_class.new.perform(0)
+  end
+end


### PR DESCRIPTION
## What this PR does
This PR resolve #6886  by  populating  the registered_at field immediately as a background job whenever a new User is created or joins a course

## AI usage
Used AI to debug why the registered_at field was not being populated and implementing the fix
