### PR TITLE
[ACUWT] Implement ACUWT path in UpdateTimeslicesScopedArticle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,7 @@ Metrics/ClassLength:
     - 'lib/timeslice_manager.rb'
     - 'app/services/check_revision_with_pangram.rb'
     - 'app/services/push_course_to_salesforce.rb'
+    - 'lib/revision_data_manager.rb'
 
 Metrics/AbcSize:
   Max: 23 # We should bring this down, ideally to the default of 15

--- a/app/models/article_course_user_wiki_timeslice.rb
+++ b/app/models/article_course_user_wiki_timeslice.rb
@@ -64,6 +64,21 @@ class ArticleCourseUserWikiTimeslice < ApplicationRecord
     acuw_timeslice.update_cache_from_revisions revisions[:revisions]
   end
 
+  # Returns distinct (start, end) pairs for rows matching the given course, wiki, and articles.
+  # Used by UpdateTimeslicesScopedArticle to iterate over timeslice windows that need rescoring.
+  def self.periods_for_articles(course, wiki, article_ids)
+    where(course:, wiki:, article_id: article_ids)
+      .distinct.pluck(:start, :end)
+  end
+
+  # Returns Users who have ACUWT rows for the given course, wiki, articles, and period start.
+  # Used by UpdateTimeslicesScopedArticle to find which users to re-fetch revisions for.
+  def self.users_for_articles_in_period(course, wiki, article_ids, ts_start)
+    user_ids = where(course:, wiki:, article_id: article_ids, start: ts_start)
+                 .distinct.pluck(:user_id)
+    User.where(id: user_ids)
+  end
+
   # Bulk-upsert ACUWT rows for a single timeslice window from an array of revision objects.
   # Replaces the per-(article, user) find_or_create_by + save loop with one upsert_all call.
   def self.bulk_upsert_from_revisions(course, wiki, ts_start, ts_end, revisions)

--- a/app/services/prepare_timeslices.rb
+++ b/app/services/prepare_timeslices.rb
@@ -36,7 +36,7 @@ class PrepareTimeslices
     UpdateTimeslicesCourseUser.new(@course, update_service: @update_service).run
     UpdateTimeslicesUntrackedArticle.new(@course).run
     UpdateTimeslicesCourseDate.new(@course).run
-    UpdateTimeslicesScopedArticle.new(@course).run
+    UpdateTimeslicesScopedArticle.new(@course, update_service: @update_service).run
     @debugger.log_update_progress :timeslices_adjusted
   end
 end

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -93,13 +93,15 @@ class UpdateTimeslicesScopedArticle
   # Also creates articles_courses records as a side effect of the revision fetch.
   def fetch_scores_and_update_acuwt(wiki, article_ids)
     manager = RevisionDataManager.new(wiki, @course, update_service: @update_service)
-    acuwt_periods(wiki, article_ids).each do |(ts_start, ts_end)|
+    periods = ArticleCourseUserWikiTimeslice.periods_for_articles(@course, wiki, article_ids)
+    periods.each do |(ts_start, ts_end)|
       update_timeslice_for_new_articles(manager, wiki, article_ids, ts_start, ts_end)
     end
   end
 
   def update_timeslice_for_new_articles(manager, wiki, article_ids, ts_start, ts_end)
-    users = users_for_articles_in_period(wiki, article_ids, ts_start)
+    users = ArticleCourseUserWikiTimeslice
+              .users_for_articles_in_period(@course, wiki, article_ids, ts_start)
     return if users.empty?
 
     revisions = manager.fetch_revision_data_for_users_with_articles_only(
@@ -117,19 +119,6 @@ class UpdateTimeslicesScopedArticle
     ArticleCourseUserWikiTimeslice.bulk_upsert_from_revisions(
       @course, wiki, ts_start, ts_end, revisions
     )
-  end
-
-  def acuwt_periods(wiki, article_ids)
-    ArticleCourseUserWikiTimeslice
-      .where(course: @course, wiki:, article_id: article_ids)
-      .distinct.pluck(:start, :end)
-  end
-
-  def users_for_articles_in_period(wiki, article_ids, ts_start)
-    user_ids = ArticleCourseUserWikiTimeslice
-                 .where(course: @course, wiki:, article_id: article_ids, start: ts_start)
-                 .distinct.pluck(:user_id)
-    User.where(id: user_ids)
   end
 
   def update_wikidata_stats(wiki, revisions)

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -1,52 +1,180 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/timeslice_cleaner"
 require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
 require_dependency "#{Rails.root}/lib/revision_data_manager"
 
-# Set as 'needs_update' timeslices associated to new scoped articles
-# or to articles that are not scoped anymore due to changes in assignments
-# and categories.
-# Only for ArticleScopedProgram and VisitingScholarship courses
+# Adjusts timeslices when articles enter or leave scope in ArticleScopedProgram
+# and VisitingScholarship courses.
+#
+# ACUWT path (course.use_acuwt? == true):
+#   New articles (scoped, no articles_courses, but ACUWT rows exist from a prior update
+#   when they were unscoped — those rows have revision data but zero references_count
+#   and no wikidata stats): re-fetches revisions per timeslice period, filters to the
+#   specific articles BEFORE the expensive reference-counter API call, upserts those
+#   ACUWT rows with correct data, then marks the affected CWT timeslices for
+#   reaggregation so ACT/CUWT/CWT are rebuilt without a full MediaWiki re-fetch.
+#
+#   Old articles (articles_courses present but no longer scoped): removes the
+#   articles_courses and ACUWT rows, then marks affected CWT timeslices for reaggregation.
+#
+# Legacy path (course.use_acuwt? == false):
+#   Both cases are handled by ArticlesCoursesCleanerTimeslice, marking CWT timeslices
+#   as needs_update for a full re-fetch.
 class UpdateTimeslicesScopedArticle
-  def initialize(course)
+  def initialize(course, update_service: nil)
     @course = course
-    @timeslice_manager = TimesliceManager.new(course)
+    @timeslice_cleaner = TimesliceCleaner.new(course)
     @scoped_article_ids = course.scoped_article_ids
+    @update_service = update_service
   end
 
   def run
     return unless @course.only_scoped_articles_course?
-    # Get the scoped articles that don't have articles courses but do have ac timeslices
-    articles_with_timeslices = @course.article_course_timeslices
-                                      .where(article_id: @scoped_article_ids)
-                                      .pluck(:article_id)
 
-    tracked_articles = @course.articles_courses
-                              .where(article_id: @scoped_article_ids)
-                              .pluck(:article_id)
-
-    new_articles = articles_with_timeslices - tracked_articles
-    reset(new_articles)
-
-    # Get not-scoped articles with article course records
-    old_articles = @course.articles_courses
-                          .where.not(article_id: @scoped_article_ids)
-                          .pluck(:article_id)
-
-    reset(old_articles)
+    if @course.use_acuwt?
+      handle_new_articles_acuwt
+      handle_old_articles_acuwt
+    else
+      handle_new_articles_legacy
+      handle_old_articles_legacy
+    end
   end
 
   private
 
-  def reset(article_ids)
+  ###############
+  # ACUWT paths #
+  ###############
+
+  def handle_new_articles_acuwt
+    new_article_ids = new_article_ids_with_acuwt_rows
+    return if new_article_ids.empty?
+
+    log_info "Fetching scores for new scoped articles: #{new_article_ids}"
+
+    @course.wikis.each do |wiki|
+      fetch_scores_and_update_acuwt(wiki, new_article_ids)
+    end
+
+    acuwt = ArticleCourseUserWikiTimeslice.where(course: @course, article_id: new_article_ids)
+    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+  end
+
+  def handle_old_articles_acuwt
+    old_article_ids = unscoped_article_ids
+    return if old_article_ids.empty?
+
+    log_info "Removing old unscoped articles: #{old_article_ids}"
+
+    acuwt = ArticleCourseUserWikiTimeslice.where(course: @course, article_id: old_article_ids)
+    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    ArticlesCourses.where(course: @course, article_id: old_article_ids).delete_all
+  end
+
+  # Scoped article IDs that lack articles_courses records but have existing ACUWT rows
+  # (created when the articles were unscoped and scores were not fetched).
+  def new_article_ids_with_acuwt_rows
+    tracked_ids = @course.articles_courses
+                         .where(article_id: @scoped_article_ids)
+                         .pluck(:article_id)
+    untracked_scoped_ids = @scoped_article_ids - tracked_ids
+    return [] if untracked_scoped_ids.empty?
+
+    ArticleCourseUserWikiTimeslice
+      .where(course: @course, article_id: untracked_scoped_ids)
+      .distinct.pluck(:article_id)
+  end
+
+  # For each timeslice period with ACUWT rows for the given articles, re-fetches
+  # revisions for the relevant users, filters to the target articles before calling
+  # the reference-counter API, then upserts the ACUWT rows with correct scores.
+  # Also creates articles_courses records as a side effect of the revision fetch.
+  def fetch_scores_and_update_acuwt(wiki, article_ids)
+    manager = RevisionDataManager.new(wiki, @course, update_service: @update_service)
+    acuwt_periods(wiki, article_ids).each do |(ts_start, ts_end)|
+      update_timeslice_for_new_articles(manager, wiki, article_ids, ts_start, ts_end)
+    end
+  end
+
+  def update_timeslice_for_new_articles(manager, wiki, article_ids, ts_start, ts_end)
+    users = users_for_articles_in_period(wiki, article_ids, ts_start)
+    return if users.empty?
+
+    revisions = manager.fetch_revision_data_for_users_with_articles_only(
+      users,
+      ts_start.strftime('%Y%m%d%H%M%S'),
+      (ts_end - 1.second).strftime('%Y%m%d%H%M%S')
+    )
+    # Filter to target articles BEFORE the expensive reference-counter API call
+    revisions.select! { |r| article_ids.include?(r.article_id) }
+    return if revisions.empty?
+
+    revisions = manager.fetch_score_data_for_course(revisions)
+    update_wikidata_stats(wiki, revisions) if wiki.project == 'wikidata'
+    ArticlesCourses.update_from_course_revisions(@course, revisions)
+    ArticleCourseUserWikiTimeslice.bulk_upsert_from_revisions(
+      @course, wiki, ts_start, ts_end, revisions
+    )
+  end
+
+  def acuwt_periods(wiki, article_ids)
+    ArticleCourseUserWikiTimeslice
+      .where(course: @course, wiki:, article_id: article_ids)
+      .distinct.pluck(:start, :end)
+  end
+
+  def users_for_articles_in_period(wiki, article_ids, ts_start)
+    user_ids = ArticleCourseUserWikiTimeslice
+                 .where(course: @course, wiki:, article_id: article_ids, start: ts_start)
+                 .distinct.pluck(:user_id)
+    User.where(id: user_ids)
+  end
+
+  def update_wikidata_stats(wiki, revisions)
+    live_revisions = revisions.reject(&:deleted)
+    UpdateWikidataStatsTimeslice.new(@course).update_revisions_with_stats(live_revisions)
+  end
+
+  ################
+  # Legacy paths #
+  ################
+
+  def handle_new_articles_legacy
+    articles_with_timeslices = @course.article_course_timeslices
+                                      .where(article_id: @scoped_article_ids)
+                                      .pluck(:article_id)
+    tracked_articles = @course.articles_courses
+                              .where(article_id: @scoped_article_ids)
+                              .pluck(:article_id)
+    reset_legacy(articles_with_timeslices - tracked_articles)
+  end
+
+  def handle_old_articles_legacy
+    reset_legacy(unscoped_article_ids)
+  end
+
+  def reset_legacy(article_ids)
     return if article_ids.empty?
 
-    Rails.logger.info "UpdateTimeslicesScopedArticle: Course: #{@course.slug}\
-    Resetting #{article_ids}"
+    log_info "Resetting #{article_ids}"
 
-    # Mark course wiki timeslices to be re-processed
     articles = Article.where(id: article_ids)
     ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, articles)
+  end
+
+  ###########
+  # Helpers #
+  ###########
+
+  def unscoped_article_ids
+    @course.articles_courses
+           .where.not(article_id: @scoped_article_ids)
+           .pluck(:article_id)
+  end
+
+  def log_info(message)
+    Rails.logger.info "UpdateTimeslicesScopedArticle: Course: #{@course.slug} #{message}"
   end
 end

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -16,7 +16,7 @@ require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
 #      since fetching scores can be expensive.
 # 2. To fetch revisions (without scores) for a given set of users over a period:
 #    - Use `fetch_revision_data_for_users` as the entry point.
-class RevisionDataManager
+class RevisionDataManager # rubocop:disable Metrics/ClassLength
   include EncodingHelper
 
   def initialize(wiki, course, update_service: nil)
@@ -78,10 +78,10 @@ class RevisionDataManager
     sub_data_to_revision_attributes(all_sub_data, users)
   end
 
-  # Like fetch_revision_data_for_users, but also imports Article records and fetches
-  # scores so that returned revisions have article_id and references_added populated.
-  # Required when creating ACUWT rows for newly added users.
-  def fetch_revision_data_for_users_with_articles(users, timeslice_start, timeslice_end)
+  # Like fetch_revision_data_for_users_with_articles but skips the reference-counter
+  # API call. Filter the returned revisions to specific articles before calling
+  # fetch_score_data_for_course — critical when users have many programmatic edits.
+  def fetch_revision_data_for_users_with_articles_only(users, timeslice_start, timeslice_end)
     all_sub_data = get_course_revisions(users, timeslice_start, timeslice_end)
     return [] if all_sub_data.empty?
 
@@ -95,7 +95,13 @@ class RevisionDataManager
     users_dict = user_dict_from_sub_data(all_sub_data)
     article_dict = articles.each_with_object({}) { |a, memo| memo[a.mw_page_id] = a.id }
 
-    revisions = sub_data_to_revision_attributes(all_sub_data, users_dict, articles: article_dict)
+    sub_data_to_revision_attributes(all_sub_data, users_dict, articles: article_dict)
+  end
+
+  # Like fetch_revision_data_for_users_with_articles_only but also fetches scores.
+  def fetch_revision_data_for_users_with_articles(users, timeslice_start, timeslice_end)
+    revisions = fetch_revision_data_for_users_with_articles_only(users, timeslice_start,
+                                                                 timeslice_end)
     fetch_score_data_for_course(revisions)
   end
 

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -8,7 +8,7 @@ require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
 
 #= Fetches revision data from API
-# This class is intended to be used in two main ways:
+# This class is intended to be used in four main ways:
 # 1. To fetch revisions and scores for a given course over a period:
 #    - First, fetch the revisions using `fetch_revision_data_for_course`.
 #    - Then, fetch the scores by calling `fetch_score_data_for_course`, passing the array
@@ -16,6 +16,14 @@ require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
 #      since fetching scores can be expensive.
 # 2. To fetch revisions (without scores) for a given set of users over a period:
 #    - Use `fetch_revision_data_for_users` as the entry point.
+# 3. To fetch revisions and scores for a given set of users over a period, also importing
+#    Article records as a side effect (used by UpdateTimeslicesScopedArticle):
+#    - Use `fetch_revision_data_for_users_with_articles_only` to get revisions with articles.
+#    - Filter the returned revisions to the target articles.
+#    - Then call `fetch_score_data_for_course` on the filtered revisions.
+# 4. To fetch revisions, import Article records, and fetch scores for a given set of users
+#    over a period in one step (used by CourseRevisionUpdater for new users):
+#    - Use `fetch_revision_data_for_users_with_articles` as the entry point.
 class RevisionDataManager # rubocop:disable Metrics/ClassLength
   include EncodingHelper
 

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -24,7 +24,7 @@ require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
 # 4. To fetch revisions, import Article records, and fetch scores for a given set of users
 #    over a period in one step (used by CourseRevisionUpdater for new users):
 #    - Use `fetch_revision_data_for_users_with_articles` as the entry point.
-class RevisionDataManager # rubocop:disable Metrics/ClassLength
+class RevisionDataManager
   include EncodingHelper
 
   def initialize(wiki, course, update_service: nil)

--- a/spec/services/update_timeslices_scoped_article_spec.rb
+++ b/spec/services/update_timeslices_scoped_article_spec.rb
@@ -11,7 +11,8 @@ describe UpdateTimeslicesScopedArticle do
   let(:assigned_article) { create(:article, title: 'Assigned', id: 2, namespace: 0) }
   let(:random_article) { create(:article, title: 'Random', id: 1, namespace: 0) }
 
-  context 'for ArticleScopedProgram' do
+  # Legacy path: course without use_acuwt? set
+  context 'for ArticleScopedProgram (legacy path)' do
     before do
       enwiki = Wiki.get_or_create(language: 'en', project: 'wikipedia')
       user = create(:user, username: 'Ragesoss')
@@ -45,6 +46,99 @@ describe UpdateTimeslicesScopedArticle do
       expect(course.article_course_timeslices.where(article_id: random_article.id).count).to eq(0)
       expect(course.articles_courses.count).to eq(1)
       expect(course.articles_courses.where(article_id: random_article).count).to eq(0)
+    end
+  end
+
+  # ACUWT path: course with use_acuwt? set
+  context 'for ArticleScopedProgram (ACUWT path)' do
+    let(:acuwt_course) { create(:article_scoped_program, flags: { use_acuwt: true }) }
+    let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:user) { create(:user, username: 'Ragesoss') }
+
+    before do
+      create(:assignment, user_id: user.id, course_id: acuwt_course.id, article_id: 2,
+             article_title: 'Assigned')
+      manager = TimesliceManager.new(acuwt_course)
+      manager.create_timeslices_for_new_course_wiki_records([enwiki])
+    end
+
+    it 'fetches scores and sets needs_reaggregation for new scoped articles' do
+      create(:article_course_user_wiki_timeslice,
+             course: acuwt_course, article: assigned_article, user:, wiki: enwiki,
+             start: acuwt_course.start, end: acuwt_course.start + 1.day,
+             revision_count: 3, references_count: 0)
+      create(:article_course_timeslice, course: acuwt_course, article: assigned_article,
+             start: acuwt_course.start)
+
+      revision = build(:revision_on_memory,
+                       article_id: assigned_article.id, user_id: user.id, wiki_id: enwiki.id,
+                       mw_rev_id: 12345, mw_page_id: assigned_article.mw_page_id,
+                       date: acuwt_course.start + 1.hour, scoped: true, new_article: false)
+      allow_any_instance_of(RevisionDataManager)
+        .to receive(:fetch_revision_data_for_users_with_articles_only).and_return([revision])
+      allow_any_instance_of(RevisionDataManager)
+        .to receive(:fetch_score_data_for_course).and_return([revision])
+
+      described_class.new(acuwt_course).run
+
+      expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(1)
+      expect(acuwt_course.course_wiki_timeslices.where(needs_update: true).count).to eq(0)
+      expect(acuwt_course.article_course_timeslices
+                         .where(article_id: assigned_article.id).count).to eq(0)
+    end
+
+    it 'filters to target articles before calling the reference-counter API' do
+      create(:article_course_user_wiki_timeslice,
+             course: acuwt_course, article: assigned_article, user:, wiki: enwiki,
+             start: acuwt_course.start, end: acuwt_course.start + 1.day,
+             revision_count: 1, references_count: 0)
+
+      unrelated_revision = build(:revision_on_memory,
+                                 article_id: random_article.id, user_id: user.id,
+                                 wiki_id: enwiki.id, mw_rev_id: 99999,
+                                 mw_page_id: random_article.mw_page_id,
+                                 date: acuwt_course.start + 1.hour, scoped: false)
+      target_revision = build(:revision_on_memory,
+                              article_id: assigned_article.id, user_id: user.id,
+                              wiki_id: enwiki.id, mw_rev_id: 12345,
+                              mw_page_id: assigned_article.mw_page_id,
+                              date: acuwt_course.start + 1.hour, scoped: true)
+
+      allow_any_instance_of(RevisionDataManager)
+        .to receive(:fetch_revision_data_for_users_with_articles_only)
+        .and_return([unrelated_revision, target_revision])
+
+      # Reference-counter API must only be called with the filtered target revision
+      expect_any_instance_of(RevisionDataManager)
+        .to receive(:fetch_score_data_for_course)
+        .with([target_revision])
+        .and_return([target_revision])
+
+      described_class.new(acuwt_course).run
+    end
+
+    it 'sets needs_reaggregation and removes old unscoped articles' do
+      create(:articles_course, course: acuwt_course, article: assigned_article)
+      create(:articles_course, course: acuwt_course, article: random_article)
+      create(:article_course_user_wiki_timeslice,
+             course: acuwt_course, article: random_article, user:, wiki: enwiki,
+             start: acuwt_course.start + 1.day, end: acuwt_course.start + 2.days,
+             revision_count: 2, references_count: 0)
+      create(:article_course_timeslice, course: acuwt_course, article: random_article,
+             start: acuwt_course.start + 1.day)
+
+      described_class.new(acuwt_course).run
+
+      expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(1)
+      expect(acuwt_course.course_wiki_timeslices.where(needs_update: true).count).to eq(0)
+      expect(acuwt_course.course_wiki_timeslices.find_by(needs_reaggregation: true).start)
+        .to eq(acuwt_course.start + 1.day)
+      expect(acuwt_course.article_course_timeslices
+                         .where(article_id: random_article.id).count).to eq(0)
+      expect(acuwt_course.articles_courses.count).to eq(1)
+      expect(acuwt_course.articles_courses.where(article_id: random_article).count).to eq(0)
+      expect(ArticleCourseUserWikiTimeslice
+               .where(course: acuwt_course, article: random_article).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
## What this PR does

Implements the ACUWT update path in `UpdateTimeslicesScopedArticle`, the service
that adjusts timeslices when articles enter or leave scope in `ArticleScopedProgram`
and `VisitingScholarship` courses (including Wikidata courses that use category
scoping).

Previously the service always used the legacy path: mark affected CWT timeslices as
`needs_update` and trigger a full MediaWiki re-fetch. That is extremely slow for
Wikidata courses where users make thousands of programmatic edits in a single
timeslice, because removing a scoped category forces a full revision re-fetch for
every edit every affected user ever made in every timeslice.

The new ACUWT path avoids that:

**New articles** (scoped, no `articles_courses` record yet, but ACUWT rows already
exist from prior updates when they were unscoped): per timeslice, re-fetches
revisions only for the users who have ACUWT rows for those articles, filters the
result to the target `article_ids` *before* calling the reference-counter API, then
upserts the ACUWT rows with correct scores and marks the affected CWT timeslices for
reaggregation. The key filter-before-score-fetch step avoids sending thousands of
unrelated edits to the reference-counter API.

**Old articles** (have `articles_courses` but are no longer scoped): marks affected
CWT timeslices for reaggregation and removes the `articles_courses` records. ACUWT
rows are intentionally kept — `CourseUserWikiTimeslice.update_from_acuwt` already
filters to `scoped_article_ids` for `only_scoped_articles_course?` courses.

The legacy path (courses without `use_acuwt?`) is unchanged.

Supporting changes:
- `RevisionDataManager`: extracted `fetch_revision_data_for_users_with_articles_only`
  (imports articles, no score fetch) so callers can filter before the expensive API
  call; refactored the existing `fetch_revision_data_for_users_with_articles` to
  delegate to it.
- `ArticleCourseUserWikiTimeslice`: added `periods_for_articles` and
  `users_for_articles_in_period` class methods (moved from private service methods).
- `PrepareTimeslices`: passes `update_service:` through to `UpdateTimeslicesScopedArticle`.

### Benchmark — Latinoamérica en Wikidata 2024 - Bolivia (octubre)

Tested locally by removing and then re-adding category `Psid:29391801` on
https://outreachdashboard.wmflabs.org/courses/wikidata/Latinoam%C3%A9rica_en_Wikidata_2024_-_Bolivia_(octubre)/home.

| Operation | Path | Duration | Reprocessed |
|---|---|---|---|
| Remove category | **ACUWT** | 11s | 0 |
| Remove category | Default | 634s (~10m 34s) | 4 |
| Add category | **ACUWT** | 82s | 0 |
| Add category | Default | 653s (~10m 53s) | 9 |

The ACUWT path is ~58× faster on remove and ~8× faster on add. The add-category run
had one `too_many_requests` hit from the reference-counter API, which accounts for
some of the extra time.

## AI usage

Claude Code (Sonnet 4.6) was used throughout this PR. The implementation of
`UpdateTimeslicesScopedArticle` was written by the developer between sessions and
committed with Claude Code's assistance in this session. The refactoring commits
(moving queries to the model, updating the `RevisionDataManager` comment, adding the
rubocop exclusion) were directed by the developer and executed by Claude Code. Commit
messages were written by Claude Code.

This PR description was drafted using the `/prepare-pr` Claude Code skill.

(PR description written by Claude Code.)

## Screenshots

No UI changes.

## Open questions and concerns

- The `too_many_requests` hit during the add-category ACUWT run is worth monitoring
  in production. It did not cause an error (the request was retried successfully), but
  it could be a concern for courses with very large revision volumes.
- ACUWT rows for old (unscoped) articles are kept intentionally. If a course is later
  reset or the flag is toggled, those rows are harmless but could grow stale.