### PR TITLE
Delete ACUWT rows in UpdateTimeslicesCourseDate

### DIFF
--- a/app/services/update_timeslices_course_date.rb
+++ b/app/services/update_timeslices_course_date.rb
@@ -83,9 +83,10 @@ class UpdateTimeslicesCourseDate
     Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
     Removing data prior to: #{@course.start}"
 
-    # Delete course and course user timeslices
+    # Delete course, course user and article course user timeslices
     @timeslice_cleaner.delete_course_wiki_timeslices_prior_to_start_date
     @timeslice_cleaner.delete_course_user_wiki_timeslices_prior_to_start_date
+    @timeslice_cleaner.delete_article_course_user_wiki_timeslices_prior_to_start_date
 
     # Delete articles courses
     ArticlesCoursesCleaner.clean_articles_courses_prior_to_course_start(@course)
@@ -97,9 +98,10 @@ class UpdateTimeslicesCourseDate
     Rails.logger.info "UpdateTimeslicesCourseDate: Course: #{@course.slug}\
     Removing data after to: #{@course.end}"
 
-    # Delete course and course user timeslices
+    # Delete course, course user and article course user timeslices
     @timeslice_cleaner.delete_course_wiki_timeslices_after_end_date
     @timeslice_cleaner.delete_course_user_wiki_timeslices_after_end_date
+    @timeslice_cleaner.delete_article_course_user_wiki_timeslices_after_end_date
 
     # Delete articles courses
     ArticlesCoursesCleaner.clean_articles_courses_after_course_end(@course)

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -93,6 +93,14 @@ class TimesliceCleaner
     delete_in_batches(timeslices)
   end
 
+  # Deletes article course user wiki timeslices records with a start date later than
+  # the specific given date
+  def delete_article_course_user_wiki_timeslices_after_date(wikis, date)
+    timeslices = ArticleCourseUserWikiTimeslice.where(course: @course).where(wiki: wikis)
+                                               .where('start > ?', date)
+    delete_in_batches(timeslices)
+  end
+
   # Deletes article course timeslices records with a start date later than the
   # specific given date
   def delete_article_course_timeslices_after_date(wikis, date)
@@ -113,6 +121,19 @@ class TimesliceCleaner
   # Deletes course user wiki timeslices records with a start date later than the current end date
   def delete_course_user_wiki_timeslices_after_end_date
     delete_course_user_wiki_timeslices_after_date(@course.wikis, @course.end)
+  end
+
+  # Deletes article course user wiki timeslices records with a date prior to the
+  # current start date
+  def delete_article_course_user_wiki_timeslices_prior_to_start_date
+    delete_in_batches(ArticleCourseUserWikiTimeslice.where(course: @course)
+                                                    .where('end <= ?', @course.start))
+  end
+
+  # Deletes article course user wiki timeslices records with a start date later than
+  # the current end date
+  def delete_article_course_user_wiki_timeslices_after_end_date
+    delete_article_course_user_wiki_timeslices_after_date(@course.wikis, @course.end)
   end
 
   # Marks CWT rows as needs_reaggregation for every (wiki, start) period covered

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -227,6 +227,70 @@ describe TimesliceCleaner do
     end
   end
 
+  describe '#delete_article_course_user_wiki_timeslices_prior_to_start_date' do
+    before do
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-01-10'.to_datetime, end: '2024-01-11'.to_datetime)
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-01-11'.to_datetime, end: '2024-01-12'.to_datetime)
+    end
+
+    it 'deletes article course user wiki timeslices for dates prior to start date properly' do
+      expect(ArticleCourseUserWikiTimeslice.where(course:).size).to eq(3)
+
+      # Update course start date
+      course.update(start: '2024-01-10'.to_datetime)
+      timeslice_cleaner.delete_article_course_user_wiki_timeslices_prior_to_start_date
+
+      # Article course user wiki timeslices prior to the new start date were deleted
+      expect(ArticleCourseUserWikiTimeslice.where(course:).size).to eq(2)
+    end
+  end
+
+  describe '#delete_article_course_user_wiki_timeslices_after_end_date' do
+    before do
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-04-10'.to_datetime, end: '2024-04-11'.to_datetime)
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+    end
+
+    it 'deletes article course user wiki timeslices for dates after the end date properly' do
+      expect(ArticleCourseUserWikiTimeslice.where(course:).size).to eq(3)
+
+      # Update course end date
+      course.update(end: '2024-04-10'.to_datetime)
+      timeslice_cleaner.delete_article_course_user_wiki_timeslices_after_end_date
+
+      # Article course user wiki timeslices after the new end date were deleted
+      expect(ArticleCourseUserWikiTimeslice.where(course:).size).to eq(2)
+    end
+  end
+
+  describe '#delete_article_course_user_wiki_timeslices_after_date' do
+    before do
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-01-08'.to_datetime, end: '2024-01-09'.to_datetime)
+      create(:article_course_user_wiki_timeslice, course:, article_id: article2.id, user_id: 1,
+             wiki: wikidata, start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+      create(:article_course_user_wiki_timeslice, course:, article_id: article1.id, user_id: 1,
+             wiki: enwiki, start: '2024-04-11'.to_datetime, end: '2024-04-12'.to_datetime)
+    end
+
+    it 'deletes article course user wiki timeslices after date properly' do
+      expect(ArticleCourseUserWikiTimeslice.where(course:).size).to eq(3)
+
+      date = '2024-04-11'.to_datetime - 1.second
+      timeslice_cleaner.delete_article_course_user_wiki_timeslices_after_date([enwiki], date)
+
+      expect(ArticleCourseUserWikiTimeslice.where(course:).size).to eq(2)
+    end
+  end
+
   describe '#delete_course_wiki_timeslices_after_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)

--- a/spec/services/update_timeslices_course_date_spec.rb
+++ b/spec/services/update_timeslices_course_date_spec.rb
@@ -37,6 +37,12 @@ describe UpdateTimeslicesCourseDate do
            start: start + 3.days, end: start + 4.days)
     create(:course_user_wiki_timeslice, course:, user: user1, wiki: enwiki,
            start: start + 6.days, end: start + 7.days)
+    create(:article_course_user_wiki_timeslice, course:, article: article1, user: user1,
+           wiki: enwiki, start:, end: start + 1.day)
+    create(:article_course_user_wiki_timeslice, course:, article: article1, user: user1,
+           wiki: enwiki, start: start + 3.days, end: start + 4.days)
+    create(:article_course_user_wiki_timeslice, course:, article: article2, user: user1,
+           wiki: enwiki, start: start + 6.days, end: start + 7.days)
   end
 
   context 'when the start date changed to a previous date' do
@@ -79,6 +85,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.count).to eq(5)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
       expect(course.course_user_wiki_timeslices.count).to eq(2)
+      expect(ArticleCourseUserWikiTimeslice.where(course:).count).to eq(2)
       # Article course for article 1 was deleted
       expect(course.articles_courses.count).to eq(1)
       expect(course.article_course_timeslices.count).to eq(1)
@@ -146,6 +153,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.count).to eq(6)
       expect(course.course_wiki_timeslices.needs_update.count).to eq(1)
       expect(course.course_user_wiki_timeslices.count).to eq(2)
+      expect(ArticleCourseUserWikiTimeslice.where(course:).count).to eq(2)
       # Article course for article 2 was deleted
       expect(course.articles_courses.count).to eq(1)
       expect(course.article_course_timeslices.count).to eq(1)
@@ -171,6 +179,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.needs_update.count).to eq(11)
       expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.article_course_timeslices.count).to eq(0)
+      expect(ArticleCourseUserWikiTimeslice.where(course:).count).to eq(0)
     end
   end
 
@@ -193,6 +202,7 @@ describe UpdateTimeslicesCourseDate do
       expect(course.course_wiki_timeslices.needs_update.count).to eq(11)
       expect(course.course_user_wiki_timeslices.count).to eq(0)
       expect(course.article_course_timeslices.count).to eq(0)
+      expect(ArticleCourseUserWikiTimeslice.where(course:).count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## What this PR does

Closes #6969. When a course's start or end date changes so that some
timeslices fall outside the new period, `UpdateTimeslicesCourseDate` removes the
now-invalid `CourseWikiTimeslice` and `CourseUserWikiTimeslice` rows but leaves
the corresponding `ArticleCourseUserWikiTimeslice` (ACUWT) rows behind. Those
orphans don't affect any statistics, but they accumulate as meaningless rows.

This PR adds ACUWT cleanup to both removal paths:

- `TimesliceCleaner` gains three methods mirroring the existing CUWT ones —
  `delete_article_course_user_wiki_timeslices_after_date`,
  `delete_article_course_user_wiki_timeslices_prior_to_start_date`, and
  `delete_article_course_user_wiki_timeslices_after_end_date`. ACUWT shares the
  same `wiki_id`/`start`/`end` columns as CUWT, so the queries are identical in
  shape.
- `UpdateTimeslicesCourseDate` calls the two new wrappers from
  `remove_timeslices_prior_to_start_date` and `remove_timeslices_after_end_date`.
  These paths already cover all three removal scenarios (start moved later, end
  moved earlier, and drastic non-overlapping change), so no ACUWT-specific branch
  was needed — the existing code reused cleanly.

The standalone `_after_date` method is only called internally by
`_after_end_date`; it's kept to stay consistent with the CWT/CUWT/ACT variants,
which follow the same pattern.

## AI usage

The code, specs, and commit message were drafted by Claude Code under the user's
direction. The user pointed it at the issue, proposed the two method names and
the observation that no ACUWT branch was needed, and made the call to keep the
`_after_date` helper for cross-table consistency after Claude questioned whether
it earned its place. The user ran RuboCop, the specs, and a local test before
committing.

This was a single focused session: one commit, all changes made within about an
hour on 2026-07-24.

This PR description was drafted using a Claude Code skill (`/prepare-pr`). The
"What this PR does" summary above was also drafted by Claude Code and may contain
errors.

## Screenshots

No UI changes — backend-only cleanup.

## Open questions and concerns

None.

(PR description written by Claude Code.)