### PR TITLE
Support courses with no set meeting days (asynchronous)

### DIFF
--- a/app/assets/javascripts/components/overview/course_cloned_modal.jsx
+++ b/app/assets/javascripts/components/overview/course_cloned_modal.jsx
@@ -41,12 +41,6 @@ const CourseClonedModal = createReactClass({
     };
   },
 
-  componentDidMount() {
-    if (this.props.course.type !== 'ClassroomProgramCourse') { return; }
-    this.props.addValidation('weekdays', 'Set the meeting days.');
-    return this.props.addValidation('holidays', 'Mark the holidays, or check "I have no class holidays".');
-  },
-
   componentDidUpdate(prevProps, prevState) {
     let isPersisting = prevState.isPersisting;
     if (this.props.firstErrorMessage && !prevProps.firstErrorMessage) {
@@ -71,12 +65,6 @@ const CourseClonedModal = createReactClass({
 
   setBlackoutDatesSelected(bool) {
     return this.setState({ blackoutDatesSelected: bool });
-  },
-
-  setNoBlackoutDatesChecked() {
-    const { checked } = this.noDates;
-    if (checked) { this.props.setValid('holidays'); }
-    return this.updateCourse('no_day_exceptions', checked);
   },
 
   cloneCompletedStatus: 2,
@@ -109,15 +97,8 @@ const CourseClonedModal = createReactClass({
   },
 
   updateCalendar(updatedCourse) {
-    if (updatedCourse.weekdays.indexOf(1) >= 0) {
-      this.props.setValid('weekdays');
-    }
-    if (__guard__(updatedCourse.day_exceptions, x => x.length) > 0 || updatedCourse.no_day_exceptions) {
-      this.props.setValid('holidays');
-    }
-
+    // Meeting days are optional: a clone with none is treated as asynchronous.
     this.setState({ course: updatedCourse });
-
     return this.props.updateCourse(updatedCourse);
   },
 
@@ -297,9 +278,6 @@ const CourseClonedModal = createReactClass({
             calendarInstructions={I18n.t('courses.creator.cloned_course_calendar_instructions')}
             updateCourse={this.updateCalendar}
           />
-          <label> {I18n.t('courses.creator.no_class_holidays')}
-            <input id="no_holidays" type="checkbox" onChange={this.setNoBlackoutDatesChecked} ref={(checkbox) => { this.noDates = checkbox; }} />
-          </label>
         </div>
       );
     // Specific to non-ClassroomProgramCourse
@@ -435,7 +413,3 @@ const CourseClonedModal = createReactClass({
 });
 
 export default CourseClonedModal;
-
-function __guard__(value, transform) {
-  return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
-}

--- a/app/assets/javascripts/components/overview/this_week.jsx
+++ b/app/assets/javascripts/components/overview/this_week.jsx
@@ -75,6 +75,7 @@ const ThisWeek = ({ course, weeks, current_user }) => {
         weeksBeforeTimeline={weeksBeforeTimeline}
         trainingLibrarySlug={course.training_library_slug}
         current_user={current_user}
+        noMeetingDays={CourseDateUtils.noMeetingDays(course)}
       />
     );
   } else {

--- a/app/assets/javascripts/components/timeline/meetings.jsx
+++ b/app/assets/javascripts/components/timeline/meetings.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import CourseLink from '../common/course_link.jsx';
@@ -10,14 +10,6 @@ import { updateCourse, persistCourse } from '../../actions/course_actions';
 import { isValid } from '../../selectors';
 
 const Meetings = (props) => {
-  const noDatesRef = useRef();
-
-  const updateCourseHandler = (valueKey, value) => {
-    const toPass = props.course;
-    toPass[valueKey] = value;
-    return props.updateCourse(toPass);
-  };
-
   const updateCourseDates = (valueKey, value) => {
     const updatedCourse = CourseDateUtils.updateCourseDates(props.course, valueKey, value);
     return props.updateCourse(updatedCourse);
@@ -31,25 +23,16 @@ const Meetings = (props) => {
     return alert(I18n.t('error.form_errors'));
   };
 
-  const updateCheckbox = (e) => {
-    updateCourseHandler('no_day_exceptions', e.target.checked);
-    return updateCourseHandler('day_exceptions', '');
-  };
-
-  const saveDisabledClass = (course) => {
-    const blackoutDatesSelected = course.day_exceptions && course.day_exceptions.length > 0;
-    const anyDatesSelected = course.weekdays && course.weekdays.indexOf(1) >= 0;
-    const enable = blackoutDatesSelected || (anyDatesSelected && props.course.no_day_exceptions);
-    if (enable) { return ''; }
-    return 'disabled';
-  };
+  // Meeting days are optional (a course with none is treated as asynchronous),
+  // so the only requirement to save is that the course dates are valid.
+  const saveDisabledClass = () => (props.isValid ? '' : 'disabled');
 
   const { course } = props;
   if (!course) { return <div />; }
 
   const dateProps = CourseDateUtils.dateProps(course);
   let courseLinkClass = 'dark button ';
-  courseLinkClass += saveDisabledClass(course);
+  courseLinkClass += saveDisabledClass();
   const courseLinkTarget = `/courses/${course.slug}/timeline`;
 
   return (
@@ -118,14 +101,6 @@ const Meetings = (props) => {
             weeks={props.weeks}
             updateCourse={props.updateCourse}
           />
-          <label> {I18n.t('timeline.no_class_holidays')}
-            <input
-              type="checkbox"
-              onChange={updateCheckbox}
-              ref={noDatesRef}
-              checked={props.course.day_exceptions === '' && props.course.no_day_exceptions}
-            />
-          </label>
         </div>
         <div className="wizard__panel__controls">
           <div className="left" />

--- a/app/assets/javascripts/components/timeline/timeline.jsx
+++ b/app/assets/javascripts/components/timeline/timeline.jsx
@@ -261,6 +261,7 @@ const Timeline = createReactClass({
               weeksBeforeTimeline={weeksBeforeTimeline}
               trainingLibrarySlug={this.props.course.training_library_slug}
               current_user={this.props.current_user}
+              noMeetingDays={CourseDateUtils.noMeetingDays(this.props.course)}
               moveBlock={this._moveBlock}
             />
         ));

--- a/app/assets/javascripts/components/timeline/week.jsx
+++ b/app/assets/javascripts/components/timeline/week.jsx
@@ -14,6 +14,7 @@ const Week = createReactClass({
     timeline_start: PropTypes.string,
     timeline_end: PropTypes.string,
     meetings: PropTypes.array,
+    noMeetingDays: PropTypes.bool,
     blocks: PropTypes.array,
     edit_permissions: PropTypes.bool,
     editableBlockIds: PropTypes.array,
@@ -76,7 +77,9 @@ const Week = createReactClass({
     const dateCalc = new DateCalculator(this.props.timeline_start, this.props.timeline_end, this.props.index, { zeroIndexed: false });
     let weekDatesContent;
     let meetDates;
-    if (this.props.meetings && this.props.meetings.length > 0) {
+    // Async courses (no meeting days set) have content every week but no
+    // meeting days to display.
+    if (!this.props.noMeetingDays && this.props.meetings && this.props.meetings.length > 0) {
       meetDates = `Meetings: ${this.props.meetings.join(', ')}`;
     }
     if (this.props.meetings) {

--- a/app/assets/javascripts/components/wizard/form_panel.jsx
+++ b/app/assets/javascripts/components/wizard/form_panel.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Panel from './panel.jsx';
 import DatePicker from '../common/date_picker.jsx';
@@ -6,15 +6,6 @@ import Calendar from '../common/calendar.jsx';
 import CourseDateUtils from '../../utils/course_date_utils.js';
 
 const FormPanel = (props) => {
-  const noDates = useRef();
-
-  const setNoBlackoutDatesChecked = () => {
-    const { checked } = noDates.current;
-    const toPass = props.course;
-    toPass.no_day_exceptions = checked;
-    return props.updateCourse(toPass);
-  };
-
   const updateCourseDates = (valueKey, value) => {
     const updatedCourse = CourseDateUtils.updateCourseDates(props.course, valueKey, value);
     return props.updateCourse(updatedCourse);
@@ -29,13 +20,9 @@ const FormPanel = (props) => {
     return false;
   };
 
-  const nextEnabled = () => {
-    if (__guard__(props.course.weekdays, x => x.indexOf(1)) >= 0
-      && (__guard__(props.course.day_exceptions, x1 => x1.length) > 0 || props.course.no_day_exceptions)) {
-      return true;
-    }
-    return false;
-  };
+  // Setting meeting days is optional: a course with no meeting days is treated
+  // as asynchronous. The user can proceed as soon as the course dates are valid.
+  const nextEnabled = () => props.isValid;
 
   const dateProps = CourseDateUtils.dateProps(props.course);
 
@@ -108,13 +95,6 @@ const FormPanel = (props) => {
             calendarInstructions={I18n.t('wizard.calendar_instructions')}
             updateCourse={props.updateCourse}
           />
-          <label> {I18n.t('wizard.no_class_holidays')}
-            <input
-              type="checkbox"
-              onChange={setNoBlackoutDatesChecked}
-              ref={noDates}
-            />
-          </label>
         </div>
       </div>
     </div>
@@ -137,9 +117,5 @@ FormPanel.propTypes = {
   updateCourse: PropTypes.func.isRequired,
   isValid: PropTypes.bool.isRequired
 };
-
-function __guard__(value, transform) {
-  return (typeof value !== 'undefined' && value !== null) ? transform(value) : undefined;
-}
 
 export default FormPanel;

--- a/app/assets/javascripts/utils/course_date_utils.js
+++ b/app/assets/javascripts/utils/course_date_utils.js
@@ -127,13 +127,26 @@ const CourseDateUtils = {
     return differenceInWeeks(timelineStart, courseStart);
   },
 
+  // A course with no weekday meetings selected and no specific meeting-date
+  // exceptions is treated as asynchronous: every day counts as a meeting day,
+  // so the timeline has content every week and no week is blacked out. Meeting
+  // days are not displayed for such a course.
+  noMeetingDays(course) {
+    if (!course) return false;
+    const noWeekdays = !course.weekdays || course.weekdays.indexOf('1') === -1;
+    const noExceptions = !course.day_exceptions || course.day_exceptions === '';
+    return noWeekdays && noExceptions;
+  },
+
   // If the timeline starts mid-week and there are no meetings in
   // that first partial week, advance the effective start to the next
   // Sunday so we don't generate an empty "Week 1". (#2360)
   effectiveTimelineStart(course) {
     const ts = toDate(course.timeline_start);
     const dayOfWeek = getDay(ts);
-    if (dayOfWeek === 0 || !course.weekdays) return course.timeline_start;
+    if (dayOfWeek === 0 || !course.weekdays || this.noMeetingDays(course)) {
+      return course.timeline_start;
+    }
 
     const weekStart = startOfWeek(ts, { weekStartsOn: 0 });
     for (let i = dayOfWeek; i <= 6; i += 1) {
@@ -149,6 +162,7 @@ const CourseDateUtils = {
   // Ex: [["Sunday (01/09)"], ["Sunday (01/16)", "Wednesday (01/19)", "Thursday (01/20)"], []]
   weekMeetings(course, exceptions) {
     const effectiveStart = this.effectiveTimelineStart(course);
+    const courseHasNoMeetingDays = this.noMeetingDays(course);
     const timelineEndOrEnd = course.timeline_end || course.end;
     const weekEnd = endOfWeek(toDate(timelineEndOrEnd), { weekStartsOn: 0 });
     let weekStart = startOfWeek(toDate(effectiveStart), { weekStartsOn: 0 });
@@ -184,7 +198,11 @@ const CourseDateUtils = {
 
       for (const i of range(firstDayOfWeek, 6, true)) {
         const day = addDays(weekStart, i);
-        if (course && this.courseMeets(course.weekdays, i, format(day, 'yyyyMMdd'), exceptions) && !isAfter(day, weekendDate)) {
+        if (!course || isAfter(day, weekendDate)) { continue; }
+        // For an async course (no meeting days set) every day counts, so the
+        // week is never blacked out; otherwise fall back to the weekday pattern.
+        if (courseHasNoMeetingDays
+          || this.courseMeets(course.weekdays, i, format(day, 'yyyyMMdd'), exceptions)) {
           ms.push(format(day, 'EEEE (MM/dd)'));
         }
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1902,8 +1902,7 @@ en:
       Select dates to add or remove them from the schedule (e.g., holidays, no
       school). This helps the course creation tool accurately space out your
       assignments. Click the date to change between unselected, selected, and
-      holiday state. If you have no holidays, check "I have no class holidays"
-      below.
+      holiday state.
     confirm_course_dates: Confirm the course's start and end dates.
     confirm_dates: Choose the course dates, weekly meetings, and holidays for your course.
     course_dates: Course Dates

--- a/lib/course_meetings_manager.rb
+++ b/lib/course_meetings_manager.rb
@@ -8,7 +8,6 @@ class CourseMeetingsManager
     @open_weeks = 0
     validate_course { return }
     @beginning_of_first_week = calculate_beginning_of_first_week
-    return unless course_has_meeting_date_data?
     @timeline_week_count = calculate_timeline_week_count
     @meeting_dates = all_actual_meetings
     @week_meeting_dates = calculate_week_meeting_dates
@@ -78,7 +77,11 @@ class CourseMeetingsManager
 
   # Returns an array of symbols on which the course meets,
   # e.g., [:tuesday, :thursday]
+  # When a course has no meeting date data at all (no weekdays and no
+  # day exceptions), it is treated as asynchronous: every day is a meeting
+  # day, so the timeline has content every week and no week is blacked out.
   def day_meetings
+    return DAYS_AS_SYM unless course_has_meeting_date_data?
     days = []
     @course.weekdays.each_char.each_with_index do |w, i|
       days.push(DAYS_AS_SYM[i]) if w.to_i == 1
@@ -123,7 +126,7 @@ class CourseMeetingsManager
   end
 
   def course_has_meeting_date_data?
-    @course.weekdays != '0000000' || @course.day_exceptions != ''
+    @course.weekdays != '0000000' || @course.day_exceptions.present?
   end
 
   def course_has_timeline_dates?

--- a/spec/features/course_cloning_spec.rb
+++ b/spec/features/course_cloning_spec.rb
@@ -85,12 +85,9 @@ describe 'cloning a course', js: true do
     omniclick find('span', text: 'MO')
     omniclick find('span', text: 'WE')
     click_button 'Save New Course'
-    expect(page).to have_content 'Mark the holidays' # Error message upon click.
-    find('input#no_holidays').click
-    expect(page).not_to have_content 'Mark the holidays'
-    click_button 'Save New Course'
 
-    # Fix the term to create an original slug, and try again
+    # Meeting days are optional now, so there's no holiday validation to clear;
+    # the only thing blocking the save is the duplicate term. Fix it and retry.
     expect(page).to have_content('This course already exists')
     fill_in 'course_term', with: new_term
     click_button 'Save New Course'
@@ -148,11 +145,9 @@ describe 'cloning a course', js: true do
     omniclick find('span', text: 'MO')
     omniclick find('span', text: 'WE')
     click_button 'Save New Course'
-    expect(page).to have_content 'Mark the holidays' # Error message upon click.
-    find('input#no_holidays').click
-    click_button 'Save New Course'
 
-    # Fix the term to create an original slug, and try again
+    # Meeting days are optional now, so there's no holiday validation to clear;
+    # the only thing blocking the save is the duplicate term. Fix it and retry.
     expect(page).to have_content('This course already exists')
     fill_in 'course_term', with: new_term
     click_button 'Save New Course'

--- a/spec/features/course_creation_spec.rb
+++ b/spec/features/course_creation_spec.rb
@@ -17,14 +17,14 @@ def interact_with_clone_form
   click_button 'Save This Course'
 end
 
-def go_through_course_dates_and_timeline_dates
-  find('span[title="Wednesday"]', match: :first).click
+def go_through_course_dates_and_timeline_dates(set_meeting_days: true)
+  # Meeting days are optional: a meeting day is selected here when requested, but
+  # the Next button is enabled as soon as the course dates are valid, with or
+  # without meeting days.
+  find('span[title="Wednesday"]', match: :first).click if set_meeting_days
   within('.wizard__panel.active') do
-    expect(page).to have_css('button.dark[disabled=""]')
-  end
-  find('.wizard__form.course-dates input[type=checkbox]', match: :first).set(true)
-  within('.wizard__panel.active') do
-    expect(page).not_to have_css('button.dark[disabled=disabled]')
+    expect(page).to have_css('button.dark')
+    expect(page).not_to have_css('button.dark[disabled]')
   end
 
   click_button 'Next'
@@ -36,8 +36,8 @@ end
 # adding, removing, or reordering a panel there requires a matching change to the
 # click-through steps below, or these specs break (often on a later panel or at
 # "Generate Timeline"). `expected_course_blocks` likewise tracks content.yml.
-def go_through_researchwrite_wizard(returning_instructor: true)
-  go_through_course_dates_and_timeline_dates
+def go_through_researchwrite_wizard(returning_instructor: true, set_meeting_days: true)
+  go_through_course_dates_and_timeline_dates(set_meeting_days:)
 
   # Choose researchwrite option
   find('.wizard__option', match: :first).find('button', match: :first).click
@@ -208,9 +208,10 @@ describe 'New course creation and editing', type: :feature do
 
       # This is the course dates screen
       sleep 3
-      # validate either blackout date chosen
-      # or "no blackout dates" checkbox checked
-      expect(page).to have_css('button.dark[disabled=""]')
+      # Meeting days are optional, so the Next button is enabled as soon as the
+      # course dates are valid.
+      expect(page).to have_css('button.dark')
+      expect(page).not_to have_css('button.dark[disabled]')
       start_input = find('input.start', match: :first).value
       sleep 1
       expect(start_input.to_date).to be_within(1.day).of(start_date.to_date)
@@ -398,6 +399,42 @@ describe 'New course creation and editing', type: :feature do
       within '.week-1' do
         expect(page).to have_content module_name
       end
+    end
+
+    it 'lets an instructor build a timeline without setting any meeting days' do
+      create(:course,
+             id: 10001,
+             title: 'Course',
+             school: 'University',
+             term: 'Term 2025',
+             slug: 'University/Course_(Term_2025)',
+             submitted: false,
+             passcode: 'passcode',
+             start: '2015-08-24'.to_date,
+             end: '2015-12-15'.to_date,
+             timeline_start: '2015-08-31'.to_date,
+             timeline_end: '2015-12-15'.to_date)
+      create(:courses_user,
+             user_id: 1,
+             course_id: 10001,
+             role: 1)
+
+      visit "/courses/#{Course.first.slug}/timeline/wizard"
+      sleep 1
+
+      # Walk the entire wizard without ever selecting a meeting day.
+      go_through_researchwrite_wizard(returning_instructor: false, set_meeting_days: false)
+      sleep 1
+
+      # The timeline generates even though no meeting days were set, and content
+      # is distributed across every week (no week is treated as a blackout).
+      expect(page).to have_content 'Week 1'
+      expect(page).to have_content 'Week 12'
+
+      # The course stays asynchronous: no meeting days are persisted and none are
+      # displayed on the timeline.
+      expect(Course.first.weekdays).to eq('0000000')
+      expect(page).not_to have_content 'Meetings:'
     end
   end
 end

--- a/spec/lib/course_meetings_manager_spec.rb
+++ b/spec/lib/course_meetings_manager_spec.rb
@@ -279,6 +279,30 @@ describe CourseMeetingsManager do
     end
   end
 
+  # A course with no weekdays selected AND no day exceptions is asynchronous:
+  # every day counts as a meeting day so the timeline has content every week.
+  # This is distinct from the "no weekdays but with day exceptions" case above,
+  # which still meets only on the specified exception dates.
+  context 'when the course has no meeting days and no day exceptions (async)' do
+    let(:weekdays) { '0000000' }
+    let(:day_ex) { '' }
+
+    it 'treats every day of the week as a meeting day' do
+      expect(described_class.new(course).send(:day_meetings))
+        .to eq(CourseMeetingsManager::DAYS_AS_SYM)
+    end
+
+    it 'has no blackout weeks, so timeline blocks can be inserted every week' do
+      expect(described_class.new(course).week_meetings).not_to include('()')
+    end
+
+    it 'counts every timeline week as open for assignments' do
+      allow_any_instance_of(Course).to receive(:weeks).and_return([])
+      # 21 timeline weeks - 0 blackout weeks - 0 assigned weeks
+      expect(described_class.new(course).open_weeks).to eq(21)
+    end
+  end
+
   # Should match the javascript function courseDateUtils.weeksBeforeTimeline
   # These tests match those in test/utils/course_date_utils.spec.js
   describe '#weeks_before_timeline' do

--- a/test/utils/course_date_utils.spec.js
+++ b/test/utils/course_date_utils.spec.js
@@ -230,3 +230,40 @@ describe('CourseDateUtils.weekMeetings boundary cases', () => {
     expect(lastWeekMeetings).not.toContain('Saturday (04/11)');
   });
 });
+
+describe('CourseDateUtils async courses (no meeting days set)', () => {
+  // No weekdays selected and no day exceptions: the course is asynchronous, so
+  // every day counts as a meeting day and no week is blacked out.
+  const asyncCourse = {
+    timeline_start: '2026-03-01', // Sunday
+    timeline_end: '2026-03-21', // Saturday — three full weeks
+    end: '2026-03-21',
+    weekdays: '0000000',
+    day_exceptions: ''
+  };
+
+  test('noMeetingDays is true when no weekdays and no exceptions are set', () => {
+    expect(CourseDateUtils.noMeetingDays(asyncCourse)).toBe(true);
+  });
+
+  test('noMeetingDays is false when a weekday is selected', () => {
+    expect(CourseDateUtils.noMeetingDays({ ...asyncCourse, weekdays: '0010100' })).toBe(false);
+  });
+
+  test('noMeetingDays is false when a day exception is set', () => {
+    expect(CourseDateUtils.noMeetingDays({ ...asyncCourse, day_exceptions: '20260302' })).toBe(false);
+  });
+
+  test('every week has meetings so none is blacked out', () => {
+    const meetings = CourseDateUtils.weekMeetings(asyncCourse, '');
+    expect(meetings.length).toBeGreaterThan(0);
+    meetings.forEach((week) => {
+      expect(week.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('openWeeks counts every week as available', () => {
+    const meetings = CourseDateUtils.weekMeetings(asyncCourse, '');
+    expect(CourseDateUtils.openWeeks(meetings)).toBe(meetings.length);
+  });
+});


### PR DESCRIPTION
## What this PR does

Adds support for courses that have a timeline but no set weekly meeting days —
fully asynchronous courses. Addresses #6291.

Rather than carrying a stored flag, the asynchronous behavior is **derived from
the data**: a course is treated as asynchronous exactly when it has no meeting
data at all — `weekdays == '0000000'` **and** no `day_exceptions` (i.e. when
`CourseMeetingsManager#course_has_meeting_date_data?` is false). In that case the
timeline treats every day as a meeting day, so blocks are distributed across
every week and no week is blacked out, but meeting days are not displayed. A
course configured only via one-off `day_exceptions` is unaffected.

To make this transparent and low-UI, the course-creation flow no longer requires
meeting days: the "I have no class holidays" checkbox and the meeting-day /
holiday gating are removed from the wizard's Course Dates panel, the "Edit Course
Dates" modal, and the clone modal. Setting meeting days is now optional; a course
with none is simply asynchronous.

This is an alternative implementation of the same feature as #6925, taking the
data-derived approach (no `no_meeting_days` flag, no toggle) instead of a stored
flag. No migration is included — the now-unused `no_day_exceptions` column is
left in place.

## AI usage

This change was implemented by Claude Code (Opus 4.8) under Sage's direction.
The session started as a review of #6925; after that review surfaced UI and copy
concerns, Sage chose to reimplement the feature from scratch with the
data-derived approach above. Claude wrote the code, the specs, the commit
message, and this PR description; Sage set the direction (automatic / low-UI / no
flag), made the key decisions (the trigger must check both `weekdays` and
`day_exceptions`; remove the checkbox entirely; keep the `no_day_exceptions`
column rather than migrate it away; trim rather than rewrite the one stale
instruction sentence), and reviewed throughout. Before implementing, a subagent
mapped every consumer of the meeting-day logic to confirm that treating async
courses as "every day meets" is safe for block/training due dates, alerts, and
on-wiki output.

Scale of effort: a single focused session, one commit, roughly a dozen short
human messages of direction. The `CourseMeetingsManager` spec, the
`course_date_utils` JS suite, and the `course_creation`, `course_cloning`, and
four downstream manager specs were run locally and pass.

The "What this PR does" summary and the analysis above were also drafted by
Claude Code and may contain errors. This description was prepared using the
`/prepare-pr` Claude Code skill.

## Screenshots

**Course creation — Course Dates wizard panel**

The "I have no class holidays" checkbox is gone, the instructions no longer
reference it, and **Next** is enabled without requiring a meeting-day selection.

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/no-meeting-days/screenshots/before/01__course_dates_wizard_panel.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/no-meeting-days/screenshots/after/01__course_dates_wizard_panel.png) |

**Timeline of a course with no meeting days (new)**

Content is distributed across every week and no week is blacked out; the
per-week "Meetings: …" line is omitted since there are no meeting days. (There
is no meaningful "before" — previously such a course's timeline was treated as
all-blackout and carried no content.)

![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/no-meeting-days/screenshots/after/02__timeline_with_no_meeting_days.png)

## Open questions and concerns

- **Behavior change for existing data**: because the behavior is derived from
  data rather than a flag, any pre-existing course with `weekdays == '0000000'`
  and no `day_exceptions` will now render as asynchronous (a full timeline)
  rather than all-blackout. Such courses were effectively broken before, so this
  is an improvement, but it does change their timeline.
- **Vestigial `no_day_exceptions` column**: kept in place to avoid a migration on
  the `courses` table. It can be dropped in a follow-up if desired.
- **Unused i18n keys**: `wizard.no_class_holidays`, `timeline.no_class_holidays`,
  and `courses.creator.no_class_holidays` are no longer referenced. Left in place;
  could be removed.

(PR description written by Claude Code.)
