### PR TITLE
Clean stale timeslice rows before reprocessing a period

### DIFF
--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -202,7 +202,7 @@ class UpdateCourseWikiTimeslices
     return [] if @revision_updater.no_point_in_importing_revisions?
 
     revisions = @revisions[wiki]
-    timeslice = acuwt_timeslice_for(wiki, revisions)
+    timeslice = course_wiki_timeslice_for(wiki, revisions)
     @timeslice_cleaner.clean_timeslices_before_reprocessing(wiki, timeslice.start, timeslice.end,
                                                             revisions[:revisions])
   end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -168,9 +168,9 @@ class UpdateCourseWikiTimeslices
   end
 
   # Processing timeslices involves:
-  # - deleting existing timeslices if reprocessing (only_new = false)
+  # - deleting existing timeslices if reprocessing (only_new = false) and use_acuwt? flag
   # - writing timeslices for the period on the db
-  # - deleting articles courses without timeslices if reprocessing
+  # - deleting articles courses without timeslices if reprocessing and use_acuwt? flag
   # - updating last mw rev datetime
   def process_timeslices(wiki, only_new:)
     @course.reload

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -2,6 +2,8 @@
 
 require_dependency "#{Rails.root}/lib/course_revision_updater"
 require_dependency "#{Rails.root}/lib/timeslice_manager"
+require_dependency "#{Rails.root}/lib/timeslice_cleaner"
+require_dependency "#{Rails.root}/lib/articles_courses_cleaner"
 require_dependency "#{Rails.root}/lib/data_cycle/update_debugger"
 require_dependency "#{Rails.root}/lib/revision_scanner"
 
@@ -16,6 +18,8 @@ class UpdateCourseWikiTimeslices
   def initialize(course, debugger, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
+    @timeslice_cleaner = TimesliceCleaner.new(@course)
+    @articles_courses_cleaner = ArticlesCoursesCleaner.new(@course)
     @splitter = SplitTimeslice.new(@course)
     @debugger = debugger
     @update_service = update_service
@@ -128,7 +132,7 @@ class UpdateCourseWikiTimeslices
     add_scores(only_new:)
     if should_update_timeslice?(wiki, only_new:)
       fetch_wikidata_stats(wiki) if wiki.project == 'wikidata'
-      process_timeslices(wiki)
+      process_timeslices(wiki, only_new:)
     end
     [start_date]
   end
@@ -163,15 +167,47 @@ class UpdateCourseWikiTimeslices
       @wikidata_stats_updater.update_revisions_with_stats(wikidata_revisions)
   end
 
-  def process_timeslices(wiki)
+  # Processing timeslices involves:
+  # - deleting existing timeslices if reprocessing (only_new = false)
+  # - writing timeslices for the period on the db
+  # - deleting articles courses without timeslices if reprocessing
+  # - updating last mw rev datetime
+  def process_timeslices(wiki, only_new:)
     @course.reload
     ActiveRecord::Base.transaction do
-      update_timeslices(wiki)
+      emptied_article_ids = only_new ? [] : clean_timeslices_before_reprocessing(wiki)
+      write_timeslices(wiki)
+      # The articles_courses cleanup has to run after rewriting the timeslices.
+      # Otherwise, it would drop the records of every article in the period.
+      @articles_courses_cleaner.remove_articles_courses_without_timeslices(emptied_article_ids)
       @timeslice_manager.update_last_mw_rev_datetime(@revisions)
     end
   end
 
-  def update_timeslices(wiki)
+  # A reprocess re-fetches the whole period and rewrites it, so rows for (article, user) pairs
+  # that no longer have revisions in the period have to go, or they would keep contributing to
+  # the aggregated timeslices. This is only done when reprocessing: the regular ingestion path
+  # runs many times a day for a single course, and there the fetch is not expected to return
+  # less data than the previous one.
+  #
+  # Only for ACUWT courses: the clean works by diffing the period's stored ACUWT rows against
+  # the fetched revisions. The legacy path is left as it was, since it is on its way out.
+  #
+  # Skipped when the fetch never asked the replica, which happens for an article scoped course
+  # with no assignments and no categories. Such a course keeps its ACUWT rows on purpose (see
+  # ArticlesCoursesCleaner#reset_excluded) while every fetch comes back empty, so cleaning
+  # would read 'not fetched' as 'the period has no revisions' and wipe them for good.
+  def clean_timeslices_before_reprocessing(wiki)
+    return [] unless @course.use_acuwt?
+    return [] if @revision_updater.no_point_in_importing_revisions?
+
+    revisions = @revisions[wiki]
+    timeslice = acuwt_timeslice_for(wiki, revisions)
+    @timeslice_cleaner.clean_timeslices_before_reprocessing(wiki, timeslice.start, timeslice.end,
+                                                            revisions[:revisions])
+  end
+
+  def write_timeslices(wiki)
     revisions = @revisions[wiki]
     if @course.use_acuwt?
       update_article_course_user_wiki_timeslices_for_wiki(wiki, revisions)
@@ -228,10 +264,19 @@ class UpdateCourseWikiTimeslices
 
   def update_course_user_wiki_timeslices_from_acuwt_for_wiki(wiki, revisions)
     timeslice = acuwt_timeslice_for(wiki, revisions)
-    revisions[:revisions].map(&:user_id).uniq.each do |user_id|
+    acuwt_user_ids(wiki, timeslice).each do |user_id|
       CourseUserWikiTimeslice.update_from_acuwt(@course, user_id, wiki,
                                                timeslice.start, timeslice.end)
     end
+  end
+
+  # Users come from the period's stored ACUWT rows rather than from the fetched revisions: a
+  # user whose revisions are no longer in the period still needs their CUWT row rebuilt, or it
+  # would keep stale values. This is what reaggregate_timeslice_from_acuwt already does.
+  def acuwt_user_ids(wiki, timeslice)
+    ArticleCourseUserWikiTimeslice.where(course: @course, wiki:, start: timeslice.start,
+                                         end: timeslice.end)
+                                  .distinct.pluck(:user_id)
   end
 
   def update_course_wiki_timeslices_from_acuwt_for_wiki(wiki, revisions)

--- a/lib/articles_courses_cleaner.rb
+++ b/lib/articles_courses_cleaner.rb
@@ -105,6 +105,22 @@ class ArticlesCoursesCleaner # rubocop:disable Metrics/ClassLength
     delete_in_batches(after_timeslices)
   end
 
+  # Removes the articles courses records of the given articles that have no timeslice left in
+  # the course. Called after a reprocessed period dropped an article's last revisions for that
+  # period: articles_courses is course wide, so the article may still have revisions in another
+  # period, and only the ones left with nothing anywhere can go.
+  # Resolved with one query per timeslice table over the given ids, rather than per article.
+  # Both queries hit indexes that lead with article_id or (course_id, article_id).
+  def remove_articles_courses_without_timeslices(article_ids)
+    return if article_ids.empty?
+
+    still_present = ArticleCourseUserWikiTimeslice.where(course: @course, article_id: article_ids)
+                                                 .distinct.pluck(:article_id)
+    still_present += ArticleCourseTimeslice.where(course: @course, article_id: article_ids)
+                                           .distinct.pluck(:article_id)
+    delete_article_course(article_ids - still_present)
+  end
+
   # Legacy reset (full re-fetch). It involves the following actions:
   # - Mark timeslices for those articles as needs_update
   # - Remove article course records for those articles (if they exist)

--- a/lib/timeslice_cleaner.rb
+++ b/lib/timeslice_cleaner.rb
@@ -152,6 +152,42 @@ class TimesliceCleaner
     delete_course_user_wiki_timeslices_for_acuwt_pairs(wikis_and_starts)
   end
 
+  # Deletes the rows for the [start_date, end_date] period of a timeslice that is about to be
+  # rewritten from a full re-fetch of that period, so that no rows survive for (article, user)
+  # pairs the re-fetch did not return. Takes the fetched revisions for the period.
+  #
+  # Only the rows the rewrite will not cover are deleted. A timeslice holds up to
+  # SplitTimeslice::REVISION_THRESHOLD revisions, so deleting the period wholesale and letting
+  # the rewrite recreate it would mean thousands of deletes and inserts on every reprocess;
+  # this way a reprocess that finds the same data as before deletes nothing. It also means the
+  # rows that survive are updated in place, so the columns the rewrite does not write
+  # (`tracked`) keep their value.
+  #
+  # ACUWT rows for articles deleted on wiki are kept: their revisions are gone from the
+  # replica, so no re-fetch can reproduce them, and they are retained on purpose so the
+  # articles can be re-included cheaply if they get undeleted (see
+  # ArticlesCoursesCleaner#reset_included).
+  #
+  # Returns the ids of the articles left without any row for the period, so the caller can drop
+  # the articles_courses records of those left without any timeslice in the course, once the
+  # period has been rewritten (see
+  # ArticlesCoursesCleaner#remove_articles_courses_without_timeslices).
+  #
+  # ACUWT courses only, since it diffs the stored ACUWT rows to decide what to delete.
+  # The plucked rows are [id, article_id, user_id] tuples.
+  def clean_timeslices_before_reprocessing(wiki, start_date, end_date, revisions)
+    stored = ArticleCourseUserWikiTimeslice.where(course: @course, wiki:, start: start_date,
+                                                  end: end_date)
+                                           .pluck(:id, :article_id, :user_id)
+    stale = stale_acuwt_rows(stored, fetched_pairs(revisions))
+    return [] if stale.empty?
+
+    delete_in_batches(ArticleCourseUserWikiTimeslice.where(id: stale.map { |row| row[0] }))
+    article_ids, user_ids = emptied_article_and_user_ids(stored, stale)
+    delete_aggregated_timeslices(wiki, start_date, end_date, article_ids, user_ids)
+    article_ids
+  end
+
   # Deletes ACUWT records for users removed from the course.
   # Takes a collection of user ids.
   def delete_acuwt_for_deleted_course_users(user_ids)
@@ -290,6 +326,51 @@ class TimesliceCleaner
                                                .where('start >= ?', start_date)
                                                .where('end <= ?', end_date)
     delete_in_batches(timeslices)
+  end
+
+  # The [article_id, user_id] pairs found in the fetched revisions. Mirrors the filter in
+  # ArticleCourseUserWikiTimeslice.acuwt_records_from_revisions, so that the pairs match the
+  # rows the rewrite is going to write.
+  def fetched_pairs(revisions)
+    revisions.filter_map do |rev|
+      [rev.article_id, rev.user_id] unless rev.article_id.nil? || rev.user_id.nil?
+    end.to_set
+  end
+
+  # The stored rows whose (article, user) pair has no revision in the fetched data, leaving out
+  # the ones for articles deleted on wiki. The Article lookup only runs when there is something
+  # to delete, which is the uncommon case.
+  def stale_acuwt_rows(stored, pairs)
+    candidates = stored.reject { |row| pairs.include?([row[1], row[2]]) }
+    return [] if candidates.empty?
+
+    deleted_ids = Article.where(id: candidates.map { |row| row[1] }.uniq, deleted: true)
+                         .pluck(:id)
+    candidates.reject { |row| deleted_ids.include?(row[1]) }
+  end
+
+  # The articles and users whose every stored row for the period is being deleted, so their
+  # aggregated rows for the period have to go too. Derived from the plucked rows, no queries.
+  def emptied_article_and_user_ids(stored, stale)
+    stale_ids = stale.map { |row| row[0] }.to_set
+    surviving = stored.reject { |row| stale_ids.include?(row[0]) }
+    [stale.map { |row| row[1] }.uniq - surviving.map { |row| row[1] },
+     stale.map { |row| row[2] }.uniq - surviving.map { |row| row[2] }]
+  end
+
+  # Deletes the ACT and CUWT rows for the period belonging to the given articles and users.
+  # Both tables' unique indexes lead with article_id and (course_id, user_id), so passing the
+  # id lists is what keeps these deletes from scanning every row the course has.
+  # ACT has no wiki_id, but an article belongs to a single wiki, so the article ids scope it.
+  def delete_aggregated_timeslices(wiki, start_date, end_date, article_ids, user_ids)
+    unless article_ids.empty?
+      delete_in_batches(ArticleCourseTimeslice.where(course: @course, article_id: article_ids,
+                                                     start: start_date, end: end_date))
+    end
+    return if user_ids.empty?
+
+    delete_in_batches(CourseUserWikiTimeslice.where(course: @course, wiki:, user_id: user_ids,
+                                                    start: start_date, end: end_date))
   end
 
   # Deletes article course timeslices records in the period [start_date, end_date]

--- a/spec/lib/articles_courses_cleaner_spec.rb
+++ b/spec/lib/articles_courses_cleaner_spec.rb
@@ -17,6 +17,52 @@ describe ArticlesCoursesCleaner do
 
   before { stub_const('TimesliceManager::TIMESLICE_DURATION', 86400) }
 
+  describe '#remove_articles_courses_without_timeslices' do
+    let(:user) { create(:user) }
+
+    before do
+      stub_wiki_validation
+      create(:articles_course, course:, article: article1)
+      create(:articles_course, course:, article: article2)
+      create(:articles_course, course:, article: article4)
+      # article2 still has an ACUWT row, article4 still has an article course timeslice
+      create(:article_course_user_wiki_timeslice, course:, article: article2, user:,
+             wiki: wikidata, start: '2024-01-10', end: '2024-01-11')
+      create(:article_course_timeslice, course:, article: article4,
+             start: '2024-01-10', end: '2024-01-11')
+    end
+
+    it 'removes the records of the articles left without timeslices' do
+      described_class.new(course)
+                     .remove_articles_courses_without_timeslices([article1.id, article2.id,
+                                                                  article4.id])
+
+      expect(course.articles_courses.where(article: article1)).to be_empty
+    end
+
+    it 'keeps the records of the articles that still have an ACUWT row' do
+      described_class.new(course)
+                     .remove_articles_courses_without_timeslices([article1.id, article2.id,
+                                                                  article4.id])
+
+      expect(course.articles_courses.where(article: article2).count).to eq(1)
+    end
+
+    it 'keeps the records of the articles that still have an article course timeslice' do
+      described_class.new(course)
+                     .remove_articles_courses_without_timeslices([article1.id, article2.id,
+                                                                  article4.id])
+
+      expect(course.articles_courses.where(article: article4).count).to eq(1)
+    end
+
+    it 'leaves alone the articles that were not passed in' do
+      described_class.new(course).remove_articles_courses_without_timeslices([article2.id])
+
+      expect(course.articles_courses.where(article: article1).count).to eq(1)
+    end
+  end
+
   describe '#reset_excluded' do
     let(:user) { create(:user) }
     let(:articles) { Article.where(id: article1.id) }

--- a/spec/lib/timeslice_cleaner_spec.rb
+++ b/spec/lib/timeslice_cleaner_spec.rb
@@ -148,6 +148,93 @@ describe TimesliceCleaner do
     end
   end
 
+  describe '#clean_timeslices_before_reprocessing' do
+    let(:start_date) { DateTime.new(2024, 3, 29) }
+    let(:end_date) { DateTime.new(2024, 3, 30) }
+    let(:deleted_article) { create(:article, wiki_id: enwiki.id, deleted: true) }
+    let(:other_article) { create(:article, wiki_id: enwiki.id) }
+    let(:student) { create(:user, username: 'Student') }
+    let(:other_student) { create(:user, username: 'OtherStudent') }
+    # Covers article1/student only, so the rows for other_article/other_student are stale
+    let(:revisions) do
+      [build(:revision_on_memory, article_id: article1.id, user_id: student.id)]
+    end
+
+    def clean
+      timeslice_cleaner.clean_timeslices_before_reprocessing(enwiki, start_date, end_date,
+                                                            revisions)
+    end
+
+    def acuwt_rows
+      ArticleCourseUserWikiTimeslice.where(course:, start: start_date, end: end_date)
+    end
+
+    before do
+      create(:article_course_user_wiki_timeslice, course:, wiki: enwiki, article: article1,
+             user_id: student.id, start: start_date, end: end_date)
+      create(:article_course_user_wiki_timeslice, course:, wiki: enwiki, article: other_article,
+             user_id: other_student.id, start: start_date, end: end_date)
+      create(:article_course_user_wiki_timeslice, course:, wiki: enwiki,
+             article: deleted_article, user_id: student.id, start: start_date, end: end_date)
+      create(:article_course_timeslice, course:, article: other_article,
+             start: start_date, end: end_date)
+      create(:course_user_wiki_timeslice, course:, wiki: enwiki, user_id: other_student.id,
+             start: start_date, end: end_date)
+    end
+
+    it 'keeps the rows whose article and user are still in the fetched revisions' do
+      clean
+
+      expect(acuwt_rows.where(article: article1, user_id: student.id).count).to eq(1)
+    end
+
+    it 'deletes the rows whose article and user are not in the fetched revisions' do
+      clean
+
+      expect(acuwt_rows.where(article: other_article)).to be_empty
+    end
+
+    it 'keeps the rows for articles deleted on wiki, which no re-fetch can reproduce' do
+      clean
+
+      expect(acuwt_rows.where(article: deleted_article).count).to eq(1)
+    end
+
+    it 'deletes the article course timeslice of an article left without rows' do
+      clean
+
+      expect(ArticleCourseTimeslice.where(course:, article: other_article)).to be_empty
+    end
+
+    it 'deletes the course user wiki timeslice of a user left without rows' do
+      clean
+
+      expect(CourseUserWikiTimeslice.where(course:, user_id: other_student.id)).to be_empty
+    end
+
+    it 'returns the ids of the articles left without rows for the period' do
+      expect(clean).to eq([other_article.id])
+    end
+
+    context 'when the fetched revisions cover every stored row' do
+      let(:revisions) do
+        [build(:revision_on_memory, article_id: article1.id, user_id: student.id),
+         build(:revision_on_memory, article_id: other_article.id, user_id: other_student.id),
+         build(:revision_on_memory, article_id: deleted_article.id, user_id: student.id)]
+      end
+
+      it 'deletes no rows' do
+        clean
+
+        expect(acuwt_rows.count).to eq(3)
+      end
+
+      it 'reports no article left without rows' do
+        expect(clean).to be_empty
+      end
+    end
+  end
+
   describe '#delete_course_wiki_timeslices_prior_to_start_date' do
     before do
       create(:courses_wikis, wiki: wikibooks, course:)

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -379,6 +379,50 @@ describe UpdateCourseWikiTimeslices do
       end
     end
 
+    context 'when cleaning timeslices before reprocessing' do
+      before do
+        allow_any_instance_of(CourseRevisionUpdater)
+          .to receive(:fetch_revisions_for_course_wiki) do |_instance, wiki, ts_start, ts_end|
+            { wiki => { start: ts_start, end: ts_end, new_data: true, revisions: [] } }
+          end
+        allow_any_instance_of(CourseRevisionUpdater).to receive(:fetch_scores_for_revisions)
+        allow_any_instance_of(UpdateWikidataStatsTimeslice)
+          .to receive(:update_revisions_with_stats).and_return([])
+        allow(RevisionScanner).to receive(:schedule_revision_checks)
+        TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
+      end
+
+      it 'does not clean a timeslice that is only being processed for new data' do
+        expect_any_instance_of(TimesliceCleaner)
+          .not_to receive(:clean_timeslices_before_reprocessing)
+        subject
+      end
+
+      context 'when a timeslice needs update' do
+        let(:timeslice) { course.course_wiki_timeslices.where(wiki: enwiki).first }
+
+        before { timeslice.update(needs_update: true) }
+
+        it 'does not clean a course that does not use ACUWT' do
+          expect_any_instance_of(TimesliceCleaner)
+            .not_to receive(:clean_timeslices_before_reprocessing)
+          subject
+        end
+
+        context 'when the course uses ACUWT' do
+          before { course.add_flag(key: :use_acuwt) }
+
+          it 'cleans the period being reprocessed' do
+            expect_any_instance_of(TimesliceCleaner)
+              .to receive(:clean_timeslices_before_reprocessing)
+              .with(enwiki, timeslice.start, timeslice.end, [])
+              .and_return([])
+            subject
+          end
+        end
+      end
+    end
+
     context 'when use_acuwt? flag is set' do
       let(:article_id) { 12345 }
 


### PR DESCRIPTION
## What this PR does

Addresses #6970. When a timeslice is reprocessed, the update re-fetches the whole period and rewrites it — but the writes only cover the `(article, user)` pairs the fetch returned. Rows for pairs whose revisions are no longer there survive and keep feeding the aggregated timeslices.

The cases that genuinely need this are the ones no marking site can predict, because nothing knows a revision is gone until a re-fetch reveals it:

- a revision deleted or suppressed on wiki while the page itself is still live (rows for deleted *pages* are kept on purpose, so they are unaffected);
- revisions re-attributed to a different `article_id` by a page move or history merge, where the old article is not flagged deleted.

It also happens to cover the course start/end date boundary period, whose re-fetch is truncated by `real_start`/`real_end`. That one is arguably better handled where the dates change, and is filed separately in issue #6978 (whether we're going to address it is still to be determined).
Removed course users are already handled at their own site by `delete_acuwt_for_deleted_course_users`.

How it works: `TimesliceCleaner#clean_timeslices_before_reprocessing` runs inside the `process_timeslices` transaction, only when `only_new` is false, and diffs the period's stored ACUWT rows against the fetched pairs — deleting only what the rewrite will not cover. A timeslice holds up to `SplitTimeslice::REVISION_THRESHOLD` (10k) revisions, so deleting the period wholesale would mean thousands of deletes and inserts on every reprocess; this way a reprocess that finds unchanged data deletes nothing, and surviving rows are updated in place, which preserves `tracked` (the one column `bulk_upsert_from_revisions` deliberately does not write). The ACT and CUWT deletes are keyed by the articles and users left with nothing for the period, since both unique indexes lead with `article_id` and `(course_id, user_id)` and would otherwise scan every row the course has. `ArticlesCoursesCleaner#remove_articles_courses_without_timeslices` then drops records for articles left without any timeslice in the course, after the rewrite rather than before. ACUWT courses only; the legacy path is untouched.

One related fix rides along: the CUWT rebuild now takes its user list from the period's stored ACUWT rows instead of the fetched revisions, so a user whose revisions are gone gets their row rebuilt rather than left stale.

## AI usage

Claude Code wrote the code, specs and both commit messages, under close and correction-driven direction. It began as analysis only, with the instruction to first verify the approach in #6970 was right. Several of its conclusions were wrong and were corrected: it claimed six `needs_update` sites were buggy (additive and retry-shaped marks cannot leave stale rows, so the real count was one); it proposed ACUWT-only scope, which was rejected, then a legacy branch was written and later removed once we decided that path is not worth hardening; the pair diff was dropped and then reinstated when the index layout and the 10k ceiling showed it was what keeps a reprocess cheap. The reviewer also rewrote the `process_timeslices` comments, renamed the write step to `write_timeslices`, and caught that the `articles_courses` cleanup must run after the rewrite.

Scale: two commits, but that understates it — one long interactive session dominated by design discussion rather than code volume (~350 lines including specs), after which three commits that belonged elsewhere were split into #6973 and #6975. The reviewer ran the suite; Claude ran RuboCop and the affected specs (69 examples) green.

The summary above was also drafted by Claude Code and may contain errors — please check it against the diff. This description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes (backend only).

## Open questions and concerns

- **The incremental path is deliberately not cleaned.** `only_new: true` runs many times a day per course, so cleaning there was ruled out on cost. If a revision is deleted on wiki and nothing marks the period `needs_update`, the orphan row survives — in practice `ArticleStatusManager` does mark, so it lands on the reprocess path anyway.

- **The `no_point_in_importing_revisions?` guard.** The clean is skipped when the fetch never asked the replica, which happens for an `ArticleScopedProgram` with no assignments and no categories. Such a course keeps its ACUWT rows on purpose while every fetch comes back empty, so without the guard a reprocess would read "not fetched" as "the period is empty" and wipe them permanently.

- **This does not remove the deletions elsewhere.** Each survives for a concrete reason: `reset_timeslices_for_update_from_acuwt` targets `deleted: true` articles, which this clean preserves by design; the reaggregation resets run on a path that never enters `process_timeslices`; `SplitTimeslice#delete_timeslices_for_period` uses pre-split period keys.

- **Possible index follow-up.** The period pluck filters `start`/`end` after an index range on `(course_id, wiki_id)` — no worse than what `act_records_from_acuwt` and `acuwt_live_article_records` already do per timeslice, but extending that index to include `start` would help all three.

(PR description written by Claude Code.)
