### PR TITLE
docs: clean up outdated comments referencing Revision records

### DIFF
--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -36,7 +36,7 @@ class RevisionDataManager
 
   INCLUDED_NAMESPACES = [0, 2, 118].freeze
   # This method gets course revisions for a given period.
-  # Returns an array of Revision records.
+  # Returns an array of RevisionOnMemory objects.
   # As a side effect, it imports Article records.
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
     all_sub_data = get_course_revisions(@course.students, timeslice_start,
@@ -68,7 +68,7 @@ class RevisionDataManager
   end
 
   # This method gets scores for specific revisions from different APIs.
-  # Returns an array of Revision records with completed scores.
+  # Returns an array of RevisionOnMemory objects with completed scores.
   def fetch_score_data_for_course(revisions)
     # We need to partition revisions because we don't want to calculate scores for revisions
     # out of important spaces
@@ -198,7 +198,7 @@ class RevisionDataManager
     # rubocop:enable Style/HashEachMethods
   end
 
-  # Creates a revision record for the given revision data.
+  # Creates a RevisionOnMemory object for the given revision data.
   def create_revision(rev_data, article_data, users, articles)
     mw_page_id = rev_data['mw_page_id'].to_i
     RevisionOnMemory.new({


### PR DESCRIPTION
Addresses #6871.
Updated comments in RevisionDataManager to correctly specify that methods return RevisionOnMemory objects rather than ActiveRecord Revision records.

NOTE: Please review the pull request process before opening your first PR: https://github.com/WikiEducationFoundation/WikiEduDashboard/blob/master/CONTRIBUTING.md#pull-request-process

## Instructions

Convert the PR to a draft unless/until:
* The tests are all passing (ie, the CI build is green)
* All feedback has been addressed. (Reviewers will convert it back to a draft if changes need to be made. Mark it ready for review when it's ready again.)
* The git history is tidy. (Each commit should be self-contained, with a clear description in the commit message. In most cases, there should be no merge commits.)
* The PR description template is complete, with a clear indication of the purpose, links to related issues, links to relevant external documentation, an AI usage statement, up-to-date screenshots or demo videos (if applicable). This "Instructions" section can be removed.

If your PR is ready but has been ignored for a week or more, feel free to leave a comment reminding us.

## What this PR does
< describe the purpose of this pull request and note the issue it addresses >

## AI usage
< if you used any AI tools to prepare this PR, say which tools you used and what you used them for.
  if you used AI to learn how to solve a problem, summarize what you asked and what advice you used.
  if you didn't use any AI tools, say so. >

## Screenshots
Before:
< add a screenshot or screen recording of the UI before your change >

After:
< add a screenshot or screen recording of the UI after your change >

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
