### PR TITLE
Stop storing zero-valued counters in timeslice wikidata stats

### DIFF
--- a/app/services/update_wikidata_stats_timeslice.rb
+++ b/app/services/update_wikidata_stats_timeslice.rb
@@ -107,9 +107,11 @@ class UpdateWikidataStatsTimeslice
     revisions
   end
 
-  # Given an array of revisions, it builds the stats for those revisions
+  # Given an array of revisions, it builds the stats for those revisions.
+  # Zero-valued counters are omitted to keep serialized timeslice stats small;
+  # absent keys mean zero.
   def build_stats_from_revisions(revisions)
-    stats = STATS_CLASSIFICATION.values.to_h { |label| [label, 0] }
+    stats = Hash.new(0)
     revisions.each do |revision|
       revision.diff_stats&.each do |key, value|
         # Skip non-counter fields the analyzer may include (e.g. merge_target).
@@ -118,12 +120,13 @@ class UpdateWikidataStatsTimeslice
       end
     end
     stats['total revisions'] = revisions.count
-    stats
+    stats.reject { |_label, count| count.zero? }
   end
 
   # Given an array of indivual stats, it creates or updates the CourseStats row for it.
   def update_wikidata_statistics(individual_stats)
-    stats = sum_up_stats individual_stats
+    # CourseStat keeps the complete hash (zeros included), since it's what the UI reads.
+    stats = full_stats_template.merge(sum_up_stats(individual_stats))
     crs_stat = CourseStat.find_by(course_id: @course.id) || CourseStat.create(course_id: @course.id)
 
     # Update the stats_hash in the CourseStat model and save it
@@ -132,16 +135,22 @@ class UpdateWikidataStatsTimeslice
   end
 
   # Given an array of stats hashes, returns a single hash with all values summed.
+  # Like build_stats_from_revisions, it omits zero-valued counters.
   def sum_up_stats(individual_stats)
-    total_stats = STATS_CLASSIFICATION.values.to_h { |label| [label, 0] }
-    total_stats['total revisions'] = 0
+    total_stats = Hash.new(0)
     individual_stats.each do |hash|
       hash.each { |key, value| total_stats[key] += value }
     end
-    total_stats
+    total_stats.reject { |_label, count| count.zero? }
   end
 
   private
+
+  def full_stats_template
+    template = STATS_CLASSIFICATION.values.to_h { |label| [label, 0] }
+    template['total revisions'] = 0
+    template
+  end
 
   def apply_diff(revision, diffs, not_analyzed)
     if not_analyzed.include?(revision.mw_rev_id)

--- a/spec/models/course_wiki_timeslice_spec.rb
+++ b/spec/models/course_wiki_timeslice_spec.rb
@@ -386,11 +386,11 @@ scoped: false)
           expect(cuwt.stats['total revisions']).to eq(7)
         end
 
-        it 'sets zero for stats keys with no ACUWT contributions' do
+        it 'omits stats keys with no ACUWT contributions' do
           cuwt = described_class.find_by(course:, wiki: wikidata_wiki, start:)
           cuwt.update_cache_from_acuwt
 
-          expect(cuwt.stats['descriptions added']).to eq(0)
+          expect(cuwt.stats).not_to have_key('descriptions added')
         end
 
         context 'when course is article-scoped' do

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -331,7 +331,7 @@ describe UpdateCourseWikiTimeslices do
           expect(wikidata_timeslice.revision_count).to eq(0)
           expect(wikidata_timeslice.needs_update).to eq(false)
           expect(wikidata_timeslice.last_mw_rev_datetime).to eq(nil)
-          expect(wikidata_timeslice.stats['total revisions']).to eq(0)
+          expect(wikidata_timeslice.stats).to be_empty
         end
       end
     end

--- a/spec/services/update_wikidata_stats_timeslice_spec.rb
+++ b/spec/services/update_wikidata_stats_timeslice_spec.rb
@@ -105,6 +105,34 @@ describe UpdateWikidataStatsTimeslice do
       expect(stats['sense qualifiers changed']).to eq(2)
     end
 
+    it 'omits zero-valued counters from built stats' do
+      revision = build(:revision_on_memory, wiki_id: wikidata.id, scoped: true)
+      revision.summary = { 'added_claims' => 2, 'removed_claims' => 0 }.to_json
+      stats = updater.build_stats_from_revisions([revision])
+      expect(stats).to eq('claims created' => 2, 'total revisions' => 1)
+    end
+
+    it 'builds an empty stats hash from no revisions' do
+      expect(updater.build_stats_from_revisions([])).to eq({})
+    end
+
+    it 'sums sparse and legacy dense stats hashes, omitting zero values' do
+      legacy_dense = { 'claims created' => 1, 'labels added' => 0, 'total revisions' => 2 }
+      sparse = { 'claims created' => 3, 'total revisions' => 4 }
+      expect(updater.sum_up_stats([legacy_dense, sparse]))
+        .to eq('claims created' => 4, 'total revisions' => 6)
+    end
+
+    it 'stores the complete hash including zero values in CourseStat' do
+      updater.update_wikidata_statistics([{ 'claims created' => 2, 'total revisions' => 3 }])
+      stats = CourseStat.last.stats_hash[wikidata.domain]
+      expect(stats['claims created']).to eq(2)
+      expect(stats['total revisions']).to eq(3)
+      expect(stats['merged to']).to eq(0)
+      expect(stats.keys)
+        .to match_array(described_class::STATS_CLASSIFICATION.values + ['total revisions'])
+    end
+
     it 'creates record in CourseStat table', :vcr do
       expect(CourseStat.count).to eq(0)
       updater.update_revisions_with_stats(revisions)

--- a/spec/support/split_timeslices/over_threshold/expected_timeslices.yml
+++ b/spec/support/split_timeslices/over_threshold/expected_timeslices.yml
@@ -1,3 +1,4 @@
+---
 timeslice_1:
   start: 2025-08-27 17:00:00 UTC
   end: 2025-08-28 17:00:00 UTC
@@ -59,73 +60,9 @@ timeslice_7:
   references_count: 4
   revision_count: 4
   stats:
-    merged to: 0
-    interwiki links added: 0
     claims created: 1
-    claims removed: 0
     claims changed: 3
-    items cleared: 0
-    items created: 0
-    labels added: 0
-    labels removed: 0
-    labels changed: 0
-    descriptions added: 0
-    descriptions removed: 0
-    descriptions changed: 0
-    aliases added: 0
-    aliases removed: 0
-    aliases changed: 0
     references added: 4
-    qualifiers added: 0
-    redirects created: 0
-    reverts performed: 0
-    restorations performed: 0
-    references removed: 0
-    references changed: 0
-    qualifiers removed: 0
-    qualifiers changed: 0
-    interwiki links removed: 0
-    interwiki links updated: 0
-    merged from: 0
-    lemmas added: 0
-    lemmas removed: 0
-    lemmas changed: 0
-    forms added: 0
-    forms removed: 0
-    forms changed: 0
-    senses added: 0
-    senses removed: 0
-    senses changed: 0
-    properties created: 0
-    lexeme items created: 0
-    representations added: 0
-    representations removed: 0
-    representations changed: 0
-    glosses added: 0
-    glosses removed: 0
-    glosses changed: 0
-    form claims added: 0
-    form claims removed: 0
-    form claims changed: 0
-    sense claims added: 0
-    sense claims removed: 0
-    sense claims changed: 0
-    form references added: 0
-    form references removed: 0
-    form references changed: 0
-    form qualifiers added: 0
-    form qualifiers removed: 0
-    form qualifiers changed: 0
-    sense references added: 0
-    sense references removed: 0
-    sense references changed: 0
-    sense qualifiers added: 0
-    sense qualifiers removed: 0
-    sense qualifiers changed: 0
-    language added: 0
-    language changed: 0
-    lexical category added: 0
-    lexical category changed: 0
     total revisions: 4
   last_mw_rev_datetime: 2025-08-26 22:25:45 UTC
   needs_update: false
@@ -136,73 +73,10 @@ timeslice_8:
   references_count: 3
   revision_count: 5
   stats:
-    merged to: 0
-    interwiki links added: 0
-    claims created: 0
     claims removed: 1
     claims changed: 4
-    items cleared: 0
-    items created: 0
-    labels added: 0
-    labels removed: 0
-    labels changed: 0
-    descriptions added: 0
-    descriptions removed: 0
-    descriptions changed: 0
-    aliases added: 0
-    aliases removed: 0
-    aliases changed: 0
     references added: 4
-    qualifiers added: 0
-    redirects created: 0
-    reverts performed: 0
-    restorations performed: 0
     references removed: 1
-    references changed: 0
-    qualifiers removed: 0
-    qualifiers changed: 0
-    interwiki links removed: 0
-    interwiki links updated: 0
-    merged from: 0
-    lemmas added: 0
-    lemmas removed: 0
-    lemmas changed: 0
-    forms added: 0
-    forms removed: 0
-    forms changed: 0
-    senses added: 0
-    senses removed: 0
-    senses changed: 0
-    properties created: 0
-    lexeme items created: 0
-    representations added: 0
-    representations removed: 0
-    representations changed: 0
-    glosses added: 0
-    glosses removed: 0
-    glosses changed: 0
-    form claims added: 0
-    form claims removed: 0
-    form claims changed: 0
-    sense claims added: 0
-    sense claims removed: 0
-    sense claims changed: 0
-    form references added: 0
-    form references removed: 0
-    form references changed: 0
-    form qualifiers added: 0
-    form qualifiers removed: 0
-    form qualifiers changed: 0
-    sense references added: 0
-    sense references removed: 0
-    sense references changed: 0
-    sense qualifiers added: 0
-    sense qualifiers removed: 0
-    sense qualifiers changed: 0
-    language added: 0
-    language changed: 0
-    lexical category added: 0
-    lexical category changed: 0
     total revisions: 5
   last_mw_rev_datetime: 2025-08-26 22:30:18 UTC
   needs_update: false
@@ -213,73 +87,9 @@ timeslice_9:
   references_count: 6
   revision_count: 6
   stats:
-    merged to: 0
-    interwiki links added: 0
     claims created: 1
-    claims removed: 0
     claims changed: 5
-    items cleared: 0
-    items created: 0
-    labels added: 0
-    labels removed: 0
-    labels changed: 0
-    descriptions added: 0
-    descriptions removed: 0
-    descriptions changed: 0
-    aliases added: 0
-    aliases removed: 0
-    aliases changed: 0
     references added: 6
-    qualifiers added: 0
-    redirects created: 0
-    reverts performed: 0
-    restorations performed: 0
-    references removed: 0
-    references changed: 0
-    qualifiers removed: 0
-    qualifiers changed: 0
-    interwiki links removed: 0
-    interwiki links updated: 0
-    merged from: 0
-    lemmas added: 0
-    lemmas removed: 0
-    lemmas changed: 0
-    forms added: 0
-    forms removed: 0
-    forms changed: 0
-    senses added: 0
-    senses removed: 0
-    senses changed: 0
-    properties created: 0
-    lexeme items created: 0
-    representations added: 0
-    representations removed: 0
-    representations changed: 0
-    glosses added: 0
-    glosses removed: 0
-    glosses changed: 0
-    form claims added: 0
-    form claims removed: 0
-    form claims changed: 0
-    sense claims added: 0
-    sense claims removed: 0
-    sense claims changed: 0
-    form references added: 0
-    form references removed: 0
-    form references changed: 0
-    form qualifiers added: 0
-    form qualifiers removed: 0
-    form qualifiers changed: 0
-    sense references added: 0
-    sense references removed: 0
-    sense references changed: 0
-    sense qualifiers added: 0
-    sense qualifiers removed: 0
-    sense qualifiers changed: 0
-    language added: 0
-    language changed: 0
-    lexical category added: 0
-    lexical category changed: 0
     total revisions: 6
   last_mw_rev_datetime: 2025-08-26 22:36:16 UTC
   needs_update: false
@@ -290,73 +100,9 @@ timeslice_10:
   references_count: 6
   revision_count: 6
   stats:
-    merged to: 0
-    interwiki links added: 0
     claims created: 1
-    claims removed: 0
     claims changed: 5
-    items cleared: 0
-    items created: 0
-    labels added: 0
-    labels removed: 0
-    labels changed: 0
-    descriptions added: 0
-    descriptions removed: 0
-    descriptions changed: 0
-    aliases added: 0
-    aliases removed: 0
-    aliases changed: 0
     references added: 6
-    qualifiers added: 0
-    redirects created: 0
-    reverts performed: 0
-    restorations performed: 0
-    references removed: 0
-    references changed: 0
-    qualifiers removed: 0
-    qualifiers changed: 0
-    interwiki links removed: 0
-    interwiki links updated: 0
-    merged from: 0
-    lemmas added: 0
-    lemmas removed: 0
-    lemmas changed: 0
-    forms added: 0
-    forms removed: 0
-    forms changed: 0
-    senses added: 0
-    senses removed: 0
-    senses changed: 0
-    properties created: 0
-    lexeme items created: 0
-    representations added: 0
-    representations removed: 0
-    representations changed: 0
-    glosses added: 0
-    glosses removed: 0
-    glosses changed: 0
-    form claims added: 0
-    form claims removed: 0
-    form claims changed: 0
-    sense claims added: 0
-    sense claims removed: 0
-    sense claims changed: 0
-    form references added: 0
-    form references removed: 0
-    form references changed: 0
-    form qualifiers added: 0
-    form qualifiers removed: 0
-    form qualifiers changed: 0
-    sense references added: 0
-    sense references removed: 0
-    sense references changed: 0
-    sense qualifiers added: 0
-    sense qualifiers removed: 0
-    sense qualifiers changed: 0
-    language added: 0
-    language changed: 0
-    lexical category added: 0
-    lexical category changed: 0
     total revisions: 6
   last_mw_rev_datetime: 2025-08-26 22:48:41 UTC
   needs_update: false
@@ -367,73 +113,9 @@ timeslice_11:
   references_count: 7
   revision_count: 7
   stats:
-    merged to: 0
-    interwiki links added: 0
     claims created: 2
-    claims removed: 0
     claims changed: 5
-    items cleared: 0
-    items created: 0
-    labels added: 0
-    labels removed: 0
-    labels changed: 0
-    descriptions added: 0
-    descriptions removed: 0
-    descriptions changed: 0
-    aliases added: 0
-    aliases removed: 0
-    aliases changed: 0
     references added: 7
-    qualifiers added: 0
-    redirects created: 0
-    reverts performed: 0
-    restorations performed: 0
-    references removed: 0
-    references changed: 0
-    qualifiers removed: 0
-    qualifiers changed: 0
-    interwiki links removed: 0
-    interwiki links updated: 0
-    merged from: 0
-    lemmas added: 0
-    lemmas removed: 0
-    lemmas changed: 0
-    forms added: 0
-    forms removed: 0
-    forms changed: 0
-    senses added: 0
-    senses removed: 0
-    senses changed: 0
-    properties created: 0
-    lexeme items created: 0
-    representations added: 0
-    representations removed: 0
-    representations changed: 0
-    glosses added: 0
-    glosses removed: 0
-    glosses changed: 0
-    form claims added: 0
-    form claims removed: 0
-    form claims changed: 0
-    sense claims added: 0
-    sense claims removed: 0
-    sense claims changed: 0
-    form references added: 0
-    form references removed: 0
-    form references changed: 0
-    form qualifiers added: 0
-    form qualifiers removed: 0
-    form qualifiers changed: 0
-    sense references added: 0
-    sense references removed: 0
-    sense references changed: 0
-    sense qualifiers added: 0
-    sense qualifiers removed: 0
-    sense qualifiers changed: 0
-    language added: 0
-    language changed: 0
-    lexical category added: 0
-    lexical category changed: 0
     total revisions: 7
   last_mw_rev_datetime: 2025-08-26 22:57:06 UTC
   needs_update: false

--- a/spec/support/split_timeslices/under_threshold/expected_timeslices.yml
+++ b/spec/support/split_timeslices/under_threshold/expected_timeslices.yml
@@ -1,3 +1,4 @@
+---
 timeslice_1:
   start: 2025-08-26 17:00:00 UTC
   end: 2025-08-27 17:00:00 UTC
@@ -5,73 +6,11 @@ timeslice_1:
   references_count: 26
   revision_count: 28
   stats:
-    merged to: 0
-    interwiki links added: 0
     claims created: 5
     claims removed: 1
     claims changed: 22
-    items cleared: 0
-    items created: 0
-    labels added: 0
-    labels removed: 0
-    labels changed: 0
-    descriptions added: 0
-    descriptions removed: 0
-    descriptions changed: 0
-    aliases added: 0
-    aliases removed: 0
-    aliases changed: 0
     references added: 27
-    qualifiers added: 0
-    redirects created: 0
-    reverts performed: 0
-    restorations performed: 0
     references removed: 1
-    references changed: 0
-    qualifiers removed: 0
-    qualifiers changed: 0
-    interwiki links removed: 0
-    interwiki links updated: 0
-    merged from: 0
-    lemmas added: 0
-    lemmas removed: 0
-    lemmas changed: 0
-    forms added: 0
-    forms removed: 0
-    forms changed: 0
-    senses added: 0
-    senses removed: 0
-    senses changed: 0
-    properties created: 0
-    lexeme items created: 0
-    representations added: 0
-    representations removed: 0
-    representations changed: 0
-    glosses added: 0
-    glosses removed: 0
-    glosses changed: 0
-    form claims added: 0
-    form claims removed: 0
-    form claims changed: 0
-    sense claims added: 0
-    sense claims removed: 0
-    sense claims changed: 0
-    form references added: 0
-    form references removed: 0
-    form references changed: 0
-    form qualifiers added: 0
-    form qualifiers removed: 0
-    form qualifiers changed: 0
-    sense references added: 0
-    sense references removed: 0
-    sense references changed: 0
-    sense qualifiers added: 0
-    sense qualifiers removed: 0
-    sense qualifiers changed: 0
-    language added: 0
-    language changed: 0
-    lexical category added: 0
-    lexical category changed: 0
     total revisions: 28
   last_mw_rev_datetime: 2025-08-26 22:57:06 UTC
   needs_update: false


### PR DESCRIPTION
## What this PR does

Shrinks the serialized `stats` field on timeslice records by storing only non-zero counters. The `article_course_user_wiki_timeslices` table is one of the largest in the database, and a big share of that size comes from its `stats` text column: for Wikidata revisions, `UpdateWikidataStatsTimeslice#build_stats_from_revisions` pre-filled all 68 `STATS_CLASSIFICATION` labels with 0 before counting, producing a ~1.5&nbsp;KB YAML blob per row in which most values were zero (~40 bytes once zeros are stripped). For a single large Wikidata course with ~900k ACUWT rows, that is over 1&nbsp;GB of mostly-zero YAML.

With this change, `build_stats_from_revisions` and `sum_up_stats` omit zero-valued counters — an absent key means zero. This applies consistently to both write paths: ACUWT rows and `course_wiki_timeslices` stats (whether built directly from revisions or aggregated from ACUWT rows). `CourseStat.stats_hash`, which is what the UI reads, still receives the complete zero-filled hash via a template merge in `update_wikidata_statistics`, so nothing changes for the frontend.

Old dense rows and new sparse rows coexist safely: `sum_up_stats` iterates each input hash's own keys, so legacy zeros are simply dropped the next time a timeslice is aggregated. No migration is required for correctness.

## AI usage

This PR was developed with Claude Code, which wrote the code, specs, and commit message under human direction. The problem diagnosis started from the human side: Gabina observed that ACUWT and ACT row counts are similar for the same course while ACUWT is far larger, hypothesized the dense `stats` text field was the cause, and proposed storing only non-zero values. Claude Code verified the hypothesis against the schema and code (ACT has no `stats` column; the dense blob measures 1,482 bytes vs 41 bytes sparse for a representative hash), confirmed every reader of the field tolerates sparse hashes, and then implemented the change as directed — including the explicit requirements that ACUWT and CWT stay consistent and that `course_stats` keep the complete hash. Local testing to validate the size measurements against real data was done by hand.

The work was completed in a single focused session (one commit), with all tests green on the first run. This summary and the rest of the description were also drafted by Claude Code (via the `/prepare-pr` skill) and may contain errors.

## Screenshots

No UI changes.

## Open questions and concerns

- This only affects newly written rows. Existing rows keep their dense blobs until their timeslice is next reprocessed; actually reclaiming disk space on the database server will eventually require a backfill of existing `stats` values plus `OPTIMIZE TABLE` (or equivalent), which is left as follow-up work.
- The `stats` serializer is still YAML. Switching to JSON would save roughly another 30% and deserialize faster, but it has to handle existing YAML rows, so it was deliberately kept out of scope.

(PR description written by Claude Code.)
