### PR TITLE
Bump websocket-driver and css_parser to patch Dependabot alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,11 @@ gem 'browser'
 ### Email
 gem 'validates_email_format_of' # Email format validation, used in User model
 gem 'premailer-rails' # used for enabling CSS for mailer emails
-# Pinned for GHSA (improper cert validation / MITM CSS injection); stays on the
-# 1.x line since premailer is not yet vetted against css_parser 2.x/3.x.
-gem 'css_parser', '~> 1.22' # transitive of premailer; held at patched 1.x
+# css_parser is a transitive dependency of premailer. Pinned to 3.x, the first
+# line with the fix for GHSA-9pmc-p236-855h (SSRF + local file disclosure in
+# read_remote_file). 3.0.0 is default-secure for premailer pipelines and needs
+# no code changes per the advisory's upgrade notes.
+gem 'css_parser', '~> 3.0' # transitive of premailer; pinned to patched 3.x
 gem 'nokogiri' # expected by premailer-rails but not required
 gem 'rubyzip', require: 'zip' # used by ExportTrainingModuleDraft
 gem 'mailgun-ruby' # email sending service

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -705,7 +705,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,8 +210,9 @@ GEM
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)
-    css_parser (1.22.0)
+    css_parser (3.0.0)
       addressable
+      ssrf_filter (~> 1.5)
     csv (3.3.5)
     dalli (3.2.3)
     date (3.5.1)
@@ -672,6 +673,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    ssrf_filter (1.5.0)
     stackprof (0.2.23)
     stringio (3.2.0)
     temple (0.10.4)
@@ -737,7 +739,7 @@ DEPENDENCIES
   capybara-screenshot
   chartkick
   connection_pool
-  css_parser (~> 1.22)
+  css_parser (~> 3.0)
   csv
   dalli
   deep_cloneable

--- a/yarn.lock
+++ b/yarn.lock
@@ -14291,13 +14291,13 @@ __metadata:
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: ">=0.5.1"
     safe-buffer: ">=5.1.0"
     websocket-extensions: ">=0.1.1"
-  checksum: fffe5a33fe8eceafd21d2a065661d09e38b93877eae1de6ab5d7d2734c6ed243973beae10ae48c6613cfd675f200e5a058d1e3531bc9e6c5d4f1396ff1f0bfb9
+  checksum: 2ad622f4627bde71ce0f25a9466ced1cfc4e789603530a67944824cbafffd518224c4cc131da0f0aafe46c1b36f968326e0199845dfa56f7d15e5774aa53119d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does

Clears all open Dependabot alerts on the repository by bumping three affected
packages to their patched versions. No application code changes — these are
dependency-manifest/lockfile updates only.

- **`websocket-driver` (Ruby) `0.8.0 → 0.8.2`** — closes three medium advisories
  (memory exhaustion in the HTTP header parser, memory exhaustion via protocol
  length headers, and resource-limit bypass via message compression). Pulled in
  transitively by `actioncable` (`websocket-driver >= 0.6.1`); patched at 0.8.1.
- **`websocket-driver` (npm) `0.7.4 → 0.7.5`** — closes one **critical** advisory
  (message corruption via abuse of protocol length headers) and one medium
  (resource-limit bypass via message compression). Transitive via
  `faye-websocket` (`>=0.5.1`) and `sockjs` (`^0.7.4`); both ranges accept 0.7.5.
- **`css_parser` (Ruby) `1.22.0 → 3.0.0`** — closes the high-severity SSRF +
  local file disclosure advisory
  ([GHSA-9pmc-p236-855h](https://github.com/advisories/GHSA-9pmc-p236-855h) /
  CVE-2026-53727) in `CssParser::Parser#read_remote_file`. The advisory has no
  1.x or 2.x backport; the fix ships only in 3.0.0, which is default-secure
  (routes outbound fetches through `ssrf_filter`, drops the `file://` redirect
  leg, and stops requesting gzip). This required reversing the deliberate
  `~> 1.22` pin. The pin's original rationale was that premailer had not been
  vetted against css_parser 2.x/3.x; the 3.0.0 advisory's upgrade notes state
  that premailer/email-rendering pipelines need no code changes, which retires
  that reservation. css_parser is used only transitively via `premailer-rails`
  (no direct references in `app/`, `lib/`, or `config/`), so the exposure and
  the fix both live entirely in the Premailer CSS-inlining path. The bump adds
  css_parser's new transitive dependency `ssrf_filter 1.5.0`.

## AI usage

This PR was produced with Claude Code (Opus 4.8) under human direction. Claude
enumerated the open Dependabot alerts, traced each affected package through the
lockfiles to confirm the patched versions satisfied existing constraints,
applied the version bumps, ran the verification specs, and wrote both commit
messages (each commit is marked `(Commit message written by Claude Code.)` with
a `Co-Authored-By` trailer). The human (Sage) provided direction — which alerts
to address, the decision to split the work into a branch, and the go-ahead to
change the css_parser pin — and reviewed the result.

For the css_parser bump, Claude verified the Premailer CSS-inlining path (the
only consumer of css_parser in this codebase): all 34 examples in
`spec/mailers/` pass, 21 examples across `spec/lib/automated_emails` and
`spec/lib/email_processor_spec.rb` pass, and the mailer-previews feature spec
(which renders every email template) passes. All suites were green on the first
run after the bump.

This was a single focused session: two commits within roughly 50 minutes. The
"What this PR does" summary and other analysis above were also drafted by Claude
Code and may contain errors. This PR description was drafted using a Claude Code
skill (`/prepare-pr`).

## Screenshots

No product UI changes — these are dependency/lockfile updates. The screenshots
below are a regression check on the one user-visible surface the css_parser
bump can affect: Premailer's CSS inlining of outgoing emails. premailer-rails
registers `Premailer::Rails::Hook` as a *preview* interceptor, so the rendered
mailer-preview body (`?part=text/html`) is the fully CSS-inlined email — the
exact css_parser output path. "Before" was captured on `master` (css_parser
1.22.0), "after" on this branch (css_parser 3.0.0), across a spread of
templates spanning the different email layouts.

**Every pair below is byte-for-byte identical** (verified by md5). css_parser
3.0.0's changes are confined to the network-fetch/security path (`ssrf_filter`,
`file://` removal); CSS parsing/inlining semantics are unchanged, so the
rendered emails are pixel-identical. Inlining is confirmed active (35 inline
`style=` attributes in the course-approval body under 3.0.0), so these are
genuine before/after renders, not a case of Premailer being skipped.

**01 course approval**

| Before (1.22.0) | After (3.0.0) |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/before/01_course_approval.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/after/01_course_approval.png) |

**02 instructor notification**

| Before (1.22.0) | After (3.0.0) |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/before/02_instructor_notification.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/after/02_instructor_notification.png) |

**03 term recap**

| Before (1.22.0) | After (3.0.0) |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/before/03_term_recap.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/after/03_term_recap.png) |

**04 survey**

| Before (1.22.0) | After (3.0.0) |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/before/04_survey.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/after/04_survey.png) |

**05 wiki email**

| Before (1.22.0) | After (3.0.0) |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/before/05_wiki_email.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/security-dependency-bumps/screenshots/after/05_wiki_email.png) |

## Open questions and concerns

- `css_parser` crosses two major versions (1.x → 3.x). Verification was scoped
  to the Premailer email-rendering path because that is the sole consumer of
  css_parser in the codebase; the default-secure 3.0.0 behaviour is what we want
  here, and no code opted into the now-gated `file://` or local-network fetch
  behaviour. Reviewers may still want to confirm no downstream/asset tooling
  relies on css_parser indirectly.
- The two `websocket-driver` bumps are patch-level transitive updates and were
  not separately spec-verified beyond confirming clean lockfile resolution.

(PR description written by Claude Code.)
