### PR TITLE
Update outdated LiftWing namespace comment in Replica

### DIFF
--- a/lib/replica.rb
+++ b/lib/replica.rb
@@ -37,9 +37,8 @@ class Replica
 
   # Given a list of users and a start and end date, get data about revisions
   # those users made between those dates.
-  # As of 2015-02-24, revisions.php only queries namespaces:
-  #   0 ([mainspace])
-  #   2 (User:)
+  # The external revisions.php API queries a predefined set of content and talk namespaces
+  # (e.g., 0, 1, 2, 3, 118, etc.) which varies by project.
   def get_revisions_raw(users, rev_start, rev_end)
     user_list = compile_usernames_query(users)
     oauth_tags = compile_oauth_tags


### PR DESCRIPTION
Replaced the outdated (2015) documentation comment above get_revisions_raw in lib/replica.rb with an accurate description of how the external API handles namespaces.

#### Reason to update
The previous comment incorrectly stated that revisions.php only queried namespace 0 (mainspace) and 2 (User:). In reality, the external API hardcodes a much wider default list of namespaces (0,1,2,3,4,5,10,11,118,119 covering Main, Talk, User, Draft, Template, etc.) and dynamically appends project-specific namespaces (like Wikidata properties or lexemes) depending on the wiki being queried. This PR updates the comment to reflect this modern behavior, ensuring future maintainers are not misled about which namespaces are actually being fetched from the Replica endpoint.
addresses #6871 
@gabina @ragesoss PTAL