### PR TITLE
[ACUWT] Populate mw_rev_count from ACUWT

### DIFF
--- a/app/models/course_wiki_timeslice.rb
+++ b/app/models/course_wiki_timeslice.rb
@@ -59,8 +59,8 @@ class CourseWikiTimeslice < ApplicationRecord
     timeslices.first.update_cache_from_revisions revisions[:revisions]
   end
 
-  def self.update_from_acuwt(course, wiki, start, finish, revisions = nil)
-    find_by!(course:, wiki:, start:, end: finish).update_cache_from_acuwt(revisions)
+  def self.update_from_acuwt(course, wiki, start, finish)
+    find_by!(course:, wiki:, start:, end: finish).update_cache_from_acuwt
   end
 
   ####################
@@ -68,21 +68,17 @@ class CourseWikiTimeslice < ApplicationRecord
   ####################
 
   # Updates CWT stats from existing ACUWT rows without fetching from MediaWiki.
-  # TODO: Remove the revisions parameter once mw_rev_count is derived from ACUWT.
-  def update_cache_from_acuwt(revisions = nil)
+  def update_cache_from_acuwt
     @students = course.courses_users.where(role: CoursesUsers::Roles::STUDENT_ROLE)
     update_character_sum_from_acuwt
     update_references_count_from_acuwt
     update_revision_count_from_acuwt
+    update_mw_rev_count_from_acuwt
     update_stats_from_acuwt
     # needs_update is cleared unconditionally: any retry need is tracked at the ACUWT level
     # (ArticleCourseUserWikiTimeslice.needs_update) and handled by
     # ReprocessArticleCourseUserWikiTimeslices, not by re-fetching the full CWT.
     self.needs_update = false
-    if revisions
-      @revisions = revisions.select(&:scoped)
-      update_mw_rev_count
-    end
     self.needs_reaggregation = false
     save
   end
@@ -144,6 +140,17 @@ class CourseWikiTimeslice < ApplicationRecord
     query = query.where(article_id: course.scoped_article_ids) if
       course.only_scoped_articles_course?
     self.revision_count = query.sum(:revision_count)
+  end
+
+  # Approximation: mw_rev_count normally includes deleted revisions (CourseRevisionUpdater
+  # cannot filter them without fetching scores), but ACUWT only stores live revisions,
+  # so deleted revisions are not counted here. This is imperfect and should be improved
+  # in the future to match exactly the same criteria as CourseRevisionUpdater#new_revisions?.
+  def update_mw_rev_count_from_acuwt
+    query = ArticleCourseUserWikiTimeslice.where(course:, wiki:, start:)
+    query = query.where(article_id: course.scoped_article_ids) if
+      course.only_scoped_articles_course?
+    self.mw_rev_count = query.sum(:revision_count)
   end
 
   def acuwt_mainspace_tracked_student_records

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -244,8 +244,7 @@ class UpdateCourseWikiTimeslices
 
   def update_course_wiki_timeslices_from_acuwt_for_wiki(wiki, revisions)
     timeslice = acuwt_timeslice_for(wiki, revisions)
-    CourseWikiTimeslice.update_from_acuwt(@course, wiki, timeslice.start, timeslice.end,
-                                          revisions[:revisions])
+    CourseWikiTimeslice.update_from_acuwt(@course, wiki, timeslice.start, timeslice.end)
   end
 
   def reaggregate_timeslices_from_acuwt(wiki)

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -238,6 +238,13 @@ scoped: false)
         expect(course_wiki_timeslice.revision_count).to eq(5)
       end
 
+      it 'computes mw_rev_count from ACUWT across all articles' do
+        course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+        course_wiki_timeslice.update_cache_from_acuwt
+
+        expect(course_wiki_timeslice.mw_rev_count).to eq(5)
+      end
+
       context 'when a student also has ACUWT for a non-mainspace article' do
         let(:draft_article) { create(:article, namespace: Article::Namespaces::DRAFT) }
 
@@ -282,6 +289,13 @@ scoped: false)
 
           expect(course_wiki_timeslice.revision_count).to eq(0)
         end
+
+        it 'includes non-tracked articles in mw_rev_count' do
+          course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+          course_wiki_timeslice.update_cache_from_acuwt
+
+          expect(course_wiki_timeslice.mw_rev_count).to eq(5)
+        end
       end
 
       context 'when an instructor has ACUWT records' do
@@ -321,6 +335,14 @@ scoped: false)
 
           # Only scoped article ACUWT: 3 + 2 = 5; unscoped article (7) is excluded
           expect(course_wiki_timeslice.revision_count).to eq(5)
+        end
+
+        it 'excludes out-of-scope articles from mw_rev_count' do
+          course_wiki_timeslice = described_class.find_by(course:, wiki:, start:)
+          course_wiki_timeslice.update_cache_from_acuwt
+
+          # Only scoped article ACUWT: 3 + 2 = 5; unscoped article (7) is excluded
+          expect(course_wiki_timeslice.mw_rev_count).to eq(5)
         end
 
         it 'excludes out-of-scope articles from character_sum' do


### PR DESCRIPTION
## What this PR does

Derives `mw_rev_count` on `CourseWikiTimeslice` from ACUWT rows instead of
from in-memory revision objects. Previously, `update_cache_from_acuwt` only
populated `mw_rev_count` when revision objects were explicitly passed in (a
leftover from the transition to the ACUWT path). This PR adds
`update_mw_rev_count_from_acuwt`, which sums `revision_count` from
`ArticleCourseUserWikiTimeslice` for the same course/wiki/timeslice without
filtering not-tracked articles — preserving the original `mw_rev_count`
semantics — and calls it unconditionally from `update_cache_from_acuwt`.

The `revisions` parameter is removed from `update_cache_from_acuwt` and
`update_from_acuwt`, eliminating the last reason to pass revision objects
into the ACUWT update path.

**Known approximation**: the revision-based `update_mw_rev_count` includes
deleted revisions (because `CourseRevisionUpdater#new_revisions?` cannot
filter them without fetching scores), while ACUWT only stores live revisions.
The new method therefore undercounts slightly relative to the revision-based
path. A comment documents this and notes it should be improved in the future
to match exactly the same criteria as `new_revisions?`.

## AI usage

Claude Code (Sonnet 4.6) drafted all code and commit messages under the
developer's direction. The developer described the approach (sum ACUWT
`revision_count` without filtering not-tracked articles, similar to
`update_revision_count_from_acuwt`), reviewed each proposed change, and
corrected the approximation comment through three rounds of iteration before
approving. The developer also tested the change locally before committing.
Specs were written by Claude Code in a follow-up exchange. This PR
description was drafted using the `/prepare-pr` Claude Code skill.

The work spans 2 commits made within a single session.

## Screenshots

No UI changes.

## Open questions and concerns

The `mw_rev_count` computed via ACUWT will undercount compared to the
revision-based path whenever there are deleted revisions in the timeslice
window. This is noted in a code comment and should be addressed in a future
PR by finding a way to include deleted revisions in the ACUWT count, matching
the filter applied by `CourseRevisionUpdater#new_revisions?`.

(PR description written by Claude Code.)