### PR TITLE
Add admin CSV reports for instructor mentorship program matching

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -5,13 +5,16 @@ require_dependency "#{Rails.root}/lib/analytics/course_statistics"
 require_dependency "#{Rails.root}/lib/analytics/campaign_csv_builder"
 require_dependency "#{Rails.root}/lib/analytics/ungreeted_list"
 require_dependency "#{Rails.root}/lib/analytics/tagged_courses_csv_builder"
+require_dependency "#{Rails.root}/lib/analytics/mentor_requests_csv_builder"
+require_dependency "#{Rails.root}/lib/analytics/mentor_volunteers_csv_builder"
 
 #= Controller for analytics tools
 class AnalyticsController < ApplicationController
   layout 'admin'
   include CourseHelper
   before_action :require_signed_in, only: :ungreeted
-  before_action :require_admin_permissions, only: :tagged_courses_csv
+  before_action :require_admin_permissions,
+                only: %i[tagged_courses_csv mentor_requests_csv mentor_volunteers_csv]
 
   ########################
   # Routing entry points #
@@ -54,6 +57,16 @@ class AnalyticsController < ApplicationController
               filename: "all_courses-#{Time.zone.today}.csv"
   end
 
+  def mentor_requests_csv
+    send_data MentorRequestsCsvBuilder.new(selected_campaign).generate_csv,
+              filename: "mentor_requests-#{selected_campaign.slug}-#{Time.zone.today}.csv"
+  end
+
+  def mentor_volunteers_csv
+    send_data MentorVolunteersCsvBuilder.new(selected_campaign).generate_csv,
+              filename: "mentor_volunteers-#{selected_campaign.slug}-#{Time.zone.today}.csv"
+  end
+
   #################
   # WMF Analytics #
   #################
@@ -77,6 +90,10 @@ class AnalyticsController < ApplicationController
   end
 
   private
+
+  def selected_campaign
+    @selected_campaign ||= Campaign.find(params[:campaign][:id])
+  end
 
   # Mirrors #all_courses (JSON): admins see every course, including private;
   # non-admins see only nonprivate courses.

--- a/app/views/analytics/index.html.haml
+++ b/app/views/analytics/index.html.haml
@@ -29,6 +29,20 @@
         %br/
         = submit_tag("Campaign Intersection", class: 'button dark')
       %br/
+      = form_tag('/mentor_requests_csv', method: :get) do
+        = label_tag('mentor_requests_campaign_id', "campaign")
+        = collection_select(:campaign, :id, Campaign.all, :id, :title, { prompt: true },
+                            { id: 'mentor_requests_campaign_id' })
+        %br/
+        = submit_tag("Mentor Requests", class: 'button dark')
+      %br/
+      = form_tag('/mentor_volunteers_csv', method: :get) do
+        = label_tag('mentor_volunteers_campaign_id', "campaign")
+        = collection_select(:campaign, :id, Campaign.all, :id, :title, { prompt: true },
+                            { id: 'mentor_volunteers_campaign_id' })
+        %br/
+        = submit_tag("Mentor Volunteers", class: 'button dark')
+      %br/
     - if params[:monthly_report]
       = render :partial => 'monthly_report', :locals => { :monthly_report => @monthly_report }
     - if params[:campaign_intersection]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,6 +320,8 @@ Rails.application.routes.draw do
   get 'usage' => 'analytics#usage'
   get 'ungreeted' => 'analytics#ungreeted'
   get 'tagged_courses_csv/:tag' => 'analytics#tagged_courses_csv'
+  get 'mentor_requests_csv' => 'analytics#mentor_requests_csv'
+  get 'mentor_volunteers_csv' => 'analytics#mentor_volunteers_csv'
   get 'all_courses_csv' => 'analytics#all_courses_csv'
   get 'all_courses' => 'analytics#all_courses'
   get 'all_campaigns' => 'analytics#all_campaigns'

--- a/lib/analytics/mentor_requests_csv_builder.rb
+++ b/lib/analytics/mentor_requests_csv_builder.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/mentorship_csv_builder"
+
+# Instructors of campaign courses tagged 'mentor_requested', which the
+# assignment wizard's mentorship panel applies when a first-time instructor
+# asks to be matched with a mentor.
+class MentorRequestsCsvBuilder < MentorshipCsvBuilder
+  MENTOR_REQUESTED_TAG = 'mentor_requested'
+
+  private
+
+  def rows
+    tagged_courses.flat_map do |course|
+      instructors(course).map do |courses_user|
+        row(courses_user.user, course, courses_user.real_name)
+      end
+    end
+  end
+
+  def tagged_courses
+    @campaign.courses.where(id: Tag.courses_tagged_with(MENTOR_REQUESTED_TAG))
+  end
+
+  def instructors(course)
+    course.courses_users.includes(:user).where(role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+  end
+end

--- a/lib/analytics/mentor_volunteers_csv_builder.rb
+++ b/lib/analytics/mentor_volunteers_csv_builder.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/mentorship_csv_builder"
+
+# Instructors who checked the "Become a mentor" option in an instructor
+# survey, scoped to responses attributable to a course in the given campaign.
+# Survey questions are cloned each term with new ids, so the question is
+# matched by its answer option wording rather than by id.
+class MentorVolunteersCsvBuilder < MentorshipCsvBuilder
+  MENTOR_OPTION = /become a mentor/i
+  SQL_PREFILTER = '%ecome a mentor%' # cheap LIKE prefilter; MENTOR_OPTION confirms per line
+
+  private
+
+  def rows
+    volunteer_pairs.map { |user, course| row(user, course) }
+  end
+
+  def volunteer_pairs
+    mentor_answers.flat_map do |answer|
+      next [] if answer.user.nil?
+      campaign_courses_for(answer).map { |course| [answer.user, course] }
+    end.uniq
+  end
+
+  def mentor_question_ids
+    Rapidfire::Question
+      .where('answer_options LIKE ?', SQL_PREFILTER)
+      .select { |question| mentor_option?(question.answer_options) }
+      .map(&:id)
+  end
+
+  def mentor_answers
+    Rapidfire::Answer
+      .where(question_id: mentor_question_ids)
+      .where('answer_text LIKE ?', SQL_PREFILTER)
+      .includes(:question, answer_group: :user)
+      .select { |answer| mentor_option?(answer.answer_text) }
+  end
+
+  # Checkbox answers store the selected option labels joined by "\r\n", so a
+  # line-level match means the mentor box was actually checked.
+  def mentor_option?(text)
+    text.to_s.split("\r\n").any? { |line| line.match?(MENTOR_OPTION) }
+  end
+
+  def campaign_courses_for(answer)
+    courses = notification_courses(answer)
+    courses = [fallback_course(answer)].compact if courses.empty?
+    courses.uniq.select { |course| course.campaigns.include?(@campaign) }
+  end
+
+  # Rapidfire::Answer#course resolves the course via the user's completed
+  # SurveyNotifications; the question group may belong to several surveys.
+  def notification_courses(answer)
+    survey_ids = answer.question.question_group.surveys.pluck(:id)
+    survey_ids.filter_map { |survey_id| answer.course(survey_id) }
+  end
+
+  # answer_groups.course_id is a guess recorded at submit time; the campaign
+  # filter in campaign_courses_for guards against misattribution.
+  def fallback_course(answer)
+    Course.find_by(id: answer.answer_group.course_id)
+  end
+end

--- a/lib/analytics/mentorship_csv_builder.rb
+++ b/lib/analytics/mentorship_csv_builder.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# Base class for campaign-scoped instructor mentorship CSVs. Subclasses
+# implement a private #rows method returning arrays shaped like CSV_HEADERS.
+class MentorshipCsvBuilder
+  CSV_HEADERS = %w[
+    real_name
+    username
+    email
+    institution
+    course_title
+    course_subject
+    course_term
+    course_slug
+  ].freeze
+
+  def initialize(campaign)
+    @campaign = campaign
+  end
+
+  def generate_csv
+    csv_data = [CSV_HEADERS]
+    rows.each { |row| csv_data << row }
+    CSV.generate { |csv| csv_data.each { |line| csv << line } }
+  end
+
+  private
+
+  def rows
+    raise NotImplementedError
+  end
+
+  def row(user, course, real_name = nil)
+    [real_name.presence || user.real_name.presence || user.username,
+     user.username,
+     user.email,
+     course.school,
+     course.title,
+     course.subject,
+     course.term,
+     course.slug]
+  end
+end

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -144,6 +144,60 @@ describe AnalyticsController, type: :request do
     end
   end
 
+  describe '#mentor_requests_csv' do
+    let(:admin) { create(:admin) }
+    let(:non_admin) { create(:user) }
+    let(:instructor) { create(:user, username: 'mentee_instructor') }
+
+    before do
+      create(:tag, course_id: 1, tag: 'mentor_requested', key: 'mentoring')
+      create(:courses_user, course_id: 1, user_id: instructor.id,
+                            role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    end
+
+    it 'blocks anonymous users' do
+      get '/mentor_requests_csv'
+      expect(response.status).to eq(401)
+    end
+
+    it 'blocks signed-in non-admin users' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(non_admin)
+      get '/mentor_requests_csv'
+      expect(response.status).to eq(401)
+    end
+
+    it 'returns a CSV for admins' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      get '/mentor_requests_csv', params: { campaign: { id: 1 } }
+      expect(response.status).to eq(200)
+      expect(response.body).to include('real_name')
+      expect(response.body).to include('mentee_instructor')
+    end
+  end
+
+  describe '#mentor_volunteers_csv' do
+    let(:admin) { create(:admin) }
+    let(:non_admin) { create(:user) }
+
+    it 'blocks anonymous users' do
+      get '/mentor_volunteers_csv'
+      expect(response.status).to eq(401)
+    end
+
+    it 'blocks signed-in non-admin users' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(non_admin)
+      get '/mentor_volunteers_csv'
+      expect(response.status).to eq(401)
+    end
+
+    it 'returns a CSV for admins' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      get '/mentor_volunteers_csv', params: { campaign: { id: 1 } }
+      expect(response.status).to eq(200)
+      expect(response.body).to include('real_name')
+    end
+  end
+
   describe '#usage' do
     it 'renders the stats page' do
       get '/usage'

--- a/spec/lib/analytics/mentor_requests_csv_builder_spec.rb
+++ b/spec/lib/analytics/mentor_requests_csv_builder_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/mentor_requests_csv_builder"
+
+describe MentorRequestsCsvBuilder do
+  let(:campaign) { create(:campaign) }
+  let(:course) do
+    create(:course, title: 'Chem 101', school: 'Test University', term: 'Fall 2026',
+                    subject: 'Chemistry', slug: 'Test_University/Chem_101_(Fall_2026)')
+  end
+  let(:instructor) do
+    create(:user, username: 'chem_instructor', real_name: 'Onboarding Name',
+                  email: 'chem@example.edu')
+  end
+
+  let(:csv) { described_class.new(campaign).generate_csv }
+  let(:lines) { csv.split("\n") }
+
+  before do
+    create(:campaigns_course, campaign_id: campaign.id, course_id: course.id)
+    create(:tag, course_id: course.id, tag: 'mentor_requested', key: 'mentoring')
+    create(:courses_user, course_id: course.id, user_id: instructor.id,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE,
+                          real_name: 'Enrollment Name')
+  end
+
+  it 'includes the expected headers' do
+    expect(lines.first).to eq(described_class::CSV_HEADERS.join(','))
+  end
+
+  it 'includes a row for the instructor of a tagged campaign course' do
+    expect(lines.second.split(',')).to eq(['Enrollment Name', 'chem_instructor',
+                                           'chem@example.edu', 'Test University', 'Chem 101',
+                                           'Chemistry', 'Fall 2026', course.slug])
+  end
+
+  it 'includes one row per co-instructor' do
+    co_instructor = create(:user, username: 'co_instructor')
+    create(:courses_user, course_id: course.id, user_id: co_instructor.id,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    expect(lines.count).to eq(3)
+    expect(csv).to include('co_instructor')
+  end
+
+  it 'excludes students of tagged courses' do
+    student = create(:user, username: 'student_user')
+    create(:courses_user, course_id: course.id, user_id: student.id,
+                          role: CoursesUsers::Roles::STUDENT_ROLE)
+    expect(csv).not_to include('student_user')
+  end
+
+  it 'excludes untagged courses in the campaign' do
+    untagged_course = create(:course, title: 'Bio 101', slug: 'Test_University/Bio_101')
+    create(:campaigns_course, campaign_id: campaign.id, course_id: untagged_course.id)
+    other_instructor = create(:user, username: 'untagged_instructor')
+    create(:courses_user, course_id: untagged_course.id, user_id: other_instructor.id,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    expect(csv).not_to include('untagged_instructor')
+  end
+
+  it 'excludes tagged courses outside the campaign' do
+    outside_course = create(:course, title: 'Phys 101', slug: 'Test_University/Phys_101')
+    create(:tag, course_id: outside_course.id, tag: 'mentor_requested', key: 'mentoring')
+    outside_instructor = create(:user, username: 'outside_instructor')
+    create(:courses_user, course_id: outside_course.id, user_id: outside_instructor.id,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    expect(csv).not_to include('outside_instructor')
+  end
+
+  it 'falls back to the user real_name, then username' do
+    CoursesUsers.find_by(user_id: instructor.id).update(real_name: nil)
+    expect(lines.second).to start_with('Onboarding Name')
+
+    instructor.update(real_name: nil)
+    fresh_csv = described_class.new(campaign).generate_csv
+    expect(fresh_csv.split("\n").second).to start_with('chem_instructor')
+  end
+end

--- a/spec/lib/analytics/mentor_volunteers_csv_builder_spec.rb
+++ b/spec/lib/analytics/mentor_volunteers_csv_builder_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/mentor_volunteers_csv_builder"
+
+describe MentorVolunteersCsvBuilder do
+  let(:campaign) { create(:campaign) }
+  let(:course) do
+    create(:course, title: 'Bio 101', school: 'Test University', term: 'Spring 2026',
+                    subject: 'Biology', slug: 'Test_University/Bio_101_(Spring_2026)')
+  end
+  let(:instructor) do
+    create(:user, username: 'bio_instructor', real_name: 'Bio Instructor',
+                  email: 'bio@example.edu')
+  end
+  let(:courses_user) do
+    create(:courses_user, course_id: course.id, user_id: instructor.id,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+  end
+
+  let(:mentor_option) { 'Become a mentor: guide a new instructor through their first term' }
+  let(:other_options) { "Host a speaker\r\nWrite a blog post" }
+  let(:survey) { create(:survey) }
+  let(:question_group) { create(:question_group) }
+  let(:question) do
+    create(:q_checkbox, question_group_id: question_group.id,
+                        answer_options: "Host a speaker\r\n#{mentor_option}\r\nWrite a blog post")
+  end
+  let(:survey_assignment) do
+    create(:survey_assignment, survey_id: survey.id, published: true,
+                               courses_user_role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+  end
+  let(:answer_group) do
+    create(:answer_group, question_group_id: question_group.id, user_id: instructor.id)
+  end
+
+  let(:csv) { described_class.new(campaign).generate_csv }
+  let(:lines) { csv.split("\n") }
+
+  before do
+    create(:campaigns_course, campaign_id: campaign.id, course_id: course.id)
+    survey.rapidfire_question_groups << question_group
+  end
+
+  def create_notification(completed: true)
+    create(:survey_notification, survey_assignment_id: survey_assignment.id,
+                                 courses_users_id: courses_user.id,
+                                 course_id: course.id, completed:)
+  end
+
+  def create_mentor_answer(question_id: question.id, group: answer_group)
+    create(:answer, answer_group_id: group.id, question_id:,
+                    answer_text: "Write a blog post\r\n#{mentor_option}")
+  end
+
+  it 'includes a row for a volunteer whose completed notification resolves the course' do
+    create_notification
+    create_mentor_answer
+    expect(lines.first).to eq(described_class::CSV_HEADERS.join(','))
+    expect(lines.second.split(',')).to eq(['Bio Instructor', 'bio_instructor',
+                                           'bio@example.edu', 'Test University', 'Bio 101',
+                                           'Biology', 'Spring 2026', course.slug])
+  end
+
+  it 'excludes answers that did not check the mentor option' do
+    create_notification
+    create(:answer, answer_group_id: answer_group.id, question_id: question.id,
+                    answer_text: other_options)
+    expect(lines.count).to eq(1)
+  end
+
+  it 'excludes responses resolving to a course outside the selected campaign' do
+    create_notification
+    create_mentor_answer
+    other_campaign = create(:campaign, title: 'Other Campaign', slug: 'other_campaign')
+    other_csv = described_class.new(other_campaign).generate_csv
+    expect(other_csv.split("\n").count).to eq(1)
+  end
+
+  it 'falls back to the answer_group course when there is no notification' do
+    answer_group.update(course_id: course.id)
+    create_mentor_answer
+    expect(lines.count).to eq(2)
+    expect(csv).to include('bio_instructor')
+  end
+
+  it 'skips responses with no notification and no answer_group course' do
+    create_mentor_answer
+    expect(lines.count).to eq(1)
+  end
+
+  it 'does not resolve a course from an incomplete notification' do
+    create_notification(completed: false)
+    create_mentor_answer
+    expect(lines.count).to eq(1)
+  end
+
+  it 'resolves the course when the question group belongs to multiple surveys' do
+    second_survey = create(:survey, name: 'Second Survey')
+    second_survey.rapidfire_question_groups << question_group
+    second_assignment = create(:survey_assignment, survey_id: second_survey.id, published: true,
+                               courses_user_role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    create(:survey_notification, survey_assignment_id: second_assignment.id,
+                                 courses_users_id: courses_user.id,
+                                 course_id: course.id, completed: true)
+    create_mentor_answer
+    expect(csv).to include('bio_instructor')
+  end
+
+  it 'matches per-term question clones by option wording rather than id' do
+    create_notification
+    clone = create(:q_checkbox, question_group_id: question_group.id,
+                                question_text: '(Copy) Checkbox Question',
+                                answer_options: question.answer_options)
+    create_mentor_answer(question_id: clone.id)
+    expect(csv).to include('bio_instructor')
+  end
+
+  it 'emits one row per (user, course) pair even with multiple matching answers' do
+    create_notification
+    clone = create(:q_checkbox, question_group_id: question_group.id,
+                                answer_options: question.answer_options)
+    create_mentor_answer
+    create_mentor_answer(question_id: clone.id, group: create(:answer_group,
+                                                              question_group_id: question_group.id,
+                                                              user_id: instructor.id))
+    expect(lines.count).to eq(2)
+  end
+end


### PR DESCRIPTION
## What this PR does

Adds two admin-only, campaign-scoped CSV downloads to the `/analytics` page to support the instructor mentorship program, which each term needs to match new instructors who asked for a mentor with experienced instructors who volunteered to be one:

- **Mentor Requests** (`/mentor_requests_csv?campaign[id]=N`) — instructors of campaign courses tagged `mentor_requested`, the tag the assignment wizard's "Mentorship program" panel applies when a first-time instructor asks to be matched with a mentor.
- **Mentor Volunteers** (`/mentor_volunteers_csv?campaign[id]=N`) — instructors who checked the "Become a mentor: …" option in an end-of-term instructor survey, scoped to responses attributable to a course in the selected campaign.

Both CSVs share one column shape: `real_name, username, email, institution, course_title, course_subject, course_term, course_slug`.

Implementation notes:

- Survey questions are cloned with new ids each term (sometimes `(Copy) `-prefixed), so the volunteers report matches the answer-option wording (`/become a mentor/i`, with a SQL `LIKE` prefilter) across all question ids rather than pinning an id. A line-level match on the `"\r\n"`-joined `answer_text` confirms the box was actually checked.
- The response→course link goes through the user's completed `SurveyNotification`s (the reliable path), falling back to `answer_groups.course_id` — a submit-time guess, guarded by the campaign filter — and skipping responses that can't be attributed at all.
- Follows the existing `tagged_courses_csv` pattern: builders in `lib/analytics/` (a shared `MentorshipCsvBuilder` base plus two small subclasses), inline `send_data` actions on `AnalyticsController` behind `require_admin_permissions`, and top-level routes (the `/analytics(/*any)` catch-all makes nested paths unreachable).

## AI usage

This feature was implemented by Claude Code (Fable 5) under direction from @ragesoss, who defined the feature (the staff request for a per-term mentee CSV, the two data sources, and the need for wording-robust survey matching), supplied the survey option wording, and made the scoping decisions (add email/username columns; scope volunteers by the course's campaign). Claude Code explored the codebase, proposed the plan, wrote all the code and specs, wrote the commit message, and drafted this PR description — including the summary above, which may contain errors.

Scale of effort: a single commit produced in one focused session on 2026-08-17, following a plan-mode design pass. The first spec run had two failures (test-setup issue: Rapidfire validates checkbox answers against the question's `answer_options`); everything passed after that fix, and the suite was re-verified after rebasing the work onto current master.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

**01 analytics tools page**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/MentorshipCsvReports/screenshots/before/01_analytics_tools_page.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/MentorshipCsvReports/screenshots/after/01_analytics_tools_page.png) |

**02 campaigns selected**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/MentorshipCsvReports/screenshots/after/02_campaigns_selected.png) |

## Open questions and concerns

- The button labels ("Mentor Requests" / "Mentor Volunteers") and the `campaign` field labels were chosen by Claude Code, matching the terse style of the existing forms on this page — rename if different wording is preferred.
- If a future survey rewords the option away from the phrase "become a mentor", the `MENTOR_OPTION` / `SQL_PREFILTER` constants in `MentorVolunteersCsvBuilder` are the single knob to update.
- The `answer_groups.course_id` fallback can name a sibling same-term course for multi-course instructors; the person and campaign membership are still correct, and the campaign filter discards wrong guesses outside the selected term.
- Submitting either form with the campaign prompt still selected raises (no campaign param) — the same behavior as the existing campaign-intersection form on this page.
- Possible follow-up, deliberately out of scope to keep both CSVs the same shape: an extra column with the exact option text the volunteer checked, useful when wording varies across terms.

(PR description written by Claude Code.)
