### PR TITLE
Limit the claim-verification pool to a curated rollout list

### DIFF
--- a/app/services/relevant_claim_revisions_for_course.rb
+++ b/app/services/relevant_claim_revisions_for_course.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
+
 # Lists the (article, flagged-revision) groups a student can choose from for the
 # claim-verification exercise, drawn from the pre-harvested pool of claims added
 # in mainspace AiEditAlert revisions. Groups are prioritized to the student's
@@ -7,13 +9,22 @@
 # `topics-*` wizard tags), then those matching the course's free-text subject,
 # then the general pool — topped up in that order until the tile limit is met, so
 # the picker is never empty when the pool has any entries. Pure DB query.
+#
+# Every one of those scopes is first narrowed to the curated rollout list
+# (config/claim_verification_rollout.yml) when one is configured, so
+# prioritization only ever reorders approved revisions and can never reach past
+# them. That list is temporary; with it absent or empty this serves the whole
+# pool, which is the behavior to expect once the rollout gate comes off.
 class RelevantClaimRevisionsForCourse
   Tile = Struct.new(:article, :mw_rev_id, :claim_count, :mw_rev_timestamp,
                     keyword_init: true)
 
   attr_reader :tiles
 
-  DEFAULT_LIMIT = 12
+  # Sized to the curated rollout list so a student can reach all of it. Revisit
+  # alongside the rollout gate: against the full harvested pool this is a
+  # display cap, and 25 tiles is a lot to scroll.
+  DEFAULT_LIMIT = 25
 
   def initialize(course, limit: DEFAULT_LIMIT)
     @course = course
@@ -54,8 +65,10 @@ class RelevantClaimRevisionsForCourse
   end
 
   def base
-    VerificationClaim.where.not(alert_id: nil)
-                     .where.not(article_id: nil).where.not(mw_rev_id: nil)
+    ClaimVerification::RolloutList.filter(
+      VerificationClaim.where.not(alert_id: nil)
+                       .where.not(article_id: nil).where.not(mw_rev_id: nil)
+    )
   end
 
   def subject_tag_scope

--- a/config/claim_verification_rollout.yml
+++ b/config/claim_verification_rollout.yml
@@ -1,0 +1,169 @@
+# The articles students may pick from in the Fact Verification exercise.
+#
+# TEMPORARY. This is a hand-curated allow-list for the initial rollout, not
+# the intended long-term serving strategy. While it is present and non-empty,
+# RelevantClaimRevisionsForCourse serves only these revisions, to every course
+# — subject-tag and subject prioritization still order the tiles, but they
+# cannot reach outside this list. Emptying `revisions` or deleting this file
+# restores the full harvested pool, which is how you turn the gate off.
+#
+# Generated — do not hand-edit. Edit the verdicts in
+# docs/analytics_scripts/fact_verification_curation/fv_rollout_shortlist.csv
+# and re-run build_rollout_list.rb in that directory.
+#
+# Selection: the 468-article harvested pool was scored for source
+# accessibility and slop signals, the top 54 were reviewed by hand against
+# their diffs and fetched sources, and the 25 that came out `strong_candidate`
+# or `usable` are listed here, ranked. Four of them were flagged twice; only
+# the revision with more claims ships. See that directory's README.md.
+revisions:
+- article_id: 376975008
+  mw_rev_id: 1321874993
+  title: Surrogacy in India
+  tier: strong_candidate
+  topic_area: social sciences (law and public policy / reproductive health policy)
+  claim_count: 35
+- article_id: 50730658
+  mw_rev_id: 1341192982
+  title: Immunosenescence
+  tier: strong_candidate
+  topic_area: health
+  claim_count: 7
+- article_id: 985108653
+  mw_rev_id: 1325604815
+  title: Honolulu Courthouse riot
+  tier: strong_candidate
+  topic_area: humanities
+  claim_count: 39
+- article_id: 989847485
+  mw_rev_id: 1339774149
+  title: 2011 Italian census
+  tier: strong_candidate
+  topic_area: social sciences
+  claim_count: 17
+- article_id: 50900921
+  mw_rev_id: 1354407078
+  title: Community health centers in the United States
+  tier: strong_candidate
+  topic_area: health
+  claim_count: 15
+- article_id: 50891566
+  mw_rev_id: 1323409611
+  title: Diseases of poverty
+  tier: strong_candidate
+  topic_area: health
+  claim_count: 12
+- article_id: 701181941
+  mw_rev_id: 1328382686
+  title: Climate finance in the United States
+  tier: strong_candidate
+  topic_area: social sciences
+  claim_count: 40
+- article_id: 1001810019
+  mw_rev_id: 1347334965
+  title: CHRFAM7A
+  tier: strong_candidate
+  topic_area: sciences
+  claim_count: 95
+- article_id: 50875139
+  mw_rev_id: 1323139167
+  title: Dysthymia
+  tier: strong_candidate
+  topic_area: health
+  claim_count: 10
+- article_id: 990290807
+  mw_rev_id: 1351433962
+  title: Extensive farming
+  tier: strong_candidate
+  topic_area: sciences
+  claim_count: 71
+- article_id: 50912774
+  mw_rev_id: 1318272956
+  title: Psychology of art
+  tier: strong_candidate
+  topic_area: social sciences
+  claim_count: 18
+- article_id: 50922489
+  mw_rev_id: 1316526434
+  title: Solar desalination
+  tier: strong_candidate
+  topic_area: sciences
+  claim_count: 9
+- article_id: 1000416953
+  mw_rev_id: 1345648440
+  title: Climate of Armenia
+  tier: usable
+  topic_area: sciences
+  claim_count: 6
+- article_id: 1003575313
+  mw_rev_id: 1347254024
+  title: Hazardous energy
+  tier: usable
+  topic_area: health
+  claim_count: 7
+- article_id: 50916513
+  mw_rev_id: 1354912064
+  title: History of immigration and nationality law in the United States
+  tier: usable
+  topic_area: social sciences
+  claim_count: 14
+- article_id: 981009190
+  mw_rev_id: 1319336556
+  title: Helianthus californicus
+  tier: usable
+  topic_area: sciences
+  claim_count: 39
+- article_id: 964363372
+  mw_rev_id: 1307132068
+  title: Dynamical decoupling
+  tier: usable
+  topic_area: sciences (quantum information / condensed matter physics)
+  claim_count: 19
+- article_id: 50885417
+  mw_rev_id: 1344492040
+  title: Curly Girl Method
+  tier: usable
+  topic_area: social sciences
+  claim_count: 5
+- article_id: 981027757
+  mw_rev_id: 1319297342
+  title: American pika
+  tier: usable
+  topic_area: sciences (mammalogy / conservation ecology)
+  claim_count: 26
+- article_id: 1011275907
+  mw_rev_id: 1350942128
+  title: Graffiti in Los Angeles
+  tier: usable
+  topic_area: humanities
+  claim_count: 17
+- article_id: 982997186
+  mw_rev_id: 1324537581
+  title: Biodesign
+  tier: usable
+  topic_area: humanities
+  claim_count: 19
+- article_id: 275419178
+  mw_rev_id: 1354912472
+  title: Immigration policy of the United States
+  tier: usable
+  topic_area: social sciences
+  claim_count: 22
+- article_id: 51150531
+  mw_rev_id: 1351811708
+  title: Central Valley groundwater pollution
+  tier: usable
+  topic_area: health
+  claim_count: 16
+- article_id: 991544795
+  mw_rev_id: 1341761529
+  title: Bullerengue
+  tier: usable
+  topic_area: humanities
+  claim_count: 11
+- article_id: 995445466
+  mw_rev_id: 1351414249
+  title: Sharpfin houndshark
+  tier: usable
+  topic_area: sciences
+  claim_count: 11

--- a/lib/claim_verification/rollout_list.rb
+++ b/lib/claim_verification/rollout_list.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ClaimVerification
+  # The hand-curated set of flagged revisions students may pick from, as
+  # declared in config/claim_verification_rollout.yml.
+  #
+  # TEMPORARY. This is the initial rollout's allow-list, not the intended
+  # serving strategy. While the config names any revisions, the exercise offers
+  # only those, to every course; empty the list or delete the file and the full
+  # harvested pool comes back. Nothing else in the app knows the list exists —
+  # RelevantClaimRevisionsForCourse is the single point that consults it.
+  #
+  # The unit is the (article_id, mw_rev_id) pair rather than the revision id
+  # alone: revision ids are unique within a wiki but not across them, and the
+  # pool spans wikis.
+  class RolloutList
+    CONFIG_PATH = "#{Rails.root}/config/claim_verification_rollout.yml"
+
+    class << self
+      def active?
+        pairs.any?
+      end
+
+      # The given VerificationClaim scope, narrowed to the rollout revisions —
+      # or returned untouched when no list is configured.
+      def filter(scope)
+        approved = pairs
+        return scope if approved.empty?
+        scope.where(tuple_condition(approved))
+      end
+
+      # [[article_id, mw_rev_id], ...]
+      def pairs
+        # Reloaded every time outside production so curation changes land
+        # without a restart, matching ClaimVerification::ExerciseForm.
+        return load_pairs unless Rails.env.production?
+        @pairs ||= load_pairs
+      end
+
+      private
+
+      def load_pairs
+        return [] unless File.exist?(CONFIG_PATH)
+        revisions = YAML.load_file(CONFIG_PATH)['revisions'] || []
+        revisions.filter_map do |revision|
+          article_id = revision['article_id']
+          mw_rev_id = revision['mw_rev_id']
+          [article_id, mw_rev_id] if article_id.present? && mw_rev_id.present?
+        end
+      end
+
+      def tuple_condition(approved)
+        placeholders = Array.new(approved.length, '(?, ?)').join(', ')
+        VerificationClaim.sanitize_sql_array(
+          ['(verification_claims.article_id, verification_claims.mw_rev_id) ' \
+           "IN (#{placeholders})", *approved.flatten]
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/claim_verification/rollout_list_spec.rb
+++ b/spec/lib/claim_verification/rollout_list_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
+
+describe ClaimVerification::RolloutList do
+  let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+
+  def claim(article_id:, mw_rev_id:)
+    VerificationClaim.create!(wiki:, article_id:, mw_rev_id:, sentence: 'A fact.')
+  end
+
+  describe '.filter' do
+    it 'keeps only claims on a listed (article, revision) pair' do
+      listed = claim(article_id: 1, mw_rev_id: 100)
+      claim(article_id: 2, mw_rev_id: 200)
+      rollout_revisions([1, 100])
+      expect(described_class.filter(VerificationClaim.all)).to eq([listed])
+    end
+
+    it 'excludes a listed revision id under a different article' do
+      claim(article_id: 2, mw_rev_id: 100)
+      rollout_revisions([1, 100])
+      expect(described_class.filter(VerificationClaim.all)).to be_empty
+    end
+
+    it 'excludes a listed article at a different revision' do
+      claim(article_id: 1, mw_rev_id: 999)
+      rollout_revisions([1, 100])
+      expect(described_class.filter(VerificationClaim.all)).to be_empty
+    end
+
+    it 'hands back the scope untouched when no list is configured' do
+      kept = claim(article_id: 1, mw_rev_id: 100)
+      rollout_revisions
+      scope = VerificationClaim.all
+      expect(described_class.filter(scope).to_sql).to eq(scope.to_sql)
+      expect(described_class.filter(scope)).to include(kept)
+    end
+  end
+
+  describe '.active?' do
+    it 'is false with no list configured' do
+      rollout_revisions
+      expect(described_class).not_to be_active
+    end
+
+    it 'is true once the list names a revision' do
+      rollout_revisions([1, 100])
+      expect(described_class).to be_active
+    end
+  end
+
+  # Guards the shipped curation output: the file the app reads must parse and
+  # must agree with the list the curation scripts generated.
+  describe 'the configured list' do
+    before { real_rollout_list }
+
+    it 'parses to one (article, revision) pair per rollout article' do
+      expect(described_class.pairs.length).to eq(25)
+      expect(described_class.pairs).to all(match([be_a(Integer), be_a(Integer)]))
+    end
+
+    it 'names each article exactly once' do
+      article_ids = described_class.pairs.map(&:first)
+      expect(article_ids.uniq.length).to eq(article_ids.length)
+    end
+  end
+end

--- a/spec/services/relevant_claim_revisions_for_course_spec.rb
+++ b/spec/services/relevant_claim_revisions_for_course_spec.rb
@@ -62,4 +62,44 @@ describe RelevantClaimRevisionsForCourse do
                               sentence: 'Legacy.', alert: nil)
     expect(described_class.new(student_course).tiles).to be_empty
   end
+
+  # The temporary rollout gate: config/claim_verification_rollout.yml.
+  context 'when a rollout list is configured' do
+    it 'offers only listed revisions' do
+      approved = article('Otter')
+      pool_claim(article: approved, rev: 10, source_course: a_course)
+      pool_claim(article: article('Rock'), rev: 20, source_course: a_course)
+      rollout_revisions([approved.id, 10])
+      expect(described_class.new(student_course).tiles.map(&:article)).to eq([approved])
+    end
+
+    it 'keeps subject-tag priority within the listed revisions' do
+      tagged_source = a_course
+      create(:tag, course: tagged_source, tag: 'biology', key: 'topics-biology')
+      create(:tag, course: student_course, tag: 'biology', key: 'topics-biology')
+      related = article('Cell')
+      general = article('Quartz')
+      pool_claim(article: related, rev: 1, source_course: tagged_source)
+      pool_claim(article: general, rev: 2, source_course: a_course)
+      rollout_revisions([related.id, 1], [general.id, 2])
+      expect(described_class.new(student_course, limit: 1).tiles.map(&:article)).to eq([related])
+    end
+
+    # Prioritization orders the approved set; it can never reach past it.
+    it 'does not fall back to unlisted revisions when the listed set is thin' do
+      approved = article('Otter')
+      pool_claim(article: approved, rev: 10, source_course: a_course)
+      3.times do |i|
+        pool_claim(article: article("Other#{i}"), rev: 30 + i, source_course: a_course)
+      end
+      rollout_revisions([approved.id, 10])
+      expect(described_class.new(student_course).tiles.map(&:article)).to eq([approved])
+    end
+
+    it 'offers nothing when the pool and the list do not overlap' do
+      pool_claim(article: article('Otter'), rev: 10, source_course: a_course)
+      rollout_revisions([999_999, 10])
+      expect(described_class.new(student_course).tiles).to be_empty
+    end
+  end
 end

--- a/spec/support/claim_verification_rollout.rb
+++ b/spec/support/claim_verification_rollout.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
+
+# The curated rollout allow-list (config/claim_verification_rollout.yml) names
+# real article and revision ids from the production claim pool. Left switched
+# on, it would filter away every claim a spec builds for itself, so specs run
+# with the gate off and opt in with `rollout_revisions` when they mean to
+# exercise it.
+module ClaimVerificationRolloutHelper
+  # Restrict the exercise to the given [article_id, mw_rev_id] pairs.
+  def rollout_revisions(*pairs)
+    allow(ClaimVerification::RolloutList).to receive(:pairs).and_return(pairs)
+  end
+
+  # Read config/claim_verification_rollout.yml for real.
+  def real_rollout_list
+    allow(ClaimVerification::RolloutList).to receive(:pairs).and_call_original
+  end
+end
+
+RSpec.configure do |config|
+  config.include ClaimVerificationRolloutHelper
+  config.before { rollout_revisions }
+end


### PR DESCRIPTION
## What this PR does

Temporarily restricts the Fact Verification exercise (#6910) to a hand-curated
set of 25 articles, one flagged revision each, for every course. Until now
`RelevantClaimRevisionsForCourse` served the whole harvested claim pool — 468
articles of varying quality — and the initial rollout needs a set we've
actually looked at.

The approved `(article_id, mw_rev_id)` pairs live in
`config/claim_verification_rollout.yml`. `ClaimVerification::RolloutList` reads
that file and narrows the claim scope; `RelevantClaimRevisionsForCourse` runs
all three of its scopes (subject-tag, subject, general) through it, so
course-based prioritization still orders the tiles but can never reach past the
list. **Emptying `revisions:` or deleting the config restores the full pool** —
that's the off switch, and no code changes with it.

`DEFAULT_LIMIT` also goes from 12 to 25 so a student can reach the whole list
rather than the 12 largest articles.

### How the list was chosen

The 468-article pool was scored for source accessibility and slop signals; the
top 54 were reviewed by hand — every flagged diff read, all 451 distinct source
URLs actually fetched (DOIs resolved through
[Unpaywall](https://unpaywall.org/)) — and the 25 rated `strong_candidate` or
`usable` are what ships. The selection favors articles whose cited sources a
student can read without a library proxy, and whose AI-added text looks like
competent encyclopedia content rather than obvious junk, since the exercise is
about text that *appears* well-sourced but isn't supported by its citation.

Topic mix: 8 sciences, 7 social sciences, 6 health, 4 humanities. 580 claims
total. The curation scripts and worksheets that produced the config are not
committed here — they live outside the repo.

## AI usage

**Claude Code wrote effectively all of the code in this PR, and the curation
work behind the list.** Human direction was terse — about ten messages over one
evening, most a single sentence ("cut this stage short", "one revision each",
"increase the limit to 25"). The decisions were the human's; the code, the
specs, the config, and the analysis were Claude's.

What Claude Code did:

- Built the curation pipeline in earlier sessions (article scoring, the
  hand-review batches, source-accessibility verification), none of which is in
  this diff.
- Wrote `ClaimVerification::RolloutList`, the `RelevantClaimRevisionsForCourse`
  change, the config generator, and all the specs.
- Wrote the commit message. Its `## Process` section has more detail on how the
  list changed shape mid-session.

Worth flagging for reviewers: an earlier version of the list keyed on the
article alone, which silently dropped 85 claims from four articles that were
flagged twice. The generator's own consistency check caught it. That class of
error — plausible output that's quietly wrong — is the reason the generator
reports mismatches rather than absorbing them, and it's worth assuming other
instances of it survived review.

Scale of effort: one commit, one session, roughly two hours of wall-clock
including the salvage of a prior session that died mid-run. The 25-article list
represents considerably more machine time than that across earlier sessions.

The "What this PR does" summary above and the analysis in this description were
also drafted by Claude Code and may contain errors. This description was
prepared using the `/prepare-pr` Claude Code skill.

## Screenshots

No visual change — no view, JSX, or stylesheet files are touched. The article
picker renders exactly as before; only its contents are gated.

The user-visible difference is which articles appear in the picker, and that
can't be shown meaningfully from a test database: the config names real article
and revision ids from the production claim pool, so a screenshot spec would
have to fabricate matching fixture data and would prove nothing about the real
list. Against a local copy of the pool the picker serves 25 tiles / 580 claims,
with nothing outside the list.

The 25, ranked (tier, then share of claims with an immediately-readable
source):

| # | Article | Area | Claims |
|---|---|---|---|
| 1 | Surrogacy in India | social sciences | 35 |
| 2 | Immunosenescence | health | 7 |
| 3 | Honolulu Courthouse riot | humanities | 39 |
| 4 | 2011 Italian census | social sciences | 17 |
| 5 | Community health centers in the United States | health | 15 |
| 6 | Diseases of poverty | health | 12 |
| 7 | Climate finance in the United States | social sciences | 40 |
| 8 | CHRFAM7A | sciences | 95 |
| 9 | Dysthymia | health | 10 |
| 10 | Extensive farming | sciences | 71 |
| 11 | Psychology of art | social sciences | 18 |
| 12 | Solar desalination | sciences | 9 |
| 13 | Climate of Armenia | sciences | 6 |
| 14 | Hazardous energy | health | 7 |
| 15 | History of immigration and nationality law in the United States | social sciences | 14 |
| 16 | Helianthus californicus | sciences | 39 |
| 17 | Dynamical decoupling | sciences | 19 |
| 18 | Curly Girl Method | social sciences | 5 |
| 19 | American pika | sciences | 26 |
| 20 | Graffiti in Los Angeles | humanities | 17 |
| 21 | Biodesign | humanities | 19 |
| 22 | Immigration policy of the United States | social sciences | 22 |
| 23 | Central Valley groundwater pollution | health | 16 |
| 24 | Bullerengue | humanities | 11 |
| 25 | Sharpfin houndshark | sciences | 11 |

## Open questions and concerns

**The gate covers what's offered, not what's taken.** `take` doesn't re-check
eligibility, and an existing `VerificationClaimAssignment` on a now-excluded
claim still resolves. That's deliberate — students mid-exercise keep their
claim — but it does mean a crafted request can still take an unlisted claim.

**85 claims are left out by the one-revision-per-article rule.** Four articles
were flagged twice and both diffs were reviewed, so both revisions are
eligible; only the one with more claims ships. 70 of those 85 are Extensive
farming's near-identical second edit. Shipping both is a one-line change in the
generator if we want the extra volume.

**`DEFAULT_LIMIT` is now coupled to the list size.** 25 tiles is a lot to
scroll, and the number is only right while the gate is on. It needs revisiting
in the same breath as removing the gate.

**The config points at scripts that aren't in the repo.** Its header says
"re-run `build_rollout_list.rb`", which lives in an uncommitted analysis
directory. Happy to commit the generator and its input CSV (~120 KB) if
reviewers would rather the config be reproducible from the repo alone.

**Only 2 of the 25 articles have been checked at the claim level.** Article
selection judged surface quality — does the text look like decent, plausibly
sourced encyclopedia content — not whether each claim is actually supported.
Two articles were then checked claim by claim, and of 16 claims settled, only 2
were fully supported. That's the exercise working as designed, but it means the
other 23 articles are unverified at that level, and a blank spot-check column
means unchecked, not clean.

One case from that check is worth designing the rubric around: a claim that is
*factually true* but cited to a source that doesn't contain it. A
supported/not-supported choice can't express that.

**The pool this was curated from is a local rebuild**, harvested from
production `AiEditAlert` rows in a 2026-06-21 dump, not a copy of production's
`verification_claims`. The article and revision ids are real, so the config is
valid against production, but whether production's pool contains all 25 of
these revisions hasn't been checked from here.

(PR description written by Claude Code.)
