### PR TITLE
fix: stabilize category_scopes_spec by retrying stale-element clicks

### DIFF
--- a/spec/features/category_scopes_spec.rb
+++ b/spec/features/category_scopes_spec.rb
@@ -12,12 +12,26 @@ describe 'Tracked categories and templates', js: true do
     stub_oauth_edit
   end
 
+  def choose_select_option(selector, option_text, **match_opts)
+    # Wait for the react-select loading indicator to disappear before looking for the option
+    expect(page).to have_no_css("#{selector} div[class*='loadingIndicator']", wait: 15)
+
+    tries = 0
+    begin
+      find(:css, "#{selector} div[class*='option']", text: option_text, wait: 15, **match_opts).click
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError
+      tries += 1
+      retry if tries < 3
+      raise
+    end
+  end
+
   it 'lets a facilitator add and remove a category' do
     visit "/courses/#{course.slug}/articles"
     expect(page).to have_content 'Tracked Categories'
     click_button 'Add category'
     find(:css, '#categories input').set('Earth ')
-    find(:css, '#categories div[class*="option"]', text: 'Earth sciences').click
+    choose_select_option('#categories', 'Earth sciences')
     click_button 'Add categories'
     click_button 'OK'
     expect(page).to have_content 'Category:Earth'
@@ -25,7 +39,7 @@ describe 'Tracked categories and templates', js: true do
     # Re-add the same category
     click_button 'Add category'
     find(:css, '#categories input').set('Earth ')
-    find(:css, '#categories div[class*="option"]', text: 'Earth sciences').click
+    choose_select_option('#categories', 'Earth sciences')
     click_button 'Add categories'
     click_button 'OK'
 
@@ -38,7 +52,7 @@ describe 'Tracked categories and templates', js: true do
     click_button 'Add template'
 
     find(:css, '#templates input').set('Earth ')
-    find(:css, '#templates div[class*="option"]', text: 'Earth mass').click
+    choose_select_option('#templates', 'Earth mass')
 
     click_button 'Add Templates'
     click_button 'OK'
@@ -50,9 +64,9 @@ describe 'Tracked categories and templates', js: true do
     click_button 'Add category'
 
     find(:css, '#categories input').set('Earth ')
-    find(:css, '#categories div[class*="option"]', text: 'Earth sciences').click
+    choose_select_option('#categories', 'Earth sciences')
     find(:css, '#categories input').set('Apple Inc. ')
-    find(:css, '#categories div[class*="option"]', text: 'en:Apple Inc.', exact_text: true).click
+    choose_select_option('#categories', 'en:Apple Inc.', exact_text: true)
 
     click_button 'Add categories'
     click_button 'OK'
@@ -64,13 +78,13 @@ describe 'Tracked categories and templates', js: true do
     visit "/courses/#{course.slug}/articles"
     click_button 'Add category'
     find(:css, '#categories input').set('Earth ')
-    find(:css, '#categories div[class*="option"]', text: 'Earth sciences').click
+    choose_select_option('#categories', 'Earth sciences')
 
     find(:css, '.multi-wiki-selector input').set('fr')
-    find(:css, '.multi-wiki-selector div[class*="option"]', text: 'fr.wikipedia.org').click
+    choose_select_option('.multi-wiki-selector', 'fr.wikipedia.org')
 
     find(:css, '#categories input').set('Matériel Apple ')
-    find(:css, '#categories div[class*="option"]', text: 'fr:Matériel Apple', exact_text: true).click # rubocop:disable Layout/LineLength
+    choose_select_option('#categories', 'fr:Matériel Apple', exact_text: true)
 
     click_button 'Add categories'
     click_button 'OK'
@@ -83,9 +97,9 @@ describe 'Tracked categories and templates', js: true do
     click_button 'Add template'
 
     find(:css, '#templates input').set('Earth ')
-    find(:css, '#templates div[class*="option"]', text: 'Earth mass').click
+    choose_select_option('#templates', 'Earth mass')
     find(:css, '#templates input').set('Apple Inc. ')
-    find(:css, '#templates div[class*="option"]', text: 'en:Apple Inc.', exact_text: true).click
+    choose_select_option('#templates', 'en:Apple Inc.', exact_text: true)
 
     click_button 'Add Templates'
     click_button 'OK'
@@ -98,13 +112,13 @@ describe 'Tracked categories and templates', js: true do
     click_button 'Add template'
 
     find(:css, '#templates input').set('Earth ')
-    find(:css, '#templates div[class*="option"]', text: 'Earth mass').click
+    choose_select_option('#templates', 'Earth mass')
 
     find(:css, '.multi-wiki-selector input').set('fr')
-    find(:css, '.multi-wiki-selector div[class*="option"]', text: 'fr.wikipedia.org').click
+    choose_select_option('.multi-wiki-selector', 'fr.wikipedia.org')
 
     find(:css, '#templates input').set('Palette Apple ')
-    find(:css, '#templates div[class*="option"]', text: 'fr:Palette Apple', exact_text: true).click
+    choose_select_option('#templates', 'fr:Palette Apple', exact_text: true)
 
     click_button 'Add Templates'
     click_button 'OK'
@@ -117,10 +131,10 @@ describe 'Tracked categories and templates', js: true do
     click_button 'Add category'
 
     find(:css, '#categories input').set('Earth ')
-    find(:css, '#categories div[class*="option"]', text: 'Earth sciences').click
+    choose_select_option('#categories', 'Earth sciences')
     find(:css, '#category_depth').set('3')
     find(:css, '#categories input').set('Apple Inc. ')
-    find(:css, '#categories div[class*="option"]', text: 'en:Apple Inc.', exact_text: true).click
+    choose_select_option('#categories', 'en:Apple Inc.', exact_text: true)
 
     expect(page).to have_content 'en:Earth sciences - 0'
     expect(page).to have_content 'en:Apple Inc. - 3'


### PR DESCRIPTION
Addresses #6726. The AsyncSelect dropdown options are fetched via a debounced API call and rendered by React. Two race conditions cause intermittent failures:

1. ElementNotFound — the options haven't rendered yet.
2. StaleElementReferenceError — React re-renders between find and click.

The new choose_select_option helper:
- waits for the react-select loading indicator to disappear
- uses an extended wait (15s vs default 10s) for CI
- retries the click up to 3 times on StaleElementReferenceError

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## Instructions

Convert the PR to a draft unless/until:
* The tests are all passing (ie, the CI build is green)
* All feedback has been addressed. (Reviewers will convert it back to a draft if changes need to be made. Mark it ready for review when it's ready again.)
* The git history is tidy. (Each commit should be self-contained, with a clear description in the commit message. In most cases, there should be no merge commits.)
* The PR description template is complete, with a clear indication of the purpose, links to related issues, links to relevant external documentation, an AI usage statement, up-to-date screenshots or demo videos (if applicable). This "Instructions" section can be removed.

If your PR is ready but has been ignored for a week or more, feel free to leave a comment reminding us.

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

## AI usage
< if you used any AI tools to prepare this PR, say which tools you used and what you used them for.
  if you used AI to learn how to solve a problem, summarize what you asked and what advice you used.
  if you didn't use any AI tools, say so. >

## Screenshots
Before:
< add a screenshot or screen recording of the UI before your change >

After:
< add a screenshot or screen recording of the UI after your change >

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
