### PR TITLE
Add zero-edit and 30-day-return aggregate metrics to retention CSV

### DIFF
--- a/lib/analytics/retention_predictors_csv_builder.rb
+++ b/lib/analytics/retention_predictors_csv_builder.rb
@@ -18,6 +18,11 @@ require 'csv'
 #   4. Edits in the 30-day window that begins 60 days after the course ends
 #      (course.end+60..course.end+90); a "survivor" made at least 5 such edits.
 #
+# The summary block also reports two aggregate conveniences derived from the
+# per-student metrics above: the count of participants with zero editing sessions
+# during the course, and the count of participants who edited in the 30 days
+# after it ended.
+#
 # Metrics are computed on each student's combined cross-wiki edit timeline, from
 # the live MediaWiki usercontribs API (all namespaces), which is why the report
 # has no dependency on stored revision data.
@@ -74,8 +79,10 @@ class RetentionPredictorsCsvBuilder
       ['Summary'],
       ['participants', @students.size],
       ['total editing sessions during course', during],
+      ['participants with no editing sessions during course', zero_edit_participants(stats)],
       ['avg days to first independent edit', avg_gap],
       ['avg editing sessions in 30 days after course', avg_after],
+      ['participants who edited in 30 days after course', returning_participants(stats)],
       ['participants with 5+ edits in days 60-90 (survivors)', survivors(stats)]
     ]
   end
@@ -137,6 +144,20 @@ class RetentionPredictorsCsvBuilder
     counts = stats.map { |s| s[:edits_60_90] }
     return nil if counts.any?(&:nil?)
     counts.count { |count| count >= SURVIVAL_THRESHOLD }
+  end
+
+  # Participants with zero editing sessions during the course. Always available,
+  # since the during-course metric never depends on a not-yet-closed window.
+  def zero_edit_participants(stats)
+    stats.count { |s| s[:sessions_during].zero? }
+  end
+
+  # Participants who made at least one edit in the 30 days after the course.
+  # Blank (nil) until the return window has closed.
+  def returning_participants(stats)
+    counts = stats.map { |s| s[:sessions_after] }
+    return nil if counts.any?(&:nil?)
+    counts.count(&:positive?)
   end
 
   # Number of distinct editing sessions: a new session starts whenever the gap

--- a/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
+++ b/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
@@ -81,6 +81,12 @@ describe RetentionPredictorsCsvBuilder do
         expect(summary_value('avg editing sessions in 30 days after course')).to eq('0.5')
         expect(summary_value('participants with 5+ edits in days 60-90 (survivors)')).to eq('1')
       end
+
+      it 'counts zero-edit and returning participants' do
+        # user2 made no edits; user1 edited during the course and returned on day 14.
+        expect(summary_value('participants with no editing sessions during course')).to eq('1')
+        expect(summary_value('participants who edited in 30 days after course')).to eq('1')
+      end
     end
 
     context 'when the course ended fewer than 31 days ago' do
@@ -98,6 +104,13 @@ describe RetentionPredictorsCsvBuilder do
         expect(summary_value('avg editing sessions in 30 days after course')).to be_nil
         expect(summary_value('participants with 5+ edits in days 60-90 (survivors)')).to be_nil
       end
+
+      it 'counts zero-edit participants but leaves returning participants blank' do
+        # user2 made no edits; the return window has not yet closed, so the
+        # returning-participants aggregate cannot be finalized.
+        expect(summary_value('participants with no editing sessions during course')).to eq('1')
+        expect(summary_value('participants who edited in 30 days after course')).to be_nil
+      end
     end
 
     context 'when the course ended between 31 and 90 days ago' do
@@ -114,6 +127,12 @@ describe RetentionPredictorsCsvBuilder do
         expect(summary_value('avg days to first independent edit')).to eq('17.5')
         expect(summary_value('avg editing sessions in 30 days after course')).to eq('0.5')
         expect(summary_value('participants with 5+ edits in days 60-90 (survivors)')).to be_nil
+      end
+
+      it 'counts zero-edit and returning participants once the window has closed' do
+        # user2 made no edits; user1 edited during the course and returned on day 5.
+        expect(summary_value('participants with no editing sessions during course')).to eq('1')
+        expect(summary_value('participants who edited in 30 days after course')).to eq('1')
       end
     end
   end


### PR DESCRIPTION
## What this PR does

Adds two aggregate convenience metrics to the "Retention predictors" CSV report
(`RetentionPredictorsCsvBuilder`), generated for the Scholars & Scientists /
FellowsCohort program:

- **participants with no editing sessions during course** — the count of
  participants whose during-course editing-session count is zero.
- **participants who edited in 30 days after course** — the count of
  participants with at least one editing session in the 30-day return window.

Both values are derived entirely from the per-student metrics the report already
computes, so they add no new API calls or data — they just surface two datapoints
explicitly that previously had to be tallied by hand from the per-student detail
block. The zero-edit count is always populated; the returning-participants count
follows the same reporting-window gating as the other post-course metrics (left
blank until the 30-day return window has closed, so every reported value is
final).

## AI usage

The code, tests, and this PR description were all written by Claude Code (Opus
4.8) under my direction. I described the two metrics to add and the rationale
(both were already derivable from the existing CSV, so this is a convenience);
Claude implemented the two summary rows and helper methods, mapped them onto the
existing metric-gating pattern, added spec coverage across the three time-window
contexts, and ran the tests and RuboCop. I reviewed the change and the row-label
wording.

Scale of effort: a single commit made within one short focused session. The
implementation was straightforward with no wrong turns; the spec passed on the
first run and RuboCop was clean.

This PR description was drafted using the `/prepare-pr` Claude Code skill, and the
summary above may contain errors — please read the diff as the source of truth.

## Screenshots

No UI changes — this only affects the generated CSV report.

## Open questions and concerns

- **Row labels**: the two new summary labels mirror the existing summary-label
  style. They're the only new text a reader sees in the CSV, so they're easy to
  rename if different wording is preferred.
- **Window boundary**: "edited in 30 days after course" uses the same return
  window the existing metrics already define (strictly after `course.end`,
  through `course.end + 30 days` inclusive), so the new count stays consistent
  with the `avg editing sessions in 30 days after course` aggregate.

(PR description written by Claude Code.)
