### PR TITLE
Keep Resources tab available when the Timeline is disabled

### DIFF
--- a/app/assets/javascripts/components/common/course_navbar.jsx
+++ b/app/assets/javascripts/components/common/course_navbar.jsx
@@ -3,9 +3,15 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import GetHelpButton from './get_help_button.jsx';
 import CourseUtils from '../../utils/course_utils.js';
+import { BLOCK_KIND_RESOURCES } from '../../constants/timeline';
 
+// Resources blocks live in the timeline but render on the Resources tab. When the
+// timeline is disabled, those blocks are the only reason to keep the tab around.
+const hasResourcesBlock = weeks => weeks.some(
+  week => (week.blocks || []).some(block => block.kind === BLOCK_KIND_RESOURCES)
+);
 
-const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
+const CourseNavbar = ({ course, location, currentUser, courseLink, weeks = [] }) => {
   // ///////////////
   // Course title //
   // ///////////////
@@ -46,7 +52,7 @@ const CourseNavbar = ({ course, location, currentUser, courseLink }) => {
   }
 
   let resources;
-  if (course.timeline_enabled) {
+  if (course.timeline_enabled || hasResourcesBlock(weeks)) {
     const resourcesLink = `${courseLink}/resources`;
     resources = (
       <div className="nav__item" id="resources-link">
@@ -113,7 +119,8 @@ CourseNavbar.propTypes = {
   course: PropTypes.object,
   location: PropTypes.object,
   currentUser: PropTypes.object,
-  courseLink: PropTypes.string
+  courseLink: PropTypes.string,
+  weeks: PropTypes.array
 };
 
 export default CourseNavbar;

--- a/app/assets/javascripts/components/course/course.jsx
+++ b/app/assets/javascripts/components/course/course.jsx
@@ -116,6 +116,7 @@ const Course = withRouter((props) => {
             location={props.router.location}
             currentUser={props.currentUser}
             courseLink={_courseLinkParams()}
+            weeks={props.weeks}
           />
           <Notifications />
         </Affix>

--- a/spec/features/resources_tab_spec.rb
+++ b/spec/features/resources_tab_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Resources tab', type: :feature, js: true do
+  let(:admin) { create(:admin) }
+  let(:course) { create(:basic_course, flags: { timeline_enabled: }) }
+  let(:week) { create(:week, course:) }
+
+  before do
+    login_as(admin)
+    stub_oauth_edit
+  end
+
+  after { logout }
+
+  context 'when the timeline is disabled and there are no resources blocks' do
+    let(:timeline_enabled) { false }
+
+    it 'shows neither the Timeline nor the Resources tab' do
+      create(:block, week:, kind: Block::KINDS['in_class'], title: 'In class activity')
+      visit "/courses/#{course.slug}/home"
+      expect(page).to have_css('#overview-link')
+      expect(page).to have_no_css('#timeline-link')
+      expect(page).to have_no_css('#resources-link')
+    end
+  end
+
+  context 'when the timeline is disabled but has a resources block' do
+    let(:timeline_enabled) { false }
+
+    it 'shows the Resources tab without the Timeline tab' do
+      create(:block, week:, kind: Block::KINDS['resources'], title: 'Extra reading')
+      visit "/courses/#{course.slug}/home"
+      expect(page).to have_css('#resources-link')
+      expect(page).to have_no_css('#timeline-link')
+    end
+
+    it 'renders the resources block on the Resources tab' do
+      create(:block, week:, kind: Block::KINDS['resources'], title: 'Extra reading')
+      visit "/courses/#{course.slug}/home"
+      find('#resources-link a').click
+      expect(page).to have_content 'Extra reading'
+    end
+  end
+
+  context 'when the timeline is enabled' do
+    let(:timeline_enabled) { true }
+
+    it 'shows the Resources tab even without any resources blocks' do
+      create(:block, week:, kind: Block::KINDS['in_class'], title: 'In class activity')
+      visit "/courses/#{course.slug}/home"
+      expect(page).to have_css('#timeline-link')
+      expect(page).to have_css('#resources-link')
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does

On Programs & Events Dashboard, the Resources tab is the only place a resources
block renders — but the tab link was gated solely on `course.timeline_enabled`.
So an organizer who enabled the Timeline, added a resources block, and then
disabled the Timeline lost the Resources tab entirely, even though the block
still existed and `/courses/.../resources` still rendered it. This PR is a
workaround that lets those users configure the Resources tab without leaving the
Timeline enabled: the Resources link now also appears when the (hidden) timeline
contains at least one resources block.

- `components/common/course_navbar.jsx` — the Resources link condition becomes
  `course.timeline_enabled || hasResourcesBlock(weeks)`. The new helper looks for
  any block with `kind === BLOCK_KIND_RESOURCES` (5). `weeks` defaults to `[]` so
  it is safe before the timeline fetch resolves. The Timeline link is untouched.
- `components/course/course.jsx` — passes `weeks={props.weeks}` to `CourseNavbar`.

No new server data was needed. `Course` already calls `fetchTimeline`
unconditionally, and already had the assembled weeks from the `getWeeksArray`
selector (it was passing them to `CourseAlerts`). The `/courses/.../resources`
route was already unconditional too, so only the nav link needed to change —
the destination page itself is unmodified by this PR.

`spec/features/resources_tab_spec.rb` is new: four examples covering the tab
appearing with a resources block, staying hidden without one, and still
appearing whenever the Timeline is enabled. It uses the `basic_course` factory
because `BasicCourse#timeline_enabled?` reads the flag, whereas
`ClassroomProgramCourse` hardcodes it to `true`.

## AI usage

Claude Code (Opus 5) wrote all of the code, the spec, and the commit message in
this PR, working from a paragraph-length problem statement from me that described
both the current broken behavior and the behavior I wanted. I did not write or
edit any of the diff by hand. My contribution was the problem definition, the
decision to treat this as a workaround rather than a redesign of how the Resources
tab relates to the Timeline, and review of the result.

Claude Code investigated first — reading the navbar, the course route table,
`resources.jsx`, `block.jsx`, the timeline controller, and the jbuilder views —
and established two things that kept the change small: disabling the Timeline
only flips a flag (blocks persist, and `courses#timeline` is not gated), and the
resources route was already unconditional. It also flagged two limitations of the
client-side approach rather than papering over them; both are recorded under Open
questions below.

One correction worth reporting, since it speaks to how much the verification can
be trusted: Claude Code's first attempt at a "before" baseline was invalid. It
reverted the condition but left the now-unused helper in place, which failed
webpack's eslint step and broke the whole JS bundle, so all four examples failed
— including the two that should have passed. It noticed the discrepancy in the
build output instead of reading the all-red result as confirmation, then redid the
baseline by checking out the original navbar from master. That run failed exactly
the two new-behavior examples and passed the two controls, which is what confirms
the spec tests the change rather than passing incidentally.

Scale of effort: one commit, written in a single focused session of well under an
hour, from two messages from me (a paragraph, then the word "commit"). This was
not a case of sustained iteration across days — the fix was small and landed on
the first design tried. Reviewers should calibrate accordingly: the code is
lightly human-reviewed, and the test evidence is the stronger signal here.

The "What this PR does" summary and the rest of the analysis in this description
were also drafted by Claude Code and may contain errors. This PR description was
drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

Captured on a `BasicCourse` with the Timeline disabled, viewed as an admin. Both
passes were run by hand rather than through `bin/pr-screenshots`, because the
change compiles into the JS bundle and that script does not rebuild webpack when
it checks out master — so its "before" pass would have silently used the new
bundle and produced two identical images.

**Nav, timeline disabled, with a resources block**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/TimelineResourcesWorkaround/screenshots/before/01_nav_timeline_disabled_with_a_resources_block.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/TimelineResourcesWorkaround/screenshots/after/01_nav_timeline_disabled_with_a_resources_block.png) |

**Nav, timeline disabled, with no resources blocks** (control — unchanged)

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/TimelineResourcesWorkaround/screenshots/before/02_nav_timeline_disabled_with_no_resources_blocks.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/TimelineResourcesWorkaround/screenshots/after/02_nav_timeline_disabled_with_no_resources_blocks.png) |

## Open questions and concerns

- **Brief pop-in on page load.** The tab appears only once the timeline JSON
  fetch resolves, so there is a short delay before it shows up. Eliminating that
  would mean exposing a server-side flag on the course JSON instead. The
  client-side check was chosen because the data is already fetched and it keeps
  the logic to two lines; happy to switch approaches if the flicker is judged
  unacceptable.
- **Blocks are still read-only on the Resources tab.** `resources.jsx` does not
  pass `editPermissions` to `Block`, so *editing* a resources block still
  requires re-enabling the Timeline. This PR only covers the "set it up once,
  then hide the Timeline" flow. Making resources blocks editable in place would
  be a reasonable follow-up and would remove the need for this workaround to be
  a workaround.
- **This is a workaround, not a fix for the underlying coupling.** Resources
  blocks living inside the timeline is the actual awkwardness; this just stops
  that coupling from hiding the tab. Worth revisiting if resources blocks ever
  get their own storage.
- The change applies to Wiki Ed as well as P&E. In practice
  `ClassroomProgramCourse` always has the Timeline enabled, so the only Wiki Ed
  courses affected are non-classroom types that have a resources block and a
  disabled Timeline — which seems like desirable behavior there too, but I have
  not checked whether any such courses exist.

(PR description written by Claude Code.)
