### PR TITLE
Compact the wizard Dates and Summary panels

### DIFF
--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -44,75 +44,78 @@ const FormPanel = (props) => {
     : <p>{I18n.t('wizard.confirm_course_dates')}</p>;
 
   const rawOptions = (
-    <div>
-      <div className="course-dates__step">
-        {step1}
-        <div className="vertical-form full-width">
-          <DatePicker
-            id="wizard_course_start"
-            onChange={updateCourseDates}
-            value={props.course.start}
-            value_key="start"
-            editable={true}
-            validation={CourseDateUtils.isDateValid}
-            label="Course Start"
-          />
-          <DatePicker
-            id="wizard_course_end"
-            onChange={updateCourseDates}
-            value={props.course.end}
-            value_key="end"
-            editable={true}
-            validation={CourseDateUtils.isDateValid}
-            label="Course End"
-            date_props={dateProps.end}
-            enabled={Boolean(props.course.start)}
-          />
+    <div className="wizard__course-dates-2col">
+      <div className="wizard__course-dates-2col__form">
+        <div className="course-dates__step">
+          {step1}
+          <div className="vertical-form full-width">
+            <DatePicker
+              id="wizard_course_start"
+              onChange={updateCourseDates}
+              value={props.course.start}
+              value_key="start"
+              editable={true}
+              validation={CourseDateUtils.isDateValid}
+              label="Course Start"
+            />
+            <DatePicker
+              id="wizard_course_end"
+              onChange={updateCourseDates}
+              value={props.course.end}
+              value_key="end"
+              editable={true}
+              validation={CourseDateUtils.isDateValid}
+              label="Course End"
+              date_props={dateProps.end}
+              enabled={Boolean(props.course.start)}
+            />
+          </div>
+        </div>
+        <hr />
+        <div className="course-dates__step">
+          <p>{I18n.t('wizard.assignment_description')}</p>
+          <div className="vertical-form full-width">
+            <DatePicker
+              id="wizard_timeline_start"
+              onChange={updateCourseDates}
+              value={props.course.timeline_start}
+              value_key="timeline_start"
+              editable={true}
+              validation={CourseDateUtils.isDateValid}
+              label={I18n.t('courses.assignment_start')}
+              date_props={dateProps.timeline_start}
+            />
+            <DatePicker
+              id="wizard_timeline_end"
+              onChange={updateCourseDates}
+              value={props.course.timeline_end}
+              value_key="timeline_end"
+              editable={true}
+              validation={CourseDateUtils.isDateValid}
+              label={I18n.t('courses.assignment_end')}
+              date_props={dateProps.timeline_end}
+              enabled={Boolean(props.course.start)}
+            />
+          </div>
         </div>
       </div>
-      <hr />
-      <div className="course-dates__step">
-        <p>{I18n.t('wizard.assignment_description')}</p>
-        <div className="vertical-form full-width">
-          <DatePicker
-            id="wizard_timeline_start"
-            onChange={updateCourseDates}
-            value={props.course.timeline_start}
-            value_key="timeline_start"
+      <div className="wizard__course-dates-2col__calendar">
+        <div className="wizard__form course-dates course-dates__step">
+          <Calendar
+            course={props.course}
             editable={true}
-            validation={CourseDateUtils.isDateValid}
-            label={I18n.t('courses.assignment_start')}
-            date_props={dateProps.timeline_start}
+            save={true}
+            calendarInstructions={I18n.t('wizard.calendar_instructions')}
+            updateCourse={props.updateCourse}
           />
-          <DatePicker
-            id="wizard_timeline_end"
-            onChange={updateCourseDates}
-            value={props.course.timeline_end}
-            value_key="timeline_end"
-            editable={true}
-            validation={CourseDateUtils.isDateValid}
-            label={I18n.t('courses.assignment_end')}
-            date_props={dateProps.timeline_end}
-            enabled={Boolean(props.course.start)}
-          />
+          <label> {I18n.t('wizard.no_class_holidays')}
+            <input
+              type="checkbox"
+              onChange={setNoBlackoutDatesChecked}
+              ref={noDates}
+            />
+          </label>
         </div>
-      </div>
-      <hr />
-      <div className="wizard__form course-dates course-dates__step">
-        <Calendar
-          course={props.course}
-          editable={true}
-          save={true}
-          calendarInstructions={I18n.t('wizard.calendar_instructions')}
-          updateCourse={props.updateCourse}
-        />
-        <label> {I18n.t('wizard.no_class_holidays')}
-          <input
-            type="checkbox"
-            onChange={setNoBlackoutDatesChecked}
-            ref={noDates}
-          />
-        </label>
       </div>
     </div>
   );

--- a/app/assets/javascripts/components/wizard/summary_panel.jsx
+++ b/app/assets/javascripts/components/wizard/summary_panel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withRouter from '../util/withRouter';
 import Panel from './panel.jsx';
+import { formatDateWithoutTime, toDate } from '../../utils/date_utils.js';
 
 const answersFromPanels = (panels) => {
   const answers = [];
@@ -43,10 +44,10 @@ const SummaryPanel = (props) => {
     if (i === 0) {
       details = [
         <p key={'course_dates_summary'}>
-          {I18n.t('timeline.course_start')} — {props.course.start} <br />
-          {I18n.t('timeline.course_end')} — {props.course.end} <br />
-          {I18n.t('courses.assignment_start')} — {props.course.timeline_start} <br />
-          {I18n.t('courses.assignment_end')} — {props.course.timeline_end}
+          {I18n.t('timeline.course_start')} — {formatDateWithoutTime(toDate(props.course.start))} <br />
+          {I18n.t('timeline.course_end')} — {formatDateWithoutTime(toDate(props.course.end))} <br />
+          {I18n.t('courses.assignment_start')} — {formatDateWithoutTime(toDate(props.course.timeline_start))} <br />
+          {I18n.t('courses.assignment_end')} — {formatDateWithoutTime(toDate(props.course.timeline_end))}
         </p>
       ];
     } else {
@@ -66,7 +67,7 @@ const SummaryPanel = (props) => {
     <Panel
       {...props}
       advance={submit}
-      raw_options={rawOptions}
+      raw_options={<div className="summary-grid">{rawOptions}</div>}
       button_text="Generate Timeline"
     />
   );

--- a/app/assets/stylesheets/modules/_wizard.styl
+++ b/app/assets/stylesheets/modules/_wizard.styl
@@ -309,6 +309,67 @@ p.red
   .DayPicker
     float none
 
+// Two-column layout for the wizard's Course Dates panel: date inputs on the
+// left, holiday calendar + legend on the right, so the whole step fits above
+// the fold. Collapses to a single column below desktop width.
+.wizard__course-dates-2col
+  +above(desktop)
+    display flex
+    align-items flex-start
+    gap 40px
+
+    .wizard__course-dates-2col__form
+      flex 0 0 34%
+      min-width 0
+      hr
+        margin 20px 0
+      // pair each date range (start + end) on one row; grid keeps the inputs
+      // from collapsing the way the legacy flex datetime-control does
+      .vertical-form.full-width
+        display grid
+        grid-template-columns 1fr 1fr
+        gap 0 16px
+        padding-left 0
+        width 100%
+        margin-top 0
+        .datetime-control, .date-picker--form-group, .date-input
+          display block
+          width 100%
+          max-width none
+        .date-input
+          margin-right 0
+        input
+          width 100%
+          box-sizing border-box
+
+    .wizard__course-dates-2col__calendar
+      flex 1 1 auto
+      min-width 0
+      .vertical-form
+        width auto
+      // instructions span the column; the month calendar and its legend sit
+      // side by side beneath, mirroring the original full-width layout (legend
+      // keeps its styling and divider border). flex-wrap drops the legend below
+      // the calendar if the column gets too narrow.
+      .course-dates__calendar-container
+        display flex
+        flex-wrap wrap
+        align-items flex-start
+        gap 0 12px
+        > p
+          width 100%
+        .DayPicker
+          float none !important
+          flex 0 0 auto
+          width auto
+          margin 0
+        .course-dates__calendar-key
+          float none
+          flex 1 1 0
+          min-width 130px
+          width auto
+          margin-left 0
+
 .course-dates__step
   display inline-block
   width 100%
@@ -409,3 +470,35 @@ p.red
   background url('../images/loader.gif') #fff 99% center no-repeat
   background-size 15px 15px
   color dove
+
+// Summary panel: lay the click-to-edit answer cards out in a multi-column grid
+// instead of one full-width card per row, so the review fits on ~one screen.
+.wizard__panel .summary-grid
+  display grid
+  grid-template-columns 1fr 1fr
+  align-items start
+  gap 14px
+  padding 10px 0
+  width 100%
+  +below(desktop)
+    grid-template-columns 1fr
+  .wizard__option.summary
+    border 1px solid mischka
+    border-top-width 1px
+    border-radius 4px
+    margin-bottom 0
+    padding 14px 16px
+    width 100%
+    &:first-child
+      border-top-width 1px
+    > p:not(:last-child)
+      width 100%
+    h3
+      font-size 16px
+      line-height 1.35
+      margin-bottom 6px
+      padding-right 40px
+    .edit
+      top 14px
+      right 16px
+      margin-top 0


### PR DESCRIPTION
## What this PR does

The assignment wizard's **Dates** panel (also reached from the Timeline) and **Summary** panel both ran well below the fold on a 1080p desktop. This reworks their layout to be more compact. It's a density/layout change only — it stays within the existing Dashboard design language and, by request, leaves all user-facing copy unchanged.

- **Dates panel** (`components/wizard/form_panel.jsx`): the date inputs (course + assignment, each range paired on one row) now sit in a left column, with the meeting-day picker, holiday calendar, and legend in a right column. The legend keeps its original styling and divider, beside the calendar. Full panel height ~1384px → ~914px.
- **Summary panel** (`components/wizard/summary_panel.jsx`): the click-to-edit selection cards are laid out in a two-column grid instead of one full-width card per row, and the Course Dates card now shows formatted dates instead of raw ISO timestamps. ~2360px → ~1522px.

Both layouts are scoped to the wizard and collapse back to a single column below desktop width. Other uses of the shared calendar component (timeline date editing, course cloning) are untouched.

## AI usage

This PR was written by Claude Code (Opus 4.8) under my direction. I asked it to screenshot both panels via the research-write wizard path, propose compact layouts, and — once we agreed on a direction from an HTML mockup — implement it. Claude wrote all of the code (`form_panel.jsx`, `summary_panel.jsx`, `modules/_wizard.styl`), the commit message, and this description (via the `/prepare-pr` skill). My input was direction and correction: keep all existing copy, don't hide the assignment-date guidance behind a hover, and fix a calendar-legend regression an early pass introduced.

Scale of effort: a single focused session, one commit. Verification along the way was via a throwaway Capybara capture harness and the existing `course_creation_spec.rb` feature spec, which passes 4/4; ESLint is clean (only a pre-existing string-literal warning). The "What this PR does" summary and other analysis here were also drafted by Claude Code and may contain errors. This description was prepared using the `/prepare-pr` Claude Code skill.

## Screenshots

Dates panel — before (1384px) and after (914px):

![Dates panel before and after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/compact-wizard-panels/screenshots/dates-before-after.png)

Summary panel — before (2360px) and after (1522px):

![Summary panel before and after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/compact-wizard-panels/screenshots/summary-before-after.png)

## Open questions and concerns

- With the legend restored beside the calendar, the Dates panel is ~914px; the footer/Next button land right around the fold on a 1080p laptop. Tightening further would mean trimming copy, which is intentionally left to staff.
- The two-column date layout overrides a few legacy rules to make the inputs fill their cells and the calendar/legend sit side by side: the `_datepicker.styl` `inline-block` / `max-width: 120px` date-input chain, a `.wizard__panel__options .vertical-form { width: 40% }`, and `.course-dates__calendar-container .DayPicker { float: left !important }`. All overrides are scoped to `.wizard__course-dates-2col`, so other calendar usages are unaffected — but the specificity/`!important` interplay is worth a careful review.

(PR description written by Claude Code.)
