### PR TITLE
Resolve dead interwiki wikilinks in training-slide

### DIFF
--- a/lib/utils/wiki_link_resolver.rb
+++ b/lib/utils/wiki_link_resolver.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Pandoc's mediawiki-to-markdown conversion leaves internal/interwiki
+# [[wikilink]] targets as the raw wiki target (eg
+# "wikipedia:Wikipedia:Notability"), since it has no access to MediaWiki's
+# interwiki table and can't resolve them into real URLs on its own. This
+# rewrites the targets we can confidently resolve into MediaWiki's external
+# link syntax (`[url text]`), which Pandoc already converts correctly.
+#
+# Anything we're not confident about — category links, image embeds,
+# same-page anchors, or namespaces/prefixes we don't recognize — is left
+# untouched, so Pandoc handles it exactly as it does today.
+class WikiLinkResolver
+  # Interwiki project prefixes, mapped to the domain they resolve to by
+  # default (English-language, unless overridden by an explicit language
+  # sub-prefix, eg the 'eu' in "w:eu:Foo").
+  PROJECT_DOMAINS = {
+    'w' => 'wikipedia.org', 'wikipedia' => 'wikipedia.org',
+    'wikt' => 'wiktionary.org', 'wiktionary' => 'wiktionary.org',
+    'n' => 'wikinews.org', 'wikinews' => 'wikinews.org',
+    'b' => 'wikibooks.org', 'wikibooks' => 'wikibooks.org',
+    'q' => 'wikiquote.org', 'wikiquote' => 'wikiquote.org',
+    's' => 'wikisource.org', 'wikisource' => 'wikisource.org',
+    'v' => 'wikiversity.org', 'wikiversity' => 'wikiversity.org',
+    'voy' => 'wikivoyage.org', 'wikivoyage' => 'wikivoyage.org'
+  }.freeze
+
+  # A leading colon (eg "[[:Category:Foo]]") turns these into a normal visible
+  # link, so only skip when there's no leading colon to override that.
+  SKIPPED_NAMESPACES = /\A(File|Image|Category):/i
+
+  WIKILINK_RE = /\[\[(?<target>[^|\]]+)(?:\|(?<text>[^\]]+))?\]\]/
+
+  def self.resolve(text)
+    text.gsub(WIKILINK_RE) { resolve_match(Regexp.last_match) }
+  end
+
+  def self.resolve_match(match)
+    url = url_for(match[:target].strip)
+    url ? "[#{url} #{(match[:text] || match[:target]).strip}]" : match[0]
+  end
+
+  def self.url_for(target)
+    return if target.start_with?('#') || target =~ SKIPPED_NAMESPACES
+    normalized = target.sub(/\A:/, '')
+    prefix, colon, rest = normalized.partition(':')
+    return "https://meta.wikimedia.org/wiki/#{escape(normalized)}" if colon.empty?
+    domain = PROJECT_DOMAINS[prefix.downcase]
+    domain && interwiki_url(domain, rest)
+  end
+
+  # Handles an optional language sub-prefix, eg the 'eu' in "w:eu:Wikipedia:Genero_oreka".
+  def self.interwiki_url(domain, rest)
+    lang, colon, page = rest.partition(':')
+    if !colon.empty? && lang == lang.downcase && lang.length.between?(2, 3)
+      "https://#{lang}.#{domain}/wiki/#{escape(page)}"
+    else
+      "https://en.#{domain}/wiki/#{escape(rest)}"
+    end
+  end
+
+  def self.escape(title)
+    title.tr(' ', '_')
+  end
+end

--- a/lib/wikitext.rb
+++ b/lib/wikitext.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pandoc-ruby'
+require_dependency "#{Rails.root}/lib/utils/wiki_link_resolver"
 
 # Interwiki shorthands, source: https://en.wikipedia.org/wiki/Help:Interwiki_linking#Project_titles_and_shortcuts
 INTERWIKI_PREFIXES = {
@@ -46,6 +47,7 @@ class Wikitext
   end
 
   def self.mediawiki_to_markdown(item)
+    item = WikiLinkResolver.resolve(item)
     PandocRuby.convert(item, { from: :mediawiki, to: :markdown_github }, '--wrap=none')
   end
 

--- a/spec/lib/utils/wiki_link_resolver_spec.rb
+++ b/spec/lib/utils/wiki_link_resolver_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/utils/wiki_link_resolver"
+
+describe WikiLinkResolver do
+  describe '.resolve' do
+    it 'resolves an interwiki wikilink with a bare project prefix to a real url' do
+      input = '[[wikipedia:Wikipedia:Notability#General_notability_guideline' \
+              '|General Notabilty Guidelines]]'
+      output = described_class.resolve(input)
+      expect(output).to eq(
+        '[https://en.wikipedia.org/wiki/Wikipedia:Notability#General_notability_guideline ' \
+        'General Notabilty Guidelines]'
+      )
+    end
+
+    it 'resolves an interwiki wikilink with no pipe using the target as the label' do
+      input = '[[wikipedia:Wikipedia:Red_link|redlinks]]'
+      output = described_class.resolve(input)
+      expect(output).to eq('[https://en.wikipedia.org/wiki/Wikipedia:Red_link redlinks]')
+    end
+
+    it 'resolves a short "w:" prefix with an explicit language sub-prefix' do
+      input = '[[w:eu:Wikipedia:Genero_oreka|Generoko zuloa]]'
+      output = described_class.resolve(input)
+      expect(output).to eq('[https://eu.wikipedia.org/wiki/Wikipedia:Genero_oreka Generoko zuloa]')
+    end
+
+    it 'resolves a bare page title to a meta.wikimedia.org link' do
+      input = '[[Gender gap]]'
+      output = described_class.resolve(input)
+      expect(output).to eq('[https://meta.wikimedia.org/wiki/Gender_gap Gender gap]')
+    end
+
+    it 'leaves a Category wikilink (no leading colon) untouched' do
+      input = '[[Category:Editathon training slides]]'
+      expect(described_class.resolve(input)).to eq(input)
+    end
+
+    it 'leaves a leading-colon Category link untouched, since it is not a recognized project' do
+      input = '[[:Category:Foo|Text]]'
+      expect(described_class.resolve(input)).to eq(input)
+    end
+
+    it 'leaves a File embed untouched' do
+      input = '[[File:Foo.jpg|thumb|caption]]'
+      expect(described_class.resolve(input)).to eq(input)
+    end
+
+    it 'leaves a same-page anchor link untouched' do
+      input = '[[#Section]]'
+      expect(described_class.resolve(input)).to eq(input)
+    end
+
+    it 'leaves an unrecognized namespace untouched' do
+      input = '[[Talk:Some Page|discussion]]'
+      expect(described_class.resolve(input)).to eq(input)
+    end
+
+    it 'leaves plain external links untouched' do
+      input = '[https://meta.wikimedia.org/wiki/Gender_gap gender gap]'
+      expect(described_class.resolve(input)).to eq(input)
+    end
+  end
+end

--- a/spec/lib/wikitext_spec.rb
+++ b/spec/lib/wikitext_spec.rb
@@ -44,6 +44,26 @@ describe Wikitext do
     end
   end
 
+  describe '.mediawiki_to_markdown' do
+    it 'resolves interwiki wikilinks into working links instead of leaving raw wiki targets' do
+      # Regression test for https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6963
+      # Source: https://meta.wikimedia.org/wiki/Training_modules/dashboard/slides/12218-identifying-content-gaps-for-editathons
+      input = 'Meet the [[wikipedia:Wikipedia:Notability#General_notability_guideline' \
+              '|General Notabilty Guidelines]].'
+      output = subject.mediawiki_to_markdown(input)
+      expect(output).to include(
+        '[General Notabilty Guidelines]' \
+        '(https://en.wikipedia.org/wiki/Wikipedia:Notability#General_notability_guideline)'
+      )
+    end
+
+    it 'still converts plain external links correctly' do
+      input = 'See the [https://meta.wikimedia.org/wiki/Gender_gap gender gap] article.'
+      output = subject.mediawiki_to_markdown(input)
+      expect(output).to include('[gender gap](https://meta.wikimedia.org/wiki/Gender_gap)')
+    end
+  end
+
   describe '.replace_code_with_nowiki' do
     it 'converts code formatting syntax from html to wikitext' do
       code_snippet = '<code></code>'


### PR DESCRIPTION
## What this PR does

Fixes #6963. Training slide content is pulled from meta.wikimedia.org as MediaWiki wikitext and converted to Markdown via Pandoc. Plain external links convert fine, but MediaWiki interwiki links like `[[wikipedia:Wikipedia:Notability#General_notability_guideline|General Notabilty Guidelines]]` rely on MediaWiki's own interwiki table to resolve, which Pandoc doesn't have — so it passed the raw wiki target through as a dead href.

This adds `WikiLinkResolver` (`lib/utils/wiki_link_resolver.rb`), which rewrites resolvable `[[wikilink]]` targets into real URLs before Pandoc runs, wired into `Wikitext.mediawiki_to_markdown` (the only place this conversion happens, for training slides). Category directives, image embeds, same-page anchors, and unrecognized namespaces are deliberately left untouched. Covered by new/updated specs in `spec/lib/utils/wiki_link_resolver_spec.rb` and `spec/lib/wikitext_spec.rb`.

## AI usage

This PR was developed in a Claude Code session. I directed the investigation and design (asked for the root cause and approach before any code was written, required verification against the real reported slide's actual wikitext rather than a synthetic example, and raised edge cases like `[[:Category:Foo]]` and same-page anchors that shaped the final design). Claude Code wrote the fix, the tests, and this description.

## Screenshots
https://www.loom.com/share/4ccdaa7ed5ed45228d0dda2954f88a71
