### PR TITLE
Scope the authorship fallback check to the displayed revision

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipAPI.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipAPI.js
@@ -23,15 +23,6 @@ export class AuthorshipAPI extends ArticleViewerAPI {
     });
   }
 
-  generateWhocolorHtml() {
-    const url = this.builder.wikiwhoColorRevisionURL();
-    return fetch(`${url}&origin=*`, {
-      headers: {
-        'Content-Type': 'application/javascript'
-      }
-    }).then(response => this.__handleFetchResponse(response));
-  }
-
   fetchWhocolorHtml(lastRevisionId) {
     let attempts = 0;
     const MAX_RETRY_ATTEMPTS = 5;
@@ -81,7 +72,12 @@ export class AuthorshipAPI extends ArticleViewerAPI {
         // The shell's __processHtml does the relative-link rewriting; if the
         // WhoColor payload lacked HTML, surface a failure marker (as before).
         const processed = this.__processHtml(response.extended_html);
-        return processed || { whocolorFailed: true };
+        if (!processed) return { whocolorFailed: true };
+        // The payload's per-token authorship rides along with the HTML. It is the
+        // same data the rev_content endpoint would return, already scoped to the
+        // requested revision, so callers can tell "edits present but not
+        // highlightable" from "no edits here" without a second request.
+        return { ...processed, tokens: response.tokens };
       });
   }
 
@@ -92,23 +88,6 @@ export class AuthorshipAPI extends ArticleViewerAPI {
         'Content-Type': 'application/javascript'
       }
     }).then(response => this.__handleFetchResponse(response));
-  }
-
-  fetchWikitextMetaData() {
-    const url = this.builder.wikiwhoColorRevisionURL();
-    return fetch(`${url}&origin=*`, {
-      headers: {
-        'Content-Type': 'application/javascript'
-      }
-    }).then(response => this.__handleFetchResponse(response))
-      .then((response) => {
-        if (response.error) throw new Error(this.__setException({ status: 404 }));
-        const revisionId = 'revisions'; // Get the first (and presumably only) revision ID
-        const revisionData = response[revisionId]?.[0];
-        if (!revisionData) throw new Error('Invalid response data');
-        const { tokens } = Object.values(revisionData)[0];
-        return { tokensForRevision: tokens };
-      });
   }
 }
 

--- a/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipAPI.spec.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipAPI.spec.js
@@ -26,6 +26,36 @@ describe('AuthorshipAPI', () => {
     expect(typeof api).toEqual('object');
   });
 
+  describe('.fetchWhocolorHtml()', () => {
+    it('should return the payload tokens alongside the processed html', async () => {
+      fetchMock.mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          success: true,
+          extended_html: '<p><a href="/wiki/Bears">Bears</a></p>',
+          tokens: [[0, 'bears', 1, [], [], '48311939', 0]]
+        })
+      }));
+      const api = new AuthorshipAPI({ builder });
+      const actual = await api.fetchWhocolorHtml(1253430861);
+
+      // The tokens carry the per-token authorship for the requested revision, so
+      // the caller never has to ask a second endpoint which editors are present.
+      expect(actual.tokens).toEqual([[0, 'bears', 1, [], [], '48311939', 0]]);
+      expect(actual.html).toEqual('<p><a href="https://en.wikipedia.org/wiki/Bears">Bears</a></p>');
+    });
+
+    it('should return a failure marker when the payload has no html', async () => {
+      fetchMock.mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true, tokens: [] })
+      }));
+      const api = new AuthorshipAPI({ builder });
+
+      expect(await api.fetchWhocolorHtml(1253430861)).toEqual({ whocolorFailed: true });
+    });
+  });
+
   describe('.fetchUserIds()', () => {
     it('should make a request to the builder.wikiUserQueryURL', async () => {
       const api = new AuthorshipAPI({ builder });

--- a/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipURLBuilder.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipURLBuilder.js
@@ -3,7 +3,7 @@ import URLBuilder from '@components/common/ArticleViewer/utils/URLBuilder';
 const WIKIWHO_DOMAIN = 'https://wikiwho-api.wmcloud.org';
 
 // Builds the URLs the authorship/WhoColor feature needs: the WikiWho coloring
-// endpoints and the MediaWiki user-id query. Extends the shell's URLBuilder so it
+// endpoint and the MediaWiki user-id query. Extends the shell's URLBuilder so it
 // inherits wikiURL() (used by the user query); the shell never imports this.
 export class AuthorshipURLBuilder extends URLBuilder {
   wikiwhoColorURL(lastRevisionId) {
@@ -16,17 +16,6 @@ export class AuthorshipURLBuilder extends URLBuilder {
     // See https://github.com/wikimedia/wikiwho_api/pull/4/commits/8f421a20c62288a1a29bcef75fffa0a21d2c92a6
     const revisionId = lastRevisionId || 0;
     const url = `${WIKIWHO_DOMAIN}/${language}/whocolor/v1.0.0-beta/${encodeURIComponent(title)}/${revisionId}/`;
-    return url;
-  }
-
-  wikiwhoColorRevisionURL() {
-    const { language, title } = this.article;
-
-    if (!language) throw new TypeError('Article language is missing!');
-    if (!title) throw new TypeError('Article title is missing!');
-
-    const query = '?o_rev_id=true&editor=true&token_id=true&out=true&in=true';
-    const url = `${WIKIWHO_DOMAIN}/${language}/api/v1.0.0-beta/rev_content/${encodeURIComponent(title)}/${query}`;
     return url;
   }
 

--- a/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipURLBuilder.spec.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/authorship/AuthorshipURLBuilder.spec.js
@@ -28,24 +28,6 @@ describe('AuthorshipURLBuilder', () => {
     });
   });
 
-  describe('#wikiwhoColorRevisionURL', () => {
-    it('should create a wikiwhoColorRevisionURL when given a valid article', () => {
-      const helper = new AuthorshipURLBuilder({ article: defaults.article });
-      const expected = 'https://wikiwho-api.wmcloud.org/en/api/v1.0.0-beta/rev_content/Brown%20Bear%2C%20Brown%20Bear%2C%20What%20Do%20You%20See%3F/?o_rev_id=true&editor=true&token_id=true&out=true&in=true';
-      expect(helper.wikiwhoColorRevisionURL()).toEqual(expected);
-    });
-    it('should throw an error if the language is missing', () => {
-      const article = { project: 'wikipedia', title: 'My Article' };
-      const result = new AuthorshipURLBuilder({ article });
-      expect(() => result.wikiwhoColorRevisionURL()).toThrow(TypeError);
-    });
-    it('should throw an error if the title is missing', () => {
-      const article = { language: 'en', project: 'wikipedia' };
-      const result = new AuthorshipURLBuilder({ article });
-      expect(() => result.wikiwhoColorRevisionURL()).toThrow(TypeError);
-    });
-  });
-
   describe('#wikiUserQueryURL', () => {
     it('should create a wikiUserQueryURL when given a valid article and multiple users', () => {
       const helper = new AuthorshipURLBuilder({ article: defaults.article, users: defaults.users });

--- a/app/assets/javascripts/components/common/ArticleViewer/hooks/useAuthorshipHighlighting.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/hooks/useAuthorshipHighlighting.js
@@ -26,12 +26,18 @@ import colors from '@components/common/ArticleViewer/authorship/colors';
   about authorship; a different feature (e.g. claim verification) can supply its own
   hook with the same contract.
 */
+// Position of the editor id inside a WhoColor token tuple:
+// [conflict_score, str, o_rev_id, in, out, editor, age]. For registered editors
+// that id is the MediaWiki user id; anonymous editors get a hashed stand-in.
+const TOKEN_EDITOR_INDEX = 5;
+
 const useAuthorshipHighlighting = ({
   article, users, assignedUsers, showArticleFinder,
   isOpen, revisionId, parsedSettle, fetchArticleDetails, requestTitleVerification,
 }) => {
   const [highlightedHtml, setHighlightedHtml] = useState(null);
   const [whoColorHtml, setWhoColorHtml] = useState(null);
+  const [whoColorEditors, setWhoColorEditors] = useState(null);
   const [usersState, setUsersState] = useState([]);
   const [userIdsFetched, setUserIdsFetched] = useState(false);
   const [unhighlightedContributors, setUnhighlightedContributors] = useState([]);
@@ -91,37 +97,22 @@ const useAuthorshipHighlighting = ({
     setPending(false);
   };
 
-  // Function to check if contributions of unhighlighted editors exist in the wikitext metadata
+  // Function to check if contributions of unhighlighted editors exist in this revision.
+  // The answer is already in the WhoColor payload that produced the HTML, so this needs
+  // no request of its own — and it is necessarily scoped to the revision on screen,
+  // whether that is the current version or the one the revision toggle selected.
   const usersContributionExists = (usersID) => {
-    // Create a URL builder and API instance for fetching wikitext metadata
-    const builder = new AuthorshipURLBuilder({ article });
-    const api = new AuthorshipAPI({ builder });
-
-    // Fetch wikitext metadata for the current article revision
-    api.fetchWikitextMetaData()
-       .then((response) => {
-         // Extract the tokensForRevision data from the response
-         const { tokensForRevision } = response;
-
-         // Iterate through the list of user IDs whose contributions couldn't be highlighted
-         usersID.forEach((userID) => {
-          // Find a token in the metadata with a matching editor ID
-          const foundToken = tokensForRevision.find(token => token.editor === userID.toString());
-
-          // If a token with a matching editor ID is found, it means the user has a contribution
-          // in the current revision's wikitext
-          if (foundToken) {
-            // Add the user ID to the unhighlightedContributors state to display in the UI
-            setUnhighlightedContributors(x => [...x, userID]);
-          } else {
-            const status = `No Contributions Found in this current version for User ID', ${userID}`;
-            // If the user ID doesn't have a contribution in the current revision's wikitext,
-            // add a message to the unhighlightedContributors state to display in the UI
-            setUnhighlightedContributors(x => [...x, status]);
-          }
-        });
-      }).catch((error) => {
-      setFailureMessage(error.message);
+    // Iterate through the list of user IDs whose contributions couldn't be highlighted
+    usersID.forEach((userID) => {
+      // If the editor owns tokens in this revision, their work is present but
+      // wasn't highlightable; otherwise none of this revision's text is theirs.
+      if (whoColorEditors?.has(userID.toString())) {
+        // Add the user ID to the unhighlightedContributors state to display in the UI
+        setUnhighlightedContributors(x => [...x, userID]);
+      } else {
+        const status = `No contributions found in this version for user ID ${userID}`;
+        setUnhighlightedContributors(x => [...x, status]);
+      }
     });
   };
 
@@ -131,6 +122,10 @@ const useAuthorshipHighlighting = ({
     setPending(true);
     api.fetchWhocolorHtml(revisionId)
       .then((response) => {
+        // Keep only the editor ids: the token list is large and nothing here needs
+        // more than membership. Set before the html, so the [whoColorHtml] effect
+        // that runs highlightAuthors always sees it.
+        setWhoColorEditors(new Set((response.tokens || []).map(token => token[TOKEN_EDITOR_INDEX])));
         setWhoColorHtml(response.html);
       }).catch((error) => {
         setWhoColorFailed(true);
@@ -226,6 +221,7 @@ const useAuthorshipHighlighting = ({
     }
     setHighlightedHtml(null);
     setWhoColorHtml(null);
+    setWhoColorEditors(null);
     setUnhighlightedContributors([]);
   }, [revisionId]);
 

--- a/app/assets/javascripts/components/common/ArticleViewer/hooks/useAuthorshipHighlighting.js
+++ b/app/assets/javascripts/components/common/ArticleViewer/hooks/useAuthorshipHighlighting.js
@@ -125,6 +125,12 @@ const useAuthorshipHighlighting = ({
         // Keep only the editor ids: the token list is large and nothing here needs
         // more than membership. Set before the html, so the [whoColorHtml] effect
         // that runs highlightAuthors always sees it.
+        //
+        // The payload's much smaller `present_editors` is not a substitute for the
+        // token list. WhoColor accumulates it while annotating the wikitext and skips
+        // any token it can't place, so it degrades in exactly the cases this fallback
+        // exists to describe. `tokens` comes straight from WikiWho, independent of
+        // that annotator.
         setWhoColorEditors(new Set((response.tokens || []).map(token => token[TOKEN_EDITOR_INDEX])));
         setWhoColorHtml(response.html);
       }).catch((error) => {


### PR DESCRIPTION
## What this PR does

When the article viewer's authorship highlighting can't color a particular editor's spans, it falls back to asking "does this editor own any text in this version?" so the legend can distinguish *"contributions present but not highlightable"* from *"none of this version is theirs"*. That check was answered by a second request to WikiWho's `rev_content` endpoint — and that request was never given a revision id. It therefore always described the **current** revision, even when the viewer had been toggled to the student's last revision, so the last-revision view could report the wrong answer.

Rather than thread the revision id through that request, this removes it. `AuthorshipAPI#fetchWhocolorHtml` already fetches a payload containing the same per-token authorship and was discarding everything except `extended_html`; it now returns `tokens` alongside the processed HTML. The fallback answer is scoped to the revision on screen by construction, with one fewer multi-megabyte request per viewer open and no way for the two to drift apart later. The methods that existed only to serve the old path (`fetchWikitextMetaData`, `wikiwhoColorRevisionURL`, and `generateWhocolorHtml`, which had already been dead since 506bb276e) are removed.

This came out of diagnosing a production report that authorship highlighting showed no contributions at all for [Stratovolcano](https://dashboard.wikiedu.org/courses/University_of_New_Mexico/Volcanology_Wikipedia_class_module_(Fall_2024)/articles/edited?showArticle=65780601). **That symptom is not fixed here and is not a Dashboard bug.** The deployed WhoColor at `wikiwho-api.wmcloud.org` misreads the namespace prefix in `[[File:...]]` as a URL scheme, which desynchronises its span annotator for the remainder of the page — an article whose lead opens with an image comes back with exactly one `editor-token` span in 140 KB of HTML. WikiWho's data itself is fine (the student owns 42% of current-revision tokens, 54% at their last revision). That is fixed upstream in [wikimedia/WhoColor#3](https://github.com/wikimedia/WhoColor/pull/3) (`9265d66`) but is not yet deployed; `wikiwho_api` also still pins its `lib/WhoColor` submodule at a pre-fix commit. The bug in this PR was a separate finding along the way.

No issue number is associated with this work.

## AI usage

Claude Code did essentially all of the work in this PR, under human direction.

The session began as a diagnosis request, not a request for a code change. Claude Code investigated by querying the production Dashboard's public JSON endpoints, the MediaWiki API, and the WikiWho whocolor/`rev_content` endpoints, then reproduced WhoColor's parser locally against the real wikitext and tokens across five historical revisions of that library, and rendered the annotated wikitext back through the MediaWiki parse API to confirm the fixed version produces 2,684 spans including the student's. It wrote the diagnosis, identified the revision-scoping bug reported here as a secondary finding, proposed two possible fixes with a recommendation, wrote all the code and specs once a direction was chosen, and wrote the commit message and this description.

The human contribution was direction and decisions: asking for the diagnosis, constraining how the WikiWho payloads were processed (memory), pointing out that local checkouts of the relevant upstream repos already existed, choosing between the two proposed approaches, and authorising the dead-code removal conditional on verifying it was genuinely unreachable.

One correction happened along the way: an early local parser run appeared to show current upstream master producing correct output, which contradicted a later run over pinned revisions. The discrepancy turned out to be a stale remote-tracking ref in a local checkout, resolved by diffing the two copies.

Scale of effort: one commit, written in a single session on 2026-08-07. The great majority of that session was investigation rather than implementation — the code change itself is small (63 insertions, 87 deletions across 5 files) and was written and verified quickly once the approach was settled. Human input across the whole session was roughly 90 words total, spread over six short messages, so reviewers should calibrate accordingly: this had light human review relative to the amount of analysis behind it.

The "What this PR does" summary and the analysis above were also drafted by Claude Code and may contain errors — in particular, the claims about the upstream WhoColor bug are worth independently confirming before acting on them.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes. The legend renders the same components with the same strings before and after: `ArticleViewerLegend` matches only exact user ids out of `unhighlightedContributors`, so the status strings in that array are never displayed — they exist only to make the array non-empty. What changes is which revision the existing "contributions are present, but cannot be highlighted" tooltip is describing, plus the removal of a spurious failure state (see below).

Capturing a meaningful before/after would require driving WhoColor into a *partially* highlighted state for a specific revision, which the existing feature spec infrastructure doesn't do — `spec/features/article_viewer_spec.rb` depends on the live WikiWho service and both of its examples are already marked pending for an unrelated CI CORS issue.

## Open questions and concerns

- **The production symptom still needs an upstream deploy.** Nothing in this PR makes authorship highlighting work again on the affected articles. That needs `wikiwho-api.wmcloud.org` redeployed with WhoColor master, and `wikiwho_api`'s `lib/WhoColor` submodule pointer bumped past `9265d66`. Both are outside this repo.
- **Behaviour change worth a second look:** the fallback can no longer fail, because it no longer makes a request. Previously a failed metadata fetch called `setFailureMessage`, so the legend reported an authorship failure even when highlighting had actually succeeded, and left `unhighlightedContributors` empty — which stalled `legendStatus` on `loading`. Both of those states are now unreachable. I believe that's strictly an improvement, but it does mean the legend always resolves to `ready`.
- **Reliance on `tokens` being present** in the whocolor payload. It is present on every `success: true` response. If it were ever absent, the editor set is empty and every unhighlighted editor falls to the "no contributions" branch — the same outcome as today's failed metadata fetch, so it degrades no worse than the current code.
- **Dead-code removal** was verified against direct references, subclasses, dynamic dispatch, any other `rev_content` mention, and git history (`generateWhocolorHtml`'s last caller went in 506bb276e; the old class component's copy in 35931b584). Worth a reviewer's sanity check regardless, since deletions are harder to un-miss than additions.
- **Not covered by an automated test:** the specific end-to-end behaviour this fixes — that the fallback now answers for the toggled revision — is exercised only indirectly. The added specs cover the token pass-through at the API layer, not the hook's use of it.

(PR description written by Claude Code.)
