### PR TITLE
Fix manual_update after copying course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -601,6 +601,21 @@ class Course < ApplicationRecord
     flags['update_logs'].present?
   end
 
+  # Start time of the most recent update log entry, as a DateTime (nil if the
+  # course was never updated). Copied courses store this via JSON, so the flag
+  # comes back as a String; we coerce it here to guarantee callers get a
+  # DateTime, matching how the value is stored during a normal update.1
+  def last_update_start_time
+    time_from_last_update_log('start_time')
+  end
+
+  # End time of the most recent update log entry, as a DateTime (nil if the
+  # course was never updated or the last update didn't finish). See
+  # last_update_start_time for why coercion is needed.
+  def last_update_end_time
+    time_from_last_update_log('end_time')
+  end
+
   # Determines if at least one timeslice update ran for the course based on the
   # 'processed' field into update_logs flag.
   def timeslice_update_ran?
@@ -691,6 +706,22 @@ class Course < ApplicationRecord
   end
 
   private
+
+  # Returns the given time field ('start_time' or 'end_time') from the most
+  # recent update log entry, coerced to a DateTime. Returns nil when the course
+  # has no update logs or the field is blank (e.g. an update that never
+  # finished has no end_time). The value comes back as a String for courses
+  # copied via JSON and as a DateTime during a normal update, so we coerce in
+  # both cases to give callers a consistent type.
+  def time_from_last_update_log(field)
+    update_logs = flags['update_logs']
+    return if update_logs.blank?
+
+    value = update_logs.values.last[field]
+    return if value.blank?
+
+    value.to_datetime
+  end
 
   def trained_students_manager
     TrainedStudentsManager.new(self)

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -76,13 +76,14 @@ class ArticlesCourses < ApplicationRecord
   # If no course update exists yet, then we update all the articles courses.
   def self.articles_courses_to_update(course)
     last_update = course.last_update_end_time
+    if last_update.nil?
+      Rails.logger.info "Updating caches for all ArticlesCourses for #{course.title}"
+      return course.articles_courses.pluck(:article_id)
+    end
     Rails.logger.info "Updating partial ArticlesCourses caches for #{course.title}"
     course.article_course_timeslices.where('updated_at >= ?', last_update)
           .distinct
           .pluck(:article_id)
-  rescue StandardError
-    Rails.logger.info "Updating caches for all ArticlesCourses for #{course.title}"
-    course.articles_courses.pluck(:article_id)
   end
 
   def self.update_required_caches_from_timeslices(course)

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -75,7 +75,7 @@ class ArticlesCourses < ApplicationRecord
   # and upate the cache only for them.
   # If no course update exists yet, then we update all the articles courses.
   def self.articles_courses_to_update(course)
-    last_update = course.flags['update_logs'].values.last['end_time']
+    last_update = course.last_update_end_time
     Rails.logger.info "Updating partial ArticlesCourses caches for #{course.title}"
     course.article_course_timeslices.where('updated_at >= ?', last_update)
           .distinct

--- a/app/services/copy_course.rb
+++ b/app/services/copy_course.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 #= Copy course from another server
 class CopyCourse # rubocop:disable Metrics/ClassLength
+  # Flags containing update logs keyed by update number, which need their keys
+  # converted back to integers after the JSON round-trip.
+  UPDATE_LOGS_KEYS = %w[update_logs unfinished_update_logs].freeze
+
   def initialize(url:, user_data:)
     @url = url
     @user_data = user_data
@@ -37,9 +41,9 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
     change_type(copied_data) # Changes the course type of certain courses
     assign_home_wiki(copied_data)
     copied_data['passcode'] = GeneratePasscode.call # set a random passcode
-    if copied_data['flags'].key?('update_logs')
-      copied_data['flags']['update_logs'] =
-        fix_update_logs_parsing(copied_data['flags']['update_logs'])
+    UPDATE_LOGS_KEYS.each do |key|
+      next unless copied_data['flags'].key?(key)
+      copied_data['flags'][key] = fix_update_logs_parsing(copied_data['flags'][key])
     end
     # The flags hash is copied via JSON so all keys are strings.
     # We must convert known feature flags to symbols because Course model
@@ -69,7 +73,8 @@ class CopyCourse # rubocop:disable Metrics/ClassLength
       "#{@course_data['school']}/#{@course_data['title']}_(#{@course_data['term']})".tr(' ', '_')
   end
 
-  # When parsing update_logs from flags, keys are set as strings instead of integers
+  # When parsing update_logs and unfinished_update_logs from flags, keys are set
+  # as strings instead of integers.
   # This causes problems, so we need to force the keys to be integers.
   def fix_update_logs_parsing(update_logs)
     update_logs.transform_keys(&:to_i)

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -29,7 +29,7 @@ class UpdateTimeslicesCourseUser
 
     # Users that were added after the last course update start are considered new
     # It's not safe to rely on new_user_ids = current_user_ids - processed_users
-    @course_update_start = @course.flags['update_logs'].values.last['start_time']
+    @course_update_start = @course.last_update_start_time
     new_user_ids = @course.students.where('courses_users.created_at >= ?',
                                           @course_update_start).pluck(:id)
     add_user_ids(new_user_ids)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -445,6 +445,69 @@ describe Course, type: :model do
     end
   end
 
+  describe '#last_update_start_time / #last_update_end_time' do
+    let(:course) { build(:basic_course, flags:) }
+    let(:start_time) { DateTime.new(2023, 1, 1, 10, 0, 0) }
+    let(:end_time) { DateTime.new(2023, 1, 1, 10, 5, 0) }
+
+    context 'when there are no update logs' do
+      let(:flags) { {} }
+
+      it 'returns nil for both' do
+        expect(course.last_update_start_time).to be_nil
+        expect(course.last_update_end_time).to be_nil
+      end
+    end
+
+    context 'when the times are stored as DateTimes (normal update)' do
+      let(:flags) do
+        { 'update_logs' => { 1 => { 'start_time' => start_time, 'end_time' => end_time } } }
+      end
+
+      it 'returns the times from the most recent log' do
+        expect(course.last_update_start_time).to eq(start_time)
+        expect(course.last_update_end_time).to eq(end_time)
+      end
+    end
+
+    context 'when the times are stored as Strings (copied course)' do
+      let(:flags) do
+        { 'update_logs' => { 1 => { 'start_time' => start_time.to_s,
+                                    'end_time' => end_time.to_s } } }
+      end
+
+      it 'coerces the values to DateTimes' do
+        expect(course.last_update_start_time).to eq(start_time)
+        expect(course.last_update_end_time).to eq(end_time)
+      end
+    end
+
+    context 'when the last update never finished (no end_time)' do
+      let(:flags) do
+        { 'update_logs' => { 1 => { 'start_time' => start_time } } }
+      end
+
+      it 'returns the start time but nil for the end time' do
+        expect(course.last_update_start_time).to eq(start_time)
+        expect(course.last_update_end_time).to be_nil
+      end
+    end
+
+    context 'with multiple logs' do
+      let(:flags) do
+        { 'update_logs' => {
+          1 => { 'start_time' => DateTime.new(2022, 1, 1), 'end_time' => DateTime.new(2022, 1, 2) },
+          2 => { 'start_time' => start_time, 'end_time' => end_time }
+        } }
+      end
+
+      it 'uses the most recent log entry' do
+        expect(course.last_update_start_time).to eq(start_time)
+        expect(course.last_update_end_time).to eq(end_time)
+      end
+    end
+  end
+
   describe '#cloneable?' do
     let(:subject) { course.cloneable? }
 

--- a/spec/services/copy_course_spec.rb
+++ b/spec/services/copy_course_spec.rb
@@ -42,6 +42,11 @@ describe CopyCourse do
               "sentry_tag_uuid": "4c0a1b87-da5a-4e82-8f40-3d560690cdb2",
               "error_count": 0
             }
+          },
+          "unfinished_update_logs": {
+            "1": {
+              "start_time": "2022-05-27T16:13:42.177+00:00"
+            }
           }
         },
         "training_library_slug": "students",
@@ -279,6 +284,11 @@ describe CopyCourse do
 
       # Update logs were correctly created
       course.flags['update_logs'].each_key do |key|
+        expect(key).to be_a(Integer)
+      end
+
+      # Unfinished update logs were correctly created
+      course.flags['unfinished_update_logs'].each_key do |key|
         expect(key).to be_a(Integer)
       end
 


### PR DESCRIPTION
## What this PR does
This PR fixes a 500 internal server error that only occurred after running a `/manual_update` on a copied course (likely never affected production).

**Steps to reproduce the bug:**

1. Copy a course from production that have update_logs flags
2. Run `/manual_update`
3. See the 500 internal server error

The error is caused in `@course_update_start - 1.second` line in `add_user_ids` method because `@course_update_start ` is a String and not a DateTime after copying a course:

Compare update_logs:

**In production:**
```
  38:
    start_time: !ruby/object:DateTime 2026-07-06 11:00:38.343173114 Z
    end_time: !ruby/object:DateTime 2026-07-06 11:00:43.615126431 Z
    sentry_tag_uuid: a13984fd-a28c-40a8-9512-821bbad583ce
    error_count: 5
    reference_counter_403_count: 0
    too_many_requests_count: 0
    processed: 5
    reprocessed: 3
    reaggregated: 0
```

**After copying a course:**
```
  38:
    start_time: '2026-07-06T11:00:38.343+00:00'
    end_time: '2026-07-06T11:00:43.615+00:00'
    sentry_tag_uuid: a13984fd-a28c-40a8-9512-821bbad583ce
    error_count: 5
    reference_counter_403_count: 0
    too_many_requests_count: 0
    processed: 5
    reprocessed: 3
    reaggregated: 0
```

```
  def add_user_ids(user_ids)
    return if user_ids.empty?

    Rails.logger.info "UpdateTimeslicesCourseUser: Course: #{@course.slug}\
    Adding new users: #{user_ids}"

    if @course.use_acuwt?
      add_user_ids_acuwt(user_ids)
    else
      add_user_ids_legacy(user_ids)
    end
    # Update created_at field for courses users to prevent re-marking them as newly added
    @course.courses_users.where(user_id: user_ids)
           .update_all(created_at: @course_update_start - 1.second) # rubocop:disable Rails/SkipsModelValidations
  end
```

## AI usage
I used Claude code to write the code and specs.


## Open questions and concerns
I copy courses from production and run manual updates locally quite frequently, it's weird that I didn’t realise this before. Note that although there were changes to the copy course service last time, I don’t think this error is related to those changes.
