### PR TITLE
Delete ACUWT rows in TimesliceCleaner#delete_timeslices_for_period

### DIFF
--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -65,6 +65,7 @@ class TimesliceCleaner
     delete_course_wiki_timeslices_for_period(wikis, start_date, end_date)
     delete_course_user_wiki_timeslices_for_period(wikis, start_date, end_date)
     delete_article_course_timeslices_for_period(wikis, start_date, end_date)
+    delete_article_course_user_wiki_timeslices_for_period(wikis, start_date, end_date)
   end
 
   # Deletes course wiki timeslices records with a date prior to the current start date
@@ -277,6 +278,17 @@ class TimesliceCleaner
     timeslices = CourseUserWikiTimeslice.where(course: @course).where(wiki: wikis)
                                         .where('start >= ?', start_date)
                                         .where('end <= ?', end_date)
+    delete_in_batches(timeslices)
+  end
+
+  # Deletes article course user wiki timeslices records in the period [start_date, end_date].
+  # ACUWT rows are keyed by (course, wiki, article, user, start, end), so rows written for a
+  # period that no longer exists as a timeslice (for example, after that period was split)
+  # would otherwise linger and keep contributing to the aggregations derived from ACUWT.
+  def delete_article_course_user_wiki_timeslices_for_period(wikis, start_date, end_date)
+    timeslices = ArticleCourseUserWikiTimeslice.where(course: @course).where(wiki: wikis)
+                                               .where('start >= ?', start_date)
+                                               .where('end <= ?', end_date)
     delete_in_batches(timeslices)
   end
 

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -114,6 +114,12 @@ describe TimesliceCleaner do
       end: end_date)
       create(:article_course_timeslice, course:, article: article3, start: end_date,
       end: end_date + 1.day)
+      create(:article_course_user_wiki_timeslice, course:, wiki: wikidata, article: article2,
+      user_id: 1, start: start_date, end: end_date)
+      create(:article_course_user_wiki_timeslice, course:, wiki: wikidata, article: article3,
+      user_id: 1, start: end_date, end: end_date + 1.day)
+      create(:article_course_user_wiki_timeslice, course:, wiki: enwiki, article: article1,
+      user_id: 1, start: start_date, end: end_date)
       course.reload
     end
 
@@ -128,6 +134,17 @@ describe TimesliceCleaner do
       expect(course.course_wiki_timeslices.size).to eq(221)
       expect(course.course_user_wiki_timeslices.size).to eq(2)
       expect(course.article_course_timeslices.size).to eq(2)
+    end
+
+    it 'deletes article course user wiki timeslices for the given period and wikis only' do
+      expect(ArticleCourseUserWikiTimeslice.where(course:).count).to eq(3)
+
+      timeslice_cleaner.delete_timeslices_for_period([wikidata], start_date, end_date)
+
+      # The wikidata record for a later period, and the enwiki record for the same period,
+      # both remain
+      expect(ArticleCourseUserWikiTimeslice.where(course:, wiki: wikidata).count).to eq(1)
+      expect(ArticleCourseUserWikiTimeslice.where(course:, wiki: enwiki).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
## What this PR does
Add ACUWT row deletion to the `delete_timeslices_for_period` method. This method is called when a timeslice is split because it has more than 10K revisions. Before this PR, ACUWT rows created for the previous start and end dates were left orphaned when the timeslice was split. This did not affect any production courses, since those timeslices were split the first time they were processed.

## AI usage
Done with Claude.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
