### PR TITLE
Refine the fact-verification exercise: source-evaluation step, highlighting fix

### DIFF
--- a/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
@@ -20,12 +20,23 @@ import formatRevisionDate from '../../utils/format_revision_date';
 //
 // The shell's `?showArticle=` deep link is article-keyed; when one article has
 // several flagged-revision tiles we auto-open the first of them on a deep link.
-export const ArticlePicker = ({ articles, course, onTaken, showArticleId }) => {
+//
+// `onReturnToClaim` is given only when the student already has a claim, and is
+// the way back out of the picker without taking a different one — browsing the
+// candidates is not meant to cost them the claim they already have.
+export const ArticlePicker = ({ articles, course, onTaken, showArticleId, onReturnToClaim }) => {
   const showWiki = new Set(articles.map(toWikiDomain)).size > 1;
   const deepLinkedTile = articles.find(article => article.id === showArticleId);
 
   return (
     <div className="container narrow claim-verification-exercise claim-verification-exercise--articles">
+      {onReturnToClaim && (
+        <div className="cv-preview-return">
+          <button type="button" className="button" onClick={onReturnToClaim}>
+            ← {I18n.t('claim_verification.back_to_claim')}
+          </button>
+        </div>
+      )}
       <div className="claim-verification-exercise__intro">
         <p>{I18n.t('claim_verification.intro_p1')}</p>
         <p>{I18n.t('claim_verification.intro_p2')}</p>
@@ -88,6 +99,8 @@ ArticlePicker.propTypes = {
   onTaken: PropTypes.func.isRequired,
   // Article id from the ?showArticle= deep link, if any; auto-opens that tile.
   showArticleId: PropTypes.number,
+  // Present only when the student already has a claim to go back to.
+  onReturnToClaim: PropTypes.func,
 };
 
 export default ArticlePicker;

--- a/app/assets/javascripts/components/claim_verification_exercise/ClaimVerificationExercise.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ClaimVerificationExercise.jsx
@@ -37,7 +37,7 @@ import InstructorResponses from './InstructorResponses.jsx';
   "choosing" is kept as local state rather than a second, competing query param.
 */
 const ClaimVerificationExercise = ({ course }) => {
-  const [state, setState] = useState(null); // { assignment, response, articles }
+  const [state, setState] = useState(null); // { assignment, response, form, articles }
   const [choosing, setChoosing] = useState(false);
   const responsesPage = useLocation().pathname.endsWith('/responses');
   const dispatch = useDispatch();
@@ -46,7 +46,7 @@ const ClaimVerificationExercise = ({ course }) => {
     if (responsesPage) { return; }
     new ClaimVerificationAPI({ courseSlug: course.slug }).fetchState()
       .then(setState)
-      .catch(() => setState({ assignment: null, response: null, articles: [] }));
+      .catch(() => setState({ assignment: null, response: null, form: null, articles: [] }));
   }, [course.slug, responsesPage]);
 
   if (responsesPage) { return <InstructorResponses course={course} />; }
@@ -78,6 +78,7 @@ const ClaimVerificationExercise = ({ course }) => {
     return (
       <TakenClaim
         assignment={state.assignment}
+        form={state.form}
         response={state.response}
         courseSlug={course.slug}
         onChooseDifferent={() => setChoosing(true)}

--- a/app/assets/javascripts/components/claim_verification_exercise/ClaimVerificationExercise.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ClaimVerificationExercise.jsx
@@ -39,6 +39,10 @@ import InstructorResponses from './InstructorResponses.jsx';
 const ClaimVerificationExercise = ({ course }) => {
   const [state, setState] = useState(null); // { assignment, response, form, articles }
   const [choosing, setChoosing] = useState(false);
+  // Bumped whenever we change ?showArticle= ourselves. The id is read fresh from
+  // the URL on each render rather than held in state (the viewer shell owns that
+  // param), so clearing it only takes effect once something re-renders us.
+  const [, urlChanged] = useState(0);
   const responsesPage = useLocation().pathname.endsWith('/responses');
   const dispatch = useDispatch();
 
@@ -64,6 +68,16 @@ const ClaimVerificationExercise = ({ course }) => {
     window.history.replaceState(null, null, window.location.pathname);
     setState(prev => ({ ...prev, assignment, response: response || null }));
     setChoosing(false);
+  };
+
+  // Leave the picker for the claim the student already has. Browsing the other
+  // candidates shouldn't cost them their claim (or, once they've answered, send
+  // them back to a blank form), so this undoes "choose a different claim" and
+  // also drops any ?showArticle= they arrived on.
+  const returnToClaim = () => {
+    window.history.replaceState(null, null, window.location.pathname);
+    setChoosing(false);
+    urlChanged(tick => tick + 1);
   };
 
   const afterResponseSaved = (response) => {
@@ -93,6 +107,7 @@ const ClaimVerificationExercise = ({ course }) => {
       course={course}
       onTaken={afterTaken}
       showArticleId={showArticleId}
+      onReturnToClaim={state.assignment ? returnToClaim : null}
     />
   );
 };

--- a/app/assets/javascripts/components/claim_verification_exercise/InstructorResponses.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/InstructorResponses.jsx
@@ -56,7 +56,7 @@ ClaimContext.propTypes = {
   a student.
 */
 const InstructorResponses = ({ course }) => {
-  const [data, setData] = useState(null); // { responses, pending }
+  const [data, setData] = useState(null); // { form, responses, pending }
   const [failed, setFailed] = useState(false);
   const studentFilter = new URLSearchParams(useLocation().search).get('student');
 
@@ -111,7 +111,7 @@ const InstructorResponses = ({ course }) => {
             </span>
           </header>
           <ClaimContext claim={response.claim} />
-          <ResponseSummary response={response} />
+          <ResponseSummary form={data.form} response={response} />
         </article>
       ))}
 

--- a/app/assets/javascripts/components/claim_verification_exercise/ResponsePopover.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ResponsePopover.jsx
@@ -45,7 +45,7 @@ const ResponsePopover = ({ student }) => {
     contents = responses.map(response => (
       <div className="cv-response-pop__item" key={response.id}>
         <blockquote>{response.claim.sentence}</blockquote>
-        <ResponseSummary response={response} />
+        <ResponseSummary form={data.form} response={response} />
       </div>
     ));
   }

--- a/app/assets/javascripts/components/claim_verification_exercise/ResponseSummary.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ResponseSummary.jsx
@@ -1,53 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// One question-and-answer pair of a submitted response. Skips unanswered
-// questions (conditional steps, blank open fields) so the summary only shows
-// what the student actually said.
-const Answer = ({ question, children }) => {
-  if (!children) { return null; }
-  return (
-    <div className="cv-response__answer">
-      <dt>{question}</dt>
-      <dd>{children}</dd>
-    </div>
-  );
-};
-
-Answer.propTypes = {
-  question: PropTypes.string.isRequired,
-  children: PropTypes.node,
-};
+import { formPropType, answeredQuestions } from './formDefinition';
 
 /*
   A submitted response, rendered as the questions the student answered — shared
-  by the student's own post-submission view (where `onEdit` reopens the form)
-  and the instructor's per-student cards (no `onEdit`). Question wording reuses
-  the form's operator copy so students and instructors read the same exercise.
+  by the student's own post-submission view (where `onEdit` reopens the form),
+  the instructor's per-student cards and the students-tab popover (no `onEdit`).
+
+  Both the questions and their wording come from the same form definition the
+  student filled in, so students and instructors always read the same exercise.
+  Only answered questions appear: an unanswered optional question, or a step the
+  student's path skipped, is simply absent.
 */
-export const ResponseSummary = ({ response, onEdit }) => (
+export const ResponseSummary = ({ form, response, onEdit }) => (
   <div className="cv-response">
     <dl className="cv-response__answers">
-      <Answer question={I18n.t('claim_verification.form.source_access_question')}>
-        {I18n.t(`claim_verification.form.source_access_options.${response.source_access}`)}
-      </Answer>
-      <Answer question={I18n.t('claim_verification.form.source_access_notes_label')}>
-        {response.source_access_notes}
-      </Answer>
-      {response.verdict && (
-        <Answer question={I18n.t('claim_verification.form.verdict_question')}>
-          {I18n.t(`claim_verification.form.verdict_options.${response.verdict}`)}
-        </Answer>
-      )}
-      <Answer question={I18n.t('claim_verification.form.claim_location_label')}>
-        {response.claim_location}
-      </Answer>
-      <Answer question={I18n.t('claim_verification.form.verification_notes_label')}>
-        {response.verification_notes}
-      </Answer>
-      <Answer question={I18n.t('claim_verification.form.other_comments_label')}>
-        {response.other_comments}
-      </Answer>
+      {answeredQuestions(form, response.answers).map(({ id, label, value }) => (
+        <div className="cv-response__answer" key={id}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
     </dl>
     {onEdit && (
       <button type="button" className="button" onClick={onEdit}>
@@ -58,13 +32,9 @@ export const ResponseSummary = ({ response, onEdit }) => (
 );
 
 ResponseSummary.propTypes = {
+  form: formPropType.isRequired,
   response: PropTypes.shape({
-    source_access: PropTypes.string.isRequired,
-    source_access_notes: PropTypes.string,
-    verdict: PropTypes.string,
-    claim_location: PropTypes.string,
-    verification_notes: PropTypes.string,
-    other_comments: PropTypes.string,
+    answers: PropTypes.object,
   }).isRequired,
   onEdit: PropTypes.func,
 };

--- a/app/assets/javascripts/components/claim_verification_exercise/TakenClaim.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/TakenClaim.jsx
@@ -3,17 +3,20 @@ import PropTypes from 'prop-types';
 
 import VerificationForm from './VerificationForm.jsx';
 import ResponseSummary from './ResponseSummary.jsx';
+import { formPropType } from './formDefinition';
 
 /*
   The student's taken claim: the claim, its cited source, and the verification
-  form (steps 3 and 4 of the exercise) — the whole exercise happens here in the
-  dashboard. Once a response is submitted the form gives way to a summary of
-  their answers (editable, since submitting is an upsert). Responses are keyed
-  per claim, so choosing a different claim stays available even after
-  submitting — the summary belongs to this claim and survives a switch. The
-  claim and source values are data.
+  form (every step of the exercise after choosing the claim) — the whole exercise
+  happens here in the dashboard. Once a response is submitted the form gives way
+  to a summary of their answers (editable, since submitting is an upsert).
+  Responses are keyed per claim, so choosing a different claim stays available
+  even after submitting — the summary belongs to this claim and survives a
+  switch. The claim and source values are data.
 */
-export const TakenClaim = ({ assignment, response, courseSlug, onChooseDifferent, onResponseSaved }) => {
+export const TakenClaim = ({
+  assignment, form, response, courseSlug, onChooseDifferent, onResponseSaved
+}) => {
   const { claim } = assignment;
   const [editing, setEditing] = useState(false);
 
@@ -70,11 +73,12 @@ export const TakenClaim = ({ assignment, response, courseSlug, onChooseDifferent
           <h2 className="claim-verification-exercise__label">
             {I18n.t('claim_verification.form.submitted_heading')}
           </h2>
-          <ResponseSummary response={response} onEdit={() => setEditing(true)} />
+          <ResponseSummary form={form} response={response} onEdit={() => setEditing(true)} />
         </section>
       ) : (
         <VerificationForm
           courseSlug={courseSlug}
+          form={form}
           initial={response}
           onSaved={saved}
           onCancel={editing ? () => setEditing(false) : null}
@@ -98,6 +102,8 @@ TakenClaim.propTypes = {
   assignment: PropTypes.shape({
     claim: PropTypes.object.isRequired,
   }).isRequired,
+  // The questions the exercise asks, as sent by the server.
+  form: formPropType.isRequired,
   // The submitted response, if any.
   response: PropTypes.object,
   courseSlug: PropTypes.string.isRequired,

--- a/app/assets/javascripts/components/claim_verification_exercise/TakenClaim.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/TakenClaim.jsx
@@ -27,8 +27,16 @@ export const TakenClaim = ({
 
   return (
     <div className="container narrow claim-verification-exercise">
-      <div className="claim-verification-exercise__intro">
+      <div className="claim-verification-exercise__intro claim-verification-exercise__taken-header">
         <h1>{I18n.t('claim_verification.your_selected_claim')}</h1>
+        {/*
+          Switching claims sits up here with the heading, not below the form:
+          a student decides their claim isn't the one they want while reading
+          it, and down at the foot of the form it was easy to miss entirely.
+        */}
+        <button type="button" className="button" onClick={onChooseDifferent}>
+          {I18n.t('claim_verification.choose_different_claim')}
+        </button>
       </div>
 
       <section className="claim-verification-exercise__claim">
@@ -84,16 +92,6 @@ export const TakenClaim = ({
           onCancel={editing ? () => setEditing(false) : null}
         />
       )}
-
-      <div className="claim-verification-exercise__switch">
-        <button
-          type="button"
-          className="claim-verification-exercise__switch-button"
-          onClick={onChooseDifferent}
-        >
-          {I18n.t('claim_verification.choose_different_claim')}
-        </button>
-      </div>
     </div>
   );
 };

--- a/app/assets/javascripts/components/claim_verification_exercise/VerificationForm.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/VerificationForm.jsx
@@ -2,99 +2,103 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
+import markdownIt from '~/app/assets/javascripts/utils/markdown_it';
+import { formPropType, visibleQuestions, missingRequired } from './formDefinition';
 
-export const SOURCE_ACCESS_VALUES = ['accessed', 'nonexistent', 'inaccessible'];
-export const VERDICT_VALUES = [
-  'full_support', 'mostly_supports', 'partial_support', 'mostly_unsupported',
-  'unsupported', 'contradicted', 'undetermined'
-];
+// Step instructions are operator copy that may link out (eg to the Reliable
+// Sources policy), so they render as Markdown with bare URLs linkified and
+// opening in a new tab — the exercise itself stays in the tab behind.
+const md = markdownIt({ openLinksExternally: true });
 
-// One multiple-choice question as a fieldset of radios. All strings are
-// operator copy from the claim_verification.form locale namespace.
-const RadioQuestion = ({ name, question, optionsKey, values, value, onChange }) => (
+const StepInstructions = ({ instructions }) => (
+  <div
+    className="cv-form__step-instructions"
+    dangerouslySetInnerHTML={{ __html: md.render(instructions) }}
+  />
+);
+
+StepInstructions.propTypes = {
+  instructions: PropTypes.string.isRequired,
+};
+
+// One multiple-choice question as a fieldset of radios. Both the question and
+// its options are operator copy resolved server-side, so this knows none of it.
+const ChoiceQuestion = ({ question, value, onChange }) => (
   <fieldset className="cv-form__question">
-    <legend className="cv-form__question-label">{question}</legend>
-    {values.map(optionValue => (
-      <label key={optionValue} className="cv-form__option">
+    <legend className="cv-form__question-label">{question.label}</legend>
+    {question.options.map(option => (
+      <label key={option.value} className="cv-form__option">
         <input
           type="radio"
-          name={name}
-          value={optionValue}
-          checked={value === optionValue}
-          onChange={() => onChange(optionValue)}
+          name={question.id}
+          value={option.value}
+          checked={value === option.value}
+          onChange={() => onChange(option.value)}
         />
-        <span>{I18n.t(`claim_verification.form.${optionsKey}.${optionValue}`)}</span>
+        <span>{option.label}</span>
       </label>
     ))}
   </fieldset>
 );
 
-RadioQuestion.propTypes = {
-  name: PropTypes.string.isRequired,
-  question: PropTypes.string.isRequired,
-  optionsKey: PropTypes.string.isRequired,
-  values: PropTypes.arrayOf(PropTypes.string).isRequired,
+ChoiceQuestion.propTypes = {
+  question: PropTypes.object.isRequired,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 
-const OpenQuestion = ({ name, label, value, onChange }) => (
+const TextQuestion = ({ question, value, onChange }) => (
   <div className="cv-form__question">
-    <label className="cv-form__question-label" htmlFor={`cv-form-${name}`}>{label}</label>
+    <label className="cv-form__question-label" htmlFor={`cv-form-${question.id}`}>
+      {question.label}
+    </label>
     <textarea
-      id={`cv-form-${name}`}
+      id={`cv-form-${question.id}`}
       className="cv-form__textarea"
       rows={3}
-      value={value}
+      value={value || ''}
       onChange={event => onChange(event.target.value)}
     />
   </div>
 );
 
-OpenQuestion.propTypes = {
-  name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+TextQuestion.propTypes = {
+  question: PropTypes.object.isRequired,
+  value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 
 /*
-  The verification form itself — the whole exercise now happens here in the
-  dashboard, not in a sandbox. Step 3 (find the source) is always asked; its
-  tell-us-more field appears only when the student couldn't get the source.
-  Step 4 (verify the claim) appears only when they could: its two open
-  questions are self-selecting by their own phrasing ("If you were able…",
-  "If you were unable…"), so both are always visible within the step. The
-  final catch-all comments field applies on every path. Submitting upserts,
-  so the same form serves both first submission and later edits (`initial`).
+  The verification form — the whole exercise happens here in the dashboard, not
+  in a sandbox. Which steps it asks, in what order, and what each question
+  accepts all come from `form`, the definition the server sends from
+  config/claim_verification_exercise.yml. So this component renders the exercise
+  without knowing what the exercise is: refining it is a change to that file and
+  its copy, not to this file.
+
+  Steps and questions can be gated on an earlier answer (`visible_when`), which
+  is how the verify-the-claim step waits until the student says they got the
+  source. Answers are held in one hash keyed by question id; the server drops
+  whatever the student's path didn't ask, so answers left behind by a changed
+  choice are harmless. Submitting upserts, so the same form serves both first
+  submission and later edits (`initial`).
 */
-const VerificationForm = ({ courseSlug, initial, onSaved, onCancel }) => {
-  const [sourceAccess, setSourceAccess] = useState(initial?.source_access || null);
-  const [sourceAccessNotes, setSourceAccessNotes] = useState(initial?.source_access_notes || '');
-  const [verdict, setVerdict] = useState(initial?.verdict || null);
-  const [claimLocation, setClaimLocation] = useState(initial?.claim_location || '');
-  const [verificationNotes, setVerificationNotes] = useState(initial?.verification_notes || '');
-  const [otherComments, setOtherComments] = useState(initial?.other_comments || '');
+const VerificationForm = ({ courseSlug, form, initial, onSaved, onCancel }) => {
+  const [answers, setAnswers] = useState(initial?.answers || {});
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(false);
 
-  const sourceAccessed = sourceAccess === 'accessed';
-  // The multiple-choice answers are the only required ones; the server clears
-  // answers for steps that don't apply, so stale hidden fields are harmless.
-  const submittable = sourceAccess && (!sourceAccessed || verdict) && !saving;
+  const answer = (questionId, value) => (
+    setAnswers(current => ({ ...current, [questionId]: value }))
+  );
+
+  const submittable = !saving && missingRequired(form, answers).length === 0;
 
   const submit = (event) => {
     event.preventDefault();
     setSaving(true);
     setError(false);
-    new ClaimVerificationAPI({ courseSlug }).submitResponse({
-      source_access: sourceAccess,
-      source_access_notes: sourceAccessNotes,
-      verdict,
-      claim_location: claimLocation,
-      verification_notes: verificationNotes,
-      other_comments: otherComments,
-    }).then(({ response }) => {
+    new ClaimVerificationAPI({ courseSlug }).submitResponse(answers).then(({ response }) => {
       onSaved(response);
     }).catch(() => {
       setError(true);
@@ -104,62 +108,31 @@ const VerificationForm = ({ courseSlug, initial, onSaved, onCancel }) => {
 
   return (
     <form className="cv-form" onSubmit={submit}>
-      <section className="cv-form__step">
-        <h2 className="cv-form__step-heading">{I18n.t('claim_verification.form.step_find_source')}</h2>
-        <p className="cv-form__step-instructions">{I18n.t('claim_verification.form.find_source_instructions')}</p>
-        <RadioQuestion
-          name="source_access"
-          question={I18n.t('claim_verification.form.source_access_question')}
-          optionsKey="source_access_options"
-          values={SOURCE_ACCESS_VALUES}
-          value={sourceAccess}
-          onChange={setSourceAccess}
-        />
-        {sourceAccess && !sourceAccessed && (
-          <OpenQuestion
-            name="source_access_notes"
-            label={I18n.t('claim_verification.form.source_access_notes_label')}
-            value={sourceAccessNotes}
-            onChange={setSourceAccessNotes}
-          />
-        )}
-      </section>
-
-      {sourceAccessed && (
-        <section className="cv-form__step">
-          <h2 className="cv-form__step-heading">{I18n.t('claim_verification.form.step_verify')}</h2>
-          <p className="cv-form__step-instructions">{I18n.t('claim_verification.form.verify_instructions')}</p>
-          <RadioQuestion
-            name="verdict"
-            question={I18n.t('claim_verification.form.verdict_question')}
-            optionsKey="verdict_options"
-            values={VERDICT_VALUES}
-            value={verdict}
-            onChange={setVerdict}
-          />
-          <OpenQuestion
-            name="claim_location"
-            label={I18n.t('claim_verification.form.claim_location_label')}
-            value={claimLocation}
-            onChange={setClaimLocation}
-          />
-          <OpenQuestion
-            name="verification_notes"
-            label={I18n.t('claim_verification.form.verification_notes_label')}
-            value={verificationNotes}
-            onChange={setVerificationNotes}
-          />
-        </section>
-      )}
-
-      <section className="cv-form__step">
-        <OpenQuestion
-          name="other_comments"
-          label={I18n.t('claim_verification.form.other_comments_label')}
-          value={otherComments}
-          onChange={setOtherComments}
-        />
-      </section>
+      {form.steps.map(step => (
+        visibleQuestions(step, answers).length > 0 && (
+          <section className="cv-form__step" key={step.id}>
+            {step.heading && <h2 className="cv-form__step-heading">{step.heading}</h2>}
+            {step.instructions && <StepInstructions instructions={step.instructions} />}
+            {visibleQuestions(step, answers).map(question => (
+              question.type === 'choice' ? (
+                <ChoiceQuestion
+                  key={question.id}
+                  question={question}
+                  value={answers[question.id]}
+                  onChange={value => answer(question.id, value)}
+                />
+              ) : (
+                <TextQuestion
+                  key={question.id}
+                  question={question}
+                  value={answers[question.id]}
+                  onChange={value => answer(question.id, value)}
+                />
+              )
+            ))}
+          </section>
+        )
+      ))}
 
       {error && <p className="cv-form__error" role="alert">{I18n.t('claim_verification.form.submit_failed')}</p>}
 
@@ -179,6 +152,7 @@ const VerificationForm = ({ courseSlug, initial, onSaved, onCancel }) => {
 
 VerificationForm.propTypes = {
   courseSlug: PropTypes.string.isRequired,
+  form: formPropType.isRequired,
   // The already-submitted response when editing; null on first submission.
   initial: PropTypes.object,
   onSaved: PropTypes.func.isRequired,

--- a/app/assets/javascripts/components/claim_verification_exercise/formDefinition.js
+++ b/app/assets/javascripts/components/claim_verification_exercise/formDefinition.js
@@ -1,0 +1,83 @@
+import PropTypes from 'prop-types';
+
+/*
+  Reading the fact-verification exercise's form definition — the steps and
+  questions the server sends from config/claim_verification_exercise.yml, with
+  their copy already resolved. The form and the submitted-answers summary share
+  this so both stay ignorant of what the exercise actually asks.
+
+  Answers are one flat object keyed by question id, matching how they're stored.
+*/
+
+// A step or question may be gated on earlier answers (`visible_when`: question
+// id → the answers that open it). Ungated ones are always asked.
+const gateOpen = (visibleWhen, answers) => (
+  Object.entries(visibleWhen || {}).every(
+    ([questionId, values]) => values.includes(answers[questionId])
+  )
+);
+
+// The questions to ask under a step right now — none at all when the step's own
+// gate is closed, which is how a whole step (the verify-the-claim one) waits on
+// an earlier answer.
+export const visibleQuestions = (step, answers) => (
+  gateOpen(step.visible_when, answers)
+    ? step.questions.filter(question => gateOpen(question.visible_when, answers))
+    : []
+);
+
+// Required questions currently being asked but not yet answered — what keeps
+// the submit button disabled. Free-text questions are never required.
+export const missingRequired = (form, answers) => (
+  form.steps
+    .flatMap(step => visibleQuestions(step, answers))
+    .filter(question => question.required && !answers[question.id])
+    .map(question => question.id)
+);
+
+// How to show one stored answer: a choice's option label, or the text as typed.
+// Falls back to the raw value so an answer whose option has since been renamed
+// still displays instead of vanishing.
+const displayValue = (question, value) => {
+  if (question.type !== 'choice') { return value; }
+  return question.options.find(option => option.value === value)?.label || value;
+};
+
+/*
+  A submitted response as question-and-answer pairs, in the order the exercise
+  asks them. Driven by what's actually stored rather than by the gates, so a
+  response saved under an older version of the exercise still shows everything
+  the student said.
+*/
+export const answeredQuestions = (form, answers = {}) => (
+  form.steps
+    .flatMap(step => step.questions)
+    .filter(question => answers[question.id])
+    .map(question => ({
+      id: question.id,
+      label: question.label,
+      value: displayValue(question, answers[question.id]),
+    }))
+);
+
+const questionPropType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['choice', 'text']).isRequired,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  visible_when: PropTypes.object,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    label: PropTypes.string,
+  })),
+});
+
+export const formPropType = PropTypes.shape({
+  steps: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    heading: PropTypes.string,
+    instructions: PropTypes.string,
+    visible_when: PropTypes.object,
+    questions: PropTypes.arrayOf(questionPropType).isRequired,
+  })).isRequired,
+});

--- a/app/assets/stylesheets/modules/claim_verification.styl
+++ b/app/assets/stylesheets/modules/claim_verification.styl
@@ -91,17 +91,6 @@
     margin 14px 0 0 0
     font-size .9em
 
-  // "Switch claim" — a tertiary action below the exercise, kept low-emphasis
-  // so it doesn't compete with opening the source or the sandbox handoff.
-  &__switch
-    margin-top 22px
-    form
-      margin 0
-
-  &__switch-button
-    font-size 13px
-    padding 6px 16px
-
   // Article picker: a compact grid of title tiles. Tiles size to their content
   // and pack several per row so a long candidate list (up to 50) stays short.
   &__article-grid
@@ -315,10 +304,11 @@
       line-height 1.5
       max-width 44em
 
-// Instructor view (/verify_claim/responses): heading row with the
-// open-the-exercise action, then one card per response (and per pending
-// student).
-.claim-verification-responses__header
+// A heading with its action alongside: the submissions page's "open the
+// exercise", and the taken claim's "choose a different claim". Wraps so the
+// action drops below the heading rather than crushing it on a narrow screen.
+.claim-verification-responses__header,
+.claim-verification-exercise__taken-header
   display flex
   align-items baseline
   justify-content space-between

--- a/app/assets/stylesheets/modules/claim_verification.styl
+++ b/app/assets/stylesheets/modules/claim_verification.styl
@@ -214,9 +214,10 @@
     padding-top 18px
     border-top 1px solid $border_lt
 
-// The verification form (steps 3 and 4 of the exercise): each step is a card
-// in the same family as the claim/source cards above, with the questions
+// The verification form (every step after choosing the claim): each step is a
+// card in the same family as the claim/source cards above, with the questions
 // inside kept quiet so the operator-provided wording carries the structure.
+// Which steps there are comes from config/claim_verification_exercise.yml.
 .cv-form
   &__step
     border 1px solid $border_lt
@@ -229,10 +230,19 @@
     font-size 1.15em
     margin 0 0 10px 0
 
+  // Markdown-rendered operator copy, so the container owns the spacing its
+  // paragraphs would otherwise each add, and a long bare URL wraps inside the
+  // card instead of overflowing it.
   &__step-instructions
     color $text_med
     max-width 40em
     margin-bottom 20px
+    p
+      margin 0 0 10px 0
+      &:last-child
+        margin-bottom 0
+    a
+      overflow-wrap break-word
 
   &__question
     border 0

--- a/app/controllers/claim_verification_exercises_controller.rb
+++ b/app/controllers/claim_verification_exercises_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/claim_verification/exercise_form"
+
 # Data + entry for the student claim-verification exercise (issue #6910).
 # The exercise UI itself is the course SPA: `/courses/*id/verify_claim` falls
 # through to `courses#show` and React Router renders the exercise (article
@@ -30,6 +32,9 @@ class ClaimVerificationExercisesController < ApplicationController
       verification_claim: @assignment.verification_claim
     )
     @tiles = RelevantClaimRevisionsForCourse.new(@course).tiles
+    # The questions to ask: the SPA renders the form from this rather than
+    # knowing the exercise itself.
+    @form = ClaimVerification::ExerciseForm.new
     # renders state.json.jbuilder
   end
 

--- a/app/controllers/claim_verification_responses_controller.rb
+++ b/app/controllers/claim_verification_responses_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/claim_verification/exercise_form"
+
 # Student responses for the claim-verification exercise, which is done
 # entirely in the dashboard: the student answers the form on their taken
 # claim (`create`, an upsert — they may revise their answers), and `index`
@@ -32,14 +34,18 @@ class ClaimVerificationResponsesController < ApplicationController
                                           .includes(:user, verification_claim: :wiki)
                                           .order(:created_at)
     @pending = pending_assignments(scope)
+    # The questions each response answered, so the view can show them as asked.
+    @form = ClaimVerification::ExerciseForm.new
     # renders index.json.jbuilder
   end
 
   private
 
+  # Whatever the exercise currently asks — the question ids come from
+  # config/claim_verification_exercise.yml, so a new question needs no change
+  # here. Answers to questions the student's path skipped are dropped downstream.
   def answer_params
-    params.permit(:source_access, :source_access_notes, :verdict, :claim_location,
-                  :verification_notes, :other_comments)
+    params.permit(*ClaimVerification::ExerciseForm.new.answer_keys)
   end
 
   def render_validation_errors

--- a/app/models/verification_claim_response.rb
+++ b/app/models/verification_claim_response.rb
@@ -8,53 +8,45 @@
 #  user_id               :integer          not null
 #  course_id             :integer          not null
 #  verification_claim_id :integer          not null
-#  source_access         :string(255)      not null
-#  source_access_notes   :text(65535)
-#  verdict               :string(255)
-#  claim_location        :text(65535)
-#  verification_notes    :text(65535)
-#  other_comments        :text(65535)
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  answers               :text(65535)
 #
 
-# A student's submitted answers for the claim-verification exercise: whether
-# they could access the cited source, how well it backs up their taken claim,
-# and their free-response notes. Done entirely in the dashboard (the exercise
-# no longer hands off to a sandbox). Keyed per claim — one response per claim
-# a student takes on, resubmittable — deliberately NOT one per student per
-# course, so the exercise can grow to verifying multiple claims.
+require_dependency "#{Rails.root}/lib/claim_verification/exercise_form"
+
+# A student's submitted answers for the fact-verification exercise, done entirely
+# in the dashboard (the exercise no longer hands off to a sandbox). Keyed per
+# claim — one response per claim a student takes on, resubmittable —
+# deliberately NOT one per student per course, so the exercise can grow to
+# verifying multiple claims.
+#
+# The answers are one serialized hash keyed by question id, not a column per
+# question, so refining the exercise doesn't touch the database. Which questions
+# exist and what each accepts is declared in
+# config/claim_verification_exercise.yml; this model enforces that declaration
+# rather than restating it.
 class VerificationClaimResponse < ApplicationRecord
   belongs_to :user
   belongs_to :course
   belongs_to :verification_claim
 
-  # "Were you able to access the full text of the cited source for your claim?"
-  SOURCE_ACCESS_VALUES = %w[
-    accessed
-    nonexistent
-    inaccessible
-  ].freeze
-
-  # "Does the source back up the claim?" — asked only when the source was accessed.
-  VERDICT_VALUES = %w[
-    full_support
-    mostly_supports
-    partial_support
-    mostly_unsupported
-    unsupported
-    contradicted
-    undetermined
-  ].freeze
+  serialize :answers, type: Hash
 
   validates :user_id, uniqueness: { scope: %i[course_id verification_claim_id] }
-  validates :source_access, inclusion: { in: SOURCE_ACCESS_VALUES }
-  # The verdict (and the rest of the verify-the-claim step) only makes sense
-  # when the student had the source in hand.
-  validates :verdict, inclusion: { in: VERDICT_VALUES }, if: :source_accessed?
-  validates :verdict, absence: true, unless: :source_accessed?
+  validate :answers_are_what_the_exercise_asked
 
-  def source_accessed?
-    source_access == 'accessed'
+  # One question's answer, or nil where the exercise didn't ask it (an
+  # unanswered optional question, or a step the student's path skipped).
+  def answer(question_id)
+    answers[question_id.to_s]
+  end
+
+  private
+
+  def answers_are_what_the_exercise_asked
+    ClaimVerification::ExerciseForm.new.errors_in(answers).each do |message|
+      errors.add(:answers, message)
+    end
   end
 end

--- a/app/services/annotate_revision_claims.rb
+++ b/app/services/annotate_revision_claims.rb
@@ -33,28 +33,55 @@ class AnnotateRevisionClaims
     extractor = ClaimVerification::ClaimCitationExtractor.new(source_html)
     citations_by_ref_id = extractor.citations.index_by(&:ref_id)
     doc = Nokogiri::HTML.fragment(source_html)
+    # One span per pool claim: the same sentence can be reached through more than
+    # one of the extractor's claims (a sentence carrying several citations), and
+    # highlighting it twice would both nest the spans and inflate the claim count.
+    highlighted = Set.new
     extractor.claims.each do |claim|
       harvested = harvested_claims[normalize(claim.sentence)]
-      highlight(doc, claim, citations_by_ref_id, harvested) if harvested
+      next if harvested.nil? || highlighted.include?(harvested.id)
+      highlighted << harvested.id if highlight(doc, claim, citations_by_ref_id, harvested)
     end
     absolutize_links(doc)
     doc.to_html
   end
 
-  # Wrap the (added) claim's sentence at its citation marker. Markers are located
-  # by the ref ids extracted from this full revision; the span data comes from the
-  # stored pool claim. Falls back to tagging just the marker if the sentence can't
-  # be located in the prose.
+  # Wrap the (added) claim's sentence where that sentence actually appears in the
+  # prose; the span data comes from the stored pool claim. The citation marker is
+  # deliberately not used to place the highlight — see SentenceHighlighter — only
+  # to identify the source and to carry the fallback tag when the sentence can't
+  # be found in any paragraph.
   def highlight(doc, claim, citations_by_ref_id, harvested)
     ref_id = claim.ref_ids.find { |id| citations_by_ref_id.key?(id) }
-    return if ref_id.nil?
+    return false if ref_id.nil?
     data = data_for(harvested, ref_id)
-    markers = markers_for(doc, ref_id)
-    return if markers.empty?
-    wrapped = markers.any? do |marker|
-      ClaimVerification::SentenceHighlighter.new(marker:, sentence: claim.sentence, data:).wrap
+    return true if wrap_sentence(doc, claim.sentence, data)
+    marker = markers_for(doc, ref_id).first
+    return false if marker.nil?
+    tag(marker, data)
+    true
+  end
+
+  # The prose paragraph holding this sentence, wrapped. Paragraphs are searched in
+  # document order because a sentence occurs once in an article's prose in all but
+  # pathological cases; the highlighter itself refuses a sentence already inside
+  # another claim's span.
+  def wrap_sentence(doc, sentence, data)
+    prose_paragraphs(doc).any? do |paragraph|
+      ClaimVerification::SentenceHighlighter.new(paragraph:, sentence:, data:).wrap
     end
-    tag(markers.first, data) unless wrapped
+  end
+
+  # The paragraphs the segmenter drew its sentences from: article prose, not the
+  # contents of tables, figures or the reference list (which
+  # ClaimCitationExtractor drops before segmenting).
+  def prose_paragraphs(doc)
+    doc.css('p').reject do |paragraph|
+      paragraph.ancestors.any? do |ancestor|
+        %w[table figure].include?(ancestor.name) ||
+          ancestor['class'].to_s.split.include?('references')
+      end
+    end
   end
 
   # The citation markers (the <sup>) for this ref id. Matched by reading each

--- a/app/services/record_verification_claim_response.rb
+++ b/app/services/record_verification_claim_response.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
-# Records (or updates) a student's claim-verification exercise response for
-# their taken claim, then marks the exercise's training module complete for
-# the course. The module has no slides — the in-dashboard form *is* the whole
+require_dependency "#{Rails.root}/lib/claim_verification/exercise_form"
+
+# Records (or updates) a student's fact-verification exercise response for their
+# taken claim, then marks the exercise's training module complete for the
+# course. The module has no slides — the in-dashboard form *is* the whole
 # exercise — so submission is the completion event: it sets both the module's
 # `completed_at` and the per-course `marked_complete` flag that course views
 # read.
 #
-# Answers for steps that don't apply are cleared rather than trusted from the
-# client: the verify-the-claim step only exists when the source was accessed,
-# and the couldn't-find-the-source notes only when it wasn't.
+# What gets stored is what the exercise actually asked (see
+# ClaimVerification::ExerciseForm#applicable_answers): answers to questions the
+# student's path skipped are dropped rather than trusted from the client, so
+# abandoning a branch leaves nothing stale behind.
 class RecordVerificationClaimResponse
   attr_reader :response
 
@@ -20,8 +23,6 @@ class RecordVerificationClaimResponse
   end
 
   private
-
-  VERIFY_STEP_FIELDS = %i[verdict claim_location verification_notes].freeze
 
   def perform
     upsert_response
@@ -35,18 +36,8 @@ class RecordVerificationClaimResponse
       user: @assignment.user, course: @assignment.course,
       verification_claim: @assignment.verification_claim
     )
-    @response.assign_attributes(applicable_answers)
+    @response.answers = ClaimVerification::ExerciseForm.new.applicable_answers(@answers)
     @response.save
-  end
-
-  def applicable_answers
-    answers = @answers.to_h.symbolize_keys
-    if answers[:source_access] == 'accessed'
-      answers[:source_access_notes] = nil
-    else
-      VERIFY_STEP_FIELDS.each { |field| answers[field] = nil }
-    end
-    answers
   end
 
   # The exercise's module is identified by its launch path, not a hardcoded id.

--- a/app/views/claim_verification_exercises/state.json.jbuilder
+++ b/app/views/claim_verification_exercises/state.json.jbuilder
@@ -16,6 +16,9 @@ else
   json.response nil
 end
 
+# The questions to ask, so the SPA can render the form without knowing them.
+json.form { json.partial! 'claim_verification_responses/form', form: @form }
+
 json.articles @tiles do |tile|
   article = tile.article
   json.id article.id

--- a/app/views/claim_verification_responses/_form.json.jbuilder
+++ b/app/views/claim_verification_responses/_form.json.jbuilder
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# The exercise form's definition with its copy resolved for the current locale:
+# the steps, their questions, and the answers each offers. The SPA renders both
+# the form and the submitted-answers summary from this, so adding a question or
+# reordering the steps in config/claim_verification_exercise.yml needs no
+# JavaScript change. `form` is a ClaimVerification::ExerciseForm.
+#
+# `visible_when` is passed through as declared — the client applies it live as
+# the student answers, and the server applies it again on submission.
+json.steps form.steps do |step|
+  json.id step.id
+  json.heading step.heading
+  json.instructions step.instructions
+  json.visible_when step.visible_when
+
+  json.questions step.questions do |question|
+    json.call(question, :id, :type, :required, :visible_when)
+    json.label question.label
+    json.options question.option_labels if question.choice?
+  end
+end

--- a/app/views/claim_verification_responses/_response.json.jbuilder
+++ b/app/views/claim_verification_responses/_response.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# A student's verification form answers. Fields for steps that didn't apply
-# (see RecordVerificationClaimResponse) are null.
-json.call(response, :id, :source_access, :source_access_notes, :verdict, :claim_location,
-          :verification_notes, :other_comments, :created_at, :updated_at)
+# A student's verification form answers, as a hash keyed by question id. Only
+# the questions the exercise actually asked them are present (see
+# RecordVerificationClaimResponse), so the SPA renders the summary by walking the
+# form definition and skipping whatever isn't here.
+json.call(response, :id, :answers, :created_at, :updated_at)

--- a/app/views/claim_verification_responses/index.json.jbuilder
+++ b/app/views/claim_verification_responses/index.json.jbuilder
@@ -6,6 +6,10 @@
 # students tab identifies students to instructors.
 real_names = CoursesUsers.where(course: @course).pluck(:user_id, :real_name).to_h
 
+# The questions the exercise asks, so each response's answers can be shown as
+# the questions the student answered.
+json.form { json.partial! 'form', form: @form }
+
 json.responses @responses do |response|
   claim = response.verification_claim
   json.username response.user.username

--- a/config/claim_verification_exercise.yml
+++ b/config/claim_verification_exercise.yml
@@ -1,0 +1,90 @@
+# The fact-verification exercise's form: which steps it asks, in what order, and
+# what each question accepts. This file is the exercise's structure, and it is
+# the only place that defines it — the database stores whatever it names, as a
+# serialized hash on VerificationClaimResponse#answers, and the SPA renders both
+# the form and the submitted-answers summary from it. So refining the exercise
+# (adding a step, reordering questions, changing the options offered) is an edit
+# here plus the matching copy in config/locales/en.yml: no migration, no model
+# change, no JavaScript change.
+#
+# Copy lives in the locales so it stays translatable, and is looked up by
+# convention from the ids below, all under `claim_verification.form`:
+#
+#   step name              step_<step id>              (omitted when heading: false)
+#   step instructions      <step id>_instructions      (optional)
+#   choice question        <question id>_question
+#   choice option          <question id>_options.<value>
+#   text question          <question id>_label
+#
+# Step numbering is derived, not written into the copy, so reordering steps
+# renumbers them on its own. Steps 1 and 2 (select an article, select a claim)
+# happen before this form, hence first_step_number.
+first_step_number: 3
+
+# `visible_when` gates a step or a question on an earlier answer: it is asked
+# only when that answer is one of the listed values. Answers to questions that
+# end up hidden are dropped on submission rather than stored, so abandoning a
+# branch never leaves stale answers behind.
+#
+# `required: true` blocks submission until the question is answered. Only choice
+# questions are ever required; the free-text ones are always optional.
+steps:
+  # Judged from the citation alone — this step comes before the student tries to
+  # get hold of the source.
+  - id: evaluate_source
+    questions:
+      - id: source_appropriate
+        type: choice
+        required: true
+        options: [appropriate, depends_on_use, inappropriate, unsure]
+      - id: source_appropriate_notes
+        type: text
+      - id: meets_rs_policy
+        type: choice
+        required: true
+        options: [generally_reliable, context_dependent, not_reliable, unsure]
+      - id: meets_rs_policy_notes
+        type: text
+
+  - id: find_source
+    questions:
+      - id: source_access
+        type: choice
+        required: true
+        options: [accessed, nonexistent, inaccessible]
+      # Only asked of students who couldn't get the source.
+      - id: source_access_notes
+        type: text
+        visible_when:
+          source_access: [nonexistent, inaccessible]
+
+  # Verifying the claim only makes sense with the source in hand. The two open
+  # questions are self-selecting by their own phrasing ("If you were able…",
+  # "If you were unable…"), so both are asked whenever the step is.
+  - id: verify
+    visible_when:
+      source_access: [accessed]
+    questions:
+      - id: verdict
+        type: choice
+        required: true
+        options:
+          - full_support
+          - mostly_supports
+          - partial_support
+          - mostly_unsupported
+          - unsupported
+          - contradicted
+          - undetermined
+      - id: claim_location
+        type: text
+      - id: verification_notes
+        type: text
+
+  # The catch-all comment field: asked on every path, and not a numbered step of
+  # the exercise, so it has no heading of its own.
+  - id: comments
+    heading: false
+    questions:
+      - id: other_comments
+        type: text

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1729,7 +1729,26 @@ en:
     step_select_article: "Step 1: Select an article."
     select_claim_instructions: "The following claims need to be checked against the cited sources, because they may be AI-generated. (Note: the article may have changed since these claims were added.)"
     form:
-      step_find_source: "Step 3: Find the source"
+      # Step numbering is composed in (see config/claim_verification_exercise.yml),
+      # so the `step_*` names below are just the names.
+      step_heading: "Step %{number}: %{name}"
+      step_evaluate_source: Evaluate the source
+      evaluate_source_instructions: "First, consider the source itself: whether it seems reliable, and whether it's a good fit for the topic. You may want to review Wikipedia's concept of 'Reliable sources': https://en.wikipedia.org/wiki/Wikipedia:Reliable_sources"
+      source_appropriate_question: "Is this source appropriate for Wikipedia, for this particular article, and for the claim it supports?"
+      source_appropriate_options:
+        appropriate: "Yes, it's an appropriate source for the claim"
+        depends_on_use: "Somewhat, but it's not the best kind of source for this"
+        inappropriate: "No, this isn't the right kind of source to use here"
+        unsure: "Unsure"
+      source_appropriate_notes_label: "Why or why not? If not, what kind of source would be appropriate instead?"
+      meets_rs_policy_question: "Is it a reliable source?"
+      meets_rs_policy_options:
+        generally_reliable: "Yes, it clearly meets the definition of a reliable source in this context"
+        context_dependent: "Somewhat, but it has shortcomings"
+        not_reliable: "No, this clearly does not meet Wikipedia's definition of a reliable source"
+        unsure: "Unsure"
+      meets_rs_policy_notes_label: "What makes this a reliable source, or not?"
+      step_find_source: "Find the source"
       find_source_instructions: "Now that you’ve selected your claim, track down the cited source. You may need to consult your instructor or librarian to find the source."
       source_access_question: "Were you able to access the full text of the cited source for your claim?"
       source_access_options:
@@ -1737,7 +1756,7 @@ en:
         nonexistent: "No, the source does not exist."
         inaccessible: "No, the source exists but I could not get access to it."
       source_access_notes_label: "If you were unable to find the source, tell us more about your experience:"
-      step_verify: "Step 4: Verify the claim"
+      step_verify: "Verify the claim"
       verify_instructions: "Once you’ve found the cited source, examine it carefully to determine how well it supports the claim you’ve chosen. If you find exactly where the information came from, note where in the document you found it. (Some citations are too imprecise for a reader to practically verify.)"
       verdict_question: "Does the source back up the claim?"
       verdict_options:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1718,6 +1718,7 @@ en:
     find_in_article: Find this in the article text
     show_surrounding: Show surrounding paragraph
     choose_different_claim: Choose a different claim
+    back_to_claim: Back to my claim
     no_online_source: This cited source doesn't include a URL.
     course_picker_heading: Choose course
     course_picker_no_courses: No courses

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1929,7 +1929,7 @@ nl:
       aan de hand van de geciteerde bronnen, omdat ze mogelijk door AI zijn gegenereerd.
       Let op: de pagina kan zijn gewijzigd sinds deze beweringen zijn toegevoegd.'
     form:
-      step_find_source: 'Stap 3: Zoek de bron'
+      step_find_source: 'Zoek de bron'
       find_source_instructions: Nu u uw bewerking hebt gekozen, gaat u op zoek naar
         de geciteerde bron. Mogelijk moet u uw docent of de bibliothecaris raadplegen
         om de bron te vinden.
@@ -1941,7 +1941,7 @@ nl:
         inaccessible: Nee, de bron bestaat wel, maar ik kon er geen toegang toe krijgen.
       source_access_notes_label: 'Als u de bron niet hebt kunnen vinden, vertel ons
         dan meer over uw ervaring:'
-      step_verify: 'Stap 4: Verifieer de bewering'
+      step_verify: 'Verifieer de bewering'
       verify_instructions: Zodra u de geciteerde bron hebt gevonden, onderzoek deze
         dan zorgvuldig om te bepalen in hoeverre deze uw gekozen bewering ondersteunt.
         Als u precies weet waar de informatie vandaan komt, noteer dan waar in het

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1859,7 +1859,7 @@ sk:
       zdrojom, pretože môžu byť generované umelou inteligenciou. (Poznámka: článok
       sa mohol od pridania týchto tvrdení zmeniť.)'
     form:
-      step_find_source: 'Krok 3: Nájdite zdroj'
+      step_find_source: 'Nájdite zdroj'
       find_source_instructions: Teraz, keď ste si vybrali tvrdenie, dohľadajte citovaný
         zdroj. Pri hľadaní zdroja sa možno budete musieť poradiť so svojím vyučujúcim
         alebo knihovníkom.
@@ -1871,7 +1871,7 @@ sk:
         inaccessible: Nie, zdroj existuje, ale nepodarilo sa mi k nemu získať prístup.
       source_access_notes_label: 'Ak sa vám zdroj nepodarilo nájsť, povedzte nám o
         tom viac:'
-      step_verify: 'Krok 4: Overte tvrdenie'
+      step_verify: 'Overte tvrdenie'
       verify_instructions: Keď citovaný zdroj nájdete, dôkladne ho preskúmajte a posúďte,
         nakoľko podporuje tvrdenie, ktoré ste si vybrali. Ak nájdete presne to miesto,
         odkiaľ informácia pochádza, poznačte si, kde v dokumente ste ju našli. (Niektoré

--- a/db/migrate/20260805120000_store_verification_claim_answers_as_hash.rb
+++ b/db/migrate/20260805120000_store_verification_claim_answers_as_hash.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Move the fact-verification exercise's answers out of the schema and into a
+# serialized hash, so refining the exercise no longer means changing the
+# database. The questions the exercise asks — and the answers each accepts — are
+# now declared in config/claim_verification_exercise.yml; this column just holds
+# whatever that names, keyed by question id.
+#
+# The columns dropped here were one-per-question, which coupled the shape of the
+# exercise to the shape of the table: every new question needed a migration.
+# Existing answers are carried across into the hash (and back out again on the
+# way down), so responses submitted before this runs are preserved.
+class StoreVerificationClaimAnswersAsHash < ActiveRecord::Migration[7.0]
+  # Stand-in for VerificationClaimResponse, which no longer knows about the
+  # per-question columns this migration has to read and write.
+  class Response < ActiveRecord::Base
+    self.table_name = 'verification_claim_responses'
+    serialize :answers, type: Hash
+  end
+
+  # The per-question columns, in the order the exercise asked them. Each becomes
+  # an `answers` key of the same name — which is why the question ids in
+  # config/claim_verification_exercise.yml match these.
+  ANSWER_COLUMNS = {
+    source_access: :string,
+    source_access_notes: :text,
+    verdict: :string,
+    claim_location: :text,
+    verification_notes: :text,
+    other_comments: :text
+  }.freeze
+
+  def up
+    add_column :verification_claim_responses, :answers, :text
+    Response.reset_column_information
+    Response.find_each { |response| response.update!(answers: pack(response)) }
+    ANSWER_COLUMNS.each_key { |column| remove_column :verification_claim_responses, column }
+  end
+
+  # Rebuilt nullable: `source_access` was NOT NULL, but a response carried down
+  # may have no answer for it, and the model is what enforces that now.
+  def down
+    ANSWER_COLUMNS.each { |column, type| add_column :verification_claim_responses, column, type }
+    Response.reset_column_information
+    Response.find_each { |response| response.update!(unpack(response)) }
+    remove_column :verification_claim_responses, :answers
+  end
+
+  private
+
+  # Only the questions the student actually answered, matching how new
+  # submissions are stored — blank answers aren't kept.
+  def pack(response)
+    ANSWER_COLUMNS.keys.index_with { |column| response[column] }.compact_blank.stringify_keys
+  end
+
+  def unpack(response)
+    ANSWER_COLUMNS.keys.index_with { |column| response.answers[column.to_s] }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_28_203000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "courses_id"
     t.string "title"
@@ -724,17 +724,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_28_203000) do
   end
 
   create_table "verification_claim_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "claim_location"
+    t.text "answers"
     t.integer "course_id", null: false
     t.datetime "created_at", null: false
-    t.text "other_comments"
-    t.string "source_access", null: false
-    t.text "source_access_notes"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.string "verdict"
     t.integer "verification_claim_id", null: false
-    t.text "verification_notes"
     t.index ["course_id"], name: "index_verification_claim_responses_on_course_id"
     t.index ["verification_claim_id"], name: "index_verification_claim_responses_on_verification_claim_id"
     t.index ["user_id", "course_id", "verification_claim_id"], name: "index_verification_claim_responses_uniqueness", unique: true

--- a/lib/claim_verification/exercise_form.rb
+++ b/lib/claim_verification/exercise_form.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/claim_verification/form_step"
+require_dependency "#{Rails.root}/lib/claim_verification/form_question"
+
+module ClaimVerification
+  # The fact-verification exercise's form, as declared in
+  # config/claim_verification_exercise.yml: the steps it asks, the questions
+  # under them, and the answers each accepts.
+  #
+  # This is the single definition of the exercise's shape. The model stores
+  # answers as a hash keyed by question id, the controller permits whatever keys
+  # it names, and the SPA renders both the form and the submitted-answers summary
+  # from it — so a change to the exercise is a change to that file alone.
+  class ExerciseForm
+    CONFIG_PATH = "#{Rails.root}/config/claim_verification_exercise.yml"
+
+    def self.definition
+      # Reloaded every time in development so editing the exercise doesn't need a
+      # server restart; read once in production.
+      return YAML.load_file(CONFIG_PATH) unless Rails.env.production?
+      @definition ||= YAML.load_file(CONFIG_PATH)
+    end
+
+    def steps
+      @steps ||= build_steps
+    end
+
+    def questions
+      steps.flat_map(&:questions)
+    end
+
+    # Every question id, whether or not it currently applies — what the
+    # controller permits from the client.
+    def answer_keys
+      questions.map(&:id)
+    end
+
+    # The submitted answers, less anything the exercise didn't actually ask:
+    # unknown keys, and answers to questions hidden by the path the student took
+    # (see FormQuestion#applicable?). Storing only what was asked keeps an
+    # abandoned branch from leaving stale answers behind.
+    def applicable_answers(submitted)
+      answers = submitted.to_h.stringify_keys
+      applicable_questions(answers).to_h { |question| [question.id, answers[question.id]] }
+                                   .compact_blank
+    end
+
+    # Questions actually asked given these answers, in form order.
+    def applicable_questions(answers)
+      steps.select { |step| step.applicable?(answers) }
+           .flat_map(&:questions)
+           .select { |question| question.applicable?(answers) }
+    end
+
+    # Why these answers aren't a valid submission: a required question left
+    # unanswered, or a choice answered with something the question doesn't offer.
+    # Developer-facing — the client blocks invalid submissions itself.
+    def errors_in(answers)
+      applicable_questions(answers.to_h.stringify_keys).filter_map do |question|
+        error_for(question, answers.to_h.stringify_keys[question.id])
+      end
+    end
+
+    private
+
+    def error_for(question, answer)
+      return "#{question.id} is required" if question.required && answer.blank?
+      return if answer.blank? || !question.choice?
+      "#{answer} is not an accepted answer for #{question.id}" unless
+        question.options.include?(answer)
+    end
+
+    # Numbers are assigned here rather than written into the copy, counting only
+    # the steps that show a heading, so reordering the config renumbers them.
+    def build_steps
+      number = self.class.definition['first_step_number']
+      self.class.definition['steps'].map do |config|
+        numbered = config['heading'] != false
+        step = FormStep.from_config(config, number: numbered ? number : nil)
+        number += 1 if numbered
+        step
+      end
+    end
+  end
+end

--- a/lib/claim_verification/form_question.rb
+++ b/lib/claim_verification/form_question.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ClaimVerification
+  # One question of the fact-verification exercise form, as declared in
+  # config/claim_verification_exercise.yml. Its copy is looked up from the
+  # locales by convention from its id (see that file), so a question is fully
+  # described by its id, its type, and the answers it accepts.
+  #
+  # - id: also the key this question's answer is stored under
+  # - type: 'choice' (one of `options`) or 'text' (free response)
+  # - options: the accepted answers, for a choice question
+  # - required: submission is blocked until this is answered
+  # - visible_when: { other question id => [answers] }; asked only when that
+  #   earlier answer is one of those (see #applicable?)
+  FormQuestion = Data.define(:id, :type, :options, :required, :visible_when) do
+    def self.from_config(config)
+      new(id: config.fetch('id'), type: config.fetch('type'),
+          options: config['options'] || [], required: config['required'] || false,
+          visible_when: config['visible_when'] || {})
+    end
+
+    def choice?
+      type == 'choice'
+    end
+
+    # Whether this question is asked at all, given the answers so far. A
+    # question with no `visible_when` is always asked.
+    def applicable?(answers)
+      visible_when.all? { |question_id, values| values.include?(answers[question_id]) }
+    end
+
+    def label
+      I18n.t("claim_verification.form.#{choice? ? "#{id}_question" : "#{id}_label"}")
+    end
+
+    # The choice options as value/label pairs, in the order the form offers them.
+    def option_labels
+      options.map do |value|
+        { value:, label: I18n.t("claim_verification.form.#{id}_options.#{value}") }
+      end
+    end
+  end
+end

--- a/lib/claim_verification/form_step.rb
+++ b/lib/claim_verification/form_step.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ClaimVerification
+  # One step of the fact-verification exercise form: a heading, optional
+  # instructions, and the questions asked under it. Declared in
+  # config/claim_verification_exercise.yml, which also documents how the copy is
+  # looked up from the step's id.
+  #
+  # `number` is assigned by ExerciseForm rather than written into the copy, so
+  # reordering the steps renumbers them; an unnumbered step (`heading: false`)
+  # has no number and no heading, like the closing comments field.
+  FormStep = Data.define(:id, :number, :questions, :visible_when) do
+    def self.from_config(config, number:)
+      new(id: config.fetch('id'), number:,
+          questions: (config['questions'] || []).map { |q| FormQuestion.from_config(q) },
+          visible_when: config['visible_when'] || {})
+    end
+
+    def numbered?
+      !number.nil?
+    end
+
+    # Whether the step is shown at all, given the answers so far.
+    def applicable?(answers)
+      visible_when.all? { |question_id, values| values.include?(answers[question_id]) }
+    end
+
+    # "Step 4: Find the source" — the number is composed in, not part of the copy.
+    def heading
+      return unless numbered?
+      I18n.t('claim_verification.form.step_heading',
+             number:, name: I18n.t("claim_verification.form.step_#{id}"))
+    end
+
+    # Steps may explain themselves before asking; most do, the comments step
+    # doesn't. `default: nil` rather than I18n.exists?, so a locale missing this
+    # string still falls back to English instead of dropping the instructions.
+    def instructions
+      I18n.t("claim_verification.form.#{id}_instructions", default: nil).presence
+    end
+  end
+end

--- a/lib/claim_verification/prose_index.rb
+++ b/lib/claim_verification/prose_index.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ClaimVerification
+  # A block element's prose as the sentence segmenter saw it, plus the means to
+  # get back from a position in that text to the DOM node it came from.
+  #
+  # `text` is built the same way SentenceSegmenter builds its input, so a stored
+  # claim sentence can be found in it by plain string search:
+  # - reference markers (`<sup class="reference">`) contribute nothing, since the
+  #   segmenter replaced them with tokens and then stripped the tokens
+  # - runs of whitespace collapse to one space
+  #
+  # `boundary_at` returns the [text node, offset] a given character came from,
+  # which is what lets a matched sentence be turned back into a node range. The
+  # positions are only valid until the document is mutated, so build an index,
+  # use it, and rebuild it if the DOM changes underneath.
+  class ProseIndex
+    attr_reader :text
+
+    def initialize(root)
+      @text = +''
+      # Parallel to @text: the [node, offset] each character was taken from.
+      @positions = []
+      absorb(root)
+    end
+
+    # The [start, end) character range of `sentence` in this prose, or nil when
+    # it isn't here. `sentence` must already be whitespace-normalized.
+    def range_of(sentence)
+      start = @text.index(sentence)
+      start && [start, start + sentence.length]
+    end
+
+    # The [node, offset] the character at `position` came from.
+    def boundary_at(position)
+      @positions[position]
+    end
+
+    private
+
+    def absorb(node)
+      node.children.each do |child|
+        next if reference_marker?(child)
+        child.text? ? absorb_text(child) : absorb(child)
+      end
+    end
+
+    # Copies `node`'s characters into the prose, collapsing whitespace runs into
+    # a single space — and recording, for each character kept, where it came from.
+    # A collapsed run is represented by its first character, so a range boundary
+    # landing on whitespace still maps to a real position in the document.
+    def absorb_text(node)
+      node.content.each_char.with_index do |char, offset|
+        if char.match?(/\s/)
+          next if @text.end_with?(' ') || @text.empty?
+          @text << ' '
+        else
+          @text << char
+        end
+        @positions << [node, offset]
+      end
+    end
+
+    def reference_marker?(node)
+      node.element? && node.name == 'sup' && node['class'].to_s.include?('reference')
+    end
+  end
+end

--- a/lib/claim_verification/sentence_highlighter.rb
+++ b/lib/claim_verification/sentence_highlighter.rb
@@ -1,104 +1,111 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/claim_verification/prose_index"
+
 module ClaimVerification
-  # Wraps a cited claim's sentence — the prose the citation marker is attached to,
-  # not just the [n] marker — in a <span class="cv-claim"> carrying the click data,
+  # Wraps a cited claim's sentence — the prose the citation is attached to, not
+  # just the [n] marker — in a `<span class="cv-claim">` carrying the click data,
   # so the whole claim can be highlighted and selected in the ArticleViewer.
   #
-  # The sentence ends just before the citation marker, so we walk backward over the
-  # marker's preceding siblings, accumulating their text until it covers the
-  # sentence (compared by non-whitespace character count, which is robust to
-  # whitespace differences between the segmenter's text and the DOM), then wrap that
-  # node range. The boundary node is split so only the sentence's share is included.
-  # Returns false (wrapping nothing) when the sentence can't be located, so the
-  # caller can fall back to tagging the marker.
+  # The sentence is located by finding its text in the paragraph's prose (see
+  # ProseIndex) and wrapping exactly that character range. It is deliberately NOT
+  # located by walking back from the citation marker: a citation can sit
+  # mid-sentence ("...informetrics[1], particularly for..."), and a named source
+  # reused across an article puts the same marker on many different sentences, so
+  # the marker says nothing reliable about where its sentence starts or ends.
+  #
+  # Returns false (wrapping nothing) when the sentence isn't in this paragraph or
+  # is already inside another claim's span, so the caller can move on or fall
+  # back to tagging the marker.
   class SentenceHighlighter
-    def initialize(marker:, sentence:, data:)
-      @marker = marker
-      @sentence = sentence
+    def initialize(paragraph:, sentence:, data:)
+      @paragraph = paragraph
+      @sentence = sentence.to_s.gsub(/\s+/, ' ').strip
       @data = data
     end
 
     def wrap
-      nodes = sentence_nodes
-      return false if nodes.empty?
-      # role=button + tabindex make the highlighted claim a real, focusable
-      # control so it can be reached and activated by keyboard / screen reader;
-      # the wrapped sentence text is the control's accessible name.
-      span = nodes.first.document.create_element('span', class: 'cv-claim',
-                                                 role: 'button', tabindex: '0')
-      @data.each { |key, value| span[key] = value if value }
-      nodes.first.add_previous_sibling(span)
-      nodes.each { |node| span.add_child(node) }
+      index = ProseIndex.new(@paragraph)
+      range = index.range_of(@sentence)
+      return false if range.nil?
+      head, tail = split_out_range(index, *range)
+      return false if head.nil? || already_claimed?(head)
+      wrap_nodes(head, tail)
       true
     end
 
     private
 
-    def sentence_nodes
-      target = non_ws_count(@sentence)
-      return [] if target.zero?
-      acc = 0
-      collected = []
-      node = @marker.previous_sibling
-      # Walk back over the sentence's prose, but stop at an already-highlighted
-      # claim: a sentence must not extend into a previous claim's span. Without
-      # this, when the count falls a little short the walk swallows the whole
-      # neighbouring span (it can't be split), nesting the spans and stacking
-      # their highlight into an ever-darker shade. The previous claim's span ends
-      # exactly where this sentence begins, so the prose gathered up to it is the
-      # sentence even if a few characters short of the segmented length.
-      while node && acc < target && !already_highlighted?(node)
-        prev = node.previous_sibling
-        acc += consume(node, collected, target - acc)
-        node = prev
+    # Splits the boundary text nodes so the sentence occupies whole nodes,
+    # returning its first and last. The end is split before the start so the
+    # start's offset is still valid when both fall in the same text node — and in
+    # that case the sentence ends up wholly within the head, so splitting the
+    # start has moved the end into it too.
+    def split_out_range(index, start, finish)
+      start_node, start_offset = index.boundary_at(start)
+      end_node, end_offset = index.boundary_at(finish - 1)
+      return [nil, nil] if start_node.nil? || end_node.nil?
+      one_node = start_node.equal?(end_node)
+      tail = split_at(end_node, end_offset + 1).first
+      head = split_at(start_node, start_offset).last
+      [head, one_node ? head : tail]
+    end
+
+    # Splits `node` at `offset` into [before, after], either of which may be the
+    # node itself when the offset is at one of its ends.
+    def split_at(node, offset)
+      return [nil, node] if offset <= 0
+      return [node, nil] if offset >= node.content.length
+      after = Nokogiri::XML::Text.new(node.content[offset..], node.document)
+      node.add_next_sibling(after)
+      node.content = node.content[0...offset]
+      [node, after]
+    end
+
+    # A sentence normally runs through text and whole inline elements of one
+    # parent. When its ends sit at different depths (it starts inside an <i>, say)
+    # we wrap the widest siblings of their common ancestor that contain them,
+    # which can take in a little adjacent text — still this sentence's region,
+    # and far better than the marker-relative guess this replaces.
+    def wrap_nodes(head, tail)
+      ancestor = common_parent(head, tail)
+      first = child_of(ancestor, head)
+      last = child_of(ancestor, tail)
+      # role=button + tabindex make the highlighted claim a real, focusable
+      # control so it can be reached and activated by keyboard / screen reader;
+      # the wrapped sentence text is the control's accessible name.
+      span = ancestor.document.create_element('span', class: 'cv-claim',
+                                              role: 'button', tabindex: '0')
+      @data.each { |key, value| span[key] = value if value }
+      first.add_previous_sibling(span)
+      siblings_through(first, last).each { |node| span.add_child(node) }
+    end
+
+    # The nearest element containing both ends as (possibly indirect) children.
+    # Searched from the head's ancestors rather than the head itself so that a
+    # sentence sitting in a single text node yields that node's parent.
+    def common_parent(head, tail)
+      tail_line = [tail, *tail.ancestors]
+      head.ancestors.find { |node| tail_line.any? { |other| other.equal?(node) } }
+    end
+
+    def child_of(ancestor, node)
+      node = node.parent until node.parent.nil? || node.parent.equal?(ancestor)
+      node
+    end
+
+    def siblings_through(first, last)
+      nodes = [first]
+      nodes << nodes.last.next_sibling while !nodes.last.equal?(last) && nodes.last.next_sibling
+      nodes
+    end
+
+    # Another claim's span already covers this text — don't nest one inside the
+    # other, which would stack their highlights into an ever-darker shade.
+    def already_claimed?(node)
+      [node, *node.ancestors].any? do |candidate|
+        candidate.element? && candidate['class'].to_s.split.include?('cv-claim')
       end
-      acc >= target || already_highlighted?(node) ? collected : []
-    end
-
-    def already_highlighted?(node)
-      node&.element? && node['class'].to_s.split.include?('cv-claim')
-    end
-
-    # Prepends `node` to the (forward-ordered) sentence run, returning how many
-    # non-whitespace characters of the sentence it contributed.
-    def consume(node, collected, remaining)
-      if reference_marker?(node)
-        collected.unshift(node)
-        return 0
-      end
-      count = non_ws_count(node.text)
-      if count >= remaining
-        collected.unshift(node.text? ? split_keeping_trailing_nonws(node, remaining) : node)
-        remaining
-      else
-        collected.unshift(node)
-        count
-      end
-    end
-
-    # Splits `text_node` so it retains only its trailing `keep` non-whitespace
-    # characters (the sentence's share); the rest stays as a preceding sibling.
-    def split_keeping_trailing_nonws(text_node, keep)
-      text = text_node.content
-      return text_node if non_ws_count(text) <= keep
-      count = 0
-      idx = text.length
-      while idx.positive? && count < keep
-        idx -= 1
-        count += 1 unless text[idx].match?(/\s/)
-      end
-      text_node.add_previous_sibling(Nokogiri::XML::Text.new(text[0...idx], text_node.document))
-      text_node.content = text[idx..]
-      text_node
-    end
-
-    def reference_marker?(node)
-      node.element? && node.name == 'sup' && node['class'].to_s.include?('reference')
-    end
-
-    def non_ws_count(string)
-      string.to_s.gsub(/\s/, '').length
     end
   end
 end

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -118,6 +118,17 @@ describe 'Claim verification exercise', type: :feature, js: true do
     expect(page).to have_no_button(I18n.t('claim_verification.form.submit'))
     expect(page).to have_content(I18n.t('claim_verification.choose_different_claim'))
 
+    # Browsing the other candidates must not cost them the claim they answered
+    # for: the picker offers a way back, and returning restores their answers
+    # rather than a blank form.
+    click_button I18n.t('claim_verification.choose_different_claim')
+    expect(page).to have_content(I18n.t('claim_verification.step_select_article'), wait: 10)
+    click_button "← #{I18n.t('claim_verification.back_to_claim')}"
+    expect(page).to have_content(I18n.t('claim_verification.your_selected_claim'), wait: 10)
+    expect(page).to have_content(
+      I18n.t('claim_verification.form.verdict_options.partial_support')
+    )
+
     response = VerificationClaimResponse.find_by(user: student, course:)
     expect(response.answer('source_appropriate')).to eq('appropriate')
     expect(response.answer('meets_rs_policy')).to eq('context_dependent')
@@ -225,6 +236,22 @@ describe 'Claim verification exercise', type: :feature, js: true do
     expect(page).to have_no_content('Slowpoke')
     click_link "← #{I18n.t('claim_verification.responses.heading')}"
     expect(page).to have_content('Slowpoke', wait: 10)
+  end
+
+  # Arriving on a shared ?showArticle= link forces the picker into view even when
+  # the student already has a claim, so the way back has to work from there too —
+  # and the open article id lives in the URL, not in component state.
+  it 'lets a student with a claim return from a ?showArticle= deep link' do
+    claim = VerificationClaim.find_by(sentence:)
+    VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
+
+    visit "/courses/#{course.slug}/verify_claim?showArticle=#{article.id}"
+    expect(page).to have_css('.article-viewer', wait: 20)
+    find('.article-viewer-button.icon-close', match: :first).click
+
+    click_button "← #{I18n.t('claim_verification.back_to_claim')}"
+    expect(page).to have_content(I18n.t('claim_verification.your_selected_claim'), wait: 10)
+    expect(page).to have_content(sentence)
   end
 
   it 'deep-links straight into an open article via ?showArticle=' do

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -91,7 +91,17 @@ describe 'Claim verification exercise', type: :feature, js: true do
     assignment = VerificationClaimAssignment.find_by(user: student, course:)
     expect(assignment.verification_claim.sentence).to eq(sentence)
 
-    # Step 3: the student got the source, so step 4 (verify the claim) appears.
+    # The source-evaluation step comes first, judged from the citation alone.
+    expect(page).to have_content(I18n.t('claim_verification.form.step_evaluate_source'))
+    # Step instructions render as Markdown, so a URL in the operator copy is a
+    # link out of the exercise rather than inert text.
+    policy_link = find('.cv-form__step-instructions a', match: :first)
+    expect(policy_link[:href]).to include('Wikipedia:Reliable_sources')
+    expect(policy_link[:target]).to eq('_blank')
+    choose I18n.t('claim_verification.form.source_appropriate_options.appropriate')
+    choose I18n.t('claim_verification.form.meets_rs_policy_options.context_dependent')
+
+    # Then finding the source; saying they got it opens the verify-the-claim step.
     expect(page).to have_content(I18n.t('claim_verification.form.step_find_source'))
     choose I18n.t('claim_verification.form.source_access_options.accessed')
     expect(page).to have_content(I18n.t('claim_verification.form.step_verify'))
@@ -109,8 +119,10 @@ describe 'Claim verification exercise', type: :feature, js: true do
     expect(page).to have_content(I18n.t('claim_verification.choose_different_claim'))
 
     response = VerificationClaimResponse.find_by(user: student, course:)
-    expect(response.verdict).to eq('partial_support')
-    expect(response.claim_location).to eq('p. 44')
+    expect(response.answer('source_appropriate')).to eq('appropriate')
+    expect(response.answer('meets_rs_policy')).to eq('context_dependent')
+    expect(response.answer('verdict')).to eq('partial_support')
+    expect(response.answer('claim_location')).to eq('p. 44')
     expect(response.verification_claim).to eq(assignment.verification_claim)
 
     # Navigating (client-side) back to the timeline shows the exercise as
@@ -130,12 +142,18 @@ describe 'Claim verification exercise', type: :feature, js: true do
     VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
     VerificationClaimResponse.create!(
       user: student, course:, verification_claim: claim,
-      source_access: 'accessed', verdict: 'mostly_supports', claim_location: 'chapter 3',
-      verification_notes: 'The chapter describes tool use at length, but the shellfish ' \
-                          'detail only appears in a figure caption, which took a while to ' \
-                          'find because the scanned copy has no searchable text at all.',
-      other_comments: 'Reference: https://example.com/very/long/unbroken/path/to/a/scanned/' \
-                      'document/section-3-2-1#page=44&highlight=sea-otters'
+      answers: {
+        'source_appropriate' => 'appropriate',
+        'meets_rs_policy' => 'generally_reliable',
+        'source_access' => 'accessed',
+        'verdict' => 'mostly_supports',
+        'claim_location' => 'chapter 3',
+        'verification_notes' => 'The chapter describes tool use at length, but the shellfish ' \
+                                'detail only appears in a figure caption, which took a while ' \
+                                'to find because the scanned copy has no searchable text.',
+        'other_comments' => 'Reference: https://example.com/very/long/unbroken/path/to/a/' \
+                            'scanned/document/section-3-2-1#page=44&highlight=sea-otters'
+      }
     )
     tmu = TrainingModulesUsers.create!(user: student, training_module_id: exercise_module.id,
                                        completed_at: Time.zone.now)
@@ -171,9 +189,13 @@ describe 'Claim verification exercise', type: :feature, js: true do
                           role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     claim = VerificationClaim.find_by(sentence:)
     VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
-    VerificationClaimResponse.create!(user: student, course:, verification_claim: claim,
-                                      source_access: 'accessed', verdict: 'contradicted',
-                                      other_comments: 'The source says the opposite.')
+    VerificationClaimResponse.create!(
+      user: student, course:, verification_claim: claim,
+      answers: { 'source_appropriate' => 'appropriate',
+                 'meets_rs_policy' => 'generally_reliable',
+                 'source_access' => 'accessed', 'verdict' => 'contradicted',
+                 'other_comments' => 'The source says the opposite.' }
+    )
     # A second student who has taken a claim but not submitted.
     slow_student = create(:user, username: 'Slowpoke', onboarded: true)
     create(:courses_user, course:, user: slow_student, role: CoursesUsers::Roles::STUDENT_ROLE)

--- a/spec/lib/claim_verification/exercise_form_spec.rb
+++ b/spec/lib/claim_verification/exercise_form_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_dependency "#{Rails.root}/lib/claim_verification/exercise_form"
+
+# The exercise's shape as declared in config/claim_verification_exercise.yml.
+# These specs are about the mechanics the declaration relies on — numbering,
+# gating, validation — rather than the particular questions asked, so that
+# refining the exercise doesn't invalidate them.
+describe ClaimVerification::ExerciseForm do
+  let(:form) { described_class.new }
+
+  # A path through the exercise where the student got the source, answering
+  # every required question.
+  let(:complete_answers) do
+    { 'source_appropriate' => 'appropriate', 'meets_rs_policy' => 'generally_reliable',
+      'source_access' => 'accessed', 'verdict' => 'full_support' }
+  end
+
+  describe 'the declared steps' do
+    it 'numbers the steps that show a heading, continuing the exercise count' do
+      numbered = form.steps.select(&:numbered?)
+      expect(numbered.map(&:number)).to eq((3..(2 + numbered.length)).to_a)
+    end
+
+    it 'gives an unnumbered step no heading' do
+      unnumbered = form.steps.reject(&:numbered?)
+      expect(unnumbered.map(&:heading)).to all(be_nil)
+    end
+
+    it 'composes the number into the heading rather than the copy' do
+      step = form.steps.find { |candidate| candidate.id == 'find_source' }
+      expect(step.heading).to eq("Step #{step.number}: Find the source")
+    end
+
+    it 'asks the source-evaluation step before the source is tracked down' do
+      expect(form.steps.map(&:id).first(2)).to eq(%w[evaluate_source find_source])
+    end
+  end
+
+  describe '#answer_keys' do
+    it 'names every question, whatever the path through the exercise' do
+      expect(form.answer_keys).to include('source_appropriate', 'source_access', 'verdict')
+    end
+
+    it 'has no duplicates, since each key stores one answer' do
+      expect(form.answer_keys.uniq).to eq(form.answer_keys)
+    end
+  end
+
+  describe '#applicable_questions' do
+    it 'skips a gated step until its answer opens it' do
+      asked = form.applicable_questions('source_access' => 'nonexistent').map(&:id)
+      expect(asked).not_to include('verdict')
+    end
+
+    it 'asks a gated step once its answer opens it' do
+      asked = form.applicable_questions('source_access' => 'accessed').map(&:id)
+      expect(asked).to include('verdict')
+    end
+
+    it 'asks a gated question only on the branch it belongs to' do
+      expect(form.applicable_questions('source_access' => 'inaccessible').map(&:id))
+        .to include('source_access_notes')
+    end
+
+    it 'asks the ungated questions whatever the answers' do
+      expect(form.applicable_questions({}).map(&:id)).to include('source_appropriate')
+    end
+  end
+
+  describe '#applicable_answers' do
+    it 'keeps the answers the exercise asked for' do
+      expect(form.applicable_answers(complete_answers)).to eq(complete_answers)
+    end
+
+    it 'drops answers to questions the path never asked' do
+      submitted = complete_answers.merge('source_access' => 'nonexistent')
+      expect(form.applicable_answers(submitted).keys).not_to include('verdict')
+    end
+
+    it 'drops keys the exercise does not ask at all' do
+      submitted = complete_answers.merge('favourite_otter' => 'Sea')
+      expect(form.applicable_answers(submitted).keys).not_to include('favourite_otter')
+    end
+
+    it 'drops blank answers rather than storing them' do
+      submitted = complete_answers.merge('claim_location' => '')
+      expect(form.applicable_answers(submitted).keys).not_to include('claim_location')
+    end
+
+    it 'accepts string or symbol keys from the client' do
+      expect(form.applicable_answers(complete_answers.symbolize_keys))
+        .to eq(complete_answers)
+    end
+  end
+
+  describe '#errors_in' do
+    it 'accepts a complete set of answers' do
+      expect(form.errors_in(complete_answers)).to be_empty
+    end
+
+    it 'reports a required question left unanswered' do
+      expect(form.errors_in(complete_answers.except('source_appropriate')))
+        .to include(/source_appropriate is required/)
+    end
+
+    it 'reports a choice answered with something it does not offer' do
+      expect(form.errors_in(complete_answers.merge('verdict' => 'sort_of')))
+        .to include(/not an accepted answer for verdict/)
+    end
+
+    it 'does not require a question the path never asked' do
+      answers = complete_answers.except('verdict').merge('source_access' => 'nonexistent')
+      expect(form.errors_in(answers)).to be_empty
+    end
+
+    it 'never requires a free-text question' do
+      expect(form.questions.select(&:required).map(&:type).uniq).to eq(['choice'])
+    end
+  end
+
+  # The point of declaring the exercise in config is that refining it needs no
+  # code change, so the mechanics must follow the declaration rather than the
+  # questions this exercise currently happens to ask. A stand-in declaration
+  # with entirely different questions proves that.
+  describe 'with a different declaration' do
+    let(:declaration) do
+      { 'first_step_number' => 1,
+        'steps' => [
+          { 'id' => 'pick',
+            'questions' => [{ 'id' => 'colour', 'type' => 'choice', 'required' => true,
+                              'options' => %w[red blue] }] },
+          { 'id' => 'explain', 'visible_when' => { 'colour' => ['red'] },
+            'questions' => [{ 'id' => 'shade', 'type' => 'text' }] }
+        ] }
+    end
+
+    before { allow(described_class).to receive(:definition).and_return(declaration) }
+
+    it 'asks whatever the declaration names' do
+      expect(form.answer_keys).to eq(%w[colour shade])
+    end
+
+    it 'numbers from the declared first step number' do
+      expect(form.steps.map(&:number)).to eq([1, 2])
+    end
+
+    it 'validates a choice against the options the declaration gives it' do
+      expect(form.errors_in('colour' => 'green'))
+        .to include(/not an accepted answer for colour/)
+    end
+
+    it 'gates a step on the answer the declaration names' do
+      expect(form.applicable_questions('colour' => 'blue').map(&:id)).to eq(['colour'])
+    end
+
+    it 'opens the gated step on the answer that satisfies it' do
+      expect(form.applicable_questions('colour' => 'red').map(&:id)).to eq(%w[colour shade])
+    end
+  end
+end

--- a/spec/lib/claim_verification/prose_index_spec.rb
+++ b/spec/lib/claim_verification/prose_index_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/claim_verification/prose_index"
+
+# The index's whole job is to present a paragraph's prose the way
+# SentenceSegmenter saw it, so a stored claim sentence can be found in it by
+# plain string search, and then mapped back to the nodes it came from.
+describe ClaimVerification::ProseIndex do
+  def index_for(html)
+    described_class.new(Nokogiri::HTML.fragment(html).at_css('p'))
+  end
+
+  def marker(ref = 'c')
+    %(<sup class="reference"><a href="##{ref}">[1]</a></sup>)
+  end
+
+  describe '#text' do
+    it 'omits reference markers, which the segmenter stripped from its sentences' do
+      expect(index_for("<p>The otter dives.#{marker}</p>").text).to eq('The otter dives.')
+    end
+
+    it 'omits a marker sitting inside a sentence' do
+      index = index_for("<p>The otter dives#{marker}, then surfaces.</p>")
+      expect(index.text).to eq('The otter dives, then surfaces.')
+    end
+
+    it 'collapses whitespace runs to a single space' do
+      expect(index_for("<p>The otter\n\n   dives.</p>").text).to eq('The otter dives.')
+    end
+
+    it 'collapses whitespace that spans element boundaries' do
+      expect(index_for('<p>The <i>otter </i> dives.</p>').text).to eq('The otter dives.')
+    end
+
+    it 'reads through inline markup as one run of prose' do
+      expect(index_for('<p>The <i>Enhydra</i> dives.</p>').text).to eq('The Enhydra dives.')
+    end
+
+    it 'drops leading whitespace rather than starting the prose with a space' do
+      expect(index_for('<p>  The otter dives.</p>').text).to eq('The otter dives.')
+    end
+  end
+
+  describe '#range_of' do
+    it 'locates a sentence within the prose' do
+      index = index_for('<p>Before it. The otter dives. After it.</p>')
+      start, finish = index.range_of('The otter dives.')
+      expect(index.text[start...finish]).to eq('The otter dives.')
+    end
+
+    it 'is nil for a sentence that is not there' do
+      expect(index_for('<p>The otter dives.</p>').range_of('The otter sleeps.')).to be_nil
+    end
+  end
+
+  describe '#boundary_at' do
+    it 'maps a position back to the node and offset it came from' do
+      index = index_for('<p>The otter dives.</p>')
+      node, offset = index.boundary_at(index.text.index('otter'))
+      expect(node.content[offset..]).to start_with('otter')
+    end
+
+    it 'maps across an inline element to the right node' do
+      index = index_for('<p>The <i>Enhydra</i> dives.</p>')
+      node, offset = index.boundary_at(index.text.index('Enhydra'))
+      expect(node.parent.name).to eq('i')
+      expect(node.content[offset..]).to start_with('Enhydra')
+    end
+  end
+end

--- a/spec/lib/claim_verification/sentence_highlighter_spec.rb
+++ b/spec/lib/claim_verification/sentence_highlighter_spec.rb
@@ -4,36 +4,110 @@ require 'rails_helper'
 require "#{Rails.root}/lib/claim_verification/sentence_highlighter"
 
 describe ClaimVerification::SentenceHighlighter do
-  def wrap(html, sentence:, data: {})
+  def wrap(html, sentence:, data: { 'data-claim-id' => '7' })
     doc = Nokogiri::HTML.fragment(html)
-    marker = doc.at_css('sup.reference')
-    result = described_class.new(marker:, sentence:, data:).wrap
+    result = described_class.new(paragraph: doc.at_css('p'), sentence:, data:).wrap
     [result, doc]
   end
 
+  def marker(ref)
+    %(<sup class="reference"><a href="##{ref}">[1]</a></sup>)
+  end
+
   it 'wraps the cited sentence in a cv-claim span carrying the data' do
-    result, doc = wrap(
-      '<p>The otter dives.<sup class="reference"><a href="#c">[1]</a></sup></p>',
-      sentence: 'The otter dives.', data: { 'data-claim-id' => '7' }
-    )
+    result, doc = wrap("<p>The otter dives.#{marker('c')}</p>", sentence: 'The otter dives.')
     expect(result).to be true
     span = doc.at_css('span.cv-claim')
     expect(span['data-claim-id']).to eq('7')
     expect(span.text).to include('The otter dives.')
   end
 
-  # Without the boundary stop, the backward walk falls a character short on this
-  # claim's own prose, reaches the previous claim's span, and (unable to split an
-  # element) swallows it whole — nesting the spans, which is what stacked the
-  # highlight into a darker shade.
-  it 'stops at a previous claim span instead of nesting it' do
+  it 'makes the span a focusable control for keyboard and screen-reader users' do
+    _result, doc = wrap("<p>The otter dives.#{marker('c')}</p>", sentence: 'The otter dives.')
+    span = doc.at_css('span.cv-claim')
+    expect(span['role']).to eq('button')
+    expect(span['tabindex']).to eq('0')
+  end
+
+  # The sentence is found by its text, so where the citation sits within it makes
+  # no difference — this is what the marker-relative approach could not do.
+  it 'wraps a sentence whose citation sits in the middle of it' do
     result, doc = wrap(
-      '<p><span class="cv-claim" data-claim-id="1">one</span> two' \
-      '<sup class="reference"><a href="#c">[1]</a></sup></p>',
-      sentence: 'abcd', data: { 'data-claim-id' => '2' }
+      "<p>The otter dives#{marker('c')}, then surfaces.#{marker('d')}</p>",
+      sentence: 'The otter dives, then surfaces.'
     )
     expect(result).to be true
-    expect(doc.css('.cv-claim').size).to eq(2)
+    expect(doc.at_css('span.cv-claim').text).to include('The otter dives', 'then surfaces.')
+  end
+
+  # The segmenter's sentence keeps the full stop that follows the citation
+  # ("physics[3]."), so the highlight has to reach past the marker to cover it.
+  it 'includes sentence-final punctuation that follows the citation' do
+    result, doc = wrap(
+      "<p>Brookes studied physics#{marker('c')}. Then he left.</p>",
+      sentence: 'Brookes studied physics.'
+    )
+    expect(result).to be true
+    span = doc.at_css('span.cv-claim')
+    expect(span.text).to end_with('.')
+    expect(span.text).not_to include('Then he left')
+  end
+
+  # A source reused across an article puts the same marker on several sentences.
+  # The highlight must follow the sentence it was given, not the nearest marker.
+  it 'wraps the sentence it was given when the same source cites several' do
+    result, doc = wrap(
+      "<p>First claim.#{marker('shared')} Second claim.#{marker('shared')}</p>",
+      sentence: 'Second claim.'
+    )
+    expect(result).to be true
+    span = doc.at_css('span.cv-claim')
+    expect(span.text).to include('Second claim.')
+    expect(span.text).not_to include('First claim')
+  end
+
+  it 'wraps a sentence that runs through inline markup' do
+    result, doc = wrap(
+      "<p>The <i>Enhydra lutris</i> dives deep.#{marker('c')}</p>",
+      sentence: 'The Enhydra lutris dives deep.'
+    )
+    expect(result).to be true
+    span = doc.at_css('span.cv-claim')
+    expect(span.at_css('i')).to be_present
+    expect(span.text).to include('The Enhydra lutris dives deep.')
+  end
+
+  it 'matches regardless of how whitespace is broken up in the markup' do
+    result, doc = wrap(
+      "<p>The otter\n   dives.#{marker('c')}</p>", sentence: 'The otter dives.'
+    )
+    expect(result).to be true
+    expect(doc.at_css('span.cv-claim')).to be_present
+  end
+
+  it 'leaves surrounding prose outside the span' do
+    _result, doc = wrap(
+      "<p>Before it. The otter dives.#{marker('c')} After it.</p>",
+      sentence: 'The otter dives.'
+    )
+    span = doc.at_css('span.cv-claim')
+    expect(span.text).not_to include('Before it', 'After it')
+  end
+
+  it 'wraps nothing when the sentence is not in this paragraph' do
+    result, doc = wrap("<p>The otter dives.#{marker('c')}</p>", sentence: 'The otter sleeps.')
+    expect(result).to be false
+    expect(doc.at_css('.cv-claim')).to be_nil
+  end
+
+  # Nesting one claim's span inside another stacks their highlights into an
+  # ever-darker shade, so a sentence already covered is refused.
+  it 'refuses a sentence already inside another claim span' do
+    result, doc = wrap(
+      '<p><span class="cv-claim" data-claim-id="1">The otter dives.</span></p>',
+      sentence: 'The otter dives.'
+    )
+    expect(result).to be false
     expect(doc.css('.cv-claim .cv-claim')).to be_empty
   end
 end

--- a/spec/models/verification_claim_response_spec.rb
+++ b/spec/models/verification_claim_response_spec.rb
@@ -10,40 +10,51 @@ describe VerificationClaimResponse do
     VerificationClaim.create!(wiki:, sentence: 'Sea otters use rocks as tools.')
   end
 
-  let(:base_attributes) do
-    { user:, course:, verification_claim: claim, source_access: 'accessed',
-      verdict: 'full_support' }
+  # Every question the exercise currently requires, answered.
+  let(:complete_answers) do
+    { 'source_appropriate' => 'appropriate', 'meets_rs_policy' => 'generally_reliable',
+      'source_access' => 'accessed', 'verdict' => 'full_support' }
   end
 
-  it 'is valid with an accessed source and a verdict' do
+  let(:base_attributes) do
+    { user:, course:, verification_claim: claim, answers: complete_answers }
+  end
+
+  it 'is valid when every required question is answered' do
     expect(described_class.new(base_attributes)).to be_valid
   end
 
-  it 'rejects a source_access value outside the answer set' do
-    response = described_class.new(base_attributes.merge(source_access: 'maybe'))
-    expect(response).not_to be_valid
+  it 'reads one answer by question id' do
+    response = described_class.new(base_attributes)
+    expect(response.answer('verdict')).to eq('full_support')
   end
 
-  it 'requires a verdict when the source was accessed' do
-    response = described_class.new(base_attributes.merge(verdict: nil))
-    expect(response).not_to be_valid
+  it 'has no answer for a question the exercise did not ask' do
+    response = described_class.new(base_attributes)
+    expect(response.answer('claim_location')).to be_nil
   end
 
-  it 'rejects a verdict outside the answer set' do
-    response = described_class.new(base_attributes.merge(verdict: 'sort_of'))
-    expect(response).not_to be_valid
+  it 'rejects an answer outside the set its question offers' do
+    answers = complete_answers.merge('source_access' => 'maybe')
+    expect(described_class.new(base_attributes.merge(answers:))).not_to be_valid
   end
 
-  it 'rejects a verdict when the source could not be accessed' do
-    response = described_class.new(base_attributes.merge(source_access: 'inaccessible'))
-    expect(response).not_to be_valid
+  it 'rejects a required question left unanswered' do
+    answers = complete_answers.except('meets_rs_policy')
+    expect(described_class.new(base_attributes.merge(answers:))).not_to be_valid
   end
 
-  it 'allows a no-source response without a verdict' do
-    response = described_class.new(base_attributes.merge(source_access: 'nonexistent',
-                                                         verdict: nil,
-                                                         source_access_notes: 'No trace of it.'))
-    expect(response).to be_valid
+  it 'rejects a response with no answers at all' do
+    expect(described_class.new(base_attributes.merge(answers: {}))).not_to be_valid
+  end
+
+  # The verify-the-claim step is gated on having got the source, so its verdict
+  # isn't required of a student who couldn't.
+  it 'allows a no-source response without the verify-step answers' do
+    answers = complete_answers.except('verdict')
+                              .merge('source_access' => 'nonexistent',
+                                     'source_access_notes' => 'No trace of it.')
+    expect(described_class.new(base_attributes.merge(answers:))).to be_valid
   end
 
   it 'allows only one response per claim per student' do

--- a/spec/requests/claim_verification_exercise_spec.rb
+++ b/spec/requests/claim_verification_exercise_spec.rb
@@ -62,10 +62,22 @@ describe 'Claim verification exercise', type: :request do
 
     it 'returns the submitted response alongside the taken claim' do
       VerificationClaimAssignment.create!(user: student, course:, verification_claim: pool_claim)
-      VerificationClaimResponse.create!(user: student, course:, verification_claim: pool_claim,
-                                        source_access: 'accessed', verdict: 'full_support')
+      VerificationClaimResponse.create!(
+        user: student, course:, verification_claim: pool_claim,
+        answers: { 'source_appropriate' => 'appropriate',
+                   'meets_rs_policy' => 'generally_reliable',
+                   'source_access' => 'accessed', 'verdict' => 'full_support' }
+      )
       get "/courses/#{course.slug}/verify_claim/state"
-      expect(response.parsed_body['response']['verdict']).to eq('full_support')
+      expect(response.parsed_body['response']['answers']['verdict']).to eq('full_support')
+    end
+
+    # The SPA renders the form from this rather than from anything it knows
+    # itself, so the state has to carry the questions.
+    it 'returns the questions the exercise asks' do
+      get "/courses/#{course.slug}/verify_claim/state"
+      steps = response.parsed_body['form']['steps']
+      expect(steps.pluck('id')).to include('evaluate_source', 'find_source', 'verify')
     end
 
     it 'is open to any signed-in user, even one not enrolled in the course' do

--- a/spec/requests/claim_verification_responses_spec.rb
+++ b/spec/requests/claim_verification_responses_spec.rb
@@ -15,8 +15,11 @@ describe 'Claim verification responses', type: :request do
                               source_url: 'https://example.com/otters')
   end
 
+  # A complete path through the exercise: every required question answered,
+  # taking the branch where the student got hold of the source.
   let(:accessed_answers) do
-    { source_access: 'accessed', verdict: 'partial_support',
+    { source_appropriate: 'appropriate', meets_rs_policy: 'generally_reliable',
+      source_access: 'accessed', verdict: 'partial_support',
       claim_location: 'p. 44', verification_notes: 'Only the tool use is there.',
       other_comments: 'Fun exercise.' }
   end
@@ -43,8 +46,8 @@ describe 'Claim verification responses', type: :request do
         expect(response.status).to eq(200)
         stored = VerificationClaimResponse.find_by(user: student, course:)
         expect(stored.verification_claim).to eq(claim)
-        expect(stored.verdict).to eq('partial_support')
-        expect(response.parsed_body['response']['claim_location']).to eq('p. 44')
+        expect(stored.answer('verdict')).to eq('partial_support')
+        expect(response.parsed_body['response']['answers']['claim_location']).to eq('p. 44')
       end
 
       it 'updates the existing response on resubmission' do
@@ -52,20 +55,20 @@ describe 'Claim verification responses', type: :request do
         post "/courses/#{course.slug}/verify_claim/response",
              params: accessed_answers.merge(verdict: 'contradicted')
         expect(VerificationClaimResponse.where(user: student, course:).count).to eq(1)
-        expect(VerificationClaimResponse.find_by(user: student, course:).verdict)
+        expect(VerificationClaimResponse.find_by(user: student, course:).answer('verdict'))
           .to eq('contradicted')
       end
 
-      it 'clears verify-step answers when the source was not accessed' do
+      it 'stores no answers for a step the student\'s path never asked' do
         post "/courses/#{course.slug}/verify_claim/response",
-             params: { source_access: 'inaccessible', verdict: 'full_support',
-                       claim_location: 'p. 44', source_access_notes: 'Paywalled.',
-                       other_comments: 'Frustrating.' }
+             params: accessed_answers.merge(source_access: 'inaccessible',
+                                            source_access_notes: 'Paywalled.')
         stored = VerificationClaimResponse.find_by(user: student, course:)
-        expect(stored.verdict).to be_nil
-        expect(stored.claim_location).to be_nil
-        expect(stored.source_access_notes).to eq('Paywalled.')
-        expect(stored.other_comments).to eq('Frustrating.')
+        # The verify-the-claim step is gated on having got the source, so its
+        # answers are dropped rather than trusted from the client.
+        expect(stored.answers.keys).not_to include('verdict', 'claim_location')
+        expect(stored.answer('source_access_notes')).to eq('Paywalled.')
+        expect(stored.answer('other_comments')).to eq('Fun exercise.')
       end
 
       it 'marks the exercise training module complete for the course' do
@@ -85,7 +88,7 @@ describe 'Claim verification responses', type: :request do
 
       it 'rejects invalid answers without storing anything' do
         post "/courses/#{course.slug}/verify_claim/response",
-             params: { source_access: 'accessed' } # missing verdict
+             params: accessed_answers.except(:verdict)
         expect(response.status).to eq(422)
         expect(VerificationClaimResponse.find_by(user: student, course:)).to be_nil
       end
@@ -97,7 +100,8 @@ describe 'Claim verification responses', type: :request do
              params: { verification_claim_id: other_claim.id }
         expect(response.status).to eq(200)
         post "/courses/#{course.slug}/verify_claim/response",
-             params: { source_access: 'nonexistent', source_access_notes: 'No trace.' }
+             params: accessed_answers.merge(source_access: 'nonexistent',
+                                            source_access_notes: 'No trace.')
         expect(VerificationClaimResponse.where(user: student, course:).count).to eq(2)
       end
 
@@ -105,7 +109,8 @@ describe 'Claim verification responses', type: :request do
         post "/courses/#{course.slug}/verify_claim/response", params: accessed_answers
         post "/courses/#{course.slug}/verify_claim/take",
              params: { verification_claim_id: claim.id }
-        expect(response.parsed_body['response']['verdict']).to eq('partial_support')
+        expect(response.parsed_body['response']['answers']['verdict'])
+          .to eq('partial_support')
       end
     end
 
@@ -125,7 +130,7 @@ describe 'Claim verification responses', type: :request do
                             role: CoursesUsers::Roles::INSTRUCTOR_ROLE, real_name: 'Ada Prof')
       VerificationClaimAssignment.create!(user: student, course:, verification_claim: claim)
       VerificationClaimResponse.create!(user: student, course:, verification_claim: claim,
-                                        **accessed_answers)
+                                        answers: accessed_answers.stringify_keys)
       # A second student who has taken a claim but not submitted.
       pending_student = create(:user, username: 'Slowpoke')
       create(:courses_user, course:, user: pending_student,
@@ -141,9 +146,25 @@ describe 'Claim verification responses', type: :request do
       submitted = response.parsed_body['responses']
       expect(submitted.length).to eq(1)
       expect(submitted.first['username']).to eq('Otterfan')
-      expect(submitted.first['verdict']).to eq('partial_support')
+      expect(submitted.first['answers']['verdict']).to eq('partial_support')
       expect(submitted.first['claim']['sentence']).to eq(claim.sentence)
       expect(response.parsed_body['pending'].first['username']).to eq('Slowpoke')
+    end
+
+    # The instructor view renders each response as the questions the student
+    # answered, so the listing has to carry the questions themselves.
+    it 'sends the exercise questions alongside the responses' do
+      login_as instructor
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      questions = response.parsed_body['form']['steps'].flat_map { |step| step['questions'] }
+      expect(questions.pluck('id')).to include(*VerificationClaimResponse.last.answers.keys)
+    end
+
+    it 'resolves the question copy server-side' do
+      login_as instructor
+      get "/courses/#{course.slug}/verify_claim/responses.json"
+      first_step = response.parsed_body['form']['steps'].first
+      expect(first_step['heading']).to start_with('Step 3:')
     end
 
     it 'counts a student as pending again once they take a new claim' do

--- a/spec/services/annotate_revision_claims_spec.rb
+++ b/spec/services/annotate_revision_claims_spec.rb
@@ -89,6 +89,88 @@ describe AnnotateRevisionClaims do
     end
   end
 
+  # The bug this guards: a source cited on several sentences renders the same
+  # cite_note href at every one of them, and locating a claim by its marker
+  # attached each claim's data to the *first* of those sentences — so the
+  # highlighted text was not the claim that came up when you clicked it.
+  context 'when one source is cited on several sentences' do
+    # The first sentence is deliberately long: locating a claim by walking back
+    # from the first marker sharing its ref id then finds plenty of prose to
+    # consume, and so silently succeeds on the wrong sentence.
+    let(:revision_html) do
+      <<~HTML
+        <p>Otters were studied extensively throughout the twentieth century by many
+        researchers.<sup class="reference"><a href="#cite_note-shared-1">[1]</a></sup>
+        Otters eat urchins.<sup class="reference"><a href="#cite_note-shared-1">[1]</a></sup>
+        Otters have dense fur.<sup class="reference"><a href="#cite_note-shared-1">[1]</a></sup></p>
+        <ol class="references">
+          <li id="cite_note-shared-1"><span class="reference-text"><cite>
+            <a class="external" href="https://example.com/r">Riedman 1990</a></cite></span></li>
+        </ol>
+      HTML
+    end
+    # Only the second and third sentences were added in this revision.
+    let!(:harvested) do
+      VerificationClaim.create!(wiki:, article:, mw_rev_id:, ref_id: 'cite_note-shared-1',
+                                sentence: 'Otters eat urchins.', cite_text: 'Riedman 1990',
+                                source_url: 'https://example.com/r')
+    end
+    let!(:other) do
+      VerificationClaim.create!(wiki:, article:, mw_rev_id:, ref_id: 'cite_note-shared-1',
+                                sentence: 'Otters have dense fur.', cite_text: 'Riedman 1990',
+                                source_url: 'https://example.com/r')
+    end
+
+    def span_for(html, claim)
+      Nokogiri::HTML.fragment(html).at_css(%(.cv-claim[data-claim-id="#{claim.id}"]))
+    end
+
+    it 'highlights the text of each claim, not the first sentence citing the source' do
+      html = annotate.html
+      expect(span_for(html, harvested).text).to include('Otters eat urchins.')
+      expect(span_for(html, other).text).to include('Otters have dense fur.')
+    end
+
+    it 'agrees with the claim data behind every highlight' do
+      spans = Nokogiri::HTML.fragment(annotate.html).css('.cv-claim')
+      expect(spans).not_to be_empty
+      spans.each do |span|
+        expect(span.text.gsub(/\[\d+\]|\s+/, ' ').squeeze(' ').strip)
+          .to include(span['data-sentence'])
+      end
+    end
+
+    it 'leaves the sentence that was not harvested unhighlighted' do
+      highlighted = Nokogiri::HTML.fragment(annotate.html).css('.cv-claim').map(&:text).join(' ')
+      expect(highlighted).not_to include('studied extensively')
+    end
+  end
+
+  # A citation can sit inside a sentence rather than at its end, which a
+  # marker-relative search could never cover: the sentence continues past it.
+  context 'when the citation sits mid-sentence' do
+    let(:revision_html) do
+      <<~HTML
+        <p>Otters use rocks<sup class="reference"><a href="#cite_note-r-1">[1]</a></sup>, and they eat urchins.</p>
+        <ol class="references">
+          <li id="cite_note-r-1"><span class="reference-text"><cite>
+            <a class="external" href="https://example.com/r">Riedman</a></cite></span></li>
+        </ol>
+      HTML
+    end
+    let!(:harvested) do
+      VerificationClaim.create!(wiki:, article:, mw_rev_id:, ref_id: 'cite_note-r-1',
+                                sentence: 'Otters use rocks, and they eat urchins.',
+                                cite_text: 'Riedman', source_url: 'https://example.com/r')
+    end
+
+    it 'highlights the whole sentence, both sides of the citation' do
+      span = Nokogiri::HTML.fragment(annotate.html).at_css('.cv-claim')
+      expect(span.text).to include('Otters use rocks')
+      expect(span.text).to include('and they eat urchins.')
+    end
+  end
+
   context 'when the revision links to other pages' do
     let(:revision_html) do
       <<~HTML


### PR DESCRIPTION
## What this PR does

Three related changes to the in-dashboard fact-verification exercise (#6910).

**A new source-evaluation step.** Before the student goes looking for the source, they now judge it from the citation alone: is this an appropriate kind of source for this topic and claim, and does it meet [Wikipedia's Reliable Sources policy](https://en.wikipedia.org/wiki/Wikipedia:Reliable_sources) — each a multiple choice plus a "why or why not". It becomes step 3; finding and verifying the source renumber to 4 and 5 on their own.

**The exercise's questions no longer live in the database schema.** Adding the step as a column per question would have meant a migration for every future refinement of the exercise's wording, options or ordering. Instead the answers moved into a serialized hash (the same pattern as `Alert#details`), and what the exercise asks is declared in `config/claim_verification_exercise.yml` — with model validation, permitted params, the React form and the instructor summary all derived from that one file. Adding or reordering a question is now that file plus locale copy: no migration, no model change, no JavaScript change. The migration carries existing answers across, and back out again on rollback.

**A highlighting bug fix.** In production the highlighted text in an article was often not the claim that came up when you clicked it. A claim's position was being located by walking backward from a citation marker counting characters, without ever checking that the text collected was the claim's sentence. That breaks when one source is cited on several sentences (every claim's data landed on the first of them), when a citation sits mid-sentence (the sentence continues past the marker, so backward-walking can never cover it), and silently in both cases because nothing verified the result. Claims are now located by finding their sentence text in the paragraph prose and wrapping exactly that range. On the article this was reported against, highlights went from 24 of 28 disagreeing with their claim to 0 of 28; across six (article, revision) pairs from a production dump — 391 highlights — 0 mismatches. No re-harvest is needed, since claims already store the sentence text the matching uses.

**Plus:** "Choose a different claim" had no `button` class (it rendered as bare text) and sat below the entire form, so it was easy to miss. It moves up beside the heading. That exposed a dead end behind it — the only ways out of the picker were taking a different claim or reloading the page — so the picker now offers "← Back to my claim" whenever the student already has one.

### Testing

87+ Ruby specs (model, request, lib, service) and 6 browser feature specs pass, along with the 413-test JS suite; RuboCop and ESLint are clean on every touched file. The three highlighting regression tests were checked against the old implementation to confirm they actually fail there. The migration's data round-trip was verified against real rows in a local production dump, and the diagnosis throughout was done against real production data rather than synthetic fixtures.

## AI usage

Claude Code wrote essentially all of the code in this PR, along with the commit messages and this description. It should be reviewed on that basis — particularly the new `ProseIndex` / `SentenceHighlighter` DOM-range logic, which is the least obvious code here.

What the human contributed: the decision to add the step and what it should ask; **all** user-facing copy (per the no-AI-text rule — Claude left `[PLACEHOLDER - …]` markers for every new string and they were filled in by hand, including "Back to my claim"); the architectural call that rejected Claude's first implementation for coupling the exercise's contents to the database structure, and the direction to use a serialized hash instead; the report of the highlighting bug with a specific production URL, plus the correct hypothesis that it involved sources used multiple times; and the choice of where the relocated button should go.

Claude's mistakes along the way are recorded candidly in the individual commit messages, and are worth skimming: two buggy diagnostic scripts (one of which briefly produced evidence *against* the approach that was ultimately correct), a crash on the first version of the range-wrapping code, a second bug caught by Claude's own new spec, and a regression test that initially passed against the old implementation for the wrong reason.

All three commits were made in a single session on 2026-08-05, spanning about two hours from first to last. That is fast for the amount of code here, which is a reason for reviewers to look closely rather than a sign of maturity.

This PR description was drafted using the `/prepare-pr` Claude Code skill, and — like the summary above — may contain errors.

## Screenshots

Captured on both branches with assets rebuilt on each side, so the "before" column is master's real behaviour.

**01 — a claim selected, in an article citing one source three times**

Before, the panel says the claim is *"Sea otters are a keystone species of the kelp forest ecosystem"* while the text actually highlighted is *"re hunted extensively fo…"* — a different sentence, and starting mid-word. After, the highlight matches the claim.

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-source-evaluation/screenshots/before/01_highlighted_claim_and_panel.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-source-evaluation/screenshots/after/01_highlighted_claim_and_panel.png) |

**02 — the taken claim**

The new source-evaluation step, and "Choose a different claim" moved up beside the heading.

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-source-evaluation/screenshots/before/02_taken_claim.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-source-evaluation/screenshots/after/02_taken_claim.png) |

**03 — the picker, after choosing to switch claims**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-source-evaluation/screenshots/before/03_picker_after_switching.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-source-evaluation/screenshots/after/03_picker_after_switching.png) |

## Open questions and concerns

**Deployment.** The migration drops six per-question columns in favour of a serialized `answers` hash. Existing responses are carried across (and back on rollback). The only responses in production so far are staff test submissions, but the copy-forward is there in case real student ones arrive before this deploys.

**Stale translations.** Step numbering is now composed in rather than written into the copy, so the English step names lost their "Step 3: " / "Step 4: " prefixes. That left the `nl` and `sk` translations carrying numbering of their own, which would have rendered as "Step 4: Stap 3: Zoek de bron", so those two strings were edited to drop it. Translatewiki will resync.

**Answer option values are identifiers.** They're stored in the hash, so rewording an option's label is free, but renaming a value after students have submitted leaves old answers keyed to the retired value. The summary falls back to displaying the raw value rather than hiding it, so nothing disappears, but old and new wouldn't aggregate. The scales are cheap to revise now, while the only responses are staff tests.

**Two pre-existing issues found but deliberately not fixed here:**

- A harvested sentence on *Toxic colonialism* is malformed — `'…"Waste colonialism." .'`, with a stray trailing space-period, apparently from diff-mode segmentation at harvest time — so it matches nothing in the full revision and is never highlighted. This was equally true before this PR.
- Pool claims outnumber selectable ones: 49 rows collapse to 28 distinct sentences on the article above, because `harvested_claims` keys by sentence and keeps the first. For a sentence carrying several citations, only one claim is ever offered. That looks intentional, but if each (sentence, source) pair should be its own verification task, that's a separate change.

**Also unchanged:** taking a different claim moves the single assignment while the earlier response stays with its own claim, so the instructor view lists that student as both answered and pending.

(PR description written by Claude Code.)
