### PR TITLE
Check for expected sandboxes on more exercises

### DIFF
--- a/app/controllers/training_modules_users_controller.rb
+++ b/app/controllers/training_modules_users_controller.rb
@@ -25,8 +25,8 @@ class TrainingModulesUsersController < ApplicationController
     set_training_module_user
     block = Block.find(params[:block_id])
     @course = block.course
-    verify_exercise_sandbox { return }
-    mark_completion_status(params[:complete], @course.id)
+    verify_exercise_sandbox { return } if marking_complete?
+    mark_completion_status(marking_complete?, @course.id)
 
     render 'courses/_block', locals: { block:, course: @course }
   end
@@ -79,13 +79,26 @@ class TrainingModulesUsersController < ApplicationController
     @training_module_user.furthest_slide?(@slide.slug)
   end
 
-  def verify_exercise_sandbox
-    return if @training_module_user.eligible_for_completion?(@course.home_wiki)
+  # The sandbox check only guards against premature completion, so unmarking an
+  # exercise doesn't have to pass it.
+  def marking_complete?
+    ActiveModel::Type::Boolean.new.cast(params[:complete]) || false
+  end
 
-    error_message = "Please complete the exercise in your Exercise Sandbox (#{@training_module_user.exercise_sandbox_location}) before marking it complete" # rubocop:disable Layout/LineLength
-    render json: { message: error_message, status: 'incomplete' },
+  def verify_exercise_sandbox
+    check = CheckExerciseSandbox.new(training_module_user: @training_module_user,
+                                     course: @course)
+    return if check.eligible?
+
+    render json: { message: exercise_sandbox_error(check), status: 'incomplete' },
            status: :forbidden
     yield
+  end
+
+  def exercise_sandbox_error(check)
+    return t('training.exercise_needs_assigned_article') if check.awaiting_article_assignment?
+
+    t('training.exercise_sandbox_incomplete', pages: check.missing_pages.join(', '))
   end
 
   def mark_completion_status(value, course_id)

--- a/app/models/training_module.rb
+++ b/app/models/training_module.rb
@@ -154,6 +154,12 @@ class TrainingModule < ApplicationRecord
     settings['sandbox_location']
   end
 
+  # For an exercise whose expected page is a subpage of an assigned article's
+  # sandbox (eg 'Bibliography'), rather than a fixed page under the userpage.
+  def assignment_sandbox_location
+    settings['assignment_sandbox_location']
+  end
+
   def sandbox_preload
     settings['preload']
   end

--- a/app/models/user_data/training_modules_users.rb
+++ b/app/models/user_data/training_modules_users.rb
@@ -29,15 +29,6 @@ class TrainingModulesUsers < ApplicationRecord
     flags[course_id] = { marked_complete: value }
   end
 
-  def eligible_for_completion?(wiki)
-    # If module doesn't have a sandbox_location, there's nothing to check.
-    return true unless training_module.sandbox_location
-
-    # Via the API, we send the title without the URL encoding of special characters.
-    sandbox_content = WikiApi.new(wiki).get_page_content CGI.unescape exercise_sandbox_location
-    sandbox_content.present?
-  end
-
   # This is only used on Wiki Education Dashboard
   # so we will assume User: prefix for en.wiki
   def exercise_sandbox_location

--- a/app/services/check_exercise_sandbox.rb
+++ b/app/services/check_exercise_sandbox.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Checks whether the wiki pages a student is expected to create for an exercise
+# exist yet, so that an exercise can't be marked complete before the student has
+# done the required work.
+#
+# Two kinds of expected page are supported, both configured via the training
+# module's YAML settings:
+#
+#   sandbox_location             a page under the student's own userpage, with
+#                                the same title for every student, eg
+#                                'Choose_an_Article'
+#   assignment_sandbox_location  a subpage of the sandbox for an article the
+#                                student has assigned themselves, eg
+#                                'Bibliography'. The title varies per student,
+#                                and a student with several assigned articles
+#                                only needs the page for one of them.
+class CheckExerciseSandbox
+  # Titles of the expected pages that don't exist yet.
+  attr_reader :missing_pages
+
+  def initialize(training_module_user:, course:)
+    @training_module_user = training_module_user
+    @training_module = training_module_user.training_module
+    @user = training_module_user.user
+    @course = course
+    @missing_pages = []
+    @awaiting_article_assignment = false
+    perform
+  end
+
+  def eligible?
+    !@awaiting_article_assignment && @missing_pages.empty?
+  end
+
+  # An expected assignment sandbox has no title until the student has assigned
+  # themselves an article, so there is nothing to look for yet.
+  def awaiting_article_assignment?
+    @awaiting_article_assignment
+  end
+
+  private
+
+  def perform
+    user_pages = user_sandbox_pages
+    assignment_pages = assignment_sandbox_pages
+    return if user_pages.empty? && assignment_pages.empty?
+
+    present = present_pages(user_pages + assignment_pages)
+    @missing_pages.concat user_pages.map(&:last).reject { |title| present.include? title }
+    return if assignment_pages.empty?
+    return if assignment_pages.any? { |_wiki, title| present.include? title }
+    @missing_pages.concat assignment_pages.map(&:last)
+  end
+
+  # Each expected page is a [wiki, title] pair, since a student's assigned
+  # articles are not necessarily all on the course's home wiki.
+  def user_sandbox_pages
+    return [] unless @training_module.sandbox_location
+    # Via the API, we send the title without the URL encoding of special characters.
+    [[@course.home_wiki, CGI.unescape(@training_module_user.exercise_sandbox_location)]]
+  end
+
+  def assignment_sandbox_pages
+    location = @training_module.assignment_sandbox_location
+    return [] unless location
+
+    pages = @course.assignments.assigned.where(user: @user).map do |assignment|
+      [assignment.wiki, "#{assignment.sandbox_pagename}/#{location}"]
+    end
+    @awaiting_article_assignment = pages.empty?
+    pages
+  end
+
+  # Returns the subset of titles that exist and have content. Pages are looked
+  # up one wiki at a time, so a student with several assigned articles still
+  # only costs one API request.
+  def present_pages(pages)
+    pages.group_by(&:first).flat_map do |wiki, wiki_pages|
+      present_titles(wiki, wiki_pages.map(&:last).uniq)
+    end.to_set
+  end
+
+  def present_titles(wiki, titles)
+    page_info = WikiApi.new(wiki).get_page_info(titles)
+    # If the wiki can't be reached, don't stand in the student's way.
+    return titles if page_info.nil?
+
+    present = normalized_present_titles(page_info)
+    titles.select { |title| present.include? title.tr(' ', '_') }
+  end
+
+  def normalized_present_titles(page_info)
+    (page_info['pages'] || {}).each_value.filter_map do |page|
+      next if page.key?('missing')
+      next unless page['length'].to_i.positive?
+      page['title'].tr(' ', '_')
+    end.to_set
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1687,6 +1687,8 @@ en:
     search_training_resources: Search for training resources
     no_training_resource_match_your_search: No training resource matches your search
     exercise_sandbox: Exercise Sandbox
+    exercise_sandbox_incomplete: Please complete the exercise in your Exercise Sandbox (%{pages}) before marking it complete
+    exercise_needs_assigned_article: You must assign yourself an article before you can complete this.
     open_exercise: Start Exercise
     remaining_exercise: "%{count} additional exercises remaining."
     view_all: View all exercises

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -762,6 +762,12 @@ qqq:
       {{Identical|View}}
     page: '{{Identical|Page}}'
     done: '{{Identical|Done}}'
+    exercise_sandbox_incomplete: Error shown when a student tries to mark an exercise
+      complete before creating the wiki page the exercise expects. %{pages} is a comma-separated
+      list of the expected page titles.
+    exercise_needs_assigned_article: Error shown when a student tries to mark an exercise
+      complete before assigning themselves an article, which the exercise's expected
+      page depends on
     invalid: Alert stating the slide does not exist
     wait: Alert to not leave the page as the training progress is being updated in
       the background

--- a/spec/controllers/training_modules_users_controller_spec.rb
+++ b/spec/controllers/training_modules_users_controller_spec.rb
@@ -71,4 +71,145 @@ describe TrainingModulesUsersController, type: :request do
       end
     end
   end
+
+  describe '#mark_exercise_complete' do
+    let(:course) { create(:course) }
+    let(:week) { create(:week, course:) }
+    let(:user) { create(:user, username: 'Ragesock') }
+    let(:training_module) { TrainingModule.find_by(slug: module_slug) }
+    let(:block) { create(:block, week:, training_module_ids: [training_module.id]) }
+    let(:request_params) do
+      { block_id: block.id, complete: true, module_id: training_module.slug }
+    end
+    let(:flags) { TrainingModulesUsers.last.flags[course.id] }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
+
+    context 'when the exercise expects no page' do
+      let(:module_slug) { 'copyedit-exercise' }
+
+      before do
+        post '/training_modules_users/exercise.json', params: request_params, as: :json
+      end
+
+      it 'marks the exercise complete' do
+        expect(flags[:marked_complete]).to eq(true)
+      end
+    end
+
+    context 'when the expected userpage sandbox exists' do
+      let(:module_slug) { 'choose-topic-exercise' }
+      let(:user) { create(:user, username: 'Kmblim') }
+
+      before do
+        VCR.use_cassette 'exercise_sandbox/user_sandbox' do
+          post '/training_modules_users/exercise.json', params: request_params, as: :json
+        end
+      end
+
+      it 'marks the exercise complete' do
+        expect(flags[:marked_complete]).to eq(true)
+      end
+    end
+
+    context 'when the expected userpage sandbox does not exist' do
+      let(:module_slug) { 'choose-topic-exercise' }
+
+      before do
+        VCR.use_cassette 'exercise_sandbox/user_sandbox' do
+          post '/training_modules_users/exercise.json', params: request_params, as: :json
+        end
+      end
+
+      it 'refuses the request' do
+        expect(response.status).to eq(403)
+      end
+
+      it 'does not mark the exercise complete' do
+        expect(flags).to be_nil
+      end
+
+      it 'names the expected page' do
+        expect(response.parsed_body['message'])
+          .to include('User:Ragesock/Choose_an_Article')
+      end
+    end
+
+    context 'when the expected bibliography page does not exist' do
+      let(:module_slug) { 'bibliography-exercise' }
+
+      before do
+        create(:assignment, course:, user:, wiki_id: 1,
+                            role: Assignment::Roles::ASSIGNED_ROLE,
+                            sandbox_url: 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox')
+        VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+          post '/training_modules_users/exercise.json', params: request_params, as: :json
+        end
+      end
+
+      it 'refuses the request' do
+        expect(response.status).to eq(403)
+      end
+
+      it 'names the expected page' do
+        expect(response.parsed_body['message'])
+          .to include('User:Ragesock/student_sandbox/Bibliography')
+      end
+    end
+
+    context 'when the expected bibliography page exists' do
+      let(:module_slug) { 'bibliography-exercise' }
+
+      before do
+        create(:assignment, course:, user:, wiki_id: 1,
+                            role: Assignment::Roles::ASSIGNED_ROLE,
+                            sandbox_url: 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox_empty')
+        VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+          post '/training_modules_users/exercise.json', params: request_params, as: :json
+        end
+      end
+
+      it 'marks the exercise complete' do
+        expect(flags[:marked_complete]).to eq(true)
+      end
+    end
+
+    context 'when unmarking an exercise whose expected page does not exist' do
+      let(:module_slug) { 'choose-topic-exercise' }
+      let(:request_params) do
+        { block_id: block.id, complete: false, module_id: training_module.slug }
+      end
+
+      before do
+        post '/training_modules_users/exercise.json', params: request_params, as: :json
+      end
+
+      it 'marks the exercise incomplete' do
+        expect(flags[:marked_complete]).to eq(false)
+      end
+
+      it 'does not query the wiki' do
+        expect(WikiApi).not_to receive(:new)
+        post '/training_modules_users/exercise.json', params: request_params, as: :json
+      end
+    end
+
+    context 'when the student has not assigned themselves an article yet' do
+      let(:module_slug) { 'bibliography-exercise' }
+
+      before do
+        post '/training_modules_users/exercise.json', params: request_params, as: :json
+      end
+
+      it 'refuses the request' do
+        expect(response.status).to eq(403)
+      end
+
+      it 'does not mark the exercise complete' do
+        expect(flags).to be_nil
+      end
+    end
+  end
 end

--- a/spec/features/assigned_exercise_spec.rb
+++ b/spec/features/assigned_exercise_spec.rb
@@ -2,8 +2,16 @@
 
 require 'rails_helper'
 
-def stub_sandbox_existence_query(content)
-  allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return content
+# The completion check asks for page info for every page an exercise expects, so
+# echo each requested title back as either an existing or a missing page.
+def stub_sandbox_existence_query(sandbox_exists)
+  allow_any_instance_of(WikiApi).to receive(:get_page_info) do |_api, titles|
+    pages = Array(titles).each_with_index.to_h do |title, index|
+      page = sandbox_exists ? { 'length' => 42 } : { 'missing' => '' }
+      [index.to_s, page.merge('title' => title)]
+    end
+    { 'pages' => pages }
+  end
 end
 
 describe 'students with assigned exercise modules', type: :feature, js: true do
@@ -31,7 +39,7 @@ describe 'students with assigned exercise modules', type: :feature, js: true do
 
   it 'can go mark a module complete, then mark it incomplete' do
     # Assume exercise sandbox has been created
-    stub_sandbox_existence_query 'sandbox content'
+    stub_sandbox_existence_query true
 
     visit "/courses/#{course.slug}"
 
@@ -45,7 +53,7 @@ describe 'students with assigned exercise modules', type: :feature, js: true do
   end
 
   it 'see an error message if exercise sandbox does not exist' do
-    stub_sandbox_existence_query ''
+    stub_sandbox_existence_query false
 
     visit "/courses/#{course.slug}"
 
@@ -59,7 +67,7 @@ describe 'students with assigned exercise modules', type: :feature, js: true do
 
     it 'shows the next incomplete exercise after complete one' do
       # Assume exercise sandbox has been created
-      stub_sandbox_existence_query 'sandbox content'
+      stub_sandbox_existence_query true
 
       visit "/courses/#{course.slug}"
 
@@ -82,7 +90,7 @@ describe 'students with assigned exercise modules', type: :feature, js: true do
 
     it 'shows the next incomplete exercise after complete one' do
       # Assume exercise sandbox has been created
-      stub_sandbox_existence_query 'sandbox content'
+      stub_sandbox_existence_query true
 
       visit "/courses/#{course.slug}"
 

--- a/spec/services/check_exercise_sandbox_spec.rb
+++ b/spec/services/check_exercise_sandbox_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CheckExerciseSandbox do
+  before { TrainingModule.load_all }
+
+  let(:course) { create(:course) }
+  let(:user) { create(:user, username: 'Ragesock') }
+  let(:training_module) { TrainingModule.find_by(slug: module_slug) }
+  let(:training_module_user) do
+    TrainingModulesUsers.create(user:, training_module_id: training_module.id)
+  end
+  let(:subject) { described_class.new(training_module_user:, course:) }
+
+  context 'when the exercise expects no page at all' do
+    let(:module_slug) { 'copyedit-exercise' }
+
+    it 'is eligible' do
+      expect(subject).to be_eligible
+    end
+
+    it 'does not query the wiki' do
+      expect(WikiApi).not_to receive(:new)
+      subject
+    end
+  end
+
+  context 'when the exercise expects a page under the userpage' do
+    let(:module_slug) { 'choose-topic-exercise' }
+
+    context 'and the page exists' do
+      let(:user) { create(:user, username: 'Kmblim') }
+
+      it 'is eligible' do
+        VCR.use_cassette 'exercise_sandbox/user_sandbox' do
+          expect(subject).to be_eligible
+        end
+      end
+    end
+
+    context 'and the page does not exist' do
+      it 'is not eligible' do
+        VCR.use_cassette 'exercise_sandbox/user_sandbox' do
+          expect(subject).not_to be_eligible
+        end
+      end
+
+      it 'reports the expected page' do
+        VCR.use_cassette 'exercise_sandbox/user_sandbox' do
+          expect(subject.missing_pages).to eq(['User:Ragesock/Choose_an_Article'])
+        end
+      end
+    end
+  end
+
+  context 'when the exercise expects a bibliography for an assigned article' do
+    let(:module_slug) { 'bibliography-exercise' }
+    # This sandbox exists, but it has no /Bibliography subpage.
+    let(:sandbox_url) { 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox' }
+    # This sandbox does not exist, but it does have a /Bibliography subpage.
+    let(:sandbox_url_with_bibliography) do
+      'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox_empty'
+    end
+    let(:assignment_params) do
+      { course:, user:, wiki_id: 1, role: Assignment::Roles::ASSIGNED_ROLE }
+    end
+
+    context 'and the student has no assigned article' do
+      it 'is not eligible' do
+        expect(subject).not_to be_eligible
+      end
+
+      it 'is awaiting an article assignment' do
+        expect(subject).to be_awaiting_article_assignment
+      end
+
+      it 'does not query the wiki' do
+        expect(WikiApi).not_to receive(:new)
+        subject
+      end
+    end
+
+    context 'and the student is only reviewing an article' do
+      before do
+        create(:assignment, **assignment_params.merge(
+          role: Assignment::Roles::REVIEWING_ROLE, sandbox_url:
+        ))
+      end
+
+      it 'is awaiting an article assignment' do
+        expect(subject).to be_awaiting_article_assignment
+      end
+    end
+
+    context 'and the bibliography page does not exist' do
+      before { create(:assignment, **assignment_params.merge(sandbox_url:)) }
+
+      it 'is not eligible' do
+        VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+          expect(subject).not_to be_eligible
+        end
+      end
+
+      it 'reports the expected page' do
+        VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+          expect(subject.missing_pages)
+            .to eq(['User:Ragesock/student_sandbox/Bibliography'])
+        end
+      end
+    end
+
+    context 'and the bibliography page exists' do
+      before do
+        create(:assignment, **assignment_params.merge(
+          sandbox_url: sandbox_url_with_bibliography
+        ))
+      end
+
+      it 'is eligible' do
+        VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+          expect(subject).to be_eligible
+        end
+      end
+    end
+
+    context 'and only one of several assigned articles has a bibliography page' do
+      before do
+        create(:assignment, **assignment_params.merge(sandbox_url:))
+        create(:assignment, **assignment_params.merge(
+          article_title: 'Selenocysteine', sandbox_url: sandbox_url_with_bibliography
+        ))
+      end
+
+      it 'is eligible' do
+        VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+          expect(subject).to be_eligible
+        end
+      end
+
+      it 'checks both pages in a single request' do
+        expect_any_instance_of(WikiApi).to receive(:get_page_info)
+          .with(['User:Ragesock/student_sandbox/Bibliography',
+                 'User:Ragesock/student_sandbox_empty/Bibliography'])
+          .and_return(nil)
+        subject
+      end
+    end
+  end
+
+  context 'when the exercise expects an outline for an assigned article' do
+    let(:module_slug) { 'outline-exercise' }
+
+    before do
+      create(:assignment, course:, user:, wiki_id: 1,
+                          role: Assignment::Roles::ASSIGNED_ROLE,
+                          sandbox_url: 'https://en.wikipedia.org/wiki/User:Ragesock/student_sandbox')
+    end
+
+    it 'reports the expected page when it does not exist' do
+      VCR.use_cassette 'exercise_sandbox/assignment_sandbox' do
+        expect(subject.missing_pages).to eq(['User:Ragesock/student_sandbox/Outline'])
+      end
+    end
+  end
+
+  context 'when the wiki cannot be reached' do
+    let(:module_slug) { 'choose-topic-exercise' }
+
+    before { allow_any_instance_of(WikiApi).to receive(:get_page_info).and_return(nil) }
+
+    it 'is eligible, rather than blocking the student' do
+      expect(subject).to be_eligible
+    end
+  end
+end

--- a/training_content/wiki_ed/modules/bibliography-exercise.yml
+++ b/training_content/wiki_ed/modules/bibliography-exercise.yml
@@ -9,3 +9,5 @@ slides:
   - slug: expand-bibliography #3802
   - slug: bibliography-and-ai #3804
   - slug: next-up-outline #7201
+settings:
+  assignment_sandbox_location: 'Bibliography'

--- a/training_content/wiki_ed/modules/outline-exercise.yml
+++ b/training_content/wiki_ed/modules/outline-exercise.yml
@@ -5,3 +5,5 @@ description: |
   Review your sources and create an outline of the changes you plan to make to your assigned article.
 slides:
   - slug: outline-proposed-changes #3803
+settings:
+  assignment_sandbox_location: 'Outline'


### PR DESCRIPTION
Add checks that prevent marking the 'Bibliography' and 'Outline' exercises complete if the student hasn't created the relevant pages (or if they don't have an assigned article)