### PR TITLE
Add "learning to edit with your students" wizard question and advice …

### DIFF
--- a/app/mailer_previews/course_advice_mailer_preview.rb
+++ b/app/mailer_previews/course_advice_mailer_preview.rb
@@ -16,7 +16,8 @@ class CourseAdviceMailerPreview < ActionMailer::Preview
     drafting_and_moving: 'Advice on drafting in sandboxes and moving articles to mainspace',
     drafting_sandbox_only: 'Drafting advice for sandbox-only courses that never move to mainspace',
     peer_review: 'Tips on facilitating peer review between students',
-    assessing_contributions: 'Guidance on how to assess student Wikipedia contributions'
+    assessing_contributions: 'Guidance on how to assess student Wikipedia contributions',
+    learning_to_edit: 'Guidance for instructors editing an article alongside students'
   }.freeze
   RECIPIENTS = 'instructor(s)'
 
@@ -58,6 +59,10 @@ class CourseAdviceMailerPreview < ActionMailer::Preview
 
   def assessing_contributions
     CourseAdviceMailer.email(example_course, 'assessing_contributions', example_staffer)
+  end
+
+  def learning_to_edit
+    CourseAdviceMailer.email(example_course, 'learning_to_edit', example_staffer)
   end
 
   private

--- a/app/mailers/course_advice_mailer.rb
+++ b/app/mailers/course_advice_mailer.rb
@@ -19,7 +19,8 @@ class CourseAdviceMailer < ApplicationMailer
     'bibliographies' => '[Wiki Education] The bibliography is key to success!',
     'drafting_and_moving' => '[Wiki Education] Tips for drafting, moving work to live article',
     'peer_review' => '[Wiki Education] Tips for peer review',
-    'assessing_contributions' => '[Wiki Education] Student work: The good, the bad, and the AI generated'
+    'assessing_contributions' => '[Wiki Education] Student work: The good, the bad, and the AI generated',
+    'learning_to_edit' => '[Wiki Education] Editing your own assigned Wikipedia article'
   }.freeze
   # rubocop:enable Layout/LineLength
 

--- a/app/services/schedule_course_advice_emails.rb
+++ b/app/services/schedule_course_advice_emails.rb
@@ -15,6 +15,7 @@ class ScheduleCourseAdviceEmails
     schedule_hype_video_email
     schedule_preliminary_work_email
     schedule_choosing_an_article_email
+    schedule_learning_to_edit_email
     schedule_bibliographies_email
     schedule_drafting_and_moving_email
     schedule_peer_review_email
@@ -76,6 +77,23 @@ class ScheduleCourseAdviceEmails
     CourseAdviceEmailWorker.schedule_email(
       course: @course,
       subject: 'choosing_an_article',
+      send_at: block.calculated_date.to_datetime
+    )
+  end
+
+  # This goes to courses that took the "learning to edit with your students"
+  # wizard option, the week students start choosing their articles.
+  def schedule_learning_to_edit_email
+    return unless @course.tag?('instructor_learner')
+
+    block = @course.find_block_by_title 'Choose possible topics'
+    block ||= @course.find_block_by_title 'Choose your article'
+    return unless block
+    return if too_late?(block)
+
+    CourseAdviceEmailWorker.schedule_email(
+      course: @course,
+      subject: 'learning_to_edit',
       send_at: block.calculated_date.to_datetime
     )
   end

--- a/app/views/course_advice_mailer/learning_to_edit.html.haml
+++ b/app/views/course_advice_mailer/learning_to_edit.html.haml
@@ -1,0 +1,49 @@
+%link{rel: 'stylesheet', href:'/mailer.css'}
+%table.row
+  %tbody
+    %tr
+      %th
+        %table
+          %tr
+            %td.main-content
+              %p.paragraph
+                = "Dear #{@greeted_users},"
+              %p.paragraph
+                Your students are about to select their Wikipedia articles for their
+                Wikipedia assignment, which means it’s time for you to join in! As we
+                noted when you set up your course page, editing alongside your students
+                is a great way to build your own Wikipedia expertise while modeling the
+                collaborative spirit of the project.
+              %p.paragraph To get started:
+              %ol
+                %li.paragraph
+                  Review our
+                  %a.link{href: 'https://dashboard.wikiedu.org/training/students/finding-your-article'} training module
+                  on finding articles.
+                %li.paragraph
+                  Log in to your course page, go to the Home tab, and find the My
+                  Articles section.
+                %li.paragraph
+                  Click on the Assign Article button, type in the article’s name, and
+                  double-check spelling and punctuation. (Creating a brand new article?
+                  Type in the title and be sure it’s exactly how you will want it to
+                  appear on Wikipedia.)
+              %p.paragraph
+                That’s it! You’re now ready to edit the article you selected, following
+                the same steps as your students.
+              %p.paragraph
+                Best wishes for a meaningful editing experience!
+              %p.paragraph
+                Best,
+                %br
+                %em
+                  = @staffer.real_name
+                %br
+                %em Wiki Education
+                %br
+                %br
+              %p.info
+                This is an automated email from Wiki Education intended to help you with your Wikipedia assignment.
+                If you have thoughts about it — anything you found confusing or important things that are missing — you can let us know
+                by replying, or
+                %a.link{href: 'https://dashboard.wikiedu.org/feedback?subject=Editing-Your-Own-Article-Advice-email'} leave feedback here.

--- a/config/wizard/researchwrite/wizard.yml
+++ b/config/wizard/researchwrite/wizard.yml
@@ -1,3 +1,12 @@
+# This file defines the ordered sequence of panels (questions) in the
+# research-write assignment wizard.
+#
+# COUPLING: the feature spec spec/features/course_creation_spec.rb walks through
+# this exact sequence in its `go_through_researchwrite_wizard` helper. If you
+# ADD, REMOVE, or REORDER a panel here, update that helper to match — otherwise
+# the wizard feature specs break, often confusingly on a *later* panel or at
+# "Generate Timeline" rather than where the change was made. Changing the blocks
+# in content.yml can also change `expected_course_blocks` in that spec.
 -
   key: essentials
   title: Training
@@ -616,6 +625,36 @@
       title: I don't know.
       tag: assignment_portion_unknown
 
+
+-
+  key: instructor_learner
+  title: Learning to edit with your students
+  description: |
+    The best way to understand what your students are experiencing with their
+    assignment is to try it yourself! Editing Wikipedia alongside your students will:
+
+    - Familiarize you with the Dashboard
+    - Teach you the basics of Wikipedia editing
+    - Show you the Wikipedia assignment from the student perspective
+    - Help you anticipate where they might need support
+    - Foster an atmosphere of shared learning in your classroom
+    - Build skills you’ll carry into future Wikipedia assignments
+
+    Through the Dashboard, you can select an article to work on that will parallel
+    your students’ experience.
+
+    #### Would you like to edit a Wikipedia article yourself?
+  type: 1  # single choice
+  minimum: 1
+  options:
+    -
+      title: "Yes"
+      blurb: Select yes and we’ll send you guidance on how to get started.
+      selected: true # selected by default
+      tag: instructor_learner
+    -
+      title: "No"
+      tag: not_instructor_learner
 
 -
   key: mentoring

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -31,6 +31,11 @@ def go_through_course_dates_and_timeline_dates
   sleep 1
 end
 
+# Walks through every panel of the research-write wizard, in order. This MUST
+# stay in sync with the panel sequence in config/wizard/researchwrite/wizard.yml:
+# adding, removing, or reordering a panel there requires a matching change to the
+# click-through steps below, or these specs break (often on a later panel or at
+# "Generate Timeline"). `expected_course_blocks` likewise tracks content.yml.
 def go_through_researchwrite_wizard(returning_instructor: true)
   go_through_course_dates_and_timeline_dates
 
@@ -106,6 +111,10 @@ def go_through_researchwrite_wizard(returning_instructor: true)
   # # sandboxes unacceptable
   # omniclick find('.wizard__option', match: :first).find('button', match: :first)
   # click_button 'Next'
+  sleep 1
+
+  # "Learning to edit with your students" panel; accept the default "Yes"
+  click_button 'Next'
   sleep 1
 
   # "Mentorship program" panel that only appears for new instructor
@@ -352,6 +361,10 @@ describe 'New course creation and editing', type: :feature do
       end
       expect(Course.first.blocks.count).to eq(expected_course_blocks)
       expect(Course.first.tag?('mentor_requested')).to be true
+
+      # The instructor accepted the default "Yes" on the "Learning to edit with
+      # your students" panel, so the course carries the opt-in tag.
+      expect(Course.first.tag?('instructor_learner')).to be true
     end
 
     it 'squeezes assignments into the course dates' do

--- a/spec/lib/wizard_timeline_manager_spec.rb
+++ b/spec/lib/wizard_timeline_manager_spec.rb
@@ -52,6 +52,30 @@ describe WizardTimelineManager do
     end
   end
 
+  describe 'instructor_learner tag' do
+    let(:course) do
+      create(:course, start: '2016-08-01', end: '2016-09-23',
+                      timeline_start: '2016-08-01', timeline_end: '2016-09-23',
+                      weekdays: '1111111')
+    end
+
+    def submit(tags)
+      params = { 'wizard_output' => { 'output' => [], 'logic' => [], 'tags' => tags } }
+      described_class.update_timeline_and_tags(course, 'researchwrite', params)
+    end
+
+    # Both wizard options carry a tag under the same key, so re-running the
+    # wizard and choosing "No" overwrites the "Yes" opt-in marker.
+    it 'updates the tag so opting out clears the opt-in marker' do
+      opt_in = [{ key: 'instructor_learner', tag: 'instructor_learner' }]
+      opt_out = [{ key: 'instructor_learner', tag: 'not_instructor_learner' }]
+      submit(opt_in)
+      expect(course.reload.tag?('instructor_learner')).to be true
+      submit(opt_out)
+      expect(course.reload.tag?('instructor_learner')).to be false
+    end
+  end
+
   describe 'wizard_id validation' do
     let(:course) do
       create(:course, start: '2016-08-01', end: '2016-09-23',

--- a/spec/services/schedule_course_advice_emails_spec.rb
+++ b/spec/services/schedule_course_advice_emails_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ScheduleCourseAdviceEmails do
+  let(:course) do
+    create(:course, timeline_start: '2016-01-01', timeline_end: '2016-03-01')
+  end
+  let(:choosing_block) { instance_double(Block, calculated_date: 1.week.from_now) }
+
+  before do
+    create(:tag, course:, tag: 'research_write_assignment', key: 'assignment_type')
+    allow(course).to receive(:find_block_by_title).and_return(nil)
+    allow(course).to receive(:find_block_by_title).with('Choose your article')
+                                                  .and_return(choosing_block)
+    allow(CourseAdviceEmailWorker).to receive(:schedule_email)
+  end
+
+  context 'when the instructor_learner tag is present' do
+    before { create(:tag, course:, tag: 'instructor_learner', key: 'instructor_learner') }
+
+    it 'schedules the learning_to_edit advice email' do
+      described_class.new(course).schedule_emails
+      expect(CourseAdviceEmailWorker).to have_received(:schedule_email)
+        .with(hash_including(course:, subject: 'learning_to_edit'))
+    end
+  end
+
+  context 'when the instructor_learner tag is absent' do
+    it 'does not schedule the learning_to_edit advice email' do
+      described_class.new(course).schedule_emails
+      expect(CourseAdviceEmailWorker).not_to have_received(:schedule_email)
+        .with(hash_including(subject: 'learning_to_edit'))
+    end
+  end
+end


### PR DESCRIPTION
…email

## Changes

A pared-down extraction of an earlier full implementation (093d0c1). That commit also enrolled the instructor as a student of their own course (dual CoursesUsers roles, an enroll service, clone carry-over, a flag). We do not want that behavior at all, so this keeps only two things: a wizard question that tags the course, and an advice email gated on that tag.

Design note — pure tag, no flag. The earlier version carried an `instructor_learner` flag whose only consumers were the dual-enrollment machinery. With that machinery gone the flag has no remaining reader, so this implementation is tag-only: the wizard option's `tag:` is the single source of truth and the email gates on it. No `logic:`/flag plumbing was added.

- **Wizard** (`config/wizard/researchwrite/wizard.yml`): new single-choice "Learning to edit with your students" panel before "Mentorship". Both options carry a tag under the same panel key (`instructor_learner` / its negation), so re-running the wizard and choosing "No" overwrites the opt-in marker — the same pattern other single-choice panels use. Operator-supplied copy. Added a coupling-warning comment (mirrored above the spec helper) because the panel sequence is duplicated in the feature spec.
- **Advice email**: `schedule_learning_to_edit_email` in `ScheduleCourseAdviceEmails`, gated on `tag?('instructor_learner')` and scheduled the week students choose articles. Subject line in `CourseAdviceMailer`, HAML template (operator copy, linked training module), and a mailer preview.
- **Tests**: a scheduler spec (email scheduled iff the tag is present), a wizard-timeline tag-toggle test (opting out clears the opt-in tag), and the full-length research-write feature example extended to click through the new panel and assert the resulting tag.

## Process

The user pointed at commit 093d0c1 and asked to extract a pared-down version scoped to just (a) the wizard question + tag and (b) the advice email, dropping all instructor-as-student enrollment. I read the full original diff, grepped to confirm the `instructor_learner` flag had no consumers outside the dual-enrollment code, and on that basis chose a tag-only implementation — dropping the wizard-controller hook, `Course#instructor_learner?`, the `ClassroomProgramCourse#multiple_roles_allowed?` change, `EnrollInstructorAsLearner`, the clone-manager carry-over, the `WizardTimelineManager::FLAG_LOGIC` additions, and their specs. I surfaced that pure-tag decision before implementing rather than just applying a subset of the old diff. I also flagged (without changing, per the no-AI-text rule) that the email copy's "My Articles → Assign Article" steps assumed the instructor was enrolled as a student, which no longer happens.

Session provenance: the feature code was written from scratch this session; nothing was applied from the original commit directly — each kept hunk was re-derived and adjusted (e.g. `logic:` removed, feature-spec assertion changed from enrollment to tag). The original 093d0c1 predates this session and is not in this branch's history.

Human input: two short directives — the extraction request with its scope, and "commit on the InstructorEdits branch". Terse direction; the scope did the heavy lifting. Short, focused session.

Tests run: RuboCop clean on all six changed Ruby files; the scheduler + wizard-timeline specs passed 9/9; the `course_creation` feature spec passed 4/4 (including the full research-write walkthrough through the new panel) on the first run; the email rendered cleanly via Rails with the expected subject. No failure-then-fix cycles.

(Commit message written by Claude Code.)

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## Instructions

Convert the PR to a draft unless/until:
* The tests are all passing (ie, the CI build is green)
* All feedback has been addressed. (Reviewers will convert it back to a draft if changes need to be made. Mark it ready for review when it's ready again.)
* The git history is tidy. (Each commit should be self-contained, with a clear description in the commit message. In most cases, there should be no merge commits.)
* The PR description template is complete, with a clear indication of the purpose, links to related issues, links to relevant external documentation, an AI usage statement, up-to-date screenshots or demo videos (if applicable). This "Instructions" section can be removed.

If your PR is ready but has been ignored for a week or more, feel free to leave a comment reminding us.

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

## AI usage
< if you used any AI tools to prepare this PR, say which tools you used and what you used them for.
  if you used AI to learn how to solve a problem, summarize what you asked and what advice you used.
  if you didn't use any AI tools, say so. >

## Screenshots
Before:
< add a screenshot or screen recording of the UI before your change >

After:
< add a screenshot or screen recording of the UI after your change >

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
