### PR TITLE
Enable SystemStatUpdateWorker for Wiki Ed dashboard in DailyUpdate

### DIFF
--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -38,7 +38,7 @@ class DailyUpdate
     generate_overdue_training_alerts if Features.wiki_ed?
     generate_mainspace_ai_followup_alerts if Features.wiki_ed?
     push_course_data_to_salesforce if Features.wiki_ed?
-    enqueue_system_stat_update unless Features.wiki_ed?
+    enqueue_system_stat_update
     log_end_of_update 'Daily update finished.'
   # rubocop:disable Lint/RescueException
   rescue Exception => e


### PR DESCRIPTION
## What this PR does
Removes the `unless Features.wiki_ed?` guard from `DailyUpdate#enqueue_system_stat_update` in `lib/data_cycle/daily_update.rb`.
Enables daily system statistics snapshot creation on Wiki Education Dashboard deployments (previously it only ran on P&E Dashboard).