### PR TITLE
add system_stat and facilitator_stat table

### DIFF
--- a/app/models/facilitator_stat.rb
+++ b/app/models/facilitator_stat.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: facilitator_stats
+#
+#  id                      :bigint           not null, primary key
+#  snapshot_date            :date             not null
+#  user_id                 :bigint           not null
+#  total_programs_count    :integer          default(0)
+#  active_programs_count   :integer          default(0)
+#  total_edits             :integer          default(0)
+#  new_editors_count       :integer          default(0)
+#  new_editors_count_with_preregistration :integer default(0)
+#  total_students_count    :integer          default(0)
+#  total_characters_added  :bigint           default(0)
+#  active_in_last_year     :boolean          default(FALSE)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+
+# Stores weekly snapshots of per-facilitator (instructor/organizer) metrics.
+# Populated by FacilitatorStatUpdateWorker (sidekiq-cron, weekly).
+# Enables WMF to identify impactful organizers and track facilitator activity.
+class FacilitatorStat < ApplicationRecord
+  belongs_to :user
+
+  validates :snapshot_date, presence: true
+  validates :user_id, uniqueness: { scope: :snapshot_date }
+
+  scope :latest, -> { where(snapshot_date: order(snapshot_date: :desc).pick(:snapshot_date)) }
+  scope :for_date_range, ->(start_date, end_date) {
+    where(snapshot_date: start_date..end_date).order(:snapshot_date)
+  }
+  scope :active_facilitators, -> { where(active_in_last_year: true) }
+
+  # Returns the most recent snapshot for all facilitators.
+  def self.current
+    latest.includes(:user)
+  end
+
+  # Returns stats for a specific facilitator over time.
+  def self.for_user(user_id)
+    where(user_id: user_id).order(:snapshot_date)
+  end
+end

--- a/app/models/system_stat.rb
+++ b/app/models/system_stat.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: system_stats
+#
+#  id                        :bigint           not null, primary key
+#  snapshot_date              :date             not null
+#  total_edits               :bigint           default(0)
+#  total_article_views       :bigint           default(0)
+#  total_articles_improved   :integer          default(0)
+#  total_articles_created    :integer          default(0)
+#  active_programs_count     :integer          default(0)
+#  archived_programs_count   :integer          default(0)
+#  new_editors_count         :integer          default(0)
+#  new_editors_count_with_preregistration :integer default(0)
+#  active_facilitators_count :integer          default(0)
+#  total_characters_added    :bigint           default(0)
+#  wiki_stats                :text(65535)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#
+
+# Stores daily snapshots of system-wide metrics across all non-private programs.
+# Populated by SystemStatUpdateWorker (sidekiq-cron, daily).
+# Serves the System Stats dashboard and JSON API.
+class SystemStat < ApplicationRecord
+  serialize :wiki_stats, type: Hash
+
+  validates :snapshot_date, presence: true, uniqueness: true
+
+  scope :latest, -> { order(snapshot_date: :desc).limit(1) }
+  scope :for_date_range, ->(start_date, end_date) {
+    where(snapshot_date: start_date..end_date).order(:snapshot_date)
+  }
+
+  # Returns the most recent snapshot, or nil if none exist.
+  def self.current
+    latest.first
+  end
+
+  # Returns the last N months of snapshots for trend charts.
+  def self.recent_months(months = 12)
+    for_date_range(months.months.ago.to_date, Date.today)
+  end
+end

--- a/db/migrate/20260613211819_create_system_stats.rb
+++ b/db/migrate/20260613211819_create_system_stats.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateSystemStats < ActiveRecord::Migration[7.0]
+  def change
+    create_table :system_stats do |t|
+      t.date     :snapshot_date,              null: false
+      t.bigint   :total_edits,               default: 0
+      t.bigint   :total_article_views,        default: 0
+      t.integer  :total_articles_improved,    default: 0
+      t.integer  :total_articles_created,     default: 0
+      t.integer  :active_programs_count,      default: 0
+      t.integer  :archived_programs_count,    default: 0
+      t.integer  :new_editors_count,          default: 0  # registered during course
+      t.integer  :new_editors_count_with_preregistration, default: 0 # includes 60-day pre-window
+      t.integer  :active_facilitators_count,  default: 0
+      t.bigint   :total_characters_added,     default: 0
+      t.text     :wiki_stats                  # Per-wiki breakdown, serialized as Hash
+      t.timestamps
+    end
+
+    add_index :system_stats, :snapshot_date, unique: true
+  end
+end

--- a/db/migrate/20260613211820_create_facilitator_stats.rb
+++ b/db/migrate/20260613211820_create_facilitator_stats.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateFacilitatorStats < ActiveRecord::Migration[7.0]
+  def change
+    create_table :facilitator_stats do |t|
+      t.date       :snapshot_date,           null: false
+      t.integer    :user_id,                 null: false
+      t.foreign_key :users, column: :user_id
+      t.integer    :total_programs_count,    default: 0
+      t.integer    :active_programs_count,   default: 0
+      t.integer    :total_edits,             default: 0
+      t.integer    :new_editors_count,       default: 0
+      t.integer    :new_editors_count_with_preregistration, default: 0
+      t.integer    :total_students_count,    default: 0
+      t.bigint     :total_characters_added,  default: 0
+      t.boolean    :active_in_last_year,     default: false
+      t.timestamps
+    end
+
+    add_index :facilitator_stats, %i[snapshot_date user_id], unique: true
+    add_index :facilitator_stats, :snapshot_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_28_223445) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_13_211820) do
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "courses_id"
     t.string "title"
@@ -350,6 +350,24 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_28_223445) do
     t.index ["wiki_id"], name: "index_courses_wikis_on_wiki_id"
   end
 
+  create_table "facilitator_stats", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.date "snapshot_date", null: false
+    t.bigint "user_id", null: false
+    t.integer "total_programs_count", default: 0
+    t.integer "active_programs_count", default: 0
+    t.integer "total_edits", default: 0
+    t.integer "new_editors_count", default: 0
+    t.integer "new_editors_count_with_preregistration", default: 0
+    t.integer "total_students_count", default: 0
+    t.bigint "total_characters_added", default: 0
+    t.boolean "active_in_last_year", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["snapshot_date", "user_id"], name: "index_facilitator_stats_on_snapshot_date_and_user_id", unique: true
+    t.index ["snapshot_date"], name: "index_facilitator_stats_on_snapshot_date"
+    t.index ["user_id"], name: "index_facilitator_stats_on_user_id"
+  end
+
   create_table "faqs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -522,6 +540,24 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_28_223445) do
     t.index ["survey_id"], name: "index_surveys_question_groups_on_survey_id"
   end
 
+  create_table "system_stats", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.date "snapshot_date", null: false
+    t.bigint "total_edits", default: 0
+    t.bigint "total_article_views", default: 0
+    t.integer "total_articles_improved", default: 0
+    t.integer "total_articles_created", default: 0
+    t.integer "active_programs_count", default: 0
+    t.integer "archived_programs_count", default: 0
+    t.integer "new_editors_count", default: 0
+    t.integer "new_editors_count_with_preregistration", default: 0
+    t.integer "active_facilitators_count", default: 0
+    t.bigint "total_characters_added", default: 0
+    t.text "wiki_stats"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["snapshot_date"], name: "index_system_stats_on_snapshot_date", unique: true
+  end
+
   create_table "tags", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "tag"
@@ -682,5 +718,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_28_223445) do
   add_foreign_key "admin_course_notes", "courses", column: "courses_id"
   add_foreign_key "course_stats", "courses"
   add_foreign_key "course_wiki_namespaces", "courses_wikis", column: "courses_wikis_id", on_delete: :cascade
+  add_foreign_key "facilitator_stats", "users"
   add_foreign_key "lti_contexts", "users", on_delete: :cascade
 end


### PR DESCRIPTION
## What this PR does

Adds the database schema for system_stats and facilitators_stats table as part of the GSoC 2026 "System-Wide Metrics & Data Downloads" project.

**Two new tables:**

1. `system_stats`: Daily snapshots of global metrics across all  non-private programs: total edits, article views, articles created,  new editors, active facilitators, per-wiki breakdown, etc.

2. `facilitator_stats` : Weekly snapshots of per-facilitator (organizer)  metrics: programs run, edits generated, new editors created, students  enrolled. Enables WMF to identify impactful organizers.


## AI usage
I used AI  throughout this PR for:
- writing migrations.
- Understanding how existing analytics code (CourseStatistics, RetainedNewEditorsStats) works.