### PR TITLE
Add acuwt_update queue for use_acuwt courses

### DIFF
--- a/app/services/system_metrics.rb
+++ b/app/services/system_metrics.rb
@@ -56,7 +56,8 @@ class SystemMetrics
     'medium_update' => 12.hours,
     'long_update' => 1.day,
     'daily_update' => 1.day,
-    'constant_update' => 15.minutes
+    'constant_update' => 15.minutes,
+    'acuwt_update' => 1.day
   }.freeze
 
   def get_queue_status(queue_name, latency)

--- a/app/workers/course_data_update_worker.rb
+++ b/app/workers/course_data_update_worker.rb
@@ -20,8 +20,12 @@ class CourseDataUpdateWorker
           phase: 'initialization')
     sidekiq_status_logger = LogSidekiqStatus.new(method(:store))
     course = Course.find(course_id)
-    logger.info "Ignoring #{course.slug} update" if course.very_long_update?
-    return if course.very_long_update?
+    # use_acuwt courses are intentionally flagged very_long_update so they stay
+    # out of the normal queues; the acuwt_update queue is the one that updates
+    # them, so we must not skip them here.
+    ignore_update = course.very_long_update? && !course.use_acuwt?
+    logger.info "Ignoring #{course.slug} update" if ignore_update
+    return if ignore_update
 
     logger.info "Updating course timeslice version: #{course.slug}"
     UpdateCourseStats.new(course, sidekiq_status_logger:)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1465,6 +1465,9 @@ en:
   status:
     active_jobs: Active jobs
     active_jobs_doc: The number of currently processing jobs.
+    acuwt_update: ACUWT update
+    acuwt_update_description: ACUWT updates process article scoped program courses with thousands of articles.
+    acuwt_update_doc: Handle updates for large article scoped program courses.
     all_queues_operational: All Queues Operational
     all_queues_not_operational: All Queues Operational except
     constant_update: Constant update

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -28,3 +28,4 @@ test:
  - daily_update
  - constant_update
  - very_long_update
+ - acuwt_update

--- a/lib/data_cycle/course_queue_sorting.rb
+++ b/lib/data_cycle/course_queue_sorting.rb
@@ -6,6 +6,7 @@ module CourseQueueSorting
 
   def queue_for(course)
     update_longest_update_time(course)
+    return 'acuwt_update' if course.use_acuwt?
     return 'very_long_update' if course.very_long_update?
     return 'long_update' if too_many_consecutive_unfinished_updates?(course)
 

--- a/server_config/systemd/sidekiq-acuwt.service
+++ b/server_config/systemd/sidekiq-acuwt.service
@@ -1,0 +1,36 @@
+# Based on https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service
+#
+# A single long-update worker dedicated to the acuwt_update queue: instead of
+# being one more `sidekiq-long@` instance reading the normal long queues, this
+# process reads ONLY from acuwt_update, which holds courses flagged use_acuwt
+# (and very_long_update, to keep them out of the normal queues).
+
+[Unit]
+Description=sidekiq-acuwt
+After=syslog.target network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ragesoss/WikiEduDashboard
+ExecStart=/home/ragesoss/.rvm/bin/rvm default do bundle exec sidekiq -e production --queue acuwt_update --concurrency 1
+User=root
+Group=root
+UMask=0002
+
+# Greatly reduce Ruby memory fragmentation and heap usage
+# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
+Environment=MALLOC_ARENA_MAX=2
+
+# if we crash, restart
+RestartSec=1
+Restart=on-failure
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=sidekiq-acuwt
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/lib/data_cycle/course_queue_sorting_spec.rb
+++ b/spec/lib/data_cycle/course_queue_sorting_spec.rb
@@ -45,6 +45,39 @@ describe CourseQueueSorting do
       end
     end
 
+    context 'when the course has use_acuwt enabled' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: { use_acuwt: true })
+      end
+
+      it 'queues in acuwt_update' do
+        expect(subject.queue_for(course)).to eq 'acuwt_update'
+      end
+    end
+
+    context 'when the course has both use_acuwt and very_long_update enabled' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: { use_acuwt: true, very_long_update: true })
+      end
+
+      it 'prefers acuwt_update over very_long_update' do
+        expect(subject.queue_for(course)).to eq 'acuwt_update'
+      end
+    end
+
+    context 'when the course has only very_long_update enabled' do
+      let(:course) do
+        create(:course, start: 1.day.ago, end: 2.months.from_now,
+                        flags: { very_long_update: true })
+      end
+
+      it 'queues in very_long_update' do
+        expect(subject.queue_for(course)).to eq 'very_long_update'
+      end
+    end
+
     context 'when there are old unfinished entries that predate the last success' do
       let(:course) do
         create(:course, start: 1.day.ago, end: 2.months.from_now,

--- a/spec/services/system_metrics_spec.rb
+++ b/spec/services/system_metrics_spec.rb
@@ -60,6 +60,7 @@ describe SystemMetrics do
       expect(service.get_queue_status('long_update', 12.hours)).to eq('Normal')
       expect(service.get_queue_status('daily_update', 12.hours)).to eq('Normal')
       expect(service.get_queue_status('constant_update', 12.minutes)).to eq('Normal')
+      expect(service.get_queue_status('acuwt_update', 12.hours)).to eq('Normal')
       expect(service.get_queue_status('default', 0)).to eq('Normal')
     end
 
@@ -69,6 +70,7 @@ describe SystemMetrics do
       expect(service.get_queue_status('long_update', 26.hours)).to eq('Backlogged')
       expect(service.get_queue_status('daily_update', 26.hours)).to eq('Backlogged')
       expect(service.get_queue_status('constant_update', 16.minutes)).to eq('Backlogged')
+      expect(service.get_queue_status('acuwt_update', 26.hours)).to eq('Backlogged')
       expect(service.get_queue_status('default', 2)).to eq('Backlogged')
     end
   end

--- a/spec/workers/course_data_update_worker_spec.rb
+++ b/spec/workers/course_data_update_worker_spec.rb
@@ -11,4 +11,16 @@ describe CourseDataUpdateWorker do
     expect(Sentry).to receive(:capture_exception)
     described_class.update_course(course_id: course.id, queue: 'default')
   end
+
+  it 'skips courses flagged very_long_update' do
+    course.update(flags: { very_long_update: true })
+    expect(UpdateCourseStats).not_to receive(:new)
+    described_class.new.perform(course.id)
+  end
+
+  it 'updates use_acuwt courses even when flagged very_long_update' do
+    course.update(flags: { use_acuwt: true, very_long_update: true })
+    expect(UpdateCourseStats).to receive(:new)
+    described_class.new.perform(course.id)
+  end
 end


### PR DESCRIPTION
## What this PR does

Adds a dedicated `acuwt_update` Sidekiq queue so that courses flagged
`use_acuwt` are updated by a single worker isolated from the normal update
queues.

The mechanism relies on two existing flags working together. A course is kept
out of the normal queues by `very_long_update` (which nothing consumes), and is
opted into the new behavior by `use_acuwt`. To keep such a course updatable, you
set both flags: `very_long_update` removes it from the regular queues, and
`use_acuwt` routes it to the new `acuwt_update` queue, which a dedicated worker
processes.

Changes:
- `queue_for` routes `use_acuwt?` courses to `acuwt_update`, checked *before*
  `very_long_update` so a course carrying both flags lands in the new queue.
- `CourseDataUpdateWorker` previously bailed on any `very_long_update?` course.
  Since acuwt courses also carry that flag, the guard now skips only
  `very_long_update? && !use_acuwt?`, so acuwt courses actually get processed.
- `config/sidekiq.yml` registers the `acuwt_update` queue.
- `SystemMetrics` reports `acuwt_update` queue health (1-day latency threshold).
  Unlike `very_long_update`, this queue is actively processed, so it must appear
  in metrics and needs a threshold (otherwise `get_queue_status` compares against
  `nil` and raises).
- `server_config/systemd/sidekiq-acuwt.service` is a reference systemd unit for
  a worker that reads only from `acuwt_update`. The intent is to repurpose one of
  the existing N independent `sidekiq-long@` workers rather than add capacity, so
  it mirrors that unit's environment. This is a P&E Dashboard concern (whose
  Sidekiq boxes are updated manually, not via Capistrano), so it is not added to
  `deploy.rb`.
- `config/locales/en.yml` adds the `status.acuwt_update`,
  `status.acuwt_update_description`, and `status.acuwt_update_doc` strings. The
  /status page renders a name/description/doc for every listed queue, so once
  `acuwt_update` joined the list the page raised a 500 on the missing keys.

## AI usage

This PR was written almost entirely by Claude Code (Opus 4.8) under my
direction. I described the flag mechanism and the routing intent; Claude wrote
the worker-guard change, the `sidekiq.yml` and `SystemMetrics` updates, the
systemd unit, the screenshot spec, and all of the other specs, and ran the test
suite. The `queue_for` guard itself I had written before the session, and I
wrote the user-facing `en.yml` strings myself (per project policy, user-facing
text is operator-authored). I corrected Claude twice on the systemd unit (it
first modeled it on the wrong reference unit, then I clarified it should reuse
one of the existing long workers rather than spin up new ones). Each logical
slice was staged by me and committed separately at my direction.

The "What this PR does" summary above and the rest of this description were also
drafted by Claude Code and may contain errors. This PR description was drafted
using the `/prepare-pr` Claude Code skill.

## Screenshots

The /status page now lists the `acuwt_update` queue (bottom row). Before this
PR the same table rendered without that row.

![status queues overview with the ACUWT update row](https://raw.githubusercontent.com/gabina/WikiEduDashboard/pr-screenshots/add-new-acuwt-queue-for-updates/screenshots/after/01_status_queues_overview.png)

## Open questions and concerns

- The systemd unit is a reference copy; deploying it means retiring one
  `sidekiq-long@` instance on the P&E Dashboard and starting `sidekiq-acuwt` in
  its place. This is a manual operational step, not handled by Capistrano.
- I added the new queue to the `/status` to keep it updated, but we may need to change it in the future, depending on how this evolves.

(PR description written by Claude Code.)
