### PR TITLE
[ACUWT] Reimplement UpdateTimeslicesUntrackedArticle for ACUWT path

### DIFF
--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -136,10 +136,8 @@ class UpdateTimeslicesCourseUser
 
   def remove_courses_users_acuwt(user_ids)
     acuwt_records = ArticleCourseUserWikiTimeslice.where(course: @course, user_id: user_ids)
-    # Marks CWT as needs_reaggregation; deletes targeted ACT rows for affected articles
+    # Marks CWT as needs_reaggregation; deletes ACT and CUWT rows for affected periods
     @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt_records)
-    # Delete course user wiki timeslices for removed users
-    @timeslice_cleaner.delete_course_user_timeslices_for_deleted_course_users(user_ids)
     # Delete ACUWT records for removed users
     @timeslice_cleaner.delete_acuwt_for_deleted_course_users(user_ids)
     # Delete articles courses that were updated only for removed users

--- a/app/services/update_timeslices_untracked_article.rb
+++ b/app/services/update_timeslices_untracked_article.rb
@@ -13,15 +13,46 @@ class UpdateTimeslicesUntrackedArticle
   def run
     # Get the untracked articles courses
     untracked_articles = @course.articles_courses.not_tracked.pluck(:article_id)
-    untrack(untracked_articles)
-
     tracked_articles = @course.articles_courses.tracked.pluck(:article_id)
-    retrack(tracked_articles)
+
+    if @course.use_acuwt?
+      untrack_acuwt(untracked_articles)
+      retrack_acuwt(tracked_articles)
+    else
+      untrack_legacy(untracked_articles)
+      retrack_legacy(tracked_articles)
+    end
   end
 
   private
 
-  def untrack(article_ids)
+  ###############
+  # ACUWT paths #
+  ###############
+
+  def untrack_acuwt(article_ids)
+    return if article_ids.empty?
+    acuwt = ArticleCourseUserWikiTimeslice
+              .where(course: @course, article_id: article_ids, tracked: true)
+    return if acuwt.empty?
+    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    acuwt.update_all(tracked: false) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def retrack_acuwt(article_ids)
+    return if article_ids.empty?
+    acuwt = ArticleCourseUserWikiTimeslice
+              .where(course: @course, article_id: article_ids, tracked: false)
+    return if acuwt.empty?
+    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    acuwt.update_all(tracked: true) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  ################
+  # Legacy paths #
+  ################
+
+  def untrack_legacy(article_ids)
     return if article_ids.empty?
     @article_course_timeslices_to_untrack = ArticleCourseTimeslice
                                             .for_course_and_article(@course, article_ids)
@@ -39,7 +70,7 @@ class UpdateTimeslicesUntrackedArticle
     ArticleCourseTimeslice.where(id: ids).update_all(tracked: false) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  def retrack(article_ids)
+  def retrack_legacy(article_ids)
     return if article_ids.empty?
 
     # Most of the time there are no untracked timeslices, so we can skip the retrack step

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -107,9 +107,8 @@ class TimesliceCleaner
   end
 
   # Marks CWT rows as needs_reaggregation for every (wiki, start) period covered
-  # by the given ACUWT records, and deletes the ACT rows for the specific
-  # (article, start) pairs those records cover so they are cleanly re-derived.
-  # CUW rows are NOT deleted here — callers handle user-specific CUW cleanup.
+  # by the given ACUWT records, and deletes the ACT and CUWT rows for those
+  # periods so they are cleanly re-derived during the next reaggregation pass.
   # Takes an ActiveRecord::Relation of ArticleCourseUserWikiTimeslice records.
   def reset_timeslices_for_reaggregation_from_acuwt(acuwt_records)
     return if acuwt_records.empty?
@@ -119,6 +118,7 @@ class TimesliceCleaner
 
     mark_timeslices_for_reaggregation(wikis_and_starts)
     delete_article_course_timeslices_for_acuwt_pairs(acuwt_records)
+    delete_course_user_wiki_timeslices_for_acuwt_pairs(wikis_and_starts)
   end
 
   # Deletes ACUWT records for users removed from the course.
@@ -214,6 +214,16 @@ class TimesliceCleaner
                                     .where("(article_id, start) IN (#{tuples})")
                                     .pluck(:id)
     delete_article_course_timeslice_ids(act_ids)
+  end
+
+  def delete_course_user_wiki_timeslices_for_acuwt_pairs(wikis_and_starts)
+    tuples = wikis_and_starts.map do |wiki_id, s|
+      "(#{wiki_id}, '#{s.strftime('%Y-%m-%d %H:%M:%S')}')"
+    end.join(', ')
+    cuwt_ids = CourseUserWikiTimeslice.where(course: @course)
+                                      .where("(wiki_id, start) IN (#{tuples})")
+                                      .pluck(:id)
+    delete_course_user_wiki_timeslice_ids(cuwt_ids)
   end
 
   # Deletes existing article course timeslices for a collection of wiki ids

--- a/spec/services/update_timeslices_untracked_article_spec.rb
+++ b/spec/services/update_timeslices_untracked_article_spec.rb
@@ -69,4 +69,101 @@ describe UpdateTimeslicesUntrackedArticle do
       expect(course.article_course_timeslices.where(tracked: false).count).to eq(0)
     end
   end
+
+  context 'ACUWT path' do
+    let(:acuwt_course) do
+      create(:course, title: 'ACUWT course', school: 'WÏNTR', term: 'spring 2021',
+             slug: 'WÏNTR/ACUWT_course_(spring_2021)', start:, end: '2021-01-30',
+             flags: { use_acuwt: true })
+    end
+    let(:acuwt_manager) { TimesliceManager.new(acuwt_course) }
+
+    before do
+      acuwt_course.campaigns << Campaign.first
+      JoinCourse.new(course: acuwt_course, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)
+      JoinCourse.new(course: acuwt_course, user: user2, role: CoursesUsers::Roles::STUDENT_ROLE)
+      acuwt_manager.create_timeslices_for_new_course_wiki_records([enwiki])
+      create(:articles_course, course: acuwt_course, article: article1)
+      create(:articles_course, course: acuwt_course, article: article2)
+      # ACUWT rows: article1 at start (user1), article2 at start (user1) and start+1.day (user2)
+      create(:article_course_user_wiki_timeslice,
+             course: acuwt_course, article: article1, user: user1, wiki: enwiki,
+             start:, end: start + 1.day)
+      create(:article_course_user_wiki_timeslice,
+             course: acuwt_course, article: article2, user: user1, wiki: enwiki,
+             start:, end: start + 1.day)
+      create(:article_course_user_wiki_timeslice,
+             course: acuwt_course, article: article2, user: user2, wiki: enwiki,
+             start: start + 1.day, end: start + 2.days)
+      # ACT rows for both articles
+      create(:article_course_timeslice, course: acuwt_course, article: article1, start:)
+      create(:article_course_timeslice, course: acuwt_course, article: article2, start:)
+      create(:article_course_timeslice, course: acuwt_course, article: article2,
+             start: start + 1.day)
+      # CUWT rows for the periods covered by article2
+      create(:course_user_wiki_timeslice,
+             course: acuwt_course, user: user1, wiki: enwiki, start:, end: start + 1.day)
+      create(:course_user_wiki_timeslice,
+             course: acuwt_course, user: user2, wiki: enwiki,
+             start: start + 1.day, end: start + 2.days)
+    end
+
+    context 'when an article is untracked' do
+      before do
+        ArticlesCourses.find_by(course: acuwt_course, article: article2).update(tracked: false)
+      end
+
+      it 'sets needs_reaggregation, deletes ACT and CUWT rows, and marks ACUWT as untracked' do
+        expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(0)
+        expect(acuwt_course.article_course_timeslices.count).to eq(3)
+        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(2)
+        expect(ArticleCourseUserWikiTimeslice
+                 .where(course: acuwt_course, tracked: false).count).to eq(0)
+
+        described_class.new(acuwt_course).run
+
+        # CWT marked for reaggregation for the two periods covered by article2's ACUWT rows
+        expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(2)
+        # ACT rows for article2 deleted; article1's row survives
+        expect(acuwt_course.article_course_timeslices.count).to eq(1)
+        expect(acuwt_course.article_course_timeslices.first.article).to eq(article1)
+        # CUWT rows deleted for the affected periods
+        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(0)
+        # ACUWT rows for article2 marked as untracked; article1's row unaffected
+        expect(ArticleCourseUserWikiTimeslice
+                 .where(course: acuwt_course, tracked: false).count).to eq(2)
+        expect(ArticleCourseUserWikiTimeslice
+                 .where(course: acuwt_course, tracked: true).count).to eq(1)
+      end
+    end
+
+    context 'when an article is re-tracked' do
+      before do
+        # Simulate article2 having been previously untracked
+        ArticleCourseUserWikiTimeslice.where(course: acuwt_course, article: article2)
+                                      .update_all(tracked: false) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      it 'sets needs_reaggregation, deletes ACT and CUWT rows, and marks ACUWT as tracked' do
+        expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(0)
+        expect(acuwt_course.article_course_timeslices.count).to eq(3)
+        expect(ArticleCourseUserWikiTimeslice
+                 .where(course: acuwt_course, tracked: false).count).to eq(2)
+
+        described_class.new(acuwt_course).run
+
+        # CWT marked for reaggregation for the two periods covered by article2's ACUWT rows
+        expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(2)
+        # ACT rows for article2 deleted; article1's row survives
+        expect(acuwt_course.article_course_timeslices.count).to eq(1)
+        # CUWT rows deleted for the affected periods
+        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(0)
+        # All ACUWT rows now tracked
+        expect(ArticleCourseUserWikiTimeslice
+                 .where(course: acuwt_course, tracked: false).count).to eq(0)
+        expect(ArticleCourseUserWikiTimeslice
+                 .where(course: acuwt_course, tracked: true).count).to eq(3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does

Reimplements `UpdateTimeslicesUntrackedArticle` to support ACUWT-path courses
(those with `use_acuwt?` enabled), and makes `reset_timeslices_for_reaggregation_from_acuwt`
in `TimesliceCleaner` consistently clean up both ACT and CUWT rows before reaggregation.

Previously, `UpdateTimeslicesUntrackedArticle` only handled the legacy path: it updated
`tracked` on `ArticleCourseTimeslice` rows and marked affected `CourseWikiTimeslice`
rows as `needs_update`. For ACUWT courses, the correct approach is to mark affected CWT
rows as `needs_reaggregation` (so they are re-derived from ACUWT without a full
MediaWiki re-fetch) and to flip the `tracked` field on the ACUWT rows themselves.

The ordering in the new `untrack_acuwt`/`retrack_acuwt` methods is crash-safe:
`reset_timeslices_for_reaggregation_from_acuwt` always runs before `update_all`,
so if the process dies mid-run the CWT is already flagged for reaggregation and
will self-correct on the next course update.

`reset_timeslices_for_reaggregation_from_acuwt` previously deleted ACT rows but
left CUWT rows for callers to handle. This PR moves CUWT deletion into the shared
method (consistent with ACT), removes the now-redundant explicit call from
`remove_courses_users_acuwt`, and prepares the ground for a future "avoid empty
rows" optimisation where both would need a clean slate anyway.

### Benchmarks
I ran some updates manually in my local computer to compare metrics and times.

**ACUWT**

```
# Untrack file
"36": {
    "start_time": "2026-06-10T00:26:07.511+00:00",
    "end_time": "2026-06-10T00:26:12.359+00:00",
    "sentry_tag_uuid": "80b0e118-d518-4cc1-8287-0ed0ba5ef640",
    "error_count": 0,
    "reference_counter_403_count": 0,
    "too_many_requests_count": 0,
    "processed": 1,
    "reprocessed": 0,
    "reaggregated": 3
},
# Retrack file
"38": {
    "start_time": "2026-06-10T00:26:35.963+00:00",
    "end_time": "2026-06-10T00:27:03.274+00:00",
    "sentry_tag_uuid": "f80c1eb1-c392-4df6-8fd7-eda211d26203",
    "error_count": 0,
    "reference_counter_403_count": 0,
    "too_many_requests_count": 1,
    "processed": 1,
    "reprocessed": 0,
    "reaggregated": 3
}
```
**Default path**

```
# Untrack file
  "25": {
      "start_time": "2026-06-10T00:22:55.503+00:00",
      "end_time": "2026-06-10T00:24:01.093+00:00",
      "sentry_tag_uuid": "fbf0bd7f-ea7d-4773-bc46-1a72cbc17b44",
      "error_count": 0,
      "reference_counter_403_count": 0,
      "too_many_requests_count": 0,
      "processed": 1,
      "reprocessed": 3,
      "reaggregated": 0
  },
# Retrack file
"26": {
    "start_time": "2026-06-10T00:27:33.741+00:00",
    "end_time": "2026-06-10T00:28:38.713+00:00",
    "sentry_tag_uuid": "3dc8af83-9a88-4bda-9d38-ad762014c991",
    "error_count": 0,
    "reference_counter_403_count": 0,
    "too_many_requests_count": 0,
    "processed": 1,
    "reprocessed": 3,
    "reaggregated": 0
}
```

## AI usage

Claude Code (claude-sonnet-4-6) was used throughout this PR: it drafted all code
changes, wrote commit messages, and participated in design discussions in the
Claude Code CLI. The human directed what to build, caught a comment-stripping
mistake and an asymmetry between `untrack_acuwt` and `retrack_acuwt` that Claude
had introduced unnecessarily, and made the key decisions (crash-safe ordering,
consistent ACT/CUWT treatment, deferring the `tracked` filter changes to
aggregation models). The work spans 2 commits made in a single session on
2026-06-09/10. This PR description was drafted using the `/prepare-pr` Claude Code
skill.

## Screenshots

No UI changes.

## Open questions and concerns

(PR description written by Claude Code.)