### PR TITLE
Add "learning to edit with your students" wizard option

### DIFF
--- a/app/controllers/wizard_controller.rb
+++ b/app/controllers/wizard_controller.rb
@@ -47,5 +47,17 @@ class WizardController < ApplicationController
     WizardTimelineManager.update_timeline_and_tags(@course, wizard_id, wizard_params)
     # JBuilder will not render weeks for previous-empty course without this...
     @course = Course.find_by(slug: params[:course_id])
+    enroll_current_instructor_as_learner
+  end
+
+  private
+
+  # When the instructor chose "learning to edit with your students", enroll the
+  # instructor running the wizard as a student of their own course. Admins who
+  # are not instructors of the course are skipped.
+  def enroll_current_instructor_as_learner
+    return unless @course.instructor_learner?
+    return unless current_user&.instructor?(@course)
+    EnrollInstructorAsLearner.new(course: @course, instructor: current_user)
   end
 end

--- a/app/mailer_previews/course_advice_mailer_preview.rb
+++ b/app/mailer_previews/course_advice_mailer_preview.rb
@@ -16,7 +16,8 @@ class CourseAdviceMailerPreview < ActionMailer::Preview
     drafting_and_moving: 'Advice on drafting in sandboxes and moving articles to mainspace',
     drafting_sandbox_only: 'Drafting advice for sandbox-only courses that never move to mainspace',
     peer_review: 'Tips on facilitating peer review between students',
-    assessing_contributions: 'Guidance on how to assess student Wikipedia contributions'
+    assessing_contributions: 'Guidance on how to assess student Wikipedia contributions',
+    learning_to_edit: 'Guidance for instructors editing an article alongside students'
   }.freeze
   RECIPIENTS = 'instructor(s)'
 
@@ -58,6 +59,10 @@ class CourseAdviceMailerPreview < ActionMailer::Preview
 
   def assessing_contributions
     CourseAdviceMailer.email(example_course, 'assessing_contributions', example_staffer)
+  end
+
+  def learning_to_edit
+    CourseAdviceMailer.email(example_course, 'learning_to_edit', example_staffer)
   end
 
   private

--- a/app/mailers/course_advice_mailer.rb
+++ b/app/mailers/course_advice_mailer.rb
@@ -19,7 +19,8 @@ class CourseAdviceMailer < ApplicationMailer
     'bibliographies' => '[Wiki Education] The bibliography is key to success!',
     'drafting_and_moving' => '[Wiki Education] Tips for drafting, moving work to live article',
     'peer_review' => '[Wiki Education] Tips for peer review',
-    'assessing_contributions' => '[Wiki Education] Student work: The good, the bad, and the AI generated'
+    'assessing_contributions' => '[Wiki Education] Student work: The good, the bad, and the AI generated',
+    'learning_to_edit' => '[Wiki Education] Editing your own assigned Wikipedia article'
   }.freeze
   # rubocop:enable Layout/LineLength
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -550,6 +550,10 @@ class Course < ApplicationRecord
     flags[:retain_available_articles].present?
   end
 
+  def instructor_learner?
+    flags[:instructor_learner].present?
+  end
+
   def disable_student_emails?
     flags[:disable_student_emails].present?
   end

--- a/app/models/course_types/classroom_program_course.rb
+++ b/app/models/course_types/classroom_program_course.rb
@@ -73,8 +73,11 @@ class ClassroomProgramCourse < Course
     false
   end
 
+  # Normally instructors and students are mutually exclusive on a classroom
+  # course. When the "learning to edit with your students" wizard option is set,
+  # we allow dual roles so an instructor can also be enrolled as a student.
   def multiple_roles_allowed?
-    false
+    instructor_learner?
   end
 
   def timeline_enabled?

--- a/app/services/enroll_instructor_as_learner.rb
+++ b/app/services/enroll_instructor_as_learner.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/course_cache_manager"
+
+# Enrolls an instructor as a student of their own course, so that they can
+# complete the assignment alongside their students ("learning to edit with your
+# students" wizard option). This creates a second CoursesUsers row with the
+# student role for a user who is already an instructor.
+#
+# Unlike a normal student enrollment (JoinCourse), this:
+#   - is allowed even before the course is approved, since the instructor is
+#     opting in via the wizard at course-creation time, and
+#   - does not post enrollment templates to the instructor's userpage/sandbox.
+class EnrollInstructorAsLearner
+  attr_reader :result
+
+  def initialize(course:, instructor:)
+    @course = course
+    @instructor = instructor
+    enroll
+  end
+
+  private
+
+  def enroll
+    return @result = { 'failure' => 'withdrawn' } if @course.withdrawn
+    return @result = { 'failure' => 'disallowed_user' } if user_disallowed?
+    return @result = { 'failure' => 'already_enrolled' } if already_a_learner?
+    create_student_courses_user
+    CourseCacheManager.new(@course).update_user_count
+    @result = { 'success' => 'Instructor enrolled as a student.' }
+  end
+
+  def user_disallowed?
+    DisallowedUsers.disallowed?(@instructor.username)
+  end
+
+  def already_a_learner?
+    CoursesUsers.exists?(user_id: @instructor.id, course_id: @course.id,
+                         role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+
+  def create_student_courses_user
+    CoursesUsers.create(user_id: @instructor.id, course_id: @course.id,
+                        role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+end

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -15,6 +15,7 @@ class ScheduleCourseAdviceEmails
     schedule_hype_video_email
     schedule_preliminary_work_email
     schedule_choosing_an_article_email
+    schedule_learning_to_edit_email
     schedule_bibliographies_email
     schedule_drafting_and_moving_email
     schedule_peer_review_email
@@ -76,6 +77,23 @@ class ScheduleCourseAdviceEmails
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
       subject: 'choosing_an_article',
+      send_at: block.calculated_date.to_datetime
+    )
+  end
+
+  # This goes to courses that took the "learning to edit with your students"
+  # wizard option, the week students start choosing their articles.
+  def schedule_learning_to_edit_email
+    return unless @course.tag?('instructor_learner')
+
+    block = @course.find_block_by_title 'Choose possible topics'
+    block ||= @course.find_block_by_title 'Choose your article'
+    return unless block
+    return if too_late?(block)
+
+    CourseAdviceEmailWorker.schedule_email(
+      course: @course,
+      subject: 'learning_to_edit',
       send_at: block.calculated_date.to_datetime
     )
   end

--- a/app/views/course_advice_mailer/learning_to_edit.html.haml
+++ b/app/views/course_advice_mailer/learning_to_edit.html.haml
@@ -1,0 +1,49 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@greeted_users},"
+              %p.paragraph
+                Your students are about to select their Wikipedia articles for their
+                Wikipedia assignment, which means it’s time for you to join in! As we
+                noted when you set up your course page, editing alongside your students
+                is a great way to build your own Wikipedia expertise while modeling the
+                collaborative spirit of the project.
+              %p.paragraph To get started:
+              %ol
+                %li.paragraph
+                  Review our
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/finding-your-article'} training module
+                  on finding articles.
+                %li.paragraph
+                  Log in to your course page, go to the Home tab, and find the My
+                  Articles section.
+                %li.paragraph
+                  Click on the Assign Article button, type in the article’s name, and
+                  double-check spelling and punctuation. (Creating a brand new article?
+                  Type in the title and be sure it’s exactly how you will want it to
+                  appear on Wikipedia.)
+              %p.paragraph
+                That’s it! You’re now ready to edit the article you selected, following
+                the same steps as your students.
+              %p.paragraph
+                Best wishes for a meaningful editing experience!
+              %p.paragraph
+                Best,
+                %br
+                %em
+                  = @staffer.real_name
+                %br
+                %em Wiki Education
+                %br
+                %br
+              %p.info
+                This is an automated email from Wiki Education intended to help you with your Wikipedia assignment.
+                If you have thoughts about it — anything you found confusing or important things that are missing — you can let us know
+                by replying, or
+                %a.link{href: 'https://dashboard.wikiedu.org/feedback?subject=Editing-Your-Own-Article-Advice-email'} leave feedback here.

--- a/config/wizard/researchwrite/wizard.yml
+++ b/config/wizard/researchwrite/wizard.yml
@@ -1,3 +1,12 @@
+# This file defines the ordered sequence of panels (questions) in the
+# research-write assignment wizard.
+#
+# COUPLING: the feature spec spec/features/course_creation_spec.rb walks through
+# this exact sequence in its `go_through_researchwrite_wizard` helper. If you
+# ADD, REMOVE, or REORDER a panel here, update that helper to match — otherwise
+# the wizard feature specs break, often confusingly on a *later* panel or at
+# "Generate Timeline" rather than where the change was made. Changing the blocks
+# in content.yml can also change `expected_course_blocks` in that spec.
 -
   key: essentials
   title: Training
@@ -616,6 +625,38 @@
       title: I don't know.
       tag: assignment_portion_unknown
 
+
+-
+  key: instructor_learner
+  title: Learning to edit with your students
+  description: |
+    The best way to understand what your students are experiencing with their
+    assignment is to try it yourself! Editing Wikipedia alongside your students will:
+
+    - Familiarize you with the Dashboard
+    - Teach you the basics of Wikipedia editing
+    - Show you the Wikipedia assignment from the student perspective
+    - Help you anticipate where they might need support
+    - Foster an atmosphere of shared learning in your classroom
+    - Build skills you’ll carry into future Wikipedia assignments
+
+    Through the Dashboard, you can select an article to work on that will parallel
+    your students’ experience.
+
+    #### Would you like to edit a Wikipedia article yourself?
+  type: 1  # single choice
+  minimum: 1
+  options:
+    -
+      title: "Yes"
+      blurb: Select yes and we’ll send you guidance on how to get started.
+      selected: true # selected by default
+      tag: instructor_learner
+      logic: instructor_learner
+    -
+      title: "No"
+      tag: not_instructor_learner
+      logic: not_instructor_learner
 
 -
   key: mentoring

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -158,7 +158,11 @@ class CourseCloneManager
     :retain_available_articles,
     :stay_in_sandbox,
     :no_sandboxes,
-    :timeslice_duration
+    :timeslice_duration,
+    # Carries the ability to dual-enroll the instructor as a student. The
+    # instructor is not auto-enrolled on the clone; that happens when they
+    # complete the wizard (which also re-confirms the opt-in and its tag).
+    :instructor_learner
   ].freeze
   def add_flags
     FLAGS_TO_CARRY_OVER.each do |flag_key|

--- a/lib/wizard_timeline_manager.rb
+++ b/lib/wizard_timeline_manager.rb
@@ -218,7 +218,9 @@ class WizardTimelineManager
     '3_peer_reviewers' => { peer_review_count: 3 },
     'working_in_groups' => { retain_available_articles: true },
     'no_sandboxes' => { no_sandboxes: true },
-    'yes_sandboxes' => { no_sandboxes: false }
+    'yes_sandboxes' => { no_sandboxes: false },
+    'instructor_learner' => { instructor_learner: true },
+    'not_instructor_learner' => { instructor_learner: false }
   }.freeze
   def add_flags
     FLAG_LOGIC.each_key do |logic_key|

--- a/spec/controllers/wizard_controller_spec.rb
+++ b/spec/controllers/wizard_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WizardController, type: :controller do
+  describe '#submit_wizard' do
+    let(:course) { create(:course) }
+    let(:wizard_params) do
+      { course_id: course.slug, wizard_id: 'researchwrite',
+        wizard_output: { output: [], logic: ['instructor_learner'], tags: [] } }
+    end
+
+    def student_role_exists_for(user)
+      CoursesUsers.exists?(course:, user:, role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
+
+    context 'when an instructor selects the learning-to-edit option' do
+      let(:instructor) { create(:user) }
+
+      before do
+        create(:courses_user, course:, user: instructor,
+                              role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+        allow(controller).to receive(:current_user).and_return(instructor)
+      end
+
+      it 'enrolls the instructor as a student' do
+        post :submit_wizard, params: wizard_params
+        expect(student_role_exists_for(instructor)).to be true
+      end
+    end
+
+    context 'when an admin who is not an instructor submits the wizard' do
+      let(:admin) { create(:admin) }
+
+      before { allow(controller).to receive(:current_user).and_return(admin) }
+
+      it 'does not enroll the admin as a student' do
+        post :submit_wizard, params: wizard_params
+        expect(student_role_exists_for(admin)).to be false
+      end
+    end
+  end
+end

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -31,6 +31,11 @@ def go_through_course_dates_and_timeline_dates
   sleep 1
 end
 
+# Walks through every panel of the research-write wizard, in order. This MUST
+# stay in sync with the panel sequence in config/wizard/researchwrite/wizard.yml:
+# adding, removing, or reordering a panel there requires a matching change to the
+# click-through steps below, or these specs break (often on a later panel or at
+# "Generate Timeline"). `expected_course_blocks` likewise tracks content.yml.
 def go_through_researchwrite_wizard(returning_instructor: true)
   go_through_course_dates_and_timeline_dates
 
@@ -106,6 +111,10 @@ def go_through_researchwrite_wizard(returning_instructor: true)
   # # sandboxes unacceptable
   # omniclick find('.wizard__option', match: :first).find('button', match: :first)
   # click_button 'Next'
+  sleep 1
+
+  # "Learning to edit with your students" panel; accept the default "Yes"
+  click_button 'Next'
   sleep 1
 
   # "Mentorship program" panel that only appears for new instructor
@@ -352,6 +361,11 @@ describe 'New course creation and editing', type: :feature do
       end
       expect(Course.first.blocks.count).to eq(expected_course_blocks)
       expect(Course.first.tag?('mentor_requested')).to be true
+
+      # The instructor accepted "Learning to edit with your students", so they
+      # are now also enrolled as a student of their own course.
+      expect(Course.first.instructor_learner?).to be true
+      expect(Course.first.students).to include(User.find(1))
     end
 
     it 'squeezes assignments into the course dates' do

--- a/spec/lib/course_clone_manager_spec.rb
+++ b/spec/lib/course_clone_manager_spec.rb
@@ -117,6 +117,23 @@ describe CourseCloneManager do
     end
   end
 
+  context 'when the source course has the instructor_learner flag' do
+    before do
+      Course.find(1).update(flags: { instructor_learner: true })
+      described_class.new(course: Course.find(1), user: User.find(1),
+                          clone_assignments: false).clone!
+    end
+
+    it 'carries over the ability to dual-enroll the instructor' do
+      expect(clone.multiple_roles_allowed?).to be true
+    end
+
+    it 'does not auto-enroll the instructor as a student' do
+      student_role = CoursesUsers::Roles::STUDENT_ROLE
+      expect(clone.courses_users.where(user_id: 1, role: student_role)).to be_empty
+    end
+  end
+
   context 'when open course creation is enabled' do
     before do
       allow(Features).to receive(:open_course_creation?).and_return(true)

--- a/spec/lib/wizard_timeline_manager_spec.rb
+++ b/spec/lib/wizard_timeline_manager_spec.rb
@@ -52,6 +52,39 @@ describe WizardTimelineManager do
     end
   end
 
+  describe 'instructor_learner flag' do
+    let(:course) do
+      create(:course, start: '2016-08-01', end: '2016-09-23',
+                      timeline_start: '2016-08-01', timeline_end: '2016-09-23',
+                      weekdays: '1111111')
+    end
+
+    def submit(logic, tags = [])
+      params = { 'wizard_output' => { 'output' => [], 'logic' => logic, 'tags' => tags } }
+      described_class.update_timeline_and_tags(course, 'researchwrite', params)
+    end
+
+    it 'sets the flag when the instructor opts in' do
+      submit(['instructor_learner'])
+      expect(course.flags[:instructor_learner]).to be true
+    end
+
+    it 'clears the flag when the instructor opts out' do
+      course.update(flags: { instructor_learner: true })
+      submit(['not_instructor_learner'])
+      expect(course.flags[:instructor_learner]).to be false
+    end
+
+    it 'updates the tag so opting out clears the opt-in marker' do
+      opt_in = [{ key: 'instructor_learner', tag: 'instructor_learner' }]
+      opt_out = [{ key: 'instructor_learner', tag: 'not_instructor_learner' }]
+      submit(['instructor_learner'], opt_in)
+      expect(course.reload.tag?('instructor_learner')).to be true
+      submit(['not_instructor_learner'], opt_out)
+      expect(course.reload.tag?('instructor_learner')).to be false
+    end
+  end
+
   describe 'wizard_id validation' do
     let(:course) do
       create(:course, start: '2016-08-01', end: '2016-09-23',

--- a/spec/services/enroll_instructor_as_learner_spec.rb
+++ b/spec/services/enroll_instructor_as_learner_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EnrollInstructorAsLearner do
+  let(:course) { create(:course, flags: { instructor_learner: true }) }
+  let(:instructor) { create(:user) }
+
+  before do
+    create(:courses_user, course:, user: instructor,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+  end
+
+  let(:subject) { described_class.new(course:, instructor:) }
+
+  it 'enrolls the instructor with the student role' do
+    subject
+    expect(CoursesUsers.exists?(course:, user: instructor,
+                                role: CoursesUsers::Roles::STUDENT_ROLE)).to be true
+  end
+
+  it 'keeps the existing instructor role' do
+    subject
+    expect(CoursesUsers.exists?(course:, user: instructor,
+                                role: CoursesUsers::Roles::INSTRUCTOR_ROLE)).to be true
+  end
+
+  it 'succeeds even when the course is not yet approved' do
+    expect(course.approved?).to be false
+    expect(subject.result['success']).not_to be_nil
+  end
+
+  it 'is idempotent' do
+    described_class.new(course:, instructor:)
+    described_class.new(course:, instructor:)
+    student_rows = CoursesUsers.where(course:, user: instructor,
+                                      role: CoursesUsers::Roles::STUDENT_ROLE)
+    expect(student_rows.count).to eq(1)
+  end
+
+  it 'does not post enrollment edits to the userpage' do
+    expect(EnrollInCourseWorker).not_to receive(:schedule_edits)
+    subject
+  end
+
+  it 'updates the cached student count' do
+    subject
+    expect(course.reload.user_count).to eq(1)
+  end
+
+  context 'when the course is withdrawn' do
+    let(:course) { create(:course, withdrawn: true, flags: { instructor_learner: true }) }
+
+    it 'does not enroll the instructor as a student' do
+      expect(subject.result['failure']).to eq('withdrawn')
+      expect(CoursesUsers.exists?(course:, user: instructor,
+                                  role: CoursesUsers::Roles::STUDENT_ROLE)).to be false
+    end
+  end
+
+  context 'when the instructor is a disallowed user' do
+    before { DisallowedUsers.add_user(instructor.username) }
+
+    it 'does not enroll the instructor as a student' do
+      expect(subject.result['failure']).to eq('disallowed_user')
+      expect(CoursesUsers.exists?(course:, user: instructor,
+                                  role: CoursesUsers::Roles::STUDENT_ROLE)).to be false
+    end
+  end
+end

--- a/spec/services/join_course_spec.rb
+++ b/spec/services/join_course_spec.rb
@@ -66,6 +66,16 @@ describe JoinCourse do
     end
   end
 
+  context 'for a ClassroomProgramCourse with the instructor_learner flag' do
+    let(:course) { create(:course, flags: { instructor_learner: true }) }
+
+    it 'allows an instructor to also join as a student' do
+      result = subject.result
+      expect(result['failure']).to be_nil
+      expect(result['success']).not_to be_nil
+    end
+  end
+
   context 'for a withdrawn course' do
     let(:course) { withdrawn_course }
 

--- a/spec/services/schedule_course_advice_emails_spec.rb
+++ b/spec/services/schedule_course_advice_emails_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ScheduleCourseAdviceEmails do
+  let(:course) do
+    create(:course, timeline_start: '2016-01-01', timeline_end: '2016-03-01')
+  end
+  let(:choosing_block) { instance_double(Block, calculated_date: 1.week.from_now) }
+
+  before do
+    create(:tag, course:, tag: 'research_write_assignment', key: 'assignment_type')
+    allow(course).to receive(:find_block_by_title).and_return(nil)
+    allow(course).to receive(:find_block_by_title).with('Choose your article')
+                                                  .and_return(choosing_block)
+    allow(CourseAdviceEmailWorker).to receive(:schedule_email)
+  end
+
+  context 'when the instructor_learner tag is present' do
+    before { create(:tag, course:, tag: 'instructor_learner', key: 'instructor_learner') }
+
+    it 'schedules the learning_to_edit advice email' do
+      described_class.new(course).schedule_emails
+      expect(CourseAdviceEmailWorker).to have_received(:schedule_email)
+        .with(hash_including(course:, subject: 'learning_to_edit'))
+    end
+  end
+
+  context 'when the instructor_learner tag is absent' do
+    it 'does not schedule the learning_to_edit advice email' do
+      described_class.new(course).schedule_emails
+      expect(CourseAdviceEmailWorker).not_to have_received(:schedule_email)
+        .with(hash_including(subject: 'learning_to_edit'))
+    end
+  end
+end

--- a/test/utils/user_utils.spec.js
+++ b/test/utils/user_utils.spec.js
@@ -1,0 +1,20 @@
+import UserUtils from '../../app/assets/javascripts/utils/user_utils';
+import { STUDENT_ROLE, INSTRUCTOR_ROLE } from '../../app/assets/javascripts/constants/user_roles';
+
+describe('UserUtils.userRoles', () => {
+  // The "learning to edit with your students" feature relies on a single user
+  // holding both the student and instructor roles for a course.
+  it('marks a user enrolled in both roles as student and instructor', () => {
+    const currentUser = { id: 1 };
+    const users = [
+      { id: 1, role: STUDENT_ROLE },
+      { id: 1, role: INSTRUCTOR_ROLE },
+    ];
+
+    const roles = UserUtils.userRoles(currentUser, users);
+
+    expect(roles.isStudent).toBe(true);
+    expect(roles.isInstructor).toBe(true);
+    expect(roles.isEnrolled).toBe(true);
+  });
+});


### PR DESCRIPTION
## What this PR does

Adds a new option to the research-write assignment wizard: **"Learning to edit with your students."** When an instructor selects it, they complete the Wikipedia writing assignment alongside their students — the Dashboard enrolls them as *both* an instructor and a student of their own course. As a result their edits are counted together with the students' edits, and they get the full student experience (trainings, exercises, and article assignment/claiming).

The whole feature is built on the existing dual-`CoursesUsers`-row mechanism (a user may already hold more than one role on a course): nearly all of the student experience and the entire edit-counting pipeline key off the presence of a student-role row, so adding that row delivers both for free. The work was therefore: capture the wizard choice, relax the one guard that blocks dual roles on classroom courses, auto-enroll the submitting instructor, and add a getting-started email to the existing course-advice drip series.

Concretely:
- A new single-choice wizard panel (research-write only) sets a `flags[:instructor_learner]` course flag and an `instructor_learner` tag.
- `ClassroomProgramCourse#multiple_roles_allowed?` now returns that flag — the single guard `JoinCourse` checks — which both unlocks manual dual-role enrollment for co-instructors and lets the new `EnrollInstructorAsLearner` service create the student row.
- `EnrollInstructorAsLearner` enrolls the wizard submitter immediately and idempotently, with no userpage edits.
- A `learning_to_edit` course-advice email is scheduled the week students choose their articles, linking the [Finding your article](https://dashboard.wikiedu.org/training/students/finding-your-article) training module.
- Cloning a course carries the flag (the dual-enroll capability) but does not auto-enroll — that happens at wizard completion.

The wizard question copy and the email copy were both supplied by the operator.

## AI usage

This PR was written with **Claude Code** (Claude Opus 4.8), driven by a human (Sage) across a single extended session.

- **Claude Code** explored the wizard, roles, and edit-counting subsystems; proposed the implementation plan; and drafted essentially all of the code, specs, the screenshot spec, the commit message, and this PR description.
- **The human** gave the direction and made every product/design decision: a dedicated enrollment service over a `JoinCourse` bypass flag; no userpage edits on auto-enroll; clone carries the capability but does not auto-enroll; surveys and the manual-add userpage-edit behavior left as-is. The human also supplied the wizard question copy and the full email copy verbatim (no user-facing text was AI-written), and asked for frequent check-ins on architecture decisions along the way.

Scale of effort: one commit, developed in a single multi-hour session of roughly a dozen human messages plus two blocks of operator copy. Tests were run repeatedly throughout (the targeted RSpec files, a JS test, and the full `course_creation` feature spec) — all green, with one rubocop line-length fix and one Haml-CLI hiccup worked around by rendering via Rails.

The "What this PR does" summary and the rest of this description were also drafted by Claude Code and may contain errors. This description was prepared using the `/prepare-pr` Claude Code skill.

## Screenshots

Before:
_(did not exist on master — this is a new wizard panel)_

After:
The new research-write wizard panel:

![wizard panel](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/learning-to-edit-with-your-students/screenshots/after/01_wizard_panel.png)

The accompanying `learning_to_edit` course-advice email is an automated drip email (sent to the course's instructors the week students choose articles). It can be previewed locally via the mailer preview at `/rails/mailers/course_advice_mailer/learning_to_edit`.

## Open questions and concerns

A few behaviors were considered and intentionally left as-is for this PR (all confirmed acceptable by the operator):

- **Surveys:** survey assignment is per-role, so a dual-role instructor-learner may match *both* the instructor survey and the student survey. Left unchanged; de-duplication would be a separate follow-up.
- **Manual dual-role adds:** once the option is set, instructors/staff can manually add an instructor as a student through the normal enrollment UI. That path *does* post the standard userpage enrollment edits (unlike the auto-enroll, which deliberately does not).
- **Campaign analytics headcount:** the instructor-learner's characters are summed with students, but they remain excluded from the *distinct* student headcount (`pure_student_ids`) at the campaign level — consistent with treating instructors as non-students for headcount.

(PR description written by Claude Code.)
