### PR TITLE
Add retention predictors CSV report for FellowsCohort courses

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -181,6 +181,13 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
     ));
   }
 
+  // Retention predictors report, available to admins for Scholars & Scientists courses only.
+  if (user.admin && course.type === 'FellowsCohort') {
+    controls.push((
+      <div key="retention_predictors" className="available-action"><a href={`/course_retention_csv?course=${course.slug}`} className="button">{I18n.t('courses.retention_predictors')}</a></div>
+    ));
+  }
+
   if (user.admin && Features.wikiEd) {
     controls.push((
       <div key="notify_instructors" className="available-action"><NotifyInstructorsButton courseId={course.id} courseTitle={course.title} /></div>

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -10,16 +10,18 @@ class ReportsController < ApplicationController
                 only: %i[campaign_instructors_csv campaign_courses_csv campaign_articles_csv
                          campaign_students_csv campaign_wikidata_csv course_csv
                          course_uploads_csv course_students_csv course_articles_csv
-                         course_wikidata_csv all_courses_and_instructors_csv]
+                         course_wikidata_csv course_retention_csv all_courses_and_instructors_csv]
   before_action :set_campaign, only: %i[campaign_courses_csv campaign_articles_csv
                                         campaign_students_csv campaign_instructors_csv
                                         campaign_wikidata_csv]
   before_action :set_course, only: %i[course_csv course_uploads_csv
                                       course_students_csv course_articles_csv
-                                      course_wikidata_csv]
+                                      course_wikidata_csv course_retention_csv]
 
   before_action :set_sidekiq_job_context
-  before_action :require_admin_permissions, only: [:all_courses_and_instructors_csv]
+  before_action :require_admin_permissions,
+                only: %i[all_courses_and_instructors_csv course_retention_csv]
+  before_action :require_fellows_cohort, only: [:course_retention_csv]
 
   #######################
   # CSV-related actions #
@@ -71,6 +73,10 @@ class ReportsController < ApplicationController
     csv_of('course_wikidata')
   end
 
+  def course_retention_csv
+    csv_of('course_retention')
+  end
+
   def all_courses_and_instructors_csv
     filename = "all-courses-and-instructors-#{Time.zone.today}.csv"
 
@@ -97,6 +103,14 @@ class ReportsController < ApplicationController
     @campaign = Campaign.find_by(slug: csv_params[:slug])
     return if @campaign
     raise ActionController::RoutingError.new('Not Found'), 'Campaign does not exist'
+  end
+
+  # The retention predictors report is only defined for Scholars & Scientists
+  # (FellowsCohort) courses.
+  def require_fellows_cohort
+    return if @course.is_a?(FellowsCohort)
+    raise ActionController::RoutingError.new('Not Found'),
+          'Report not available for this course type'
   end
 
   def csv_of(type)

--- a/app/workers/report_csv_worker.rb
+++ b/app/workers/report_csv_worker.rb
@@ -5,6 +5,7 @@ require_dependency "#{Rails.root}/lib/analytics/course_uploads_csv_builder"
 require_dependency "#{Rails.root}/lib/analytics/course_students_csv_builder"
 require_dependency "#{Rails.root}/lib/analytics/course_articles_csv_builder"
 require_dependency "#{Rails.root}/lib/analytics/course_wikidata_csv_builder"
+require_dependency "#{Rails.root}/lib/analytics/retention_predictors_csv_builder"
 require_dependency "#{Rails.root}/app/controllers/reports_controller"
 require_dependency "#{Rails.root}/app/workers/csv_cleanup_worker"
 require_dependency "#{Rails.root}/lib/analytics/all_courses_and_instructors_csv_builder"
@@ -64,6 +65,8 @@ class ReportCsvWorker
       CourseArticlesCsvBuilder.new(course).generate_csv
     when 'course_wikidata'
       CourseWikidataCsvBuilder.new(course).generate_csv
+    when 'course_retention'
+      RetentionPredictorsCsvBuilder.new(course).generate_csv
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -894,6 +894,7 @@ en:
     retain_available_articles_info_wikidata: >
       When enabled, selecting an Available Item does not remove it from
       the list, allowing a group of students to select the same item.
+    retention_predictors: Retention predictors
     review_timeline: >
       Now, review your assignment timeline, customizing it to fit your needs.
       Once you're satisfied, you can submit it for approval by Wiki Education staff.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,6 +292,7 @@ Rails.application.routes.draw do
   get 'course_students_csv' => 'reports#course_students_csv'
   get 'course_articles_csv' => 'reports#course_articles_csv'
   get 'course_wikidata_csv' => 'reports#course_wikidata_csv'
+  get 'course_retention_csv' => 'reports#course_retention_csv'
   get "all_courses_and_instructors_csv" => "reports#all_courses_and_instructors_csv"
 
   # Campaign reports

--- a/lib/analytics/retention_predictors_csv_builder.rb
+++ b/lib/analytics/retention_predictors_csv_builder.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/wiki_api"
+require 'csv'
+
+# Builds the "Retention predictors" CSV report for a course (currently the
+# Scholars & Scientists / FellowsCohort program).
+#
+# v1 has a single metric: the number of distinct editing sessions per student.
+# Edits an hour or more apart count as distinct sessions; edits closer together
+# are lumped into one session. Sessions are counted per tracked wiki and across
+# all tracked wikis combined, in two independent windows: during the course
+# (course.start..course.end) and after it ended (course.end..now).
+#
+# Edit timestamps come straight from the live MediaWiki usercontribs API, across
+# all namespaces, so this report has no dependency on stored revision data.
+class RetentionPredictorsCsvBuilder
+  SESSION_GAP = 1.hour
+
+  def initialize(course)
+    @course = course
+    @wikis = course.wikis.to_a
+    @students = course.students.to_a.sort_by(&:username)
+  end
+
+  def generate_csv
+    CSV.generate do |csv|
+      csv << headers
+      @students.each { |student| csv << row(student) }
+    end
+  end
+
+  private
+
+  def headers
+    wiki_headers = @wikis.flat_map do |wiki|
+      ["#{wiki.domain} sessions (during course)", "#{wiki.domain} sessions (after course)"]
+    end
+    ['username', *wiki_headers,
+     'all wikis sessions (during course)', 'all wikis sessions (after course)']
+  end
+
+  def row(student)
+    during_all = []
+    after_all = []
+    wiki_cells = @wikis.flat_map do |wiki|
+      during, after = edit_times(student.username, wiki).partition { |t| t <= @course.end }
+      during_all.concat(during)
+      after_all.concat(after)
+      [count_sessions(during), count_sessions(after)]
+    end
+    [student.username, *wiki_cells, count_sessions(during_all), count_sessions(after_all)]
+  end
+
+  # Number of distinct editing sessions: a new session starts whenever the gap
+  # since the previous edit is at least SESSION_GAP.
+  def count_sessions(times)
+    return 0 if times.empty?
+    sessions = 1
+    times.sort.each_cons(2) { |earlier, later| sessions += 1 if later - earlier >= SESSION_GAP }
+    sessions
+  end
+
+  # All of a user's edit timestamps on a wiki since the course start, fetched
+  # from the usercontribs API and paginated until exhausted.
+  def edit_times(username, wiki)
+    api = WikiApi.new(wiki)
+    times = []
+    continue = {}
+    loop do
+      response = api.query(usercontribs_query(username).merge(continue))
+      break unless response
+      contribs = response.data['usercontribs'] || []
+      times.concat(contribs.map { |c| Time.zone.parse(c['timestamp']) })
+      continue = response['continue']
+      break unless continue
+    end
+    times
+  end
+
+  def usercontribs_query(username)
+    {
+      list: 'usercontribs',
+      ucuser: username,
+      ucstart: Time.zone.now.strftime('%Y%m%d%H%M%S'),
+      ucend: @course.start.strftime('%Y%m%d%H%M%S'),
+      ucprop: 'timestamp',
+      uclimit: 'max'
+    }
+  end
+end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -71,6 +71,47 @@ describe ReportsController, type: :request do
     end
   end
 
+  describe '#course_retention_csv' do
+    let(:fellows_course) { create(:course, type: 'FellowsCohort', slug: 'fellows/cohort_(2026)') }
+    let(:admin) { create(:admin) }
+
+    before do
+      allow_any_instance_of(RetentionPredictorsCsvBuilder)
+        .to receive(:generate_csv).and_return("username\nstudent1\n")
+    end
+
+    context 'as an admin on a FellowsCohort course' do
+      before { login_as admin }
+
+      it 'generates and returns the retention predictors CSV' do
+        expect(CsvCleanupWorker).to receive(:perform_at)
+        get '/course_retention_csv', params: { course: fellows_course.slug }
+        expect(response.body).to include('file is being generated')
+        get '/course_retention_csv', params: { course: fellows_course.slug }
+        follow_redirect!
+        expect(response.body.force_encoding('utf-8')).to include('username')
+      end
+    end
+
+    context 'as a non-admin user' do
+      before { login_as user }
+
+      it 'is not authorized' do
+        get '/course_retention_csv', params: { course: fellows_course.slug }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'as an admin on a non-FellowsCohort course' do
+      before { login_as admin }
+
+      it 'is not found' do
+        get '/course_retention_csv', params: { course: course.slug }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe '#campaign_students_csv' do
     let(:student) { create(:user) }
 

--- a/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
+++ b/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/retention_predictors_csv_builder"
+
+describe RetentionPredictorsCsvBuilder do
+  let(:course) do
+    create(:course, start: Time.zone.local(2026, 1, 1),
+                    end: Time.zone.local(2026, 1, 31, 23, 59, 59))
+  end
+  let(:wiki1) { Wiki.find_or_create_by(language: 'en', project: 'wikipedia') }
+  let(:wiki2) { Wiki.find_or_create_by(language: 'es', project: 'wikipedia') }
+  let(:user1) { create(:user, username: 'user1') }
+  let(:user2) { create(:user, username: 'user2') }
+
+  before do
+    # The Wiki model validates against the live API on create; skip that here.
+    allow_any_instance_of(Wiki).to receive(:ensure_wiki_exists)
+    course.wikis = [wiki1, wiki2]
+    create(:courses_user, course:, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)
+    create(:courses_user, course:, user: user2, role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+
+  # Builds a stub MediaWiki API response object for a list of edit Times.
+  def response_for(times, continue: nil)
+    contribs = times.map { |t| { 'timestamp' => t.utc.strftime('%Y-%m-%dT%H:%M:%SZ') } }
+    instance_double(MediawikiApi::Response).tap do |response|
+      allow(response).to receive(:data).and_return('usercontribs' => contribs)
+      allow(response).to receive(:[]).with('continue').and_return(continue)
+    end
+  end
+
+  # Stubs WikiApi.new(wiki) so that usercontribs queries return the given
+  # per-username timestamps. `contribs_by_user` maps username => [Time, ...].
+  def stub_wiki(wiki, contribs_by_user)
+    api = instance_double(WikiApi)
+    allow(WikiApi).to receive(:new).with(wiki).and_return(api)
+    allow(api).to receive(:query) do |params|
+      response_for(contribs_by_user.fetch(params[:ucuser], []))
+    end
+  end
+
+  let(:subject) { described_class.new(course).generate_csv }
+  let(:rows) { CSV.parse(subject, headers: true) }
+  let(:user1_row) { rows.find { |r| r['username'] == 'user1' } }
+
+  describe '#generate_csv' do
+    before do
+      # user1 on en.wikipedia: two clusters during the course, one after.
+      stub_wiki(wiki1, 'user1' => [
+                  Time.zone.local(2026, 1, 5, 10, 0),   # cluster A (during)
+                  Time.zone.local(2026, 1, 5, 10, 30),  # +30 min -> same session
+                  Time.zone.local(2026, 1, 10, 14, 0),  # cluster B (during), days later
+                  Time.zone.local(2026, 2, 15, 9, 0)    # after course end
+                ])
+      # user1 on es.wikipedia: one edit during (45 min after the 10:00 wiki1 edit)
+      # and one after (30 min after the wiki1 post-course edit).
+      stub_wiki(wiki2, 'user1' => [
+                  Time.zone.local(2026, 1, 5, 10, 45),
+                  Time.zone.local(2026, 2, 15, 9, 30)
+                ])
+    end
+
+    it 'counts distinct per-wiki sessions using the one-hour gap rule' do
+      expect(user1_row['en.wikipedia.org sessions (during course)']).to eq('2')
+      expect(user1_row['es.wikipedia.org sessions (during course)']).to eq('1')
+    end
+
+    it 'splits sessions before and after the course end date' do
+      expect(user1_row['en.wikipedia.org sessions (after course)']).to eq('1')
+      expect(user1_row['es.wikipedia.org sessions (after course)']).to eq('1')
+    end
+
+    it 'merges timestamps across wikis for the combined session counts' do
+      # During: 10:00, 10:30, 10:45 collapse to one session; 01-10 is a second.
+      expect(user1_row['all wikis sessions (during course)']).to eq('2')
+      # After: 09:00 and 09:30 collapse to one session.
+      expect(user1_row['all wikis sessions (after course)']).to eq('1')
+    end
+
+    it 'reports zeros for a student with no edits' do
+      user2_row = rows.find { |r| r['username'] == 'user2' }
+      expect(user2_row.fields[1..]).to all(eq('0'))
+    end
+  end
+
+  describe 'pagination' do
+    before do
+      first = response_for([Time.zone.local(2026, 1, 5, 10, 0)], continue: { 'uccontinue' => 'x' })
+      second = response_for([Time.zone.local(2026, 1, 20, 10, 0)])
+      api1 = instance_double(WikiApi)
+      allow(WikiApi).to receive(:new).with(wiki1).and_return(api1)
+      allow(api1).to receive(:query).and_return(first, second)
+      stub_wiki(wiki2, {})
+    end
+
+    it 'follows the continue token to fetch all pages of contributions' do
+      # The two pages are days apart, so both must be fetched to count 2 sessions.
+      expect(user1_row['en.wikipedia.org sessions (during course)']).to eq('2')
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does

Adds a new admin-only, on-demand CSV report — **Retention predictors** — for
Scholars & Scientists (`FellowsCohort`) courses. The first iteration reports a
single metric: the number of **distinct editing sessions** per student, where
edits an hour or more apart count as separate sessions and closer edits are
lumped into one. Sessions are counted per tracked wiki and across all tracked
wikis combined, in two independent windows — **during the course** and **after
it ended** (through the report-generation time), so staff can see both
in-program activity and post-program retention.

Edit timestamps are pulled live from the MediaWiki `usercontribs` API across all
namespaces. This is deliberate: the `revisions` table was dropped (migration
`20260127212149`), and the live API is the only source that covers all
namespaces (the Replica endpoint only returns namespaces 0 and 2).

The report follows the existing async CSV pattern (`ReportsController` →
`ReportCsvWorker` → builder → cached file → `CsvCleanupWorker`). The route,
report type, and builder are named generically ("retention") so future
predictor columns can be added without renaming.

## AI usage

Claude Code (Opus 4.8) wrote essentially all of this PR under direction from
Sage Ross. Sage provided the spec (the metric definition, the FellowsCohort
scope, the per-wiki + combined breakdown), made the two product decisions that
shaped the output (count edits across **all namespaces**, and report **both**
the during-course and after-course windows separately), and chose the button
label ("Retention predictors"); per repo policy, no user-facing copy was
AI-generated. Claude Code explored the codebase (CSV-report infrastructure,
the revision data model, course-type/admin gating), chose the data source,
implemented the builder and plumbing, wrote the specs, and verified the feature
end-to-end by importing three completed S&S courses from production into a dev
database and generating real CSVs.

Claude Code also wrote the commit message and drafted this PR description (via
the `/prepare-pr` skill). The "What this PR does" summary and the analysis here
were AI-drafted and may contain errors.

Scale of effort: a single commit made in one focused AI-assisted session;
human input was a handful of messages (a detailed opening spec, then terse
direction and confirmations).

## Screenshots

Minimal UI: one button. This change adds a **Retention predictors** button to
the course **Actions** module (`available_actions.jsx`), rendered only for
admins on `FellowsCohort` courses. Clicking it downloads the CSV (same
generate-then-download flow as the other course CSV downloads).

Before: no such button (the Actions module is unchanged for all other courses
and users).

After: on a FellowsCohort course, signed in as an admin, the Actions module
shows a "Retention predictors" button. To see it locally: log in as an admin,
open a `FellowsCohort` course, and look in the Actions box on the Overview.

Sample of the generated CSV (one row per student; columns repeat per tracked
wiki, plus a combined pair):

```
username,en.wikipedia.org sessions (during course),en.wikipedia.org sessions (after course),www.wikidata.org sessions (during course),www.wikidata.org sessions (after course),all wikis sessions (during course),all wikis sessions (after course)
ExampleStudent,12,3,0,0,12,3
```

## Open questions and concerns

- **Performance / API load:** the builder makes one paginated `usercontribs`
  request per student per tracked wiki. For typical S&S cohort sizes (≈10–25
  students, 1–4 wikis) this is a modest number of calls and runs fine as a
  background job. For much larger cohorts we could batch multiple users per
  query; left out of scope for v1 and noted in code.
- **Combined column:** when a student edits only one wiki (common in the
  cohorts tested), the combined session count equals that wiki's count. The
  cross-wiki merge (e.g. a Wikipedia edit and a Wikidata edit within the hour
  collapsing into one combined session) is exercised by the unit spec rather
  than by the sampled real data.
- **Live data:** counts are computed at report-generation time from the live
  API, so re-running on a different day can change the "after course" numbers
  as students keep (or stop) editing. That is the intended behavior for a
  retention signal.

(PR description written by Claude Code.)
