### PR TITLE
Stop deleting derived timeslices when reaggregation

### DIFF
--- a/app/services/reprocess_article_course_user_wiki_timeslices.rb
+++ b/app/services/reprocess_article_course_user_wiki_timeslices.rb
@@ -37,7 +37,7 @@ class ReprocessArticleCourseUserWikiTimeslices
       @course, @wiki, article_ids, ts_start
     )
     fetch_scores_and_update_acuwt(users, article_ids, ts_start, ts_end) if users.any?
-    reset_for_reaggregation(article_ids, ts_start)
+    mark_for_reaggregation(article_ids, ts_start)
   end
 
   def failing_article_ids_for(ts_start)
@@ -69,14 +69,15 @@ class ReprocessArticleCourseUserWikiTimeslices
     UpdateWikidataStatsTimeslice.new(@course).update_revisions_with_stats(live_revisions)
   end
 
-  # Marks the CWT for reaggregation (deleting the stale ACT/CUWT rows) and clears
-  # needs_update so the reaggregation pass picks it up. Reaggregation then rebuilds
-  # ACT, CUWT and CWT from ACUWT and re-derives needs_update from ACUWT state.
-  def reset_for_reaggregation(article_ids, ts_start)
+  # Marks the CWT for reaggregation and clears needs_update so the reaggregation pass picks it
+  # up. Reaggregation then rebuilds ACT, CUWT and CWT from ACUWT and re-derives needs_update
+  # from ACUWT state. The re-scored ACUWT rows are kept, so the rebuild covers every ACT and
+  # CUWT row of the period and there is nothing to delete first.
+  def mark_for_reaggregation(article_ids, ts_start)
     acuwt = ArticleCourseUserWikiTimeslice.where(
       course: @course, wiki: @wiki, start: ts_start, article_id: article_ids
     )
-    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    @timeslice_cleaner.mark_timeslices_for_reaggregation_from_acuwt(acuwt)
   end
 
   def revision_data_manager

--- a/app/services/reprocess_article_course_user_wiki_timeslices.rb
+++ b/app/services/reprocess_article_course_user_wiki_timeslices.rb
@@ -69,10 +69,8 @@ class ReprocessArticleCourseUserWikiTimeslices
     UpdateWikidataStatsTimeslice.new(@course).update_revisions_with_stats(live_revisions)
   end
 
-  # Marks the CWT for reaggregation and clears needs_update so the reaggregation pass picks it
-  # up. Reaggregation then rebuilds ACT, CUWT and CWT from ACUWT and re-derives needs_update
-  # from ACUWT state. The re-scored ACUWT rows are kept, so the rebuild covers every ACT and
-  # CUWT row of the period and there is nothing to delete first.
+  # Marks the CWT for the period as needing reaggregation, so that the re-scored ACUWT rows
+  # reach the derived caches (see TimesliceCleaner#mark_timeslices_for_reaggregation_from_acuwt).
   def mark_for_reaggregation(article_ids, ts_start)
     acuwt = ArticleCourseUserWikiTimeslice.where(
       course: @course, wiki: @wiki, start: ts_start, article_id: article_ids

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -215,19 +215,19 @@ class UpdateCourseWikiTimeslices
   end
 
   def update_article_course_user_wiki_timeslices_for_wiki(wiki, revisions)
-    timeslice = acuwt_timeslice_for(wiki, revisions)
+    timeslice = course_wiki_timeslice_for(wiki, revisions)
     ArticleCourseUserWikiTimeslice.bulk_upsert_from_revisions(
       @course, wiki, timeslice.start, timeslice.end, revisions[:revisions]
     )
   end
 
   def update_article_course_timeslices_from_acuwt_for_wiki(wiki, revisions)
-    timeslice = acuwt_timeslice_for(wiki, revisions)
+    timeslice = course_wiki_timeslice_for(wiki, revisions)
     ArticleCourseTimeslice.bulk_update_from_acuwt(@course, wiki, timeslice.start, timeslice.end)
   end
 
   def update_course_user_wiki_timeslices_from_acuwt_for_wiki(wiki, revisions)
-    timeslice = acuwt_timeslice_for(wiki, revisions)
+    timeslice = course_wiki_timeslice_for(wiki, revisions)
     revisions[:revisions].map(&:user_id).uniq.each do |user_id|
       CourseUserWikiTimeslice.update_from_acuwt(@course, user_id, wiki,
                                                timeslice.start, timeslice.end)
@@ -235,7 +235,7 @@ class UpdateCourseWikiTimeslices
   end
 
   def update_course_wiki_timeslices_from_acuwt_for_wiki(wiki, revisions)
-    timeslice = acuwt_timeslice_for(wiki, revisions)
+    timeslice = course_wiki_timeslice_for(wiki, revisions)
     CourseWikiTimeslice.update_from_acuwt(@course, wiki, timeslice.start, timeslice.end)
   end
 
@@ -260,7 +260,7 @@ class UpdateCourseWikiTimeslices
     CourseWikiTimeslice.update_from_acuwt(@course, wiki, cwt.start, cwt.end)
   end
 
-  def acuwt_timeslice_for(wiki, revisions)
+  def course_wiki_timeslice_for(wiki, revisions)
     @course.course_wiki_timeslices.where(wiki:)
            .for_revisions_between(revisions[:start], revisions[:end]).first
   end

--- a/app/services/update_timeslices_untracked_article.rb
+++ b/app/services/update_timeslices_untracked_article.rb
@@ -35,7 +35,7 @@ class UpdateTimeslicesUntrackedArticle
     acuwt = ArticleCourseUserWikiTimeslice
               .where(course: @course, article_id: article_ids, tracked: true)
     return if acuwt.empty?
-    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    @timeslice_cleaner.mark_timeslices_for_reaggregation_from_acuwt(acuwt)
     acuwt.update_all(tracked: false) # rubocop:disable Rails/SkipsModelValidations
   end
 
@@ -44,7 +44,7 @@ class UpdateTimeslicesUntrackedArticle
     acuwt = ArticleCourseUserWikiTimeslice
               .where(course: @course, article_id: article_ids, tracked: false)
     return if acuwt.empty?
-    @timeslice_cleaner.reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    @timeslice_cleaner.mark_timeslices_for_reaggregation_from_acuwt(acuwt)
     acuwt.update_all(tracked: true) # rubocop:disable Rails/SkipsModelValidations
   end
 

--- a/lib/article_namespaces_manager.rb
+++ b/lib/article_namespaces_manager.rb
@@ -4,9 +4,8 @@ require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 
 ##= Resets articles whose tracked status changed during the course timeline, so
 # that they are included in or excluded from course stats as appropriate.
-# Resetting an article means marking its course wiki timeslices for reprocessing
-# and removing its articles_courses record and article course timeslices
-# (see ArticlesCoursesCleaner#reset).
+# Resetting an article means marking its course wiki timeslices for reprocessing,
+# and removing its articles_courses record (and timeslices too for non-acuwt courses).
 #
 # The following cases are handled for every course, including article scoped
 # programs (which never run ArticleStatusManager), as a best effort to

--- a/lib/articles_courses_cleaner.rb
+++ b/lib/articles_courses_cleaner.rb
@@ -127,7 +127,7 @@ class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
 
     article_ids = articles.pluck(:id)
     acuwt = ArticleCourseUserWikiTimeslice.where(course: @course, article_id: article_ids)
-    TimesliceCleaner.new(@course).reset_timeslices_for_reaggregation_from_acuwt(acuwt)
+    TimesliceCleaner.new(@course).mark_timeslices_for_reaggregation_from_acuwt(acuwt)
     delete_article_course(article_ids)
   end
 

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -137,9 +137,32 @@ class TimesliceCleaner
     delete_article_course_user_wiki_timeslices_after_date(@course.wikis, @course.end)
   end
 
+  # Marks CWT rows as needs_reaggregation for every (wiki, start) period covered by the given
+  # ACUWT records, without touching the ACT and CUWT rows for those periods. The reaggregation
+  # pass rebuilds one ACT row per article and one CUWT row per user holding an ACUWT row in the
+  # period, so as long as the caller keeps its ACUWT rows, every row that could be stale is
+  # rewritten in place and deleting it first would only turn an update into a delete plus an
+  # insert. Whatever changed (namespace, scope, tracked flag, re-scored values) is recomputed
+  # by the rebuild.
+  # Callers that delete the ACUWT rows themselves must use
+  # reset_timeslices_for_reaggregation_from_acuwt instead, since the rebuild no longer covers
+  # the rows those records would have produced.
+  # Takes an ActiveRecord::Relation of ArticleCourseUserWikiTimeslice records.
+  def mark_timeslices_for_reaggregation_from_acuwt(acuwt_records)
+    return if acuwt_records.empty?
+
+    wikis_and_starts = acuwt_records.pluck(:wiki_id, :start).uniq
+    return if wikis_and_starts.empty?
+
+    mark_timeslices_for_reaggregation(wikis_and_starts)
+  end
+
   # Marks CWT rows as needs_reaggregation for every (wiki, start) period covered
   # by the given ACUWT records, and deletes the ACT and CUWT rows for those
   # periods so they are cleanly re-derived during the next reaggregation pass.
+  # Only for callers that delete the ACUWT records afterwards: the reaggregation pass derives
+  # the rows it rebuilds from the surviving ACUWT rows, so it would leave these ones behind.
+  # Every other caller wants mark_timeslices_for_reaggregation_from_acuwt.
   # Takes an ActiveRecord::Relation of ArticleCourseUserWikiTimeslice records.
   def reset_timeslices_for_reaggregation_from_acuwt(acuwt_records)
     return if acuwt_records.empty?

--- a/spec/lib/article_namespaces_manager_spec.rb
+++ b/spec/lib/article_namespaces_manager_spec.rb
@@ -117,7 +117,9 @@ describe ArticleNamespacesManager do
         described_class.new(course)
 
         expect(course.articles_courses.where(article: article3)).to be_empty
-        expect(course.article_course_timeslices.where(article: article3)).to be_empty
+        # The article course timeslice is left for the reaggregation pass to rewrite from the
+        # kept ACUWT rows, which is what applies the exclusion
+        expect(course.article_course_timeslices.where(article: article3).count).to eq(1)
         course_wiki_timeslice = course.course_wiki_timeslices.find_by(wiki: wikidata,
                                                                       start: '2024-01-11')
         expect(course_wiki_timeslice.needs_reaggregation).to eq(true)
@@ -131,7 +133,9 @@ describe ArticleNamespacesManager do
         described_class.new(course, statuses_synced: true)
 
         expect(course.articles_courses.where(article: article1)).to be_empty
-        expect(course.article_course_timeslices.where(article: article1)).to be_empty
+        # The article course timeslice is left for the reaggregation pass to rewrite from the
+        # kept ACUWT rows, which is what applies the exclusion
+        expect(course.article_course_timeslices.where(article: article1).count).to eq(1)
         course_wiki_timeslice = course.course_wiki_timeslices.find_by(wiki: enwiki,
                                                                       start: '2024-04-11')
         expect(course_wiki_timeslice.needs_reaggregation).to eq(true)

--- a/spec/lib/articles_courses_cleaner_spec.rb
+++ b/spec/lib/articles_courses_cleaner_spec.rb
@@ -40,7 +40,9 @@ describe ArticlesCoursesCleaner do
         described_class.new(course).reset_excluded(articles)
 
         expect(course.articles_courses.where(article: article1)).to be_empty
-        expect(course.article_course_timeslices.where(article: article1)).to be_empty
+        # The article course timeslice is left for the reaggregation pass to rewrite from the
+        # kept ACUWT rows, which is what applies the exclusion
+        expect(course.article_course_timeslices.where(article: article1).count).to eq(1)
         timeslice = course.course_wiki_timeslices.find_by(wiki: enwiki, start: '2024-01-10')
         expect(timeslice.needs_reaggregation).to eq(true)
         expect(timeslice.needs_update).to eq(false)

--- a/spec/services/reprocess_article_course_user_wiki_timeslices_spec.rb
+++ b/spec/services/reprocess_article_course_user_wiki_timeslices_spec.rb
@@ -49,7 +49,7 @@ describe ReprocessArticleCourseUserWikiTimeslices do
                start: ts_start, end: ts_end)
       end
 
-      it 'marks CWT for reaggregation and removes ACT/CUWT rows' do
+      it 'marks CWT for reaggregation and leaves the ACT/CUWT rows to be rewritten' do
         revision = build(:revision_on_memory,
                          article_id: article1.id, user_id: user1.id, wiki_id: enwiki.id,
                          mw_rev_id: 12345, date: ts_start + 1.hour, error: false)
@@ -62,9 +62,11 @@ describe ReprocessArticleCourseUserWikiTimeslices do
 
         expect(course.course_wiki_timeslices.where(start: ts_start).first.needs_reaggregation)
           .to eq(true)
+        # The re-scored ACUWT rows are kept, so the reaggregation pass rewrites these rows
+        # from them rather than needing them deleted here
         expect(course.article_course_timeslices.where(article: article1, start: ts_start).count)
-          .to eq(0)
-        expect(CourseUserWikiTimeslice.where(course:, start: ts_start).count).to eq(0)
+          .to eq(1)
+        expect(CourseUserWikiTimeslice.where(course:, start: ts_start).count).to eq(1)
       end
 
       it 'filters to failing articles before calling the score API' do
@@ -107,7 +109,7 @@ describe ReprocessArticleCourseUserWikiTimeslices do
         expect(course.course_wiki_timeslices.where(start: ts_start).first.needs_reaggregation)
           .to eq(true)
         expect(course.article_course_timeslices.where(article: article1, start: ts_start).count)
-          .to eq(0)
+          .to eq(1)
       end
     end
 
@@ -143,7 +145,7 @@ describe ReprocessArticleCourseUserWikiTimeslices do
         described_class.new(course, enwiki).run
 
         expect(course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(2)
-        expect(course.article_course_timeslices.count).to eq(0)
+        expect(course.article_course_timeslices.count).to eq(2)
       end
     end
   end

--- a/spec/services/update_timeslices_scoped_article_spec.rb
+++ b/spec/services/update_timeslices_scoped_article_spec.rb
@@ -108,8 +108,10 @@ describe UpdateTimeslicesScopedArticle do
       expect(acuwt_course.course_wiki_timeslices.where(needs_update: true).count).to eq(0)
       expect(acuwt_course.course_wiki_timeslices.find_by(needs_reaggregation: true).start)
         .to eq(acuwt_course.start + 1.day)
+      # Left for the reaggregation pass to rewrite from the kept ACUWT rows, which is what
+      # applies the exclusion
       expect(acuwt_course.article_course_timeslices
-                         .where(article_id: random_article.id).count).to eq(0)
+                         .where(article_id: random_article.id).count).to eq(1)
       expect(acuwt_course.articles_courses.count).to eq(1)
       expect(acuwt_course.articles_courses.where(article_id: random_article).count).to eq(0)
       expect(ArticleCourseUserWikiTimeslice

--- a/spec/services/update_timeslices_untracked_article_spec.rb
+++ b/spec/services/update_timeslices_untracked_article_spec.rb
@@ -113,7 +113,7 @@ describe UpdateTimeslicesUntrackedArticle do
         ArticlesCourses.find_by(course: acuwt_course, article: article2).update(tracked: false)
       end
 
-      it 'sets needs_reaggregation, deletes ACT and CUWT rows, and marks ACUWT as untracked' do
+      it 'sets needs_reaggregation and marks ACUWT as untracked' do
         expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(0)
         expect(acuwt_course.article_course_timeslices.count).to eq(3)
         expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(2)
@@ -124,11 +124,10 @@ describe UpdateTimeslicesUntrackedArticle do
 
         # CWT marked for reaggregation for the two periods covered by article2's ACUWT rows
         expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(2)
-        # ACT rows for article2 deleted; article1's row survives
-        expect(acuwt_course.article_course_timeslices.count).to eq(1)
-        expect(acuwt_course.article_course_timeslices.first.article).to eq(article1)
-        # CUWT rows deleted for the affected periods
-        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(0)
+        # ACT and CUWT rows are left for the reaggregation pass to rewrite from the kept
+        # ACUWT rows, whose tracked flag is what applies the exclusion
+        expect(acuwt_course.article_course_timeslices.count).to eq(3)
+        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(2)
         # ACUWT rows for article2 marked as untracked; article1's row unaffected
         expect(ArticleCourseUserWikiTimeslice
                  .where(course: acuwt_course, tracked: false).count).to eq(2)
@@ -144,7 +143,7 @@ describe UpdateTimeslicesUntrackedArticle do
                                       .update_all(tracked: false) # rubocop:disable Rails/SkipsModelValidations
       end
 
-      it 'sets needs_reaggregation, deletes ACT and CUWT rows, and marks ACUWT as tracked' do
+      it 'sets needs_reaggregation and marks ACUWT as tracked' do
         expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(0)
         expect(acuwt_course.article_course_timeslices.count).to eq(3)
         expect(ArticleCourseUserWikiTimeslice
@@ -154,10 +153,10 @@ describe UpdateTimeslicesUntrackedArticle do
 
         # CWT marked for reaggregation for the two periods covered by article2's ACUWT rows
         expect(acuwt_course.course_wiki_timeslices.where(needs_reaggregation: true).count).to eq(2)
-        # ACT rows for article2 deleted; article1's row survives
-        expect(acuwt_course.article_course_timeslices.count).to eq(1)
-        # CUWT rows deleted for the affected periods
-        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(0)
+        # ACT and CUWT rows are left for the reaggregation pass to rewrite from the kept
+        # ACUWT rows, whose tracked flag is what applies the re-inclusion
+        expect(acuwt_course.article_course_timeslices.count).to eq(3)
+        expect(CourseUserWikiTimeslice.where(course: acuwt_course).count).to eq(2)
         # All ACUWT rows now tracked
         expect(ArticleCourseUserWikiTimeslice
                  .where(course: acuwt_course, tracked: false).count).to eq(0)


### PR DESCRIPTION
## What this PR does
Reaggregation involves regenerating ACT, CUWT, and CWT rows from existing ACUWT rows. In most cases, we don't need to manually delete ACT and CUWT rows when marking a timeslice as `needs_reaggregation`, since they will be regenerated automatically during the reaggregation process. This PR avoids deleting derived timeslices when it isn't necessary.

Currently we mark timeslices as `needs_reaggregation` in the following places:

- New user added (`UpdateTimeslicesCourseUser`). There is no need to delete any timeslices; we only need to add the new ACUWT rows.
- User deleted (`UpdateTimeslicesCourseUser`). In this case, we need to delete the timeslices associated with the deleted user ID.
- Article manually excluded/reincluded (`UpdateTimeslicesUntrackedArticle`). We don't need to delete any timeslices in this case.
- ACUWT reprocessed (`ReprocessArticleCourseUserWikiTimeslices`). We don't need to delete timeslices in this case.
- Article excluded reset (`ArticlesCoursesCleaner`). This happens when an article is excluded because it changed namespace or because it fell out of scoped.  We don't need to delete the timeslices here, since the caches will be recalculated excluding this article.


## AI usage
Done with Claude Code.


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
