### PR TITLE
Delete course timeslices in batches before destroying the course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -114,9 +114,14 @@ class Course < ApplicationRecord
 
   has_many :course_wiki_namespaces, class_name: 'CourseWikiNamespaces', through: :courses_wikis
 
-  has_many :article_course_timeslices, dependent: :destroy
-  has_many :course_user_wiki_timeslices, dependent: :destroy
-  has_many :course_wiki_timeslices, dependent: :destroy
+  # Timeslices are intentionally NOT dependent: :destroy. They can number in the
+  # millions for large courses, so deleting them through the destroy cascade (one
+  # instantiated record at a time) is prohibitively slow. DeleteCourseWorker
+  # deletes them in batches via TimesliceCleaner#delete_all_timeslices_for_course
+  # before destroying the course.
+  has_many :article_course_timeslices
+  has_many :course_user_wiki_timeslices
+  has_many :course_wiki_timeslices
 
   has_many :sandboxes, lambda {
     distinct.sandbox

--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -2,7 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 
 class UpdateTimeslicesCourseDate
   def initialize(course)
@@ -88,7 +88,7 @@ class UpdateTimeslicesCourseDate
     @timeslice_cleaner.delete_course_user_wiki_timeslices_prior_to_start_date
 
     # Delete articles courses
-    ArticlesCoursesCleanerTimeslice.clean_articles_courses_prior_to_course_start(@course)
+    ArticlesCoursesCleaner.clean_articles_courses_prior_to_course_start(@course)
   end
 
   def remove_timeslices_after_end_date
@@ -102,7 +102,7 @@ class UpdateTimeslicesCourseDate
     @timeslice_cleaner.delete_course_user_wiki_timeslices_after_end_date
 
     # Delete articles courses
-    ArticlesCoursesCleanerTimeslice.clean_articles_courses_after_course_end(@course)
+    ArticlesCoursesCleaner.clean_articles_courses_after_course_end(@course)
   end
 
   def add_wiki_timeslices_from_new_start_date(wiki)

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -144,13 +144,12 @@ class UpdateTimeslicesCourseUser
     ArticlesCoursesCleanerTimeslice.clean_articles_courses_for_user_ids(@course, user_ids)
   end
 
-  # Returns ArticleCourseTimeslice records that have edits from users
+  # Returns an ArticleCourseTimeslice relation with edits from the given users
   def get_article_course_timeslices_for_users(user_ids)
-    timeslices = user_ids.map do |user_id|
-      ArticleCourseTimeslice.search_by_course_and_user(@course, user_id)
-    end
+    return ArticleCourseTimeslice.none if user_ids.empty?
 
     # These are the ArticleCourseTimeslice records that were updated by users
-    timeslices.flatten
+    user_ids.map { |user_id| ArticleCourseTimeslice.search_by_course_and_user(@course, user_id) }
+            .reduce(:or)
   end
 end

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -2,7 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
 require_dependency "#{Rails.root}/lib/timeslice_manager"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/revision_data_manager"
 require_dependency "#{Rails.root}/lib/course_revision_updater"
 
@@ -131,7 +131,7 @@ class UpdateTimeslicesCourseUser
       @article_course_timeslices_for_users
     )
     # Delete articles courses that were updated only for removed users
-    ArticlesCoursesCleanerTimeslice.clean_articles_courses_for_user_ids(@course, user_ids)
+    ArticlesCoursesCleaner.clean_articles_courses_for_user_ids(@course, user_ids)
   end
 
   def remove_courses_users_acuwt(user_ids)
@@ -141,7 +141,7 @@ class UpdateTimeslicesCourseUser
     # Delete ACUWT records for removed users
     @timeslice_cleaner.delete_acuwt_for_deleted_course_users(user_ids)
     # Delete articles courses that were updated only for removed users
-    ArticlesCoursesCleanerTimeslice.clean_articles_courses_for_user_ids(@course, user_ids)
+    ArticlesCoursesCleaner.clean_articles_courses_for_user_ids(@course, user_ids)
   end
 
   # Returns an ArticleCourseTimeslice relation with edits from the given users

--- a/app/services/update_timeslices_course_wiki.rb
+++ b/app/services/update_timeslices_course_wiki.rb
@@ -2,7 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 
 class UpdateTimeslicesCourseWiki
   def initialize(course)
@@ -34,7 +34,7 @@ class UpdateTimeslicesCourseWiki
     # Delete timeslices for the deleted wikis
     @timeslice_cleaner.delete_timeslices_for_deleted_course_wikis wiki_ids
     # Delete articles courses
-    ArticlesCoursesCleanerTimeslice.clean_articles_courses_for_wiki_ids(@course, wiki_ids)
+    ArticlesCoursesCleaner.clean_articles_courses_for_wiki_ids(@course, wiki_ids)
   end
 
   def add_courses_wikis(wiki_ids)

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -2,7 +2,7 @@
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/revision_data_manager"
 
 # Adjusts timeslices when articles enter or leave scope in ArticleScopedProgram
@@ -20,7 +20,7 @@ require_dependency "#{Rails.root}/lib/revision_data_manager"
 #   articles_courses and ACUWT rows, then marks affected CWT timeslices for reaggregation.
 #
 # Legacy path (course.use_acuwt? == false):
-#   Both cases are handled by ArticlesCoursesCleanerTimeslice, marking CWT timeslices
+#   Both cases are handled by ArticlesCoursesCleaner, marking CWT timeslices
 #   as needs_update for a full re-fetch.
 class UpdateTimeslicesScopedArticle
   def initialize(course, update_service: nil)
@@ -150,7 +150,7 @@ class UpdateTimeslicesScopedArticle
     log_info "Resetting #{article_ids}"
 
     articles = Article.where(id: article_ids)
-    ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, articles)
+    ArticlesCoursesCleaner.reset_specific_articles(@course, articles)
   end
 
   ###########

--- a/app/services/update_timeslices_untracked_article.rb
+++ b/app/services/update_timeslices_untracked_article.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/revision_data_manager"
 
 class UpdateTimeslicesUntrackedArticle

--- a/app/workers/delete_course_worker.rb
+++ b/app/workers/delete_course_worker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/wiki_course_edits"
+require_dependency "#{Rails.root}/lib/timeslice_cleaner"
 
 class DeleteCourseWorker
   include Sidekiq::Worker
@@ -23,6 +24,11 @@ class DeleteCourseWorker
                              participants: course_users(course),
                              username: current_user.username
                            }
+    # Delete timeslices in batches first. They are not dependent: :destroy on
+    # Course (see the Course model), because the destroy cascade is far too slow
+    # for the millions of timeslice rows large courses can have. This must run
+    # before course.destroy, which no longer removes them.
+    TimesliceCleaner.new(course).delete_all_timeslices_for_course
     # destroy the course, clean up the on-wiki copy if necessary
     course.destroy
     WikiCourseEdits.new(action: :update_course,

--- a/lib/article_namespaces_manager.rb
+++ b/lib/article_namespaces_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 
 ##= Identifies articles that move to a different namespace during the course timeline.
 # Specifically, it handles the following cases:
@@ -25,14 +25,14 @@ class ArticleNamespacesManager
 
     reset_articles_that_moved_to_mainspace
 
-    ArticlesCoursesCleanerTimeslice.reset_articles_in_untracked_namespaces(@course)
+    ArticlesCoursesCleaner.reset_articles_in_untracked_namespaces(@course)
   end
 
   private
 
   def reset_articles_that_moved_to_mainspace
     articles = Article.find(moved_to_mainspace)
-    ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, articles)
+    ArticlesCoursesCleaner.reset_specific_articles(@course, articles)
   end
 
   # Articles that have an article course record that was created *after* some of its article

--- a/lib/article_status_manager_timeslice.rb
+++ b/lib/article_status_manager_timeslice.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/assignment_updater"
 
 #= Updates articles to reflect deletion and page moves on Wikipedia
@@ -48,7 +48,7 @@ class ArticleStatusManagerTimeslice
       end
     end
 
-    ArticlesCoursesCleanerTimeslice.reset_articles_for_course(course)
+    ArticlesCoursesCleaner.reset_articles_for_course(course)
   end
 
   ####################
@@ -170,7 +170,7 @@ class ArticleStatusManagerTimeslice
     # If there is only one copy of the article, it was already found and updated
     # via `update_title_and_namespace`
     return unless nondeleted_article
-    ArticlesCoursesCleanerTimeslice.reset_specific_articles(@course, [article])
+    ArticlesCoursesCleaner.reset_specific_articles(@course, [article])
   end
 
   def data_matches_article?(article_data, article)

--- a/lib/articles_courses_cleaner.rb
+++ b/lib/articles_courses_cleaner.rb
@@ -4,6 +4,9 @@ require_dependency "#{Rails.root}/lib/timeslice_cleaner"
 
 #= Cleaner for ArticlesCourses that are not part of a course anymore.
 class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
+  # Number of records deleted per batch when bulk-deleting.
+  DELETE_BATCH_SIZE = 5000
+
   ################
   # Entry points #
   ################
@@ -87,19 +90,15 @@ class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
     delete_article_course(article_ids_to_delete)
 
     # Delete article course timeslices for deleted articles
-    timeslice_ids = ArticleCourseTimeslice.where(course: @course)
-                                          .where(article_id: article_ids_to_delete)
-                                          .pluck(:id)
-
-    delete_article_course_timeslice_ids(timeslice_ids)
+    delete_in_batches(
+      ArticleCourseTimeslice.where(course: @course, article_id: article_ids_to_delete)
+    )
 
     # Delete article course timeslices for dates prior to the course start date
-    timeslice_ids, article_ids = ArticleCourseTimeslice.where(course: @course)
-                                                       .where('end <= ?', @course.start)
-                                                       .pluck(:id, :article_id)
-                                                       .transpose
-    touch_timeslices(article_ids.uniq) unless article_ids.nil?
-    delete_article_course_timeslice_ids(timeslice_ids) unless timeslice_ids.nil?
+    prior_timeslices = ArticleCourseTimeslice.where(course: @course)
+                                             .where('end <= ?', @course.start)
+    touch_timeslices(prior_timeslices.distinct.pluck(:article_id))
+    delete_in_batches(prior_timeslices)
   end
 
   def remove_articles_courses_for_dates_after_end_date
@@ -109,19 +108,15 @@ class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
     delete_article_course(article_ids_to_delete)
 
     # Delete article course timeslices for deleted articles
-    timeslice_ids = ArticleCourseTimeslice.where(course: @course)
-                                          .where(article_id: article_ids_to_delete)
-                                          .pluck(:id)
-
-    delete_article_course_timeslice_ids(timeslice_ids)
+    delete_in_batches(
+      ArticleCourseTimeslice.where(course: @course, article_id: article_ids_to_delete)
+    )
 
     # Delete article course timeslices for dates after the course end date
-    timeslice_ids, article_ids = ArticleCourseTimeslice.where(course: @course)
-                                                       .where('start > ?', @course.end)
-                                                       .pluck(:id, :article_id)
-                                                       .transpose
-    touch_timeslices(article_ids.uniq) unless article_ids.nil?
-    delete_article_course_timeslice_ids(timeslice_ids) unless timeslice_ids.nil?
+    after_timeslices = ArticleCourseTimeslice.where(course: @course)
+                                             .where('start > ?', @course.end)
+    touch_timeslices(after_timeslices.distinct.pluck(:article_id))
+    delete_in_batches(after_timeslices)
   end
 
   def reset_deleted_or_untracked_articles
@@ -208,15 +203,15 @@ class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
   end
 
   def delete_article_course(article_ids)
-    article_ids.each_slice(5000) do |slice|
+    article_ids.each_slice(DELETE_BATCH_SIZE) do |slice|
       ArticlesCourses.where(course: @course).where(article_id: slice).delete_all
     end
   end
 
-  def delete_article_course_timeslice_ids(ids)
-    ids.each_slice(5000) do |slice|
-      ArticleCourseTimeslice.where(id: slice).delete_all
-    end
+  # Deletes all records matching the relation in primary-key batches, without
+  # loading the ids into memory.
+  def delete_in_batches(relation)
+    relation.in_batches(of: DELETE_BATCH_SIZE).delete_all
   end
 
   def mark_as_needs_update(article_batch, wiki)

--- a/lib/articles_courses_cleaner.rb
+++ b/lib/articles_courses_cleaner.rb
@@ -3,9 +3,7 @@
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
 
 #= Cleaner for ArticlesCourses that are not part of a course anymore.
-# This class has to be renamed to ArticlesCoursesCleaner when deleting
-# the existing ArticlesCoursesCleaner class.
-class ArticlesCoursesCleanerTimeslice # rubocop:disable Metrics/ClassLength
+class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
   ################
   # Entry points #
   ################

--- a/lib/articles_courses_cleaner.rb
+++ b/lib/articles_courses_cleaner.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/cleaner_helper"
 require_dependency "#{Rails.root}/lib/timeslice_cleaner"
 
 #= Cleaner for ArticlesCourses that are not part of a course anymore.
 class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
-  # Number of records deleted per batch when bulk-deleting.
-  DELETE_BATCH_SIZE = 5000
+  include CleanerHelper
 
   ################
   # Entry points #
@@ -206,12 +206,6 @@ class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
     article_ids.each_slice(DELETE_BATCH_SIZE) do |slice|
       ArticlesCourses.where(course: @course).where(article_id: slice).delete_all
     end
-  end
-
-  # Deletes all records matching the relation in primary-key batches, without
-  # loading the ids into memory.
-  def delete_in_batches(relation)
-    relation.in_batches(of: DELETE_BATCH_SIZE).delete_all
   end
 
   def mark_as_needs_update(article_batch, wiki)

--- a/lib/cleaner_helper.rb
+++ b/lib/cleaner_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Shared helper for cleaner classes that bulk-delete records. Deletes from an
+# ActiveRecord::Relation in primary-key batches, without loading the ids into
+# memory, so each batch is its own statement and InnoDB purge and replication
+# can keep up between batches.
+module CleanerHelper
+  # Number of records deleted per batch when bulk-deleting.
+  DELETE_BATCH_SIZE = 5000
+
+  private
+
+  def delete_in_batches(relation)
+    relation.in_batches(of: DELETE_BATCH_SIZE).delete_all
+  end
+end

--- a/lib/duplicate_article_deleter.rb
+++ b/lib/duplicate_article_deleter.rb
@@ -24,7 +24,7 @@ class DuplicateArticleDeleter
     course_ids = ArticlesCourses.where(article_id: @deleted_ids).pluck(:course_id).uniq
     course_ids.each do |course_id|
       # Reset articles for every course involved
-      ArticlesCoursesCleanerTimeslice.reset_specific_articles(Course.find(course_id), articles)
+      ArticlesCoursesCleaner.reset_specific_articles(Course.find(course_id), articles)
     end
   end
 

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/cleaner_helper"
+
 #= Removes/resets ArticleCourseTimeslice, CourseUserWikiTimeslice, CourseWikiTimeslice
 #= and ArticleCourseUserWikiTimeslice records.
 class TimesliceCleaner
-  # Number of records deleted per batch when bulk-deleting timeslices.
-  TIMESLICE_DELETE_BATCH_SIZE = 5000
+  include CleanerHelper
 
   def initialize(course)
     @course = course
@@ -267,12 +268,5 @@ class TimesliceCleaner
                                        .where('start >= ?', start_date)
                                        .where('end <= ?', end_date)
     delete_in_batches(timeslices)
-  end
-
-  # Deletes all records matching the relation in primary-key batches, without
-  # loading the ids into memory. Each batch is its own statement, so InnoDB
-  # purge and replication can keep up between batches.
-  def delete_in_batches(relation)
-    relation.in_batches(of: TIMESLICE_DELETE_BATCH_SIZE).delete_all
   end
 end

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -3,8 +3,39 @@
 #= Removes/resets ArticleCourseTimeslice, CourseUserWikiTimeslice, CourseWikiTimeslice
 #= and ArticleCourseUserWikiTimeslice records.
 class TimesliceCleaner
+  # Number of records deleted per batch when bulk-deleting timeslices.
+  TIMESLICE_DELETE_BATCH_SIZE = 5000
+
   def initialize(course)
     @course = course
+  end
+
+  # Deletes every timeslice record for the course across the four timeslice
+  # tables (ACUWT, ACT, CUWT, CWT). Used both when fully deleting a course and
+  # when purging timeslices for old courses that are no longer updated.
+  # Deletes in primary-key batches so each transaction stays small and ids are
+  # never loaded into memory wholesale.
+  def delete_all_timeslices_for_course
+    delete_all_article_course_user_wiki_timeslices
+    delete_all_article_course_timeslices
+    delete_all_course_user_wiki_timeslices
+    delete_all_course_wiki_timeslices
+  end
+
+  def delete_all_article_course_user_wiki_timeslices
+    delete_in_batches(ArticleCourseUserWikiTimeslice.where(course: @course))
+  end
+
+  def delete_all_article_course_timeslices
+    delete_in_batches(ArticleCourseTimeslice.where(course: @course))
+  end
+
+  def delete_all_course_user_wiki_timeslices
+    delete_in_batches(CourseUserWikiTimeslice.where(course: @course))
+  end
+
+  def delete_all_course_wiki_timeslices
+    delete_in_batches(CourseWikiTimeslice.where(course: @course))
   end
 
   # Deletes course user wiki timeslices records for removed course users
@@ -295,26 +326,33 @@ class TimesliceCleaner
     delete_article_course_timeslice_ids(timeslice_ids)
   end
 
+  # Deletes all records matching the relation in primary-key batches, without
+  # loading the ids into memory. Each batch is its own statement, so InnoDB
+  # purge and replication can keep up between batches.
+  def delete_in_batches(relation)
+    relation.in_batches(of: TIMESLICE_DELETE_BATCH_SIZE).delete_all
+  end
+
   def delete_article_course_user_wiki_timeslice_ids(ids)
-    ids.each_slice(5000) do |slice|
+    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
       ArticleCourseUserWikiTimeslice.where(id: slice).delete_all
     end
   end
 
   def delete_article_course_timeslice_ids(ids)
-    ids.each_slice(5000) do |slice|
+    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
       ArticleCourseTimeslice.where(id: slice).delete_all
     end
   end
 
   def delete_course_wiki_timeslice_ids(ids)
-    ids.each_slice(5000) do |slice|
+    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
       CourseWikiTimeslice.where(id: slice).delete_all
     end
   end
 
   def delete_course_user_wiki_timeslice_ids(ids)
-    ids.each_slice(5000) do |slice|
+    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
       CourseUserWikiTimeslice.where(id: slice).delete_all
     end
   end

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -141,7 +141,7 @@ class TimesliceCleaner
   # - Marking timeslices as needs_update for dates with associated article course timeslices
   # - Deleting given article course timeslices if no soft
   # - Deleting course user wiki timeslices for those dates and wikis
-  # Takes a collection of article course timeslices
+  # Takes an ActiveRecord::Relation of article course timeslices
   def reset_timeslices_that_need_update_from_article_timeslices(timeslices,
                                                                 wiki: nil,
                                                                 soft: false)
@@ -161,8 +161,7 @@ class TimesliceCleaner
     # Update all CourseWikiTimeslice records with matching course, wiki and start dates
     course_wiki_timeslices.update_all(needs_update: true) # rubocop:disable Rails/SkipsModelValidations
 
-    # `timeslices` may be a plain Array (not a relation), so delete by id.
-    delete_in_batches(ArticleCourseTimeslice.where(id: timeslices.pluck(:id))) unless soft
+    delete_in_batches(timeslices) unless soft
 
     # Perform the query using raw SQL for specific (wiki_id, start_date) pairs
     cuw_imeslices = CourseUserWikiTimeslice.where(course: @course)

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -43,11 +43,7 @@ class TimesliceCleaner
   def delete_course_user_timeslices_for_deleted_course_users(user_ids)
     return if user_ids.empty?
 
-    timeslice_ids = CourseUserWikiTimeslice.where(course: @course, user_id: user_ids).pluck(:id)
-
-    return if timeslice_ids.empty?
-
-    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+    delete_in_batches(CourseUserWikiTimeslice.where(course: @course, user_id: user_ids))
   end
 
   # Deletes course wiki timeslices records for removed course wikis
@@ -72,12 +68,7 @@ class TimesliceCleaner
 
   # Deletes course wiki timeslices records with a date prior to the current start date
   def delete_course_wiki_timeslices_prior_to_start_date
-    # Delete course wiki timeslices
-    timeslice_ids = CourseWikiTimeslice.where(course: @course)
-                                       .where('end <= ?', @course.start)
-                                       .pluck(:id)
-
-    delete_course_wiki_timeslice_ids(timeslice_ids)
+    delete_in_batches(CourseWikiTimeslice.where(course: @course).where('end <= ?', @course.start))
   end
 
   # Deletes course wiki timeslices records with a start date later than the current end date
@@ -88,24 +79,17 @@ class TimesliceCleaner
 
   # Deletes course wiki timeslices records with a start date later than the specific given date
   def delete_course_wiki_timeslices_after_date(wikis, date)
-    # Delete course wiki timeslices
-    timeslice_ids = CourseWikiTimeslice.where(course: @course)
-                                       .where(wiki: wikis)
-                                       .where('start > ?', date)
-                                       .pluck(:id)
-
-    delete_course_wiki_timeslice_ids(timeslice_ids)
+    timeslices = CourseWikiTimeslice.where(course: @course).where(wiki: wikis)
+                                    .where('start > ?', date)
+    delete_in_batches(timeslices)
   end
 
   # Deletes course user wiki timeslices records with a start date later than the
   # specific given date
   def delete_course_user_wiki_timeslices_after_date(wikis, date)
-    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
-                                           .where(wiki: wikis)
-                                           .where('start > ?', date)
-                                           .pluck(:id)
-
-    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+    timeslices = CourseUserWikiTimeslice.where(course: @course).where(wiki: wikis)
+                                        .where('start > ?', date)
+    delete_in_batches(timeslices)
   end
 
   # Deletes article course timeslices records with a start date later than the
@@ -114,22 +98,15 @@ class TimesliceCleaner
     # Collect the ids of articles to be deleted
     article_ids = @course.articles_from_timeslices(wikis).pluck(:id)
 
-    timeslice_ids = ArticleCourseTimeslice.where(course: @course)
-                                          .where(article_id: article_ids)
-                                          .where('start > ?', date)
-                                          .pluck(:id)
-
-    delete_article_course_timeslice_ids(timeslice_ids)
+    timeslices = ArticleCourseTimeslice.where(course: @course).where(article_id: article_ids)
+                                       .where('start > ?', date)
+    delete_in_batches(timeslices)
   end
 
   # Deletes course user wiki timeslices records with a date prior to the current start date
   def delete_course_user_wiki_timeslices_prior_to_start_date
-    # Delete course user wiki timeslices
-    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
-                                           .where('end <= ?', @course.start)
-                                           .pluck(:id)
-
-    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+    delete_in_batches(CourseUserWikiTimeslice.where(course: @course)
+                                             .where('end <= ?', @course.start))
   end
 
   # Deletes course user wiki timeslices records with a start date later than the current end date
@@ -157,8 +134,7 @@ class TimesliceCleaner
   def delete_acuwt_for_deleted_course_users(user_ids)
     return if user_ids.empty?
 
-    ids = ArticleCourseUserWikiTimeslice.where(course: @course, user_id: user_ids).pluck(:id)
-    delete_article_course_user_wiki_timeslice_ids(ids)
+    delete_in_batches(ArticleCourseUserWikiTimeslice.where(course: @course, user_id: user_ids))
   end
 
   # Resets course wiki timeslices. This involves:
@@ -185,44 +161,32 @@ class TimesliceCleaner
     # Update all CourseWikiTimeslice records with matching course, wiki and start dates
     course_wiki_timeslices.update_all(needs_update: true) # rubocop:disable Rails/SkipsModelValidations
 
-    delete_article_course_timeslice_ids(timeslices.pluck(:id)) unless soft
+    # `timeslices` may be a plain Array (not a relation), so delete by id.
+    delete_in_batches(ArticleCourseTimeslice.where(id: timeslices.pluck(:id))) unless soft
 
     # Perform the query using raw SQL for specific (wiki_id, start_date) pairs
     cuw_imeslices = CourseUserWikiTimeslice.where(course: @course)
                                            .where("(wiki_id, start) IN (#{tuples_list})")
 
-    delete_course_user_wiki_timeslice_ids(cuw_imeslices.pluck(:id))
+    delete_in_batches(cuw_imeslices)
   end
 
   private
 
   # Deletes existing course wiki timeslices for a collection of wiki ids
   def delete_existing_course_wiki_timeslices(wiki_ids)
-    # Collect the ids of timeslices to be deleted
-    timeslice_ids = CourseWikiTimeslice.where(course_id: @course.id, wiki_id: wiki_ids).pluck(:id)
-
-    return if timeslice_ids.empty?
-
-    delete_course_wiki_timeslice_ids(timeslice_ids)
+    delete_in_batches(CourseWikiTimeslice.where(course_id: @course.id, wiki_id: wiki_ids))
   end
 
   # Deletes existing course user wiki timeslices for a collection of wiki ids
   def delete_existing_course_user_wiki_timeslices(wiki_ids)
-    # Collect the ids of timeslices to be deleted
-    timeslice_ids = CourseUserWikiTimeslice.where(course_id: @course.id,
-                                                  wiki_id: wiki_ids).pluck(:id)
-
-    return if timeslice_ids.empty?
-
-    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+    delete_in_batches(CourseUserWikiTimeslice.where(course_id: @course.id, wiki_id: wiki_ids))
   end
 
   # Deletes existing article course user wiki timeslices for a collection of wiki ids
   def delete_existing_article_course_user_wiki_timeslices(wiki_ids)
-    timeslice_ids = ArticleCourseUserWikiTimeslice.where(course_id: @course.id,
-                                                         wiki_id: wiki_ids).pluck(:id)
-    return if timeslice_ids.empty?
-    delete_article_course_user_wiki_timeslice_ids(timeslice_ids)
+    delete_in_batches(ArticleCourseUserWikiTimeslice.where(course_id: @course.id,
+                                                           wiki_id: wiki_ids))
   end
 
   def mark_timeslices_for_reaggregation(wikis_and_starts)
@@ -241,20 +205,16 @@ class TimesliceCleaner
     tuples = article_starts.map do |article_id, s|
       "(#{article_id}, '#{s.strftime('%Y-%m-%d %H:%M:%S')}')"
     end.join(', ')
-    act_ids = ArticleCourseTimeslice.where(course: @course)
-                                    .where("(article_id, start) IN (#{tuples})")
-                                    .pluck(:id)
-    delete_article_course_timeslice_ids(act_ids)
+    delete_in_batches(ArticleCourseTimeslice.where(course: @course)
+                                            .where("(article_id, start) IN (#{tuples})"))
   end
 
   def delete_course_user_wiki_timeslices_for_acuwt_pairs(wikis_and_starts)
     tuples = wikis_and_starts.map do |wiki_id, s|
       "(#{wiki_id}, '#{s.strftime('%Y-%m-%d %H:%M:%S')}')"
     end.join(', ')
-    cuwt_ids = CourseUserWikiTimeslice.where(course: @course)
-                                      .where("(wiki_id, start) IN (#{tuples})")
-                                      .pluck(:id)
-    delete_course_user_wiki_timeslice_ids(cuwt_ids)
+    delete_in_batches(CourseUserWikiTimeslice.where(course: @course)
+                                             .where("(wiki_id, start) IN (#{tuples})"))
   end
 
   # Deletes existing article course timeslices for a collection of wiki ids
@@ -262,13 +222,7 @@ class TimesliceCleaner
     # Collect the ids of articles to be deleted
     article_ids = @course.articles_from_timeslices(wiki_ids).pluck(:id)
 
-    # Collect the ids of timeslices to be deleted
-    timeslice_ids = ArticleCourseTimeslice.where(course_id: @course.id,
-                                                 article_id: article_ids).pluck(:id)
-
-    return if timeslice_ids.empty?
-
-    delete_article_course_timeslice_ids(timeslice_ids)
+    delete_in_batches(ArticleCourseTimeslice.where(course_id: @course.id, article_id: article_ids))
   end
 
   # Returns (wiki, start) tuples for timeslices to reprocess
@@ -291,25 +245,18 @@ class TimesliceCleaner
 
   # Deletes course wiki timeslices records in the period [start_date, end_date]
   def delete_course_wiki_timeslices_for_period(wikis, start_date, end_date)
-    # Delete course wiki timeslices
-    timeslice_ids = CourseWikiTimeslice.where(course: @course)
-                                       .where(wiki: wikis)
-                                       .where('start >= ?', start_date)
-                                       .where('end <= ?', end_date)
-                                       .pluck(:id)
-
-    delete_course_wiki_timeslice_ids(timeslice_ids)
+    timeslices = CourseWikiTimeslice.where(course: @course).where(wiki: wikis)
+                                    .where('start >= ?', start_date)
+                                    .where('end <= ?', end_date)
+    delete_in_batches(timeslices)
   end
 
   # Deletes course user wiki timeslices records in the period [start_date, end_date]
   def delete_course_user_wiki_timeslices_for_period(wikis, start_date, end_date)
-    timeslice_ids = CourseUserWikiTimeslice.where(course: @course)
-                                           .where(wiki: wikis)
-                                           .where('start >= ?', start_date)
-                                           .where('end <= ?', end_date)
-                                           .pluck(:id)
-
-    delete_course_user_wiki_timeslice_ids(timeslice_ids)
+    timeslices = CourseUserWikiTimeslice.where(course: @course).where(wiki: wikis)
+                                        .where('start >= ?', start_date)
+                                        .where('end <= ?', end_date)
+    delete_in_batches(timeslices)
   end
 
   # Deletes article course timeslices records in the period [start_date, end_date]
@@ -317,13 +264,10 @@ class TimesliceCleaner
     # Collect the ids of articles to be deleted
     article_ids = @course.articles_from_timeslices(wikis).pluck(:id)
 
-    timeslice_ids = ArticleCourseTimeslice.where(course: @course)
-                                          .where(article_id: article_ids)
-                                          .where('start >= ?', start_date)
-                                          .where('end <= ?', end_date)
-                                          .pluck(:id)
-
-    delete_article_course_timeslice_ids(timeslice_ids)
+    timeslices = ArticleCourseTimeslice.where(course: @course).where(article_id: article_ids)
+                                       .where('start >= ?', start_date)
+                                       .where('end <= ?', end_date)
+    delete_in_batches(timeslices)
   end
 
   # Deletes all records matching the relation in primary-key batches, without
@@ -331,29 +275,5 @@ class TimesliceCleaner
   # purge and replication can keep up between batches.
   def delete_in_batches(relation)
     relation.in_batches(of: TIMESLICE_DELETE_BATCH_SIZE).delete_all
-  end
-
-  def delete_article_course_user_wiki_timeslice_ids(ids)
-    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
-      ArticleCourseUserWikiTimeslice.where(id: slice).delete_all
-    end
-  end
-
-  def delete_article_course_timeslice_ids(ids)
-    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
-      ArticleCourseTimeslice.where(id: slice).delete_all
-    end
-  end
-
-  def delete_course_wiki_timeslice_ids(ids)
-    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
-      CourseWikiTimeslice.where(id: slice).delete_all
-    end
-  end
-
-  def delete_course_user_wiki_timeslice_ids(ids)
-    ids.each_slice(TIMESLICE_DELETE_BATCH_SIZE) do |slice|
-      CourseUserWikiTimeslice.where(id: slice).delete_all
-    end
   end
 end

--- a/spec/lib/articles_courses_cleaner_spec.rb
+++ b/spec/lib/articles_courses_cleaner_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require "#{Rails.root}/lib/articles_courses_cleaner"
 require "#{Rails.root}/lib/timeslice_manager"
 
-describe ArticlesCoursesCleanerTimeslice do
+describe ArticlesCoursesCleaner do
   let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
   let(:wikidata) { Wiki.get_or_create(project: 'wikidata', language: nil) }
   let(:start) { '2024-01-01'.to_datetime }

--- a/spec/lib/duplicate_article_deleter_spec.rb
+++ b/spec/lib/duplicate_article_deleter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 require "#{Rails.root}/lib/duplicate_article_deleter"
-require_dependency "#{Rails.root}/lib/articles_courses_cleaner_timeslice"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 
 describe DuplicateArticleDeleter do
   describe '.resolve_duplicates_for_timeslices' do
@@ -94,7 +94,7 @@ describe DuplicateArticleDeleter do
       create(:articles_course, course_id: course1.id, article_id: new_article.id)
       create(:articles_course, course_id: course2.id, article_id: duplicate_article.id)
 
-      expect(ArticlesCoursesCleanerTimeslice).to receive(:reset_specific_articles).once
+      expect(ArticlesCoursesCleaner).to receive(:reset_specific_articles).once
 
       described_class.new.resolve_duplicates_for_timeslices([new_article, extant_article])
     end

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -290,7 +290,8 @@ describe TimesliceCleaner do
   end
 
   describe '#reset_timeslices_that_need_update_from_article_timeslices' do
-    let(:timeslices) { [] }
+    let(:timeslice_ids) { [] }
+    let(:timeslices) { ArticleCourseTimeslice.where(id: timeslice_ids) }
 
     before do
       timeslice_manager.create_timeslices_for_new_course_wiki_records([wikidata,
@@ -301,10 +302,10 @@ describe TimesliceCleaner do
               start: '2024-04-10'.to_datetime, end: '2024-04-11'.to_datetime)
       create(:course_user_wiki_timeslice, course:, user_id: 1, wiki: wikidata,
               start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
-      timeslices << create(:article_course_timeslice, course:, article: article1,
-             start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
-      timeslices << create(:article_course_timeslice, course:, article: article1,
-             start: '2024-04-10'.to_datetime, end: '2024-04-11'.to_datetime)
+      timeslice_ids << create(:article_course_timeslice, course:, article: article1,
+             start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime).id
+      timeslice_ids << create(:article_course_timeslice, course:, article: article1,
+             start: '2024-04-10'.to_datetime, end: '2024-04-11'.to_datetime).id
       create(:article_course_timeslice, course:, article: article3,
              start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
     end

--- a/spec/workers/delete_course_worker_spec.rb
+++ b/spec/workers/delete_course_worker_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DeleteCourseWorker do
+  let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
+  let(:course) { create(:course, slug: 'School/Course_(Term)') }
+  let(:other_course) { create(:course, slug: 'Other/Course_(Term)') }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, wiki_id: enwiki.id) }
+
+  before do
+    stub_wiki_validation
+    # Avoid making real on-wiki edits when the course is deleted.
+    allow(WikiCourseEdits).to receive(:new)
+  end
+
+  def create_timeslices_for(some_course)
+    create(:article_course_timeslice, course: some_course, article_id: article.id)
+    create(:course_user_wiki_timeslice, course: some_course, user_id: user.id, wiki: enwiki)
+    create(:course_wiki_timeslice, course: some_course, wiki: enwiki)
+    create(:article_course_user_wiki_timeslice, course: some_course, wiki: enwiki,
+                                                article_id: article.id, user_id: user.id)
+  end
+
+  it 'destroys the course' do
+    create_timeslices_for(course)
+
+    described_class.new.perform(course.id, user.id)
+
+    expect(Course.exists?(course.id)).to be false
+  end
+
+  it 'deletes the course timeslices across all four timeslice tables' do
+    create_timeslices_for(course)
+
+    described_class.new.perform(course.id, user.id)
+
+    expect(ArticleCourseTimeslice.where(course_id: course.id)).to be_empty
+    expect(CourseUserWikiTimeslice.where(course_id: course.id)).to be_empty
+    expect(CourseWikiTimeslice.where(course_id: course.id)).to be_empty
+    expect(ArticleCourseUserWikiTimeslice.where(course_id: course.id)).to be_empty
+  end
+
+  it 'leaves timeslices belonging to other courses intact' do
+    create_timeslices_for(course)
+    create_timeslices_for(other_course)
+
+    described_class.new.perform(course.id, user.id)
+
+    expect(ArticleCourseTimeslice.where(course_id: other_course.id).count).to eq(1)
+    expect(CourseUserWikiTimeslice.where(course_id: other_course.id).count).to eq(1)
+    expect(CourseWikiTimeslice.where(course_id: other_course.id).count).to eq(1)
+    expect(ArticleCourseUserWikiTimeslice.where(course_id: other_course.id).count).to eq(1)
+  end
+end


### PR DESCRIPTION
## What this PR does

Splits complete course deletion into two explicit steps so a course's timeslice
tables are deleted in batches instead of through the ActiveRecord `destroy`
cascade, which does not scale for courses with millions of timeslice rows.

- Removes `dependent: :destroy` from the three timeslice associations on `Course`
  (`article_course_timeslices`, `course_user_wiki_timeslices`,
  `course_wiki_timeslices`). The cascade destroys rows one instantiated record at
  a time.
- `DeleteCourseWorker` now calls
  `TimesliceCleaner#delete_all_timeslices_for_course` (batched, all four timeslice
  tables) **before** `course.destroy`. Order matters — with the cascade gone,
  destroying first would orphan every timeslice row.
- This also fixes a pre-existing bug: `course.destroy` never deleted
  `ArticleCourseUserWikiTimeslice` (ACUWT) rows (there is no association for them
  on `Course`), so they were orphaned on every course deletion. The new path
  cleans them up.
- Adds a `DeleteCourseWorker` spec (there was none) asserting the course is
  destroyed, all four timeslice tables are cleared, and other courses' timeslices
  are left intact.

**This PR is stacked on #6922** (which adds `delete_in_batches` /
`delete_all_timeslices_for_course` and the cleaner refactors). Until #6922
merges, the diff here shows all of its commits too; the substantive changes in
*this* PR are the last two commits (the `Course` / `DeleteCourseWorker` change and
its spec). Once #6922 merges, this diff collapses to just those.

## AI usage

Developed with Claude Code (Opus 4.8) under interactive human direction, as part
of a larger effort to bound the growth of the ACUWT timeslice table. Claude Code
drafted the code and the commit messages and wrote the spec; the human set the
direction and made the decisions — including the delete-then-destroy ordering,
declining a `before_destroy` orphan guard for now, and structuring the work as a
stacked PR on top of #6922. Before changing the associations, Claude checked that
`DeleteCourseWorker` is the only app/lib caller of `course.destroy` and that no
spec relied on the cascade removing timeslices.

Scale of effort: the two commits unique to this PR were made in a single focused
session, with the spec verified green and RuboCop clean.

This PR description was drafted using the `/prepare-pr` Claude Code skill, and —
like the analysis above — may contain errors.

## Screenshots

No UI changes (backend only).

## Open questions and concerns

- **Depends on #6922** and should merge after it. The deletion primitive it calls
  (`delete_all_timeslices_for_course`) lives in that PR.
- **No `before_destroy` guard.** If `course.destroy` is ever called directly
  (rails console, future code) instead of through `DeleteCourseWorker`, timeslices
  will orphan silently — there is no DB-level foreign key to catch it. A cheap
  existence-check guard was considered and intentionally deferred.
- This is one step of a larger plan; the actual purge job for old courses (and
  blocking re-updates on purged courses) is planned as a separate follow-up PR.

(PR description written by Claude Code.)
