### PR TITLE
Refine the fact-verification exercise UI: step labels and comment gating

### DIFF
--- a/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ClaimVerificationViewer from '@components/common/ArticleViewer/containers/ClaimVerificationViewer.jsx';
 import { toWikiDomain } from '../../utils/wiki_utils';
 import formatRevisionDate from '../../utils/format_revision_date';
+import { stepHeading } from './steps';
 
 // The article picker: each candidate is an (article, flagged-revision) tile from
 // the pre-harvested claim pool, and is its own ArticleViewer laid out in a compact
@@ -41,7 +42,7 @@ export const ArticlePicker = ({ articles, course, onTaken, showArticleId, onRetu
         <p>{I18n.t('claim_verification.intro_p1')}</p>
         <p>{I18n.t('claim_verification.intro_p2')}</p>
         <p>{I18n.t('claim_verification.intro_p3')}</p>
-        <h1>{I18n.t('claim_verification.step_select_article')}</h1>
+        <h1>{stepHeading('select_article')}</h1>
       </div>
       {articles.length ? (
         <ul className="claim-verification-exercise__article-grid">

--- a/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/ArticlePicker.jsx
@@ -39,10 +39,17 @@ export const ArticlePicker = ({ articles, course, onTaken, showArticleId, onRetu
         </div>
       )}
       <div className="claim-verification-exercise__intro">
+        {/*
+          The exercise's own title, so the page says what it is before it says
+          what to do. That makes it the page's h1, which demotes the step heading
+          below to an h2 — the level every other step of the exercise uses.
+        */}
+        <h1>{I18n.t('claim_verification.exercise_heading')}</h1>
         <p>{I18n.t('claim_verification.intro_p1')}</p>
         <p>{I18n.t('claim_verification.intro_p2')}</p>
         <p>{I18n.t('claim_verification.intro_p3')}</p>
-        <h1>{stepHeading('select_article')}</h1>
+        <h2>{stepHeading('select_article')}</h2>
+        <p>{I18n.t('claim_verification.select_article_instructions')}</p>
       </div>
       {articles.length ? (
         <ul className="claim-verification-exercise__article-grid">

--- a/app/assets/javascripts/components/claim_verification_exercise/formDefinition.js
+++ b/app/assets/javascripts/components/claim_verification_exercise/formDefinition.js
@@ -10,10 +10,14 @@ import PropTypes from 'prop-types';
 */
 
 // A step or question may be gated on earlier answers (`visible_when`: question
-// id → the answers that open it). Ungated ones are always asked.
+// id → what opens it — the answers that do, or `true` for any answer at all).
+// Ungated ones are always asked. Mirrors ClaimVerification::AnswerGate, which
+// applies the same rules again on submission.
 const gateOpen = (visibleWhen, answers) => (
   Object.entries(visibleWhen || {}).every(
-    ([questionId, values]) => values.includes(answers[questionId])
+    ([questionId, opensOn]) => (
+      opensOn === true ? Boolean(answers[questionId]) : opensOn.includes(answers[questionId])
+    )
   )
 );
 

--- a/app/assets/javascripts/components/claim_verification_exercise/steps.js
+++ b/app/assets/javascripts/components/claim_verification_exercise/steps.js
@@ -1,0 +1,20 @@
+/*
+  The steps of the fact-verification exercise that happen before the verification
+  form: picking an article, then picking a claim within the article viewer. The
+  form's own steps are declared server-side in
+  config/claim_verification_exercise.yml and arrive with their headings already
+  composed, so these two are the only ones the client numbers itself.
+
+  Numbering works the same way on both sides — derived from position, not written
+  into the copy — and continues across the boundary: the config's
+  `first_step_number` must be the next number after the steps listed here.
+*/
+
+const PRE_FORM_STEPS = ['select_article', 'select_claim'];
+
+// "Step 2: Choose claim to verify", using the same format string the form's
+// steps compose (see ClaimVerification::FormStep#heading).
+export const stepHeading = id => I18n.t('claim_verification.step_heading', {
+  number: PRE_FORM_STEPS.indexOf(id) + 1,
+  name: I18n.t(`claim_verification.step_${id}`),
+});

--- a/app/assets/javascripts/components/common/ArticleViewer/hooks/useClaimHighlighting.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/hooks/useClaimHighlighting.js
@@ -7,6 +7,7 @@ import ClaimLegend from '@components/common/ArticleViewer/claim_verification/Cla
 // Helpers
 import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
 import formatRevisionDate from '~/app/assets/javascripts/utils/format_revision_date';
+import { stepHeading } from '@components/claim_verification_exercise/steps';
 
 /*
   Claim-verification highlighting feature for the ArticleViewer shell.
@@ -182,13 +183,16 @@ const useClaimHighlighting = ({ article, course, revisionId, isOpen, onTaken }) 
       });
   };
 
-  // Pinned to the top of the article (the shell's `banner` slot): a notice that
-  // this is the article at the flagged revision (a point in time, not the
-  // current version), plus the claim-picking instructions. Shown only while the
-  // annotated flagged revision is in view.
+  // Pinned to the top of the article (the shell's `banner` slot): the step
+  // heading — this is a numbered step of the exercise like any other, and
+  // without it the viewer was the one stop that didn't say where the student
+  // was — then a notice that this is the article at the flagged revision (a
+  // point in time, not the current version), plus the claim-picking
+  // instructions. Shown only while the annotated flagged revision is in view.
   const banner = annotatedHtml
     ? (
       <div className="cv-pick-banner">
+        <h2 className="cv-pick-banner__heading">{stepHeading('select_claim')}</h2>
         {article.mw_rev_timestamp && (
           <p className="cv-revision-notice">
             {I18n.t('claim_verification.revision_notice', {

--- a/app/assets/stylesheets/modules/claim_verification.styl
+++ b/app/assets/stylesheets/modules/claim_verification.styl
@@ -10,9 +10,18 @@
 
   &__intro
     margin-bottom 28px
+    // The exercise's title. Bigger than the step heading below it but well short
+    // of the global h1 scale, which would shout over the intro it introduces.
     h1
+      font-size 2em
+      margin-bottom 14px
+    // The step heading. Keeps the size it had while it was this block's h1 — the
+    // title above has taken that level, not its prominence in the layout. Sits
+    // clear of the intro copy above and close to its own instruction line below.
+    h2
       font-size 1.6em
-      margin-bottom 8px
+      margin-top 26px
+      margin-bottom 6px
     p
       color $text_med
       max-width 40em

--- a/app/assets/stylesheets/modules/claim_verification.styl
+++ b/app/assets/stylesheets/modules/claim_verification.styl
@@ -461,6 +461,17 @@
   line-height 1.4
   p
     margin 0
+
+  // "Step 2: …" — the exercise's step label, matching the form's step headings
+  // in weight and hierarchy. Kept tight: the banner is sticky, so every pixel
+  // here is article text the student can't see. The heading default (bayoux) is
+  // too close to the band's own tint to read, so it takes the banner's dark text.
+  &__heading
+    margin 0 0 6px 0
+    font-size 1.1em
+    line-height 1.3
+    color $text_dk
+
   // The point-in-time notice: secondary to the instruction below it, but still
   // dark enough for AA contrast (was $text_med, which failed on the band).
   .cv-revision-notice

--- a/config/claim_verification_exercise.yml
+++ b/config/claim_verification_exercise.yml
@@ -18,7 +18,9 @@
 #
 # Step numbering is derived, not written into the copy, so reordering steps
 # renumbers them on its own. Steps 1 and 2 (select an article, select a claim)
-# happen before this form, hence first_step_number.
+# happen before this form and are numbered client-side the same way — see
+# app/assets/javascripts/components/claim_verification_exercise/steps.js — so
+# this must be the next number after the steps listed there.
 first_step_number: 3
 
 # `visible_when` gates a step or a question on an earlier answer: it is asked

--- a/config/claim_verification_exercise.yml
+++ b/config/claim_verification_exercise.yml
@@ -24,7 +24,8 @@
 first_step_number: 3
 
 # `visible_when` gates a step or a question on an earlier answer: it is asked
-# only when that answer is one of the listed values. Answers to questions that
+# only when that answer is one of the listed values, or — with `true` instead of
+# a list — once that question has any answer at all. Answers to questions that
 # end up hidden are dropped on submission rather than stored, so abandoning a
 # branch never leaves stale answers behind.
 #
@@ -84,9 +85,14 @@ steps:
         type: text
 
   # The catch-all comment field: asked on every path, and not a numbered step of
-  # the exercise, so it has no heading of its own.
+  # the exercise, so it has no heading of its own. It waits on the source-access
+  # answer all the same — either way it is answered, but not before — so that a
+  # student working down the form isn't invited to comment on an exercise they
+  # haven't done yet.
   - id: comments
     heading: false
+    visible_when:
+      source_access: true
     questions:
       - id: other_comments
         type: text

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1727,12 +1727,16 @@ en:
     intro_p1: "Every fact on Wikipedia should be backed up by a reliable source. When consulting Wikipedia for information, you shouldn’t have to take the author’s word for it; you can find the cited source and read that information for yourself. This is what’s known as verifiability, and it’s one of the most critical policies behind Wikipedia’s credibility."
     intro_p2: "As AI tools become more widely used, it's more important than ever to learn how to verify information. AI-generated content often mismatches facts and sources — which is one of the major reasons why you cannot use it to add content to Wikipedia."
     intro_p3: "In this exercise, you’ll see verifiability in action. You’ll practice how to verify claims by trying to find a specific fact in a cited source."
-    step_select_article: "Step 1: Select an article."
+    # Every step's heading, across the whole exercise: the numbers are composed in
+    # rather than written into the copy (see config/claim_verification_exercise.yml),
+    # so every `step_*` name — here and under `form` — is just the name.
+    step_heading: "Step %{number}: %{name}"
+    # The two steps before the form: the article picker, then choosing a claim
+    # inside the article viewer.
+    step_select_article: "Select an article"
+    step_select_claim: "Choose claim to verify"
     select_claim_instructions: "The following claims need to be checked against the cited sources, because they may be AI-generated. (Note: the article may have changed since these claims were added.)"
     form:
-      # Step numbering is composed in (see config/claim_verification_exercise.yml),
-      # so the `step_*` names below are just the names.
-      step_heading: "Step %{number}: %{name}"
       step_evaluate_source: Evaluate the source
       evaluate_source_instructions: "First, consider the source itself: whether it seems reliable, and whether it's a good fit for the topic. You may want to review Wikipedia's concept of 'Reliable sources': https://en.wikipedia.org/wiki/Wikipedia:Reliable_sources"
       source_appropriate_question: "Is this source appropriate for Wikipedia, for this particular article, and for the claim it supports?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1724,6 +1724,7 @@ en:
     course_picker_no_courses: No courses
     take_not_enrolled: You must be enrolled in the course to do that.
     # Exercise copy (operator-provided; see claim_verification_instructions.txt).
+    exercise_heading: "Fact Verification Exercise"
     intro_p1: "Every fact on Wikipedia should be backed up by a reliable source. When consulting Wikipedia for information, you shouldn’t have to take the author’s word for it; you can find the cited source and read that information for yourself. This is what’s known as verifiability, and it’s one of the most critical policies behind Wikipedia’s credibility."
     intro_p2: "As AI tools become more widely used, it's more important than ever to learn how to verify information. AI-generated content often mismatches facts and sources — which is one of the major reasons why you cannot use it to add content to Wikipedia."
     intro_p3: "In this exercise, you’ll see verifiability in action. You’ll practice how to verify claims by trying to find a specific fact in a cited source."
@@ -1735,6 +1736,8 @@ en:
     # inside the article viewer.
     step_select_article: "Select an article"
     step_select_claim: "Choose claim to verify"
+    # What each of those two steps asks the student to do.
+    select_article_instructions: "Choose from the list of articles below to begin this exercise."
     select_claim_instructions: "The following claims need to be checked against the cited sources, because they may be AI-generated. (Note: the article may have changed since these claims were added.)"
     form:
       step_evaluate_source: Evaluate the source

--- a/lib/claim_verification/answer_gate.rb
+++ b/lib/claim_verification/answer_gate.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ClaimVerification
+  # Whether a `visible_when` gate is open, given the answers so far. Steps and
+  # questions of the fact-verification exercise gate identically, so both ask
+  # here, and the client applies the same rules (see formDefinition.js).
+  #
+  # A gate maps another question's id to what opens it: a list of accepted
+  # answers, or `true` for any answer at all — which is how the closing comments
+  # step waits until the student has said whether they got the source without
+  # having to name every way they might have answered that. A gate with no
+  # entries is always open.
+  module AnswerGate
+    def self.open?(visible_when, answers)
+      visible_when.all? do |question_id, opens_on|
+        answer = answers[question_id]
+        opens_on == true ? answer.present? : opens_on.include?(answer)
+      end
+    end
+  end
+end

--- a/lib/claim_verification/form_question.rb
+++ b/lib/claim_verification/form_question.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/claim_verification/answer_gate"
+
 module ClaimVerification
   # One question of the fact-verification exercise form, as declared in
   # config/claim_verification_exercise.yml. Its copy is looked up from the
@@ -10,8 +12,8 @@ module ClaimVerification
   # - type: 'choice' (one of `options`) or 'text' (free response)
   # - options: the accepted answers, for a choice question
   # - required: submission is blocked until this is answered
-  # - visible_when: { other question id => [answers] }; asked only when that
-  #   earlier answer is one of those (see #applicable?)
+  # - visible_when: { other question id => [answers] | true }; asked only when
+  #   that earlier answer is one of those, or any answer at all (see AnswerGate)
   FormQuestion = Data.define(:id, :type, :options, :required, :visible_when) do
     def self.from_config(config)
       new(id: config.fetch('id'), type: config.fetch('type'),
@@ -26,7 +28,7 @@ module ClaimVerification
     # Whether this question is asked at all, given the answers so far. A
     # question with no `visible_when` is always asked.
     def applicable?(answers)
-      visible_when.all? { |question_id, values| values.include?(answers[question_id]) }
+      AnswerGate.open?(visible_when, answers)
     end
 
     def label

--- a/lib/claim_verification/form_step.rb
+++ b/lib/claim_verification/form_step.rb
@@ -26,9 +26,12 @@ module ClaimVerification
     end
 
     # "Step 4: Find the source" — the number is composed in, not part of the copy.
+    # The format string is shared with the two steps that come before the form
+    # (see app/assets/javascripts/components/claim_verification_exercise/steps.js),
+    # so every step of the exercise reads as one sequence.
     def heading
       return unless numbered?
-      I18n.t('claim_verification.form.step_heading',
+      I18n.t('claim_verification.step_heading',
              number:, name: I18n.t("claim_verification.form.step_#{id}"))
     end
 

--- a/lib/claim_verification/form_step.rb
+++ b/lib/claim_verification/form_step.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency "#{Rails.root}/lib/claim_verification/answer_gate"
+
 module ClaimVerification
   # One step of the fact-verification exercise form: a heading, optional
   # instructions, and the questions asked under it. Declared in
@@ -22,7 +24,7 @@ module ClaimVerification
 
     # Whether the step is shown at all, given the answers so far.
     def applicable?(answers)
-      visible_when.all? { |question_id, values| values.include?(answers[question_id]) }
+      AnswerGate.open?(visible_when, answers)
     end
 
     # "Step 4: Find the source" — the number is composed in, not part of the copy.

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -116,10 +116,14 @@ describe 'Claim verification exercise', type: :feature, js: true do
     choose I18n.t('claim_verification.form.source_appropriate_options.appropriate')
     choose I18n.t('claim_verification.form.meets_rs_policy_options.context_dependent')
 
-    # Then finding the source; saying they got it opens the verify-the-claim step.
+    # Then finding the source. The closing comments field has no business being
+    # asked before the student has said whether they even got the source, so it
+    # waits on that answer too — and then arrives whichever way they answered.
     expect(page).to have_content(I18n.t('claim_verification.form.step_find_source'))
+    expect(page).to have_no_field(I18n.t('claim_verification.form.other_comments_label'))
     choose I18n.t('claim_verification.form.source_access_options.accessed')
     expect(page).to have_content(I18n.t('claim_verification.form.step_verify'))
+    expect(page).to have_field(I18n.t('claim_verification.form.other_comments_label'))
     choose I18n.t('claim_verification.form.verdict_options.partial_support')
     fill_in I18n.t('claim_verification.form.claim_location_label'), with: 'p. 44'
     click_button I18n.t('claim_verification.form.submit')

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -25,6 +25,14 @@ describe 'Claim verification exercise', type: :feature, js: true do
   let(:flagged_rev) { 2_998_441 } # the first revision of en:Sea otter
   let(:sentence) { 'Sea otters use rocks as tools to break open shellfish.' }
 
+  # The exercise's step headings, composed the way the app composes them, so
+  # these pin the numbers rather than restating the copy. The two pre-form steps
+  # name their copy directly; the form's steps keep theirs under `form`.
+  def step_heading(number, name_key)
+    I18n.t('claim_verification.step_heading',
+           number:, name: I18n.t("claim_verification.#{name_key}"))
+  end
+
   let(:article_html) do
     <<~HTML
       <p>#{sentence}<sup class="reference"><a href="#cite_note-1">[1]</a></sup>
@@ -68,11 +76,16 @@ describe 'Claim verification exercise', type: :feature, js: true do
 
     # The article picker is the first sub-view (no claim taken yet). Mark the
     # window so we can prove the rest of the flow never triggers a reload.
-    expect(page).to have_content(I18n.t('claim_verification.step_select_article'), wait: 20)
+    expect(page).to have_content(step_heading(1, 'step_select_article'), wait: 20)
     page.execute_script('window.cvSameDocument = true;')
     # Each article tile is itself the opener for its in-place viewer (a button,
     # not a link).
     click_on 'Sea otter'
+
+    # Choosing a claim is step 2, and the viewer's banner says so: the numbering
+    # runs on from the picker into the server-numbered form steps below.
+    expect(page).to have_css('.cv-pick-banner__heading',
+                             text: step_heading(2, 'step_select_claim'), wait: 20)
 
     # The viewer renders the flagged revision annotated with its harvested claims;
     # clicking the highlighted claim sentence opens the in-viewer panel.
@@ -91,8 +104,10 @@ describe 'Claim verification exercise', type: :feature, js: true do
     assignment = VerificationClaimAssignment.find_by(user: student, course:)
     expect(assignment.verification_claim.sentence).to eq(sentence)
 
-    # The source-evaluation step comes first, judged from the citation alone.
-    expect(page).to have_content(I18n.t('claim_verification.form.step_evaluate_source'))
+    # The source-evaluation step comes first, judged from the citation alone. It
+    # is step 3: the form's numbering (config's `first_step_number`) picks up
+    # where the two pre-form steps left off.
+    expect(page).to have_content(step_heading(3, 'form.step_evaluate_source'))
     # Step instructions render as Markdown, so a URL in the operator copy is a
     # link out of the exercise rather than inert text.
     policy_link = find('.cv-form__step-instructions a', match: :first)

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -74,9 +74,13 @@ describe 'Claim verification exercise', type: :feature, js: true do
 
     visit "/courses/#{course.slug}/verify_claim"
 
-    # The article picker is the first sub-view (no claim taken yet). Mark the
-    # window so we can prove the rest of the flow never triggers a reload.
-    expect(page).to have_content(step_heading(1, 'step_select_article'), wait: 20)
+    # The article picker is the first sub-view (no claim taken yet). The exercise
+    # names itself before it says what to do, so the title is the page's h1 and
+    # step 1 an h2 — the level every other step of the exercise uses.
+    expect(page).to have_css('h2', text: step_heading(1, 'step_select_article'), wait: 20)
+    expect(page).to have_css('h1', text: I18n.t('claim_verification.exercise_heading'))
+    expect(page).to have_content(I18n.t('claim_verification.select_article_instructions'))
+    # Mark the window so we can prove the rest of the flow never triggers a reload.
     page.execute_script('window.cvSameDocument = true;')
     # Each article tile is itself the opener for its in-place viewer (a button,
     # not a link).

--- a/spec/lib/claim_verification/exercise_form_spec.rb
+++ b/spec/lib/claim_verification/exercise_form_spec.rb
@@ -67,6 +67,21 @@ describe ClaimVerification::ExerciseForm do
     it 'asks the ungated questions whatever the answers' do
       expect(form.applicable_questions({}).map(&:id)).to include('source_appropriate')
     end
+
+    it 'holds back the closing comments until the source-access answer is in' do
+      expect(form.applicable_questions({}).map(&:id)).not_to include('other_comments')
+    end
+
+    # Whichever way the student answers it — the point of gating on `true`
+    # rather than a list, so a new source_access option can't leave the comments
+    # behind. Derived from the declared options for the same reason.
+    it 'asks the closing comments on every source-access answer' do
+      source_access = form.questions.find { |question| question.id == 'source_access' }
+      asked = source_access.options.map do |option|
+        form.applicable_questions('source_access' => option).map(&:id)
+      end
+      expect(asked).to all(include('other_comments'))
+    end
   end
 
   describe '#applicable_answers' do
@@ -132,18 +147,20 @@ describe ClaimVerification::ExerciseForm do
             'questions' => [{ 'id' => 'colour', 'type' => 'choice', 'required' => true,
                               'options' => %w[red blue] }] },
           { 'id' => 'explain', 'visible_when' => { 'colour' => ['red'] },
-            'questions' => [{ 'id' => 'shade', 'type' => 'text' }] }
+            'questions' => [{ 'id' => 'shade', 'type' => 'text' }] },
+          { 'id' => 'note', 'visible_when' => { 'colour' => true },
+            'questions' => [{ 'id' => 'why', 'type' => 'text' }] }
         ] }
     end
 
     before { allow(described_class).to receive(:definition).and_return(declaration) }
 
     it 'asks whatever the declaration names' do
-      expect(form.answer_keys).to eq(%w[colour shade])
+      expect(form.answer_keys).to eq(%w[colour shade why])
     end
 
     it 'numbers from the declared first step number' do
-      expect(form.steps.map(&:number)).to eq([1, 2])
+      expect(form.steps.map(&:number)).to eq([1, 2, 3])
     end
 
     it 'validates a choice against the options the declaration gives it' do
@@ -152,11 +169,19 @@ describe ClaimVerification::ExerciseForm do
     end
 
     it 'gates a step on the answer the declaration names' do
-      expect(form.applicable_questions('colour' => 'blue').map(&:id)).to eq(['colour'])
+      expect(form.applicable_questions('colour' => 'blue').map(&:id)).not_to include('shade')
     end
 
     it 'opens the gated step on the answer that satisfies it' do
-      expect(form.applicable_questions('colour' => 'red').map(&:id)).to eq(%w[colour shade])
+      expect(form.applicable_questions('colour' => 'red').map(&:id)).to eq(%w[colour shade why])
+    end
+
+    it 'holds back a step gated on `true` while its question is unanswered' do
+      expect(form.applicable_questions({}).map(&:id)).to eq(['colour'])
+    end
+
+    it 'opens a step gated on `true` on any answer, not a named one' do
+      expect(form.applicable_questions('colour' => 'blue').map(&:id)).to eq(%w[colour why])
     end
   end
 end


### PR DESCRIPTION
## What this PR does

Three refinements to the in-dashboard fact-verification exercise (`/courses/:slug/verify_claim`), all of them about making the exercise legible to a student working through it:

1. **Claim selection is labelled as step 2.** The article viewer was the only stop in the exercise with no step heading, so a student who clicked into an article had nothing telling them where they were. It now carries one, and all five step numbers derive from a single sequence instead of being written into the copy — steps 1 and 2 numbered client-side, steps 3–5 server-side from `first_step_number` in `config/claim_verification_exercise.yml`, both composing the same `step_heading` format string.
2. **The closing comments question waits for the source-access answer.** "Any other comments about this exercise?" used to sit at the foot of the form from the moment it loaded, inviting a student to comment on an exercise they hadn't started. It now waits on the same answer the verify-the-claim step waits on, but opens whichever way that answer goes — a student who never got hold of the source has as much to report as one who did.
3. **The exercise has a title, and step 1 has an instruction line.** The landing view opened straight into three paragraphs about verifiability without ever naming itself.

Change 2 needed one new piece of vocabulary in the exercise config. `visible_when` previously matched a list of accepted answers; it now also accepts `true`, meaning "any answer at all". Listing the three `source_access` options instead would have worked today and silently hidden the comments step the day a fourth option was added. The predicate was duplicated between `FormStep#applicable?` and `FormQuestion#applicable?`, so it moved to a new `ClaimVerification::AnswerGate` and the client's `gateOpen` mirrors it.

No issue number is referenced by these commits. The exercise itself is still gated behind a feature setting (added in 8213d4ec7), so none of this is live for students yet.

Relevant background: [Wikipedia:Verifiability](https://en.wikipedia.org/wiki/Wikipedia:Verifiability), which is the policy the exercise teaches.

## AI usage

Claude Code (Opus 5) wrote essentially all of the code, tests, and commit messages in this PR, working from my direction turn by turn. Every commit carries a `Co-Authored-By: Claude` trailer and a `(Commit message written by Claude Code.)` marker, and each commit body has a `## Process` section describing how that specific change came about.

What I contributed: the problem statements (each change started as a one- or two-sentence description of what was wrong with the UI), **all of the user-facing copy** — "Fact Verification Exercise", "Choose claim to verify", and "Choose from the list of articles below to begin this exercise." are mine, not generated — and the decisions at the two points where Claude stopped to ask. Those were (a) whether to normalise the step numbering into one derived sequence or just hardcode a third "Step 2:" string, and (b) whether to add an "any answer" gate form or list the three source-access values. I picked the first option in both cases. I also reviewed the screenshots at each step.

One thing Claude got wrong and fixed on its own: the first version of the step-2 heading inherited the global heading colour (`bayoux`), which was too close to the banner's own purple tint to read. It caught this by looking at its own screenshot and set the colour explicitly. It also made one judgement call without asking — demoting the step-1 heading from `h1` to `h2` once the exercise title took that level — and flagged it rather than burying it.

Scale of effort: **3 commits within a single ~85-minute session** (08:28 to 09:54 on 6 Aug 2026), so this had one sitting's worth of human review, not days of iteration. Reviewers should calibrate accordingly: the diff is small (178 insertions across 12 files, over half of it tests and comments) and I read all of it, but it has not been lived with.

Verification was local and manual on top of the automated specs: 29 examples in `exercise_form_spec.rb`, 6 in `claim_verification_exercise_spec.rb`, and 126 across the claim-verification controller, lib, model and request specs, plus RuboCop and ESLint clean. The screenshots below were driven through the real UI in a browser.

This PR description was drafted using a Claude Code skill (`/prepare-pr`), and — like the summary and analysis above — may contain errors.

## Screenshots

A note on how these were produced, because it affects whether you can trust them: the compiled bundles under `public/assets` are gitignored, so the usual `bin/pr-screenshots` before-pass would have rendered master using *this branch's* JavaScript and CSS. Each pass below was run by hand with `yarn build` on the branch it belongs to, so the "before" column really is master.

**1 — Exercise landing view and step 1**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/before/01__exercise-landing-and-step-1.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/after/01__exercise-landing-and-step-1.png) |

The title and the instruction line are new. "Step 1: Select an article" also loses its trailing period, because the number is now composed in by a shared format string and none of the other step names carry terminal punctuation.

**2 — Claim selection in the article viewer**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/before/02__claim-selection-in-article-viewer.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/after/02__claim-selection-in-article-viewer.png) |

The heading is added to the top of the existing sticky banner. It's kept deliberately tight, since the banner is `position: sticky` and every pixel of it is article text the student can't see.

**3 — Foot of the form, source-access question still unanswered**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/before/03__form-foot-with-source-access-unanswered.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/after/03__form-foot-with-source-access-unanswered.png) |

This is the change in behaviour: before, the comments card sat there from page load; after, the form ends at step 4 and Submit.

**4 — Foot of the form on the "could not get access" path**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/before/04__form-foot-on-the-could-not-access-path.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/FactVerificationUI/screenshots/after/04__form-foot-on-the-could-not-access-path.png) |

This pair is intentionally near-identical, and that's the point — it's the check that the comments field still appears for a student who *couldn't* get the source, rather than being gated away with the verify-the-claim step. Note there is no step 5 on this path in either column; verifying a claim needs the source in hand.

## Open questions and concerns

- **Step 1's heading lost its trailing period** ("Step 1: Select an article" rather than "Step 1: Select an article."). This falls out of composing the number in via one shared format string, since the other step names have no terminal punctuation. Easy to put back on all of them if you'd rather.
- **`visible_when: true` is new vocabulary in `config/claim_verification_exercise.yml`.** It's documented in that file and in `AnswerGate`, and it exists in three places that must agree — `AnswerGate.open?`, the client's `gateOpen`, and the config's own docs. The alternative was listing the accepted values, which is less to learn but silently wrong the moment a `source_access` option is added.
- **Step numbering now spans a client/server boundary.** `first_step_number: 3` in the config has to stay one greater than the number of pre-form steps listed in `steps.js`. There's a comment at each end saying so, and a spec asserts the rendered sequence runs 1 → 3 across the seam, but it isn't enforced structurally.
- **The screenshot spec is deliberately not committed.** It needs to run against both master and this branch, so committing it here wouldn't help the before-pass anyway. If it'd be more useful checked in for future iterations on this UI, say so and I'll add it.
- **Heading levels changed** on the landing view (step 1 went from `h1` to `h2` so the new title could be the page's `h1`). Nothing shrank visually — the CSS carries the old size over — but it's a real change to the document outline, now consistent with steps 2–5, which were already `h2`.

(PR description written by Claude Code.)
