### PR TITLE
Checks for completion  in 'Add a Fact' exercise

### DIFF
--- a/app/assets/javascripts/actions/training_actions.js
+++ b/app/assets/javascripts/actions/training_actions.js
@@ -93,6 +93,13 @@ const setExerciseModule = (complete = true) => (block_id, module_id) => (dispatc
 export const setExerciseModuleComplete = setExerciseModule();
 export const setExerciseModuleIncomplete = setExerciseModule(false);
 
+export const verifyExerciseArticle = (block_id, module_id, article_title) => () => {
+  return request('/training_modules_users/verify_exercise_article.json', {
+    body: JSON.stringify({ block_id, module_id, article_title }),
+    method: 'POST'
+  }).then(resp => resp.json());
+};
+
 export const toggleMenuOpen = opts => (dispatch) => {
   return dispatch({
     type: MENU_TOGGLE,

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ExerciseButton.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ExerciseButton.jsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { verifyExerciseArticle } from '~/app/assets/javascripts/actions/training_actions';
+import { fetchTrainingModuleExercisesByUser } from '~/app/assets/javascripts/actions/exercises_actions';
+import ArticleTitleInputModal from './ModuleStatus/ArticleTitleInputModal';
 
-export const ExerciseButton = ({ module }) => {
+export const ExerciseButton = ({ module, course, verifyArticle, fetchExercises }) => {
+  const [modalOpen, setModalOpen] = useState(false);
+
   // An in-app exercise (eg fact verification) is a nested route of the course
   // SPA, so link to it with React Router to keep the student in-app (no reload).
   if (module.exercise_url) {
@@ -10,6 +16,50 @@ export const ExerciseButton = ({ module }) => {
         <Link className="button" to={module.exercise_url}>
           {I18n.t('training.open_exercise')}
         </Link>
+      </td>
+    );
+  }
+
+  if (module.article_title_input) {
+    const articleTitle = module.flags?.exercise_article_title;
+    const isMarkedComplete = !!module.flags?.marked_complete;
+
+    if (articleTitle && isMarkedComplete) {
+      return (
+        <td className="block__training-modules-table__module-exercise-button">
+          <a
+            href={`https://en.wikipedia.org/wiki/${encodeURIComponent(articleTitle)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={articleTitle}
+          >
+            {articleTitle.split(' ').slice(0, 2).join(' ')}{articleTitle.split(' ').length > 2 ? '…' : ''}
+          </a>
+        </td>
+      );
+    }
+
+    const handleVerify = (block_id, module_id, article_title) => {
+      return verifyArticle(block_id, module_id, article_title);
+    };
+
+    return (
+      <td className="block__training-modules-table__module-exercise-button">
+        {modalOpen && (
+          <ArticleTitleInputModal
+            block_id={module.block_id}
+            module_id={module.slug}
+            verifyArticle={handleVerify}
+            onVerified={() => {
+              setModalOpen(false);
+              if (course) fetchExercises(course.id);
+            }}
+            onClose={() => setModalOpen(false)}
+          />
+        )}
+        <button className="button small" onClick={() => setModalOpen(true)}>
+          {I18n.t('training.article_title_input.submit')}
+        </button>
       </td>
     );
   }
@@ -28,4 +78,13 @@ export const ExerciseButton = ({ module }) => {
   );
 };
 
-export default ExerciseButton;
+const mapStateToProps = state => ({
+  course: state.course
+});
+
+const mapDispatchToProps = dispatch => ({
+  verifyArticle: (block_id, module_id, article_title) => dispatch(verifyExerciseArticle(block_id, module_id, article_title)),
+  fetchExercises: course_id => dispatch(fetchTrainingModuleExercisesByUser(course_id))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExerciseButton);

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ArticleTitleInputModal.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ArticleTitleInputModal.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const parseArticleTitle = (input) => {
+  const urlMatch = input.match(/\/wiki\/([^#?]+)/);
+  if (urlMatch) return decodeURIComponent(urlMatch[1].replace(/_/g, ' '));
+  return input.trim();
+};
+
+const ArticleTitleInputModal = ({ block_id, module_id, verifyArticle, onVerified, onClose }) => {
+  const [inputValue, setInputValue] = useState('');
+  const [status, setStatus] = useState('idle'); // idle | loading | error | success
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = () => {
+    const articleTitle = parseArticleTitle(inputValue);
+    if (!articleTitle) return;
+    setStatus('loading');
+    verifyArticle(block_id, module_id, articleTitle)
+      .then((resp) => {
+        if (resp.status === 'verified') {
+          setStatus('success');
+          setTimeout(() => onVerified(articleTitle), 1500);
+        } else {
+          setStatus('error');
+          setErrorMessage(resp.message);
+        }
+      })
+      .catch(() => {
+        setStatus('error');
+        setErrorMessage(I18n.t('application.error_saving'));
+      });
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') handleSubmit();
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div className="blur-backdrop-for-alert-box" onClick={onClose}>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div className="alert-box-container" onClick={e => e.stopPropagation()}>
+        <div className="alert-box">
+          <h2 className="alert-title">{I18n.t('training.article_title_input.modal_title')}</h2>
+          {status === 'success' ? (
+            <p className="alert-content alert-content--success">
+              {I18n.t('training.article_title_input.success')}
+            </p>
+          ) : (
+            <>
+              <input
+                type="text"
+                className="alert-box__input"
+                value={inputValue}
+                onChange={e => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={I18n.t('training.article_title_input.placeholder')}
+                disabled={status === 'loading'}
+              />
+              {status === 'error' && (
+                <p className="alert-content alert-content--error">{errorMessage}</p>
+              )}
+              <div className="alert-button-container">
+                <button className="alert-button" onClick={onClose}>
+                  {I18n.t('application.cancel')}
+                </button>
+                <button
+                  className="btn btn-primary"
+                  onClick={handleSubmit}
+                  disabled={status === 'loading' || !inputValue.trim()}
+                >
+                  {status === 'loading' ? I18n.t('training.article_title_input.checking') : I18n.t('training.article_title_input.verify')}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ArticleTitleInputModal.propTypes = {
+  block_id: PropTypes.number,
+  module_id: PropTypes.string.isRequired,
+  verifyArticle: PropTypes.func.isRequired,
+  onVerified: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default ArticleTitleInputModal;

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ExerciseButton.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ExerciseButton.jsx
@@ -12,7 +12,7 @@ export const ExerciseButton = ({
   );
 
   if (isComplete && isExercise) {
-    const isVerified = flags?.marked_complete || flags?.exercise_article_title;
+    const isVerified = !!flags?.marked_complete;
     if (isVerified) {
       const onClick = () => incomplete(block_id, slug).then(() => fetchExercises(course.id));
       button = (

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ExerciseButton.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ExerciseButton.jsx
@@ -12,7 +12,8 @@ export const ExerciseButton = ({
   );
 
   if (isComplete && isExercise) {
-    if (flags.marked_complete) {
+    const isVerified = flags?.marked_complete || flags?.exercise_article_title;
+    if (isVerified) {
       const onClick = () => incomplete(block_id, slug).then(() => fetchExercises(course.id));
       button = (
         <div>
@@ -41,7 +42,8 @@ ExerciseButton.propTypes = {
     id: PropTypes.number.isRequired
   }).isRequired,
   flags: PropTypes.shape({
-    marked_complete: PropTypes.bool
+    marked_complete: PropTypes.bool,
+    exercise_article_title: PropTypes.string,
   }),
   isComplete: PropTypes.bool.isRequired,
   isExercise: PropTypes.bool.isRequired,

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ModuleStatus.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ModuleStatus.jsx
@@ -27,7 +27,6 @@ export const ModuleStatus = ({
 
   // Display current information about the training module
   if (isTrainingModule || isExercise) {
-    const isExerciseVerified = isExercise && (flags?.exercise_article_title || flags?.marked_complete);
     const button = (
       <ExerciseButton
         block_id={block_id}
@@ -44,7 +43,7 @@ export const ModuleStatus = ({
     const progress = module_progress || '--';
     return (
       <td className={progressClass}>
-        { (isTrainingModule || isExerciseVerified) ? progress : button }
+        { isTrainingModule ? progress : button }
         { isOverdue ? ` (due on ${due_date})` : null }
       </td>
     );

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ModuleStatus.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ModuleStatus.jsx
@@ -27,6 +27,7 @@ export const ModuleStatus = ({
 
   // Display current information about the training module
   if (isTrainingModule || isExercise) {
+    const isExerciseVerified = isExercise && (flags?.exercise_article_title || flags?.marked_complete);
     const button = (
       <ExerciseButton
         block_id={block_id}
@@ -43,7 +44,7 @@ export const ModuleStatus = ({
     const progress = module_progress || '--';
     return (
       <td className={progressClass}>
-        { isTrainingModule ? progress : button }
+        { (isTrainingModule || isExerciseVerified) ? progress : button }
         { isOverdue ? ` (due on ${due_date})` : null }
       </td>
     );

--- a/app/assets/javascripts/training/components/training_slide_handler.jsx
+++ b/app/assets/javascripts/training/components/training_slide_handler.jsx
@@ -2,12 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { extend } from 'lodash-es';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchTrainingModule, setSlideCompleted, setCurrentSlide, toggleMenuOpen } from '../../actions/training_actions.js';
+import { fetchTrainingModule, setSlideCompleted, setCurrentSlide, toggleMenuOpen, verifyExerciseArticle } from '../../actions/training_actions.js';
 import SlideLink from './slide_link.jsx';
 import SlideMenu from './slide_menu.jsx';
 import Quiz from './quiz.jsx';
 import Notifications from '../../components/common/notifications.jsx';
 import { FastTrainingAlert, fastTrainingAlertHandler } from './fast_training_alert';
+import ArticleTitleInputModal from '../../components/timeline/TrainingModules/ModuleRow/ModuleStatus/ArticleTitleInputModal';
 
 
 
@@ -68,9 +69,13 @@ const TrainingSlideHandler = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const [baseTitle, setBaseTitle] = useState('');
+  const [articleModalOpen, setArticleModalOpen] = useState(false);
+  const [articleVerified, setArticleVerified] = useState(false);
 
   // useState for fastTrainingAlertHandler function
   const [isShown, setIsShown] = useState(false);
+
+  const verifyArticle = (block_id, module_id, article_title) => dispatch(verifyExerciseArticle(block_id, module_id, article_title));
 
   const setSlideCompleted_FC = (slideId) => {
     const userId = __guard__(document.getElementById('main'), x => x.getAttribute('data-user-id'));
@@ -172,13 +177,27 @@ const TrainingSlideHandler = () => {
     if (!nextHref) {
       nextHref = userLoggedIn() ? '/' : `/training/${routeParams.library_id}`;
     }
-    if (training.completed) {
+
+    const needsArticleInput = training.module.article_title_input
+      && !articleVerified
+      && !training.module.exercise_article_title;
+
+    if (needsArticleInput) {
+      nextLink = (
+        <button
+          className="slide-nav btn btn-primary pull-right"
+          onClick={() => setArticleModalOpen(true)}
+        >
+          {I18n.t('training.article_title_input.submit')}
+        </button>
+      );
+    } else if (training.completed) {
       nextLink = <a href={nextHref} className="slide-nav btn btn-primary pull-right"> {training.currentSlide.buttonText || I18n.t('training.done')} </a>;
     } else {
       nextLink = <a href={nextHref} className="slide-nav btn btn-primary disabled pull-right"> {training.currentSlide.buttonText || I18n.t('training.done')} </a>;
     }
 
-    if (training.completed === false) {
+    if (training.completed === false && !needsArticleInput) {
       pendingWarning = (
         <div className="training__slide__notification" key="pending">
           <div className="container">
@@ -258,6 +277,18 @@ const TrainingSlideHandler = () => {
   return (
     <div>
       <Notifications />
+      {articleModalOpen && (
+        <ArticleTitleInputModal
+          block_id={null}
+          module_id={routeParams.module_id}
+          verifyArticle={verifyArticle}
+          onVerified={() => {
+            setArticleVerified(true);
+            setArticleModalOpen(false);
+          }}
+          onClose={() => setArticleModalOpen(false)}
+        />
+      )}
       <header>
         <div
           role="button"

--- a/app/assets/stylesheets/main.styl
+++ b/app/assets/stylesheets/main.styl
@@ -13,6 +13,7 @@ Author: team@wintr.us
 @import "_base"
 @import "modules/*"
 @import "modules/_nav_news"
+@import "training_modules/_fast_training_alert"
 @import "home"
 @import "~flatpickr/dist/flatpickr.min.css"
 @import "~tom-select/dist/css/tom-select.css"

--- a/app/assets/stylesheets/training.styl
+++ b/app/assets/stylesheets/training.styl
@@ -80,6 +80,8 @@ old-ie ?= false
 
 @import "_base"
 @import "_fonts"
+@import "modules/_wizard"
+@import "modules/_controls"
 @import "modules/_inputs"
 @import "modules/_loading"
 @import "modules/_tooltips"

--- a/app/assets/stylesheets/training_modules/_fast_training_alert.styl
+++ b/app/assets/stylesheets/training_modules/_fast_training_alert.styl
@@ -24,11 +24,13 @@
     left: 50%
     transform: translate(-50%, -50%)
     background: white
-    padding: 20px
+    padding: 30px
     border-radius: 5px
     box-shadow: 0px 0px 10px #ccc
     z-index: 1000
     text-align: left
+    width: 480px
+    min-height: 220px
     h2
      font-weight: 500
      text-align: left
@@ -40,14 +42,35 @@
       font-weight: 200
       font-size: 16px
       color: rgb(111, 111, 111)
+    .alert-box__input
+      width: 100%
+      padding: 8px 12px
+      font-size: 15px
+      border: 1px solid #ccc
+      border-radius: 4px
+      margin-bottom: 10px
+      box-sizing: border-box
+      &:focus
+        outline: none
+        border-color: #4CAF50
+    .alert-content--success
+      color: #2e7d32
+    .alert-content--error
+      color: #c62828
+      font-size: 14px
     div
       text-align: right
-      button
-        color: green
+      margin-top: 10px
+      .alert-button
+        color: $training_primary
         padding: 10px 20px
         font-size: 1.0em
         border-radius: 500px
         border: none
-        margin: 0 auto
         cursor: pointer
         background: transparent
+      .btn.btn-primary
+        margin-left: 8px
+        &:disabled
+          opacity: 0.5
+          cursor: not-allowed

--- a/app/controllers/training_modules_controller.rb
+++ b/app/controllers/training_modules_controller.rb
@@ -10,6 +10,10 @@ class TrainingModulesController < ApplicationController
 
   def show
     @training_module = TrainingModule.find_by(slug: params[:module_id])
+    if @training_module&.article_title_input && current_user
+      @exercise_tmu = TrainingModulesUsers.find_by(user: current_user,
+                                                    training_module: @training_module)
+    end
   end
 
   def find

--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -2,7 +2,8 @@
 
 class TrainingModulesUsersController < ApplicationController
   respond_to :json
-  before_action :require_signed_in, only: [:create_or_update, :mark_exercise_complete]
+  before_action :require_signed_in, only: [:create_or_update, :mark_exercise_complete,
+                                            :verify_exercise_article]
 
   def index
     course = Course.find(params[:course_id])
@@ -18,6 +19,22 @@ class TrainingModulesUsersController < ApplicationController
     complete_module if last_slide?
     @completed = @training_module_user.completed_at.present?
     render_slide
+  end
+
+  def verify_exercise_article
+    set_training_module
+    set_training_module_user
+    article_title = params[:article_title]
+    if WikiApi.new(wiki_for_exercise).user_has_edited_article?(current_user.username, article_title)
+      @training_module_user.store_exercise_article_title(article_title)
+      auto_mark_complete_for_user_courses
+      @training_module_user.save
+      render json: { status: 'verified', article_title: }
+    else
+      message = I18n.t('training.article_title_input.not_found')
+      render json: { status: 'not_found', message: },
+             status: :unprocessable_entity
+    end
   end
 
   def mark_exercise_complete
@@ -79,13 +96,40 @@ class TrainingModulesUsersController < ApplicationController
     @training_module_user.furthest_slide?(@slide.slug)
   end
 
+  def wiki_for_exercise
+    return Block.find(params[:block_id]).course.home_wiki if params[:block_id].present?
+    Wiki.find_by(language: 'en', project: 'wikipedia')
+  end
+
+  def auto_mark_complete_for_user_courses
+    blocks = Block.joins(week: { course: :courses_users })
+                  .where(courses_users: { user_id: current_user.id,
+                                         role: CoursesUsers::Roles::STUDENT_ROLE })
+                  .where.not('training_module_ids = ?', [].to_yaml)
+                  .includes(:week)
+    course_ids = blocks.select { |b| b.training_module_ids.include?(@training_module.id) }
+                       .map { |b| b.week.course_id }
+                       .uniq
+    course_ids.each { |cid| @training_module_user.mark_completion(true, cid) }
+  end
+
   def verify_exercise_sandbox
     return if @training_module_user.eligible_for_completion?(@course.home_wiki)
 
-    error_message = "Please complete the exercise in your Exercise Sandbox (#{@training_module_user.exercise_sandbox_location}) before marking it complete" # rubocop:disable Layout/LineLength
+    error_message = exercise_incomplete_message
     render json: { message: error_message, status: 'incomplete' },
            status: :forbidden
     yield
+  end
+
+  def exercise_incomplete_message
+    if @training_module_user.training_module.sandbox_location
+      sandbox = @training_module_user.exercise_sandbox_location
+      "Please complete the exercise in your Exercise Sandbox (#{sandbox}) " \
+      'before marking it complete'
+    else
+      'Please verify your Wikipedia edit before marking this exercise complete.'
+    end
   end
 
   def mark_completion_status(value, course_id)

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -157,6 +157,10 @@ class TrainingModule < ApplicationRecord
     settings['preload']
   end
 
+  def article_title_input
+    settings['article_title_input']
+  end
+
   # For an in-app exercise: the course-relative path it launches (eg
   # 'verify_claim'), rather than an external sandbox.
   def exercise_path

--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -31,11 +31,25 @@ class TrainingModulesUsers < ApplicationRecord
 
   def eligible_for_completion?(wiki)
     # If module doesn't have a sandbox_location, there's nothing to check.
-    return true unless training_module.sandbox_location
+    return true unless training_module.sandbox_location || training_module.article_title_input
 
-    # Via the API, we send the title without the URL encoding of special characters.
-    sandbox_content = WikiApi.new(wiki).get_page_content CGI.unescape exercise_sandbox_location
-    sandbox_content.present?
+    if training_module.sandbox_location
+      # Via the API, we send the title without the URL encoding of special characters.
+      sandbox_content = WikiApi.new(wiki).get_page_content CGI.unescape exercise_sandbox_location
+      return sandbox_content.present?
+    end
+
+    # For article_title_input exercises: the title is only saved after WikiApi
+    # confirmed the edit in verify_exercise_article, so presence is sufficient.
+    exercise_article_title.present?
+  end
+
+  def store_exercise_article_title(title)
+    flags['exercise_article_title'] = title
+  end
+
+  def exercise_article_title
+    flags['exercise_article_title']
   end
 
   # This is only used on Wiki Education Dashboard

--- a/app/views/courses/_block.json.jbuilder
+++ b/app/views/courses/_block.json.jbuilder
@@ -14,7 +14,8 @@ if block.training_module_ids.present?
       training_module: tm,
       user:
     )
-    json.call(tm, :slug, :id, :name, :kind, :sandbox_preload, :translated_name)
+    json.call(tm, :slug, :id, :name, :kind, :sandbox_preload, :translated_name,
+    :article_title_input)
     json.module_progress due_date_manager.module_progress
     json.due_date due_date_manager.computed_due_date
     json.overdue due_date_manager.overdue?

--- a/app/views/training_modules/show.json.jbuilder
+++ b/app/views/training_modules/show.json.jbuilder
@@ -2,7 +2,8 @@
 progress_manager = TrainingProgressManager.new(current_user, @training_module)
 
 json.training_module do
-  json.call(@training_module, :slug, :id, :wiki_page)
+  json.call(@training_module, :slug, :id, :wiki_page, :article_title_input)
+  json.exercise_article_title @exercise_tmu&.exercise_article_title if @exercise_tmu
   json.slides @training_module.slides do |slide|
     json.call(slide, :title_prefix, :title, :summary, :slug, :id, :content,
               :translations, :wiki_page)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1650,7 +1650,7 @@ en:
     loading: "Loading…"
     wiki_source: "wiki source"
     article_title_input:
-      submit: "Submit your article"
+      submit: "Submit Article"
       modal_title: "Which article did you edit?"
       success: "Great work! Your edit has been verified. You can now mark this exercise complete."
       placeholder: "e.g. Marie Curie or https://en.wikipedia.org/wiki/Marie_Curie"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1649,6 +1649,14 @@ en:
     close: "CLOSE"
     loading: "Loading…"
     wiki_source: "wiki source"
+    article_title_input:
+      submit: "Submit your article"
+      modal_title: "Which article did you edit?"
+      success: "Great work! Your edit has been verified. You can now mark this exercise complete."
+      placeholder: "e.g. Marie Curie or https://en.wikipedia.org/wiki/Marie_Curie"
+      checking: "Checking..."
+      verify: "Verify"
+      not_found: "We could not find your edit on that article. Please check the article name and try again."
 
   claim_verification:
     pick_instructions: Click a highlighted claim to see the citation details.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,6 +397,7 @@ Rails.application.routes.draw do
   get 'training_modules_users' => 'training_modules_users#index'
   post 'training_modules_users' => 'training_modules_users#create_or_update'
   post 'training_modules_users/exercise' => 'training_modules_users#mark_exercise_complete'
+  post 'training_modules_users/verify_exercise_article' => 'training_modules_users#verify_exercise_article'
   get 'reload_trainings' => 'training#reload'
 
   get 'training_status' => 'training_status#show'

--- a/lib/training_module_due_date_manager.rb
+++ b/lib/training_module_due_date_manager.rb
@@ -49,8 +49,16 @@ class TrainingModuleDueDateManager
 
   def flags(course_id)
     flags_hash = @tmu&.flags
-    return flags_hash[course_id] || flags_hash if @training_module.exercise? && flags_hash.present?
-    return flags_hash
+    if @training_module.exercise? && flags_hash.present?
+      course_flags = flags_hash[course_id]
+      if course_flags
+        return course_flags.merge(
+          'exercise_article_title' => flags_hash['exercise_article_title']
+          ).compact
+      end
+      return flags_hash
+    end
+    flags_hash
   end
 
   def sandbox_url

--- a/lib/training_progress_manager.rb
+++ b/lib/training_progress_manager.rb
@@ -51,11 +51,12 @@ class TrainingProgressManager
 
   # This is shown for the logged in user where the module is listed
   def assignment_status
-    return unless @training_module.training?
-    if due_date_manager.blocks_with_module_assigned(@training_module).any?
-      parenthetical = I18n.t('training_status.due', due_date: overall_due_date)
-      assingment_status = module_completed? ? I18n.t('training_status.completed') : parenthetical
-      return I18n.t('training_status.assignment_status', status: assingment_status)
+    if @training_module.training?
+      if due_date_manager.blocks_with_module_assigned(@training_module).any?
+        parenthetical = I18n.t('training_status.due', due_date: overall_due_date)
+        assingment_status = module_completed? ? I18n.t('training_status.completed') : parenthetical
+        return I18n.t('training_status.assignment_status', status: assingment_status)
+      end
     end
     return I18n.t('training_status.completed') if module_completed?
   end

--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -87,6 +87,18 @@ class WikiApi
     response&.status == 200 ? response.data : nil
   end
 
+  def user_has_edited_article?(username, title)
+    query_params = { prop: 'revisions',
+                     titles: title,
+                     rvprop: 'user',
+                     rvlimit: 1,
+                     rvuser: username }
+    response = query(query_params)
+    pages = response&.data&.dig('pages')
+    return false unless pages
+    pages.values.any? { |page| page['revisions'].present? }
+  end
+
   def get_article_rating(titles)
     titles = [titles] unless titles.is_a?(Array)
     titles = titles.sort_by(&:downcase)

--- a/spec/controllers/training_modules_users_controller_spec.rb
+++ b/spec/controllers/training_modules_users_controller_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 describe TrainingModulesUsersController, type: :request do
-  before { TrainingModule.load_all }
-
   describe '#create_or_update' do
+    before { TrainingModule.load_all }
     let(:user) { create(:user) }
     let(:training_module) { TrainingModule.find_by(slug: 'editing-basics') }
     let(:slide) { TrainingModule.find(training_module.id).slides.first }
@@ -68,6 +67,121 @@ describe TrainingModulesUsersController, type: :request do
       it 'sets the correct module_id' do
         expect(TrainingModulesUsers.last.training_module_id)
           .to eq(training_module.id)
+      end
+    end
+  end
+
+  describe '#mark_exercise_complete' do
+    let(:user) { create(:user) }
+    let(:course) { create(:course) }
+    let(:week) { create(:week, course: course) }
+    let(:block) { create(:block, week: week) }
+    let(:training_module) do
+      TrainingModule.find_by(slug: 'update-a-biography-exercise') ||
+        create(:training_module, slug: 'update-a-biography-exercise',
+                                 settings: { 'article_title_input' => true }, kind: 1)
+    end
+    let!(:tmu) do
+      TrainingModulesUsers.create(user_id: user.id, training_module_id: training_module.id)
+    end
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+
+    context 'when article_title_input has not been verified' do
+      before do
+        post '/training_modules_users/exercise',
+             params: { module_id: training_module.slug, block_id: block.id, complete: true }
+      end
+
+      it 'returns forbidden status' do
+        expect(response.status).to eq(403)
+      end
+
+      it 'returns the article verification message' do
+        expect(response.parsed_body['message']).to include('verify your Wikipedia edit')
+      end
+    end
+
+    context 'when article title has already been verified' do
+      before do
+        tmu.store_exercise_article_title('Selfie')
+        tmu.save
+        post '/training_modules_users/exercise',
+             params: { module_id: training_module.slug, block_id: block.id, complete: true }
+      end
+
+      it 'does not return forbidden' do
+        expect(response.status).not_to eq(403)
+      end
+    end
+  end
+
+  describe '#verify_exercise_article' do
+    let(:user) { create(:user) }
+    let(:training_module) do
+      TrainingModule.find_by(slug: 'update-a-biography-exercise') ||
+        create(:training_module, slug: 'update-a-biography-exercise',
+                                 settings: { 'article_title_input' => true }, kind: 1)
+    end
+    let!(:tmu) do
+      TrainingModulesUsers.create(user_id: user.id, training_module_id: training_module.id)
+    end
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+
+    context 'when the user has edited the article' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:user_has_edited_article?).and_return(true)
+        post '/training_modules_users/verify_exercise_article',
+             params: { module_id: training_module.slug, article_title: 'Selfie' }
+      end
+
+      it 'returns verified status' do
+        expect(response.parsed_body['status']).to eq('verified')
+      end
+
+      it 'saves the article title in flags' do
+        expect(tmu.reload.flags['exercise_article_title']).to eq('Selfie')
+      end
+    end
+
+    context 'when the user has not edited the article' do
+      before do
+        allow_any_instance_of(WikiApi).to receive(:user_has_edited_article?).and_return(false)
+        post '/training_modules_users/verify_exercise_article',
+             params: { module_id: training_module.slug, article_title: 'SomeArticle' }
+      end
+
+      it 'returns not_found status' do
+        expect(response.parsed_body['status']).to eq('not_found')
+      end
+
+      it 'does not save the article title in flags' do
+        expect(tmu.reload.flags['exercise_article_title']).to be_nil
+      end
+    end
+
+    context 'when the user is enrolled as a student in a course with this module' do
+      let(:course) { create(:course) }
+      let(:week) { create(:week, course: course) }
+      let!(:block) { create(:block, week: week, training_module_ids: [training_module.id]) }
+      let!(:courses_user) do
+        create(:courses_user, course: course, user: user, role: CoursesUsers::Roles::STUDENT_ROLE)
+      end
+
+      before do
+        allow_any_instance_of(WikiApi).to receive(:user_has_edited_article?).and_return(true)
+        post '/training_modules_users/verify_exercise_article',
+             params: { module_id: training_module.slug,
+                       article_title: 'Computational neuroscience' }
+      end
+
+      it 'auto-marks the exercise complete for the course' do
+        expect(tmu.reload.flags[course.id]).to include(marked_complete: true)
       end
     end
   end

--- a/spec/lib/training_module_due_date_manager_spec.rb
+++ b/spec/lib/training_module_due_date_manager_spec.rb
@@ -255,6 +255,54 @@ describe TrainingModuleDueDateManager do
     end
   end
 
+  describe '#flags' do
+    subject {
+ described_class.new(course:, training_module: exercise_module, user:).flags(course.id) }
+
+    let(:exercise_module) do
+      TrainingModule.find_by(slug: 'update-a-biography-exercise') ||
+        create(:training_module, slug: 'update-a-biography-exercise',
+                                 settings: { 'article_title_input' => true }, kind: 1)
+    end
+
+    context 'when the student has verified an article and marked the course complete' do
+      before do
+        tmu.update!(training_module_id: exercise_module.id)
+        tmu.store_exercise_article_title('Marie Curie')
+        tmu.mark_completion(true, course.id)
+        tmu.save!
+      end
+
+      it 'includes exercise_article_title merged into the course flags' do
+        expect(subject['exercise_article_title']).to eq('Marie Curie')
+      end
+
+      it 'includes marked_complete from the course-specific flags' do
+        expect(subject[:marked_complete]).to eq(true)
+      end
+    end
+
+    context 'when the student has verified an article but has no course-specific flags' do
+      before do
+        tmu.update!(training_module_id: exercise_module.id)
+        tmu.store_exercise_article_title('Marie Curie')
+        tmu.save!
+      end
+
+      it 'returns all flags including exercise_article_title' do
+        expect(subject['exercise_article_title']).to eq('Marie Curie')
+      end
+    end
+
+    context 'for a non-exercise module' do
+      subject { described_class.new(course:, training_module: t_module, user:).flags(course.id) }
+
+      it 'returns flags as-is' do
+        expect(subject).to eq(tmu.flags)
+      end
+    end
+  end
+
   describe '#exercise_url' do
     subject { described_class.new(course:, training_module:, user:).exercise_url }
 

--- a/spec/lib/training_progress_manager_spec.rb
+++ b/spec/lib/training_progress_manager_spec.rb
@@ -169,8 +169,8 @@ describe TrainingProgressManager do
 
       after { t_module.update(kind: TrainingModule::Kinds::TRAINING) }
 
-      it 'returns nil' do
-        expect(subject).to be_nil
+      it 'returns Completed when module is completed' do
+        expect(subject).to eq(I18n.t('training_status.completed'))
       end
     end
 

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -225,6 +225,27 @@ describe WikiApi do
     end
   end
 
+  describe '#user_has_edited_article?' do
+    let(:wiki) { Wiki.find_by(language: 'en', project: 'wikipedia') }
+    let(:subject) { described_class.new(wiki) }
+
+    it 'returns true when the API response includes a revision for the user' do
+      revision = { 'revid' => 1_102_334_271, 'user' => 'Ragesoss' }
+      pages = { '2082' => { 'pageid' => 2082, 'ns' => 0, 'title' => 'Ada Lovelace',
+                            'revisions' => [revision] } }
+      allow(subject).to receive(:query)
+        .and_return(double(data: { 'pages' => pages }))
+      expect(subject.user_has_edited_article?('Ragesoss', 'Ada Lovelace')).to be true
+    end
+
+    it 'returns false when the API response has no revisions for the user' do
+      pages = { '20604' => { 'pageid' => 20604, 'ns' => 0, 'title' => 'Marie Curie' } }
+      allow(subject).to receive(:query)
+        .and_return(double(data: { 'pages' => pages }))
+      expect(subject.user_has_edited_article?('Ragesoss', 'Marie Curie')).to be false
+    end
+  end
+
   describe '#fetch_all' do
     it 'returns the same data as a single complete query would' do
       VCR.use_cassette 'wiki/continue_response' do

--- a/spec/models/training_modules_users_spec.rb
+++ b/spec/models/training_modules_users_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TrainingModulesUsers do
+  let(:user) { create(:user) }
+
+  describe '#eligible_for_completion?' do
+    let(:wiki) { Wiki.find_by(language: 'en', project: 'wikipedia') }
+
+    context 'when the module has no sandbox_location and no article_title_input' do
+      let(:training_module) { create(:training_module) }
+      let(:tmu) do
+        TrainingModulesUsers.create(user:, training_module:)
+      end
+
+      it 'returns true without any API check' do
+        expect(tmu.eligible_for_completion?(wiki)).to be true
+      end
+    end
+
+    context 'when the module has sandbox_location' do
+      let(:training_module) do
+        create(:training_module, settings: { 'sandbox_location' => 'Evaluate_an_Article' })
+      end
+      let(:tmu) do
+        TrainingModulesUsers.create(user:, training_module:)
+      end
+
+      it 'returns true when the sandbox page has content' do
+        allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return('some content')
+        expect(tmu.eligible_for_completion?(wiki)).to be true
+      end
+
+      it 'returns false when the sandbox page is empty' do
+        allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return('')
+        expect(tmu.eligible_for_completion?(wiki)).to be false
+      end
+    end
+
+    context 'when the module has article_title_input' do
+      let(:training_module) do
+        create(:training_module, settings: { 'article_title_input' => true }, kind: 1)
+      end
+      let(:tmu) do
+        TrainingModulesUsers.create(user:, training_module:)
+      end
+
+      it 'returns false when no article title has been saved' do
+        expect(tmu.eligible_for_completion?(wiki)).to be false
+      end
+
+      it 'returns true when an article title has been saved' do
+        tmu.store_exercise_article_title('Selfie')
+        tmu.save
+        expect(tmu.eligible_for_completion?(wiki)).to be true
+      end
+
+      it 'does not make a WikiApi call' do
+        tmu.store_exercise_article_title('Selfie')
+        tmu.save
+        expect(WikiApi).not_to receive(:new)
+        tmu.eligible_for_completion?(wiki)
+      end
+    end
+  end
+
+  describe '#store_exercise_article_title and #exercise_article_title' do
+    let(:training_module) { create(:training_module) }
+    let(:tmu) { TrainingModulesUsers.create(user:, training_module:) }
+
+    it 'stores and retrieves the article title from flags' do
+      tmu.store_exercise_article_title('Octopus')
+      tmu.save
+      expect(tmu.reload.exercise_article_title).to eq('Octopus')
+    end
+  end
+end

--- a/training_content/wiki_ed/modules/update-a-biography-exercise.yml
+++ b/training_content/wiki_ed/modules/update-a-biography-exercise.yml
@@ -1,5 +1,6 @@
 name: 'Exercise: Add a fact to Wikipedia'
 id: 69
+kind: 'exercise'
 description: |
   This exercise will guide you through how to add new information to an existing Wikipedia article.
 slides:
@@ -9,3 +10,5 @@ slides:
   - slug: add-missing-information # 6904
   - slug: check-your-work # 6905
   - slug: update-a-bio-complete # 6906
+settings:
+  article_title_input: true


### PR DESCRIPTION
## What this PR does
Implements article title verification for the "Add a Fact" biography exercise, addressing #6293 .

Before this PR, the exercise had no completion check,  students could mark it done without having made a real Wikipedia edit. Now:

- On the last slide, students are prompted to enter the article title or URL they edited instead of seeing the Done button directly.
- The Dashboard calls the MediaWiki revisions API to confirm that the student has an actual edit on that article before accepting the submission.
- The verified article title is stored in the `flags` hash on the `TrainingModulesUsers` record, and the exercise cannot be marked complete via `mark_exercise_complete` without it.
- Once verified, the exercise shows as completed in the student's course view.

This extends the existing `eligible_for_completion?` / `sandbox_location` pattern to cover a new `article_title_input` module setting, following the approach used by evaluate-wikipedia-exercise

## AI usage
Claude Code was used throughout this PR for implementation, debugging, and writing this description. Specifically:
- Traced the existing sandbox-location completion flow to understand where to extend it for article title input.
- Identified and fixed a bug where `TrainingProgressManager#assignment_status` silenced exercises with an early `return unless @training_module.training?`, preventing "Completed" from showing in the training library.
- Moved a database query from the jbuilder view into the controller where it belongs.
- All code was reviewed and approved by the author before committing

## Screenshots

https://www.loom.com/share/a8c65719562e466ab3e1830b1efbca39

<img width="1920" height="1080" alt="Screenshot 2026-07-04 at 12 10 19" src="https://github.com/user-attachments/assets/bcc152f8-ab78-4def-af6e-3e663a3ff234" />

<img width="1920" height="1080" alt="Screenshot 2026-07-04 at 12 11 19" src="https://github.com/user-attachments/assets/30719be8-bb1d-41c2-8efb-19cb3236a5a3" />


## Open questions and concerns
The article title a student submits for verification is stored in their TrainingModulesUsers flags record. Currently it's used only to gate completion — instructors can see that the exercise is done, but not which article the student chose. Is it worth displaying the article title (e.g. as a link) on the exercise row in the instructor view, or is knowing it's completed sufficient?