### PR TITLE
Expand WikiWho authorship highlighting to all 70 supported languages

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/authorship/wikiwhoLanguages.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/authorship/wikiwhoLanguages.js
@@ -1,0 +1,34 @@
+/*
+  Wikipedia language editions covered by the WikiWho / WhoColor API at
+  https://wikiwho-api.wmcloud.org.
+
+  The service adds languages over time, so this list goes stale. To refresh it,
+  read the language codes out of the per-language endpoint URLs listed on the
+  service's index page:
+
+    curl -s https://wikiwho-api.wmcloud.org/ \
+      | grep -oE '/[a-z-]+/whocolor/v1\.0\.0-beta' \
+      | sed 's|/whocolor.*||; s|^/||' | sort -u
+
+  Codes not on the list return 404 from the WhoColor endpoint, which is why we
+  gate on it rather than letting every request through.
+
+  Last verified against the live service: 2026-08-07 (70 languages).
+*/
+export const WIKIWHO_LANGUAGES = [
+  'af', 'als', 'ar', 'az', 'be', 'bg', 'bn', 'bs', 'ce', 'cs',
+  'cy', 'da', 'de', 'dsb', 'el', 'en', 'eo', 'es', 'et', 'eu',
+  'fa', 'fi', 'fr', 'gl', 'he', 'hi', 'hr', 'hu', 'ia', 'id',
+  'it', 'ja', 'ka', 'kk', 'ko', 'ku', 'lt', 'lv', 'mk', 'ml',
+  'mr', 'ms', 'mt', 'ne', 'nl', 'no', 'pl', 'pt', 'ro', 'ru',
+  'sh', 'simple', 'sk', 'sl', 'sq', 'sr', 'sv', 'sw', 'ta', 'te',
+  'tg', 'th', 'tl', 'tr', 'uk', 'ur', 'uz', 'vec', 'vi', 'zh',
+];
+
+// WhoColor only covers Wikipedia. Other projects (Wiktionary, Wikisource, etc.)
+// have no authorship data even when their language code appears above.
+export const isWikiwhoSupported = article => (
+  article.project === 'wikipedia' && WIKIWHO_LANGUAGES.includes(article.language)
+);
+
+export default WIKIWHO_LANGUAGES;

--- a/app/assets/javascripts/components/common/ArticleViewer/authorship/wikiwhoLanguages.spec.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/authorship/wikiwhoLanguages.spec.js
@@ -1,0 +1,36 @@
+import { WIKIWHO_LANGUAGES, isWikiwhoSupported } from './wikiwhoLanguages';
+
+describe('WIKIWHO_LANGUAGES', () => {
+  it('contains no duplicate language codes', () => {
+    expect(new Set(WIKIWHO_LANGUAGES).size).toEqual(WIKIWHO_LANGUAGES.length);
+  });
+
+  it('includes the non-standard "simple" code used by Simple English Wikipedia', () => {
+    expect(WIKIWHO_LANGUAGES).toContain('simple');
+  });
+});
+
+describe('isWikiwhoSupported', () => {
+  it('is true for a supported language on Wikipedia', () => {
+    expect(isWikiwhoSupported({ language: 'en', project: 'wikipedia' })).toBe(true);
+  });
+
+  it('is true for languages the service added after the original list was written', () => {
+    ['ru', 'sv', 'uk', 'vec', 'zh'].forEach((language) => {
+      expect(isWikiwhoSupported({ language, project: 'wikipedia' })).toBe(true);
+    });
+  });
+
+  it('is false for a Wikipedia language the service does not cover', () => {
+    // Norwegian Nynorsk has a Wikipedia but no WikiWho endpoint.
+    expect(isWikiwhoSupported({ language: 'nn', project: 'wikipedia' })).toBe(false);
+  });
+
+  it('is false for non-Wikipedia projects even in a supported language', () => {
+    expect(isWikiwhoSupported({ language: 'en', project: 'wikisource' })).toBe(false);
+  });
+
+  it('is false when the article has no language', () => {
+    expect(isWikiwhoSupported({ language: null, project: 'wikipedia' })).toBe(false);
+  });
+});

--- a/app/assets/javascripts/components/common/ArticleViewer/hooks/useAuthorshipHighlighting.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/hooks/useAuthorshipHighlighting.js
@@ -10,6 +10,7 @@ import AuthorshipAPI from '@components/common/ArticleViewer/authorship/Authorshi
 
 // Constants
 import colors from '@components/common/ArticleViewer/authorship/colors';
+import { isWikiwhoSupported } from '@components/common/ArticleViewer/authorship/wikiwhoLanguages';
 
 /*
   WhoColor authorship-highlighting feature for the ArticleViewer shell.
@@ -41,12 +42,7 @@ const useAuthorshipHighlighting = ({
 
   const isFirstRevisionRender = useRef(true);
 
-  const isWhocolorLang = () => {
-    // Supported languages for https://wikiwho-api.wmcloud.org as of 2023-05-15
-    // See https://github.com/wikimedia/wikiwho_api/blob/main/wikiwho_api/settings_wmcloud.py#L21
-    const supported = ['ar', 'de', 'en', 'es', 'eu', 'fr', 'hu', 'id', 'it', 'ja', 'nl', 'pl', 'pt', 'tr'];
-    return supported.includes(article.language) && article.project === 'wikipedia';
-  };
+  const isWhocolorLang = () => isWikiwhoSupported(article);
 
   // This takes the extended_html from the whoColor API, and replaces the span
   // annotations with ones that are more convenient to style in React.


### PR DESCRIPTION
## What this PR does

The WhoColor authorship-highlighting feature gated itself on a hardcoded list of 14 language codes, commented as accurate "as of 2023-05-15." The [WikiWho service](https://wikiwho-api.wmcloud.org/) has added many language editions since then, so the Dashboard was silently withholding authorship highlighting on wikis it now covers — among them ru, sv, uk, zh, fa, he, ko, vi, cs, fi, da, no, ro, and simple.

This replaces that list with the current set of 70 supported languages, read off the running service rather than the upstream source file (the old comment's GitHub line-number anchor had drifted). The list and the Wikipedia-only condition move into a small `wikiwhoLanguages.js` module so they're greppable and unit-testable, and the module's header comment records the command that regenerates the list from the live service plus the date it was last verified.

The gate itself is kept rather than dropped. Unsupported language codes return 404 from the WhoColor endpoint, so letting every request through would surface the authorship button and a failing legend on the ~270 Wikipedias that have no authorship data.

Relevant documentation: [WikiWho / WhoColor API](https://wikiwho-api.wmcloud.org/gesis_home), [source](https://github.com/wikimedia/wikiwho_api).

## AI usage

Claude Code wrote all of the code, the tests, and the commit message in this PR, working from short human prompts. The human contribution was direction and one substantive correction: Claude's first move was to read the supported-language list out of the upstream `settings_wmcloud.py` on GitHub, and the human interrupted and redirected it to the actual production server at `wikiwho-api.wmcloud.org`. That correction mattered — it produced a list read from what is actually deployed rather than from source that may not match. Claude then verified the codes against the live WhoColor endpoints directly (ru, sv, simple, vec returned 200; nn and xx returned 404), which confirmed both that the list is accurate and that unsupported languages hard-fail, which is what justifies keeping the gate at all.

This PR description, including the "What this PR does" summary above, was also drafted by Claude Code and may contain errors.

Scale of effort: one commit, produced in a single focused session of roughly a dozen turns. The human sent three short messages totalling about two sentences of text. There were no false starts in the implementation itself; the only correction was the redirect described above. Tests were green on the first run.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No new UI. The change widens an existing gate, so the visible effect is that the "Current version with authorship highlighting" button and its contributor legend now appear on article viewers for 56 additional Wikipedia language editions instead of being hidden.

Before/after screenshots were not captured because reproducing the difference requires live WikiWho responses for a non-English wiki, which a local feature spec can't produce. To see it manually, open the article viewer for an article on any newly-covered wiki (for example a ru.wikipedia or sv.wikipedia article in a P&E Dashboard course) and check that the authorship-highlighting button is offered.

## Open questions and concerns

- The list is still a hardcoded snapshot and will go stale again as WikiWho adds languages. Fetching it from the service at runtime was considered and rejected as adding a network round-trip and a new failure mode to every article-viewer open. The refresh command in the module's header comment is the mitigation; a periodic check would be a reasonable follow-up if the drift proves annoying.
- `course_ores_plot.jsx` has a structurally similar `ORESSupportedWiki.languages` gate. That's the ORES/quality service with its own separate list, so it was deliberately left alone here — but it may be worth auditing for the same kind of staleness.
- `be-tarask` is intentionally absent: WikiWho covers `be` but not `be-tarask`, and they are separate wikis.

(PR description written by Claude Code.)
