### PR TITLE
Fix reference-counter API support for multilingual Wikisource and wikimedia wikis

### DIFF
--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -153,7 +153,11 @@ class ReferenceCounterApi
   end
 
   def batch_query_url
-    "/api/v1/references/#{@project_code}/#{@language_code}"
+    # Multilingual Wikisource (wikisource.org) is stored with language = nil;
+    # the reference-counter API reaches it as www.wikisource.org.
+    language = @language_code
+    language = 'www' if @project_code == 'wikisource' && language.nil?
+    "/api/v1/references/#{@project_code}/#{language}"
   end
 
   # A batch lookup has no reason to take longer than this. Without timeouts,

--- a/lib/reference_counter_api.rb
+++ b/lib/reference_counter_api.rb
@@ -16,14 +16,10 @@ class ReferenceCounterApi
   RETRY_COUNT = 5
   MAX_NON_200_RESPONSE_LOGS = 5
 
-  # The reference-counter Toolforge API only supports language-edition wikis
-  # (en.wikipedia, fr.wiktionary, etc.). Wikidata is excluded because it has
-  # its own data model and reference-counting approach. The wikimedia
-  # pseudo-project (commons, meta, incubator, species, foundationwiki) is
-  # excluded because none of its members are language-edition wikis with
-  # article-style <ref> markup; the API responds with 400 "Language X is not
-  # a valid language" for any of them.
-  UNSUPPORTED_PROJECTS = %w[wikidata wikimedia].freeze
+  # Wikidata is excluded because it has its own data model and
+  # reference-counting approach; the API rejects it server-side with
+  # "Project wikidata is not a valid project."
+  UNSUPPORTED_PROJECTS = %w[wikidata].freeze
 
   def self.valid_wiki?(wiki)
     !UNSUPPORTED_PROJECTS.include?(wiki.project)

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -19,10 +19,10 @@ describe ReferenceCounterApi do
     end.to raise_error(described_class::InvalidProjectError)
   end
 
-  it 'raises InvalidProjectError for wikimedia projects (commons, meta, etc.)' do
+  it 'does not raise InvalidProjectError for wikimedia projects (commons, meta, incubator)' do
     expect do
       described_class.new(commons)
-    end.to raise_error(described_class::InvalidProjectError)
+    end.not_to raise_error
   end
 
   context 'when the API returns 200 responses' do

--- a/spec/lib/reference_counter_api_spec.rb
+++ b/spec/lib/reference_counter_api_spec.rb
@@ -10,6 +10,7 @@ describe ReferenceCounterApi do
   let(:es_wiktionary) { Wiki.get_or_create(language: 'es', project: 'wiktionary') }
   let(:commons) { Wiki.get_or_create(language: 'commons', project: 'wikimedia') }
   let(:wikidata) { Wiki.get_or_create(language: nil, project: 'wikidata') }
+  let(:multilingual_wikisource) { Wiki.get_or_create(language: nil, project: 'wikisource') }
   let(:deleted_rev_id) { [6115106] }
   let(:rev_ids) { [5006940, 5006942, 5006946] }
 
@@ -23,6 +24,16 @@ describe ReferenceCounterApi do
     expect do
       described_class.new(commons)
     end.not_to raise_error
+  end
+
+  it 'uses www as the language for multilingual Wikisource' do
+    ref_counter_api = described_class.new(multilingual_wikisource)
+    expect(ref_counter_api.send(:batch_query_url)).to eq('/api/v1/references/wikisource/www')
+  end
+
+  it 'uses the wiki language for language-edition wikis' do
+    ref_counter_api = described_class.new(es_wiktionary)
+    expect(ref_counter_api.send(:batch_query_url)).to eq('/api/v1/references/wiktionary/es')
   end
 
   context 'when the API returns 200 responses' do


### PR DESCRIPTION
# Fix reference-counter API support for multilingual Wikisource and wikimedia wikis

## What this PR does

Fixes a steady stream of Sentry errors — `Non-200 response hitting references counter API: (404)` — coming from courses that track multilingual Wikisource (wikisource.org). That wiki is deliberately stored with `language = nil`, so `ReferenceCounterApi#batch_query_url` interpolated an empty final URL segment (`/api/v1/references/wikisource/`), which matches no route on the Toolforge app and 404s on every batch, through all 5 retries. The reference-counter API builds hostnames as `{language}.{project}.org`, and `www.wikisource.org` is the real multilingual Wikisource domain, so the fix is to substitute `www` for the nil language. Verified live with the exact rev_ids from the Sentry events (200 with per-rev counts) and with a page containing two literal `<ref>` tags (`num_ref: 2`).

While auditing related edge cases, we also found that the `wikimedia` project exclusion in `UNSUPPORTED_PROJECTS` is stale: the code comment claimed the API responds 400 "Language X is not a valid language" for wikimedia wikis, but live testing showed all three wikimedia wikis the Dashboard can actually have (`commons`, `incubator`, `meta` — anything else fails `Wiki` model validation) return 200 with correct counts, verified against pages containing literal `<ref>` tags. So this PR removes `wikimedia` from the exclusion list, and those wikis will start accumulating real reference counts. Wikidata remains excluded; the API rejects it server-side with "Project wikidata is not a valid project."
Note that we don't get "Language X is not a valid language" error anymore since we deleted the constant list of supported language from the reference-counter API source code. 

Relevant external context: [reference-counter on Toolforge](https://toolsadmin.wikimedia.org/tools/id/reference-counter).

## AI usage

This PR was developed with Claude Code (Claude Fable 5). Claude investigated the Sentry errors, traced the 404 to the nil-language URL segment, and initially proposed excluding multilingual Wikisource from the API — trusting the stale code comment. The human author pushed back and asked to verify empirically; Claude's live probes against the Toolforge API showed the `www` segment works, and a follow-up sweep requested by the author showed the wikimedia wikis work too, turning a proposed exclusion into a fix that recovers data. The author specified the shape of both changes (scope the `www` fallback inside `batch_query_url`; drop `wikimedia` from `UNSUPPORTED_PROJECTS`) and the two-commit split; Claude drafted the code, specs, and commit messages under that direction, and the author reviewed each edit.

Both commits were made within a single session on 2026-07-10, a few minutes apart; the investigation and live API verification took roughly an hour of back-and-forth. This summary and the rest of this description were also drafted by Claude Code and may contain errors.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes.

## Open questions and concerns

- Removing `wikimedia` from the exclusion list means commons/incubator/meta revisions will start getting reference counts where they previously got none. Refs are meaningful on incubator (proto-Wikipedia articles) and present-but-rare on commons/meta; if that data is unwanted for some reason, the first commit can be dropped independently of the wikisource fix.
- The `www` fallback is scoped to wikisource specifically (not any nil-language wiki) so wikidata — also nil-language, but rejected by the API — can't slip through if its exclusion ever changes.

(PR description written by Claude Code.)
