### PR TITLE
Make pre-commit hook respect RuboCop's AllCops Exclude

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -11,7 +11,10 @@ staged=$(git diff --cached --name-only --diff-filter=ACM | grep '\.rb$')
 [ -z "$staged" ] && exit 0
 
 echo "Running RuboCop on staged Ruby files..."
-bundle exec rubocop --no-color $staged
+# --force-exclusion makes RuboCop honor the AllCops Exclude list (e.g.
+# config/**/*) even though we pass file paths explicitly. Without it, staging
+# an excluded file surfaces pre-existing offenses that the full CI run ignores.
+bundle exec rubocop --no-color --force-exclusion $staged
 
 if [ $? -ne 0 ]; then
   echo "Linting failed. Please fix the offenses before committing."


### PR DESCRIPTION
## What this PR does

Makes the `.git-hooks/pre-commit` hook honor RuboCop's `AllCops: Exclude` list,
so it lints the same set of files that CI does.

The hook runs RuboCop on staged Ruby files by passing their paths explicitly.
RuboCop ignores `Exclude` for files named explicitly on the command line unless
`--force-exclusion` is given. As a result, staging an otherwise-excluded file —
e.g. `config/routes.rb`, which is covered by the `config/**/*` exclude — made
the hook fail on pre-existing offenses (block length, long lines) that the full
`bundle exec rubocop` run used by CI never reports. This blocks commits that
touch excluded files even when the actual change is clean.

This PR adds `--force-exclusion` to the hook's RuboCop invocation. Excluded
files are now skipped by the hook (as they are by CI), while offenses in normal
files are still caught.

## AI usage

Written by Claude Code (Opus 4.8) under direction from Sage Ross. Sage
identified the problem (the hook shouldn't lint `config/routes.rb`) in a single
one-sentence instruction; Claude Code located the hook (`core.hooksPath` →
`.git-hooks/`), diagnosed the explicit-file-overrides-`Exclude` behavior, made
the one-line fix, and validated it by running the hook's exact RuboCop command
against an excluded file (skipped), a mix of excluded and clean files (only the
clean one inspected), and a file with a deliberate >100-character line (offense
reported, non-zero exit — confirming the hook still catches real offenses).

This surfaced while committing a separate feature whose `config/routes.rb`
change tripped the hook. Single commit, one focused session. Claude Code wrote
the commit message and drafted this PR description via the `/prepare-pr` skill;
this summary may contain errors.

## Screenshots

No UI changes (developer tooling / git hook only).

## Open questions and concerns

None. The change is scoped to one line of the pre-commit hook and does not
affect application code or CI configuration.

(PR description written by Claude Code.)
