### PR TITLE
Upgrade react-cookie-consent to clear js-cookie High alert (GHSA-qjx8-664m-686j)

### DIFF
--- a/docs/dependency_security_audit.md
+++ b/docs/dependency_security_audit.md
@@ -57,21 +57,25 @@ time of triage (local HEAD matched `origin/master`, i.e. what Dependabot scans).
   markdown specs, the full Jest suite (406 tests), the production build, and an
   ad-hoc footnote+linkify render all pass.
 
-### 3. js-cookie (needs react-cookie-consent upgrade)
+### 3. js-cookie (needs react-cookie-consent upgrade) — ✅ RESOLVED 2026-06-29
 
 - **Alert:** GHSA-qjx8-664m-686j (high) — per-instance prototype hijack in
   `assign()` enabling cookie-attribute injection.
 - **Range / patch:** `<= 3.0.5`, patched `3.0.7`.
-- **Current:** `js-cookie 2.2.1`, pulled by `react-cookie-consent@8.0.1`
-  (`js-cookie ^2.2.1`). **Runtime** — the cookie-consent banner.
-- **Why deferred:** `js-cookie` 2 → 3 is a major API change.
-  `react-cookie-consent@8.0.1` expects js-cookie 2.x; forcing 3.x via a
-  resolution could break the consent banner in the browser.
-- **Recommended:** Upgrade `react-cookie-consent` to a release that depends on
-  js-cookie 3.x, then functionally verify the cookie-consent banner (set/read/
-  expiry behavior).
-- **Risk:** Runtime, but the attack requires control over cookie-attribute input;
-  low-to-moderate. Still, a functional check of the banner is required.
+- **Was:** `js-cookie 2.2.1`, pulled by `react-cookie-consent@8.0.1`. **Runtime**
+  — the cookie-consent banner, and the re-exported `Cookies` used by
+  notes_panel / notes_modal_trigger / news_nav_icon.
+- **Fix shipped (branch `js-cookie-upgrade`):** bumped `react-cookie-consent`
+  ^8.0.1 → ^10.0.1, the first release on js-cookie 3.x (requires React ≥18, which
+  we satisfy). That carries js-cookie 2.2.1 → 3.0.8 (patched). v10 still
+  re-exports `Cookies` and `CookieConsent` (default), and js-cookie's
+  `set(name, value, { expires })` / `get(name)` API is unchanged 2 → 3, so no app
+  source changed.
+- **Verification:** js-cookie resolves to a single 3.0.8; production build
+  compiles; Jest suite passes; and a throwaway Capybara feature spec rendered the
+  banner and confirmed "I understand" dismisses it in a real browser (the banner
+  is disabled in the test env, so the spec temporarily enabled it; that edit was
+  reverted).
 
 ### 4. tar (only patched on the 7.x line; cacache pins 6.x) — ✅ RESOLVED 2026-06-29
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prop-types": "^15.7.2",
     "query-string": "7.1.1",
     "react": "^18.2.0",
-    "react-cookie-consent": "^8.0.1",
+    "react-cookie-consent": "^10.0.1",
     "react-day-picker": "7.4.8",
     "react-dnd": "^16.0.0",
     "react-dnd-html5-backend": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3421,7 +3421,7 @@ __metadata:
     prop-types: ^15.7.2
     query-string: 7.1.1
     react: ^18.2.0
-    react-cookie-consent: ^8.0.1
+    react-cookie-consent: ^10.0.1
     react-day-picker: 7.4.8
     react-dnd: ^16.0.0
     react-dnd-html5-backend: ^16.0.0
@@ -8351,10 +8351,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
+"js-cookie@npm:^3.0.5":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 73ce2e57d352caf01b4ff40406fd474e7e2edd545a6fdcecbe8fb1d764ef761db99b40a2ca990473064f0519a6af0f2cfae30410c93fcb8bf2a4bc4215c5395d
   languageName: node
   linkType: hard
 
@@ -10489,14 +10489,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-cookie-consent@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "react-cookie-consent@npm:8.0.1"
+"react-cookie-consent@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "react-cookie-consent@npm:10.0.1"
   dependencies:
-    js-cookie: ^2.2.1
+    js-cookie: ^3.0.5
   peerDependencies:
-    react: ">=16"
-  checksum: c99f3e40e3091c439956498158b5b8906cce170763836d6fade98a06ce667eca25aaf3bc407e10a6fb72fc44e5178a2ebf14cbbe4e1b5684a74b7d7f484bd359
+    react: ">=18"
+    react-dom: ">=18"
+  checksum: f45487c8e5abe6d995bdc179149f6b3dd4b7189fd28eaf4cd2aefc839f11c18abc6a02827d74aca2d79978fbb47242c87d6e2fd756ca0e9864e165f7433dbe19
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does

Clears the **js-cookie** High-severity Dependabot alert (GHSA-qjx8-664m-686j —
per-instance prototype hijack in `assign()` enabling cookie-attribute injection),
one of the items deferred to `docs/dependency_security_audit.md` in the earlier
dependency work.

js-cookie can't be bumped in isolation: it's pulled transitively by
`react-cookie-consent`, whose 8.x line pins js-cookie 2.x, and the 2 → 3 API
differs. The fix is bumping the parent:

- **`react-cookie-consent` ^8.0.1 → ^10.0.1**, which carries **js-cookie 2.2.1 →
  3.0.8** (patched; the advisory covers `<= 3.0.5`). v10.0.0 is the first
  react-cookie-consent release on js-cookie 3.x; it requires React ≥18, which we
  satisfy at 18.2.0.

No application source changed. react-cookie-consent 10 still re-exports `Cookies`
and exports `CookieConsent` as its default, and js-cookie's
`set(name, value, { expires })` / `get(name)` API is identical between 2 and 3,
so all existing usages keep working:

- `components/nav/consent_banner.jsx` — the default `CookieConsent` banner;
- `components/admin_notes/notes_panel.jsx`,
  `components/admin_notes/notes_modal_trigger.jsx`,
  `components/nav/news/news_nav_icon.jsx` — the re-exported `Cookies`.

The audit doc is updated to mark this item resolved.

Reference: the repo's
[Dependabot alerts](https://github.com/WikiEducationFoundation/WikiEduDashboard/security/dependabot).

### Verification

- js-cookie resolves to a single **3.0.8** in `yarn.lock` (no residual 2.x).
- `yarn build` (production webpack build) compiles and bundles the new imports.
- `yarn test` passes: 63 suites / 406 tests.
- Because this is a runtime, user-facing component with no existing automated
  coverage, I also ran a **throwaway** Capybara feature spec (not committed): it
  rendered the consent banner in a real browser and confirmed that clicking
  "I understand" dismisses it — which exercises react-cookie-consent 10 persisting
  consent through js-cookie 3. The banner is disabled in the test env
  (`_head.html.haml` sets `consentBanner: user_signed_in? && !Rails.env.test?`),
  so the spec temporarily enabled it; that edit was reverted and the spec deleted.

## AI usage

Produced by **Claude Code** under human direction, continuing the dependency-
security work from PRs #6926 and #6927. The human chose this item and suggested
verifying it with a throwaway feature spec; Claude Code did the dependency
analysis (npm registry checks confirming v10 is the first js-cookie-3 release and
that it still re-exports `Cookies`/`CookieConsent`), made the bump, ran the
build/tests, wrote and ran the throwaway feature spec, updated the audit doc, and
wrote the commit messages (each with a `Co-Authored-By: Claude` trailer and a
`## Process` note). The human contributed the direction, the verification
approach, and review. This summary was also drafted by Claude Code and may
contain errors; please review.

Scale of effort: 2 commits within a single focused session on 2026-06-29.

This PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes — this PR only bumps dependency manifests/lockfiles and updates the
`docs/dependency_security_audit.md` tracking doc. (The consent banner's
appearance and behavior are unchanged; the throwaway feature spec above confirmed
it still renders and dismisses.)

## Open questions and concerns

- This branch was rebased onto the current master (after #6926 and #6927 merged),
  so its diff is scoped to just the react-cookie-consent / js-cookie change plus
  the js-cookie entry in `docs/dependency_security_audit.md`; master's other
  audit-doc resolutions are preserved. The combined tree (js-cookie 3 alongside
  the markdown-it 14 / tar 7 / rewire 9 / serialize-javascript 7 changes already
  on master) was re-verified: Jest 406 passing, production build green.
- The consent banner remains disabled in the test environment by design, so there
  is no committed automated coverage for it; verification here was the throwaway
  browser spec described above.
- With this merged, **tinymce** is the only remaining High Dependabot alert from
  the audit doc — and it has no fixed release (needs a TinyMCE 6/7 migration plus
  a licensing review).

(PR description written by Claude Code.)
