### PR TITLE
Add assume_ssl for Peony's proxy-terminated TLS

### DIFF
--- a/config/application.programs-and-events.yml
+++ b/config/application.programs-and-events.yml
@@ -64,3 +64,8 @@
   update_debug_DailyUpdate: 'true'
 
   REDIS_URL: 'redis://p-and-e-dashboard-redis'
+
+# Peony sits behind WMCloud's TLS-terminating proxy. This tells Rails to
+# treat every request as SSL, avoiding redirect loops when the proxy
+# omits the X-Forwarded-Proto header.
+  ASSUME_SSL: 'true'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,6 +29,14 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  # The P&E Dashboard sits behind WMCloud's TLS-terminating proxy, which
+  # forwards plain HTTP to Apache. Rails relies on X-Forwarded-Proto to know the
+  # original request was HTTPS. If the proxy ever omits that header, force_ssl
+  # enters a redirect loop — this caused a 91-minute outage on 2026-08-17.
+  # assume_ssl makes request.ssl? unconditionally true, eliminating that mode.
+  # Only safe behind a TLS-terminating proxy; the Wiki Ed Dashboard terminates
+  # TLS directly and needs force_ssl to redirect plain HTTP.
+  config.assume_ssl = true if ENV['ASSUME_SSL']
 
   # Set to :debug to see everything in the log.
   config.logger = Logger.new(STDOUT)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  config.assume_ssl = true if ENV['ASSUME_SSL']
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
## Summary

- Add `config.assume_ssl = true if ENV['ASSUME_SSL']` to production.rb and staging.rb, with an explanatory comment in production.rb
- Add `ASSUME_SSL: 'true'` to the P&E `application.yml` template

On 2026-08-17, the P&E Dashboard had a ~91-minute outage caused by a redirect loop: WMCloud's TLS-terminating proxy temporarily stopped sending `X-Forwarded-Proto: https`, so `config.force_ssl` saw every request as plain HTTP and redirected it — which the proxy forwarded right back, creating an infinite loop.

`config.assume_ssl` (Rails 7.1+) makes `request.ssl?` unconditionally true, eliminating the redirect-loop failure mode entirely. It's gated on `ENV['ASSUME_SSL']` so it only activates on Peony (behind the proxy); the Wiki Ed Dashboard terminates TLS directly and still needs `force_ssl` to redirect plain HTTP.

After merging and deploying, `ASSUME_SSL: 'true'` also needs to be added to the real `application.yml` on peony-web.

Relates to #6990.

## Test plan

- [ ] Deploy to Peony with `ASSUME_SSL: 'true'` in `application.yml`
- [ ] Verify `https://outreachdashboard.wmflabs.org/` loads normally
- [ ] Verify Wiki Ed production (no env var set) still redirects HTTP → HTTPS

(PR description written by Claude Code.)