### PR TITLE
Enhance Wikidata Overview Stats Component

### DIFF
--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -1,240 +1,378 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import OverviewStat from './OverviewStats/overview_stat';
+import { onEnterOrSpace } from '../../utils/keyboard_handlers';
+
+const TABS = [
+  { id: 'summary', labelKey: 'metrics.summary' },
+  { id: 'statements', labelKey: 'metrics.statements' },
+  { id: 'content', labelKey: 'metrics.content' },
+  { id: 'lexemes', labelKey: 'metrics.lexemes' }
+];
+
+const StatSection = ({ label, children, className = '' }) => (
+  <div className={`stat-display__row ${className}`}>
+    <h5 className="stats-label">{label}</h5>
+    <div className="stat-display__value-group">
+      {children}
+    </div>
+  </div>
+);
+
+const WikidataTab = ({ id, title, active, onClick }) => {
+  const tabClass = `wikidata-tab${active ? ' active' : ''}`;
+  return (
+    <div
+      role="tab"
+      tabIndex={0}
+      aria-selected={active}
+      className={tabClass}
+      onClick={onClick}
+      onKeyDown={onEnterOrSpace(onClick)}
+      id={`wikidata-tab-${id}`}
+      aria-controls={`wikidata-panel-${id}`}
+    >
+      <p>{title}</p>
+    </div>
+  );
+};
+
+WikidataTab.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  active: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired
+};
+
+const SummaryTab = ({ statistics }) => (
+  <>
+    <StatSection label={I18n.t('metrics.general')}>
+      <OverviewStat
+        id="total-revisions"
+        className="stat-display__value-small"
+        stat={statistics['total revisions']}
+        statMsg={I18n.t('metrics.total_revisions')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="merged"
+        className="stat-display__value-small"
+        stat={statistics['merged to']}
+        statMsg={I18n.t('metrics.merged')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="merged-from"
+        className="stat-display__value-small"
+        stat={statistics['merged from']}
+        statMsg={I18n.t('metrics.merged_from')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="interwiki-links"
+        className="stat-display__value-small"
+        stat={statistics['interwiki links added']}
+        statMsg={I18n.t('metrics.interwiki_links_added')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('items.items')}>
+      <OverviewStat
+        id="items-created"
+        className="stat-display__value-small"
+        stat={statistics['items created']}
+        statMsg={I18n.t('metrics.created')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="items-cleared"
+        className="stat-display__value-small"
+        stat={statistics['items cleared']}
+        statMsg={I18n.t('metrics.cleared')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.claims')}>
+      <OverviewStat
+        id="claims-created"
+        className="stat-display__value-small"
+        stat={statistics['claims created']}
+        statMsg={I18n.t('metrics.created')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="claims-changed"
+        className="stat-display__value-small"
+        stat={statistics['claims changed']}
+        statMsg={I18n.t('metrics.changed')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="claims-removed"
+        className="stat-display__value-small"
+        stat={statistics['claims removed']}
+        statMsg={I18n.t('metrics.removed')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.references')}>
+      <OverviewStat
+        id="references-added"
+        className="stat-display__value-small"
+        stat={statistics['references added']}
+        statMsg={I18n.t('metrics.added')}
+        renderZero={true}
+        info={I18n.t('metrics.references_added_info')}
+        infoId="references-added-info"
+      />
+    </StatSection>
+  </>
+);
+
+SummaryTab.propTypes = {
+  statistics: PropTypes.object.isRequired
+};
+
+const StatementsTab = ({ statistics }) => (
+  <>
+    <StatSection label={I18n.t('metrics.claims')}>
+      <OverviewStat
+        id="statements-claims-created"
+        className="stat-display__value-small"
+        stat={statistics['claims created']}
+        statMsg={I18n.t('metrics.created')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="statements-claims-changed"
+        className="stat-display__value-small"
+        stat={statistics['claims changed']}
+        statMsg={I18n.t('metrics.changed')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="statements-claims-removed"
+        className="stat-display__value-small"
+        stat={statistics['claims removed']}
+        statMsg={I18n.t('metrics.removed')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.qualifiers')}>
+      <OverviewStat
+        id="qualifiers-added"
+        className="stat-display__value-small"
+        stat={statistics['qualifiers added']}
+        statMsg={I18n.t('metrics.added')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.references')}>
+      <OverviewStat
+        id="statements-references-added"
+        className="stat-display__value-small"
+        stat={statistics['references added']}
+        statMsg={I18n.t('metrics.added')}
+        renderZero={true}
+        info={I18n.t('metrics.references_added_info')}
+        infoId="statements-references-added-info"
+      />
+    </StatSection>
+  </>
+);
+
+StatementsTab.propTypes = {
+  statistics: PropTypes.object.isRequired
+};
+
+const ContentTab = ({ statistics }) => (
+  <>
+    <StatSection label={I18n.t('items.items')}>
+      <OverviewStat
+        id="content-items-created"
+        className="stat-display__value-small"
+        stat={statistics['items created']}
+        statMsg={I18n.t('metrics.created')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="content-items-cleared"
+        className="stat-display__value-small"
+        stat={statistics['items cleared']}
+        statMsg={I18n.t('metrics.cleared')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.labels')}>
+      <OverviewStat
+        id="labels-added"
+        className="stat-display__value-small"
+        stat={statistics['labels added']}
+        statMsg={I18n.t('metrics.added')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="labels-changed"
+        className="stat-display__value-small"
+        stat={statistics['labels changed']}
+        statMsg={I18n.t('metrics.changed')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="labels-removed"
+        className="stat-display__value-small"
+        stat={statistics['labels removed']}
+        statMsg={I18n.t('metrics.removed')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.descriptions')}>
+      <OverviewStat
+        id="descriptions-added"
+        className="stat-display__value-small"
+        stat={statistics['descriptions added']}
+        statMsg={I18n.t('metrics.added')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="descriptions-changed"
+        className="stat-display__value-small"
+        stat={statistics['descriptions changed']}
+        statMsg={I18n.t('metrics.changed')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="descriptions-removed"
+        className="stat-display__value-small"
+        stat={statistics['descriptions removed']}
+        statMsg={I18n.t('metrics.removed')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.aliases')}>
+      <OverviewStat
+        id="aliases-added"
+        className="stat-display__value-small"
+        stat={statistics['aliases added']}
+        statMsg={I18n.t('metrics.added')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="aliases-changed"
+        className="stat-display__value-small"
+        stat={statistics['aliases changed']}
+        statMsg={I18n.t('metrics.changed')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="aliases-removed"
+        className="stat-display__value-small"
+        stat={statistics['aliases removed']}
+        statMsg={I18n.t('metrics.removed')}
+        renderZero={true}
+      />
+    </StatSection>
+    <StatSection label={I18n.t('metrics.other')}>
+      <OverviewStat
+        id="content-qualifiers-added"
+        className="stat-display__value-small"
+        stat={statistics['qualifiers added']}
+        statMsg={I18n.t('metrics.qualifiers_added')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="redirects-created"
+        className="stat-display__value-small"
+        stat={statistics['redirects created']}
+        statMsg={I18n.t('metrics.redirects_created')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="reverts-performed"
+        className="stat-display__value-small"
+        stat={statistics['reverts performed']}
+        statMsg={I18n.t('metrics.reverts_performed')}
+        renderZero={true}
+      />
+      <OverviewStat
+        id="restorations-performed"
+        className="stat-display__value-small"
+        stat={statistics['restorations performed']}
+        statMsg={I18n.t('metrics.restorations_performed')}
+        renderZero={true}
+      />
+    </StatSection>
+  </>
+);
+
+ContentTab.propTypes = {
+  statistics: PropTypes.object.isRequired
+};
+
+const LexemesTab = ({ statistics }) => (
+  <StatSection label={I18n.t('items.lexeme')}>
+    <OverviewStat
+      id="lexeme-created"
+      className="stat-display__value-small"
+      stat={statistics['lexeme items created']}
+      statMsg={I18n.t('metrics.created')}
+      renderZero={true}
+    />
+  </StatSection>
+);
+
+LexemesTab.propTypes = {
+  statistics: PropTypes.object.isRequired
+};
+
+const TAB_PANELS = {
+  summary: SummaryTab,
+  statements: StatementsTab,
+  content: ContentTab,
+  lexemes: LexemesTab
+};
 
 const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
+  const [activeTab, setActiveTab] = useState('summary');
+
   let containerClass = 'wikidata-stats-container';
   let title = 'Wikidata stats';
   if (isCourseOverview) {
     containerClass = 'wikidata-stats-container course-overview';
     title = null;
   }
+
+  const onTabChange = (e) => {
+    const tabId = e.currentTarget.id.replace('wikidata-tab-', '');
+    setActiveTab(tabId);
+  };
+
+  const ActivePanel = TAB_PANELS[activeTab];
+
   return (
     <div className={containerClass}>
       <h2 className="wikidata-stats-title">{title}</h2>
-      <div className="wikidata-display">
-        <div className="stat-display__row">
-          <h5 className="stats-label">{I18n.t('metrics.general')}</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="total-revisions"
-              className="stat-display__value-small"
-              stat={statistics['total revisions']}
-              statMsg={I18n.t('metrics.total_revisions')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="merged"
-              className="stat-display__value-small"
-              stat={statistics['merged to']}
-              statMsg={I18n.t('metrics.merged')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="merged-from"
-              className="stat-display__value-small"
-              stat={statistics['merged from']}
-              statMsg={I18n.t('metrics.merged_from')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="interwiki-links"
-              className="stat-display__value-small"
-              stat={statistics['interwiki links added']}
-              statMsg={I18n.t('metrics.interwiki_links_added')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row">
-          <h5 className="stats-label">{I18n.t('items.items')}</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="items-created"
-              className="stat-display__value-small"
-              stat={statistics['items created']}
-              statMsg={I18n.t('metrics.created')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="items-cleared"
-              className="stat-display__value-small"
-              stat={statistics['items cleared']}
-              statMsg={I18n.t('metrics.cleared')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row">
-          <h5 className="stats-label">{I18n.t('metrics.claims')}</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="claims-created"
-              className="stat-display__value-small"
-              stat={statistics['claims created']}
-              statMsg={I18n.t('metrics.created')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="claims-changed"
-              className="stat-display__value-small"
-              stat={statistics['claims changed']}
-              statMsg={I18n.t('metrics.changed')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="claims-removed"
-              className="stat-display__value-small"
-              stat={statistics['claims removed']}
-              statMsg={I18n.t('metrics.removed')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row">
-          <h5 className="stats-label">{I18n.t('metrics.labels')}</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="labels-added"
-              className="stat-display__value-small"
-              stat={statistics['labels added']}
-              statMsg={I18n.t('metrics.added')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="labels-changed"
-              className="stat-display__value-small"
-              stat={statistics['labels changed']}
-              statMsg={I18n.t('metrics.changed')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="labels-removed"
-              className="stat-display__value-small"
-              stat={statistics['labels removed']}
-              statMsg={I18n.t('metrics.removed')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row">
-          <h5 className="stats-label">Descriptions</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="descriptions-added"
-              className="stat-display__value-small"
-              stat={statistics['descriptions added']}
-              statMsg={I18n.t('metrics.added')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="descriptions-changed"
-              className="stat-display__value-small"
-              stat={statistics['descriptions changed']}
-              statMsg={I18n.t('metrics.changed')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="descriptions-removed"
-              className="stat-display__value-small"
-              stat={statistics['descriptions removed']}
-              statMsg={I18n.t('metrics.removed')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row">
-          <h5 className="stats-label">Aliases</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="aliases-added"
-              className="stat-display__value-small"
-              stat={statistics['aliases added']}
-              statMsg={I18n.t('metrics.added')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="aliases-changed"
-              className="stat-display__value-small"
-              stat={statistics['aliases changed']}
-              statMsg={I18n.t('metrics.changed')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="aliases-removed"
-              className="stat-display__value-small"
-              stat={statistics['aliases removed']}
-              statMsg={I18n.t('metrics.removed')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row double-row">
-          <h5 className="stats-label">Other</h5>
-          <div className="stat-display__value-group double">
-            <OverviewStat
-              id="qualifiers-added"
-              className="stat-display__value-small"
-              stat={statistics['qualifiers added']}
-              statMsg={I18n.t('metrics.qualifiers_added')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="references-added"
-              className="stat-display__value-small"
-              stat={statistics['references added']}
-              statMsg={I18n.t('metrics.references_added')}
-              renderZero={true}
-              info={I18n.t('metrics.references_added_info')}
-              infoId="references-added-info"
-            />
-            <OverviewStat
-              id="redirects-created"
-              className="stat-display__value-small"
-              stat={statistics['redirects created']}
-              statMsg={I18n.t('metrics.redirects_created')}
-              renderZero={true}
-            />
-          </div>
-          <div className="stat-display__value-group double">
-            <OverviewStat
-              id="reverts-performed"
-              className="stat-display__value-small"
-              stat={statistics['reverts performed']}
-              statMsg={I18n.t('metrics.reverts_performed')}
-              renderZero={true}
-            />
-            <OverviewStat
-              id="restorations-performed"
-              className="stat-display__value-small"
-              stat={statistics['restorations performed']}
-              statMsg={I18n.t('metrics.restorations_performed')}
-              renderZero={true} i
-            />
-            <OverviewStat
-              id="other-updates"
-              className="stat-display__value-small"
-              stat={statistics['other updates']}
-              statMsg={I18n.t('metrics.other_updates')}
-              renderZero={true}
-            />
-          </div>
-        </div>
-        <div className="stat-display__row">
-          <h5 className="stats-label">{I18n.t('items.lexeme')}</h5>
-          <div className="stat-display__value-group">
-            <OverviewStat
-              id="lexeme-created"
-              className="stat-display__value-small"
-              stat={statistics['lexeme items created']}
-              statMsg={I18n.t('metrics.created')}
-              renderZero={true}
-            />
-          </div>
-        </div>
+      <div className="wikidata-tabs" role="tablist">
+        {TABS.map(tab => (
+          <WikidataTab
+            key={tab.id}
+            id={tab.id}
+            title={I18n.t(tab.labelKey)}
+            active={activeTab === tab.id}
+            onClick={onTabChange}
+          />
+        ))}
+      </div>
+      <div
+        className="wikidata-display"
+        role="tabpanel"
+        id={`wikidata-panel-${activeTab}`}
+        aria-labelledby={`wikidata-tab-${activeTab}`}
+      >
+        <ActivePanel statistics={statistics} />
       </div>
     </div>
-    );
+  );
 };
 
 WikidataOverviewStats.propTypes = {
@@ -242,4 +380,4 @@ WikidataOverviewStats.propTypes = {
   isCourseOverview: PropTypes.bool
 };
 
-  export default WikidataOverviewStats;
+export default WikidataOverviewStats;

--- a/app/assets/stylesheets/modules/_stats.styl
+++ b/app/assets/stylesheets/modules/_stats.styl
@@ -128,6 +128,30 @@
     -webkit-font-smoothing auto
     margin 0
 
+  .wikidata-tabs
+    display flex
+    border-bottom 1px solid #e2e2e2
+    margin-bottom 15px
+    overflow-x auto
+
+    .wikidata-tab
+      padding 10px 16px 8px
+      cursor pointer
+      border-bottom 3px solid transparent
+      margin-bottom -1px
+      white-space nowrap
+
+      p
+        margin 0
+        font-size 14px
+        color $brand_primary
+
+      &.active
+        border-bottom-color $brand_primary
+
+        p
+          font-weight 600
+
   .wikidata-display
     width 100%
     display flex

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1268,6 +1268,13 @@ en:
     word_count: Words Added
     word_count_average: Average Word Count
     general: General
+    summary: Summary
+    statements: Statements
+    content: Content
+    lexemes: Lexemes
+    references: References
+    qualifiers: Qualifiers
+    other: Other
     total_revisions: Total revisions
     claims: Claims
     aliases: Aliases

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -654,6 +654,13 @@ qqq:
     view: Label for the number of article views.
     descriptions: '{{identical|Description}}'
     labels: '{{identical|Label}}'
+    summary: Tab label for the Wikidata stats summary view.
+    statements: Tab label for the Wikidata stats statements view.
+    content: Tab label for the Wikidata stats content view.
+    lexemes: Tab label for the Wikidata stats lexemes view.
+    references: Section label for Wikidata reference statistics.
+    qualifiers: Section label for Wikidata qualifier statistics.
+    other: Section label for other Wikidata content statistics.
   namespace:
     main: Long label for the Main namespace.
     main_char_added: Label for number of characters added to the Main namespace.


### PR DESCRIPTION

### What this PR does
Resolves - https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6877
Reorganizes the Wikidata statistics panel on course and campaign overviews into a tabbed layout modeled on [Wikidata's own statistics UI](https://www.wikidata.org), so related counters are grouped instead of shown in one long scroll.

**Summary** — General (total revisions, merged to/from, interwiki links), Items, Claims, References

**Statements** — Claims, Qualifiers, References

**Content** — Items, Labels, Descriptions, Aliases, Other (qualifiers added, redirects, reverts, restorations)

**Lexemes** — Lexeme created

Changes:

- Refactored `wikidata_overview_stats.jsx` to introduce tabbed navigation for the four categories above, with `StatSection` and `WikidataTab` helpers for layout and keyboard accessibility (`role="tab"`, `onEnterOrSpace`).
- Updated styles in `_stats.styl` for the tab bar (active underline, horizontal scroll on narrow viewports).
- Added i18n keys in `en.yml` and translator notes in `qqq.yml` for tab labels and new section headers (`summary`, `statements`, `content`, `lexemes`, `references`, `qualifiers`, `other`).

No backend or stats-pipeline changes; existing `statistics` keys and `UpdateWikidataStatsTimeslice` mappings are unchanged.

### AI usage

Cursor (Auto) was used during development to:

- Implement the tabbed layout and component structure in `wikidata_overview_stats.jsx` from reference screenshots of Wikidata's statistics UI.
- Add Stylus styles for the tab bar in `_stats.styl`.
- Add `en.yml` / `qqq.yml` locale entries for new labels.


### Screenshots



**Before:**
<img width="1096" height="513" alt="Screenshot 2026-06-09 at 10 55 55 PM" src="https://github.com/user-attachments/assets/5c7855d4-6525-4f9a-a252-f973ada6de90" />



**After:**

<img width="1091" height="402" alt="Screenshot 2026-06-09 at 10 55 11 PM" src="https://github.com/user-attachments/assets/6f77a5d9-cca5-4cb0-af92-65d41a884f9e" />

