### PR TITLE
Improve Lexeme support for Wikidata stats

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Layout/LineLength:
   Max: 100
 
 Metrics/ClassLength:
-  Max: 130 # We should bring this down, ideally to the default of 100
+  Max: 145 # We should bring this down, ideally to the default of 100
   Exclude: # These are too big, and should be shrunk if feasible.
     - 'app/models/alert.rb'
     - 'app/models/alert_types/ai_edit_alert.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/WikiEducationFoundation/wikidata-diff-analyzer
-  revision: 683c88e6744f6c95cc4653dd4a0df4e32a092c65
+  revision: 21a2914a32554b4372633463a34b2801c16c3311
   specs:
     wikidata-diff-analyzer (2.2.0)
       json (~> 2.1)
@@ -242,7 +242,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.23.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -253,7 +253,7 @@ GEM
       faraday (>= 1, < 3)
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
@@ -331,7 +331,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.4)
+    json (2.19.9)
     jwt (2.5.0)
     kt-paperclip (7.2.2)
       activemodel (>= 4.2.0)

--- a/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
+++ b/app/assets/javascripts/components/common/wikidata_overview_stats.jsx
@@ -232,6 +232,304 @@ const WikidataOverviewStats = ({ statistics, isCourseOverview }) => {
             />
           </div>
         </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.language')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="language-added"
+              className="stat-display__value-small"
+              stat={statistics['language added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="language-changed"
+              className="stat-display__value-small"
+              stat={statistics['language changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.lexical_category')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="lexical-category-added"
+              className="stat-display__value-small"
+              stat={statistics['lexical category added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="lexical-category-changed"
+              className="stat-display__value-small"
+              stat={statistics['lexical category changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.lemmas')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="lemmas-added"
+              className="stat-display__value-small"
+              stat={statistics['lemmas added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="lemmas-removed"
+              className="stat-display__value-small"
+              stat={statistics['lemmas removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="lemmas-changed"
+              className="stat-display__value-small"
+              stat={statistics['lemmas changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.forms')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="forms-added"
+              className="stat-display__value-small"
+              stat={statistics['forms added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="forms-removed"
+              className="stat-display__value-small"
+              stat={statistics['forms removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="forms-changed"
+              className="stat-display__value-small"
+              stat={statistics['forms changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.form_claims')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="form-claims-added"
+              className="stat-display__value-small"
+              stat={statistics['form claims added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="form-claims-removed"
+              className="stat-display__value-small"
+              stat={statistics['form claims removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="form-claims-changed"
+              className="stat-display__value-small"
+              stat={statistics['form claims changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.form_references')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="form-references-added"
+              className="stat-display__value-small"
+              stat={statistics['form references added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="form-references-removed"
+              className="stat-display__value-small"
+              stat={statistics['form references removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="form-references-changed"
+              className="stat-display__value-small"
+              stat={statistics['form references changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.form_qualifiers')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="form-qualifiers-added"
+              className="stat-display__value-small"
+              stat={statistics['form qualifiers added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="form-qualifiers-removed"
+              className="stat-display__value-small"
+              stat={statistics['form qualifiers removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="form-qualifiers-changed"
+              className="stat-display__value-small"
+              stat={statistics['form qualifiers changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.senses')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="senses-added"
+              className="stat-display__value-small"
+              stat={statistics['senses added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="senses-removed"
+              className="stat-display__value-small"
+              stat={statistics['senses removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="senses-changed"
+              className="stat-display__value-small"
+              stat={statistics['senses changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.glosses')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="glosses-added"
+              className="stat-display__value-small"
+              stat={statistics['glosses added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="glosses-removed"
+              className="stat-display__value-small"
+              stat={statistics['glosses removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="glosses-changed"
+              className="stat-display__value-small"
+              stat={statistics['glosses changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.sense_claims')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="sense-claims-added"
+              className="stat-display__value-small"
+              stat={statistics['sense claims added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="sense-claims-removed"
+              className="stat-display__value-small"
+              stat={statistics['sense claims removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="sense-claims-changed"
+              className="stat-display__value-small"
+              stat={statistics['sense claims changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.sense_references')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="sense-references-added"
+              className="stat-display__value-small"
+              stat={statistics['sense references added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="sense-references-removed"
+              className="stat-display__value-small"
+              stat={statistics['sense references removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="sense-references-changed"
+              className="stat-display__value-small"
+              stat={statistics['sense references changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
+        <div className="stat-display__row">
+          <h5 className="stats-label">{I18n.t('metrics.sense_qualifiers')}</h5>
+          <div className="stat-display__value-group">
+            <OverviewStat
+              id="sense-qualifiers-added"
+              className="stat-display__value-small"
+              stat={statistics['sense qualifiers added']}
+              statMsg={I18n.t('metrics.added')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="sense-qualifiers-removed"
+              className="stat-display__value-small"
+              stat={statistics['sense qualifiers removed']}
+              statMsg={I18n.t('metrics.removed')}
+              renderZero={true}
+            />
+            <OverviewStat
+              id="sense-qualifiers-changed"
+              className="stat-display__value-small"
+              stat={statistics['sense qualifiers changed']}
+              statMsg={I18n.t('metrics.changed')}
+              renderZero={true}
+            />
+          </div>
+        </div>
       </div>
     </div>
     );

--- a/app/services/update_wikidata_stats_timeslice.rb
+++ b/app/services/update_wikidata_stats_timeslice.rb
@@ -68,7 +68,23 @@ class UpdateWikidataStatsTimeslice
     'changed_formclaims' => 'form claims changed',
     'added_senseclaims' => 'sense claims added',
     'removed_senseclaims' => 'sense claims removed',
-    'changed_senseclaims' => 'sense claims changed'
+    'changed_senseclaims' => 'sense claims changed',
+    'added_form_references' => 'form references added',
+    'removed_form_references' => 'form references removed',
+    'changed_form_references' => 'form references changed',
+    'added_form_qualifiers' => 'form qualifiers added',
+    'removed_form_qualifiers' => 'form qualifiers removed',
+    'changed_form_qualifiers' => 'form qualifiers changed',
+    'added_sense_references' => 'sense references added',
+    'removed_sense_references' => 'sense references removed',
+    'changed_sense_references' => 'sense references changed',
+    'added_sense_qualifiers' => 'sense qualifiers added',
+    'removed_sense_qualifiers' => 'sense qualifiers removed',
+    'changed_sense_qualifiers' => 'sense qualifiers changed',
+    'added_language' => 'language added',
+    'changed_language' => 'language changed',
+    'added_lexical_category' => 'lexical category added',
+    'changed_lexical_category' => 'lexical category changed'
   }.freeze
 
   def initialize(course)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1293,6 +1293,18 @@ en:
       or "Created claim" instead.
     restorations_performed: Restorations performed
     reverts_performed: Reverts performed
+    lemmas: Lemmas
+    language: Language
+    lexical_category: Lexical category
+    forms: Forms
+    form_claims: Form claims
+    form_references: Form references
+    form_qualifiers: Form qualifiers
+    senses: Senses
+    glosses: Glosses
+    sense_claims: Sense claims
+    sense_references: Sense references
+    sense_qualifiers: Sense qualifiers
 
   namespace:
     all: All

--- a/spec/services/update_wikidata_stats_timeslice_spec.rb
+++ b/spec/services/update_wikidata_stats_timeslice_spec.rb
@@ -44,6 +44,45 @@ describe UpdateWikidataStatsTimeslice do
       expect(stats['merged from']).to eq(1)
     end
 
+    it 'counts new lexeme stat keys in built stats' do
+      revision = build(:revision_on_memory, wiki_id: wikidata.id, scoped: true)
+      revision.summary = {
+        'added_language' => 1,
+        'changed_language' => 2,
+        'added_lexical_category' => 1,
+        'changed_lexical_category' => 1,
+        'added_form_references' => 3,
+        'removed_form_references' => 1,
+        'changed_form_references' => 2,
+        'added_form_qualifiers' => 2,
+        'removed_form_qualifiers' => 1,
+        'changed_form_qualifiers' => 1,
+        'added_sense_references' => 4,
+        'removed_sense_references' => 2,
+        'changed_sense_references' => 1,
+        'added_sense_qualifiers' => 3,
+        'removed_sense_qualifiers' => 1,
+        'changed_sense_qualifiers' => 2
+      }.to_json
+      stats = updater.build_stats_from_revisions([revision])
+      expect(stats['language added']).to eq(1)
+      expect(stats['language changed']).to eq(2)
+      expect(stats['lexical category added']).to eq(1)
+      expect(stats['lexical category changed']).to eq(1)
+      expect(stats['form references added']).to eq(3)
+      expect(stats['form references removed']).to eq(1)
+      expect(stats['form references changed']).to eq(2)
+      expect(stats['form qualifiers added']).to eq(2)
+      expect(stats['form qualifiers removed']).to eq(1)
+      expect(stats['form qualifiers changed']).to eq(1)
+      expect(stats['sense references added']).to eq(4)
+      expect(stats['sense references removed']).to eq(2)
+      expect(stats['sense references changed']).to eq(1)
+      expect(stats['sense qualifiers added']).to eq(3)
+      expect(stats['sense qualifiers removed']).to eq(1)
+      expect(stats['sense qualifiers changed']).to eq(2)
+    end
+
     it 'creates record in CourseStat table', :vcr do
       expect(CourseStat.count).to eq(0)
       updater.update_revisions_with_stats(revisions)

--- a/spec/services/update_wikidata_stats_timeslice_spec.rb
+++ b/spec/services/update_wikidata_stats_timeslice_spec.rb
@@ -25,6 +25,28 @@ describe UpdateWikidataStatsTimeslice do
       stub_wiki_validation
     end
 
+    context 'emits new Lexeme keys using revision 2414438514' do
+      let(:lexeme_revision) do
+        build(:revision_on_memory, wiki_id: wikidata.id, mw_rev_id: 2414438514, scoped: true)
+      end
+
+      it 'includes the 16 new Lexeme keys in the diff' do
+        VCR.use_cassette 'wikidata/lexeme_revision_new_keys' do
+          updater.update_revisions_with_stats([lexeme_revision])
+        end
+        expect(lexeme_revision.summary).not_to be_nil
+        diff = JSON.parse(lexeme_revision.summary)
+        expect(diff.keys).to include(
+          'added_language', 'changed_language',
+          'added_lexical_category', 'changed_lexical_category',
+          'added_form_references', 'removed_form_references', 'changed_form_references',
+          'added_form_qualifiers', 'removed_form_qualifiers', 'changed_form_qualifiers',
+          'added_sense_references', 'removed_sense_references', 'changed_sense_references',
+          'added_sense_qualifiers', 'removed_sense_qualifiers', 'changed_sense_qualifiers'
+        )
+      end
+    end
+
     it 'imports wikidata', :vcr do
       revisions.each do |rev|
         expect(rev.summary).to be_nil

--- a/spec/support/split_timeslices/over_threshold/expected_timeslices.yml
+++ b/spec/support/split_timeslices/over_threshold/expected_timeslices.yml
@@ -110,6 +110,22 @@ timeslice_7:
     sense claims added: 0
     sense claims removed: 0
     sense claims changed: 0
+    form references added: 0
+    form references removed: 0
+    form references changed: 0
+    form qualifiers added: 0
+    form qualifiers removed: 0
+    form qualifiers changed: 0
+    sense references added: 0
+    sense references removed: 0
+    sense references changed: 0
+    sense qualifiers added: 0
+    sense qualifiers removed: 0
+    sense qualifiers changed: 0
+    language added: 0
+    language changed: 0
+    lexical category added: 0
+    lexical category changed: 0
     total revisions: 4
   last_mw_rev_datetime: 2025-08-26 22:25:45 UTC
   needs_update: false
@@ -171,6 +187,22 @@ timeslice_8:
     sense claims added: 0
     sense claims removed: 0
     sense claims changed: 0
+    form references added: 0
+    form references removed: 0
+    form references changed: 0
+    form qualifiers added: 0
+    form qualifiers removed: 0
+    form qualifiers changed: 0
+    sense references added: 0
+    sense references removed: 0
+    sense references changed: 0
+    sense qualifiers added: 0
+    sense qualifiers removed: 0
+    sense qualifiers changed: 0
+    language added: 0
+    language changed: 0
+    lexical category added: 0
+    lexical category changed: 0
     total revisions: 5
   last_mw_rev_datetime: 2025-08-26 22:30:18 UTC
   needs_update: false
@@ -232,6 +264,22 @@ timeslice_9:
     sense claims added: 0
     sense claims removed: 0
     sense claims changed: 0
+    form references added: 0
+    form references removed: 0
+    form references changed: 0
+    form qualifiers added: 0
+    form qualifiers removed: 0
+    form qualifiers changed: 0
+    sense references added: 0
+    sense references removed: 0
+    sense references changed: 0
+    sense qualifiers added: 0
+    sense qualifiers removed: 0
+    sense qualifiers changed: 0
+    language added: 0
+    language changed: 0
+    lexical category added: 0
+    lexical category changed: 0
     total revisions: 6
   last_mw_rev_datetime: 2025-08-26 22:36:16 UTC
   needs_update: false
@@ -293,6 +341,22 @@ timeslice_10:
     sense claims added: 0
     sense claims removed: 0
     sense claims changed: 0
+    form references added: 0
+    form references removed: 0
+    form references changed: 0
+    form qualifiers added: 0
+    form qualifiers removed: 0
+    form qualifiers changed: 0
+    sense references added: 0
+    sense references removed: 0
+    sense references changed: 0
+    sense qualifiers added: 0
+    sense qualifiers removed: 0
+    sense qualifiers changed: 0
+    language added: 0
+    language changed: 0
+    lexical category added: 0
+    lexical category changed: 0
     total revisions: 6
   last_mw_rev_datetime: 2025-08-26 22:48:41 UTC
   needs_update: false
@@ -354,6 +418,22 @@ timeslice_11:
     sense claims added: 0
     sense claims removed: 0
     sense claims changed: 0
+    form references added: 0
+    form references removed: 0
+    form references changed: 0
+    form qualifiers added: 0
+    form qualifiers removed: 0
+    form qualifiers changed: 0
+    sense references added: 0
+    sense references removed: 0
+    sense references changed: 0
+    sense qualifiers added: 0
+    sense qualifiers removed: 0
+    sense qualifiers changed: 0
+    language added: 0
+    language changed: 0
+    lexical category added: 0
+    lexical category changed: 0
     total revisions: 7
   last_mw_rev_datetime: 2025-08-26 22:57:06 UTC
   needs_update: false

--- a/spec/support/split_timeslices/under_threshold/expected_timeslices.yml
+++ b/spec/support/split_timeslices/under_threshold/expected_timeslices.yml
@@ -56,6 +56,22 @@ timeslice_1:
     sense claims added: 0
     sense claims removed: 0
     sense claims changed: 0
+    form references added: 0
+    form references removed: 0
+    form references changed: 0
+    form qualifiers added: 0
+    form qualifiers removed: 0
+    form qualifiers changed: 0
+    sense references added: 0
+    sense references removed: 0
+    sense references changed: 0
+    sense qualifiers added: 0
+    sense qualifiers removed: 0
+    sense qualifiers changed: 0
+    language added: 0
+    language changed: 0
+    lexical category added: 0
+    lexical category changed: 0
     total revisions: 28
   last_mw_rev_datetime: 2025-08-26 22:57:06 UTC
   needs_update: false


### PR DESCRIPTION
## What this PR does
This addresses PART II of issue #6878
Adds backend mapping and frontend display for the 16 new Lexeme-specific stat keys introduced in the wikidata-diff-analyzer gem , specifically form references, form qualifiers, sense references, sense qualifiers, language, and lexical category. Also wires in the related Lexeme stats that were already tracked by the analyzer (lemmas, forms, form claims, senses, glosses, sense claims) but had never been shown in the UI. Addresses part II of .

Changes:
- `STATS_CLASSIFICATION` in `UpdateWikidataStatsTimeslice` extended with 16 new analyzer keys so they are summed and stored in `CourseStat`
- `wikidata_overview_stats.jsx` expanded with stat rows for all Lexeme sub-categories (language, lexical category, lemmas, forms, form claims, form references, form qualifiers, senses, glosses, sense claims, sense references, sense qualifiers)
- i18n labels added for all new section headers
- `Metrics/ClassLength` ceiling raised to 145 in `.rubocop.yml` to accommodate the larger `STATS_CLASSIFICATION` hash

## AI usage
No AI usage

## Screenshots

<img width="1091" height="537" alt="Screenshot 2026-06-15 at 16 20 34" src="https://github.com/user-attachments/assets/9ff6e85d-7c95-4f29-a2f6-a2db6f4acac1" />


<img width="1680" height="967" alt="Screenshot 2026-06-15 at 16 21 01" src="https://github.com/user-attachments/assets/f23d2b93-12bb-4295-a7ec-be71a5344ebe" />
