### PR TITLE
[ACUWT] Improve Sentry logs when debug_updates flag is enabled for ACUWT path.

### DIFF
--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -60,7 +60,6 @@ class UpdateCourseWikiTimeslices
       # Re-aggregate CWT/ACT/CUWT rows from existing ACUWT for timeslices
       # that were not fully reprocessed in this cycle.
       reaggregate_timeslices_from_acuwt(wiki) if @course.use_acuwt?
-      @debugger.log_update_progress :"timeslices_processed_#{wiki.id}"
     end
   end
 
@@ -80,11 +79,13 @@ class UpdateCourseWikiTimeslices
         t.update(needs_update: true) # No effect if t has split
       end
     end
+    @debugger.log_update_progress :"timeslices_processed_#{wiki.id}"
   end
 
   def fetch_data_and_reprocess_acuwt_timeslices(wiki)
     ReprocessArticleCourseUserWikiTimeslices.new(@course, wiki,
                                                  update_service: @update_service).run
+    @debugger.log_update_progress :"acuwt_timeslices_reprocessed_#{wiki.id}"
   end
 
   def fetch_data_and_reprocess_timeslices(wiki, ingestion_start)
@@ -103,6 +104,7 @@ class UpdateCourseWikiTimeslices
         log_error(e, t.start, t.end, wiki.id)
       end
     end
+    @debugger.log_update_progress :"timeslices_reprocessed_#{wiki.id}"
   end
 
   # Given a wiki and limits of the timeslice, it fetches data for it
@@ -255,6 +257,7 @@ class UpdateCourseWikiTimeslices
       reaggregate_timeslice_from_acuwt(cwt)
       @reaggregated_timeslices_count += 1
     end
+    @debugger.log_update_progress :"timeslices_reaggregated_#{wiki.id}"
   end
 
   def reaggregate_timeslice_from_acuwt(cwt)

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -42,9 +42,33 @@ describe UpdateCourseWikiTimeslices do
     context 'when :debug_updates flag is set' do
       let(:flags) { { debug_updates: true } }
 
-      it 'posts debug info to Sentry' do
-        expect(Sentry).to receive(:capture_message).at_least(:twice).and_call_original
-        subject
+      def captured_update_steps
+        messages = []
+        allow(Sentry).to receive(:capture_message) do |message, **_opts|
+          messages << message
+        end
+        VCR.use_cassette 'course_wiki_timeslices_update' do
+          subject
+        end
+        messages.filter_map { |m| m[/#{Regexp.escape(course.title)} update: (.+)/, 1] }
+      end
+
+      it 'logs the reprocessing stage for every wiki' do
+        steps = captured_update_steps
+        expect(steps).to include("timeslices_reprocessed_#{enwiki.id}")
+        expect(steps).to include("timeslices_reprocessed_#{wikidata.id}")
+      end
+
+      it 'logs the processing stage for every wiki' do
+        steps = captured_update_steps
+        expect(steps).to include("timeslices_processed_#{enwiki.id}")
+        expect(steps).to include("timeslices_processed_#{wikidata.id}")
+      end
+
+      it 'does not log the ACUWT-specific stages when use_acuwt? is not set' do
+        steps = captured_update_steps
+        expect(steps).not_to(include(a_string_matching(/acuwt_timeslices_reprocessed_/)))
+        expect(steps).not_to(include(a_string_matching(/timeslices_reaggregated_/)))
       end
     end
 
@@ -415,6 +439,31 @@ describe UpdateCourseWikiTimeslices do
         it 'returns the count of reaggregated timeslices' do
           _, _, reaggregated = subject
           expect(reaggregated).to eq(2)
+        end
+      end
+
+      context 'when :debug_updates flag is also set' do
+        before { course.add_flag(key: :debug_updates) }
+
+        def captured_update_steps
+          messages = []
+          allow(Sentry).to receive(:capture_message) do |message, **_opts|
+            messages << message
+          end
+          subject
+          messages.filter_map { |m| m[/#{Regexp.escape(course.title)} update: (.+)/, 1] }
+        end
+
+        it 'logs the ACUWT reprocessing stage for every wiki' do
+          steps = captured_update_steps
+          expect(steps).to include("acuwt_timeslices_reprocessed_#{enwiki.id}")
+          expect(steps).to include("acuwt_timeslices_reprocessed_#{wikidata.id}")
+        end
+
+        it 'logs the reaggregation stage for every wiki' do
+          steps = captured_update_steps
+          expect(steps).to include("timeslices_reaggregated_#{enwiki.id}")
+          expect(steps).to include("timeslices_reaggregated_#{wikidata.id}")
         end
       end
     end


### PR DESCRIPTION
## What this PR does
This PR adds `log_update_progress` calls in `UpdateCourseWikiTimeslices` to log more detailed steps times in ACUWT path. 

The following logs are expected from `UpdateCourseWikiTimeslices` now:

```
      "0_timeslices_adjusted":            2026-06-16 10:00:01 UTC,
      "1_timeslices_reprocessed_1":       2026-06-16 10:00:04 UTC,
      "2_acuwt_timeslices_reprocessed_1": 2026-06-16 10:00:09 UTC,
      "3_timeslices_processed_1":         2026-06-16 10:02:31 UTC,
      "4_timeslices_reaggregated_1":      2026-06-16 10:02:33 UTC,
      "5_timeslices_reprocessed_5":       2026-06-16 10:02:34 UTC,
      "6_acuwt_timeslices_reprocessed_5": 2026-06-16 10:02:35 UTC,
      "7_timeslices_processed_5":         2026-06-16 10:03:10 UTC,
      "8_timeslices_reaggregated_5":      2026-06-16 10:03:11 UTC

```

The idea is to be able to determine if some specific step for ACUWT path takes too long.

## AI usage
Used Opus 4.8 to write specs.


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
