### PR TITLE
Fix automatic backup when long updates running

### DIFF
--- a/app/models/system/backup.rb
+++ b/app/models/system/backup.rb
@@ -14,10 +14,10 @@
 #
 class Backup < ApplicationRecord
   IN_PROCESS = %w[waiting running].freeze
-  # A healthy backup run touches its row within minutes and waits at most 2 hours
-  # to start. Anything older is an orphaned row left behind by a crashed backup.sh
-  # (e.g., host restart), and must not indefinitely block CourseDataUpdateWorker via
-  # LogSidekiqStatus#pause_until_no_backup.
+  # A backup run waits at most 2 hours to start and then takes well under an hour.
+  # A row created longer ago than that is an orphan left behind by a crashed
+  # backup.sh (e.g., host restart), and must not indefinitely block
+  # CourseDataUpdateWorker via LogSidekiqStatus#pause_until_no_backup.
   FRESH_WINDOW = 5.hours
 
   def self.current_backup
@@ -25,7 +25,7 @@ class Backup < ApplicationRecord
     # than necessary since it doesn't detect the backup finished.
     ActiveRecord::Base.uncached do
       Backup.where(status: IN_PROCESS)
-            .where('updated_at >= ?', FRESH_WINDOW.ago)
+            .where('created_at >= ?', FRESH_WINDOW.ago)
             .order(id: :desc)
             .first
     end

--- a/app/models/system/backup.rb
+++ b/app/models/system/backup.rb
@@ -14,11 +14,11 @@
 #
 class Backup < ApplicationRecord
   IN_PROCESS = %w[waiting running].freeze
-  # A healthy backup run touches its row within minutes. Anything older is an
-  # orphaned row left behind by a crashed backup.sh (e.g., host restart), and
-  # must not indefinitely block CourseDataUpdateWorker via
+  # A healthy backup run touches its row within minutes and waits at most 2 hours
+  # to start. Anything older is an orphaned row left behind by a crashed backup.sh
+  # (e.g., host restart), and must not indefinitely block CourseDataUpdateWorker via
   # LogSidekiqStatus#pause_until_no_backup.
-  FRESH_WINDOW = 2.hours
+  FRESH_WINDOW = 5.hours
 
   def self.current_backup
     # Force uncaching because otherwise pause_until_no_backup may sleep more

--- a/config/backup/backup.sh
+++ b/config/backup/backup.sh
@@ -7,6 +7,11 @@ QUERY_ROUTE="ROUTE_TO_QUERIES"
 DASHBOARD_URL="URL_TO_DASHBOARD"
 JSON_ENDPOINT="$DASHBOARD_URL/system/can_start_backup.json"
 
+# Give up after MAX_WAIT_ATTEMPTS * WAIT_INTERVAL_IN_SECONDS (two hours) instead of
+# polling forever, so a course update that never goes to sleep can't hang the script.
+WAIT_INTERVAL_IN_SECONDS=300
+MAX_WAIT_ATTEMPTS=24
+
 log() {
   printf '%s : %s\n' "$(date '+%m%d%Y %T')" "$1" >> "$LOG_FILE"
 }
@@ -28,11 +33,19 @@ check_app_is_ready_for_backup() {
 }
 
 wait_until_ready_for_backup() {
+  local attempts=0
   local status=$(check_app_is_ready_for_backup)
 
   while [ $status != 200 ];
   do
-      sleep 300
+      if [ $attempts -ge $MAX_WAIT_ATTEMPTS ]; then
+        log "Waiting for more than two hours. Aborting"
+        mysql < "$QUERY_ROUTE/failed.sql" || true
+        exit 1
+      fi
+
+      attempts=$((attempts + 1))
+      sleep $WAIT_INTERVAL_IN_SECONDS
       status=$(check_app_is_ready_for_backup)
   done
 }

--- a/config/backup/backup.sh
+++ b/config/backup/backup.sh
@@ -7,10 +7,13 @@ QUERY_ROUTE="ROUTE_TO_QUERIES"
 DASHBOARD_URL="URL_TO_DASHBOARD"
 JSON_ENDPOINT="$DASHBOARD_URL/system/can_start_backup.json"
 
-# Give up after MAX_WAIT_ATTEMPTS * WAIT_INTERVAL_IN_SECONDS (two hours) instead of
-# polling forever, so a course update that never goes to sleep can't hang the script.
+# Give up once two hours have gone by, instead of polling forever, so a course update
+# that never goes to sleep can't hang the script. The settle sleep counts towards that
+# budget, so the script never spends more than MAX_WAIT_IN_SECONDS before the dump.
+MAX_WAIT_IN_SECONDS=7200
+SETTLE_SLEEP_IN_SECONDS=120
 WAIT_INTERVAL_IN_SECONDS=300
-MAX_WAIT_ATTEMPTS=24
+MAX_WAIT_ATTEMPTS=$(( (MAX_WAIT_IN_SECONDS - SETTLE_SLEEP_IN_SECONDS) / WAIT_INTERVAL_IN_SECONDS ))
 
 log() {
   printf '%s : %s\n' "$(date '+%m%d%Y %T')" "$1" >> "$LOG_FILE"
@@ -39,7 +42,7 @@ wait_until_ready_for_backup() {
   while [ $status != 200 ];
   do
       if [ $attempts -ge $MAX_WAIT_ATTEMPTS ]; then
-        log "Waiting for more than two hours. Aborting"
+        log "Waited two hours for the app to be ready. Aborting"
         mysql < "$QUERY_ROUTE/failed.sql" || true
         exit 1
       fi
@@ -93,8 +96,8 @@ fi
 # Create waiting backup record
 mysql < $QUERY_ROUTE/waiting.sql
 
-# Sleep two minutes to guarantee that all processes see the new data table record
-sleep 120
+# Sleep to guarantee that all processes see the new data table record
+sleep $SETTLE_SLEEP_IN_SECONDS
 
 wait_until_ready_for_backup
 

--- a/config/backup/failed.sql
+++ b/config/backup/failed.sql
@@ -2,4 +2,4 @@ USE dashboard;
 
 UPDATE backups
 SET status = 'failed', end = NOW()
-WHERE status = 'running';
+WHERE status IN ('waiting', 'running');

--- a/config/backup/waiting.sql
+++ b/config/backup/waiting.sql
@@ -1,5 +1,13 @@
 USE dashboard;
 
+-- Backups run weekly, so a waiting/running row older than 6 days is an orphan left
+-- behind by a backup.sh that died without cleaning up (OOM, host restart). Fail it
+-- first, otherwise it would keep the NOT EXISTS below from ever inserting a new row.
+UPDATE backups
+SET status = 'failed', end = NOW()
+WHERE status IN ('waiting', 'running')
+  AND created_at < NOW() - INTERVAL 6 DAY;
+
 INSERT INTO backups (scheduled_at, status, created_at, updated_at)
 SELECT NOW(), 'waiting', NOW(), NOW()
         WHERE NOT EXISTS (SELECT * FROM backups

--- a/server_config/SERVER_CONFIG.md
+++ b/server_config/SERVER_CONFIG.md
@@ -41,13 +41,20 @@ itself. The first task it performs is creating a new backup record with status
 set to *waiting*. This works as a way to let the backend app knowing that a
 backup is waiting to run.
 - From this point, all CourseDataUpdateWorker jobs that start the UpdateCourseStats
-in the background will be paused sleeping until the backup record leaves the *waiting*/*running*
-status. Already running CourseDataUpdateWorker jobs will continue until completion.
+in the background will be paused sleeping until: either 1) the backup record leaves the
+*waiting*/*running* status or 2) a maximum amount of time has passed since the current backup
+row was updated. This is to avoid an orphaned backup row caused by an expected error leaving
+the course update processes sleeping indefinitely. Already running CourseDataUpdateWorker
+jobs will continue until completion.
 - Some minutes later, the script running on the db server checks the `can_start_backup.json`
 endpoint to determine whether it's safe to start the backup. The criterion is that a backup
 can only run if all currently running CourseDataUpdateWorker jobs are in sleeping phase. If
 the response is 503 server unavailable, it waits for 2 minutes and retries until it receives
 a 200 OK response. Once it gets the 200 OK response, it sets the backup status to *running*.
+Note that, to avoid the backup process waiting indefinitely while a long course update is
+running (possibly for days), the backup process has a maximum number of retries to the
+`can_start_backup.json` endpoint. If it reaches that limit, it sets the backup status as *failed*
+and exits.
 - The backup script runs the backup itself.	
 - Once the backup finishes, the backup script updates the data table record status to *finished*.
 - CourseDataUpdateWorker jobs leaves the sleeping phase and woke up. The application returns

--- a/server_config/SERVER_CONFIG.md
+++ b/server_config/SERVER_CONFIG.md
@@ -43,13 +43,13 @@ backup is waiting to run.
 - From this point, all CourseDataUpdateWorker jobs that start the UpdateCourseStats
 in the background will be paused sleeping until: either 1) the backup record leaves the
 *waiting*/*running* status or 2) a maximum amount of time has passed since the current backup
-row was updated. This is to avoid an orphaned backup row caused by an expected error leaving
+row was created. This is to avoid an orphaned backup row caused by an unexpected error leaving
 the course update processes sleeping indefinitely. Already running CourseDataUpdateWorker
 jobs will continue until completion.
 - Some minutes later, the script running on the db server checks the `can_start_backup.json`
 endpoint to determine whether it's safe to start the backup. The criterion is that a backup
 can only run if all currently running CourseDataUpdateWorker jobs are in sleeping phase. If
-the response is 503 server unavailable, it waits for 2 minutes and retries until it receives
+the response is 503 server unavailable, it waits for 5 minutes and retries until it receives
 a 200 OK response. Once it gets the 200 OK response, it sets the backup status to *running*.
 Note that, to avoid the backup process waiting indefinitely while a long course update is
 running (possibly for days), the backup process has a maximum number of retries to the
@@ -75,5 +75,5 @@ To enable automatic backups, we did the following in peony db server and wiki ed
     ```
 3. Copy the script and queries to the server at ``/home/dbbackup/backup.sh``.
 4. Ensure *dbbackup* user is the owner of the script and it has execution permission.
-4. Update the script with the correct values for ``BACKUP_ROUTE``, ``QUERY_ROUTE`` and ``DASHBOARD_URL``. For the wiki-edu server the ``BACKUP_ROUTE`` is ``/home/dbbackup/dumps``. For peony server, it's ``/srv/dumps``. Note that the cinder volume is mounted on ``/srv``, so that's where we have free space.
-5. Add a cronjob to run the script weekly: run ``sudo crontab -u dbbackup -e`` and add ``0 20 * * SUN /home/dbbackup/backup.sh`` to the crontab.
+5. Update the script with the correct values for ``BACKUP_ROUTE``, ``QUERY_ROUTE`` and ``DASHBOARD_URL``. For the wiki-edu server the ``BACKUP_ROUTE`` is ``/home/dbbackup/dumps``. For peony server, it's ``/srv/dumps``. Note that the cinder volume is mounted on ``/srv``, so that's where we have free space.
+6. Add a cronjob to run the script weekly: run ``sudo crontab -u dbbackup -e`` and add ``0 20 * * SUN /home/dbbackup/backup.sh`` to the crontab.

--- a/spec/models/system/backup_spec.rb
+++ b/spec/models/system/backup_spec.rb
@@ -27,21 +27,23 @@ describe Backup do
       expect(described_class.current_backup).to eq(backup)
     end
 
-    it 'ignores a waiting backup older than FRESH_WINDOW' do
-      create(:backup, status: 'waiting',
-                      created_at: 6.hours.ago, updated_at: 6.hours.ago)
+    it 'ignores a waiting backup created longer ago than FRESH_WINDOW' do
+      create(:backup, status: 'waiting', created_at: 6.hours.ago)
       expect(described_class.current_backup).to be_nil
     end
 
-    it 'ignores a running backup older than FRESH_WINDOW' do
-      create(:backup, status: 'running',
-                      created_at: 6.hours.ago, updated_at: 6.hours.ago)
+    it 'ignores a running backup created longer ago than FRESH_WINDOW' do
+      create(:backup, status: 'running', created_at: 6.hours.ago)
+      expect(described_class.current_backup).to be_nil
+    end
+
+    it 'ignores a stale backup even if it was updated recently' do
+      create(:backup, status: 'running', created_at: 6.hours.ago, updated_at: 1.minute.ago)
       expect(described_class.current_backup).to be_nil
     end
 
     it 'returns the fresh backup when a stale one is also present' do
-      create(:backup, status: 'waiting',
-                      created_at: 6.hours.ago, updated_at: 6.hours.ago)
+      create(:backup, status: 'waiting', created_at: 6.hours.ago)
       fresh = create(:backup, status: 'waiting')
       expect(described_class.current_backup).to eq(fresh)
     end

--- a/spec/models/system/backup_spec.rb
+++ b/spec/models/system/backup_spec.rb
@@ -29,19 +29,19 @@ describe Backup do
 
     it 'ignores a waiting backup older than FRESH_WINDOW' do
       create(:backup, status: 'waiting',
-                      created_at: 3.hours.ago, updated_at: 3.hours.ago)
+                      created_at: 6.hours.ago, updated_at: 6.hours.ago)
       expect(described_class.current_backup).to be_nil
     end
 
     it 'ignores a running backup older than FRESH_WINDOW' do
       create(:backup, status: 'running',
-                      created_at: 3.hours.ago, updated_at: 3.hours.ago)
+                      created_at: 6.hours.ago, updated_at: 6.hours.ago)
       expect(described_class.current_backup).to be_nil
     end
 
     it 'returns the fresh backup when a stale one is also present' do
       create(:backup, status: 'waiting',
-                      created_at: 3.hours.ago, updated_at: 3.hours.ago)
+                      created_at: 6.hours.ago, updated_at: 6.hours.ago)
       fresh = create(:backup, status: 'waiting')
       expect(described_class.current_backup).to eq(fresh)
     end


### PR DESCRIPTION
## What this PR does
This PR changes the approach we use to prevent the backup system from waiting indefinitely for a huge course update to finish.

Note that, while a backup row exists in the `waiting` or `running` state, all course update processes go to sleep until the backup finishes. At the same time, however, the backup doesn't start until all current course updates are sleeping. This means that, if the backup script runs while there is a long course update, all other course updates will sleep until the huge one finishes. That's undesirable.

The previous approach was to update the `current_backup` definition to ignore rows that had been updated more than 2 hours ago. This meant that a course update would sleep for at most 2 hours and, after that, regardless of whether the backup had run, processing would return to normal. That strategy had two main problems:
**(1)** the backup process running on the database server never finished because it waited forever. In fact, there were 4 backup processes running in the db server (all waiting for `/system/can_start_backup.json` endpoint returning OK). All of them finished successfully when I manually ran the new backup after failing the last row because the  `/system/can_start_backup.json` endpoint  finally returned OK.
**(2)** a backup row remained in the `waiting` state indefinitely, meaning that the next week's backup wouldn't run either unless we manually updated the row.

The new approach lives in the backup script rather than on the Ruby side. It waits until the system is ready to start a backup for up to 2 hours (sleeping up to 24 times for 300 seconds each). If 2 hours pass without the system becoming ready, the script marks the row as `failed` and exits. Since there are no longer any backup rows in the `waiting` or `running` state, `current_backup` returns nothing and all course updates wake up.

Note that removing `FRESH_WINDOW` would have a disadvantage: if the script terminated unexpectedly, for example because of an OOM condition or because the database server was restarted midway through the backup, a backup row would remain in the `waiting` or `running` state and the course update processes would continue sleeping. Because of that, we decided to keep `FRESH_WINDOW` and extend it to 5 hours (2 hours of waiting plus 3 hours to ensure the backup has enough time to run). A backup row that has remained in the `waiting` or `running` state for more than 5 hours is considered orphaned and ignored by the ruby side.

We also updated the `config/backup/waiting.sql` query so that, before creating a new `waiting` row when the backup script runs, it marks any `waiting` or `running` rows older than 6 days as `failed`. These are orphaned rows left over from the previous week's backup that never ran. Since we don't want those orphaned rows to prevent a new backup from starting, we clean them up before creating the new `waiting` row.


## AI usage
I used Claude Code to discuss some minor things, but I did the PR and the description myself (ChatGPT corrected some grammar and verb tenses).

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
