### PR TITLE
[ACUWT] Count reaggregated timeslices in course update log

### DIFF
--- a/app/services/update_course_stats.rb
+++ b/app/services/update_course_stats.rb
@@ -35,9 +35,9 @@ class UpdateCourseStats
     import_uploads
     update_categories
     update_articles
-    @processed, @reprocessed = UpdateCourseWikiTimeslices.new(@course, @debugger,
-                                                              update_service: self)
-                                                         .run(all_time: @full_update)
+    @processed, @reprocessed, @reaggregated = UpdateCourseWikiTimeslices.new(@course, @debugger,
+                                                                             update_service: self)
+                                                                        .run(all_time: @full_update)
     update_average_pageviews
     update_caches
     update_wikidata_stats if wikidata
@@ -127,7 +127,8 @@ class UpdateCourseStats
                                'reference_counter_403_count' => reference_counter_403_count,
                                'too_many_requests_count' => too_many_requests_count,
                                'processed' => @processed,
-                               'reprocessed' => @reprocessed)
+                               'reprocessed' => @reprocessed,
+                               'reaggregated' => @reaggregated)
   end
 
   def wikidata

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -21,6 +21,7 @@ class UpdateCourseWikiTimeslices
     @update_service = update_service
     @processed_timeslices_count = 0
     @reprocessed_timeslices = Hash.new { |h, k| h[k] = [] }
+    @reaggregated_timeslices_count = 0
     @revision_updater = CourseRevisionUpdater.new(@course, update_service:)
     @wikidata_stats_updater = UpdateWikidataStatsTimeslice.new(@course) if wikidata
   end
@@ -29,7 +30,7 @@ class UpdateCourseWikiTimeslices
     pre_update(all_time)
     @course.update(needs_update: false)
     fetch_data_and_process_timeslices_for_every_wiki(all_time)
-    [@processed_timeslices_count, @reprocessed_timeslices.values.flatten.count]
+    [@processed_timeslices_count, @reprocessed_timeslices.values.flatten.count, @reaggregated_timeslices_count]
   end
 
   private
@@ -246,7 +247,10 @@ class UpdateCourseWikiTimeslices
     to_reaggregate = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
                                         .needs_reaggregation
                                         .where(needs_update: false)
-    to_reaggregate.each { |cwt| reaggregate_timeslice_from_acuwt(cwt) }
+    to_reaggregate.each do |cwt|
+      reaggregate_timeslice_from_acuwt(cwt)
+      @reaggregated_timeslices_count += 1
+    end
   end
 
   def reaggregate_timeslice_from_acuwt(cwt)

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -30,7 +30,8 @@ class UpdateCourseWikiTimeslices
     pre_update(all_time)
     @course.update(needs_update: false)
     fetch_data_and_process_timeslices_for_every_wiki(all_time)
-    [@processed_timeslices_count, @reprocessed_timeslices.values.flatten.count, @reaggregated_timeslices_count]
+    [@processed_timeslices_count, @reprocessed_timeslices.values.flatten.count,
+     @reaggregated_timeslices_count]
   end
 
   private

--- a/spec/services/update_course_stats_spec.rb
+++ b/spec/services/update_course_stats_spec.rb
@@ -46,6 +46,21 @@ describe UpdateCourseStats do
     end
   end
 
+  context 'when logging the end of an update' do
+    before do
+      allow_any_instance_of(UpdateCourseWikiTimeslices).to receive(:run)
+        .and_return([5, 2, 3])
+    end
+
+    it 'logs processed, reprocessed, and reaggregated counts' do
+      subject
+      update_log = course.reload.flags['update_logs'].values.last
+      expect(update_log['processed']).to eq(5)
+      expect(update_log['reprocessed']).to eq(2)
+      expect(update_log['reaggregated']).to eq(3)
+    end
+  end
+
   context 'when there are revisions' do
     before do
       stub_wiki_validation

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -32,9 +32,10 @@ describe UpdateCourseWikiTimeslices do
     context 'when debugging is not enabled' do
       it 'posts no Sentry logs' do
         expect(Sentry).not_to receive(:capture_message)
-        processed, reprocessed = subject
+        processed, reprocessed, reaggregated = subject
         expect(processed).to eq(14)
         expect(reprocessed).to eq(0)
+        expect(reaggregated).to eq(0)
       end
     end
 
@@ -398,6 +399,25 @@ describe UpdateCourseWikiTimeslices do
       it 'does not call the legacy course_user_wiki_timeslices updater' do
         expect(CourseUserWikiTimeslice).not_to receive(:update_course_user_wiki_timeslices)
         subject
+      end
+
+      context 'when some timeslices need reaggregation' do
+        before do
+          # Override parent stub so normal processing never calls update_cache_from_acuwt
+          # (which would reset needs_reaggregation = false before reaggregation runs).
+          allow_any_instance_of(CourseRevisionUpdater)
+            .to receive(:fetch_revisions_for_course_wiki) do |_instance, wiki, ts_start, ts_end|
+              { wiki => { start: ts_start, end: ts_end, new_data: false, revisions: [] } }
+            end
+          TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
+          course.course_wiki_timeslices.where(wiki: enwiki).first(2)
+                .each { |cwt| cwt.update(needs_reaggregation: true, needs_update: false) }
+        end
+
+        it 'returns the count of reaggregated timeslices' do
+          _, _, reaggregated = subject
+          expect(reaggregated).to eq(2)
+        end
       end
     end
   end


### PR DESCRIPTION
## What this PR does

Adds a reaggregated-timeslice counter to the course update pipeline, alongside the existing processed and reprocessed counts.

`UpdateCourseWikiTimeslices#run` now returns a three-element array `[processed, reprocessed, reaggregated]`. The reaggregated count tracks how many `CourseWikiTimeslice` records were handled by the `reaggregate_timeslices_from_acuwt` step — timeslices that carry `needs_reaggregation: true` but were not fully reprocessed in the current cycle. `UpdateCourseStats` captures this value and passes it to `UpdateLogger` so it appears in the update log alongside the other two counters.

### Examples
Logs in default path:
```
                "22": {
                    "start_time": "2026-06-09T21:00:03.239+00:00",
                    "end_time": "2026-06-09T21:11:05.420+00:00",
                    "sentry_tag_uuid": "6ad92845-21ed-4a9b-b822-48d12c626775",
                    "error_count": 0,
                    "reference_counter_403_count": 0,
                    "too_many_requests_count": 0,
                    "processed": 1,
                    "reprocessed": 9,
                    "reaggregated": 0
                }
```

Logs in new ACUWT path:
```
                "30": {
                    "start_time": "2026-06-09T20:59:30.420+00:00",
                    "end_time": "2026-06-09T20:59:39.870+00:00",
                    "sentry_tag_uuid": "7073bb82-4163-4ec4-83e3-1454607eb3ea",
                    "error_count": 0,
                    "reference_counter_403_count": 0,
                    "too_many_requests_count": 0,
                    "processed": 1,
                    "reprocessed": 0,
                    "reaggregated": 9
                }
```

## AI usage

Claude Code (claude-sonnet-4-6) drafted all code and commit messages in this PR. The human provided terse direction ("add reaggregated timeslice count", "add tests", "prepare PR") and reviewed the output at each step.

This was developed in a single session with two commits, both made within about 30 minutes. The implementation was straightforward; the spec work required three test runs to get right (a bad `instance_double` stub, then a timing issue with `needs_reaggregation` being reset before the assertion could observe it).

This PR description was drafted using the `/prepare-pr` Claude Code skill.

(PR description written by Claude Code.)

## Screenshots

No UI changes.

## Open questions and concerns

None.