### PR TITLE
Publish VPAT accessibility report at /accessibility

### DIFF
--- a/app/assets/stylesheets/modules/_accessibility_report.styl
+++ b/app/assets/stylesheets/modules/_accessibility_report.styl
@@ -1,0 +1,48 @@
+// Styles for the public /accessibility page (rendered VPAT).
+// The content is generated from docs/vpat_draft.md as Markdown, so
+// these rules target the plain element output rather than BEM classes.
+.accessibility-report
+  padding 20px 0 60px
+  max-width 900px
+
+  h1
+    margin-bottom 0.5em
+
+  h2
+    margin-top 1.5em
+    padding-bottom 0.2em
+    border-bottom 1px solid $border_lt
+
+  h3
+    margin-top 1.25em
+
+  p, li
+    line-height 1.5
+
+  ul
+    margin-bottom 1em
+    padding-left 1.5em
+    list-style disc
+
+  table
+    width 100%
+    border-collapse collapse
+    margin 1em 0
+
+    th, td
+      border 1px solid $border_lt
+      padding 8px 12px
+      text-align left
+      vertical-align top
+
+    th
+      background-color $bg_light_gray
+
+    // The conformance-level column reads better without wrapping.
+    td:nth-child(2)
+      white-space nowrap
+
+  code
+    background-color $bg_light_gray
+    padding 1px 4px
+    border-radius 3px

--- a/app/controllers/about_this_site_controller.rb
+++ b/app/controllers/about_this_site_controller.rb
@@ -4,4 +4,11 @@ class AboutThisSiteController < ApplicationController
   respond_to :html
 
   def private_information; end
+
+  # The published VPAT covers the Wiki Education Dashboard only; it
+  # explicitly disclaims the P&E Dashboard deployment, so it is not
+  # served there.
+  def accessibility
+    raise ActionController::RoutingError, 'Not Found' unless Features.wiki_ed?
+  end
 end

--- a/app/helpers/about_this_site_helper.rb
+++ b/app/helpers/about_this_site_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#= Helpers for the about-this-site static pages
+module AboutThisSiteHelper
+  ACCESSIBILITY_REPORT_PATH = "#{Rails.root}/docs/vpat.md"
+
+  # Renders the canonical VPAT Markdown file to HTML for the public
+  # /accessibility page. The Markdown file in docs/ is the single
+  # source of truth; rendering it here avoids a second hand-maintained
+  # copy. escape_html neutralizes any literal HTML in the source, so
+  # the rendered output is safe to mark html_safe.
+  def accessibility_report_html
+    source = File.read(ACCESSIBILITY_REPORT_PATH)
+    renderer = Redcarpet::Render::HTML.new(escape_html: true)
+    markdown = Redcarpet::Markdown.new(renderer, tables: true, autolink: true)
+    markdown.render(source).html_safe
+  end
+end

--- a/app/views/about_this_site/accessibility.html.haml
+++ b/app/views/about_this_site/accessibility.html.haml
@@ -1,0 +1,4 @@
+- content_for(:title) { 'Accessibility' }
+.container
+  .accessibility-report
+    = accessibility_report_html

--- a/app/views/shared/_wiki_ed_footer.html.haml
+++ b/app/views/shared/_wiki_ed_footer.html.haml
@@ -6,6 +6,7 @@
     #{ link_to 'Terms of Service', 'https://wikiedu.org/terms-of-service', target: '_blank'}.
     It makes limited use of
     #{ link_to 'Private Information', '/private_information' }.
+    #{ link_to 'Accessibility', '/accessibility' }.
     All content is
     #{ link_to 'CC-BY-SA', 'https://creativecommons.org/licenses/by-sa/4.0/', target: '_blank' }.
     #{ link_to 'Code contributions welcome', 'https://github.com/WikiEducationFoundation/WikiEduDashboard', target: '_blank' }.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -585,6 +585,7 @@ Rails.application.routes.draw do
   get '/mailer_previews' => 'mailer_previews#index'
 
   get '/private_information' => 'about_this_site#private_information'
+  get '/accessibility' => 'about_this_site#accessibility'
   get '/styleguide' => 'styleguide#index'
 
   get '/status' => 'system_status#index'

--- a/docs/vpat.md
+++ b/docs/vpat.md
@@ -15,7 +15,7 @@ Wiki Education Dashboard — `dashboard.wikiedu.org`.
 
 ## Report Date
 
-2026-05-15
+2026-06-01
 
 ## Product Description
 
@@ -206,16 +206,12 @@ the public dashboard FAQ at <https://dashboard.wikiedu.org/faq/23>.
 
 ## Legal Disclaimer
 
-*Filled in at each signed snapshot. Start from the standard
-disclaimer language in the ITI VPAT 2.5 template
-(<https://www.itic.org/policy/accessibility/vpat>) and adapt as
-needed.*
+This Voluntary Product Accessibility Template (VPAT) is provided for informational purposes only. Although the information herein is provided in good faith based on the analysis of the product as of the date of publication, it is subject to change without notice. Electronic information technology is a dynamic field, and accessibility standards and assistive technologies continue to evolve.
+
+The VPAT does not constitute a legally binding guarantee or certification of compliance with any accessibility standard (such as WCAG or Section 508). Conformance levels are subject to interpretation and the context in which the product is used. Reliance on this report is at your own risk. Wiki Education makes no warranty, express or implied, regarding the accuracy of the information contained herein, including any warranty of merchantability or fitness for a particular purpose, and Wiki Education disclaims any liability for inaccuracies, omissions, or any decisions or actions taken based upon the information provided in this report.
 
 ## Signature
 
-**Sage Ross**, Chief Technology Officer
-Wiki Education Foundation
+**Sage Ross**, Chief Technology Officer, Wiki Education Foundation
 
-Signature: ____________________________
-
-Date: ____________________________
+Attested 2026-06-01

--- a/spec/controllers/about_this_site_controller_spec.rb
+++ b/spec/controllers/about_this_site_controller_spec.rb
@@ -10,4 +10,20 @@ describe AboutThisSiteController, type: :request do
       expect(response.body).to include('Private Information')
     end
   end
+
+  describe '#accessibility' do
+    it 'renders the VPAT from the Markdown source, with tables' do
+      get '/accessibility'
+      expect(response.status).to eq(200)
+      expect(response.body).to include('Voluntary Product Accessibility Template')
+      expect(response.body).to include('<table>')
+      expect(response.body).to include('Success Criteria, Level AA')
+    end
+
+    it 'is not served on the P&E Dashboard deployment' do
+      allow(Features).to receive(:wiki_ed?).and_return(false)
+      get '/accessibility'
+      expect(response.status).to eq(404)
+    end
+  end
 end

--- a/spec/features/accessibility_page_spec.rb
+++ b/spec/features/accessibility_page_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'accessibility (VPAT) page', type: :feature, js: true do
+  it 'loads cleanly and renders the conformance report' do
+    visit '/accessibility'
+    expect(page).to have_content 'WCAG 2.1 Report'
+    expect(page).to have_selector 'table'
+    expect(page).to be_axe_clean
+  end
+end


### PR DESCRIPTION
## What this PR does

Publishes the finalized WCAG 2.1 AA VPAT (Voluntary Product Accessibility
Template) as a public page at **`/accessibility`** on the Wiki Education
Dashboard.

The report content and the underlying accessibility remediations were merged
to master earlier (the VPAT-Prep work, #6879). What was missing was the
publish surface itself — the page that actually serves the report. This PR
adds it and lands the last finalization edits to the document.

- `docs/vpat_draft.md` → `docs/vpat.md`: renamed now that the content is
  final. Report Date set to `2026-06-01`; the print-template signature stubs
  are replaced with a typed attestation line (the norm for a self-attested
  VPAT, and it renders cleanly as HTML). The Legal Disclaimer prose was
  written by Sage Ross.
- `GET /accessibility` route + `AboutThisSiteController#accessibility`, gated
  to `Features.wiki_ed?`. The VPAT explicitly disclaims the Programs & Events
  Dashboard deployment, so the page 404s there rather than serving a report
  that doesn't apply.
- `AboutThisSiteHelper#accessibility_report_html` renders `docs/vpat.md` to
  HTML at request time, so the Markdown file stays the single source of truth
  (no second hand-maintained copy). Redcarpet with `tables: true` (the report
  is almost entirely Markdown tables) and `escape_html: true` so any literal
  HTML in the source is neutralized and the output is safe to mark
  `html_safe`.
- View, table/prose styling (`modules/_accessibility_report.styl`), and a
  one-word "Accessibility" link in the Wiki Ed footer (which renders under
  the same `Features.wiki_ed?` gate as the page).
- Request specs for the rendered page and the P&E 404, plus an axe-clean
  feature spec — the accessibility page is itself axe-clean.

## AI usage

The publication code was written by **Claude Code** under Sage Ross's
direction in a prior session: it drafted the route, controller action,
helper, view, stylesheet, and specs from scratch, and wrote the original
commit message. Sage chose the scope, wrote the Legal Disclaimer prose
himself, and confirmed the signing date. The report's substantive content
predates this work — it came from the earlier VPAT-Prep effort and is not
AI-rewritten here.

That finalized publish commit had been stranded on a staging branch among
unrelated work and never reached master. In this session, Claude Code
located it, cherry-picked it cleanly onto a fresh branch off master, and
verified it against the current master codebase (request spec, axe-clean
feature spec, RuboCop, and an asset build all green). It is a single commit
originally authored on 2026-06-01; the work here was recovery and
verification, not new feature development.

This PR description was also drafted by Claude Code (via the `/prepare-pr`
skill) and may contain errors.

## Screenshots

The `/accessibility` page is new, so there is no "before" state.

**Report — top**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/publish-vpat/screenshots/after/01_report_top.png) |

**Conformance tables**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/publish-vpat/screenshots/after/02_conformance_tables.png) |

## Open questions and concerns

- **Dates left as-is.** Report Date and the attestation read `2026-06-01`,
  the original signing date, intentionally preserved rather than bumped to
  the publication date.
- **Deliberate omissions carried over from the original commit:** the
  admin-install-page link target named in planning didn't exist yet (an
  unbuilt item), so only the footer link was wired; and a HECVAT
  documentation reference that lived in an untracked local planning file was
  left out. Both were intentional and remain out of scope here.

(PR description written by Claude Code.)
