### PR TITLE
Fix invisible stat numbers in dark tooltips

### DIFF
--- a/app/assets/stylesheets/modules/_tooltips.styl
+++ b/app/assets/stylesheets/modules/_tooltips.styl
@@ -53,7 +53,7 @@
       border 0
       &:before
         border-bottom 6px solid manatee
-      p, h4
+      p, h4, .stat-display__value
         margin-bottom 0
         color white !important
       h4


### PR DESCRIPTION
## What this PR does

Fixes the invisible numbers in the Commons Uploads and Student Editors stat
tooltips on the course overview page. The dark tooltip's background color is
`manatee`, which `_variables.styl` aliases to `$brand_primary` (#676EB4) — the
exact color that `_stats.styl` gives `.stat-display__value` numbers. Identical
foreground and background made the numbers unreadable. The fix adds
`.stat-display__value` to the existing rule that whitens `p` and `h4` inside
`.tooltip.dark`. White on #676EB4 is ~4.7:1 contrast, which clears WCAG AA
even for normal-size text (these numbers render at 38px).

Fixes #6937.

Although the issue guessed a connection to #6879, that PR didn't touch any of
the relevant color tokens or rules — the collision dates back to the
`manatee = $brand_primary` aliasing in a much older commit, and the two
purples were near-identical even before that.

`OverviewStatInfo` is the only component that renders `.stat-display__value`
inside a dark tooltip, so this one selector change covers every affected
tooltip. Page-level stat numbers (outside tooltips) and string-only dark
tooltips are unaffected, which was verified in a live browser session via
computed styles.

## AI usage

This fix was made with Claude Code (Claude Fable 5), which investigated the
issue, traced the root cause to the color-token aliasing, wrote the one-line
CSS change, and verified it by driving a real course page in headless Chrome —
checking computed colors of the tooltip numbers, the page-level stats, and a
string-only tooltip before and after. The human contribution was direction
("let's fix #6937") and review. The commit message, this PR description, and
the analysis above were also written by Claude Code and may contain errors.

The change is a single commit made in one short session (well under an hour of
human time).

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

**Commons Uploads tooltip**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-tooltip-stat-contrast/screenshots/before/01_commons_uploads_tooltip.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-tooltip-stat-contrast/screenshots/after/01_commons_uploads_tooltip.png) |

**Student Editors tooltip**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-tooltip-stat-contrast/screenshots/before/02_student_editors_tooltip.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-tooltip-stat-contrast/screenshots/after/02_student_editors_tooltip.png) |

## Open questions and concerns

`manatee` being an alias for `$brand_primary` is a small trap — `_tooltips.styl`
reads as if the dark tooltip background were gray. De-aliasing or renaming it
could prevent similar collisions, but that felt out of scope for a one-line
bug fix.

(PR description written by Claude Code.)
