### PR TITLE
Memoize Course#scoped_article_titles and store it as a Set

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -382,10 +382,12 @@ class Course < ApplicationRecord
     article_course_timeslices.where(article_id: scoped_article_ids)
   end
 
+  # A Set rather than a uniq'd Array because scoped_article? looks a title up once per
+  # article of every fetched timeslice; the pricier build only pays off thanks to the memo.
   def scoped_article_titles(wiki)
     @scoped_article_titles ||= {}
     @scoped_article_titles[wiki] ||= (assigned_article_titles(wiki) + category_article_titles(wiki))
-                                     .uniq
+                                     .to_set
   end
 
   def assigned_article_titles(wiki)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -383,7 +383,9 @@ class Course < ApplicationRecord
   end
 
   def scoped_article_titles(wiki)
-    (assigned_article_titles(wiki) + category_article_titles(wiki)).uniq
+    @scoped_article_titles ||= {}
+    @scoped_article_titles[wiki] ||= (assigned_article_titles(wiki) + category_article_titles(wiki))
+                                     .uniq
   end
 
   def assigned_article_titles(wiki)

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -187,6 +187,10 @@ describe ArticleScopedProgram, type: :model do
       expect(course.scoped_article_titles(wiki)).to equal(course.scoped_article_titles(wiki))
     end
 
+    it 'returns a Set, so that looking a title up does not scan the whole scope' do
+      expect(course.scoped_article_titles(wiki)).to be_a(Set)
+    end
+
     it 'memoizes per wiki rather than for the whole course' do
       other_wiki = Wiki.get_or_create(language: 'es', project: 'wikipedia')
       course.scoped_article_titles(wiki)

--- a/spec/models/article_scoped_program_spec.rb
+++ b/spec/models/article_scoped_program_spec.rb
@@ -162,4 +162,42 @@ describe ArticleScopedProgram, type: :model do
       expect(course.scoped_article?(wiki, 'Unassigned_article', mw_page_id)).to eq(false)
     end
   end
+
+  # scoped_article? calls scoped_article_titles once per article of every fetched timeslice,
+  # so rebuilding the list on each call is the dominant cost for a course with a large
+  # scope. The memo below is what keeps that list from being rebuilt.
+  describe '#scoped_article_titles' do
+    before do
+      stub_wiki_validation
+      create(:assignment, course:, article:, article_title: article.title, wiki:)
+      create(:categories_courses, course:, category:)
+    end
+
+    let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:course) { create(:article_scoped_program, start: '2018-01-01', end: '2018-12-31') }
+    let(:category) { create(:category, wiki:, article_titles: ['Category_article']) }
+    let(:article) { create(:article, title: 'Assigned_article') }
+
+    it 'includes both assigned and category article titles' do
+      expect(course.scoped_article_titles(wiki))
+        .to contain_exactly('Assigned_article', 'Category_article')
+    end
+
+    it 'returns the same object on repeated calls, without rebuilding the list' do
+      expect(course.scoped_article_titles(wiki)).to equal(course.scoped_article_titles(wiki))
+    end
+
+    it 'memoizes per wiki rather than for the whole course' do
+      other_wiki = Wiki.get_or_create(language: 'es', project: 'wikipedia')
+      course.scoped_article_titles(wiki)
+      expect(course.scoped_article_titles(other_wiki)).to be_empty
+    end
+
+    it 'picks up category changes for a freshly loaded course' do
+      course.scoped_article_titles(wiki)
+      category.update(article_titles: %w[Category_article New_category_article])
+      expect(Course.find(course.id).scoped_article_titles(wiki))
+        .to include('New_category_article')
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does

`Course#scoped_article_titles` rebuilt its list on every call, and `Course#scoped_article?`
calls it once per article of every fetched timeslice. For an `ArticleScopedProgram` tracking
a large scope, that dominated the timeslice-processing loop: on a production-shaped course
with ~580k scoped titles, a single scope check cost ~102 ms, of which ~91 ms was rebuilding
the array (concat + `uniq`) and only ~4 ms was the lookup itself.

This PR memoizes the list per wiki and stores it as a `Set` instead of a uniq'd `Array`:

- **Memoize** — the list is now built once per `Course` object (so once per update) instead of
  once per article. This is where most of the win is.
- **`Set` instead of `uniq`** — a `Set` is inherently unique, so this replaces the dedup pass
  rather than adding one, and turns the lookup from a linear scan into a hash probe.

Measured on a dev database against two real production course shapes (a 229k-title scope and
a 579k-title scope), running the real `scoped_article?` code path:

| | 229k titles | 579k titles |
|---|---:|---:|
| `scoped_article?` per article, before | 28.3 ms | 102.5 ms |
| ├ of which: rebuilding the array | 25.8 ms | 91.5 ms |
| └ of which: `Array#include?` scan | 1.8 ms | 4.1 ms |
| `Set#include?` | 0.0004 ms | 0.007 ms |

For a timeslice touching ~6,300 distinct articles, that is ~645 s of scope checking before
this PR and ~0 after.

A note on why the `Set` conversion is correct now but was not in #6427: when `uniq` was added
there, a `Set` benchmarked *slower*, because the collection was rebuilt on every call and
building a `Set` costs ~0.57 s more than `uniq` at 579k titles. Without memoization a `Set`
pays that build cost on every single lookup. With memoization the build happens once and the
break-even is ~142 lookups, which a large scoped course crosses in the first few percent of
one timeslice.

## AI usage

Claude Code was used throughout, under the user's direction.

The user asked Claude Code to investigate why one article-scoped Wikidata course completed a
full update in under three days while a comparable one had been running for over a week.
Claude Code did the analysis (public dashboard JSON endpoints, the update-stage timings, and
a benchmark harness run against a dev database) and identified this method as the largest
per-timeslice cost. The user wrote the memoization commit; Claude Code wrote the `Set`
conversion, the explanatory code comment, and the four specs, and drafted this description.

The user directed the scope at each step, and pushed back on Claude Code's suggestions more
than once — Claude Code proposed adding a `clear_scoped_article_memos` invalidation hook, and
the user correctly rejected it as unreachable code, since the only caller of
`Category.refresh_categories_for` runs before anything reads the scope. The user also supplied
the #6427 benchmark that prompted the build-vs-lookup analysis above. The user ran RuboCop and
the specs; Claude Code did not.

This was developed across 2 commits within about a 45-minute session, on top of a longer
investigation session that preceded it. The "What this PR does" summary and the measurements
quoted above were drafted by Claude Code and may contain errors.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes.

## Open questions and concerns

- The benchmark numbers come from a dev database. The scope-check figures are pure Ruby with
  no database access, so they should transfer to production closely; anything database-bound
  would not.
- This does not explain the whole gap between the two courses it came out of. Measured
  per-timeslice costs still account for well under half of the observed time for the slow
  course, so investigation continues separately.
- The memoized value lives for the lifetime of the `Course` object, which spans a whole
  update. That is intentional and matches the two lookups it is built from
  (`assigned_article_titles` and `category_article_titles`), which were already memoized the
  same way. `Category.refresh_categories_for` runs before anything reads the scope, so the
  memo cannot be built from stale categories.
- Adjacent, not addressed here: `Course#scoped_article_ids` is rebuilt on every call and is
  spliced into SQL as an `IN` list roughly once per user per timeslice by
  `CourseUserWikiTimeslice.update_from_acuwt` and `CourseWikiTimeslice#update_cache_from_acuwt`.
  On the same dev benchmark that costs 16.7 s plus 2.1 s per user per timeslice at 579k ids,
  and it scales worse than linearly with the size of the scope.

(PR description written by Claude Code.)
