### PR TITLE
Move fact-verification exercise fully into the dashboard

### DIFF
--- a/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
@@ -27,7 +27,10 @@ export const ArticlePicker = ({ articles, course, onTaken, showArticleId }) => {
   return (
     <div className="container narrow claim-verification-exercise claim-verification-exercise--articles">
       <div className="claim-verification-exercise__intro">
-        <h1>{I18n.t('claim_verification.choose_article')}</h1>
+        <p>{I18n.t('claim_verification.intro_p1')}</p>
+        <p>{I18n.t('claim_verification.intro_p2')}</p>
+        <p>{I18n.t('claim_verification.intro_p3')}</p>
+        <h1>{I18n.t('claim_verification.step_select_article')}</h1>
       </div>
       {articles.length ? (
         <ul className="claim-verification-exercise__article-grid">

--- a/app/assets/javascripts/components/claim_verification_exercise/ClaimVerificationExercise.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ClaimVerificationExercise.jsx
@@ -1,19 +1,33 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 
 import Loading from '@components/common/loading.jsx';
+import { fetchTimeline } from '~/app/assets/javascripts/actions/timeline_actions';
 import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
 import ArticlePicker from './ArticlePicker.jsx';
 import TakenClaim from './TakenClaim.jsx';
+import InstructorResponses from './InstructorResponses.jsx';
 
 /*
-  The claim-verification exercise, as a nested route of the course SPA. It fetches
-  the exercise state once and drives the whole flow client-side with no page
-  reloads. The article picker is the resting view: each article tile is its own
-  ArticleViewer that opens the article (and its in-context claim selection) in
-  place and closes back to the grid. Taking a claim transitions to the taken-claim
-  view, which becomes the resting view once the student has a claim; "choose a
-  different claim" returns to the picker.
+  The claim-verification exercise, as a nested route of the course SPA.
+  `/verify_claim` is the exercise itself, for every role — instructors can walk
+  through (and even complete) it exactly as a student would. The instructor
+  view of everyone's submissions lives on its own sub-page,
+  `/verify_claim/responses`, linked from the timeline module row and from each
+  student's exercise listing (the JSON behind it is instructor-gated
+  server-side).
+
+  For the exercise it fetches the state once and drives the whole flow
+  client-side with no page reloads. The article picker is the resting view:
+  each article tile is its own ArticleViewer that opens the article (and its
+  in-context claim selection) in place and closes back to the grid. Taking a
+  claim transitions to the taken-claim view — where the verification form
+  lives — which becomes the resting view once the student has a claim; "choose
+  a different claim" returns to the picker. Responses are keyed per claim, so
+  switching claims after submitting is allowed (the earlier response stays with
+  its claim, and re-taking that claim brings the submitted answers back).
 
   Deep-linking reuses the ArticleViewer shell's own `?showArticle=<id>` permalink:
   opening a tile pushes it, closing strips it, so the open article is refresh-
@@ -23,15 +37,19 @@ import TakenClaim from './TakenClaim.jsx';
   "choosing" is kept as local state rather than a second, competing query param.
 */
 const ClaimVerificationExercise = ({ course }) => {
-  const [state, setState] = useState(null); // { assignment, articles }
+  const [state, setState] = useState(null); // { assignment, response, articles }
   const [choosing, setChoosing] = useState(false);
+  const responsesPage = useLocation().pathname.endsWith('/responses');
+  const dispatch = useDispatch();
 
   useEffect(() => {
+    if (responsesPage) { return; }
     new ClaimVerificationAPI({ courseSlug: course.slug }).fetchState()
       .then(setState)
-      .catch(() => setState({ assignment: null, articles: [] }));
-  }, [course.slug]);
+      .catch(() => setState({ assignment: null, response: null, articles: [] }));
+  }, [course.slug, responsesPage]);
 
+  if (responsesPage) { return <InstructorResponses course={course} />; }
   if (!state) { return <Loading />; }
 
   // The article opened via the shell's ?showArticle= permalink (deep link or
@@ -39,20 +57,31 @@ const ClaimVerificationExercise = ({ course }) => {
   // opens and closes.
   const showArticleId = Number(new URLSearchParams(window.location.search).get('showArticle'));
 
-  const afterTaken = (assignment) => {
+  const afterTaken = ({ assignment, response }) => {
     // The viewer was open when the claim was taken, so its ?showArticle= permalink
     // is still in the URL. Clear it so the taken-claim view shows and a refresh
     // doesn't reopen the article.
     window.history.replaceState(null, null, window.location.pathname);
-    setState(prev => ({ ...prev, assignment }));
+    setState(prev => ({ ...prev, assignment, response: response || null }));
     setChoosing(false);
+  };
+
+  const afterResponseSaved = (response) => {
+    setState(prev => ({ ...prev, response }));
+    // Submitting completed the exercise's training module; refresh the
+    // timeline store so navigating back there shows it complete without a
+    // page reload.
+    dispatch(fetchTimeline(course.slug));
   };
 
   if (state.assignment && !choosing && !showArticleId) {
     return (
       <TakenClaim
         assignment={state.assignment}
+        response={state.response}
+        courseSlug={course.slug}
         onChooseDifferent={() => setChoosing(true)}
+        onResponseSaved={afterResponseSaved}
       />
     );
   }

--- a/app/assets/javascripts/components/claim_verification_exercise/InstructorResponses.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/InstructorResponses.jsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Link, useLocation } from 'react-router-dom';
+import { format } from 'date-fns';
+
+import Loading from '@components/common/loading.jsx';
+import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
+import ResponseSummary from './ResponseSummary.jsx';
+
+const formatDate = isoDate => format(new Date(isoDate), 'MMM do, yyyy');
+
+// "Real Name (username)" when the enrollment has a real name, else username —
+// matching how the students tab identifies students to instructors.
+const studentName = ({ username, real_name: realName }) => (
+  realName ? `${realName} (${username})` : username
+);
+
+// The claim a card is about: the sentence, plus article/source links when the
+// listing includes them (submitted responses do; pending rows keep it short).
+const ClaimContext = ({ claim }) => (
+  <div className="cv-response-card__claim">
+    <blockquote>{claim.sentence}</blockquote>
+    <p className="cv-response-card__claim-links">
+      {claim.article_url && (
+        <a href={claim.article_url} target="_blank" rel="noopener noreferrer">
+          {claim.article_title}
+        </a>
+      )}
+      {claim.source_url && (
+        <a href={claim.source_url} target="_blank" rel="noopener noreferrer">
+          {I18n.t('claim_verification.cited_source')}
+        </a>
+      )}
+    </p>
+  </div>
+);
+
+ClaimContext.propTypes = {
+  claim: PropTypes.shape({
+    sentence: PropTypes.string,
+    article_title: PropTypes.string,
+    article_url: PropTypes.string,
+    source_url: PropTypes.string,
+  }).isRequired,
+};
+
+/*
+  The instructor view of student submissions, at /verify_claim/responses
+  (linked from the timeline module row and from each student's exercise
+  listing): every submitted response as a card (the student, their claim, and
+  their answers rendered with the same question wording the student saw),
+  followed by students who have taken a claim but not yet submitted. A
+  `?student=<username>` param narrows the page to one student — that's the
+  per-student deep link — with a back link to the full list. The preview link
+  opens the exercise itself, which instructors can do (and even complete) like
+  a student.
+*/
+const InstructorResponses = ({ course }) => {
+  const [data, setData] = useState(null); // { responses, pending }
+  const [failed, setFailed] = useState(false);
+  const studentFilter = new URLSearchParams(useLocation().search).get('student');
+
+  useEffect(() => {
+    new ClaimVerificationAPI({ courseSlug: course.slug }).fetchResponses()
+      .then(setData)
+      .catch(() => setFailed(true));
+  }, [course.slug]);
+
+  if (failed) {
+    return (
+      <div className="container narrow claim-verification-responses">
+        <p role="alert">{I18n.t('claim_verification.form.submit_failed')}</p>
+      </div>
+    );
+  }
+  if (!data) { return <Loading />; }
+
+  const byStudent = entry => !studentFilter || entry.username === studentFilter;
+  const responses = data.responses.filter(byStudent);
+  const pending = data.pending.filter(byStudent);
+
+  return (
+    <div className="container narrow claim-verification-responses">
+      {studentFilter && (
+        <div className="cv-preview-return">
+          <Link to={`/courses/${course.slug}/verify_claim/responses`}>
+            ← {I18n.t('claim_verification.responses.heading')}
+          </Link>
+        </div>
+      )}
+      <div className="claim-verification-exercise__intro claim-verification-responses__header">
+        <h1>{I18n.t('claim_verification.responses.heading')}</h1>
+        <Link className="button" to={`/courses/${course.slug}/verify_claim`}>
+          {I18n.t('claim_verification.responses.preview_exercise')}
+        </Link>
+      </div>
+
+      {(responses.length === 0 && pending.length === 0) && (
+        <p className="claim-verification-exercise__empty">
+          {I18n.t('claim_verification.responses.none_yet')}
+        </p>
+      )}
+
+      {responses.map(response => (
+        <article className="cv-response-card" key={response.id}>
+          <header className="cv-response-card__header">
+            <h2>{studentName(response)}</h2>
+            <span className="cv-response-card__date">
+              {I18n.t('claim_verification.responses.submitted_at',
+                      { date: formatDate(response.created_at) })}
+            </span>
+          </header>
+          <ClaimContext claim={response.claim} />
+          <ResponseSummary response={response} />
+        </article>
+      ))}
+
+      {pending.length > 0 && (
+        <section className="cv-response-pending">
+          <h2>{I18n.t('claim_verification.responses.pending_heading')}</h2>
+          {pending.map(assignment => (
+            <article className="cv-response-card cv-response-card--pending" key={assignment.id}>
+              <header className="cv-response-card__header">
+                <h3>{studentName(assignment)}</h3>
+                <span className="cv-response-card__date">
+                  {I18n.t('claim_verification.responses.taken_at',
+                          { date: formatDate(assignment.taken_at) })}
+                </span>
+              </header>
+              <ClaimContext claim={assignment.claim} />
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+};
+
+InstructorResponses.propTypes = {
+  course: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default InstructorResponses;

--- a/app/assets/javascripts/components/claim_verification_exercise/ResponsePopover.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ResponsePopover.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+
+import Popover from '@components/common/popover.jsx';
+import useOutsideClick from '~/app/assets/javascripts/hooks/useOutsideClick';
+import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
+import ResponseSummary from './ResponseSummary.jsx';
+
+/*
+  "Submitted response" popover on a student's exercise row (Students tab
+  drawer): shows that student's verification-form answers in place, with no
+  navigation away from the tab. The answers are fetched lazily on first open,
+  through the same viewer-scoped endpoint as the submissions page — staff can
+  read any student's, a student their own.
+
+  Open state is local rather than useExpandablePopover's: that hook shares the
+  single global ui.openKey that the surrounding student drawer also uses, so
+  opening this popover through it would close the drawer out from under us.
+*/
+const ResponsePopover = ({ student }) => {
+  const courseSlug = useSelector(state => state.course.slug);
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useOutsideClick(() => setIsOpen(false));
+  const [data, setData] = useState(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || data || failed) { return; }
+    new ClaimVerificationAPI({ courseSlug }).fetchResponses()
+      .then(setData)
+      .catch(() => setFailed(true));
+  }, [isOpen, data, failed, courseSlug]);
+
+  const responses = data && data.responses.filter(r => r.username === student.username);
+
+  let contents;
+  if (failed) {
+    contents = <p role="alert">{I18n.t('claim_verification.form.submit_failed')}</p>;
+  } else if (!responses) {
+    contents = <p>{I18n.t('claim_verification.admin.loading')}</p>;
+  } else if (!responses.length) {
+    contents = <p>{I18n.t('claim_verification.responses.none_yet')}</p>;
+  } else {
+    contents = responses.map(response => (
+      <div className="cv-response-pop__item" key={response.id}>
+        <blockquote>{response.claim.sentence}</blockquote>
+        <ResponseSummary response={response} />
+      </div>
+    ));
+  }
+
+  let buttonClassName = 'button small';
+  if (isOpen) { buttonClassName += ' dark'; }
+
+  return (
+    <div className="pop__container cv-response-pop" ref={ref}>
+      <button className={buttonClassName} onClick={() => setIsOpen(current => !current)}>
+        {I18n.t('claim_verification.form.submitted_heading')}
+      </button>
+      <Popover
+        is_open={isOpen}
+        right
+        rows={<tr><td>{contents}</td></tr>}
+        styles={{ width: '440px' }}
+      />
+    </div>
+  );
+};
+
+ResponsePopover.propTypes = {
+  // The student whose drawer this is.
+  student: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    username: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default ResponsePopover;

--- a/app/assets/javascripts/components/claim_verification_exercise/ResponseSummary.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ResponseSummary.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// One question-and-answer pair of a submitted response. Skips unanswered
+// questions (conditional steps, blank open fields) so the summary only shows
+// what the student actually said.
+const Answer = ({ question, children }) => {
+  if (!children) { return null; }
+  return (
+    <div className="cv-response__answer">
+      <dt>{question}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+};
+
+Answer.propTypes = {
+  question: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};
+
+/*
+  A submitted response, rendered as the questions the student answered — shared
+  by the student's own post-submission view (where `onEdit` reopens the form)
+  and the instructor's per-student cards (no `onEdit`). Question wording reuses
+  the form's operator copy so students and instructors read the same exercise.
+*/
+export const ResponseSummary = ({ response, onEdit }) => (
+  <div className="cv-response">
+    <dl className="cv-response__answers">
+      <Answer question={I18n.t('claim_verification.form.source_access_question')}>
+        {I18n.t(`claim_verification.form.source_access_options.${response.source_access}`)}
+      </Answer>
+      <Answer question={I18n.t('claim_verification.form.source_access_notes_label')}>
+        {response.source_access_notes}
+      </Answer>
+      {response.verdict && (
+        <Answer question={I18n.t('claim_verification.form.verdict_question')}>
+          {I18n.t(`claim_verification.form.verdict_options.${response.verdict}`)}
+        </Answer>
+      )}
+      <Answer question={I18n.t('claim_verification.form.claim_location_label')}>
+        {response.claim_location}
+      </Answer>
+      <Answer question={I18n.t('claim_verification.form.verification_notes_label')}>
+        {response.verification_notes}
+      </Answer>
+      <Answer question={I18n.t('claim_verification.form.other_comments_label')}>
+        {response.other_comments}
+      </Answer>
+    </dl>
+    {onEdit && (
+      <button type="button" className="button" onClick={onEdit}>
+        {I18n.t('claim_verification.form.edit_response')}
+      </button>
+    )}
+  </div>
+);
+
+ResponseSummary.propTypes = {
+  response: PropTypes.shape({
+    source_access: PropTypes.string.isRequired,
+    source_access_notes: PropTypes.string,
+    verdict: PropTypes.string,
+    claim_location: PropTypes.string,
+    verification_notes: PropTypes.string,
+    other_comments: PropTypes.string,
+  }).isRequired,
+  onEdit: PropTypes.func,
+};
+
+export default ResponseSummary;

--- a/app/assets/javascripts/components/claim_verification_exercise/TakenClaim.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/TakenClaim.jsx
@@ -1,13 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
+import VerificationForm from './VerificationForm.jsx';
+import ResponseSummary from './ResponseSummary.jsx';
+
 /*
-  The student's taken claim: the claim, its cited source, and the handoff to do
-  the verification in their Wikipedia sandbox. "Choose a different claim" returns
-  to the picker client-side (no reload). The claim and source values are data.
+  The student's taken claim: the claim, its cited source, and the verification
+  form (steps 3 and 4 of the exercise) — the whole exercise happens here in the
+  dashboard. Once a response is submitted the form gives way to a summary of
+  their answers (editable, since submitting is an upsert). Responses are keyed
+  per claim, so choosing a different claim stays available even after
+  submitting — the summary belongs to this claim and survives a switch. The
+  claim and source values are data.
 */
-export const TakenClaim = ({ assignment, onChooseDifferent }) => {
-  const { claim, sandbox_url: sandboxUrl } = assignment;
+export const TakenClaim = ({ assignment, response, courseSlug, onChooseDifferent, onResponseSaved }) => {
+  const { claim } = assignment;
+  const [editing, setEditing] = useState(false);
+
+  const saved = (savedResponse) => {
+    setEditing(false);
+    onResponseSaved(savedResponse);
+  };
 
   return (
     <div className="container narrow claim-verification-exercise">
@@ -52,17 +65,21 @@ export const TakenClaim = ({ assignment, onChooseDifferent }) => {
         )}
       </section>
 
-      <section className="claim-verification-exercise__sandbox">
-        <p>{I18n.t('claim_verification.complete_in_sandbox')}</p>
-        <a
-          href={sandboxUrl}
-          className="button border claim-verification-exercise__sandbox-link"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {I18n.t('training.exercise_sandbox')}
-        </a>
-      </section>
+      {response && !editing ? (
+        <section className="claim-verification-exercise__response">
+          <h2 className="claim-verification-exercise__label">
+            {I18n.t('claim_verification.form.submitted_heading')}
+          </h2>
+          <ResponseSummary response={response} onEdit={() => setEditing(true)} />
+        </section>
+      ) : (
+        <VerificationForm
+          courseSlug={courseSlug}
+          initial={response}
+          onSaved={saved}
+          onCancel={editing ? () => setEditing(false) : null}
+        />
+      )}
 
       <div className="claim-verification-exercise__switch">
         <button
@@ -80,9 +97,12 @@ export const TakenClaim = ({ assignment, onChooseDifferent }) => {
 TakenClaim.propTypes = {
   assignment: PropTypes.shape({
     claim: PropTypes.object.isRequired,
-    sandbox_url: PropTypes.string,
   }).isRequired,
+  // The submitted response, if any.
+  response: PropTypes.object,
+  courseSlug: PropTypes.string.isRequired,
   onChooseDifferent: PropTypes.func.isRequired,
+  onResponseSaved: PropTypes.func.isRequired,
 };
 
 export default TakenClaim;

--- a/app/assets/javascripts/components/claim_verification_exercise/VerificationForm.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/VerificationForm.jsx
@@ -1,0 +1,189 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
+
+export const SOURCE_ACCESS_VALUES = ['accessed', 'nonexistent', 'inaccessible'];
+export const VERDICT_VALUES = [
+  'full_support', 'mostly_supports', 'partial_support', 'mostly_unsupported',
+  'unsupported', 'contradicted', 'undetermined'
+];
+
+// One multiple-choice question as a fieldset of radios. All strings are
+// operator copy from the claim_verification.form locale namespace.
+const RadioQuestion = ({ name, question, optionsKey, values, value, onChange }) => (
+  <fieldset className="cv-form__question">
+    <legend className="cv-form__question-label">{question}</legend>
+    {values.map(optionValue => (
+      <label key={optionValue} className="cv-form__option">
+        <input
+          type="radio"
+          name={name}
+          value={optionValue}
+          checked={value === optionValue}
+          onChange={() => onChange(optionValue)}
+        />
+        <span>{I18n.t(`claim_verification.form.${optionsKey}.${optionValue}`)}</span>
+      </label>
+    ))}
+  </fieldset>
+);
+
+RadioQuestion.propTypes = {
+  name: PropTypes.string.isRequired,
+  question: PropTypes.string.isRequired,
+  optionsKey: PropTypes.string.isRequired,
+  values: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+const OpenQuestion = ({ name, label, value, onChange }) => (
+  <div className="cv-form__question">
+    <label className="cv-form__question-label" htmlFor={`cv-form-${name}`}>{label}</label>
+    <textarea
+      id={`cv-form-${name}`}
+      className="cv-form__textarea"
+      rows={3}
+      value={value}
+      onChange={event => onChange(event.target.value)}
+    />
+  </div>
+);
+
+OpenQuestion.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+/*
+  The verification form itself — the whole exercise now happens here in the
+  dashboard, not in a sandbox. Step 3 (find the source) is always asked; its
+  tell-us-more field appears only when the student couldn't get the source.
+  Step 4 (verify the claim) appears only when they could: its two open
+  questions are self-selecting by their own phrasing ("If you were able…",
+  "If you were unable…"), so both are always visible within the step. The
+  final catch-all comments field applies on every path. Submitting upserts,
+  so the same form serves both first submission and later edits (`initial`).
+*/
+const VerificationForm = ({ courseSlug, initial, onSaved, onCancel }) => {
+  const [sourceAccess, setSourceAccess] = useState(initial?.source_access || null);
+  const [sourceAccessNotes, setSourceAccessNotes] = useState(initial?.source_access_notes || '');
+  const [verdict, setVerdict] = useState(initial?.verdict || null);
+  const [claimLocation, setClaimLocation] = useState(initial?.claim_location || '');
+  const [verificationNotes, setVerificationNotes] = useState(initial?.verification_notes || '');
+  const [otherComments, setOtherComments] = useState(initial?.other_comments || '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(false);
+
+  const sourceAccessed = sourceAccess === 'accessed';
+  // The multiple-choice answers are the only required ones; the server clears
+  // answers for steps that don't apply, so stale hidden fields are harmless.
+  const submittable = sourceAccess && (!sourceAccessed || verdict) && !saving;
+
+  const submit = (event) => {
+    event.preventDefault();
+    setSaving(true);
+    setError(false);
+    new ClaimVerificationAPI({ courseSlug }).submitResponse({
+      source_access: sourceAccess,
+      source_access_notes: sourceAccessNotes,
+      verdict,
+      claim_location: claimLocation,
+      verification_notes: verificationNotes,
+      other_comments: otherComments,
+    }).then(({ response }) => {
+      onSaved(response);
+    }).catch(() => {
+      setError(true);
+      setSaving(false);
+    });
+  };
+
+  return (
+    <form className="cv-form" onSubmit={submit}>
+      <section className="cv-form__step">
+        <h2 className="cv-form__step-heading">{I18n.t('claim_verification.form.step_find_source')}</h2>
+        <p className="cv-form__step-instructions">{I18n.t('claim_verification.form.find_source_instructions')}</p>
+        <RadioQuestion
+          name="source_access"
+          question={I18n.t('claim_verification.form.source_access_question')}
+          optionsKey="source_access_options"
+          values={SOURCE_ACCESS_VALUES}
+          value={sourceAccess}
+          onChange={setSourceAccess}
+        />
+        {sourceAccess && !sourceAccessed && (
+          <OpenQuestion
+            name="source_access_notes"
+            label={I18n.t('claim_verification.form.source_access_notes_label')}
+            value={sourceAccessNotes}
+            onChange={setSourceAccessNotes}
+          />
+        )}
+      </section>
+
+      {sourceAccessed && (
+        <section className="cv-form__step">
+          <h2 className="cv-form__step-heading">{I18n.t('claim_verification.form.step_verify')}</h2>
+          <p className="cv-form__step-instructions">{I18n.t('claim_verification.form.verify_instructions')}</p>
+          <RadioQuestion
+            name="verdict"
+            question={I18n.t('claim_verification.form.verdict_question')}
+            optionsKey="verdict_options"
+            values={VERDICT_VALUES}
+            value={verdict}
+            onChange={setVerdict}
+          />
+          <OpenQuestion
+            name="claim_location"
+            label={I18n.t('claim_verification.form.claim_location_label')}
+            value={claimLocation}
+            onChange={setClaimLocation}
+          />
+          <OpenQuestion
+            name="verification_notes"
+            label={I18n.t('claim_verification.form.verification_notes_label')}
+            value={verificationNotes}
+            onChange={setVerificationNotes}
+          />
+        </section>
+      )}
+
+      <section className="cv-form__step">
+        <OpenQuestion
+          name="other_comments"
+          label={I18n.t('claim_verification.form.other_comments_label')}
+          value={otherComments}
+          onChange={setOtherComments}
+        />
+      </section>
+
+      {error && <p className="cv-form__error" role="alert">{I18n.t('claim_verification.form.submit_failed')}</p>}
+
+      <div className="cv-form__actions">
+        <button type="submit" className="button dark" disabled={!submittable}>
+          {I18n.t('claim_verification.form.submit')}
+        </button>
+        {onCancel && (
+          <button type="button" className="button" onClick={onCancel}>
+            {I18n.t('application.cancel')}
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};
+
+VerificationForm.propTypes = {
+  courseSlug: PropTypes.string.isRequired,
+  // The already-submitted response when editing; null on first submission.
+  initial: PropTypes.object,
+  onSaved: PropTypes.func.isRequired,
+  // Present only when editing an existing response (returns to the summary).
+  onCancel: PropTypes.func,
+};
+
+export default VerificationForm;

--- a/app/assets/javascripts/components/common/ArticleViewer/claim_verification/ClaimVerificationAPI.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/claim_verification/ClaimVerificationAPI.js
@@ -36,6 +36,20 @@ export class ClaimVerificationAPI {
       .then(response => this.__json(response, 'Take claim request failed'));
   }
 
+  // The student's verification form answers (an upsert; submitting completes
+  // the exercise).
+  submitResponse(answers) {
+    return request(`${this.basePath()}/response`, { method: 'POST', body: JSON.stringify(answers) })
+      .then(response => this.__json(response, 'Submit response request failed'));
+  }
+
+  // Everyone's responses, for the instructor view. The explicit .json matters:
+  // the bare path is the instructor view's own SPA page.
+  fetchResponses() {
+    return request(`${this.basePath()}/responses.json`)
+      .then(response => this.__json(response, 'Responses request failed'));
+  }
+
   __json(response, message) {
     if (!response.ok) {
       // Carry the HTTP status so callers can tailor the message (eg a 403 from

--- a/app/assets/javascripts/components/common/ArticleViewer/claim_verification/ClaimVerificationAPI.spec.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/claim_verification/ClaimVerificationAPI.spec.js
@@ -57,4 +57,29 @@ describe('ClaimVerificationAPI', () => {
         .rejects.toMatchObject({ status: 403 });
     });
   });
+
+  describe('.submitResponse()', () => {
+    it('POSTs the form answers and resolves the saved response', async () => {
+      const answers = { source_access: 'accessed', verdict: 'full_support' };
+      const payload = { response: { ...answers } };
+      global.fetch = jest.fn(okResponse(payload));
+      const result = await api.submitResponse(answers);
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain('/courses/School/Claims_2024/verify_claim/response');
+      expect(options.method).toEqual('POST');
+      expect(JSON.parse(options.body)).toEqual(answers);
+      expect(result).toEqual(payload);
+    });
+  });
+
+  describe('.fetchResponses()', () => {
+    it('GETs the responses endpoint and resolves its JSON', async () => {
+      const payload = { responses: [], pending: [] };
+      global.fetch = jest.fn(okResponse(payload));
+      const result = await api.fetchResponses();
+      expect(global.fetch.mock.calls[0][0])
+        .toContain('/courses/School/Claims_2024/verify_claim/responses');
+      expect(result).toEqual(payload);
+    });
+  });
 });

--- a/app/assets/javascripts/components/common/ArticleViewer/hooks/useClaimHighlighting.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/hooks/useClaimHighlighting.js
@@ -25,7 +25,8 @@ import formatRevisionDate from '~/app/assets/javascripts/utils/format_revision_d
   with the shell's parse rather than after it.
 
   Taking a claim is an async POST; on success the hook calls `onTaken` with the
-  resulting assignment so the exercise can transition to the taken-claim view
+  result — the assignment, plus the student's earlier response for that claim
+  if they had one — so the exercise can transition to the taken-claim view
   without a reload.
 
   Claims belong to the flagged revision the article opens at (the shell's
@@ -167,7 +168,7 @@ const useClaimHighlighting = ({ article, course, revisionId, isOpen, onTaken }) 
       .take({ articleId: article.id, verificationClaimId: selectedClaim.claimId })
       .then((data) => {
         setTaking(false);
-        onTaken(data.assignment);
+        onTaken(data);
       })
       .catch((error) => {
         setTaking(false);
@@ -195,6 +196,7 @@ const useClaimHighlighting = ({ article, course, revisionId, isOpen, onTaken }) 
             })}
           </p>
         )}
+        <p className="cv-select-claim-note">{I18n.t('claim_verification.select_claim_instructions')}</p>
         <p>{I18n.t('claim_verification.pick_instructions')}</p>
       </div>
     )

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/StudentDrawer.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/StudentDrawer.jsx
@@ -28,7 +28,7 @@ export const StudentDrawer = ({
                 student={student}
                 wikidataLabels={wikidataLabels}
               />
-            ) : <TrainingStatus trainingModules={trainingModules} />
+            ) : <TrainingStatus trainingModules={trainingModules} student={student} />
         }
       </td>
     </tr>

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/ExerciseRows.jsx
@@ -1,38 +1,63 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { capitalize } from 'lodash-es';
 
 // Helper Functions
 import { getExerciseStatus, isTrainingDue, orderByDueDate } from '@components/students/utils/trainingHelperFunctions';
+import { getCurrentUser } from '~/app/assets/javascripts/selectors';
 import { toDate } from '../../../../../../utils/date_utils';
 import { format } from 'date-fns';
 
 // Helper Components
-const ExerciseStatusCell = ({ status, sandboxUrl }) => {
+import ResponsePopover from '@components/claim_verification_exercise/ResponsePopover.jsx';
+
+const ExerciseStatusCell = ({ status, sandboxUrl, responsePopover }) => {
   let exerciseLink;
   if (sandboxUrl && status === 'complete') {
     exerciseLink = <> &nbsp; &nbsp; <a className="assignment-links" target="_blank" href={sandboxUrl}>Exercise Sandbox</a></>;
   }
 
-  return <td className={`exercise-status ${status}`}>{capitalize(status)} {exerciseLink}</td>;
+  return (
+    <td className={`exercise-status ${status}`}>
+      {capitalize(status)} {exerciseLink}
+      {responsePopover && <> &nbsp; &nbsp; {responsePopover}</>}
+    </td>
+  );
 };
 
-const generateRow = () => (exercise) => {
+const generateRow = popoverFor => (exercise) => {
   const dueDate = format(toDate(exercise.due_date), 'MMM do, yyyy');
   const exerciseStatus = getExerciseStatus(exercise);
   return (
     <tr className={exercise.due_date && isTrainingDue(exercise.due_date) ? 'student-training-module due-training' : 'student-training-module'} key={exercise.id}>
       <td>{exercise.name} <small>Due by {dueDate}</small></td>
-      <ExerciseStatusCell status={exerciseStatus} sandboxUrl={exercise.sandbox_url}/>
+      <ExerciseStatusCell
+        status={exerciseStatus}
+        sandboxUrl={exercise.sandbox_url}
+        responsePopover={popoverFor(exercise, exerciseStatus)}
+      />
     </tr>
   );
 };
 
-export const ExerciseRows = ({ exercises }) => {
+export const ExerciseRows = ({ exercises, student }) => {
+  const currentUser = useSelector(getCurrentUser);
+  const isStaff = Boolean(currentUser?.isAdvancedRole);
+  const isSelf = student?.id != null && currentUser?.id === student.id;
+
+  // The in-app-exercise counterpart of the sandbox link: a popover with the
+  // student's submitted answers, shown in place. Staff can see any student's;
+  // a student can see their own (the endpoint scopes to the viewer).
+  const popoverFor = (exercise, status) => {
+    if (!(isStaff || isSelf) || !exercise.exercise_url || status !== 'complete') { return null; }
+    return <ResponsePopover student={student} />;
+  };
+
   const { unread, incomplete, complete } = exercises;
   const allExercises = [...unread, ...incomplete, ...complete];
   return [
-    allExercises.sort(orderByDueDate).map(generateRow()),
+    allExercises.sort(orderByDueDate).map(generateRow(popoverFor)),
   ];
 };
 
@@ -46,7 +71,9 @@ ExerciseRows.propTypes = {
     unread: PropTypes.arrayOf(exerciseShape),
     incomplete: PropTypes.arrayOf(exerciseShape),
     complete: PropTypes.arrayOf(exerciseShape)
-  }).isRequired
+  }).isRequired,
+  // The student whose drawer this is.
+  student: PropTypes.object
 };
 
 export default ExerciseRows;

--- a/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx
+++ b/app/assets/javascripts/components/students/shared/StudentList/StudentDrawer/TrainingStatus/TrainingStatus.jsx
@@ -10,7 +10,7 @@ import {
 } from '~/app/assets/javascripts/constants';
 import { useSelector } from 'react-redux';
 
-const TrainingStatus = ({ trainingModules }) => {
+const TrainingStatus = ({ trainingModules, student }) => {
   const exercises = useSelector(state => state.exercises);
   if (!trainingModules.length) return <div />;
 
@@ -23,7 +23,7 @@ const TrainingStatus = ({ trainingModules }) => {
         </tr>
       </thead>
       <tbody>
-        <ExerciseRows exercises={exercises} />
+        <ExerciseRows exercises={exercises} student={student} />
       </tbody>
     </table>
   );
@@ -53,7 +53,10 @@ const TrainingStatus = ({ trainingModules }) => {
 };
 
 TrainingStatus.propTypes = {
-  trainingModules: PropTypes.array
+  trainingModules: PropTypes.array,
+  // The student whose drawer this is; used for per-student links into the
+  // in-app exercise submissions view.
+  student: PropTypes.object
 };
 
 export default TrainingStatus;

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ExerciseButton.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ExerciseButton.jsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-export const ExerciseButton = ({ module }) => {
+export const ExerciseButton = ({ module, isStaff }) => {
   // An in-app exercise (eg fact verification) is a nested route of the course
-  // SPA, so link to it with React Router to keep the student in-app (no reload).
+  // SPA, so link to it with React Router to keep the student in-app (no
+  // reload). Instructional staff also get the link to everyone's submissions.
   if (module.exercise_url) {
     return (
       <td className="block__training-modules-table__module-exercise-button">
         <Link className="button" to={module.exercise_url}>
           {I18n.t('training.open_exercise')}
         </Link>
+        {isStaff && (
+          <Link
+            className="block__training-modules-table__responses-link"
+            to={`${module.exercise_url}/responses`}
+          >
+            {I18n.t('claim_verification.responses.heading')}
+          </Link>
+        )}
       </td>
     );
   }

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleRow.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleRow.jsx
@@ -19,7 +19,7 @@ const calcProgressClass = (progress) => {
   return `${linkStart}in-progress `;
 };
 
-export const ModuleRow = ({ isStudent, module, trainingLibrarySlug }) => {
+export const ModuleRow = ({ isStudent, isStaff, module, trainingLibrarySlug }) => {
   const isTrainingModule = module.kind === TRAINING_MODULE_KIND;
   const isExercise = module.kind === EXERCISE_KIND;
   const isDiscussion = module.kind === DISCUSSION_KIND;
@@ -50,23 +50,31 @@ export const ModuleRow = ({ isStudent, module, trainingLibrarySlug }) => {
   if (module.deadline_status === 'complete') progressClass += ' complete';
 
   const link = `/training/${trainingLibrarySlug}/${module.slug}`;
+  // A slide-less module (an in-app exercise) has no training page: the
+  // exercise button is the whole interaction, so no view/start link.
+  const hasTrainingPage = module.slide_count !== 0;
   return (
     <tr className="training-module">
       <ModuleName {...module} isExercise={isExercise} />
-      { isExercise ? <ExerciseButton module={module} /> : null }
+      { isExercise ? <ExerciseButton module={module} isStaff={isStaff} /> : null }
       { isStudent ? <ModuleStatus {...module} progressClass={progressClass} /> : null }
-      <ModuleLink
-        iconClassName={iconClassName}
-        link={link}
-        linkText={linkText}
-        module_progress={module.module_progress}
-      />
+      { hasTrainingPage ? (
+        <ModuleLink
+          iconClassName={iconClassName}
+          link={link}
+          linkText={linkText}
+          module_progress={module.module_progress}
+        />
+      ) : <td className="block__training-modules-table__module-link" /> }
     </tr>
   );
 };
 
 ModuleRow.propTypes = {
   isStudent: PropTypes.bool,
+  // Instructor/staff/admin viewer: shows the student-submissions link on
+  // in-app exercises.
+  isStaff: PropTypes.bool,
   module: PropTypes.object.isRequired,
   trainingLibrarySlug: PropTypes.string.isRequired
 };

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ExerciseButton.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ExerciseButton.jsx
@@ -2,9 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const ExerciseButton = ({
-  block_id, course, flags, isComplete, isExercise, slug,
+  block_id, course, exercise_url, flags, isComplete, isExercise, slug,
   complete, fetchExercises, incomplete
 }) => {
+  // An in-app exercise completes itself when the student submits it, so there
+  // is nothing to mark manually: show the status instead of the buttons.
+  if (exercise_url) {
+    return flags?.marked_complete ? <div>Status: Complete!</div> : <span>--</span>;
+  }
+
   let button = (
     <button className="button small left dark" disabled>
       Mark Complete
@@ -40,6 +46,7 @@ ExerciseButton.propTypes = {
   course: PropTypes.shape({
     id: PropTypes.number.isRequired
   }).isRequired,
+  exercise_url: PropTypes.string,
   flags: PropTypes.shape({
     marked_complete: PropTypes.bool
   }),

--- a/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ModuleStatus.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/ModuleRow/ModuleStatus/ModuleStatus.jsx
@@ -17,8 +17,8 @@ import {
 } from '~/app/assets/javascripts/actions/exercises_actions';
 
 export const ModuleStatus = ({
-  block_id, course, deadline_status, due_date, flags, kind, module_progress, progressClass, slug,
-  complete, fetchExercises, incomplete
+  block_id, course, deadline_status, due_date, exercise_url, flags, kind, module_progress,
+  progressClass, slug, complete, fetchExercises, incomplete
 }) => {
   const isTrainingModule = kind === TRAINING_MODULE_KIND;
   const isExercise = kind === EXERCISE_KIND;
@@ -31,6 +31,7 @@ export const ModuleStatus = ({
       <ExerciseButton
         block_id={block_id}
         course={course}
+        exercise_url={exercise_url}
         flags={flags}
         isComplete={isComplete}
         isExercise={isExercise}
@@ -59,6 +60,7 @@ ModuleStatus.propTypes = {
   }).isRequired,
   deadline_status: PropTypes.string,
   due_date: PropTypes.string.isRequired,
+  exercise_url: PropTypes.string,
   flags: PropTypes.object,
   kind: PropTypes.oneOf([
     DISCUSSION_KIND, EXERCISE_KIND, TRAINING_MODULE_KIND

--- a/app/assets/javascripts/components/timeline/TrainingModules/TrainingModules.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/TrainingModules.jsx
@@ -18,6 +18,7 @@ const TrainingModules = createReactClass({
     editable: PropTypes.bool,
     header: PropTypes.any,
     isStudent: PropTypes.bool,
+    isStaff: PropTypes.bool,
     onChange: PropTypes.func,
     trainingLibrarySlug: PropTypes.string.isRequired,
   },
@@ -88,6 +89,7 @@ const TrainingModules = createReactClass({
       <ModuleRow
         key={module.id}
         isStudent={this.props.isStudent}
+        isStaff={this.props.isStaff}
         module={module}
         trainingLibrarySlug={this.props.trainingLibrarySlug}
       />

--- a/app/assets/javascripts/components/timeline/TrainingModules/TrainingModulesViewMode.jsx
+++ b/app/assets/javascripts/components/timeline/TrainingModules/TrainingModulesViewMode.jsx
@@ -43,6 +43,7 @@ const TrainingModulesViewMode = (props) => {
         key="assignment-modules"
         trainingLibrarySlug={props.trainingLibrarySlug}
         isStudent={props.isStudent}
+        isStaff={props.isStaff}
       />);
     }
 
@@ -68,6 +69,9 @@ TrainingModulesViewMode.propTypes = {
     all_training_modules: PropTypes.array,
     trainingLibrarySlug: PropTypes.string.isRequired,
     editable: PropTypes.bool,
-    isStudent: PropTypes.bool
+    isStudent: PropTypes.bool,
+    // Instructor/staff/admin viewer: shows the student-submissions link on
+    // in-app exercises.
+    isStaff: PropTypes.bool
   };
 export default TrainingModulesViewMode;

--- a/app/assets/javascripts/components/timeline/block.jsx
+++ b/app/assets/javascripts/components/timeline/block.jsx
@@ -51,6 +51,7 @@ const updateBlock = (valueKey, value) => {
     const block = props.block;
     const isEditable = _isEditable();
     const isStudent = props.current_user && props.current_user.isStudent;
+    const isStaff = Boolean(props.current_user && props.current_user.isAdvancedRole);
     if (_hidden()) { return null; }
 
     let className = 'block';
@@ -134,6 +135,7 @@ const updateBlock = (valueKey, value) => {
           block={block}
           editable={isEditable}
           isStudent={isStudent}
+          isStaff={isStaff}
           trainingLibrarySlug={props.trainingLibrarySlug}
         />);
       }

--- a/app/assets/stylesheets/modules/claim_verification.styl
+++ b/app/assets/stylesheets/modules/claim_verification.styl
@@ -1,6 +1,7 @@
 // Student claim-verification exercise (/verify_claim). Two focal elements: the
-// claim, and the source it cites. Intro, context and the sandbox handoff are
-// kept visually subordinate so attention lands on the claim and the source.
+// claim, and the source it cites; the verification form follows as the work
+// area. Intro and context are kept visually subordinate so attention lands on
+// the claim and the source.
 // Variables come from _variables.styl (globally in scope via _shared).
 
 .claim-verification-exercise
@@ -77,14 +78,13 @@
     color $text_med
     font-style italic
 
-  // Handoff to the sandbox, set off below a divider as the follow-on step.
-  &__sandbox
-    margin-top 28px
-    padding-top 24px
-    border-top 1px solid $border_lt
-    p
-      color $text_med
-      margin-bottom 16px
+  // The submitted-answers section (post-submission resting view).
+  &__response
+    border 1px solid $border_lt
+    border-radius 4px
+    padding 28px 32px
+    margin-bottom 20px
+    background white
 
   // Small link from the claim into the source article (at the cited footnote).
   &__article-link
@@ -177,6 +177,204 @@
       margin-bottom 12px
       font-size 1.1em
 
+// Staff-only link to the submissions view, tucked under the timeline module
+// row's "Open Exercise" button.
+.block__training-modules-table__responses-link
+  display block
+  margin-top 6px
+  font-size .9em
+
+// "Submitted response" popover on the students-tab exercise rows: the claim
+// and the form answers, shown in place of navigating anywhere.
+.cv-response-pop
+  .pop
+    max-height 420px
+    overflow-y auto
+    text-align left
+    // The base .pop styles assume a compact edit-form popover and force
+    // nowrap on cells; this popover is prose, so wrap it and keep the table
+    // at its set width (long unbroken tokens break rather than overflow).
+    table
+      table-layout fixed
+      max-width 76vw
+    td
+      padding 16px 18px
+      white-space normal
+      overflow-wrap break-word
+
+  &__item blockquote
+    margin 0 0 12px 0
+    padding 0 0 0 12px
+    border-left 3px solid $brand_primary
+    font-family $header-font
+    color $text_dk
+
+  &__item + &__item
+    margin-top 18px
+    padding-top 18px
+    border-top 1px solid $border_lt
+
+// The verification form (steps 3 and 4 of the exercise): each step is a card
+// in the same family as the claim/source cards above, with the questions
+// inside kept quiet so the operator-provided wording carries the structure.
+.cv-form
+  &__step
+    border 1px solid $border_lt
+    border-radius 4px
+    padding 28px 32px
+    margin-bottom 20px
+    background white
+
+  &__step-heading
+    font-size 1.15em
+    margin 0 0 10px 0
+
+  &__step-instructions
+    color $text_med
+    max-width 40em
+    margin-bottom 20px
+
+  &__question
+    border 0
+    padding 0
+    margin 0 0 22px 0
+    &:last-child
+      margin-bottom 0
+
+  &__question-label
+    display block
+    font-weight 600
+    color $text_dk
+    margin-bottom 10px
+    max-width 44em
+    line-height 1.45
+
+  &__option
+    display flex
+    align-items baseline
+    gap 8px
+    margin-bottom 8px
+    cursor pointer
+    max-width 44em
+    line-height 1.45
+    input
+      flex none
+      cursor pointer
+
+  &__textarea
+    display block
+    width 100%
+    max-width 44em
+    padding 8px 10px
+    border 1px solid $border_lt
+    border-radius 4px
+    font inherit
+    line-height 1.5
+    &:focus-visible
+      outline 2px solid $brand_primary
+      outline-offset 1px
+
+  &__error
+    color $warning_text
+    margin-bottom 14px
+
+  &__actions
+    display flex
+    gap 10px
+
+// A submitted response as question/answer pairs — the student's own summary
+// and the instructor cards share this.
+.cv-response
+  &__answers
+    margin 0 0 18px 0
+
+  &__answer
+    margin-bottom 16px
+    &:last-child
+      margin-bottom 0
+    dt
+      font-weight 600
+      color $text_med
+      font-size .92em
+      max-width 44em
+      line-height 1.45
+      margin-bottom 4px
+    dd
+      margin 0
+      color $text_dk
+      line-height 1.5
+      max-width 44em
+
+// Instructor view (/verify_claim/responses): heading row with the
+// open-the-exercise action, then one card per response (and per pending
+// student).
+.claim-verification-responses__header
+  display flex
+  align-items baseline
+  justify-content space-between
+  gap 12px
+  flex-wrap wrap
+
+// Return bar on the single-student-filtered submissions view: the way back to
+// the full list. The content below brings its own top margin.
+.cv-preview-return
+  margin-top 24px
+  font-size .95em
+  a
+    display inline-block
+
+.cv-response-card
+  border 1px solid $border_lt
+  border-radius 4px
+  padding 24px 28px
+  margin-bottom 20px
+  background white
+
+  &__header
+    display flex
+    align-items baseline
+    justify-content space-between
+    gap 12px
+    flex-wrap wrap
+    margin-bottom 14px
+    // The card header is a <header> element, which the site-wide layout rule
+    // gives 20px padding and centering; neutralize that here.
+    padding 0
+    text-align left
+    h2, h3
+      font-size 1.15em
+      margin 0
+
+  &__date
+    color $text_med
+    font-size .88em
+
+  &__claim
+    margin-bottom 18px
+    blockquote
+      margin 0 0 8px 0
+      padding 0 0 0 14px
+      border-left 3px solid $brand_primary
+      font-family $header-font
+      font-size 1.05em
+      line-height 1.45
+      color $text_dk
+
+  &__claim-links
+    margin 0
+    font-size .9em
+    a
+      margin-right 16px
+
+  &--pending
+    background $bg_light_gray
+
+.cv-response-pending
+  margin-top 34px
+  h2
+    font-size 1.2em
+    margin-bottom 14px
+
 // In-viewer claim selection (the ArticleViewer claim-highlighting variant).
 // The annotated article HTML tags each cited claim's citation marker `.cv-claim`;
 // clicking one opens the selection panel that floats over the article.
@@ -268,6 +466,14 @@
   .cv-revision-notice
     margin-bottom 6px
     font-size .82em
+    font-weight 400
+    color $text_dk
+
+  // The step-2 explanation (why these claims need checking): supporting copy
+  // above the bold click instruction.
+  .cv-select-claim-note
+    margin-bottom 6px
+    font-size .88em
     font-weight 400
     color $text_dk
 

--- a/app/controllers/claim_verification_exercises_controller.rb
+++ b/app/controllers/claim_verification_exercises_controller.rb
@@ -5,22 +5,30 @@
 # through to `courses#show` and React Router renders the exercise (article
 # picker → in-viewer claim selection → taken claim) with no reloads. This
 # controller serves only that flow's JSON and the slug-less entry funnel:
-# - GET state: the student's taken claim (if any) + the (article, flagged
-#   revision) tiles they can pick, drawn from the pre-harvested claim pool.
+# - GET state: the student's taken claim + submitted response (if any) + the
+#   (article, flagged revision) tiles they can pick, drawn from the
+#   pre-harvested claim pool.
 # - GET annotated_article: the flagged revision's HTML with its pre-harvested
 #   claims tagged.
 # - POST take: assign the chosen (already-persisted) pool claim, return it.
 # - GET entry (slug-less): infer the course and send the student into its SPA
 #   exercise, else show a course picker.
 # Claims are harvested ahead of time (rake claim_verification:harvest_pool) from
-# mainspace AiEditAlert revisions; the student does the verification in their
-# sandbox, so nothing they produce is stored.
+# mainspace AiEditAlert revisions; the student then does the verification in
+# the dashboard, submitting the form handled by
+# ClaimVerificationResponsesController.
 class ClaimVerificationExercisesController < ApplicationController
   before_action :require_signed_in
 
   def state
     @course = course_from_slug
     @assignment = VerificationClaimAssignment.find_by(user: current_user, course: @course)
+    # The response for the *current* claim (responses are keyed per claim);
+    # after switching claims, the fresh claim has no response yet.
+    @response = @assignment && VerificationClaimResponse.find_by(
+      user: current_user, course: @course,
+      verification_claim: @assignment.verification_claim
+    )
     @tiles = RelevantClaimRevisionsForCourse.new(@course).tiles
     # renders state.json.jbuilder
   end
@@ -43,6 +51,11 @@ class ClaimVerificationExercisesController < ApplicationController
     return head(:forbidden) unless enrolled_in_course?
     claim = VerificationClaim.find_by(id: params[:verification_claim_id])
     assign(claim) if claim
+    # An earlier response for this same claim, if any (responses are keyed per
+    # claim, so switching claims never orphans one) — re-taking a claim brings
+    # the student back to their submitted answers.
+    @response = claim && VerificationClaimResponse.find_by(user: current_user, course: @course,
+                                                           verification_claim: claim)
     # renders take.json.jbuilder (@assignment is nil if the claim was not found),
     # so the SPA can transition. Claims are shareable: no exclusivity is enforced.
   end

--- a/app/controllers/claim_verification_responses_controller.rb
+++ b/app/controllers/claim_verification_responses_controller.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# Student responses for the claim-verification exercise, which is done
+# entirely in the dashboard: the student answers the form on their taken
+# claim (`create`, an upsert — they may revise their answers), and `index`
+# serves the submissions back — everyone's for the course's instructional
+# staff, their own for an enrolled student.
+class ClaimVerificationResponsesController < ApplicationController
+  respond_to :json
+  before_action :require_signed_in
+  before_action :set_course
+
+  # Upsert the current user's response. Requires a taken claim — the form only
+  # exists on the taken-claim view — and course enrollment. Submission marks
+  # the exercise's training module complete for this course.
+  def create
+    return head(:forbidden) unless enrolled_in_course?
+    assignment = VerificationClaimAssignment.find_by(user: current_user, course: @course)
+    return head(:unprocessable_entity) if assignment.nil?
+    @response = RecordVerificationClaimResponse.new(assignment:, answers: answer_params).response
+    return render_validation_errors unless @response.errors.empty?
+    # renders create.json.jbuilder
+  end
+
+  # Submitted responses plus taken-but-unsubmitted claims, scoped to the
+  # viewer: the course's instructional staff read everyone's, while an
+  # enrolled student reads only their own.
+  def index
+    scope = viewer_scope
+    return head(:forbidden) if scope.nil?
+    @responses = VerificationClaimResponse.where(course: @course, **scope)
+                                          .includes(:user, verification_claim: :wiki)
+                                          .order(:created_at)
+    @pending = pending_assignments(scope)
+    # renders index.json.jbuilder
+  end
+
+  private
+
+  def answer_params
+    params.permit(:source_access, :source_access_notes, :verdict, :claim_location,
+                  :verification_notes, :other_comments)
+  end
+
+  def render_validation_errors
+    render json: { errors: @response.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  # Who may read what: staff read everyone's responses ({}), an enrolled
+  # student reads only their own, and anyone else is refused (nil).
+  def viewer_scope
+    return {} if can_view_responses?
+    return { user: current_user } if enrolled_in_course?
+    nil
+  end
+
+  # Current claims with no submitted form yet. Responses are keyed per claim,
+  # so a student who submitted for an earlier claim and then took a new one
+  # counts as pending again for the new claim.
+  def pending_assignments(scope)
+    responded = @responses.map { |r| [r.user_id, r.verification_claim_id] }.to_set
+    VerificationClaimAssignment.where(course: @course, **scope)
+                               .includes(:user, verification_claim: :wiki)
+                               .reject do |assignment|
+      responded.include?([assignment.user_id, assignment.verification_claim_id])
+    end
+  end
+
+  def enrolled_in_course?
+    current_user.courses.exists?(@course.id)
+  end
+
+  # Any non-student course role (or admin) may read the responses; students
+  # may not see each other's answers.
+  NONSTUDENT_ROLES = [
+    CoursesUsers::Roles::INSTRUCTOR_ROLE,
+    CoursesUsers::Roles::CAMPUS_VOLUNTEER_ROLE,
+    CoursesUsers::Roles::ONLINE_VOLUNTEER_ROLE,
+    CoursesUsers::Roles::WIKI_ED_STAFF_ROLE
+  ].freeze
+
+  def can_view_responses?
+    current_user.admin? ||
+      current_user.courses_users.exists?(course: @course, role: NONSTUDENT_ROLES)
+  end
+
+  def set_course
+    @course = Course.find_by(slug: params[:id])
+    raise ActionController::RoutingError, 'Course not found' if @course.nil?
+  end
+end

--- a/app/helpers/claim_verification_helper.rb
+++ b/app/helpers/claim_verification_helper.rb
@@ -3,11 +3,6 @@
 # View helpers for the student claim-verification exercise (issue #6910).
 module ClaimVerificationHelper
   include MediawikiUrlHelper
-  # On-wiki worksheet template the sandbox is preloaded with. This page must be
-  # created on-wiki by an operator, like Template:Dashboard.wikiedu.org_draft_template.
-  CLAIM_VERIFICATION_PRELOAD_TEMPLATE = 'Template:Dashboard.wikiedu.org_claim_verification'
-  # Subpage, under the student's user page, where they do the exercise.
-  SANDBOX_SUBPAGE = 'Claim_verification_exercise'
 
   # URL the student opens to read the cited source: the live source if present,
   # otherwise the archived copy. Nil for offline-only citations.
@@ -24,16 +19,5 @@ module ClaimVerificationHelper
     return if claim.article_title.blank? || claim.wiki.nil?
     url = "#{claim.wiki.base_url}/wiki/#{url_encoded_mediawiki_title(claim.article_title)}"
     claim.ref_id.present? ? "#{url}##{claim.ref_id}" : url
-  end
-
-  # Link to the student's sandbox subpage, opened in the editor preloaded with
-  # the worksheet template. NOTE: injecting the specific claim/source into the
-  # template (via preloadparams, and whether that needs action=edit rather than
-  # veaction=edit) is still undecided — see issue #6910. For now the link only
-  # preloads the template.
-  def claim_verification_sandbox_url(course, user)
-    title = "User:#{user.url_encoded_username}/#{SANDBOX_SUBPAGE}"
-    "#{course.home_wiki.base_url}/wiki/#{title}" \
-      "?veaction=edit&preload=#{CLAIM_VERIFICATION_PRELOAD_TEMPLATE}"
   end
 end

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -114,7 +114,8 @@ class TrainingModule < ApplicationRecord
     self.estimated_ttc = content['estimated_ttc']
     self.translations = TrainingBase.format_translation_keys content['translations']
     self.settings = content['settings']
-    self.slide_slugs = content['slides'].pluck('slug')
+    # An in-app exercise module (see exercise_path) may have no slides at all.
+    self.slide_slugs = (content['slides'] || []).pluck('slug')
   end
 
   ####################

--- a/app/models/verification_claim_assignment.rb
+++ b/app/models/verification_claim_assignment.rb
@@ -12,10 +12,11 @@
 #  updated_at            :datetime         not null
 #
 
-# Records that a student in a course has been assigned one pooled
-# VerificationClaim to verify against its source. This is assignment only:
-# the student does the verification in their Wikipedia sandbox, and nothing
-# they produce is stored here. One assignment per student per course.
+# Records the pooled VerificationClaim a student in a course is currently
+# working on. This is assignment only: the verification work itself is
+# submitted as a VerificationClaimResponse (keyed per claim). The assignment
+# is a re-pointable "current claim" cursor — one row per student per course —
+# so it puts no limit on how many claims a student responds to over time.
 class VerificationClaimAssignment < ApplicationRecord
   belongs_to :user
   belongs_to :course

--- a/app/models/verification_claim_response.rb
+++ b/app/models/verification_claim_response.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: verification_claim_responses
+#
+#  id                    :bigint           not null, primary key
+#  user_id               :integer          not null
+#  course_id             :integer          not null
+#  verification_claim_id :integer          not null
+#  source_access         :string(255)      not null
+#  source_access_notes   :text(65535)
+#  verdict               :string(255)
+#  claim_location        :text(65535)
+#  verification_notes    :text(65535)
+#  other_comments        :text(65535)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
+
+# A student's submitted answers for the claim-verification exercise: whether
+# they could access the cited source, how well it backs up their taken claim,
+# and their free-response notes. Done entirely in the dashboard (the exercise
+# no longer hands off to a sandbox). Keyed per claim — one response per claim
+# a student takes on, resubmittable — deliberately NOT one per student per
+# course, so the exercise can grow to verifying multiple claims.
+class VerificationClaimResponse < ApplicationRecord
+  belongs_to :user
+  belongs_to :course
+  belongs_to :verification_claim
+
+  # "Were you able to access the full text of the cited source for your claim?"
+  SOURCE_ACCESS_VALUES = %w[
+    accessed
+    nonexistent
+    inaccessible
+  ].freeze
+
+  # "Does the source back up the claim?" — asked only when the source was accessed.
+  VERDICT_VALUES = %w[
+    full_support
+    mostly_supports
+    partial_support
+    mostly_unsupported
+    unsupported
+    contradicted
+    undetermined
+  ].freeze
+
+  validates :user_id, uniqueness: { scope: %i[course_id verification_claim_id] }
+  validates :source_access, inclusion: { in: SOURCE_ACCESS_VALUES }
+  # The verdict (and the rest of the verify-the-claim step) only makes sense
+  # when the student had the source in hand.
+  validates :verdict, inclusion: { in: VERDICT_VALUES }, if: :source_accessed?
+  validates :verdict, absence: true, unless: :source_accessed?
+
+  def source_accessed?
+    source_access == 'accessed'
+  end
+end

--- a/app/services/record_verification_claim_response.rb
+++ b/app/services/record_verification_claim_response.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Records (or updates) a student's claim-verification exercise response for
+# their taken claim, then marks the exercise's training module complete for
+# the course. The module has no slides — the in-dashboard form *is* the whole
+# exercise — so submission is the completion event: it sets both the module's
+# `completed_at` and the per-course `marked_complete` flag that course views
+# read.
+#
+# Answers for steps that don't apply are cleared rather than trusted from the
+# client: the verify-the-claim step only exists when the source was accessed,
+# and the couldn't-find-the-source notes only when it wasn't.
+class RecordVerificationClaimResponse
+  attr_reader :response
+
+  def initialize(assignment:, answers:)
+    @assignment = assignment
+    @answers = answers
+    perform
+  end
+
+  private
+
+  VERIFY_STEP_FIELDS = %i[verdict claim_location verification_notes].freeze
+
+  def perform
+    upsert_response
+    complete_exercise_module if @response.persisted? && @response.errors.empty?
+  end
+
+  def upsert_response
+    # Keyed per claim: resubmitting for the same claim updates in place, while
+    # a later response for a different claim is a new record.
+    @response = VerificationClaimResponse.find_or_initialize_by(
+      user: @assignment.user, course: @assignment.course,
+      verification_claim: @assignment.verification_claim
+    )
+    @response.assign_attributes(applicable_answers)
+    @response.save
+  end
+
+  def applicable_answers
+    answers = @answers.to_h.symbolize_keys
+    if answers[:source_access] == 'accessed'
+      answers[:source_access_notes] = nil
+    else
+      VERIFY_STEP_FIELDS.each { |field| answers[field] = nil }
+    end
+    answers
+  end
+
+  # The exercise's module is identified by its launch path, not a hardcoded id.
+  def complete_exercise_module
+    exercise_modules.each do |training_module|
+      tmu = TrainingModulesUsers.create_or_find_by(user: @assignment.user,
+                                                   training_module_id: training_module.id)
+      tmu.completed_at ||= Time.zone.now
+      tmu.mark_completion(true, @assignment.course_id)
+      tmu.save
+    end
+  end
+
+  def exercise_modules
+    TrainingModule.all.select { |tm| tm.exercise_path == 'verify_claim' }
+  end
+end

--- a/app/views/claim_verification_exercises/_assignment.json.jbuilder
+++ b/app/views/claim_verification_exercises/_assignment.json.jbuilder
@@ -1,6 +1,6 @@
-# The student's taken claim and the sandbox handoff, for the SPA's taken-claim
-# view. URLs are computed by ClaimVerificationHelper (the same helpers the old
-# HAML view used). `assignment` is a VerificationClaimAssignment.
+# The student's taken claim, for the SPA's taken-claim view (where the
+# verification form lives). URLs are computed by ClaimVerificationHelper.
+# `assignment` is a VerificationClaimAssignment.
 claim = assignment.verification_claim
 # Only expose the surrounding paragraph when it adds something beyond the claim.
 surrounding = claim.context if claim.context.present? && claim.context != claim.sentence
@@ -12,4 +12,3 @@ json.claim do
   json.source_url claim_source_url(claim)
   json.article_url claim_article_url(claim)
 end
-json.sandbox_url claim_verification_sandbox_url(@course, current_user)

--- a/app/views/claim_verification_exercises/state.json.jbuilder
+++ b/app/views/claim_verification_exercises/state.json.jbuilder
@@ -8,6 +8,14 @@ else
   json.assignment nil
 end
 
+# The student's submitted form answers, if any: the SPA shows the submitted
+# view (with editing) instead of the form, and stops offering claim switching.
+if @response
+  json.response { json.partial! 'claim_verification_responses/response', response: @response }
+else
+  json.response nil
+end
+
 json.articles @tiles do |tile|
   article = tile.article
   json.id article.id

--- a/app/views/claim_verification_exercises/take.json.jbuilder
+++ b/app/views/claim_verification_exercises/take.json.jbuilder
@@ -1,8 +1,15 @@
 # The result of taking a claim: the new assignment (null if the chosen claim
 # could no longer be found in the article), so the SPA can transition to the
-# taken-claim view without a reload.
+# taken-claim view without a reload — plus the student's earlier response for
+# this claim, if they had already submitted one for it.
 if @assignment
   json.assignment { json.partial! 'assignment', assignment: @assignment }
 else
   json.assignment nil
+end
+
+if @response
+  json.response { json.partial! 'claim_verification_responses/response', response: @response }
+else
+  json.response nil
 end

--- a/app/views/claim_verification_responses/_response.json.jbuilder
+++ b/app/views/claim_verification_responses/_response.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# A student's verification form answers. Fields for steps that didn't apply
+# (see RecordVerificationClaimResponse) are null.
+json.call(response, :id, :source_access, :source_access_notes, :verdict, :claim_location,
+          :verification_notes, :other_comments, :created_at, :updated_at)

--- a/app/views/claim_verification_responses/create.json.jbuilder
+++ b/app/views/claim_verification_responses/create.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# The saved response, so the SPA can transition to the submitted view.
+json.response do
+  json.partial! 'response', response: @response
+end

--- a/app/views/claim_verification_responses/index.json.jbuilder
+++ b/app/views/claim_verification_responses/index.json.jbuilder
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# All of a course's exercise activity for the instructor view: submitted
+# responses first, then students who have taken a claim but not yet submitted.
+# Real names come from the course enrollment records, matching how the
+# students tab identifies students to instructors.
+real_names = CoursesUsers.where(course: @course).pluck(:user_id, :real_name).to_h
+
+json.responses @responses do |response|
+  claim = response.verification_claim
+  json.username response.user.username
+  json.real_name real_names[response.user_id]
+  json.claim do
+    json.sentence claim.sentence
+    json.cite_text claim.cite_text
+    json.source_url claim_source_url(claim)
+    json.article_url claim_article_url(claim)
+    json.article_title claim.article_title&.tr('_', ' ')
+  end
+  json.partial! 'response', response:
+end
+
+json.pending @pending do |assignment|
+  claim = assignment.verification_claim
+  json.id assignment.id
+  json.username assignment.user.username
+  json.real_name real_names[assignment.user_id]
+  json.claim do
+    json.sentence claim.sentence
+    json.article_title claim.article_title&.tr('_', ' ')
+  end
+  json.taken_at assignment.updated_at
+end

--- a/app/views/courses/_block.json.jbuilder
+++ b/app/views/courses/_block.json.jbuilder
@@ -15,6 +15,8 @@ if block.training_module_ids.present?
       user:
     )
     json.call(tm, :slug, :id, :name, :kind, :sandbox_preload, :translated_name)
+    # A slide-less module (an in-app exercise) has no training page to link to.
+    json.slide_count tm.slide_slugs.count
     json.module_progress due_date_manager.module_progress
     json.due_date due_date_manager.computed_due_date
     json.overdue due_date_manager.overdue?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1665,7 +1665,6 @@ en:
     cited_source: Cited source
     source_url: Source URL
     select_claim: Select this claim to verify
-    choose_article: Choose an article
     no_articles: No articles available
     your_selected_claim: Your selected claim
     find_in_article: Find this in the article text
@@ -1675,7 +1674,47 @@ en:
     course_picker_heading: Choose course
     course_picker_no_courses: No courses
     take_not_enrolled: You must be enrolled in the course to do that.
-    complete_in_sandbox: Complete this exercise in your Wikipedia sandbox.
+    # Exercise copy (operator-provided; see claim_verification_instructions.txt).
+    intro_p1: "Every fact on Wikipedia should be backed up by a reliable source. When consulting Wikipedia for information, you shouldn’t have to take the author’s word for it; you can find the cited source and read that information for yourself. This is what’s known as verifiability, and it’s one of the most critical policies behind Wikipedia’s credibility."
+    intro_p2: "As AI tools become more widely used, it's more important than ever to learn how to verify information. AI-generated content often mismatches facts and sources — which is one of the major reasons why you cannot use it to add content to Wikipedia."
+    intro_p3: "In this exercise, you’ll see verifiability in action. You’ll practice how to verify claims by trying to find a specific fact in a cited source."
+    step_select_article: "Step 1: Select an article."
+    select_claim_instructions: "The following claims need to be checked against the cited sources, because they may be AI-generated. (Note: the article may have changed since these claims were added.)"
+    form:
+      step_find_source: "Step 3: Find the source"
+      find_source_instructions: "Now that you’ve selected your claim, track down the cited source. You may need to consult your instructor or librarian to find the source."
+      source_access_question: "Were you able to access the full text of the cited source for your claim?"
+      source_access_options:
+        accessed: "Yes, I got the source."
+        nonexistent: "No, the source does not exist."
+        inaccessible: "No, the source exists but I could not get access to it."
+      source_access_notes_label: "If you were unable to find the source, tell us more about your experience:"
+      step_verify: "Step 4: Verify the claim"
+      verify_instructions: "Once you’ve found the cited source, examine it carefully to determine how well it supports the claim you’ve chosen. If you find exactly where the information came from, note where in the document you found it. (Some citations are too imprecise for a reader to practically verify.)"
+      verdict_question: "Does the source back up the claim?"
+      verdict_options:
+        full_support: "Yes — it explicitly supports the full claim."
+        mostly_supports: "Mostly yes — the core of the claim comes from this source."
+        partial_support: "Partially — some elements of the claim come from this source, but a significant part does not."
+        mostly_unsupported: "Mostly no — the source is compatible with the claim, but doesn’t directly back it up."
+        unsupported: "No — the source does not cover what the claim says."
+        contradicted: "The opposite — the source actually contradicts the claim."
+        undetermined: "I was unable to determine whether the claim was in the cited source."
+      claim_location_label: "If you were able to find the claim, where in the source was it located? (e.g. page number, chapter, etc…)"
+      verification_notes_label: "If you were unable to verify the information, tell us more about your experience. (e.g. was the source unclear or difficult to read? Was the source unrelated to the claim? Was the citation imprecise and the source too long to reasonably consult?)"
+      other_comments_label: "Any other comments about this exercise?"
+      submit: Submit
+      submitted_heading: "Submitted response"
+      edit_response: Edit response
+      submit_failed: "Error! Your response was not saved."
+    # Instructor view of everyone's responses.
+    responses:
+      heading: Student responses
+      preview_exercise: Preview exercise
+      submitted_at: "Submitted %{date}"
+      pending_heading: "In progress"
+      taken_at: "Claim taken %{date}"
+      none_yet: "No students have selected a claim yet."
     # Internal staff harvest page.
     admin:
       loading: Loading…

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,17 @@ Rails.application.routes.draw do
   # assignment so the SPA can transition without a reload.
   post 'courses/*id/verify_claim/take' => 'claim_verification_exercises#take',
        :as => :take_verify_claim, constraints: { id: /.*/ }, defaults: { format: :json }
+  # The student's verification form answers (an upsert; submitting completes
+  # the exercise).
+  post 'courses/*id/verify_claim/response' => 'claim_verification_responses#create',
+       :as => :verify_claim_response, constraints: { id: /.*/ }, defaults: { format: :json }
+  # Everyone's responses, for the course's instructional staff. The explicit
+  # `.json` is mandatory (format: true): the bare path then falls through to
+  # courses#show, so `/courses/*id/verify_claim/responses` is an SPA page (the
+  # instructor view) while this same path with .json is its data.
+  get 'courses/*id/verify_claim/responses' => 'claim_verification_responses#index',
+      :as => :verify_claim_responses, format: true,
+      constraints: { id: /.*/, format: :json }
   # Slug-less entry (eg from the course-agnostic exercise training module):
   # infers the course and sends the student into its SPA exercise, else asks
   # which course.

--- a/db/migrate/20260715120000_create_verification_claim_responses.rb
+++ b/db/migrate/20260715120000_create_verification_claim_responses.rb
@@ -1,0 +1,24 @@
+class CreateVerificationClaimResponses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :verification_claim_responses do |t|
+      t.integer :user_id, null: false
+      t.integer :course_id, null: false
+      t.integer :verification_claim_id, null: false
+      t.string :source_access, null: false
+      t.text :source_access_notes
+      t.string :verdict
+      t.text :claim_location
+      t.text :verification_notes
+      t.text :other_comments
+
+      t.timestamps
+    end
+
+    # One response per claim a student takes on — deliberately NOT one per
+    # student per course, so the exercise can grow to multiple claims.
+    add_index :verification_claim_responses, [:user_id, :course_id, :verification_claim_id],
+              unique: true, name: 'index_verification_claim_responses_uniqueness'
+    add_index :verification_claim_responses, :course_id
+    add_index :verification_claim_responses, :verification_claim_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_15_120000) do
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "courses_id"
     t.string "title"
@@ -720,6 +720,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_210000) do
     t.integer "verification_claim_id", null: false
     t.index ["user_id", "course_id"], name: "index_verification_claim_assignments_on_user_id_and_course_id", unique: true
     t.index ["verification_claim_id"], name: "index_verification_claim_assignments_on_verification_claim_id"
+  end
+
+  create_table "verification_claim_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "claim_location"
+    t.integer "course_id", null: false
+    t.datetime "created_at", null: false
+    t.text "other_comments"
+    t.string "source_access", null: false
+    t.text "source_access_notes"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.string "verdict"
+    t.integer "verification_claim_id", null: false
+    t.text "verification_notes"
+    t.index ["course_id"], name: "index_verification_claim_responses_on_course_id"
+    t.index ["verification_claim_id"], name: "index_verification_claim_responses_on_verification_claim_id"
+    t.index ["user_id", "course_id", "verification_claim_id"], name: "index_verification_claim_responses_uniqueness", unique: true
   end
 
   create_table "verification_claims", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -55,12 +55,20 @@ describe 'Claim verification exercise', type: :feature, js: true do
     login_as student
   end
 
-  it 'goes picker -> viewer -> take -> taken claim with no page reloads' do
+  it 'goes picker -> viewer -> take -> taken claim -> submitted form, with no page reloads' do
+    # A timeline block assigning the exercise module, to verify that
+    # submitting marks it complete on the timeline without a reload.
+    TrainingModule.load_all
+    exercise_module = TrainingModule.find_by(slug: 'fact-verification-exercise')
+    week = create(:week, course:)
+    create(:block, week:, due_date: course.start + 1.week,
+                   training_module_ids: [exercise_module.id])
+
     visit "/courses/#{course.slug}/verify_claim"
 
     # The article picker is the first sub-view (no claim taken yet). Mark the
     # window so we can prove the rest of the flow never triggers a reload.
-    expect(page).to have_content(I18n.t('claim_verification.choose_article'), wait: 20)
+    expect(page).to have_content(I18n.t('claim_verification.step_select_article'), wait: 20)
     page.execute_script('window.cvSameDocument = true;')
     # Each article tile is itself the opener for its in-place viewer (a button,
     # not a link).
@@ -74,13 +82,127 @@ describe 'Claim verification exercise', type: :feature, js: true do
       click_button I18n.t('claim_verification.select_claim')
     end
 
-    # Taking the claim transitions to the taken-claim view in place.
+    # Taking the claim transitions to the taken-claim view in place, where the
+    # verification form lives.
     expect(page).to have_content(I18n.t('claim_verification.your_selected_claim'), wait: 10)
     expect(page).to have_content(sentence)
     expect(page.evaluate_script('window.cvSameDocument')).to be(true)
 
     assignment = VerificationClaimAssignment.find_by(user: student, course:)
     expect(assignment.verification_claim.sentence).to eq(sentence)
+
+    # Step 3: the student got the source, so step 4 (verify the claim) appears.
+    expect(page).to have_content(I18n.t('claim_verification.form.step_find_source'))
+    choose I18n.t('claim_verification.form.source_access_options.accessed')
+    expect(page).to have_content(I18n.t('claim_verification.form.step_verify'))
+    choose I18n.t('claim_verification.form.verdict_options.partial_support')
+    fill_in I18n.t('claim_verification.form.claim_location_label'), with: 'p. 44'
+    click_button I18n.t('claim_verification.form.submit')
+
+    # Submission swaps the form for the summary of their answers. Switching
+    # claims stays possible — responses are keyed per claim, so another claim
+    # would simply start a fresh form.
+    expect(page).to have_content(
+      I18n.t('claim_verification.form.verdict_options.partial_support'), wait: 10
+    )
+    expect(page).to have_no_button(I18n.t('claim_verification.form.submit'))
+    expect(page).to have_content(I18n.t('claim_verification.choose_different_claim'))
+
+    response = VerificationClaimResponse.find_by(user: student, course:)
+    expect(response.verdict).to eq('partial_support')
+    expect(response.claim_location).to eq('p. 44')
+    expect(response.verification_claim).to eq(assignment.verification_claim)
+
+    # Navigating (client-side) back to the timeline shows the exercise as
+    # complete right away — submitting refreshed the timeline data.
+    click_link 'Timeline'
+    expect(page).to have_content('Status: Complete!', wait: 10)
+    expect(page.evaluate_script('window.cvSameDocument')).to be(true)
+  end
+
+  it 'shows a student their own submitted response in a popover on the students tab' do
+    TrainingModule.load_all
+    exercise_module = TrainingModule.find_by(slug: 'fact-verification-exercise')
+    week = create(:week, course:)
+    create(:block, week:, due_date: course.start + 1.week,
+                   training_module_ids: [exercise_module.id])
+    claim = VerificationClaim.find_by(sentence:)
+    VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
+    VerificationClaimResponse.create!(
+      user: student, course:, verification_claim: claim,
+      source_access: 'accessed', verdict: 'mostly_supports', claim_location: 'chapter 3',
+      verification_notes: 'The chapter describes tool use at length, but the shellfish ' \
+                          'detail only appears in a figure caption, which took a while to ' \
+                          'find because the scanned copy has no searchable text at all.',
+      other_comments: 'Reference: https://example.com/very/long/unbroken/path/to/a/scanned/' \
+                      'document/section-3-2-1#page=44&highlight=sea-otters'
+    )
+    tmu = TrainingModulesUsers.create!(user: student, training_module_id: exercise_module.id,
+                                       completed_at: Time.zone.now)
+    tmu.mark_completion(true, course.id)
+    tmu.save!
+
+    # The student detail view's exercise listing: expanding the exercise row's
+    # drawer reveals the submitted response as a popover — no navigation.
+    details_path = "/courses/#{course.slug}/students/articles/Otterfan"
+    visit details_path
+    find('tr.students-exercise', wait: 20).click
+    click_button I18n.t('claim_verification.form.submitted_heading'), wait: 10
+    within '.cv-response-pop' do
+      expect(page).to have_content(sentence)
+      expect(page).to have_content(
+        I18n.t('claim_verification.form.verdict_options.mostly_supports')
+      )
+      expect(page).to have_content('chapter 3')
+    end
+    # Long free-text answers wrap inside the popover rather than pushing it
+    # off the right edge of the screen.
+    fits_viewport = page.evaluate_script(
+      'document.querySelector(".cv-response-pop .pop").getBoundingClientRect().right' \
+      ' <= window.innerWidth'
+    )
+    expect(fits_viewport).to be(true)
+    expect(page).to have_current_path(details_path, ignore_query: true)
+  end
+
+  it 'gives an instructor the exercise itself, and the submissions on their own page' do
+    instructor = create(:user, username: 'Prof', onboarded: true)
+    create(:courses_user, course:, user: instructor,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    claim = VerificationClaim.find_by(sentence:)
+    VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
+    VerificationClaimResponse.create!(user: student, course:, verification_claim: claim,
+                                      source_access: 'accessed', verdict: 'contradicted',
+                                      other_comments: 'The source says the opposite.')
+    # A second student who has taken a claim but not submitted.
+    slow_student = create(:user, username: 'Slowpoke', onboarded: true)
+    create(:courses_user, course:, user: slow_student, role: CoursesUsers::Roles::STUDENT_ROLE)
+    VerificationClaimAssignment.create!(user: slow_student, course:, verification_claim: claim)
+    # courses#show verifies an instructor's OAuth edit credentials.
+    stub_token_request
+    login_as instructor
+
+    # /verify_claim is the exercise for instructors too.
+    visit "/courses/#{course.slug}/verify_claim"
+    expect(page).to have_content(I18n.t('claim_verification.step_select_article'), wait: 20)
+
+    # The submissions live on their own page (a full-page load must work too).
+    visit "/courses/#{course.slug}/verify_claim/responses"
+    expect(page).to have_content(I18n.t('claim_verification.responses.heading'), wait: 20)
+    expect(page).to have_content('Otterfan')
+    expect(page).to have_content(sentence)
+    expect(page).to have_content(I18n.t('claim_verification.form.verdict_options.contradicted'))
+    expect(page).to have_content('The source says the opposite.')
+    expect(page).to have_content(I18n.t('claim_verification.responses.pending_heading'))
+    expect(page).to have_content('Slowpoke')
+
+    # The ?student= deep link (used from the student detail view) narrows the
+    # page to one student; the return link restores the full list.
+    visit "/courses/#{course.slug}/verify_claim/responses?student=Otterfan"
+    expect(page).to have_content('Otterfan', wait: 20)
+    expect(page).to have_no_content('Slowpoke')
+    click_link "← #{I18n.t('claim_verification.responses.heading')}"
+    expect(page).to have_content('Slowpoke', wait: 10)
   end
 
   it 'deep-links straight into an open article via ?showArticle=' do
@@ -96,7 +218,7 @@ describe 'Claim verification exercise', type: :feature, js: true do
     login_as outsider
 
     visit "/courses/#{course.slug}/verify_claim"
-    expect(page).to have_content(I18n.t('claim_verification.choose_article'), wait: 20)
+    expect(page).to have_content(I18n.t('claim_verification.step_select_article'), wait: 20)
     click_on 'Sea otter'
     find('.parsed-article .cv-claim', wait: 20).click
     within '.cv-selection-panel' do

--- a/spec/models/verification_claim_response_spec.rb
+++ b/spec/models/verification_claim_response_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VerificationClaimResponse do
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:course) { create(:course) }
+  let(:user) { create(:user) }
+  let(:claim) do
+    VerificationClaim.create!(wiki:, sentence: 'Sea otters use rocks as tools.')
+  end
+
+  let(:base_attributes) do
+    { user:, course:, verification_claim: claim, source_access: 'accessed',
+      verdict: 'full_support' }
+  end
+
+  it 'is valid with an accessed source and a verdict' do
+    expect(described_class.new(base_attributes)).to be_valid
+  end
+
+  it 'rejects a source_access value outside the answer set' do
+    response = described_class.new(base_attributes.merge(source_access: 'maybe'))
+    expect(response).not_to be_valid
+  end
+
+  it 'requires a verdict when the source was accessed' do
+    response = described_class.new(base_attributes.merge(verdict: nil))
+    expect(response).not_to be_valid
+  end
+
+  it 'rejects a verdict outside the answer set' do
+    response = described_class.new(base_attributes.merge(verdict: 'sort_of'))
+    expect(response).not_to be_valid
+  end
+
+  it 'rejects a verdict when the source could not be accessed' do
+    response = described_class.new(base_attributes.merge(source_access: 'inaccessible'))
+    expect(response).not_to be_valid
+  end
+
+  it 'allows a no-source response without a verdict' do
+    response = described_class.new(base_attributes.merge(source_access: 'nonexistent',
+                                                         verdict: nil,
+                                                         source_access_notes: 'No trace of it.'))
+    expect(response).to be_valid
+  end
+
+  it 'allows only one response per claim per student' do
+    described_class.create!(base_attributes)
+    duplicate = described_class.new(base_attributes)
+    expect(duplicate).not_to be_valid
+  end
+
+  it 'allows the same student to respond to multiple claims in a course' do
+    described_class.create!(base_attributes)
+    other_claim = VerificationClaim.create!(wiki:, sentence: 'Another claim.')
+    second = described_class.new(base_attributes.merge(verification_claim: other_claim))
+    expect(second).to be_valid
+  end
+end

--- a/spec/requests/claim_verification_exercise_spec.rb
+++ b/spec/requests/claim_verification_exercise_spec.rb
@@ -51,13 +51,21 @@ describe 'Claim verification exercise', type: :request do
                     'language' => 'en', 'project' => 'wikipedia')
     end
 
-    it 'returns the taken claim and the sandbox handoff when one is taken' do
+    it 'returns the taken claim when one is taken' do
       VerificationClaimAssignment.create!(user: student, course:, verification_claim: pool_claim)
       get "/courses/#{course.slug}/verify_claim/state"
       assignment = response.parsed_body['assignment']
       expect(assignment['claim']['sentence']).to eq('Sea otters use rocks as tools.')
       expect(assignment['claim']['source_url']).to eq('https://example.com/otters')
-      expect(assignment['sandbox_url']).to include('User:Otterfan/Claim_verification_exercise')
+      expect(response.parsed_body['response']).to be_nil
+    end
+
+    it 'returns the submitted response alongside the taken claim' do
+      VerificationClaimAssignment.create!(user: student, course:, verification_claim: pool_claim)
+      VerificationClaimResponse.create!(user: student, course:, verification_claim: pool_claim,
+                                        source_access: 'accessed', verdict: 'full_support')
+      get "/courses/#{course.slug}/verify_claim/state"
+      expect(response.parsed_body['response']['verdict']).to eq('full_support')
     end
 
     it 'is open to any signed-in user, even one not enrolled in the course' do

--- a/spec/requests/claim_verification_responses_spec.rb
+++ b/spec/requests/claim_verification_responses_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The claim-verification exercise's form submission (create, an upsert that
+# also completes the exercise's training module) and the instructor-facing
+# listing of everyone's responses (index).
+describe 'Claim verification responses', type: :request do
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:course) { create(:course, slug: 'School/Claims_2024', home_wiki: wiki) }
+  let(:student) { create(:user, username: 'Otterfan') }
+  let(:claim) do
+    VerificationClaim.create!(wiki:, article_title: 'Sea_otter',
+                              sentence: 'Sea otters use rocks as tools.',
+                              source_url: 'https://example.com/otters')
+  end
+
+  let(:accessed_answers) do
+    { source_access: 'accessed', verdict: 'partial_support',
+      claim_location: 'p. 44', verification_notes: 'Only the tool use is there.',
+      other_comments: 'Fun exercise.' }
+  end
+
+  before do
+    create(:courses_user, course:, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+
+  describe 'POST response' do
+    before { login_as student }
+
+    it 'requires a taken claim' do
+      post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+      expect(response.status).to eq(422)
+    end
+
+    context 'with a taken claim' do
+      before do
+        VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
+      end
+
+      it 'stores the response for the taken claim and returns it' do
+        post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+        expect(response.status).to eq(200)
+        stored = VerificationClaimResponse.find_by(user: student, course:)
+        expect(stored.verification_claim).to eq(claim)
+        expect(stored.verdict).to eq('partial_support')
+        expect(response.parsed_body['response']['claim_location']).to eq('p. 44')
+      end
+
+      it 'updates the existing response on resubmission' do
+        post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+        post "/courses/#{course.slug}/verify_claim/response",
+             params: accessed_answers.merge(verdict: 'contradicted')
+        expect(VerificationClaimResponse.where(user: student, course:).count).to eq(1)
+        expect(VerificationClaimResponse.find_by(user: student, course:).verdict)
+          .to eq('contradicted')
+      end
+
+      it 'clears verify-step answers when the source was not accessed' do
+        post "/courses/#{course.slug}/verify_claim/response",
+             params: { source_access: 'inaccessible', verdict: 'full_support',
+                       claim_location: 'p. 44', source_access_notes: 'Paywalled.',
+                       other_comments: 'Frustrating.' }
+        stored = VerificationClaimResponse.find_by(user: student, course:)
+        expect(stored.verdict).to be_nil
+        expect(stored.claim_location).to be_nil
+        expect(stored.source_access_notes).to eq('Paywalled.')
+        expect(stored.other_comments).to eq('Frustrating.')
+      end
+
+      it 'marks the exercise training module complete for the course' do
+        # Training modules survive database cleaning, so the real module may
+        # already be loaded from another suite's TrainingModule.load_all.
+        exercise_module = TrainingModule.find_by(slug: 'fact-verification-exercise') ||
+                          TrainingModule.create!(
+                            slug: 'fact-verification-exercise', name: 'Fact verification',
+                            kind: TrainingModule::Kinds::EXERCISE,
+                            settings: { 'exercise_path' => 'verify_claim' }
+                          )
+        post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+        tmu = TrainingModulesUsers.find_by(user: student, training_module_id: exercise_module.id)
+        expect(tmu.completed_at).to be_present
+        expect(tmu.flags[course.id][:marked_complete]).to eq(true)
+      end
+
+      it 'rejects invalid answers without storing anything' do
+        post "/courses/#{course.slug}/verify_claim/response",
+             params: { source_access: 'accessed' } # missing verdict
+        expect(response.status).to eq(422)
+        expect(VerificationClaimResponse.find_by(user: student, course:)).to be_nil
+      end
+
+      it 'allows a further claim and response after submitting (no per-course limit)' do
+        post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+        other_claim = VerificationClaim.create!(wiki:, sentence: 'Another claim.')
+        post "/courses/#{course.slug}/verify_claim/take",
+             params: { verification_claim_id: other_claim.id }
+        expect(response.status).to eq(200)
+        post "/courses/#{course.slug}/verify_claim/response",
+             params: { source_access: 'nonexistent', source_access_notes: 'No trace.' }
+        expect(VerificationClaimResponse.where(user: student, course:).count).to eq(2)
+      end
+
+      it 'returns the earlier response when re-taking an already-answered claim' do
+        post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+        post "/courses/#{course.slug}/verify_claim/take",
+             params: { verification_claim_id: claim.id }
+        expect(response.parsed_body['response']['verdict']).to eq('partial_support')
+      end
+    end
+
+    it 'is forbidden for a signed-in user not enrolled in the course' do
+      outsider = create(:user, username: 'Interloper')
+      login_as outsider
+      post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'GET responses' do
+    let(:instructor) { create(:user, username: 'Prof') }
+
+    before do
+      create(:courses_user, course:, user: instructor,
+                            role: CoursesUsers::Roles::INSTRUCTOR_ROLE, real_name: 'Ada Prof')
+      VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
+      VerificationClaimResponse.create!(user: student, course:, verification_claim: claim,
+                                        **accessed_answers)
+      # A second student who has taken a claim but not submitted.
+      pending_student = create(:user, username: 'Slowpoke')
+      create(:courses_user, course:, user: pending_student,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      VerificationClaimAssignment.create!(user: pending_student, course:,
+                                          verification_claim: claim)
+    end
+
+    it 'lists responses and pending students for an instructor' do
+      login_as instructor
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      expect(response.status).to eq(200)
+      submitted = response.parsed_body['responses']
+      expect(submitted.length).to eq(1)
+      expect(submitted.first['username']).to eq('Otterfan')
+      expect(submitted.first['verdict']).to eq('partial_support')
+      expect(submitted.first['claim']['sentence']).to eq(claim.sentence)
+      expect(response.parsed_body['pending'].first['username']).to eq('Slowpoke')
+    end
+
+    it 'counts a student as pending again once they take a new claim' do
+      other_claim = VerificationClaim.create!(wiki:, sentence: 'Another claim.')
+      VerificationClaimAssignment.find_by(user: student, course:)
+                                 .update!(verification_claim: other_claim)
+      login_as instructor
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      # The earlier response still shows, and the fresh claim shows as pending.
+      expect(response.parsed_body['responses'].pluck('username')).to include('Otterfan')
+      expect(response.parsed_body['pending'].pluck('username'))
+        .to contain_exactly('Otterfan', 'Slowpoke')
+    end
+
+    it 'gives a student only their own responses and pending claims' do
+      login_as student
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body['responses'].pluck('username')).to eq(['Otterfan'])
+      # Slowpoke's taken-but-unsubmitted claim is not theirs to see.
+      expect(response.parsed_body['pending']).to be_empty
+    end
+
+    it 'is forbidden for a signed-in user with no role in the course' do
+      outsider = create(:user, username: 'Interloper')
+      login_as outsider
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      expect(response.status).to eq(403)
+    end
+
+    it 'is allowed for admins not enrolled in the course' do
+      admin = create(:admin)
+      login_as admin
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/training_content/wiki_ed/libraries/students.yml
+++ b/training_content/wiki_ed/libraries/students.yml
@@ -133,8 +133,6 @@ categories:
       - slug: extra-credit-article
         name: 'Exercise: Select an extra credit article'
         description: Optionally, choose another article to work on for extra credit.
-      - slug: fact-verification-exercise
-        name: 'Exercise: Fact verification'
   - title: Discussions
     description: |
       Prompts for in-class discussions

--- a/training_content/wiki_ed/modules/fact-verification-exercise.yml
+++ b/training_content/wiki_ed/modules/fact-verification-exercise.yml
@@ -3,8 +3,8 @@ id: 86
 kind: 'exercise'
 description: |
   In this exercise, you'll fact-check a claim added to a real Wikipedia article to see if the cited source backs it up.
-slides:
-  - slug: about-fact-verification # 8601
-  - slug: do-fact-verification # 8602
+# This module has no slides: the whole exercise (instructions included) lives
+# in the dashboard at the exercise_path below. The module exists so that
+# timeline blocks can assign the exercise and completion can be tracked.
 settings:
   exercise_path: verify_claim

--- a/training_content/wiki_ed/slides/86-fact-verification-exercise/8601-about-fact-verification.yml
+++ b/training_content/wiki_ed/slides/86-fact-verification-exercise/8601-about-fact-verification.yml
@@ -1,4 +1,0 @@
-title: "[coming soon]"
-id: 8601
-content: |
-  [coming soon]

--- a/training_content/wiki_ed/slides/86-fact-verification-exercise/8602-do-fact-verification.yml
+++ b/training_content/wiki_ed/slides/86-fact-verification-exercise/8602-do-fact-verification.yml
@@ -1,6 +1,0 @@
-title: "[coming soon]"
-id: 8602
-content: |
-  [coming soon]
-
-  [Find a claim to verify.](/verify_claim)


### PR DESCRIPTION
## What this PR does

Moves the fact-verification exercise fully into the dashboard. Instead of handing students off to a Wikipedia sandbox after they take a claim, the exercise now presents a form (multiple choice + free response, per operator-written instructions) about whether they could access the cited source and how well it backs up the claim. Submissions are stored per claim, auto-complete the exercise's training module for the course, and are visible to the course's instructional staff — on a dedicated submissions page linked from the timeline, and as an in-place popover on each student's exercise row (students can view their own the same way). The training module keeps its id for block inclusion but no longer has slides or a user-facing training page.

Follow-up to #6921 (the claim-selection flow this builds on); related to #6910.

## AI usage

This PR was developed with Claude Code, which wrote the code, tests, commit message, and this description under close human direction. The human (Sage) specified the feature and its revisions across an extended session — including the operator-written instruction text for all user-facing form copy (per the no-AI-user-facing-text rule; the only AI-written strings are short labels like "Submit", "Edit response", "Student responses", and "Preview exercise") — made the product decisions (per-claim storage with no one-per-course limit, no user-accessible training module, submissions on a separate page rather than overloading the exercise route, popover instead of navigation from the students tab), and caught two bugs during manual review that Claude then fixed (stale timeline completion status after submitting; popover text overflowing the viewport).

The work is squashed into a single commit from a single-day session (2026-07-15); the commit message's Process section describes the iteration in detail, including several feature-spec failures fixed along the way (routing, OAuth stubbing, a popover/drawer UI-state collision). All flows are covered by feature specs (5 examples), request/model specs (31 examples), and jest tests, which were run repeatedly through development and pass. The summary and analysis in this description were also drafted by Claude Code and may contain errors.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

The "before" state for the taken-claim view was a handoff link to the student's Wikipedia sandbox ("Complete this exercise in your Wikipedia sandbox"); everything shown below is new UI, so there are no meaningful before screenshots.

**1. Exercise landing: operator intro + article picker (student)**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/01_exercise_landing.png) |

**2. Taken claim with Step 3 of the form (replaces the sandbox handoff)**

| Before | After |
|--------|-------|
| _(sandbox handoff link)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/02_taken_claim_form.png) |

**3. Answering "Yes, I got the source" reveals Step 4**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/03_form_verify_step.png) |

**4. After submitting: the response summary (editable)**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/04_submitted_summary.png) |

**5. Instructor submissions page (`/verify_claim/responses`): responses + in-progress students**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/05_instructor_responses.png) |

**6. Timeline exercise row with the staff-only "Student responses" link (no more training-page link for the slide-less module)**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/06_timeline_staff_row.png) |

**7. "Submitted response" popover on the student detail view (staff for any student; students for themselves)**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/ClaimVerificationRefinement/screenshots/after/07_response_popover.png) |

## Open questions and concerns

- **Deploy steps**: the migration adds `verification_claim_responses`; training content needs a reload so module 86 drops its slides, and the two now-orphaned `TrainingSlide` rows (`about-fact-verification`, `do-fact-verification`) can be deleted (done already on the dev database).
- **Single-claim UX over a multi-claim schema**: responses are keyed per (student, course, claim) with no one-per-course limit, so the exercise can grow to multiple claims later — but the current UX still treats one submission as completing the exercise, and nothing prompts students toward a second claim.
- **Completion is submission-only for in-app exercises**: the manual Mark Complete / Mark Incomplete buttons no longer appear for exercises with an `exercise_path`; submitting the form is the completion event. Sandbox-based exercises are unchanged.
- The `?student=<username>` filter on the submissions page still works but is no longer linked from the UI (the students-tab popover replaced that navigation); it remains useful as a shareable deep link.
- The popover component intentionally does not use `useExpandablePopover`: that hook shares the single global `ui.openKey` with the student drawer that contains the popover, so opening it through the hook would close the drawer. Open state is local, with the shared outside-click hook.

(PR description written by Claude Code.)
