### PR TITLE
Harden CI ImageMagick step against broken third-party apt repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
       # Paperclip.options[:command_path] in config/environments/test.rb.
       - name: install ImageMagick
         run: |
+          # The ubuntu-24.04 runner preinstalls Microsoft/Azure apt repos whose
+          # signatures intermittently break ("Clearsigned file isn't valid ...
+          # got 'NOSPLIT'"), which makes `apt-get update` exit non-zero and abort
+          # this step (it runs under `bash -e`). ImageMagick comes from Ubuntu's
+          # own repos, so drop those third-party sources before updating.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
           sudo apt-get update
           sudo apt-get install -y imagemagick
 


### PR DESCRIPTION
## What this PR does

Fixes CI, which is currently failing on every PR at the "install ImageMagick"
setup step (before any test runs). The ubuntu-24.04 GitHub runner ships
preinstalled Microsoft/Azure apt repos (`packages.microsoft.com`) whose Release
signatures broke today:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease
   Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
E: The repository 'https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease' is no longer signed.
```

Because the step runs under `bash -e`, that non-zero `apt-get update` aborts the
whole job before ImageMagick — or any test — installs. ImageMagick comes from
Ubuntu's own repos (which fetch fine), so this PR drops the unrelated
Microsoft/Azure sources before `apt-get update`:

```yaml
sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
sudo apt-get update
sudo apt-get install -y imagemagick
```

`apt-get update` still fails loudly on problems in the repos we actually depend
on; it just no longer trips over a broken third-party feed the build never uses.
The most recent master CI run (2026-07-06) was green, so this is a fresh runner
environment breakage rather than a code regression.

## AI usage

Found and fixed by Claude Code (Opus 4.8) while investigating a CI failure on an
unrelated feature PR (#6947). Claude read the failing job log, identified that
the abort was in the ImageMagick apt step (not the test suite), confirmed master
had been green a day earlier, and proposed the source-removal workaround; the
author chose to land it as a standalone PR against master to unblock all open
PRs. One-line workflow change, one commit, made in a single session.

This PR description was drafted using a Claude Code skill (`/prepare-pr`); the
analysis above was written by Claude Code and may contain errors.

## Screenshots

No UI changes — CI workflow only. The proof is this PR's own CI run getting past
the "install ImageMagick" step and into the JS/Ruby suites.

## Open questions and concerns

- This is a targeted workaround for a broken upstream apt repo; once
  `packages.microsoft.com` is fixed on the runner image the removal becomes a
  harmless no-op, so it's safe to leave in place.
- The `rm -f` globs only match filenames in `sources.list.d` containing
  `microsoft`/`azure` (the azure-cli and microsoft-prod feeds). Ubuntu's own
  archive mirror (`azure.archive.ubuntu.com`) is configured in
  `ubuntu.sources`, which the globs do not match, so it is untouched.

(PR description written by Claude Code.)
