### PR TITLE
Prune stale Passenger instance dirs on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -75,6 +75,37 @@ namespace :deploy do
     end
   end
 
+  desc 'Remove stale Passenger instance directories left by past restarts/reboots'
+  task :clean_stale_passenger_instances do
+    on roles(:web) do
+      # Passenger's instance registry is pinned to a persistent shared dir (via
+      # PASSENGER_INSTANCE_REGISTRY_DIR) so the deploy user and Apache's
+      # root-owned Passenger agents look in the same place. The cost: dead
+      # instance dirs survive reboots/restarts instead of being cleared from
+      # /tmp, and being root-owned, the deploy user's `passenger-config
+      # restart-app` can't remove them -- it just logs a wall of "Permission
+      # denied" warnings on every deploy. Prune them here with sudo. (This runs
+      # after the restart, so the warnings only stop on the *next* deploy, but
+      # they never reaccumulate past one cycle.)
+      #
+      # Safety: we keep whichever instance dir the running Passenger processes
+      # still reference -- their lock file / mmaps live under it, found via
+      # /proc -- and delete the rest. We must NOT key off mtime alone: an idle
+      # instance's directory mtime is its old start time, so an age cutoff could
+      # delete the live instance. If no live instance is detected, we skip.
+      registry = "#{shared_path}/tmp/pids"
+      detect = 'live=$({ cat /proc/[0-9]*/maps; ls -l /proc/[0-9]*/fd/; } ' \
+               '2>/dev/null | grep -oE "passenger\\.[A-Za-z0-9]+" | sort -u)'
+      guard  = 'if [ -z "$live" ]; then ' \
+               'echo "No live Passenger instance found; skipping prune."; exit 0; fi'
+      build  = 'excl=; for name in $live; do excl="$excl ! -name $name"; done'
+      prune  = "find #{registry} -maxdepth 1 -type d -name \"passenger.*\" " \
+               '-mmin +60 $excl -print -exec rm -rf {} +'
+      execute :sudo, 'sh', '-c', "'#{[detect, guard, build, prune].join('; ')}'",
+              raise_on_non_zero_exit: false
+    end
+  end
+
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
       # nothing
@@ -85,6 +116,7 @@ namespace :deploy do
   before :deploy, 'deploy:local_yarn_build' unless ENV['skip_build'] || skip_assets
   before 'deploy:symlink:release', 'deploy:upload_compiled_assets' unless skip_assets
   before 'deploy:restart', 'deploy:ensure_tmp_permissions'
+  after 'deploy:restart', 'deploy:clean_stale_passenger_instances'
 
   ##############################
   # Sidekiq process management #


### PR DESCRIPTION
## What this PR does

The `passenger:restart` step of every Capistrano deploy logs a wall of
`Permission denied @ apply2files` warnings while Passenger tries (and fails) to
clean up stale instance-registry directories under
`<deploy_to>/shared/tmp/pids/`. This PR adds a deploy task that prunes those
stale directories so the noise stops and never reaccumulates.

**Why they pile up:** `PASSENGER_INSTANCE_REGISTRY_DIR` (set in each stage's
deploy config, and mirrored by `PassengerInstanceRegistryDir` in
`server_config/apache2.conf`) pins Passenger's instance registry to a
persistent, shared directory so the deploy user and Apache's Passenger agents
agree on its location. The side effect is that dead instance dirs survive
reboots and restarts instead of being cleared from `/tmp`. Apache spawns
Passenger's agents as root, so the dirs are root-owned — which means the deploy
user's `passenger-config restart-app` can't remove them and just logs the
warnings on every deploy.

**The fix:** a new `deploy:clean_stale_passenger_instances` task, hooked
`after 'deploy:restart'` on `roles(:web)`, prunes them under `sudo` (the
privilege the deploy user lacks). It identifies the live instance from the open
files / memory maps of the running Passenger processes (their lock file and
mmaps live under the instance dir, discovered via `/proc`), keeps that one,
and deletes the rest — additionally gated on `-mmin +60`. It deliberately does
**not** key off mtime alone: an idle instance's directory mtime is its old
start time, so an age-only cutoff could delete the *live* instance. If no live
instance can be identified, it skips entirely rather than risk a bad delete.
The task is stage-agnostic (uses `shared_path`), so it applies to both the Wiki
Ed (`production`) and Programs & Events (`peony`) deployments, which share the
same layout.

## AI usage

This change was written by Claude Code (via the Claude Code CLI) under my
direction. I pasted the noisy deploy log and asked it to diagnose the cause and
stop it from recurring. Claude Code traced the root cause through the repo's
deploy and server configs, proposed a one-time cleanup command (which I ran on
the server), and — after I picked between a few prevention options it laid out —
wrote the `config/deploy.rb` task. It also weighed and rejected the
`capistrano-passenger` gem's built-in `passenger_restart_with_sudo` option,
because that prefixes a bare `sudo` whose env-reset would strip
`PASSENGER_INSTANCE_REGISTRY_DIR` and make the restart clean nothing. It
validated the emitted shell command and the prune logic against a simulated
registry locally before committing. My contribution was the problem,
the server-side execution and verification, and the choice of approach.

All commits were made within a single focused session (1 commit). The commit
message was also written by Claude Code (noted in the commit body, along with a
`Co-Authored-By: Claude` trailer). This PR description was drafted using a
Claude Code skill (`/prepare-pr`); its summary and analysis may contain errors.

## Screenshots

No UI changes — this is a deploy-configuration change only.

## Open questions and concerns

- **Residual noise between deploys.** The prune runs *after* the restart, so the
  warnings only fully stop from the *next* deploy onward. If many days pass
  between deploys, a handful of stale dirs (left by reboots or logrotate-driven
  Apache restarts in the interim) can briefly reappear during the restart step
  before this task cleans them. This is the tradeoff of the deploy-time approach
  versus a daily root-level systemd timer — bounded to a few lines per deploy
  instead of the ~100 seen before, but not strictly zero between deploys.
- **`/proc`-based live detection.** Identifying the live instance relies on a
  running Passenger process holding an open file / mmap under its instance dir
  (reliable in practice — the watchdog holds the lock file for the instance's
  lifetime). If that ever fails to match, the task fails safe by skipping the
  prune rather than deleting anything. Worth a glance at the
  `deploy:clean_stale_passenger_instances` step output on the first real deploy
  to confirm it lists the expected stale dirs (it `-print`s what it removes).

(PR description written by Claude Code.)
