### PR TITLE
Fix invisible inline code in Chrome (drop bare Courier font)

### DIFF
--- a/app/assets/stylesheets/_base.styl
+++ b/app/assets/stylesheets/_base.styl
@@ -112,7 +112,10 @@ blockquote
 code
   display inline-block
   font-size 0.8em
-  font-family Courier, monospace
+  // Not bare "Courier": Chrome matches the installed Type1 "Courier 10 Pitch"
+  // face and paints blank glyphs (invisible code; Firefox is unaffected).
+  // Use a TrueType monospace stack that always ends in the generic keyword.
+  font-family ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace
   background-color rgba(0,0,0,0.04)
   border-radius 3px
   line-height 1.4

--- a/app/assets/stylesheets/_training_base.styl
+++ b/app/assets/stylesheets/_training_base.styl
@@ -113,7 +113,10 @@ blockquote
 code
   display inline-block
   font-size 0.8em
-  font-family Courier, monospace
+  // Not bare "Courier": Chrome matches the installed Type1 "Courier 10 Pitch"
+  // face and paints blank glyphs (invisible code; Firefox is unaffected).
+  // Use a TrueType monospace stack that always ends in the generic keyword.
+  font-family ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace
   background-color rgba(0,0,0,0.04)
   border-radius 3px
   line-height 1.4


### PR DESCRIPTION
## What this PR does

Fixes inline `<code>` text rendering as invisible blank boxes in Chrome —
most visibly the URLs and identifiers throughout the published VPAT at
`/accessibility`, but the bug was site-wide.

Root cause: the global inline-`code` rule declared `font-family Courier,
monospace`. On Linux/Chrome the bare name `Courier` matches an installed
Type1 PostScript face ("Courier 10 Pitch", `c0419bt_.pfb`), which Blink
renders as blank glyphs instead of falling back to a real monospace font.
The text was always present and correctly colored (`#595959`, selectable,
and axe-clean) — Chrome simply painted nothing. Firefox falls back to a real
monospace face, so it was unaffected, which is why the bug looked
browser-specific. (The same class of bug shows up on other sites that name
bare `Courier`, e.g. the Rails guides.)

The fix replaces `Courier, monospace` with a TrueType monospace stack that
never names bare Courier and always ends in the generic keyword, in both base
stylesheets:

```
font-family ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace
```

- `app/assets/stylesheets/_base.styl` — main bundle (the VPAT page and the
  rest of the app)
- `app/assets/stylesheets/_training_base.styl` — training/surveys bundle
  (same latent bug)

A comment is added at each site so the Courier name isn't reintroduced.

## AI usage

Diagnosed and written by **Claude Code** under direction. The human reported
the symptom (inline code unreadable on the deployed `/accessibility` page and
in the prior PR's screenshots) and supplied the key lead — that it was likely
a Chrome rendering quirk also seen on the Rails docs site. Claude Code then
confirmed the mechanism with a headless-Chrome computed-style probe (color and
visibility were fine, so it wasn't contrast) and `fc-match`/`fc-list` (an
installed Type1 "Courier 10 Pitch" face is what Chrome was picking), applied
the font-stack fix, and verified it by re-rendering the page in the same
headless Chrome that had shown the bug. Claude Code also wrote the commit
message.

Scale of effort: a single commit (CSS only, +8/−2) produced in one short,
focused session today.

This PR description was drafted using a Claude Code skill (`/prepare-pr`); the
summary above was written by Claude Code and may contain errors.

## Screenshots

Both rendered in headless Chrome (the renderer that exhibited the bug).

**Inline code on the /accessibility page**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-accessibility-code-contrast/screenshots/before/01_report_top.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-accessibility-code-contrast/screenshots/after/01_report_top.png) |

## Open questions and concerns

- The fix is intentionally global, not scoped to the accessibility page,
  because the buggy rule is global — every inline `code` span on the site was
  affected in the same Chrome configurations. The visible appearance of code
  for users where Courier *did* render now changes to the new monospace stack;
  this is a deliberate, low-risk cosmetic change.
- The deployed staging `/accessibility` page won't reflect this until assets
  are recompiled/deployed there.

(PR description written by Claude Code.)
