### PR TITLE
Expand retention predictors CSV with return-gap and survival metrics

### DIFF
--- a/lib/analytics/retention_predictors_csv_builder.rb
+++ b/lib/analytics/retention_predictors_csv_builder.rb
@@ -6,50 +6,137 @@ require 'csv'
 # Builds the "Retention predictors" CSV report for a course (currently the
 # Scholars & Scientists / FellowsCohort program).
 #
-# v1 has a single metric: the number of distinct editing sessions per student.
-# Edits an hour or more apart count as distinct sessions; edits closer together
-# are lumped into one session. Sessions are counted per tracked wiki and across
-# all tracked wikis combined, in two independent windows: during the course
-# (course.start..course.end) and after it ended (course.end..now).
+# The report combines a per-course summary block with a per-student detail
+# block in a single CSV. Metrics (edits an hour or more apart count as distinct
+# "sessions"; edits closer together are lumped into one session):
 #
-# Edit timestamps come straight from the live MediaWiki usercontribs API, across
-# all namespaces, so this report has no dependency on stored revision data.
+#   1. Editing sessions during the course (course.start..course.end).
+#   2. Days from course end to the student's first independent edit in the 30
+#      days after the course. Capped/defaulted to 30 when they do not return
+#      (smaller is better).
+#   3. Editing sessions in the 30 days after the course ends.
+#   4. Edits in the 30-day window that begins 60 days after the course ends
+#      (course.end+60..course.end+90); a "survivor" made at least 5 such edits.
+#
+# Metrics are computed on each student's combined cross-wiki edit timeline, from
+# the live MediaWiki usercontribs API (all namespaces), which is why the report
+# has no dependency on stored revision data.
+#
+# A metric's window can only be read once real-world time has passed the window
+# plus a one-day buffer: metrics 2 and 3 fill in 31 days after the course ends,
+# metric 4 fills in 91 days after. Cells (and the summary aggregates that depend
+# on them) are left blank until then, so every reported value is final.
 class RetentionPredictorsCsvBuilder
   SESSION_GAP = 1.hour
+  RETURN_WINDOW_DAYS = 30
+  SURVIVAL_START_DAY = 60
+  SURVIVAL_END_DAY = 90
+  SURVIVAL_THRESHOLD = 5
+  REPORTING_BUFFER_DAYS = 1
 
   def initialize(course)
     @course = course
     @wikis = course.wikis.to_a
     @students = course.students.to_a.sort_by(&:username)
+    @now = Time.zone.now
   end
 
   def generate_csv
+    stats = @students.map { |student| student_stats(student) }
     CSV.generate do |csv|
-      csv << headers
-      @students.each { |student| csv << row(student) }
+      summary_rows(stats).each { |row| csv << row }
+      csv << []
+      detail_rows(stats).each { |row| csv << row }
     end
   end
 
   private
 
-  def headers
-    wiki_headers = @wikis.flat_map do |wiki|
-      ["#{wiki.domain} sessions (during course)", "#{wiki.domain} sessions (after course)"]
-    end
-    ['username', *wiki_headers,
-     'all wikis sessions (during course)', 'all wikis sessions (after course)']
+  DETAIL_HEADERS = ['username', 'sessions during course', 'days to first independent edit',
+                    'sessions in 30 days after course', 'edits in days 60-90'].freeze
+
+  def student_stats(student)
+    times = combined_edit_times(student.username).sort
+    {
+      username: student.username,
+      sessions_during: count_sessions(times.select { |t| t <= @course.end }),
+      days_to_return: days_to_return(times),
+      sessions_after: sessions_after(times),
+      edits_60_90: edits_in_survival_window(times)
+    }
   end
 
-  def row(student)
-    during_all = []
-    after_all = []
-    wiki_cells = @wikis.flat_map do |wiki|
-      during, after = edit_times(student.username, wiki).partition { |t| t <= @course.end }
-      during_all.concat(during)
-      after_all.concat(after)
-      [count_sessions(during), count_sessions(after)]
+  def summary_rows(stats)
+    during = stats.sum { |s| s[:sessions_during] }
+    avg_gap = average(stats.map { |s| s[:days_to_return] })
+    avg_after = average(stats.map { |s| s[:sessions_after] })
+    [
+      ['Summary'],
+      ['participants', @students.size],
+      ['total editing sessions during course', during],
+      ['avg days to first independent edit', avg_gap],
+      ['avg editing sessions in 30 days after course', avg_after],
+      ['participants with 5+ edits in days 60-90 (survivors)', survivors(stats)]
+    ]
+  end
+
+  def detail_rows(stats)
+    rows = stats.map do |s|
+      [s[:username], s[:sessions_during], s[:days_to_return], s[:sessions_after], s[:edits_60_90]]
     end
-    [student.username, *wiki_cells, count_sessions(during_all), count_sessions(after_all)]
+    [['Per-student detail'], DETAIL_HEADERS, *rows]
+  end
+
+  # Days from course end to the first edit in the 30-day return window, floored
+  # to whole days. Defaults to the window length (30) when the student does not
+  # return. Blank (nil) until the window has closed.
+  def days_to_return(times)
+    return nil unless return_window_available?
+    first = return_window(times).min
+    return RETURN_WINDOW_DAYS if first.nil?
+    ((first - @course.end) / 1.day.to_i).floor
+  end
+
+  def sessions_after(times)
+    return nil unless return_window_available?
+    count_sessions(return_window(times))
+  end
+
+  def edits_in_survival_window(times)
+    return nil unless survival_window_available?
+    window = survival_window
+    times.count { |t| window.cover?(t) }
+  end
+
+  # Edits strictly after the course end, through the RETURN_WINDOW_DAYS cutoff.
+  def return_window(times)
+    cutoff = @course.end + RETURN_WINDOW_DAYS.days
+    times.select { |t| t > @course.end && t <= cutoff }
+  end
+
+  def survival_window
+    (@course.end + SURVIVAL_START_DAY.days)..(@course.end + SURVIVAL_END_DAY.days)
+  end
+
+  def return_window_available?
+    @now >= @course.end + (RETURN_WINDOW_DAYS + REPORTING_BUFFER_DAYS).days
+  end
+
+  def survival_window_available?
+    @now >= @course.end + (SURVIVAL_END_DAY + REPORTING_BUFFER_DAYS).days
+  end
+
+  # Mean over students, rounded to one decimal. Blank (nil) when the underlying
+  # metric is not yet available (its per-student values are all nil).
+  def average(values)
+    return nil if values.empty? || values.any?(&:nil?)
+    (values.sum.to_f / values.size).round(1)
+  end
+
+  def survivors(stats)
+    counts = stats.map { |s| s[:edits_60_90] }
+    return nil if counts.any?(&:nil?)
+    counts.count { |count| count >= SURVIVAL_THRESHOLD }
   end
 
   # Number of distinct editing sessions: a new session starts whenever the gap
@@ -59,6 +146,12 @@ class RetentionPredictorsCsvBuilder
     sessions = 1
     times.sort.each_cons(2) { |earlier, later| sessions += 1 if later - earlier >= SESSION_GAP }
     sessions
+  end
+
+  # A student's edit timestamps across every tracked wiki, merged into one
+  # timeline (sessions and returns count regardless of which wiki they land on).
+  def combined_edit_times(username)
+    @wikis.flat_map { |wiki| edit_times(username, wiki) }
   end
 
   # All of a user's edit timestamps on a wiki since the course start, fetched

--- a/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
+++ b/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
@@ -4,19 +4,16 @@ require 'rails_helper'
 require "#{Rails.root}/lib/analytics/retention_predictors_csv_builder"
 
 describe RetentionPredictorsCsvBuilder do
-  let(:course) do
-    create(:course, start: Time.zone.local(2026, 1, 1),
-                    end: Time.zone.local(2026, 1, 31, 23, 59, 59))
-  end
   let(:wiki1) { Wiki.find_or_create_by(language: 'en', project: 'wikipedia') }
   let(:wiki2) { Wiki.find_or_create_by(language: 'es', project: 'wikipedia') }
   let(:user1) { create(:user, username: 'user1') }
   let(:user2) { create(:user, username: 'user2') }
+  let(:course_wikis) { [wiki1] }
 
   before do
     # The Wiki model validates against the live API on create; skip that here.
     allow_any_instance_of(Wiki).to receive(:ensure_wiki_exists)
-    course.wikis = [wiki1, wiki2]
+    course.wikis = course_wikis
     create(:courses_user, course:, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)
     create(:courses_user, course:, user: user2, role: CoursesUsers::Roles::STUDENT_ROLE)
   end
@@ -40,63 +37,102 @@ describe RetentionPredictorsCsvBuilder do
     end
   end
 
-  let(:subject) { described_class.new(course).generate_csv }
-  let(:rows) { CSV.parse(subject, headers: true) }
-  let(:user1_row) { rows.find { |r| r['username'] == 'user1' } }
+  let(:table) { CSV.parse(described_class.new(course).generate_csv) }
+
+  # value cell of a "label,value" summary row
+  def summary_value(label)
+    table.find { |row| row[0] == label }&.at(1)
+  end
+
+  # full per-student detail row, keyed by username
+  def detail_row(username)
+    table.find { |row| row[0] == username }
+  end
 
   describe '#generate_csv' do
-    before do
-      # user1 on en.wikipedia: two clusters during the course, one after.
-      stub_wiki(wiki1, 'user1' => [
-                  Time.zone.local(2026, 1, 5, 10, 0),   # cluster A (during)
-                  Time.zone.local(2026, 1, 5, 10, 30),  # +30 min -> same session
-                  Time.zone.local(2026, 1, 10, 14, 0),  # cluster B (during), days later
-                  Time.zone.local(2026, 2, 15, 9, 0)    # after course end
-                ])
-      # user1 on es.wikipedia: one edit during (45 min after the 10:00 wiki1 edit)
-      # and one after (30 min after the wiki1 post-course edit).
-      stub_wiki(wiki2, 'user1' => [
-                  Time.zone.local(2026, 1, 5, 10, 45),
-                  Time.zone.local(2026, 2, 15, 9, 30)
-                ])
+    context 'when the course is more than 91 days past its end date' do
+      let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
+      let(:course_wikis) { [wiki1, wiki2] }
+
+      before do
+        e = course.end
+        stub_wiki(wiki1, 'user1' => [
+                    e - 26.days, e - 26.days + 30.minutes, e - 21.days, # 2 sessions during
+                    e + 14.days, e + 14.days + 30.minutes,             # 1 session, day 14 after
+                    e + 70.days, e + 70.days + 5.minutes,              # 5 edits in the 60-90
+                    e + 71.days, e + 72.days, e + 73.days              # survival window
+                  ])
+        # An es.wikipedia edit that lands mid-cluster in the first during-course session.
+        stub_wiki(wiki2, 'user1' => [e - 26.days + 45.minutes])
+      end
+
+      it 'fills every per-student metric on the combined cross-wiki timeline' do
+        expect(detail_row('user1')).to eq(%w[user1 2 14 1 5])
+      end
+
+      it 'defaults a non-returning student to a 30-day gap and zero counts' do
+        expect(detail_row('user2')).to eq(%w[user2 0 30 0 0])
+      end
+
+      it 'aggregates the per-course summary block' do
+        expect(summary_value('participants')).to eq('2')
+        expect(summary_value('total editing sessions during course')).to eq('2')
+        expect(summary_value('avg days to first independent edit')).to eq('22.0')
+        expect(summary_value('avg editing sessions in 30 days after course')).to eq('0.5')
+        expect(summary_value('participants with 5+ edits in days 60-90 (survivors)')).to eq('1')
+      end
     end
 
-    it 'counts distinct per-wiki sessions using the one-hour gap rule' do
-      expect(user1_row['en.wikipedia.org sessions (during course)']).to eq('2')
-      expect(user1_row['es.wikipedia.org sessions (during course)']).to eq('1')
+    context 'when the course ended fewer than 31 days ago' do
+      let(:course) { create(:course, start: 45.days.ago, end: 15.days.ago) }
+
+      before do
+        e = course.end
+        stub_wiki(wiki1, 'user1' => [e - 5.days, e - 5.days + 30.minutes]) # 1 during session
+      end
+
+      it 'reports during-course sessions but leaves the post-course metrics blank' do
+        expect(detail_row('user1')).to eq(['user1', '1', nil, nil, nil])
+        expect(summary_value('total editing sessions during course')).to eq('1')
+        expect(summary_value('avg days to first independent edit')).to be_nil
+        expect(summary_value('avg editing sessions in 30 days after course')).to be_nil
+        expect(summary_value('participants with 5+ edits in days 60-90 (survivors)')).to be_nil
+      end
     end
 
-    it 'splits sessions before and after the course end date' do
-      expect(user1_row['en.wikipedia.org sessions (after course)']).to eq('1')
-      expect(user1_row['es.wikipedia.org sessions (after course)']).to eq('1')
-    end
+    context 'when the course ended between 31 and 90 days ago' do
+      let(:course) { create(:course, start: 95.days.ago, end: 65.days.ago) }
 
-    it 'merges timestamps across wikis for the combined session counts' do
-      # During: 10:00, 10:30, 10:45 collapse to one session; 01-10 is a second.
-      expect(user1_row['all wikis sessions (during course)']).to eq('2')
-      # After: 09:00 and 09:30 collapse to one session.
-      expect(user1_row['all wikis sessions (after course)']).to eq('1')
-    end
+      before do
+        e = course.end
+        stub_wiki(wiki1, 'user1' => [e - 10.days, e + 5.days]) # 1 during session, returns day 5
+      end
 
-    it 'reports zeros for a student with no edits' do
-      user2_row = rows.find { |r| r['username'] == 'user2' }
-      expect(user2_row.fields[1..]).to all(eq('0'))
+      it 'fills the 30-day metrics but leaves the 60-90-day metric blank' do
+        expect(detail_row('user1')).to eq(['user1', '1', '5', '1', nil])
+        expect(detail_row('user2')).to eq(['user2', '0', '30', '0', nil])
+        expect(summary_value('avg days to first independent edit')).to eq('17.5')
+        expect(summary_value('avg editing sessions in 30 days after course')).to eq('0.5')
+        expect(summary_value('participants with 5+ edits in days 60-90 (survivors)')).to be_nil
+      end
     end
   end
 
   describe 'pagination' do
+    let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
+
     before do
-      first = response_for([Time.zone.local(2026, 1, 5, 10, 0)], continue: { 'uccontinue' => 'x' })
-      second = response_for([Time.zone.local(2026, 1, 20, 10, 0)])
+      e = course.end
+      first = response_for([e - 26.days], continue: { 'uccontinue' => 'x' })
+      second = response_for([e - 20.days])
       api1 = instance_double(WikiApi)
       allow(WikiApi).to receive(:new).with(wiki1).and_return(api1)
       allow(api1).to receive(:query).and_return(first, second)
-      stub_wiki(wiki2, {})
     end
 
     it 'follows the continue token to fetch all pages of contributions' do
       # The two pages are days apart, so both must be fetched to count 2 sessions.
-      expect(user1_row['en.wikipedia.org sessions (during course)']).to eq('2')
+      expect(detail_row('user1')).to eq(['user1', '2', '30', '0', '0'])
     end
   end
 end


### PR DESCRIPTION
## What this PR does

Expands the admin-only "Retention predictors" CSV report for Scholars &
Scientists (`FellowsCohort`) courses. The v1 report (added in #6915) had a
single metric — distinct editing sessions per student. This adds three
retention signals and reshapes the output into a combined per-course **summary**
block plus a per-student **detail** block in one CSV:

1. **Editing sessions during the course** (the v1 metric, 1-hour gap rule).
2. **Days to first independent edit** — days from `course.end` to the student's
   first edit in the 30 days after the course, floored to whole days and
   defaulting to 30 when they never return (smaller = returned sooner).
3. **Editing sessions in the 30 days after** the course ends.
4. **Long-term survivors** — edits in the 30-day window beginning 60 days after
   course end (`end+60..end+90`); a survivor made ≥5 such edits.

The summary reports the participant count, total during-course sessions, the two
averages (over all enrolled students), and the survivor count.

Metrics are computed on each student's **combined cross-wiki** edit timeline,
pulled from the live MediaWiki `usercontribs` API (all namespaces) — the same
single paginated fetch v1 already made, so there is **no extra API load**.

Because the later windows only close as real-world time passes, each metric is
**time-gated with a one-day buffer** so every printed value is final: the 30-day
metrics fill in at `end+31d` and the survivor metric at `end+91d`. Until then the
relevant per-student cells and their summary aggregates are left **blank** —
the report is always available, it just fills in over time.

Only the builder (`lib/analytics/retention_predictors_csv_builder.rb`) and its
spec change. The Sidekiq worker, route, controller, admin button, and locale
string are untouched — the report still generates on demand from the same button
on a FellowsCohort course's overview.

Design notes:
- Windows anchor on `course.end` (not each student's last edit).
- Survivors are a raw **count** with a ≥5 threshold; a summed edit-count would be
  dominated by a single prolific editor (real data showed one participant with
  2,566 edits in the 60–90 window).
- v1's per-wiki columns are dropped in favor of the combined timeline for
  readability.

## AI usage

Claude Code (Opus 4.8) wrote the code, the spec, and the commit message under
the author's direction. The session was primarily a design dialogue: the author
supplied the four metric definitions and then made a series of decisions —
report shape (summary + detail), window anchor (`course.end`), the return-gap
definition (measured from course end), scope (one course at a time), CSV
delivery (one combined file), and, after initially choosing to disable the whole
report until mature, switching to blank cells for not-yet-available data. Claude
surfaced the key structural point that three of the four requested metrics are
aggregates (a different granularity from the per-student v1 CSV) and asked
clarifying questions at the genuine forks; the author decided each one.

The change was developed in a single focused session (one commit). Claude ran
the builder spec (6 examples, green first pass), the reports controller spec (27
examples, still green as it stubs the builder), and RuboCop (clean), then
verified end-to-end by generating a real CSV against a completed S&S course in a
dev database loaded from a production dump — the summary aggregates reconciled
exactly against the per-student detail rows.

This PR description was drafted using a Claude Code skill (`/prepare-pr`); the
summary and analysis above were written by Claude Code and may contain errors.

## Screenshots

No UI changes. The change is to the contents of the generated CSV; the report is
still triggered from the existing "Retention predictors" admin button. Example
output for a fully mature course:

```csv
Summary
participants,9
total editing sessions during course,39
avg days to first independent edit,23.6
avg editing sessions in 30 days after course,4.4
participants with 5+ edits in days 60-90 (survivors),1

Per-student detail
username,sessions during course,days to first independent edit,sessions in 30 days after course,edits in days 60-90
ExampleUserA,9,30,0,0
ExampleUserB,8,0,3,0
ExampleUserC,2,14,36,2566
```

For a course that ended fewer than 91 days ago, the day-60–90 column and the
survivors row come back blank; under 31 days, all three post-course metrics are
blank.

## Open questions and concerns

- **One-day reporting buffer.** Metrics fill one day after their window closes
  (31 and 91 days), matching the "measure 31 days after" phrasing in the metric
  spec. If reviewers would rather a metric appear the moment its window closes
  (30 and 90 days), that's a one-line constant change.
- **Aggregate denominator.** Averages and the survivor count are over all
  enrolled students, so students with zero activity count (as a 30-day gap and
  zero sessions). This is intentional but worth confirming.
- **Combined-timeline only.** v1's per-wiki session columns were dropped. If the
  per-wiki breakdown is still wanted, it can be added back to the detail block.

(PR description written by Claude Code.)
