### PR TITLE
[WIP] Add weekly worker to purge timeslices for purgeable courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -588,6 +588,18 @@ class Course < ApplicationRecord
     flags[:use_acuwt].present?
   end
 
+  # True once MarkPurgeableCourses has flagged this course for timeslice purging
+  # (it ended long ago, was tracked in the timeslice system, and has no pending
+  # timeslice work).
+  def purgeable?
+    flags[:purgeable].present?
+  end
+
+  # True once PurgeTimeslicesWorker has deleted this course's timeslice records.
+  def purged?
+    flags[:purged].present?
+  end
+
   def debug_updates?
     flags[:debug_updates].present?
   end

--- a/app/workers/purge_timeslices_worker.rb
+++ b/app/workers/purge_timeslices_worker.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/timeslice_cleaner"
+
+# Deletes every timeslice record for courses that MarkPurgeableCourses has
+# flagged as purgeable. See Course#purgeable?.
+class PurgeTimeslicesWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  # Cap how many courses are purged per run so a large backlog doesn't hit the
+  # DB with a flood of deletes at once. Remaining courses keep their purgeable
+  # flag and are picked up on the next run.
+  COURSES_PER_RUN = 20
+
+  def perform
+    purgeable_courses.each do |course|
+      TimesliceCleaner.new(course).delete_all_timeslices_for_course
+      # Drop the purgeable flag and record that the purge happened, so this
+      # course drops out of the query on the next run instead of being
+      # re-scanned every week.
+      course.flags.delete(:purgeable)
+      course.add_flag(key: :purged, value: true)
+    end
+  end
+
+  private
+
+  # `flags` is a serialized Hash stored as text, so it cannot be filtered
+  # precisely in SQL. Narrow with a LIKE on the raw column, then confirm with
+  # the model predicate. Already-purged courses no longer carry the purgeable
+  # flag, so they are excluded.
+  def purgeable_courses
+    Course.where('flags LIKE ?', '%purgeable%').limit(COURSES_PER_RUN).select(&:purgeable?)
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -44,3 +44,11 @@ update_default_campaign:
   cron: "1 0 1 1,7 *" # every January, 1st and July, 1st at 00:01 (UTC -7)
   class: "DefaultCampaignUpdateWorker"
   queue: default
+
+# Deletes timeslices for courses flagged as purgeable by MarkPurgeableCourses.
+# Runs on Fridays so a course spends a few days flagged before its timeslices
+# are actually removed, leaving a window to catch a mistake.
+purge_timeslices:
+  cron: "0 10 * * 5" # every Friday at 3am PT (UTC -7)
+  class: "PurgeTimeslicesWorker"
+  queue: daily_update

--- a/spec/workers/purge_timeslices_worker_spec.rb
+++ b/spec/workers/purge_timeslices_worker_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PurgeTimeslicesWorker do
+  let(:enwiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, wiki_id: enwiki.id) }
+  let(:other_course) { create(:course, slug: 'Other/Course_(Term)') }
+  let(:purgeable_course) do
+    create(:course, slug: 'Purgeable/Course_(Term)', flags: { purgeable: true })
+  end
+
+  def create_timeslices_for(some_course)
+    create(:article_course_timeslice, course: some_course, article_id: article.id)
+    create(:course_user_wiki_timeslice, course: some_course, user_id: user.id, wiki: enwiki)
+    create(:course_wiki_timeslice, course: some_course, wiki: enwiki)
+    create(:article_course_user_wiki_timeslice, course: some_course, wiki: enwiki,
+                                                article_id: article.id, user_id: user.id)
+  end
+
+  it 'deletes the purgeable course timeslices across all four timeslice tables' do
+    create_timeslices_for(purgeable_course)
+
+    described_class.new.perform
+
+    expect(ArticleCourseTimeslice.where(course_id: purgeable_course.id)).to be_empty
+    expect(CourseUserWikiTimeslice.where(course_id: purgeable_course.id)).to be_empty
+    expect(CourseWikiTimeslice.where(course_id: purgeable_course.id)).to be_empty
+    expect(ArticleCourseUserWikiTimeslice.where(course_id: purgeable_course.id)).to be_empty
+  end
+
+  it 'leaves timeslices belonging to non-purgeable courses intact' do
+    create_timeslices_for(other_course)
+
+    described_class.new.perform
+
+    expect(ArticleCourseTimeslice.where(course_id: other_course.id).count).to eq(1)
+    expect(CourseUserWikiTimeslice.where(course_id: other_course.id).count).to eq(1)
+    expect(CourseWikiTimeslice.where(course_id: other_course.id).count).to eq(1)
+    expect(ArticleCourseUserWikiTimeslice.where(course_id: other_course.id).count).to eq(1)
+  end
+
+  it 'clears the purgeable flag and records the purge' do
+    course = purgeable_course # create it before the worker runs (let is lazy)
+
+    described_class.new.perform
+
+    course.reload
+    expect(course.purgeable?).to be false
+    expect(course.purged?).to be true
+  end
+
+  it 'purges at most COURSES_PER_RUN courses per run' do
+    stub_const('PurgeTimeslicesWorker::COURSES_PER_RUN', 1)
+    first = create(:course, slug: 'First/Course_(Term)', flags: { purgeable: true })
+    second = create(:course, slug: 'Second/Course_(Term)', flags: { purgeable: true })
+
+    described_class.new.perform
+
+    purged = [first, second].map { |c| c.reload.purged? }
+    # Exactly one of the two purgeable courses is purged; the other keeps its flag.
+    expect(purged.count(true)).to eq(1)
+    expect(purged.count(false)).to eq(1)
+  end
+end


### PR DESCRIPTION
## What this PR does

Adds the timeslice purge job from the ACUWT bloat-deletion plan: the piece
that actually deletes timeslices for courses flagged as purgeable.

`PurgeTimeslicesWorker` runs weekly (scheduled on Fridays via
`config/schedule.yml`), finds courses carrying the `purgeable` flag, and
deletes all four of their timeslice tables (ACUWT, ACT, CUWT, CWT) via the
existing `TimesliceCleaner#delete_all_timeslices_for_course`. After purging a
course it drops the `:purgeable` flag and sets a `:purged` flag, so the course
falls out of the query on subsequent runs instead of being re-scanned.

Design notes:
- **Friday schedule** is deliberate: a course stays flagged for a few days
  before its timeslices are actually removed, leaving a window to catch a
  mistake before the data is gone.
- **`COURSES_PER_RUN = 20`** caps how many courses are purged per run so a
  large backlog doesn't hit the DB with a flood of deletes at once; the
  remainder drains at 20/week.
- **Querying the flag**: `flags` is a serialized Hash stored as text, so it
  can't be filtered precisely in SQL. The query narrows with a raw
  `LIKE '%purgeable%'` and then confirms with the `purgeable?` predicate.
- **`daily_update` queue** was chosen for process isolation — it's serviced
  by a dedicated Sidekiq process, so a heavy batch of deletes can't starve the
  course-update queues. The queue is set only in the schedule entry (not in
  `sidekiq_options`), matching the other scheduled workers.
- `Course#purgeable?` is reused from the MarkPurgeableCourses PR (#6924),
  which sets the flag. That PR is not yet merged; this branch is otherwise
  independent of it and includes only the `purgeable?`/`purged?` predicates it
  needs. Until #6924 merges and starts setting the flag, this worker simply
  finds nothing to purge.

This is the "actual purge/delete job" listed as future work in the ACUWT
bloat-deletion plan; it builds on the already-merged
`TimesliceCleaner#delete_all_timeslices_for_course`.

## AI usage

The code, specs, and commit messages were written by Claude Code (Opus 4.8)
under my direction. I described the goal (a weekly Friday worker that purges
timeslices for purgeable courses) and pointed it at the `purgeable?` method to
reuse; Claude explored the codebase, wrote the worker, schedule entry, model
predicates, and spec, and ran the tests and RuboCop. I steered the design
through several corrections: renaming the marker flag to `purged`, keeping the
schedule rationale out of the worker, removing a redundant `queue:` from
`sidekiq_options`, confirming the worker belongs at the top level rather than
in the `daily_update/` sub-folder, and adding the per-run cap.

Note that this description — including the "What this PR does" summary — was
also drafted by Claude Code and may contain errors.

This PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes — this is a backend worker plus a scheduler entry.

## Open questions and concerns

- **Coordination with MarkPurgeableCourses (#6924).** That service should skip
  courses that are already `purged?` so it can't re-flag a purged course as
  `purgeable` and feed it back through this worker. Worth confirming when the
  two branches come together.
- **Blocking re-updates** of purged courses (so a purged course can't be
  re-inflated by a full update or zeroed by partial re-aggregation) is separate
  follow-up work from the ACUWT plan and is not in this PR. The new `purged?`
  predicate is the marker that future work would consume.

(PR description written by Claude Code.)
