### PR TITLE
Fix ticket reply formatting and CC serialization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/WikiEducationFoundation/TicketDispenser.git
-  revision: fb9f7372bfb67c95b91662b83f4ae67da67d7263
+  revision: e0cbc2bfd46a563e634369d5ec8dde0c4a09c9d8
   specs:
     ticket_dispenser (0.1.0)
       active_model_serializers

--- a/app/assets/javascripts/components/tickets/reply.jsx
+++ b/app/assets/javascripts/components/tickets/reply.jsx
@@ -7,6 +7,35 @@ import HelperIcon from './helper_icon';
 import DeleteNote from './delete_note';
 import { formatDateWithTime } from '../../utils/date_utils';
 
+// Message content arrives in two shapes. Replies composed in the WYSIWYG editor
+// are HTML, and that is exactly what the recipient receives, since the mailer
+// renders the content raw. Inbound email replies are plain text with real
+// newlines (see EmailProcessor). So detect which shape a message is in by
+// looking for the block markup an editor message always carries: HTML renders
+// with its own block structure, while plain text keeps relying on
+// `white-space: pre-line` to turn its newlines into breaks.
+const BLOCK_MARKUP = /<(?:p|br|div|ul|ol|li|h[1-6]|blockquote|pre)\b[^>]*>/i;
+
+// The tags the WYSIWYG editor can emit, plus the basics used by messages from
+// the earlier TinyMCE editor. Attributes stay limited to link targets, so
+// nothing here can carry a script handler.
+const RICH_TEXT_TAGS = [
+  'a', 'b', 'blockquote', 'br', 'code', 'div', 'em', 'h1', 'h2', 'h3', 'h4',
+  'h5', 'h6', 'hr', 'i', 'li', 'ol', 'p', 'pre', 's', 'strong', 'u', 'ul'
+];
+
+const sanitizedBody = (content) => {
+  const isHtml = BLOCK_MARKUP.test(content);
+  const linkified = linkifyHtml(content, { target: { url: '_blank' } });
+  return {
+    isHtml,
+    html: DOMPurify.sanitize(linkified, {
+      ALLOWED_TAGS: isHtml ? RICH_TEXT_TAGS : ['a'],
+      ALLOWED_ATTR: ['href', 'target', 'rel']
+    })
+  };
+};
+
 export const Reply = ({ message }) => {
   const { sender, details } = message;
   let delivered_message;
@@ -48,13 +77,17 @@ export const Reply = ({ message }) => {
   }
 
   const from = sender.real_name || sender.username || details.sender_email;
+  const body = sanitizedBody(message.content);
   return (
     <div className={messageClass} >
       <section className="reply-header module mb0 mt0">
         {subject}
         { cc }
         { (subject || cc) && <hr /> }
-        <div className="plaintext message-body" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(linkifyHtml(message.content, { target: { url: '_blank' } }), { ALLOWED_TAGS: ['a'], ALLOWED_ATTR: ['href', 'target', 'rel'] }) }} />
+        <div
+          className={`message-body ${body.isHtml ? 'rich-text' : 'plaintext'}`}
+          dangerouslySetInnerHTML={{ __html: body.html }}
+        />
       </section>
       <div className="reply-details">
         <span className="from">

--- a/app/assets/stylesheets/modules/_ticket_dashboard.styl
+++ b/app/assets/stylesheets/modules/_ticket_dashboard.styl
@@ -20,6 +20,15 @@
   .message-body
     white-space pre-line
     overflow-x auto
+  // Messages composed in the WYSIWYG editor carry their own block markup, so
+  // they need normal whitespace handling rather than `pre-line`, and their
+  // paragraphs need the spacing that `.messages p` below otherwise removes.
+  .message-body.rich-text
+    white-space normal
+    p
+      margin-bottom 16px
+      &:last-child
+        margin-bottom 0
   .messages
     span(3/4)
     p

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -68,6 +68,19 @@ describe TicketsController, type: :request do
       expect(delivery.text_part.body).to include('this is a reply')
     end
 
+    it 'keeps the paragraph breaks of a reply composed in the wysiwyg editor' do
+      message.update(content: '<p>First paragraph.</p><p>Second paragraph.</p>')
+      expect(TicketNotificationMailer).to receive(:notify_of_message).and_call_original
+      post '/tickets/reply', params: { message_id: message.id, sender_id: admin.id }
+
+      delivery = ActionMailer::Base.deliveries.first
+      # Premailer inlines CSS onto the paragraphs, so match the block boundary
+      # rather than the bare tags.
+      expect(delivery.html_part.body.to_s)
+        .to match(%r{First paragraph\.</p>\s*<p[^>]*>Second paragraph\.})
+      expect(delivery.text_part.body.to_s).to include("First paragraph.\n\nSecond paragraph.")
+    end
+
     it 'triggers an email reply even if there is no sender' do
       message.update(sender: nil, details: { sender_email: user.email })
       expect(TicketNotificationMailer).to receive(:notify_of_message).and_call_original

--- a/spec/features/ticket_reply_cc_spec.rb
+++ b/spec/features/ticket_reply_cc_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'replying to a ticket with a CC address', type: :feature, js: true do
+  let(:course) { create(:course) }
+  let(:admin) { create(:admin, email: 'spec@wikiedu.org') }
+
+  before do
+    login_as admin
+    stub_token_request
+    create(:courses_user, course:, user: admin,
+                          role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+  end
+
+  it 'sends the reply instead of failing to save it' do
+    visit "/courses/#{course.slug}"
+    click_button 'Get Help'
+    click_button 'question about editing Wikipedia'
+    fill_in 'message', with: 'I need some help with adding a photo to my article.'
+    click_button 'Send'
+    click_button 'Ok'
+
+    click_link 'Admin'
+    click_link 'Open Tickets: 1'
+    click_link 'Show'
+
+    within('form.tickets-reply') do
+      find('button.plus').click
+      fill_in 'cc', with: 'cc@example.com'
+      find('.wysiwyg-editor__content').click
+      find('.wysiwyg-editor__content').send_keys('Looping in a colleague.')
+    end
+    click_button 'Send Reply'
+
+    # The CC details used to 500 on save, which surfaced here as a failure
+    # notice and left the reply unsent.
+    expect(page).to have_content 'Ticket is currently Awaiting Response'
+    expect(page).not_to have_content 'Creation of message failed'
+    # The CC line is uppercased by `text-transform`, which Capybara reflects.
+    expect(page).to have_content(/cc@example\.com/i)
+    expect(TicketDispenser::Message.last.details[:cc]).to eq([{ email: 'cc@example.com' }])
+  end
+end

--- a/spec/features/ticket_reply_formatting_spec.rb
+++ b/spec/features/ticket_reply_formatting_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'ticket reply formatting', type: :feature, js: true do
+  let(:course) { create(:course) }
+  let(:admin) { create(:admin, email: 'spec@wikiedu.org') }
+
+  before do
+    login_as admin
+    stub_token_request
+    create(:courses_user, course:, user: admin,
+                          role: CoursesUsers::Roles::WIKI_ED_STAFF_ROLE)
+  end
+
+  it 'keeps the paragraph breaks of a reply composed in the wysiwyg editor' do
+    visit "/courses/#{course.slug}"
+    click_button 'Get Help'
+    click_button 'question about editing Wikipedia'
+    fill_in 'message', with: 'I need some help with adding a photo to my article.'
+    click_button 'Send'
+    click_button 'Ok'
+
+    click_link 'Admin'
+    click_link 'Open Tickets: 1'
+    click_link 'Show'
+
+    within('form.tickets-reply') do
+      find('.wysiwyg-editor__content').click
+      find('.wysiwyg-editor__content').send_keys('First paragraph.', :enter, :enter,
+                                                 'Second paragraph.')
+    end
+    click_button 'Send Reply'
+    expect(page).to have_content 'Ticket is currently Awaiting Response'
+
+    # The two paragraphs must stay separate blocks. Before the reply body
+    # rendered its HTML, the paragraph tags were stripped and the text ran
+    # together as 'First paragraph.Second paragraph.'
+    body = all('.message-body').find { |div| div.text.include?('First paragraph.') }
+    expect(body.text).not_to include 'First paragraph.Second paragraph.'
+    expect(body).to have_selector 'p', text: 'First paragraph.'
+    expect(body).to have_selector 'p', text: 'Second paragraph.'
+  end
+
+  it 'keeps the newlines of a plain text message that has no markup' do
+    ticket = TicketDispenser::Dispenser.call(
+      content: "First line.\n\nSecond line.",
+      owner_id: admin.id,
+      project_id: course.id,
+      sender_id: admin.id,
+      details: { subject: 'Plain text reply' }
+    )
+
+    visit "/tickets/dashboard/#{ticket.id}"
+
+    body = all('.message-body').find { |div| div.text.include?('First line.') }
+    expect(body[:class]).to include 'plaintext'
+    expect(body.text).not_to include 'First line.Second line.'
+  end
+end

--- a/spec/requests/ticket_reply_cc_spec.rb
+++ b/spec/requests/ticket_reply_cc_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the TicketDispenser engine endpoint the reply form posts to. A reply
+# carrying CC addresses used to 500 here: the engine turned the permitted
+# `details` params into a HashWithIndifferentAccess, which the YAML-serialized
+# `details` column cannot dump under safe_dump.
+describe 'creating a ticket reply', type: :request do
+  let(:admin) { create(:admin, email: 'admin@wikiedu.org') }
+  let(:user) { create(:user, email: 'student@hello.edu') }
+  let(:ticket) do
+    TicketDispenser::Dispenser.call(content: 'hello', owner_id: admin.id, sender_id: user.id)
+  end
+
+  before { login_as admin }
+
+  def post_reply(details)
+    post '/td/tickets/replies', params: {
+      content: '<p>Reply body.</p>',
+      kind: TicketDispenser::Message::Kinds::REPLY,
+      ticket_id: ticket.id,
+      sender_id: admin.id,
+      read: true,
+      status: TicketDispenser::Ticket::Statuses::AWAITING_RESPONSE,
+      **details
+    }, as: :json
+  end
+
+  it 'stores CC addresses so the mailer can read them' do
+    post_reply(details: { cc: [{ email: 'cc@example.com' }, { email: 'two@example.com' }] })
+
+    expect(response.status).to eq(201)
+    # Symbol keys all the way down: TicketNotificationMailer#carbon_copy reads
+    # `details[:cc]` and then `entry[:email]` on each entry.
+    expect(TicketDispenser::Message.last.details[:cc])
+      .to eq([{ email: 'cc@example.com' }, { email: 'two@example.com' }])
+  end
+
+  it 'creates a reply with no CC addresses' do
+    post_reply({})
+
+    expect(response.status).to eq(201)
+    expect(TicketDispenser::Message.last.details).to eq({})
+  end
+end


### PR DESCRIPTION
## What this PR does

Fixes two bugs in the Tickets UI, both found while using the ticket thread after
the TinyMCE → TipTap editor switch (#6929).

**1. Replies lost all their formatting in the thread view.** Composing a reply
with two paragraphs rendered as a single run-together line — a sentence ending
in a period followed immediately by the next sentence, no space at all.
`reply.jsx` sanitized message content with `ALLOWED_TAGS: ['a']`, which deletes
every block tag and keeps only the text. That looked correct under TinyMCE purely
by accident: TinyMCE's serializer emitted a literal newline between blocks, and
`.message-body { white-space: pre-line }` turned those newlines into breaks.
TipTap's `getHTML()` emits no whitespace between blocks, so once the tags were
stripped there was nothing left to break on. The thread now renders the tags the
editor can emit, so it shows what the recipient actually received.

The emailed reply was never affected — `notify.html.haml` renders
`raw(@message.content)`, and both MIME parts of a delivery were verified to keep
the paragraph break. This was display-only.

**2. Replying with a CC address returned a 500.** Reported via Sentry
([DASHBOARD-WIKIEDU-ORG-2R2](https://wiki-education.sentry.io/issues/DASHBOARD-WIKIEDU-ORG-2R2)):
`Psych::DisallowedClass: Tried to dump unspecified class:
ActiveSupport::HashWithIndifferentAccess`. The bug was in the TicketDispenser
engine, fixed in
[TicketDispenser#43](https://github.com/WikiEducationFoundation/TicketDispenser/pull/43)
and picked up here as a `Gemfile.lock` bump. `Parameters#to_h` returns a
`HashWithIndifferentAccess`, which the YAML-serialized `details` column cannot
dump under `safe_dump` given our `yaml_column_permitted_classes`; the engine's
`deep_transform_keys(&:to_sym)` was a no-op against it, since on a
`HashWithIndifferentAccess` it re-stringifies the keys it is handed.

Because `Message.create` succeeded before the raise, the reply was saved to the
thread without its CC and no email was sent — staff saw both "Creation of
message failed. Please try again." and "Message was created but email could not
be sent." for the same reply, and retrying saved a duplicate. Only the CC path
was affected: with no CC field `details` is `nil`, so `nil.to_h` already produced
a plain empty `Hash` that dumped fine. No data repair is needed, since the dump
always failed and no malformed rows were persisted.

Widening the sanitizer allowlist touches the stored-XSS fix from 794ebbf11, so
that guarantee was re-checked against ten payloads (script tags,
`onerror`/`onclick`, `javascript:` hrefs, iframe, `svg onload`, `style` overlay,
object/embed, form) — all still neutralized, since attributes stay limited to
`href`/`target`/`rel` and no script-bearing tag is allowed.

## AI usage

Claude Code did essentially all of the work here — diagnosis, both fixes, the
specs, and the commit messages — under short human direction. Across the whole
session the operator sent about eight messages: an opening paragraph-length bug
report with reproduction detail, a two-sentence report of the CC bug with the
Sentry link, two multiple-choice answers picking the approach for each fix, and
the rest one-liners ("sounds good. please commit.", cut a branch from latest
master, push and open a PR, combine both fixes). The technical choices, the
verification strategy, and the cross-repo sequencing were delegated. The commit
messages carry `Co-Authored-By: Claude` trailers and `## Process` sections with
more detail.

Two decisions were escalated rather than assumed, because they changed the
work materially: whether the thread should render the rich text or stay plain
with breaks restored (operator chose rendering it), and whether to fix the CC
bug properly in the gem or work around it here by adding
`HashWithIndifferentAccess` to `yaml_column_permitted_classes` (operator chose
the gem).

Both commits were made within a single session on 2026-08-18, roughly two hours
apart, so this represents one focused sitting rather than sustained iteration.
Reviewers should calibrate accordingly: the human review of the generated code
was correspondingly light, and the "What this PR does" summary and other
analysis above were also drafted by Claude Code and may contain errors.

Verification (all re-run on this combined branch against the bumped gem):
28 Ruby examples across `tickets_controller_spec` / `ticket_reply_cc_spec`
request spec / `email_processor_spec`, plus four feature specs —
`ticket_reply_formatting_spec` (2), `ticket_reply_cc_spec` (1), `tickets_spec`
(1), `tickets_dashboard_spec` (14). Each new spec was confirmed to fail without
its fix, not merely pass with it. RuboCop clean; ESLint 0 errors (the three
warnings in `reply.jsx` are pre-existing i18next warnings on untouched lines).

This PR description was drafted using the `/prepare-pr` Claude Code skill.

## Screenshots

One thread showing both fixes: a staff reply with paragraphs, bold and a bullet
list, carrying a CC address. The student's opening message is plain text with
real newlines, so it also exercises the plain-text path that inbound email
replies use.

Captured manually rather than with `bin/pr-screenshots`, because that script's
"before" pass checks out master without rebuilding assets — which would have
silently reused this branch's compiled CSS and JS and shown no difference at all.
Each pass here got its own `yarn build`.

Before:

![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/TicketReplyFixes/screenshots/before/01_ticket_thread_reply.png)

After:

![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/TicketReplyFixes/screenshots/after/01_ticket_thread_reply.png)

## Open questions and concerns

- **The P&E Dashboard needs this too.** It deploys TicketDispenser
  independently, so `wmflabs`/`peony` carries the same CC bug and needs this
  `Gemfile.lock` bump, not just Wiki Ed.
- **Heading sizes in replies.** A "Heading 2" in a reply now renders at the
  global base size (~1.95em), which is large next to the 1.25em subject line.
  Left alone rather than expanding scope into heading sizing; worth a follow-up
  if staff actually use headings in replies.
- **The gem's own test suite cannot run.** TicketDispenser's `Gemfile.lock` can
  no longer be installed — `mimemagic 0.3.3` has been yanked from rubygems — so
  the regression specs for the CC fix live in this repo instead, and the gem PR
  ships without one. Refreshing that lockfile is worth doing separately.
- **`bundle update ticket_dispenser` is not safe to run plainly here.** It drags
  in ~25 unrelated gems (`rdoc` 7.2 → 8.0, `minitest`, `json`, `i18n`, `mysql2`,
  `zeitwerk`) and drops `psych` and `stringio` from the lockfile. This PR used
  `--conservative` to keep the diff to the one revision line.
- **HTML detection is a heuristic.** A message is treated as HTML if it contains
  a block-level tag. A plain-text message that merely mentions an inline tag in
  prose is therefore safe, but one that literally contains `<p>` in its text
  would be misread. Both editors always wrap content in a block, so the inverse
  case does not arise in practice.

(PR description written by Claude Code.)
