### PR TITLE
Bump seven deps to patch new Dependabot alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.4.2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5127,8 +5127,8 @@ __metadata:
   linkType: hard
 
 "body-parser@npm:~1.20.5":
-  version: 1.20.5
-  resolution: "body-parser@npm:1.20.5"
+  version: 1.20.6
+  resolution: "body-parser@npm:1.20.6"
   dependencies:
     bytes: ~3.1.2
     content-type: ~1.0.5
@@ -5142,7 +5142,7 @@ __metadata:
     raw-body: ~2.5.3
     type-is: ~1.6.18
     unpipe: ~1.0.0
-  checksum: f108e1c8b513c33b8848d0fa26ad97f086ae0e338a49d6e1b7013071a8e6ac8c74792fc9ff019aa519cdb9d98484a485191ddd151085d0710dd1533f5ca0c9bd
+  checksum: 9201c4c65362a7b81dd2dde6c006251905a62e5d56abacfc50f8cac2f91f27222c29e28a68325a4fa1b34dbd95c79ea1b725a15be45eab604bd2645f209f7ace
   languageName: node
   linkType: hard
 
@@ -5164,21 +5164,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.13":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: ^1.0.0
     concat-map: 0.0.1
-  checksum: f2a950034e670523cc186da61aabe3beab74b1b8a7c74a756bf6b172dad1917312f255d9ec46906c9f0cab530868095d8c143918576930dd0e1323c3803850f1
+  checksum: 11ab2d5b39d61bc0d0de9240a5d08a5f210a5650885ca4876271ef5996b4c5d172d697b501d673fe099ab721aa8bf0348507ad23a6148e169856209d2f9cab94
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.3":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: ^1.0.0
-  checksum: 4681c533dc4e6c77b3ad795b38683d297fd03c739a17bfb2a338529fa7dcf4540683a79dcd662905f4c5b0db7cfda18daafcd18dd1bbf7c3b076fe0c9c3487eb
+  checksum: 90ae144540b4dc988c787ef32dc5c00d44aa48472681baf99f967272366cf30c6eddb837a30b4f20ba3205a38348f1bb295c86ae2750da13e7fe25c42fcfb00a
   languageName: node
   linkType: hard
 
@@ -6393,14 +6393,14 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^3.4.11":
-  version: 3.4.11
-  resolution: "dompurify@npm:3.4.11"
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": ^2.0.7
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: f96ec0f1ea763779ee0c08e05015422d600c14d4e0a6dd4b21cfb4ac30082c333534c2092206d55fcf9597f9750622facdaf295463b3f826b38569c928d16f19
+  checksum: 477e944e669bac9247c9ebfa55c7ea5c73f3cc6cd6b21ee72e306000e3e53d308e7bdaac89e655a0e2661de2ffbdd877e6a92537d07ba1d70c6c441fcef8c65c
   languageName: node
   linkType: hard
 
@@ -9508,7 +9508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"launch-editor@npm:^2.6.1":
+"launch-editor@npm:^2.14.1":
   version: 2.14.1
   resolution: "launch-editor@npm:2.14.1"
   dependencies:
@@ -9578,11 +9578,11 @@ __metadata:
   linkType: hard
 
 "linkify-it@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "linkify-it@npm:5.0.1"
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: ^2.0.0
-  checksum: bd5b4ebaca5495d5c2f41d284f0c8c42bffaa9e38223628f6b17038256302e4cba1e5161cf3e336a13963430cb2b37eca5ad0a595195bb5e54d051d73539210f
+  checksum: 3ac965e7df2c8788dc5c4c3009aab745f0288dcbc8776ab5bf4317b106c7b7b84fd0f502565d81f9c07f61fa0f0a4150893a6af9d86c36af985aac115bb5c293
   languageName: node
   linkType: hard
 
@@ -13381,8 +13381,8 @@ __metadata:
   linkType: hard
 
 "svgo@npm:^2.8.1":
-  version: 2.8.2
-  resolution: "svgo@npm:2.8.2"
+  version: 2.8.3
+  resolution: "svgo@npm:2.8.3"
   dependencies:
     commander: ^7.2.0
     css-select: ^4.1.3
@@ -13393,7 +13393,7 @@ __metadata:
     stable: ^0.1.8
   bin:
     svgo: ./bin/svgo
-  checksum: 6294a2a1cd7b324c5aa7a087d6eb91aa5a0c62ca604ef39271bf830c790cda3cc3bd97b7ada2e0ed2a5b3609367bb0739e1e799e8f777d6117601c30ed90bd22
+  checksum: e3636760dfb7fb898919fd8eade7ad4a69a10b8650e9b3062b3beff6045f39063da18d537b454ed5bca638a9db45bb0bfa8d9b920efac2157964ec20ff35d829
   languageName: node
   linkType: hard
 
@@ -14169,8 +14169,8 @@ __metadata:
   linkType: hard
 
 "webpack-dev-server@npm:^5.2.5":
-  version: 5.2.5
-  resolution: "webpack-dev-server@npm:5.2.5"
+  version: 5.2.6
+  resolution: "webpack-dev-server@npm:5.2.6"
   dependencies:
     "@types/bonjour": ^3.5.13
     "@types/connect-history-api-fallback": ^1.5.4
@@ -14190,7 +14190,7 @@ __metadata:
     graceful-fs: ^4.2.6
     http-proxy-middleware: ^2.0.9
     ipaddr.js: ^2.1.0
-    launch-editor: ^2.6.1
+    launch-editor: ^2.14.1
     open: ^10.0.3
     p-retry: ^6.2.0
     schema-utils: ^4.2.0
@@ -14209,7 +14209,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 349719d0487a5672f65a7427d54afc9f8ddc6b695042641ed9f468cb5a3c90866e16a236ecdb2ac62d2a922712f9c1296b8805b7ec0880f6a3f5c4280785f200
+  checksum: 0953b27bf9a9cc591f0118cedea6463f4f2190b9f297be63a372b033f4abd261bf297ee92611a7c875e3b71458ba8f11aa8ce8a342528776d20029629e74ea1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does

Closes nine Dependabot alerts (#439–#447) with lockfile-only version bumps of
seven packages. Every patched version already satisfies the existing semver
range, so no manifest constraints (`package.json` / `Gemfile`) change.

These alerts appeared when #6965 (the websocket-driver / css_parser bumps)
merged to `master`, but they were **not caused by that change** — the merge
diff added only `css_parser`, `ssrf_filter`, and `websocket-driver`, none of
the packages below. Merging to the default branch triggers a fresh Dependabot
scan; that single scan both marked #6965's fixes as resolved and opened these
nine, which had accumulated (advisories published against dependencies already
in the tree) since the previous scan.

**yarn.lock:**
- `svgo` 2.8.2 → 2.8.3 (high) — direct devDependency (`^2.8.1`)
- `linkify-it` 5.0.1 → 5.0.2 (high) — transitive
- `brace-expansion` 1.1.15 → 1.1.16 and 2.1.1 → 2.1.2 (high) — transitive; both
  major lines were present, both bumped
- `webpack-dev-server` 5.2.5 → 5.2.6 (medium ×2) — direct devDependency
  (`^5.2.5`); affects `yarn start` only, not the build or production
- `dompurify` 3.4.11 → 3.4.12 (low) — direct dependency (`^3.4.11`); the
  frontend HTML sanitizer used in `tickets/reply`. The bump is itself a
  sanitizer fix.
- `body-parser` 1.20.5 → 1.20.6 (low) — transitive

**Gemfile.lock:**
- `loofah` 2.25.1 → 2.25.2 (low) — transitive via `rails-html-sanitizer`
  (`~> 2.25`); backs the Rails `sanitize` helper

Transitive npm packages were re-resolved with `yarn up -R`; the direct
devDeps/deps with the same (their ranges were already wide enough, so
`package.json` is untouched); `loofah` with `bundle update loofah
--conservative`.

## AI usage

This PR was produced with Claude Code (Opus 4.8) under human direction. After
#6965 merged, Sage asked whether the merge had caused a batch of new alerts;
Claude checked the merge diff, confirmed it had not, and explained the
rescan-on-merge behaviour. Sage then asked Claude to branch off the merged
`master` and fix the alerts. Claude traced each package through the lockfiles,
confirmed the patched versions fit the existing ranges, applied the bumps, and
verified the result. The commit message is marked `(Commit message written by
Claude Code.)` with a `Co-Authored-By` trailer.

Verification: `yarn install --immutable` confirms lockfile consistency;
`yarn build` compiles cleanly (exercising svgo's SVG optimization and bundling
dompurify); a throwaway sanitizer smoke test confirmed loofah 2.25.2 still
strips `<script>` / `javascript:` and preserves allowlisted tags.
`webpack-dev-server` affects only the local dev server and was not separately
exercised. No targeted spec exists for the dompurify or loofah call sites, so
runtime coverage is the build plus that smoke test.

Scale of effort: a single commit made in one short session immediately after
the #6965 merge, with terse high-level direction from Sage. The "What this PR
does" summary and analysis above were also drafted by Claude Code and may
contain errors. This PR description was drafted using a Claude Code skill
(`/prepare-pr`).

## Screenshots

No UI changes — dependency-lockfile updates only. (`webpack-dev-server` and
`svgo` are build/dev tooling; `dompurify` and `loofah` are sanitizers whose
patched behaviour is covered by the verification above.)

## Open questions and concerns

- The dompurify and loofah call sites have no dedicated test, so their runtime
  behaviour is covered only by the build and the sanitizer smoke test noted
  above rather than by committed specs. All seven are patch-level bumps within
  existing ranges, so the regression risk is low.

(PR description written by Claude Code.)
