### PR TITLE
Fetch new users' revisions per user and per timeslice in ACUWT path

### DIFF
--- a/app/services/reprocess_article_course_user_wiki_timeslices.rb
+++ b/app/services/reprocess_article_course_user_wiki_timeslices.rb
@@ -59,9 +59,7 @@ class ReprocessArticleCourseUserWikiTimeslices
 
   def fetch_filtered_revisions(users, article_ids, ts_start, ts_end)
     revisions = revision_data_manager.fetch_revision_data_for_users_with_articles_only(
-      users,
-      ts_start.strftime('%Y%m%d%H%M%S'),
-      (ts_end - 1.second).strftime('%Y%m%d%H%M%S')
+      users, ts_start, ts_end
     )
     revisions.select { |r| article_ids.include?(r.article_id) }
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -144,18 +144,8 @@ class UpdateCourseWikiTimeslices
   def fetch_only_revisions(wiki, timeslice_start, timeslice_end)
     # Fetches only revision for wiki
     @revisions = @revision_updater.fetch_revisions_for_course_wiki(
-      wiki,
-      real_start(timeslice_start).strftime('%Y%m%d%H%M%S'),
-      real_end(timeslice_end).strftime('%Y%m%d%H%M%S')
+      wiki, timeslice_start, timeslice_end
     )
-  end
-
-  def real_start(timeslice_start)
-    [timeslice_start, @course.start].max
-  end
-
-  def real_end(timeslice_end)
-    [timeslice_end - 1.second, @course.end].min
   end
 
   def should_update_timeslice?(wiki, only_new:)

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -47,8 +47,12 @@ class UpdateTimeslicesCourseUser
       add_user_ids_acuwt(user_ids)
     else
       add_user_ids_legacy(user_ids)
+      update_created_at_for_users(user_ids)
     end
-    # Update created_at field for courses users to prevent re-marking them as newly added
+  end
+
+  # Update created_at field for courses users to prevent re-marking them as newly added
+  def update_created_at_for_users(user_ids)
     @course.courses_users.where(user_id: user_ids)
            .update_all(created_at: @course_update_start - 1.second) # rubocop:disable Rails/SkipsModelValidations
   end
@@ -59,35 +63,64 @@ class UpdateTimeslicesCourseUser
     end
   end
 
+  # Process new users one at a time, marking each as no-longer-new as soon as all their
+  # revisions were processed, so that an interrupted update doesn't redo completed users.
+  # If processing fails for some wiki, the user stays new (to be retried next update),
+  # so we skip their remaining wikis instead of doing work that would be redone anyway.
   def add_user_ids_acuwt(user_ids)
-    @course.wikis.each do |wiki|
-      fetch_and_create_acuwt_for_new_users(wiki, user_ids)
+    user_ids.each do |user_id|
+      user = User.find(user_id)
+      failed = false
+      @course.wikis.each do |wiki|
+        fetch_and_create_acuwt_for_new_user(wiki, user)
+      rescue StandardError => e
+        failed = true
+        log_user_processing_error(e, user_id, wiki.id)
+        break
+      end
+      update_created_at_for_users([user_id]) unless failed
     end
   end
 
-  def fetch_and_create_acuwt_for_new_users(wiki, user_ids)
+  # Fetch the new user's revisions one course wiki timeslice at a time, so that a single
+  # fetch/processing pass is never bigger than what the timeslice splitting already
+  # determined this course can handle.
+  def fetch_and_create_acuwt_for_new_user(wiki, user)
     updater = CourseRevisionUpdater.new(@course, update_service: @update_service)
-    revisions = updater.fetch_revisions_for_new_users(
-      wiki, User.find(user_ids),
-      @course.start.strftime('%Y%m%d%H%M%S'),
-      @course.end.strftime('%Y%m%d%H%M%S')
-    )
-    mark_timeslices_and_create_acuwt(wiki, revisions) if revisions.any?
+    timeslices_to_process(wiki).each do |cwt|
+      revisions = updater.fetch_revisions_for_new_users(
+        wiki, [user], real_start(cwt.start), real_end(cwt.end)
+      )
+      next if revisions.empty?
+
+      create_acuwt_records_for_timeslice(wiki, cwt, revisions)
+      CourseWikiTimeslice.where(id: cwt.id)
+                         .update_all(needs_reaggregation: true) # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 
-  def mark_timeslices_and_create_acuwt(wiki, revisions)
-    needs_reaggregation_ids = []
-    CourseWikiTimeslice.for_course_and_wiki(@course, wiki).each do |cwt|
-      revs_in_period = revisions.select { |r| cwt.start <= r.date && r.date < cwt.end }
-      next if revs_in_period.empty?
+  # Every timeslice up to the current ingestion limit. Future timeslices can't
+  # contain revisions yet, so fetching them would be wasted requests.
+  def timeslices_to_process(wiki)
+    timeslices = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
+    latest_start = @timeslice_manager.get_latest_start_time_for_wiki(wiki)
+    latest_start ? timeslices.where('start <= ?', latest_start) : timeslices
+  end
 
-      create_acuwt_records_for_timeslice(wiki, cwt, revs_in_period)
-      needs_reaggregation_ids << cwt.id
-    end
-    return if needs_reaggregation_ids.empty?
+  def real_start(timeslice_start)
+    [timeslice_start, @course.start].max.strftime('%Y%m%d%H%M%S')
+  end
 
-    CourseWikiTimeslice.where(id: needs_reaggregation_ids)
-                       .update_all(needs_reaggregation: true) # rubocop:disable Rails/SkipsModelValidations
+  # Replica treats both bounds as inclusive, so subtract a second from the timeslice
+  # end to avoid fetching boundary revisions for two adjacent timeslices.
+  def real_end(timeslice_end)
+    [timeslice_end - 1.second, @course.end].min.strftime('%Y%m%d%H%M%S')
+  end
+
+  def log_user_processing_error(error, user_id, wiki_id)
+    Sentry.capture_message "#{@course.slug} new user processing error: #{error}",
+                           level: 'error',
+                           extra: { course_id: @course.id, user_id:, wiki_id: }
   end
 
   def create_acuwt_records_for_timeslice(wiki, cwt, revisions)

--- a/app/services/update_timeslices_course_user.rb
+++ b/app/services/update_timeslices_course_user.rb
@@ -89,7 +89,7 @@ class UpdateTimeslicesCourseUser
     updater = CourseRevisionUpdater.new(@course, update_service: @update_service)
     timeslices_to_process(wiki).each do |cwt|
       revisions = updater.fetch_revisions_for_new_users(
-        wiki, [user], real_start(cwt.start), real_end(cwt.end)
+        wiki, [user], cwt.start, cwt.end
       )
       next if revisions.empty?
 
@@ -105,16 +105,6 @@ class UpdateTimeslicesCourseUser
     timeslices = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
     latest_start = @timeslice_manager.get_latest_start_time_for_wiki(wiki)
     latest_start ? timeslices.where('start <= ?', latest_start) : timeslices
-  end
-
-  def real_start(timeslice_start)
-    [timeslice_start, @course.start].max.strftime('%Y%m%d%H%M%S')
-  end
-
-  # Replica treats both bounds as inclusive, so subtract a second from the timeslice
-  # end to avoid fetching boundary revisions for two adjacent timeslices.
-  def real_end(timeslice_end)
-    [timeslice_end - 1.second, @course.end].min.strftime('%Y%m%d%H%M%S')
   end
 
   def log_user_processing_error(error, user_id, wiki_id)

--- a/app/services/update_timeslices_scoped_article.rb
+++ b/app/services/update_timeslices_scoped_article.rb
@@ -105,9 +105,7 @@ class UpdateTimeslicesScopedArticle
     return if users.empty?
 
     revisions = manager.fetch_revision_data_for_users_with_articles_only(
-      users,
-      ts_start.strftime('%Y%m%d%H%M%S'),
-      (ts_end - 1.second).strftime('%Y%m%d%H%M%S')
+      users, ts_start, ts_end
     )
     # Filter to target articles BEFORE the expensive reference-counter API call
     revisions.select! { |r| article_ids.include?(r.article_id) }

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_dependency "#{Rails.root}/lib/replica"
 require_dependency "#{Rails.root}/lib/revision_data_manager"
+require_dependency "#{Rails.root}/lib/utils/replica_timeslice_bounds"
 
 #= Fetches and imports new revisions for courses and creates ArticlesCourses records
 class CourseRevisionUpdater
@@ -29,9 +30,11 @@ class CourseRevisionUpdater
   # {wiki0 => {:start=>"20160320", :end=>"20160401", :new_data=>true, :revisions=>[...]}}
   # :revisions array is empty if no point in importing revisions.
   # Creates ArticlesCourses records as side effect.
-  def fetch_revisions_for_course_wiki(wiki, ts_start, ts_end)
+  def fetch_revisions_for_course_wiki(wiki, timeslice_start, timeslice_end)
+    ts_start = ReplicaTimesliceBounds.real_start(@course, timeslice_start)
+    ts_end = ReplicaTimesliceBounds.real_end(@course, timeslice_end)
     return empty_response(wiki, ts_start, ts_end) if no_point_in_importing_revisions?
-    revision_data = fetch_revisions(wiki, ts_start, ts_end)
+    revision_data = fetch_revisions(wiki, timeslice_start, timeslice_end)
     create_articles_courses(revision_data)
 
     format_revision_response(wiki, ts_start, ts_end, revision_data)

--- a/lib/course_revision_updater.rb
+++ b/lib/course_revision_updater.rb
@@ -43,6 +43,7 @@ class CourseRevisionUpdater
   def fetch_revisions_for_new_users(wiki, users, ts_start, ts_end)
     manager = RevisionDataManager.new(wiki, @course, update_service: @update_service)
     revisions = manager.fetch_revision_data_for_users_with_articles(users, ts_start, ts_end)
+    return revisions if revisions.empty?
     create_articles_courses(revisions)
     return revisions unless wiki.project == 'wikidata'
     live_revisions = revisions.reject(&:deleted)

--- a/lib/importers/revision_score_importer.rb
+++ b/lib/importers/revision_score_importer.rb
@@ -20,6 +20,11 @@ class RevisionScoreImporter
 
   # Takes an array of RevisionOnMemory records, and returns them with scores completed.
   def get_revision_scores(new_revisions)
+    # If no scoring API can return data for this wiki (e.g. wikidata), skip the whole
+    # loop: fetching parent revision ids would be wasted API calls, since the parent
+    # scores they're used for would be empty anyway.
+    return new_revisions unless @api_handler.scores_available?
+
     scores = {}
     parent_scores = {}
     parent_revisions = {}
@@ -38,7 +43,7 @@ class RevisionScoreImporter
       parent_revisions.merge!(my_parent_revisions)
 
       # Get scores for the parent revision batch
-      parent_scores.merge!(@api_handler.get_revision_data(my_parent_revisions.values.map(&:to_i)))
+      parent_scores.merge!(get_parent_scores(my_parent_revisions))
     end
 
     add_scores_to_revisions(revision_batches.flatten, parent_revisions, scores, parent_scores)
@@ -62,6 +67,10 @@ class RevisionScoreImporter
     rev_ids = non_new_revisions(rev_batch)
     WikiApi::ArticleContent.new(@wiki, update_service: @update_service)
                            .parent_revision_ids(rev_ids)
+  end
+
+  def get_parent_scores(parent_revisions)
+    @api_handler.get_revision_data(parent_revisions.values.map(&:to_i))
   end
 
   def non_new_revisions(revisions)

--- a/lib/revision_data_manager.rb
+++ b/lib/revision_data_manager.rb
@@ -6,6 +6,7 @@ require_dependency "#{Rails.root}/lib/importers/article_importer"
 require_dependency "#{Rails.root}/app/helpers/encoding_helper"
 require_dependency "#{Rails.root}/lib/importers/revision_score_importer"
 require_dependency "#{Rails.root}/lib/duplicate_article_deleter"
+require_dependency "#{Rails.root}/lib/utils/replica_timeslice_bounds"
 
 #= Fetches revision data from API
 # This class is intended to be used in four main ways:
@@ -39,8 +40,9 @@ class RevisionDataManager
   # Returns an array of RevisionOnMemory objects.
   # As a side effect, it imports Article records.
   def fetch_revision_data_for_course(timeslice_start, timeslice_end)
-    all_sub_data = get_course_revisions(@course.students, timeslice_start,
-                                        timeslice_end)
+    all_sub_data = get_course_revisions(@course.students,
+                                        ReplicaTimesliceBounds.real_start(@course, timeslice_start),
+                                        ReplicaTimesliceBounds.real_end(@course, timeslice_end))
 
     # Extract all article data from the slice. Outputs a hash with article attrs.
     article_attributes = sub_data_to_article_attributes(all_sub_data)
@@ -90,7 +92,10 @@ class RevisionDataManager
   # API call. Filter the returned revisions to specific articles before calling
   # fetch_score_data_for_course — critical when users have many programmatic edits.
   def fetch_revision_data_for_users_with_articles_only(users, timeslice_start, timeslice_end)
-    all_sub_data = get_course_revisions(users, timeslice_start, timeslice_end)
+    all_sub_data = get_course_revisions(
+      users, ReplicaTimesliceBounds.real_start(@course, timeslice_start),
+      ReplicaTimesliceBounds.real_end(@course, timeslice_end)
+    )
     return [] if all_sub_data.empty?
 
     article_attributes = sub_data_to_article_attributes(all_sub_data)

--- a/lib/revision_score_api_handler.rb
+++ b/lib/revision_score_api_handler.rb
@@ -14,6 +14,12 @@ class RevisionScoreApiHandler
     @reference_counter_api = ReferenceCounterApi.new(@wiki, @update_service)
   end
 
+  # Whether any scoring API can return data for this wiki. Wikis unsupported by
+  # the reference-counter API (e.g. wikidata) have no revision scores at all.
+  def scores_available?
+    !@reference_counter_api.nil?
+  end
+
   # Returns data from the reference-counter API.
   # The response has the following format:
   # { "rev_0"=>

--- a/lib/utils/replica_timeslice_bounds.rb
+++ b/lib/utils/replica_timeslice_bounds.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ReplicaTimesliceBounds
+  class << self
+    def real_start(course, timeslice_start)
+      [timeslice_start, course.start].max.strftime('%Y%m%d%H%M%S')
+    end
+
+    # Replica treats both bounds as inclusive, so subtract a second from the timeslice
+    # end to avoid fetching boundary revisions for two adjacent timeslices.
+    def real_end(course, timeslice_end)
+      [timeslice_end - 1.second, course.end].min.strftime('%Y%m%d%H%M%S')
+    end
+  end
+end

--- a/spec/lib/course_revision_updater_spec.rb
+++ b/spec/lib/course_revision_updater_spec.rb
@@ -7,8 +7,10 @@ describe CourseRevisionUpdater do
   describe '#fetch_scores_for_revisions' do
     let(:user) { create(:user, username: 'Tedholtby') }
     let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-    let(:start_date) { '20160320000000' }
-    let(:end_date) { '20160331235959' }
+    # let(:start_date) { '20160320000000' }
+    let(:start_date) { Time.new(2016, 3, 20, 0, 0, 0, '+00:00') }
+    # let(:end_date) { '20160331235959' }
+    let(:end_date) { Time.new(2016, 4, 1, 0, 0, 0, '+00:00') }
 
     context 'for regular courses' do
       let(:course) { create(:course, start: '2016-03-20', end: '2016-03-31') }
@@ -21,7 +23,7 @@ describe CourseRevisionUpdater do
 
       before do
         create(:course_wiki_timeslice, course:, wiki:, start: start_date,
-        end: end_date.to_datetime + 1.day)
+        end: end_date + 1.day)
       end
 
       it 'fetches all the scores if only_new is false' do
@@ -155,8 +157,9 @@ describe CourseRevisionUpdater do
                                              last_mw_rev_datetime:)
         VCR.use_cassette 'course_revision_updater' do
           expect(Sentry).not_to receive(:capture_message)
-          revisions = instance_class.fetch_revisions_for_course_wiki(wiki, '20160331092530',
-                                                                     '20160331225055')
+          revisions = instance_class.fetch_revisions_for_course_wiki(wiki,
+                                                                    '20160331092530'.to_datetime,
+                                                                    '20160331225055'.to_datetime)
           revisions_with_scores = instance_class.fetch_scores_for_revisions(revisions,
                                                                             only_new: true)
           expect(revisions_with_scores[wiki][:new_data]).to eq(false)
@@ -201,8 +204,10 @@ describe CourseRevisionUpdater do
   describe '#fetch_revisions_for_course_wiki' do
     let(:user) { create(:user, username: 'Tedholtby') }
     let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
-    let(:start_date) { '20160320000000' }
-    let(:end_date) { '20160331235959' }
+    # let(:start_date) { '20160320000000' }
+    let(:start_date) { Time.new(2016, 3, 20, 0, 0, 0, '+00:00') }
+    # let(:end_date) { '20160331235959' }
+    let(:end_date) { Time.new(2016, 4, 1, 0, 0, 0, '+00:00') }
 
     context 'for regular courses' do
       let(:course) { create(:course, start: '2016-03-20', end: '2016-03-31') }
@@ -215,7 +220,7 @@ describe CourseRevisionUpdater do
 
       before do
         create(:course_wiki_timeslice, course:, wiki:, start: start_date,
-        end: end_date.to_datetime + 1.day)
+        end: end_date + 1.day)
       end
 
       it 'fetches all the revisions without scores' do
@@ -250,8 +255,10 @@ describe CourseRevisionUpdater do
                                              last_mw_rev_datetime:)
         VCR.use_cassette 'course_revision_updater' do
           expect(Sentry).not_to receive(:capture_message)
-          revision_data = instance_class.fetch_revisions_for_course_wiki(wiki, '20160331092530',
-                                                                         '20160331225055')
+          revision_data = instance_class.fetch_revisions_for_course_wiki(
+            wiki,
+            '20160331092530'.to_datetime,
+            '20160331225055'.to_datetime)
           expect(revision_data[wiki][:new_data]).to eq(false)
           revisions = revision_data.values.flat_map { |data| data[:revisions] }.flatten
           expect(revisions.count).to eq(3)
@@ -271,6 +278,37 @@ describe CourseRevisionUpdater do
           expect(revisions.last.features).to be_empty
           expect(revisions.last.features_previous).to be_empty
         end
+      end
+    end
+
+    # BasicCourse#use_start_and_end_times is true, so its start/end aren't rounded to
+    # beginning/end of day, letting a timeslice extend past the course's own bounds.
+    context 'for courses that allow own start and end' do
+      let(:course) do
+        create(:basic_course, start: Time.new(2016, 3, 31, 15, 0, 0, '+00:00'),
+                              end: Time.new(2016, 3, 31, 20, 0, 0, '+00:00'))
+      end
+      let(:instance_class) { described_class.new(course) }
+      let(:timeslice_start) { Time.new(2016, 3, 31, 0, 0, 0, '+00:00') }
+      let(:timeslice_end) { Time.new(2016, 4, 1, 0, 0, 0, '+00:00') }
+      let!(:courses_user) do
+        create(:courses_user, course:,
+                            user:,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      end
+
+      before do
+        create(:course_wiki_timeslice, course:, wiki:,
+                                       start: timeslice_start, end: timeslice_end)
+      end
+
+      it 'sends Replica bounds clamped to the course start and end, not the timeslice limits' do
+        expect(Sentry).not_to receive(:capture_message)
+        expect_any_instance_of(Replica).to receive(:get_revisions)
+          .with(anything, '20160331150000', '20160331200000')
+          .and_return({})
+
+        instance_class.fetch_revisions_for_course_wiki(wiki, timeslice_start, timeslice_end)
       end
     end
 
@@ -298,7 +336,7 @@ describe CourseRevisionUpdater do
 
         before do
           create(:course_wiki_timeslice, course: scoped_course, wiki:,
-                                         start: start_date, end: end_date.to_datetime + 1.day,
+                                         start: start_date, end: end_date + 1.day,
                                          mw_rev_count: 1, last_mw_rev_datetime: rev_date)
           allow(scoped_instance_class).to receive(:no_point_in_importing_revisions?)
             .and_return(false)

--- a/spec/lib/importers/revision_score_importer_spec.rb
+++ b/spec/lib/importers/revision_score_importer_spec.rb
@@ -132,5 +132,20 @@ describe RevisionScoreImporter do
       revisions = described_class.new.get_revision_scores(array_revisions)
       expect(revisions[0].error).to eq(true)
     end
+
+    context 'when the wiki has no scoring API (wikidata)' do
+      before { stub_wiki_validation }
+
+      let(:wikidata) { create(:wiki, project: 'wikidata', language: nil) }
+
+      it 'returns the revisions untouched without fetching parent revision ids' do
+        expect(WikiApi::ArticleContent).not_to receive(:new)
+
+        revisions = described_class.new(wiki: wikidata).get_revision_scores(array_revisions)
+
+        expect(revisions).to eq(array_revisions)
+        expect(revisions.map(&:error)).to all(be_falsey)
+      end
+    end
   end
 end

--- a/spec/lib/revision_data_manager_merge_scoping_spec.rb
+++ b/spec/lib/revision_data_manager_merge_scoping_spec.rb
@@ -80,7 +80,8 @@ describe 'issue #6813 Wikidata merge scoping' do
     allow(manager).to receive(:get_revisions)
       .and_return([tracked_target_revision, merge_source_revision, unrelated_merge_revision])
 
-    revisions = manager.fetch_revision_data_for_course('20260401', '20260430')
+    revisions = manager.fetch_revision_data_for_course('20260401'.to_datetime,
+                                                       '20260430'.to_datetime)
 
     target_rev    = revisions.find { |r| r.mw_rev_id == normal_rev_id }
     merge_rev     = revisions.find { |r| r.mw_rev_id == merge_rev_id }

--- a/spec/lib/revision_data_manager_spec.rb
+++ b/spec/lib/revision_data_manager_spec.rb
@@ -14,10 +14,11 @@ describe RevisionDataManager do
     let(:instance_class) { described_class.new(home_wiki, course) }
     let(:instance_class2) { described_class.new(arwiki, course2) }
     let(:subject) do
-      instance_class.fetch_revision_data_for_course('20180706', '20180707')
+      instance_class.fetch_revision_data_for_course('20180706'.to_datetime, '20180707'.to_datetime)
     end
     let(:subject2) do
-      instance_class2.fetch_revision_data_for_course('20241129134300', '20241130201900')
+      instance_class2.fetch_revision_data_for_course('20241129134300'.to_datetime,
+                                                     '20241130201900'.to_datetime)
     end
     let(:revision_data) do
       [{ 'mw_page_id' => '55345266',
@@ -173,7 +174,8 @@ describe RevisionDataManager do
       scoped_instance_class = described_class.new(home_wiki, scoped_course)
       allow(scoped_instance_class).to receive(:get_revisions).and_return([data1, data2])
       allow(scoped_course).to receive(:scoped_article_titles).and_return(['Draft_article'])
-      revisions = scoped_instance_class.fetch_revision_data_for_course('20180706', '20180707')
+      revisions = scoped_instance_class.fetch_revision_data_for_course('20180706'.to_datetime,
+                                                                       '20180707'.to_datetime)
       expect(revisions.first.scoped).to eq(false)
       expect(revisions.second.scoped).to eq(true)
     end
@@ -184,7 +186,8 @@ describe RevisionDataManager do
     let(:user) { create(:user, username: 'Ragesoss') }
     let(:home_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
     let(:instance_class) { described_class.new(home_wiki, course) }
-    let(:revisions) { instance_class.fetch_revision_data_for_course('20180706', '20180707') }
+    let(:revisions) { instance_class.fetch_revision_data_for_course('20180706'.to_datetime,
+                                                                    '20180707'.to_datetime) }
     let(:subject) do
       instance_class.fetch_score_data_for_course(revisions)
     end
@@ -299,7 +302,8 @@ describe RevisionDataManager do
       allow(scoped_instance_class).to receive(:get_revisions).and_return([data1, data2, data3])
       allow(scoped_course).to receive(:scoped_article_titles).and_return(['Scoped_article'])
       VCR.use_cassette 'revision_importer/all_v2', match_requests_on: [:method, :uri, :body] do
-        revisions = scoped_instance_class.fetch_revision_data_for_course('20180706', '20180707')
+        revisions = scoped_instance_class.fetch_revision_data_for_course('20180706'.to_datetime,
+                                                                         '20180707'.to_datetime)
         revisions = scoped_instance_class.fetch_score_data_for_course(revisions)
         # Returns all revisions
         expect(revisions.length).to eq(3)

--- a/spec/lib/revision_score_api_handler_spec.rb
+++ b/spec/lib/revision_score_api_handler_spec.rb
@@ -13,6 +13,12 @@ describe RevisionScoreApiHandler do
 
     let(:handler) { described_class.new(wiki: Wiki.find(1)) }
 
+    describe '#scores_available?' do
+      it 'is true' do
+        expect(handler.scores_available?).to eq(true)
+      end
+    end
+
     describe '#get_revision_data' do
       let(:subject) { handler.get_revision_data [829840090, 829840091] }
 
@@ -64,6 +70,12 @@ describe RevisionScoreApiHandler do
     # Wikidata is no longer scored via either API: Lift Wing features/wp10 aren't used for
     # Wikidata, and reference-counter doesn't support Wikidata. Deletion detection has
     # moved to UpdateWikidataStatsTimeslice (via WikidataDiffAnalyzer).
+    describe '#scores_available?' do
+      it 'is false' do
+        expect(handler.scores_available?).to eq(false)
+      end
+    end
+
     describe '#get_revision_data' do
       it 'returns no scores and makes no HTTP calls' do
         stub_request(:any, /.*api.wikimedia.org.*/).to_raise('should not be called')

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -198,13 +198,13 @@ describe UpdateCourseWikiTimeslices do
 
       it 'fetches revisions up to end date' do
         expected_dates = [
-          %w[20181124000000 20181124235959],
-          %w[20181125000000 20181125235959],
-          %w[20181126000000 20181126235959],
-          %w[20181127000000 20181127235959],
-          %w[20181128000000 20181128235959],
-          %w[20181129000000 20181129235959],
-          %w[20181130000000 20181130235500]
+          %w[20181124000000 20181125000000],
+          %w[20181125000000 20181126000000],
+          %w[20181126000000 20181127000000],
+          %w[20181127000000 20181128000000],
+          %w[20181128000000 20181129000000],
+          %w[20181129000000 20181130000000],
+          %w[20181130000000 20181201000000]
         ]
 
         expected_wikis = [enwiki, wikidata]
@@ -213,7 +213,7 @@ describe UpdateCourseWikiTimeslices do
           expected_wikis.each do |wiki|
             expect_any_instance_of(CourseRevisionUpdater)
               .to receive(:fetch_revisions_for_course_wiki)
-              .with(wiki, start_time, end_time)
+              .with(wiki, start_time.to_datetime, end_time.to_datetime)
               .once
               .and_call_original
           end

--- a/spec/services/update_timeslices_course_user_spec.rb
+++ b/spec/services/update_timeslices_course_user_spec.rb
@@ -236,8 +236,11 @@ describe UpdateTimeslicesCourseUser do
                        article_id: article1.id, user_id: user2.id, wiki_id: enwiki.id,
                        mw_rev_id: 12_345, mw_page_id: article1.mw_page_id,
                        date: start + 1.hour, scoped: true, new_article: false)
+      # Revisions are fetched per timeslice; only the first timeslice has a revision
       allow_any_instance_of(CourseRevisionUpdater)
-        .to receive(:fetch_revisions_for_new_users).and_return([revision])
+        .to receive(:fetch_revisions_for_new_users) do |_updater, _wiki, _users, ts_start, _ts_end|
+        ts_start == start.strftime('%Y%m%d%H%M%S') ? [revision] : []
+      end
 
       expect(ArticleCourseUserWikiTimeslice.where(course:, user: user2).count).to eq(0)
 
@@ -251,6 +254,55 @@ describe UpdateTimeslicesCourseUser do
       # The CWT for that period is flagged for reaggregation
       expect(course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(1)
       expect(course.course_wiki_timeslices.find_by(needs_reaggregation: true).start).to eq(start)
+    end
+
+    it 'fetches revisions once per course wiki timeslice' do
+      fetch_calls = []
+      allow_any_instance_of(CourseRevisionUpdater)
+        .to receive(:fetch_revisions_for_new_users) do |_updater, _wiki, _users, ts_start, ts_end|
+        fetch_calls << [ts_start, ts_end]
+        []
+      end
+
+      described_class.new(course).run
+
+      # One fetch per timeslice, bounded to the timeslice period. The end bound is
+      # inclusive for Replica, so it's one second before the next timeslice start.
+      expect(fetch_calls.count).to eq(7)
+      expect(fetch_calls.min).to eq([start.strftime('%Y%m%d%H%M%S'),
+                                     (start + 1.day - 1.second).strftime('%Y%m%d%H%M%S')])
+    end
+
+    it 'marks the new user as processed so an interrupted update does not redo them' do
+      allow_any_instance_of(CourseRevisionUpdater)
+        .to receive(:fetch_revisions_for_new_users).and_return([])
+
+      expect(CoursesUsers.find_by(course:, user: user2).created_at)
+        .to be >= course.last_update_start_time
+
+      described_class.new(course).run
+
+      expect(CoursesUsers.find_by(course:, user: user2).created_at)
+        .to be < course.last_update_start_time
+    end
+
+    it 'continues with remaining users when processing one user fails' do
+      JoinCourse.new(course:, user: user3, role: CoursesUsers::Roles::STUDENT_ROLE)
+      allow_any_instance_of(CourseRevisionUpdater)
+        .to receive(:fetch_revisions_for_new_users) do |_updater, _wiki, users, _ts_start, _ts_end|
+        raise StandardError, 'Replica timeout' if users.first.id == user2.id
+        []
+      end
+      expect(Sentry).to receive(:capture_message)
+
+      described_class.new(course).run
+
+      # The failed user is still considered new, so the next update retries them;
+      # the successfully processed user is not redone
+      expect(CoursesUsers.find_by(course:, user: user2).created_at)
+        .to be >= course.last_update_start_time
+      expect(CoursesUsers.find_by(course:, user: user3).created_at)
+        .to be < course.last_update_start_time
     end
   end
 end

--- a/spec/services/update_timeslices_course_user_spec.rb
+++ b/spec/services/update_timeslices_course_user_spec.rb
@@ -258,10 +258,10 @@ describe UpdateTimeslicesCourseUser do
 
     it 'fetches revisions once per course wiki timeslice' do
       fetch_calls = []
-      allow_any_instance_of(CourseRevisionUpdater)
-        .to receive(:fetch_revisions_for_new_users) do |_updater, _wiki, _users, ts_start, ts_end|
+      allow_any_instance_of(Replica)
+        .to receive(:get_revisions) do |_replica, _users, ts_start, ts_end|
         fetch_calls << [ts_start, ts_end]
-        []
+        {}
       end
 
       described_class.new(course).run


### PR DESCRIPTION
## What this PR does

Makes the ACUWT "new users" step of the course update survivable for huge courses, prompted by `Wikidata/Coordinate_Me_2026_DE_(2026)` (course 36020 on the P&E Dashboard), which had not completed an update since May 12: its 40 newly added users had 423k+ Wikidata revisions in the course window (three users with 100k+ each), and `UpdateTimeslicesCourseUser` fetched and processed all of them in a single un-checkpointed pass over the whole course period. The worker died before finishing, `courses_users.created_at` was never ratcheted, so the same users were treated as "new" again on every subsequent update — an infinite restart-from-zero loop.

Two changes:

1. **Per-user, per-timeslice processing in the ACUWT new-users path.** `add_user_ids_acuwt` now processes one user at a time and marks each as no-longer-new as soon as all their wikis complete, so an interrupted update never redoes finished users. Within a user, revisions are fetched one `CourseWikiTimeslice` at a time (bounds match the main update loop, including the `end - 1.second` adjustment for Replica's inclusive bounds, and iteration stops at the ingestion limit), so a single fetch/processing pass is never bigger than what the adaptive timeslice splitting already determined the course can handle. If a wiki fails for a user, the error is logged to Sentry (course/user/wiki) and that user's remaining wikis are skipped — they stay "new" and are fully retried next update. `CourseRevisionUpdater#fetch_revisions_for_new_users` early-returns on empty fetches so the many empty slices cost nothing beyond the Replica call.

2. **Skip parent revision lookups for wikis with no scoring API.** On Wikidata, `RevisionScoreImporter#get_revision_scores` made a real `parent_revision_ids` MediaWiki API call per 50-revision batch even though both reference-counter lookups return `{}` there — the parent ids only ever keyed into an always-empty parent-scores hash. A new `RevisionScoreApiHandler#scores_available?` predicate lets the importer return the revisions untouched before the batch loop, eliminating thousands of sequential no-op API calls per update on high-volume Wikidata courses.

## AI usage

This PR was developed with Claude Code, which wrote all of the code, specs, and commit messages, as well as this PR description, under direction from the human author. The session started from a production investigation: the human pasted syslog output from the stuck course update along with their hypothesis about the cause; Claude Code confirmed the hypothesis by reading the code and probing the course's public data (quantifying the 423k+ revision workload), and proposed fixes. The key design decisions were the human's: fixing incremental progress first, fetching per real `CourseWikiTimeslice` record rather than fixed windows (so split timeslices are respected), bailing out of a user's remaining wikis on first failure instead of continuing, and adding course/wiki ids to the Sentry log. Both commits were made within a single session on 2026-07-16, about half an hour apart. The analysis above was drafted by Claude Code and may contain errors; this description was prepared with the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes (backend-only).

## Open questions and concerns

- The per-timeslice fetch trades a few giant Replica requests for many small ones (one per user per timeslice, most returning empty). For Coordinate Me this is clearly the right trade — the giant requests are what killed the worker — but it does add request volume for courses with many timeslices and inactive new users.
- A related, larger optimization is deliberately out of scope: `WikidataDiffAnalyzer` still runs on all live revisions (not just scoped ones) to detect merges into in-scope items, which dominates the remaining cost for scoped Wikidata courses. An issue will be filed to handle that separately.
- The reaggregation pass (~25 min per split 1.5h timeslice observed on this course) is untouched and will likely become the visible bottleneck once this deploys.
- New users are processed strictly one at a time: each user's revisions are fetched per course wiki
  timeslice, and the user's courses_users.created_at is ratcheted as soon as all their wikis complete, so
  an interrupted update loses at most one user's partial work and never redoes finished users. This
  maximizes durability and failure isolation at the cost of request volume, since Replica accepts up to 10
  usernames per request (RevisionDataManager::MAX_USERNAMES) and per-user fetching forgoes that batching
  — for a course with many inactive new users and many timeslices, most of the extra requests are empty
  responses. If that overhead proves significant in practice, a possible follow-up is to process users in
  chunks of up to 10, fetching each timeslice for the whole chunk and ratcheting the chunk's created_at
  together: roughly 10× fewer Replica requests, in exchange for coarser checkpoints (a crash or a single
  user's failure would redo up to 10 users instead of 1). The expensive work — revision processing and, on
  Wikidata, diff analysis — scales with revision volume and is identical under both schemes, which is why
  the simpler per-user version was chosen first.

(PR description written by Claude Code.)
