### PR TITLE
Skip empty timeslices via wide-window precheck during course updates

### DIFF
--- a/app/services/find_timeslices_with_revisions.rb
+++ b/app/services/find_timeslices_with_revisions.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/replica"
+require_dependency "#{Rails.root}/lib/revision_data_manager"
 require_dependency "#{Rails.root}/lib/utils/replica_timeslice_bounds"
 
 #= Determines which of a course's wiki timeslices contain at least one tracked
-# revision, using a single wide-window Replica query instead of one query per
+# revision, using a wide-window Replica query instead of one query per
 # timeslice. UpdateCourseWikiTimeslices uses this to skip fetching timeslices
 # that are known to be empty — the dominant update cost for long-dormant
 # courses with far-future end dates, whose ingestion watermark never advances
 # past the last student edit (issue #7005).
 #
 # Exposes `slice_starts`: a Set of start datetimes for the timeslices that
-# contain revisions, or nil if the Replica query failed — callers should fall
+# contain revisions, or nil if a Replica query failed — callers should fall
 # back to a full per-timeslice scan in that case.
 class FindTimeslicesWithRevisions
   attr_reader :slice_starts
@@ -29,20 +30,40 @@ class FindTimeslicesWithRevisions
 
   def perform
     return if @timeslices.empty?
-    raw = fetch_wide_window_revisions
-    # A non-Enumerable result means the Replica query failed after retries;
-    # leave slice_starts nil so the caller knows the gap couldn't be checked.
-    return unless raw.is_a?(Enumerable)
-    rev_timestamps = raw.filter_map { |row| row['rev_timestamp'] }.sort
+    rows = fetch_wide_window_revisions
+    # nil means a Replica query failed after retries; leave slice_starts nil so
+    # the caller knows the gap couldn't be checked.
+    return if rows.nil?
+    rev_timestamps = rows.filter_map { |row| row['rev_timestamp'] }.sort
     @slice_starts = nonempty_slice_starts(rev_timestamps)
   end
 
+  # One query per chunk of users, each covering the whole timeslice range. The
+  # user list is chunked at the same limit RevisionDataManager uses, to stay
+  # within the Replica endpoint's memory limit; a wide window makes that limit
+  # more relevant here, not less. Utils.chunk_requests can't be used: it maps a
+  # failed chunk's nil to [], which is indistinguishable from a genuinely empty
+  # result and would mark timeslices empty in error. Returns nil if any chunk
+  # fails, so that the caller falls back to a full per-timeslice scan.
   def fetch_wide_window_revisions
-    Replica.new(@wiki, @update_service).get_revisions_raw(
-      @course.students,
-      ReplicaTimesliceBounds.real_start(@course, @timeslices.first.start),
-      ReplicaTimesliceBounds.real_end(@course, @timeslices.last.end)
-    )
+    @course.students.each_slice(RevisionDataManager::MAX_USERNAMES)
+           .each_with_object([]) do |users, rows|
+      raw = query_replica(users)
+      return nil unless raw.is_a?(Enumerable)
+      rows.concat raw.to_a
+    end
+  end
+
+  def query_replica(users)
+    Replica.new(@wiki, @update_service).get_revisions_raw(users, rev_start, rev_end)
+  end
+
+  def rev_start
+    @rev_start ||= ReplicaTimesliceBounds.real_start(@course, @timeslices.first.start)
+  end
+
+  def rev_end
+    @rev_end ||= ReplicaTimesliceBounds.real_end(@course, @timeslices.last.end)
   end
 
   # Replica rev_timestamps are '%Y%m%d%H%M%S' strings, the same format

--- a/app/services/find_timeslices_with_revisions.rb
+++ b/app/services/find_timeslices_with_revisions.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/replica"
+require_dependency "#{Rails.root}/lib/utils/replica_timeslice_bounds"
+
+#= Determines which of a course's wiki timeslices contain at least one tracked
+# revision, using a single wide-window Replica query instead of one query per
+# timeslice. UpdateCourseWikiTimeslices uses this to skip fetching timeslices
+# that are known to be empty — the dominant update cost for long-dormant
+# courses with far-future end dates, whose ingestion watermark never advances
+# past the last student edit (issue #7005).
+#
+# Exposes `slice_starts`: a Set of start datetimes for the timeslices that
+# contain revisions, or nil if the Replica query failed — callers should fall
+# back to a full per-timeslice scan in that case.
+class FindTimeslicesWithRevisions
+  attr_reader :slice_starts
+
+  # `timeslices` is a collection of CourseWikiTimeslice records for one wiki.
+  def initialize(course, wiki, timeslices, update_service: nil)
+    @course = course
+    @wiki = wiki
+    @timeslices = timeslices.sort_by(&:start)
+    @update_service = update_service
+    perform
+  end
+
+  private
+
+  def perform
+    return if @timeslices.empty?
+    raw = fetch_wide_window_revisions
+    # A non-Enumerable result means the Replica query failed after retries;
+    # leave slice_starts nil so the caller knows the gap couldn't be checked.
+    return unless raw.is_a?(Enumerable)
+    rev_timestamps = raw.filter_map { |row| row['rev_timestamp'] }.sort
+    @slice_starts = nonempty_slice_starts(rev_timestamps)
+  end
+
+  def fetch_wide_window_revisions
+    Replica.new(@wiki, @update_service).get_revisions_raw(
+      @course.students,
+      ReplicaTimesliceBounds.real_start(@course, @timeslices.first.start),
+      ReplicaTimesliceBounds.real_end(@course, @timeslices.last.end)
+    )
+  end
+
+  # Replica rev_timestamps are '%Y%m%d%H%M%S' strings, the same format
+  # ReplicaTimesliceBounds produces, so lexicographic comparison matches
+  # chronological order and no timezone parsing is needed.
+  def nonempty_slice_starts(rev_timestamps)
+    @timeslices.each_with_object(Set.new) do |timeslice, starts|
+      first_in_slice = rev_timestamps.bsearch do |ts|
+        ts >= ReplicaTimesliceBounds.real_start(@course, timeslice.start)
+      end
+      next if first_in_slice.nil?
+      starts << timeslice.start if within_slice?(first_in_slice, timeslice)
+    end
+  end
+
+  def within_slice?(rev_timestamp, timeslice)
+    rev_timestamp <= ReplicaTimesliceBounds.real_end(@course, timeslice.end)
+  end
+end

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -13,10 +13,10 @@ require_dependency "#{Rails.root}/lib/revision_scanner"
 # and, if the timeslice exceeds the threshold, recursively splits it until all
 # timeslices are within limits.
 class UpdateCourseWikiTimeslices
-  # When the range of timeslices to process is longer than this, a single
-  # wide-window Replica query determines which of them actually contain
-  # revisions, so that empty ones can be skipped instead of fetched one by
-  # one. Short ranges (the common case for active courses) aren't worth the
+  # When the range of timeslices to process is longer than this, a wide-window
+  # Replica query (one per chunk of users) determines which of them actually
+  # contain revisions, so that empty ones can be skipped instead of fetched one
+  # by one. Short ranges (the common case for active courses) aren't worth the
   # extra query.
   GAP_PRECHECK_THRESHOLD = 7
 
@@ -90,20 +90,30 @@ class UpdateCourseWikiTimeslices
     @debugger.log_update_progress :"timeslices_processed_#{wiki.id}"
   end
 
-  # Skips timeslices that a single wide-window Replica query shows to contain
-  # no revisions; processing them would be a no-op. The first timeslice is
+  # Skips timeslices that a wide-window Replica query shows to contain no
+  # revisions; processing them would be a no-op. The first timeslice is
   # always kept: it's the only one in the range that can already have recorded
   # revisions (it contains the ingestion watermark), so it must be re-fetched
   # to detect on-wiki revision deletions and to re-ingest partial data. If the
   # wide query fails, fall back to processing the full range.
   def precheck_nonempty_timeslices(wiki, to_process)
-    return to_process if to_process.count <= GAP_PRECHECK_THRESHOLD
     slices = to_process.to_a
-    nonempty = FindTimeslicesWithRevisions.new(@course, wiki, slices,
-                                               update_service: @update_service).slice_starts
-    return to_process if nonempty.nil?
+    return slices if slices.size <= GAP_PRECHECK_THRESHOLD
+    nonempty = nonempty_slice_starts(wiki, slices)
+    return slices if nonempty.nil?
     watermark_start = slices.map(&:start).min
     slices.select { |t| t.start == watermark_start || nonempty.include?(t.start) }
+  end
+
+  # The starts of the timeslices that contain revisions, or nil if that couldn't
+  # be determined. When there's no point importing revisions for this course,
+  # every per-timeslice fetch would short-circuit before reaching Replica, so no
+  # timeslice can contain revisions and no query is needed — skipping the query
+  # keeps such courses from paying for a precheck they can't benefit from.
+  def nonempty_slice_starts(wiki, slices)
+    return Set.new if @revision_updater.no_point_in_importing_revisions?
+    FindTimeslicesWithRevisions.new(@course, wiki, slices,
+                                    update_service: @update_service).slice_starts
   end
 
   def fetch_data_and_reprocess_acuwt_timeslices(wiki)

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -94,8 +94,11 @@ class UpdateCourseWikiTimeslices
   # revisions; processing them would be a no-op. The first timeslice is
   # always kept: it's the only one in the range that can already have recorded
   # revisions (it contains the ingestion watermark), so it must be re-fetched
-  # to detect on-wiki revision deletions and to re-ingest partial data. If the
-  # wide query fails, fall back to processing the full range.
+  # to detect on-wiki revision deletions and to re-ingest partial data. (In an
+  # all_time update the range instead starts at the course start, but there
+  # recreate_timeslices has already deleted and recreated every timeslice, so
+  # later slices hold no recorded data in that mode either.) If the wide query
+  # fails, fall back to processing the full range.
   def precheck_nonempty_timeslices(wiki, to_process)
     slices = to_process.to_a
     return slices if slices.size <= GAP_PRECHECK_THRESHOLD

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -16,9 +16,11 @@ class UpdateCourseWikiTimeslices
   # When the range of timeslices to process is longer than this, a wide-window
   # Replica query (one per chunk of users) determines which of them actually
   # contain revisions, so that empty ones can be skipped instead of fetched one
-  # by one. Short ranges (the common case for active courses) aren't worth the
-  # extra query.
-  GAP_PRECHECK_THRESHOLD = 7
+  # by one. Short ranges aren't worth the extra query: this covers active
+  # courses (typically a range of a day or two) with margin to spare, so that
+  # even a backlog from several days of queue latency doesn't push every
+  # course through the precheck branch.
+  GAP_PRECHECK_THRESHOLD = 30
 
   def initialize(course, debugger, update_service: nil)
     @course = course

--- a/app/services/update_course_wiki_timeslices.rb
+++ b/app/services/update_course_wiki_timeslices.rb
@@ -13,6 +13,13 @@ require_dependency "#{Rails.root}/lib/revision_scanner"
 # and, if the timeslice exceeds the threshold, recursively splits it until all
 # timeslices are within limits.
 class UpdateCourseWikiTimeslices
+  # When the range of timeslices to process is longer than this, a single
+  # wide-window Replica query determines which of them actually contain
+  # revisions, so that empty ones can be skipped instead of fetched one by
+  # one. Short ranges (the common case for active courses) aren't worth the
+  # extra query.
+  GAP_PRECHECK_THRESHOLD = 7
+
   def initialize(course, debugger, update_service: nil)
     @course = course
     @timeslice_manager = TimesliceManager.new(@course)
@@ -67,6 +74,7 @@ class UpdateCourseWikiTimeslices
     to_process = CourseWikiTimeslice.for_course_and_wiki(@course, wiki)
                                     .where('start >= ?', first_start)
                                     .where('start <= ?', latest_start)
+    to_process = precheck_nonempty_timeslices(wiki, to_process)
     to_process.each do |t|
       # If the timeslice was reprocessed in this update, then skip it
       next if timeslice_reprocessed?(wiki.id, t.start)
@@ -80,6 +88,22 @@ class UpdateCourseWikiTimeslices
       end
     end
     @debugger.log_update_progress :"timeslices_processed_#{wiki.id}"
+  end
+
+  # Skips timeslices that a single wide-window Replica query shows to contain
+  # no revisions; processing them would be a no-op. The first timeslice is
+  # always kept: it's the only one in the range that can already have recorded
+  # revisions (it contains the ingestion watermark), so it must be re-fetched
+  # to detect on-wiki revision deletions and to re-ingest partial data. If the
+  # wide query fails, fall back to processing the full range.
+  def precheck_nonempty_timeslices(wiki, to_process)
+    return to_process if to_process.count <= GAP_PRECHECK_THRESHOLD
+    slices = to_process.to_a
+    nonempty = FindTimeslicesWithRevisions.new(@course, wiki, slices,
+                                               update_service: @update_service).slice_starts
+    return to_process if nonempty.nil?
+    watermark_start = slices.map(&:start).min
+    slices.select { |t| t.start == watermark_start || nonempty.include?(t.start) }
   end
 
   def fetch_data_and_reprocess_acuwt_timeslices(wiki)

--- a/spec/services/find_timeslices_with_revisions_spec.rb
+++ b/spec/services/find_timeslices_with_revisions_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_dependency "#{Rails.root}/lib/revision_data_manager"
 
 describe FindTimeslicesWithRevisions do
   let(:course) do
@@ -12,6 +13,9 @@ describe FindTimeslicesWithRevisions do
   let(:service) { described_class.new(course, enwiki, timeslices) }
 
   before do
+    # Students can't join a course with no campaign, and a course with no
+    # students makes no Replica query at all.
+    course.campaigns << Campaign.first
     JoinCourse.new(course:, user:, role: 0)
     TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([enwiki])
   end
@@ -50,8 +54,43 @@ describe FindTimeslicesWithRevisions do
     replica = instance_double(Replica)
     allow(Replica).to receive(:new).with(enwiki, nil).and_return(replica)
     expect(replica).to receive(:get_revisions_raw)
-      .with(course.students, '20181101000000', '20181130235500')
+      .with([user], '20181101000000', '20181130235500')
       .once.and_return([])
     service
+  end
+
+  context 'with more students than fit in one Replica query' do
+    let(:extra_students) { RevisionDataManager::MAX_USERNAMES }
+
+    before do
+      extra_students.times do |i|
+        JoinCourse.new(course:, user: create(:user, username: "Student#{i}"), role: 0)
+      end
+    end
+
+    it 'chunks the user list and unions the results' do
+      queried = []
+      allow_any_instance_of(Replica).to receive(:get_revisions_raw) do |_r, users, _s, _e|
+        queried << users.size
+        [{ 'rev_timestamp' => '20181105123456' }]
+      end
+      expect(slice_start_days).to contain_exactly('20181105')
+      expect(queried).to eq([RevisionDataManager::MAX_USERNAMES, 1])
+    end
+
+    it 'returns nil if any chunk fails, rather than treating it as empty' do
+      responses = [[{ 'rev_timestamp' => '20181105123456' }], nil]
+      allow_any_instance_of(Replica).to receive(:get_revisions_raw) { responses.shift }
+      expect(service.slice_starts).to be_nil
+    end
+  end
+
+  context 'when the course has no students' do
+    before { course.courses_users.destroy_all }
+
+    it 'makes no Replica query and reports no timeslices with revisions' do
+      expect_any_instance_of(Replica).not_to receive(:get_revisions_raw)
+      expect(service.slice_starts).to be_empty
+    end
   end
 end

--- a/spec/services/find_timeslices_with_revisions_spec.rb
+++ b/spec/services/find_timeslices_with_revisions_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FindTimeslicesWithRevisions do
+  let(:course) do
+    create(:basic_course, start: '2018-11-01 00:00:00', end: '2018-11-30 23:55:00')
+  end
+  let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+  let(:user) { create(:user, username: 'Ragesoss') }
+  let(:timeslices) { course.course_wiki_timeslices.where(wiki: enwiki).to_a }
+  let(:service) { described_class.new(course, enwiki, timeslices) }
+
+  before do
+    JoinCourse.new(course:, user:, role: 0)
+    TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records([enwiki])
+  end
+
+  def stub_replica_rows(rows)
+    allow_any_instance_of(Replica).to receive(:get_revisions_raw).and_return(rows)
+  end
+
+  def slice_start_days
+    service.slice_starts.map { |start| start.strftime('%Y%m%d') }
+  end
+
+  it 'returns the start datetimes of timeslices containing revisions' do
+    stub_replica_rows([{ 'rev_timestamp' => '20181105123456' },
+                       { 'rev_timestamp' => '20181112080910' },
+                       { 'rev_timestamp' => '20181112235959' }])
+    expect(slice_start_days).to contain_exactly('20181105', '20181112')
+  end
+
+  it 'assigns a revision on a timeslice boundary to the later timeslice' do
+    stub_replica_rows([{ 'rev_timestamp' => '20181112000000' }])
+    expect(slice_start_days).to contain_exactly('20181112')
+  end
+
+  it 'returns an empty set when there are no revisions' do
+    stub_replica_rows([])
+    expect(service.slice_starts).to be_empty
+  end
+
+  it 'returns nil when the Replica query fails' do
+    stub_replica_rows(nil)
+    expect(service.slice_starts).to be_nil
+  end
+
+  it 'queries Replica once, over the whole timeslice range' do
+    replica = instance_double(Replica)
+    allow(Replica).to receive(:new).with(enwiki, nil).and_return(replica)
+    expect(replica).to receive(:get_revisions_raw)
+      .with(course.students, '20181101000000', '20181130235500')
+      .once.and_return([])
+    service
+  end
+end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -469,6 +469,80 @@ describe UpdateCourseWikiTimeslices do
     end
   end
 
+  describe 'empty-gap precheck' do
+    # A dormant course: the ingestion watermark (last recorded revision) is
+    # weeks behind the end of the scan range, so the range exceeds
+    # GAP_PRECHECK_THRESHOLD and the wide-window precheck kicks in.
+    let(:course) do
+      create(:basic_course, start: '2018-11-01 00:00:00', end: '2018-11-30 23:55:00')
+    end
+    let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
+    let(:updater) { described_class.new(course, UpdateDebugger.new(course)) }
+    let(:user) { create(:user, username: 'Ragesoss') }
+    let(:fetched_slice_days) { [] }
+    let(:watermark_day) { '2018-11-10' }
+
+    before do
+      stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
+      travel_to Date.new(2018, 12, 1)
+      JoinCourse.new(course:, user:, role: 0)
+      TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
+      CourseWikiTimeslice.find_by(course:, wiki: enwiki, start: "#{watermark_day} 00:00:00")
+                         .update(last_mw_rev_datetime: "#{watermark_day} 14:05:30")
+      allow_any_instance_of(CourseRevisionUpdater)
+        .to receive(:fetch_revisions_for_course_wiki) do |_instance, wiki, ts_start, ts_end|
+          fetched_slice_days << ts_start.strftime('%Y-%m-%d')
+          { wiki => { start: ts_start, end: ts_end, new_data: false, revisions: [] } }
+        end
+    end
+
+    after do
+      travel_back
+    end
+
+    context 'when the wide query finds no revisions in the gap' do
+      it 'fetches only the watermark timeslice' do
+        expect_any_instance_of(Replica).to receive(:get_revisions_raw).once.and_return([])
+        processed, = updater.run(all_time: false)
+        expect(fetched_slice_days).to eq([watermark_day])
+        expect(processed).to eq(1)
+      end
+    end
+
+    context 'when the wide query finds revisions in some timeslices' do
+      it 'fetches those timeslices plus the watermark timeslice' do
+        allow_any_instance_of(Replica).to receive(:get_revisions_raw)
+          .and_return([{ 'rev_timestamp' => '20181120103000' },
+                       { 'rev_timestamp' => '20181125235959' }])
+        processed, = updater.run(all_time: false)
+        expect(fetched_slice_days).to contain_exactly(watermark_day, '2018-11-20', '2018-11-25')
+        expect(processed).to eq(3)
+      end
+    end
+
+    context 'when the wide query fails' do
+      it 'falls back to fetching every timeslice in the range' do
+        allow_any_instance_of(Replica).to receive(:get_revisions_raw).and_return(nil)
+        processed, = updater.run(all_time: false)
+        # 21 daily timeslices from 2018-11-10 through 2018-11-30
+        expect(fetched_slice_days.count).to eq(21)
+        expect(processed).to eq(21)
+      end
+    end
+
+    context 'when the scan range is within the threshold' do
+      let(:watermark_day) { '2018-11-26' }
+
+      it 'fetches every timeslice without a precheck query' do
+        expect_any_instance_of(Replica).not_to receive(:get_revisions_raw)
+        processed, = updater.run(all_time: false)
+        # 5 daily timeslices from 2018-11-26 through 2018-11-30
+        expect(fetched_slice_days.count).to eq(5)
+        expect(processed).to eq(5)
+      end
+    end
+  end
+
   describe 'adaptive timeslice splitting strategy' do
     let(:start) { '2025-08-26 17:00:00'.to_datetime }
     let(:end_date) { '2025-08-27 17:00:00'.to_datetime }

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -546,6 +546,29 @@ describe UpdateCourseWikiTimeslices do
       end
     end
 
+    context 'when a full update runs (all_time)' do
+      it 'skips slices whose revisions vanished on-wiki, because the wipe already cleared them' do
+        # The all_time range starts at the course start, before the watermark,
+        # so a slice with recorded revisions sits mid-range. Its on-wiki
+        # revisions have all since been deleted: Replica reports nothing
+        # anywhere. Skipping it is safe only because recreate_timeslices has
+        # already deleted and recreated every timeslice — this example pins
+        # that invariant by asserting the recorded data is actually gone.
+        CourseWikiTimeslice.find_by(course:, wiki: enwiki, start: '2018-11-05 00:00:00')
+                           .update(mw_rev_count: 5, revision_count: 5, character_sum: 1000,
+                                   last_mw_rev_datetime: '2018-11-05 12:00:00')
+        allow_any_instance_of(Replica).to receive(:get_revisions_raw).and_return([])
+        updater.run(all_time: true)
+        # Only the range's first slice gets fetched (via the reprocess loop);
+        # every later slice is fresh and empty, so the precheck skips it.
+        expect(fetched_slice_days).to eq(['2018-11-01'])
+        slice = CourseWikiTimeslice.find_by(course:, wiki: enwiki, start: '2018-11-05 00:00:00')
+        expect(slice.last_mw_rev_datetime).to be_nil
+        expect(slice.character_sum).to eq(0)
+        expect(slice.revision_count).to eq(0)
+      end
+    end
+
     context 'when the scan range is within the threshold' do
       let(:watermark_day) { '2018-11-26' }
 

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -474,13 +474,13 @@ describe UpdateCourseWikiTimeslices do
     # weeks behind the end of the scan range, so the range exceeds
     # GAP_PRECHECK_THRESHOLD and the wide-window precheck kicks in.
     let(:course) do
-      create(:basic_course, start: '2018-11-01 00:00:00', end: '2018-11-30 23:55:00')
+      create(:basic_course, start: '2018-10-01 00:00:00', end: '2018-11-30 23:55:00')
     end
     let(:enwiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
     let(:updater) { described_class.new(course, UpdateDebugger.new(course)) }
     let(:user) { create(:user, username: 'Ragesoss') }
     let(:fetched_slice_days) { [] }
-    let(:watermark_day) { '2018-11-10' }
+    let(:watermark_day) { '2018-10-10' }
 
     before do
       stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
@@ -527,9 +527,9 @@ describe UpdateCourseWikiTimeslices do
       it 'falls back to fetching every timeslice in the range' do
         allow_any_instance_of(Replica).to receive(:get_revisions_raw).and_return(nil)
         processed, = updater.run(all_time: false)
-        # 21 daily timeslices from 2018-11-10 through 2018-11-30
-        expect(fetched_slice_days.count).to eq(21)
-        expect(processed).to eq(21)
+        # 52 daily timeslices from 2018-10-10 through 2018-11-30
+        expect(fetched_slice_days.count).to eq(52)
+        expect(processed).to eq(52)
       end
     end
 
@@ -561,7 +561,7 @@ describe UpdateCourseWikiTimeslices do
         updater.run(all_time: true)
         # Only the range's first slice gets fetched (via the reprocess loop);
         # every later slice is fresh and empty, so the precheck skips it.
-        expect(fetched_slice_days).to eq(['2018-11-01'])
+        expect(fetched_slice_days).to eq(['2018-10-01'])
         slice = CourseWikiTimeslice.find_by(course:, wiki: enwiki, start: '2018-11-05 00:00:00')
         expect(slice.last_mw_rev_datetime).to be_nil
         expect(slice.character_sum).to eq(0)
@@ -570,14 +570,16 @@ describe UpdateCourseWikiTimeslices do
     end
 
     context 'when the scan range is within the threshold' do
-      let(:watermark_day) { '2018-11-26' }
+      # A three-week backlog — e.g. from queue latency — stays under the
+      # threshold and on the plain per-timeslice path.
+      let(:watermark_day) { '2018-11-10' }
 
       it 'fetches every timeslice without a precheck query' do
         expect_any_instance_of(Replica).not_to receive(:get_revisions_raw)
         processed, = updater.run(all_time: false)
-        # 5 daily timeslices from 2018-11-26 through 2018-11-30
-        expect(fetched_slice_days.count).to eq(5)
-        expect(processed).to eq(5)
+        # 21 daily timeslices from 2018-11-10 through 2018-11-30
+        expect(fetched_slice_days.count).to eq(21)
+        expect(processed).to eq(21)
       end
     end
   end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -485,6 +485,9 @@ describe UpdateCourseWikiTimeslices do
     before do
       stub_const('TimesliceManager::TIMESLICE_DURATION', 86400)
       travel_to Date.new(2018, 12, 1)
+      # Without a campaign the course isn't approved, the student can't join,
+      # and no_point_in_importing_revisions? would skip the precheck entirely.
+      course.campaigns << Campaign.first
       JoinCourse.new(course:, user:, role: 0)
       TimesliceManager.new(course).create_timeslices_for_new_course_wiki_records(course.wikis)
       CourseWikiTimeslice.find_by(course:, wiki: enwiki, start: "#{watermark_day} 00:00:00")
@@ -527,6 +530,19 @@ describe UpdateCourseWikiTimeslices do
         # 21 daily timeslices from 2018-11-10 through 2018-11-30
         expect(fetched_slice_days.count).to eq(21)
         expect(processed).to eq(21)
+      end
+    end
+
+    context 'when there is no point importing revisions for the course' do
+      it 'fetches only the watermark timeslice without a precheck query' do
+        # Every per-timeslice fetch short-circuits before reaching Replica, so
+        # the precheck can't find anything and shouldn't spend a query looking.
+        allow_any_instance_of(CourseRevisionUpdater)
+          .to receive(:no_point_in_importing_revisions?).and_return(true)
+        expect_any_instance_of(Replica).not_to receive(:get_revisions_raw)
+        processed, = updater.run(all_time: false)
+        expect(fetched_slice_days).to eq([watermark_day])
+        expect(processed).to eq(1)
       end
     end
 


### PR DESCRIPTION
## What this PR does

Addresses #7005.

For a dormant course with a far-future end date, every course update re-fetched every daily timeslice between the last tracked student edit and today — one replica-revision-tools query per wiki-timeslice — because empty timeslices never advance the ingestion watermark (`TimesliceManager#get_ingestion_start_time_for_wiki`). On P&E course 10781 that meant 3,867 no-op queries and ~22.7 minutes per update, roughly 10 times a day, growing by 2 timeslices per day until the course ends in 2030 (~3.7 hours of Sidekiq worker time and ~38,000 Toolforge queries daily for a course with no tracked activity since January 2025).

The fix: when the range of timeslices to process exceeds `GAP_PRECHECK_THRESHOLD` (7), a new `FindTimeslicesWithRevisions` service makes ~~**one** wide-window `revisions.php` query~~ **one wide-window `revisions.php` query per chunk of ten students (see Review updates below)** over the whole range and the update processes only the timeslices that actually contain revisions — plus, always, the first (watermark) timeslice, which is the only one in range that can already have recorded revisions and must be re-fetched to preserve deletion detection (the `mw_rev_count` comparison in `CourseRevisionUpdater#new_revisions?`) and partial re-ingestion. Skipping the rest is safe by construction: for an empty timeslice in `only_new` mode, `should_update_timeslice?` is false and nothing is persisted, so processing it was a pure no-op.

Design properties, per the priorities discussed for #7005 (simplicity first, then efficiency):

- **No schema change and no new persistent state.** The gap is still re-checked on every update — just with ~~one query~~ **a handful of queries** instead of thousands — so correctness is identical to the previous behavior.
- **Failure falls back to the old path.** The precheck uses `Replica#get_revisions_raw`, which distinguishes a failed query (`nil`) from a genuinely empty result (`[]`); on failure the full range is processed exactly as before. (`revisions.php` was also checked for server-side row limits — there are none, so a truncated wide result can't silently mark timeslices empty.) **Review update: that check didn't cover the endpoint's *memory* limit, which is the reason `RevisionDataManager` chunks its user list at ten. The precheck now chunks the same way, and treats a failure in any chunk as a failure of the whole precheck.**
- **Active courses are untouched.** Their scan ranges are short (the watermark is at their most recent edit), so they stay below the threshold and gain zero added queries.
- **The reprocess loop (`needs_update` timeslices) is deliberately untouched.** A flagged timeslice can carry stale data that reprocessing must clear, so "no revisions on wiki" does not imply no-op there. ~~Consequence: a flagged full update of a course with *no timeslices yet* (`recreate_timeslices` marks everything `needs_update`) does not benefit, while scheduled first updates and full updates of courses with existing timeslices do.~~ **Review update: this was wrong, and there is no uncovered case. `fetch_data_and_reprocess_timeslices` only reprocesses flagged timeslices whose `start` is at or before the ingestion start, while the precheck's range *begins* at the ingestion start — so the two sets overlap in at most the watermark timeslice, which the precheck keeps unconditionally anyway. A flagged full update of a brand-new course benefits like any other: `recreate_timeslices` flags everything, but the reprocess loop then clears the flag on every timeslice after the course start without reprocessing it, leaving the whole range to the precheck. Measured on a 30-timeslice course with everything freshly flagged: `processed=29` with the precheck disabled versus `processed=0` with it active.**

Expected impact on course 10781: each update drops from 3,867 fetches to ~~2 wide queries~~ **2 wide queries per chunk of ten students** + 2 watermark fetches — from ~22.7 minutes to a few seconds.

Validation beyond the specs: the service was smoke-tested against the live replica endpoint using a real course from a production data dump (110 timeslices): zero false negatives versus the recorded per-timeslice state, with the only extra selections being course-start timeslices containing system edits, which fetch and no-op harmlessly. The cost model and slice arithmetic were validated against course 10781's live update logs (predicted `processed=3867` exactly).

## Review updates

A Claude Code review session on this branch ([notes](https://github.com/WikiEducationFoundation/WikiEduDashboard/pull/7007#issuecomment-5360386308)) found two ways the precheck added Replica load instead of removing it, plus the spec gap that hid both. Struck-through text above marks what changed. A follow-up commit on this branch addresses:

- **Courses where importing revisions is pointless paid for a query they previously didn't.** `CourseRevisionUpdater#no_point_in_importing_revisions?` already short-circuits every per-timeslice fetch for a course with no students, and for an `only_scoped_articles_course?` with no assignments and no categories — but the precheck had no equivalent guard, and `Course.ready_for_update` picks up every current course regardless of student count. The precheck now returns an empty set without querying in that case, which also skips the whole no-op range, so those courses come out ahead of pre-PR master rather than behind it.
- **The wide query bypassed the `MAX_USERNAMES` chunking** that exists to stay inside the Replica endpoint's memory limit, amplified by the widest window in the update. It now chunks at ten students, and collapses to the full-range fallback if any chunk fails. `Utils.chunk_requests` is deliberately not used: its `Array(info)` maps a failed chunk's `nil` to `[]`, which is indistinguishable from a genuinely empty result.
- **Both new spec files exercised the precheck on a course with zero students.** `JoinCourse` fails `student_joining_before_approval?` silently when the course has no campaign, and the `empty-gap precheck` block is a sibling of `describe 'UpdateCourseWikiTimeslices.run'` rather than nested inside it, so it never inherited that block's campaign setup. Every "fetches N timeslices" assertion was therefore measured on a course that in production issues no Replica query at all. Both setups now add a campaign, and that is what makes the two items above observable.
- Minor: `precheck_nonempty_timeslices` was issuing a `SELECT COUNT(*)` and then re-querying the same rows.

## AI usage

This PR was developed with Claude Code, which wrote all of the code, specs, and commit message under human direction. The investigation that produced #7005 (public-API recon against the live dashboard and replica endpoints, code reading, and the cost-model arithmetic), the implementation plan, and this implementation were all Claude Code sessions; Sage set the priorities (simple/understandable over maximally efficient), approved the plan's central design choice (a stateless wide-query precheck rather than a persisted scan watermark), and reviewed the work. The single implementation commit was made in one focused session on 2026-08-20, following a planning discussion in the same session. The commit's `## Process` section has a fuller account, including the one test misstep (a `stub_const` ordering issue in a new spec, fixed by removing the stub). This summary and the rest of this description were also drafted by Claude Code and may contain errors.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes.

## Open questions and concerns

- `GAP_PRECHECK_THRESHOLD = 7` is a judgment call; anything from ~3 to ~30 is defensible. Existing specs' 7-slice courses sit exactly at the threshold, keeping them on the unmodified path.
- `processed` in update logs now counts only actually-fetched timeslices (it will drop from ~3,867 to ~2 for dormant courses), which makes the logs more meaningful but changes their scale for such courses.
- ~~The uncovered case — flagged full update of a course with no timeslices yet — could be closed by letting the reprocess loop skip provably-fresh empty timeslices, but that adds a multi-column "provably fresh" guard plus flag-clearing logic; it fires at most once per copied/new course and seemed not worth the added invariants. Can revisit if it turns out to matter.~~ **Withdrawn: there is no uncovered case — see the Review updates section.**

(PR description written by Claude Code.)

