### PR TITLE
Exclude long-term Wikipedians and split retention CSV by prior participation

### DIFF
--- a/lib/analytics/retention_participant_history.rb
+++ b/lib/analytics/retention_participant_history.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/wiki_api"
+
+# What a participant had already done before the course being reported on began:
+# how much they had edited, and whether they had already taken an earlier course.
+#
+# RetentionPredictorsCsvBuilder uses both to decide which participants belong in
+# which summary column. Long-term Wikipedians are listed in the report but left
+# out of every aggregate; returning participants are aggregated separately from
+# first-time ones, so a repeat participant's second-course numbers don't get read
+# as a first-course outcome.
+class RetentionParticipantHistory
+  # At or above this many edits before the course started, a participant is
+  # treated as an established Wikipedian rather than a retention subject.
+  LONG_TERM_EDIT_THRESHOLD = 1000
+
+  attr_reader :prior_edit_count, :prior_courses
+
+  def initialize(course, user, wikis)
+    @course = course
+    @user = user
+    @wikis = wikis
+    @prior_courses = find_prior_courses
+    @prior_edit_count = count_prior_edits
+  end
+
+  def long_term_wikipedian?
+    @prior_edit_count >= LONG_TERM_EDIT_THRESHOLD
+  end
+
+  def returning?
+    @prior_courses.any?
+  end
+
+  # Exact below the threshold; "1000+" once counting stopped at it.
+  def prior_edit_count_label
+    long_term_wikipedian? ? "#{LONG_TERM_EDIT_THRESHOLD}+" : @prior_edit_count.to_s
+  end
+
+  # Blank rather than an empty string, so a first-course participant's cell is
+  # genuinely empty in the CSV.
+  def prior_course_slugs
+    @prior_courses.map(&:slug).join('; ').presence
+  end
+
+  private
+
+  # Courses this user took as a student that started before this one did.
+  # Courses that merely overlap this one do not count as prior.
+  def find_prior_courses
+    Course.joins(:courses_users)
+          .where(courses_users: { user_id: @user.id,
+                                  role: CoursesUsers::Roles::STUDENT_ROLE })
+          .where('courses.start < ?', @course.start)
+          .order(:start)
+          .to_a
+  end
+
+  # Edits before the course start across every tracked wiki, summed. Counting
+  # stops at the threshold: an editor with 50,000 prior edits costs no more API
+  # calls than one with exactly 1,000.
+  def count_prior_edits
+    count = 0
+    @wikis.each do |wiki|
+      count += prior_edits_on(wiki, LONG_TERM_EDIT_THRESHOLD - count)
+      break if count >= LONG_TERM_EDIT_THRESHOLD
+    end
+    count
+  end
+
+  # Edits on one wiki before the course start, paginated until `limit` of them
+  # have been counted (or the user's contributions run out).
+  def prior_edits_on(wiki, limit)
+    api = WikiApi.new(wiki)
+    count = 0
+    continue = {}
+    loop do
+      response = api.query(prior_contribs_query.merge(continue))
+      break unless response
+      count += (response.data['usercontribs'] || []).count
+      break if count >= limit
+      continue = response['continue']
+      break unless continue
+    end
+    [count, limit].min
+  end
+
+  # usercontribs defaults to listing backwards from ucstart, so this walks from
+  # the moment before the course began into the past. The one-second offset keeps
+  # an edit made exactly at the course start out of the "before" count, since the
+  # report's during-course window already includes it.
+  def prior_contribs_query
+    {
+      list: 'usercontribs',
+      ucuser: @user.username,
+      ucstart: (@course.start - 1.second).strftime('%Y%m%d%H%M%S'),
+      ucprop: 'timestamp',
+      uclimit: 'max'
+    }
+  end
+end

--- a/lib/analytics/retention_predictors_csv_builder.rb
+++ b/lib/analytics/retention_predictors_csv_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/wiki_api"
+require_dependency "#{Rails.root}/lib/analytics/retention_participant_history"
+require_dependency "#{Rails.root}/lib/analytics/retention_summary_block"
 require 'csv'
 
 # Builds the "Retention predictors" CSV report for a course (currently the
@@ -23,6 +25,13 @@ require 'csv'
 # during the course, and the count of participants who edited in the 30 days
 # after it ended.
 #
+# Every participant is additionally classified by RetentionParticipantHistory as
+# a long-term Wikipedian (1000+ edits before the course), a returning participant
+# (had already taken an earlier course), or neither. That classification decides
+# how the summary block aggregates them; see RetentionSummaryBlock. The detail
+# block reports all three groups alike, so an excluded participant is still
+# visible as somebody who took part.
+#
 # Metrics are computed on each student's combined cross-wiki edit timeline, from
 # the live MediaWiki usercontribs API (all namespaces), which is why the report
 # has no dependency on stored revision data.
@@ -36,7 +45,6 @@ class RetentionPredictorsCsvBuilder
   RETURN_WINDOW_DAYS = 30
   SURVIVAL_START_DAY = 60
   SURVIVAL_END_DAY = 90
-  SURVIVAL_THRESHOLD = 5
   REPORTING_BUFFER_DAYS = 1
 
   def initialize(course)
@@ -49,7 +57,7 @@ class RetentionPredictorsCsvBuilder
   def generate_csv
     stats = @students.map { |student| student_stats(student) }
     CSV.generate do |csv|
-      summary_rows(stats).each { |row| csv << row }
+      RetentionSummaryBlock.new(stats).rows.each { |row| csv << row }
       csv << []
       detail_rows(stats).each { |row| csv << row }
     end
@@ -58,12 +66,19 @@ class RetentionPredictorsCsvBuilder
   private
 
   DETAIL_HEADERS = ['username', 'sessions during course', 'days to first independent edit',
-                    'sessions in 30 days after course', 'edits in days 60-90'].freeze
+                    'sessions in 30 days after course', 'edits in days 60-90',
+                    'edits before course', 'long-term Wikipedian (1000+ edits)',
+                    'prior courses', 'prior course slugs'].freeze
 
   def student_stats(student)
     times = combined_edit_times(student.username).sort
+    history = RetentionParticipantHistory.new(@course, student, @wikis)
+    edit_metrics(student.username, times).merge(history_columns(history))
+  end
+
+  def edit_metrics(username, times)
     {
-      username: student.username,
+      username:,
       sessions_during: count_sessions(times.select { |t| t <= @course.end }),
       days_to_return: days_to_return(times),
       sessions_after: sessions_after(times),
@@ -71,27 +86,20 @@ class RetentionPredictorsCsvBuilder
     }
   end
 
-  def summary_rows(stats)
-    during = stats.sum { |s| s[:sessions_during] }
-    avg_gap = average(stats.map { |s| s[:days_to_return] })
-    avg_after = average(stats.map { |s| s[:sessions_after] })
-    [
-      ['Summary'],
-      ['participants', @students.size],
-      ['total editing sessions during course', during],
-      ['participants with no editing sessions during course', zero_edit_participants(stats)],
-      ['avg days to first independent edit', avg_gap],
-      ['avg editing sessions in 30 days after course', avg_after],
-      ['participants who edited in 30 days after course', returning_participants(stats)],
-      ['participants with 1+ edits in days 60-90', edited_in_survival_window(stats, 1)],
-      ['participants with 5+ edits in days 60-90 (survivors)',
-       edited_in_survival_window(stats, SURVIVAL_THRESHOLD)]
-    ]
+  def history_columns(history)
+    {
+      prior_edits: history.prior_edit_count_label,
+      long_term: history.long_term_wikipedian?,
+      returning: history.returning?,
+      prior_courses: history.prior_courses.size,
+      prior_course_slugs: history.prior_course_slugs
+    }
   end
 
   def detail_rows(stats)
     rows = stats.map do |s|
-      [s[:username], s[:sessions_during], s[:days_to_return], s[:sessions_after], s[:edits_60_90]]
+      [s[:username], s[:sessions_during], s[:days_to_return], s[:sessions_after], s[:edits_60_90],
+       s[:prior_edits], (s[:long_term] ? 'yes' : nil), s[:prior_courses], s[:prior_course_slugs]]
     end
     [['Per-student detail'], DETAIL_HEADERS, *rows]
   end
@@ -133,35 +141,6 @@ class RetentionPredictorsCsvBuilder
 
   def survival_window_available?
     @now >= @course.end + (SURVIVAL_END_DAY + REPORTING_BUFFER_DAYS).days
-  end
-
-  # Mean over students, rounded to one decimal. Blank (nil) when the underlying
-  # metric is not yet available (its per-student values are all nil).
-  def average(values)
-    return nil if values.empty? || values.any?(&:nil?)
-    (values.sum.to_f / values.size).round(1)
-  end
-
-  # Participants with at least `threshold` edits in the 60-90-day survival
-  # window. Blank (nil) until that window has closed.
-  def edited_in_survival_window(stats, threshold)
-    counts = stats.map { |s| s[:edits_60_90] }
-    return nil if counts.any?(&:nil?)
-    counts.count { |count| count >= threshold }
-  end
-
-  # Participants with zero editing sessions during the course. Always available,
-  # since the during-course metric never depends on a not-yet-closed window.
-  def zero_edit_participants(stats)
-    stats.count { |s| s[:sessions_during].zero? }
-  end
-
-  # Participants who made at least one edit in the 30 days after the course.
-  # Blank (nil) until the return window has closed.
-  def returning_participants(stats)
-    counts = stats.map { |s| s[:sessions_after] }
-    return nil if counts.any?(&:nil?)
-    counts.count(&:positive?)
   end
 
   # Number of distinct editing sessions: a new session starts whenever the gap

--- a/lib/analytics/retention_summary_block.rb
+++ b/lib/analytics/retention_summary_block.rb
@@ -14,7 +14,12 @@
 #   * Everyone else is a first-course participant.
 #
 # Every aggregate is therefore reported twice, once per counted group. A group
-# with no members gets blanks rather than a column of zeros.
+# with no members gets blanks rather than a column of zeros, so an absent group
+# does not read as one that did no editing. The two participant-count rows are
+# the exception: they report a genuine zero, since how many people fell into a
+# group is a fact whether or not there were any. The excluded row is split the
+# same way as the rest, so it also says which column each excluded participant
+# would otherwise have been counted in.
 class RetentionSummaryBlock
   SURVIVAL_THRESHOLD = 5
 
@@ -32,8 +37,8 @@ class RetentionSummaryBlock
   ].freeze
 
   def initialize(stats)
-    @excluded = stats.select { |s| s[:long_term] }
-    counted = stats.reject { |s| s[:long_term] }
+    excluded, counted = stats.partition { |s| s[:long_term] }
+    @excluded_returning, @excluded_first_time = excluded.partition { |s| s[:returning] }
     @returning, @first_time = counted.partition { |s| s[:returning] }
   end
 
@@ -41,7 +46,7 @@ class RetentionSummaryBlock
     [
       HEADER,
       ['participants', @first_time.size, @returning.size],
-      [EXCLUDED_LABEL, @excluded.size],
+      [EXCLUDED_LABEL, @excluded_first_time.size, @excluded_returning.size],
       *metric_rows
     ]
   end

--- a/lib/analytics/retention_summary_block.rb
+++ b/lib/analytics/retention_summary_block.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Builds the summary block at the top of the retention predictors CSV from the
+# per-student stats RetentionPredictorsCsvBuilder has already computed.
+#
+# Participants are split into three groups:
+#
+#   * Long-term Wikipedians (1000+ edits before the course began) are listed in
+#     the per-student detail block but excluded from every aggregate here — the
+#     report only counts them so the reader knows how many there were.
+#   * Returning participants, who had already taken an earlier course, are
+#     aggregated in their own column so their numbers are not read as
+#     first-course outcomes.
+#   * Everyone else is a first-course participant.
+#
+# Every aggregate is therefore reported twice, once per counted group. A group
+# with no members gets blanks rather than a column of zeros.
+class RetentionSummaryBlock
+  SURVIVAL_THRESHOLD = 5
+
+  HEADER = ['Summary', 'first course', 'returning participants'].freeze
+  EXCLUDED_LABEL = 'long-term Wikipedians (excluded from all counts)'
+
+  METRICS = [
+    ['total editing sessions during course', :total_sessions_during],
+    ['participants with no editing sessions during course', :zero_edit_participants],
+    ['avg days to first independent edit', :avg_days_to_return],
+    ['avg editing sessions in 30 days after course', :avg_sessions_after],
+    ['participants who edited in 30 days after course', :editors_after_course],
+    ['participants with 1+ edits in days 60-90', :any_survival_edits],
+    ["participants with #{SURVIVAL_THRESHOLD}+ edits in days 60-90 (survivors)", :survivors]
+  ].freeze
+
+  def initialize(stats)
+    @excluded = stats.select { |s| s[:long_term] }
+    counted = stats.reject { |s| s[:long_term] }
+    @returning, @first_time = counted.partition { |s| s[:returning] }
+  end
+
+  def rows
+    [
+      HEADER,
+      ['participants', @first_time.size, @returning.size],
+      [EXCLUDED_LABEL, @excluded.size],
+      *metric_rows
+    ]
+  end
+
+  private
+
+  def metric_rows
+    METRICS.map do |label, metric|
+      [label, value(metric, @first_time), value(metric, @returning)]
+    end
+  end
+
+  # Blank rather than zero when the group is empty, so an absent group reads as
+  # "no data" instead of "no editing".
+  def value(metric, group)
+    return nil if group.empty?
+    send(metric, group)
+  end
+
+  def total_sessions_during(stats)
+    stats.sum { |s| s[:sessions_during] }
+  end
+
+  # Participants with zero editing sessions during the course. Always available,
+  # since the during-course metric never depends on a not-yet-closed window.
+  def zero_edit_participants(stats)
+    stats.count { |s| s[:sessions_during].zero? }
+  end
+
+  def avg_days_to_return(stats)
+    average(stats.map { |s| s[:days_to_return] })
+  end
+
+  def avg_sessions_after(stats)
+    average(stats.map { |s| s[:sessions_after] })
+  end
+
+  # Participants who made at least one edit in the 30 days after the course.
+  # Blank (nil) until the return window has closed.
+  def editors_after_course(stats)
+    counts = stats.map { |s| s[:sessions_after] }
+    return nil if counts.any?(&:nil?)
+    counts.count(&:positive?)
+  end
+
+  def any_survival_edits(stats)
+    edited_in_survival_window(stats, 1)
+  end
+
+  def survivors(stats)
+    edited_in_survival_window(stats, SURVIVAL_THRESHOLD)
+  end
+
+  # Participants with at least `threshold` edits in the 60-90-day survival
+  # window. Blank (nil) until that window has closed.
+  def edited_in_survival_window(stats, threshold)
+    counts = stats.map { |s| s[:edits_60_90] }
+    return nil if counts.any?(&:nil?)
+    counts.count { |count| count >= threshold }
+  end
+
+  # Mean over students, rounded to one decimal. Blank (nil) when the underlying
+  # metric is not yet available (its per-student values are all nil).
+  def average(values)
+    return nil if values.empty? || values.any?(&:nil?)
+    (values.sum.to_f / values.size).round(1)
+  end
+end

--- a/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
+++ b/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
@@ -27,21 +27,48 @@ describe RetentionPredictorsCsvBuilder do
     end
   end
 
-  # Stubs WikiApi.new(wiki) so that usercontribs queries return the given
-  # per-username timestamps. `contribs_by_user` maps username => [Time, ...].
-  def stub_wiki(wiki, contribs_by_user)
+  # One page of a user's pre-course contributions, out of `total` of them.
+  # Pages at the real API's 500-per-page limit, so the builder's
+  # stop-counting-at-the-threshold pagination gets exercised for real.
+  def prior_edits_response(total, params)
+    offset = (params['uccontinue'] || params[:uccontinue]).to_i
+    remaining = total - offset
+    page = [remaining, 500].min
+    continue = remaining > page ? { 'uccontinue' => (offset + page).to_s } : nil
+    response_for([Time.zone.now] * page, continue:)
+  end
+
+  # Stubs WikiApi.new(wiki) for both queries the builder makes. The during-course
+  # timeline query is bounded by :ucend; the pre-course edit count query is not,
+  # which is how the stub tells them apart. `contribs_by_user` maps
+  # username => [Time, ...]; `prior_edits` maps username => edit count.
+  def stub_wiki(wiki, contribs_by_user, prior_edits = {})
     api = instance_double(WikiApi)
     allow(WikiApi).to receive(:new).with(wiki).and_return(api)
     allow(api).to receive(:query) do |params|
-      response_for(contribs_by_user.fetch(params[:ucuser], []))
+      if params.key?(:ucend)
+        response_for(contribs_by_user.fetch(params[:ucuser], []))
+      else
+        prior_edits_response(prior_edits.fetch(params[:ucuser], 0), params)
+      end
     end
   end
 
   let(:table) { CSV.parse(described_class.new(course).generate_csv) }
 
-  # value cell of a "label,value" summary row
+  # full "label,first course,returning participants" summary row
+  def summary_row(label)
+    table.find { |row| row[0] == label }
+  end
+
+  # first-course column of a summary row
   def summary_value(label)
-    table.find { |row| row[0] == label }&.at(1)
+    summary_row(label)&.at(1)
+  end
+
+  # returning-participant column of a summary row
+  def returning_value(label)
+    summary_row(label)&.at(2)
   end
 
   # full per-student detail row, keyed by username
@@ -67,11 +94,11 @@ describe RetentionPredictorsCsvBuilder do
       end
 
       it 'fills every per-student metric on the combined cross-wiki timeline' do
-        expect(detail_row('user1')).to eq(%w[user1 2 14 1 5])
+        expect(detail_row('user1')).to eq(['user1', '2', '14', '1', '5', '0', nil, '0', nil])
       end
 
       it 'defaults a non-returning student to a 30-day gap and zero counts' do
-        expect(detail_row('user2')).to eq(%w[user2 0 30 0 0])
+        expect(detail_row('user2')).to eq(['user2', '0', '30', '0', '0', '0', nil, '0', nil])
       end
 
       it 'aggregates the per-course summary block' do
@@ -99,7 +126,7 @@ describe RetentionPredictorsCsvBuilder do
       end
 
       it 'reports during-course sessions but leaves the post-course metrics blank' do
-        expect(detail_row('user1')).to eq(['user1', '1', nil, nil, nil])
+        expect(detail_row('user1')).to eq(['user1', '1', nil, nil, nil, '0', nil, '0', nil])
         expect(summary_value('total editing sessions during course')).to eq('1')
         expect(summary_value('avg days to first independent edit')).to be_nil
         expect(summary_value('avg editing sessions in 30 days after course')).to be_nil
@@ -124,8 +151,8 @@ describe RetentionPredictorsCsvBuilder do
       end
 
       it 'fills the 30-day metrics but leaves the 60-90-day metric blank' do
-        expect(detail_row('user1')).to eq(['user1', '1', '5', '1', nil])
-        expect(detail_row('user2')).to eq(['user2', '0', '30', '0', nil])
+        expect(detail_row('user1')).to eq(['user1', '1', '5', '1', nil, '0', nil, '0', nil])
+        expect(detail_row('user2')).to eq(['user2', '0', '30', '0', nil, '0', nil, '0', nil])
         expect(summary_value('avg days to first independent edit')).to eq('17.5')
         expect(summary_value('avg editing sessions in 30 days after course')).to eq('0.5')
         expect(summary_value('participants with 1+ edits in days 60-90')).to be_nil
@@ -159,21 +186,137 @@ describe RetentionPredictorsCsvBuilder do
     end
   end
 
+  describe 'long-term Wikipedians' do
+    let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
+
+    context 'when a participant edited 1000+ times before the course' do
+      before do
+        e = course.end
+        timeline = [e - 10.days, e + 5.days, e + 70.days]
+        stub_wiki(wiki1, { 'user1' => timeline, 'user2' => timeline },
+                  { 'user1' => 1000 })
+      end
+
+      it 'reports them in the detail block, flagged and capped at the threshold' do
+        expect(detail_row('user1'))
+          .to eq(['user1', '1', '5', '1', '1', '1000+', 'yes', '0', nil])
+      end
+
+      it 'leaves them out of every summary aggregate' do
+        # Both students have identical timelines, so any aggregate that still
+        # counted user1 would be doubled.
+        expect(summary_value('participants')).to eq('1')
+        expect(summary_value('long-term Wikipedians (excluded from all counts)')).to eq('1')
+        expect(summary_value('total editing sessions during course')).to eq('1')
+        expect(summary_value('participants who edited in 30 days after course')).to eq('1')
+        expect(summary_value('participants with 1+ edits in days 60-90')).to eq('1')
+      end
+    end
+
+    context 'when a participant edited just under 1000 times before the course' do
+      before do
+        stub_wiki(wiki1, { 'user1' => [] }, { 'user1' => 999 })
+      end
+
+      it 'reports the exact count and counts them as an ordinary participant' do
+        # 999 spans two pages of contributions, so the count is only right if
+        # pagination continued past the first page.
+        expect(detail_row('user1')&.at(5)).to eq('999')
+        expect(detail_row('user1')&.at(6)).to be_nil
+        expect(summary_value('participants')).to eq('2')
+        expect(summary_value('long-term Wikipedians (excluded from all counts)')).to eq('0')
+      end
+    end
+
+    context 'when prior edits are spread across more than one course wiki' do
+      let(:course_wikis) { [wiki1, wiki2] }
+
+      before do
+        stub_wiki(wiki1, { 'user1' => [] }, { 'user1' => 600 })
+        stub_wiki(wiki2, { 'user1' => [] }, { 'user1' => 500 })
+      end
+
+      it 'sums them across wikis to reach the threshold' do
+        expect(detail_row('user1')&.at(5)).to eq('1000+')
+        expect(detail_row('user1')&.at(6)).to eq('yes')
+      end
+    end
+
+    context 'when every participant is a long-term Wikipedian' do
+      before do
+        stub_wiki(wiki1, { 'user1' => [], 'user2' => [] },
+                  { 'user1' => 1000, 'user2' => 1000 })
+      end
+
+      it 'leaves the aggregates blank rather than reporting a column of zeros' do
+        expect(summary_value('participants')).to eq('0')
+        expect(summary_value('long-term Wikipedians (excluded from all counts)')).to eq('2')
+        expect(summary_value('total editing sessions during course')).to be_nil
+        expect(summary_value('participants with 1+ edits in days 60-90')).to be_nil
+      end
+    end
+  end
+
+  describe 'returning participants' do
+    let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
+    let(:earlier_course) do
+      create(:course, slug: 'School/Earlier_course_(2014)',
+                      start: 2.years.ago, end: 20.months.ago)
+    end
+    let(:later_course) do
+      create(:course, slug: 'School/Later_course_(2016)',
+                      start: 10.days.ago, end: 5.days.ago)
+    end
+
+    before do
+      create(:courses_user, course: earlier_course, user: user2,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      # user1 is also in a course that started later, which is not a prior course.
+      create(:courses_user, course: later_course, user: user1,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      e = course.end
+      stub_wiki(wiki1, 'user1' => [e - 10.days], 'user2' => [e - 10.days, e - 9.days])
+    end
+
+    it 'names the prior course in the detail block' do
+      expect(detail_row('user2')).to eq(['user2', '2', '30', '0', '0', '0', nil, '1',
+                                         'School/Earlier_course_(2014)'])
+    end
+
+    it 'treats a course that started later as no prior course at all' do
+      expect(detail_row('user1')).to eq(['user1', '1', '30', '0', '0', '0', nil, '0', nil])
+    end
+
+    it 'aggregates them in a column of their own' do
+      expect(summary_row('Summary')).to eq(['Summary', 'first course', 'returning participants'])
+      expect(summary_value('participants')).to eq('1')
+      expect(returning_value('participants')).to eq('1')
+      expect(summary_value('total editing sessions during course')).to eq('1')
+      expect(returning_value('total editing sessions during course')).to eq('2')
+    end
+  end
+
   describe 'pagination' do
     let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
 
     before do
       e = course.end
-      first = response_for([e - 26.days], continue: { 'uccontinue' => 'x' })
-      second = response_for([e - 20.days])
+      pages = [response_for([e - 26.days], continue: { 'uccontinue' => 'x' }),
+               response_for([e - 20.days])]
       api1 = instance_double(WikiApi)
       allow(WikiApi).to receive(:new).with(wiki1).and_return(api1)
-      allow(api1).to receive(:query).and_return(first, second)
+      allow(api1).to receive(:query) do |params|
+        if !params.key?(:ucend) || params[:ucuser] != 'user1'
+          response_for([])
+        else
+          params['uccontinue'] ? pages[1] : pages[0]
+        end
+      end
     end
 
     it 'follows the continue token to fetch all pages of contributions' do
       # The two pages are days apart, so both must be fetched to count 2 sessions.
-      expect(detail_row('user1')).to eq(['user1', '2', '30', '0', '0'])
+      expect(detail_row('user1')).to eq(['user1', '2', '30', '0', '0', '0', nil, '0', nil])
     end
   end
 end

--- a/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
+++ b/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
@@ -251,8 +251,37 @@ describe RetentionPredictorsCsvBuilder do
       it 'leaves the aggregates blank rather than reporting a column of zeros' do
         expect(summary_value('participants')).to eq('0')
         expect(summary_value('long-term Wikipedians (excluded from all counts)')).to eq('2')
+        expect(returning_value('long-term Wikipedians (excluded from all counts)')).to eq('0')
         expect(summary_value('total editing sessions during course')).to be_nil
         expect(summary_value('participants with 1+ edits in days 60-90')).to be_nil
+      end
+    end
+
+    context 'when a participant is both long-term and returning' do
+      let(:earlier_course) do
+        create(:course, slug: 'School/Earlier_course_(2014)',
+                        start: 2.years.ago, end: 20.months.ago)
+      end
+
+      before do
+        create(:courses_user, course: earlier_course, user: user1,
+                              role: CoursesUsers::Roles::STUDENT_ROLE)
+        e = course.end
+        stub_wiki(wiki1, { 'user1' => [e - 10.days], 'user2' => [e - 10.days] },
+                  { 'user1' => 1000 })
+      end
+
+      it 'excludes them from the returning column, not just the first-course one' do
+        # user2 has the identical timeline and is counted, so a returning column
+        # that still held user1 would report a session here instead of a blank.
+        expect(returning_value('participants')).to eq('0')
+        expect(returning_value('total editing sessions during course')).to be_nil
+        expect(summary_value('total editing sessions during course')).to eq('1')
+      end
+
+      it 'reports them in the returning column of the excluded row' do
+        expect(summary_row('long-term Wikipedians (excluded from all counts)'))
+          .to eq(['long-term Wikipedians (excluded from all counts)', '0', '1'])
       end
     end
   end
@@ -293,6 +322,24 @@ describe RetentionPredictorsCsvBuilder do
       expect(returning_value('participants')).to eq('1')
       expect(summary_value('total editing sessions during course')).to eq('1')
       expect(returning_value('total editing sessions during course')).to eq('2')
+    end
+
+    context 'when a participant has taken more than one earlier course' do
+      let(:earliest_course) do
+        create(:course, slug: 'School/Earliest_course_(2012)',
+                        start: 4.years.ago, end: 46.months.ago)
+      end
+
+      before do
+        create(:courses_user, course: earliest_course, user: user2,
+                              role: CoursesUsers::Roles::STUDENT_ROLE)
+      end
+
+      it 'counts them all and joins the slugs oldest first' do
+        expect(detail_row('user2')&.at(7)).to eq('2')
+        expect(detail_row('user2')&.at(8))
+          .to eq('School/Earliest_course_(2012); School/Earlier_course_(2014)')
+      end
     end
   end
 


### PR DESCRIPTION
## What this PR does

The "Retention predictors" CSV (admin-only, Scholars & Scientists courses) counted
every participant identically. That made two distinct populations invisible in the
aggregates: people who were already established Wikipedians before joining the
cohort, and people who had taken an earlier course and were therefore not having a
first-course experience at all. Both distort what the retention numbers can tell us.

Participants are now classified on two axes and the summary block is split
accordingly:

- **Long-term Wikipedians** — 1000 or more edits before the course start date — are
  still listed in the per-student detail block with all their metrics, but are
  excluded from every summary aggregate. A count row reports how many were excluded.
- **Returning participants** — anyone who took an earlier course as a student — get
  their own summary column, so their second-course numbers are not read as
  first-course outcomes.

Four columns are appended to the per-student detail block: `edits before course`,
`long-term Wikipedian (1000+ edits)`, `prior courses`, and `prior course slugs`. They
go at the end so existing column positions are unchanged for anyone with a
spreadsheet built on the old layout.

Both thresholds and definitions came from the report's operator: the 1000-edit bar,
prior edit count as the sole criterion (no account-age condition), and "any earlier
course where they were a student" as the prior-course rule.

Relevant API documentation: [`list=usercontribs`](https://www.mediawiki.org/wiki/API:Usercontribs).

## AI usage

Claude Code wrote all of the code in this PR, along with the commit message and this
description. The human contribution was direction and decisions: stating the two
problems to solve, choosing among four presented options for how to identify a
long-term Wikipedian and how to present the split, supplying the 1000-edit threshold
directly rather than picking from the offered values, and correcting a proposed
column label. Claude proposed the plan and asked those four questions before writing
anything; the human approved the plan and the implementation proceeded from there.

Note that the "What this PR does" summary above and the analysis throughout this
description were also drafted by Claude Code and may contain errors — review the diff
rather than trusting the summary.

Scale of effort: one commit, written in a single session of roughly fifteen turns
with three user messages totalling about a paragraph of text. This is a small,
focused change; there was no extended iteration or multi-day development. The commit
message's `## Process` section has a fuller accounting.

This PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

No UI changes — the only visible surface is the generated CSV. Below is the same
illustrative fixture (four participants, one of them a long-term Wikipedian, one of
them a repeat participant) rendered by the old and new code. These are synthetic
fixture numbers, not real cohort data.

**Before:**

```
Summary
participants,4
total editing sessions during course,4
participants with no editing sessions during course,1
avg days to first independent edit,9.0
avg editing sessions in 30 days after course,0.8
participants who edited in 30 days after course,3
participants with 1+ edits in days 60-90,3
participants with 5+ edits in days 60-90 (survivors),1

Per-student detail
username,sessions during course,days to first independent edit,sessions in 30 days after course,edits in days 60-90
Newcomer,2,3,1,5
Quiet,0,30,0,0
Repeat,1,2,1,1
Veteran,1,1,1,2
```

**After:**

```
Summary,first course,returning participants
participants,2,1
long-term Wikipedians (excluded from all counts),1
total editing sessions during course,2,1
participants with no editing sessions during course,1,0
avg days to first independent edit,16.5,2.0
avg editing sessions in 30 days after course,0.5,1.0
participants who edited in 30 days after course,1,1
participants with 1+ edits in days 60-90,1,1
participants with 5+ edits in days 60-90 (survivors),1,0

Per-student detail
username,sessions during course,days to first independent edit,sessions in 30 days after course,edits in days 60-90,edits before course,long-term Wikipedian (1000+ edits),prior courses,prior course slugs
Newcomer,2,3,1,5,0,,0,
Quiet,0,30,0,0,0,,0,
Repeat,1,2,1,1,0,,1,Uni/Intro_(2024)
Veteran,1,1,1,2,1000+,yes,0,
```

Note how the "Veteran" row keeps its full metrics in the detail block while
contributing to no aggregate, and how "Repeat" moves out of the first-course column.

## Open questions and concerns

**The prior-edit count is scoped to the course's wikis, not global.** It sums
`usercontribs` across `course.wikis`. A participant arriving with 3,000 edits on
de.wikipedia and none on en.wikipedia would read as 0 prior edits in an en-only
cohort. `meta=globaluserinfo` would catch that in a single API call, but it reports
all-time edit counts including edits made *after* the course, which would break the
before-the-course framing and could exclude someone whose post-course editing is
exactly the retention success the report exists to measure. This PR chose accuracy on
the time window over breadth of wikis; if cross-wiki arrivals turn out to be common
in Scholars & Scientists cohorts, that tradeoff is worth revisiting.

**Concurrent enrollments do not count as prior courses.** The comparison is on course
start dates, so a participant enrolled in two overlapping courses is treated as
first-course in both. This seemed right — neither course precedes the other — but it
is a judgment call.

**The 1000-edit bar is measured only at the course start.** Someone who crossed 1000
edits during or after the course is not retroactively excluded, by design.

**Added API cost.** Each participant now costs up to two extra `usercontribs` pages
per course wiki (counting stops the moment it reaches 1000, so a 50,000-edit account
costs no more than a 1,000-edit one). For a 20-person, 2-wiki cohort that is at most
80 extra requests in an already-asynchronous Sidekiq job.

**Class extraction.** `RetentionPredictorsCsvBuilder` was close enough to RuboCop's
130-line class limit that adding a second summary column would have pushed it over,
so the summary block moved into its own `RetentionSummaryBlock` class. That is a
larger diff than the feature strictly required, but the aggregate helpers moved
wholesale rather than being rewritten.

(PR description written by Claude Code.)
