### PR TITLE
Add dynamic links to connected Wikimedia Event Center pages

### DIFF
--- a/app/assets/javascripts/components/enroll/enroll_card.jsx
+++ b/app/assets/javascripts/components/enroll/enroll_card.jsx
@@ -18,9 +18,15 @@ const EnrollCard = ({
       </div>
     );
   } else if (course.flags.event_sync) {
+    const eventCenterUrl = `https://meta.wikimedia.org/wiki/Special:EventDetails/${course.flags.event_sync}`;
     messageBody = (
       <div>
         <h1>{I18n.t('courses.controlled_by_event_center')}</h1>
+        <p>
+          <a href={eventCenterUrl} target="_blank" rel="noopener noreferrer" className="button dark">
+            {I18n.t('courses.go_to_event_center')}
+          </a>
+        </p>
       </div>
     );
   } else if (enrolledParam !== undefined) {

--- a/app/assets/javascripts/components/overview/details.jsx
+++ b/app/assets/javascripts/components/overview/details.jsx
@@ -173,6 +173,7 @@ const Details = createReactClass({
     let academic_system;
     let online;
     let eventSyncTooltip;
+    let eventSyncLink;
 
     if (Features.wikiEd) {
       staff = <WikiEdStaff {...this.props} />;
@@ -193,6 +194,22 @@ const Details = createReactClass({
             </p>
           </div>
         </div>
+      );
+    }
+
+    if (eventSync) {
+      const eventCenterUrl = `https://meta.wikimedia.org/wiki/Special:EventDetails/${eventSync}`;
+      eventSyncLink = (
+        <p>
+          <span className="text-input-component__label">
+            <strong>{I18n.t('courses.event_center_link')}: </strong>
+          </span>
+          <span>
+            <a href={eventCenterUrl} target="_blank" rel="noopener noreferrer">
+              {I18n.t('courses.view_event_center_page')}
+            </a>
+          </span>
+        </p>
       );
     }
 
@@ -612,6 +629,7 @@ const Details = createReactClass({
               {title}
               {term}
               {academic_system}
+              {eventSyncLink}
               {wikiSelector}
               {multiWikiSelector}
               {namespaceSelector}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -837,6 +837,9 @@ en:
       If enabled, the dashboard will post a template to the userpage and talk page of
       each editor who joins the program.
     event_sync: "Editing disabled: This field cannot be changed because the course is already linked to an event. Changing it would disrupt the event's integration."
+    event_center_link: Event Center Page
+    view_event_center_page: View associated Event Center page
+    go_to_event_center: Go to Event Center to Register
     courses_enrolled: Courses enrolled
     error:
       exists: That course already exists! Please try again with a different title, school, or term.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -838,8 +838,8 @@ en:
       each editor who joins the program.
     event_sync: "Editing disabled: This field cannot be changed because the course is already linked to an event. Changing it would disrupt the event's integration."
     event_center_link: Event Center Page
-    view_event_center_page: View associated Event Center page
-    go_to_event_center: Go to Event Center to Register
+    view_event_center_page: View page
+    go_to_event_center: Go to Event Center to register
     courses_enrolled: Courses enrolled
     error:
       exists: That course already exists! Please try again with a different title, school, or term.

--- a/test/components/enroll_card.spec.js
+++ b/test/components/enroll_card.spec.js
@@ -10,7 +10,7 @@ if (typeof I18n !== 'undefined') {
   I18n.translations.en = I18n.translations.en || {};
   I18n.translations.en.courses = I18n.translations.en.courses || {};
   I18n.translations.en.courses.controlled_by_event_center = 'Enrollment in this event is controlled by Wikimedia Event Center. It cannot be joined from the Dashboard.';
-  I18n.translations.en.courses.go_to_event_center = 'Go to Event Center to Register';
+  I18n.translations.en.courses.go_to_event_center = 'Go to Event Center to register';
 }
 
 const React = require('react');
@@ -48,7 +48,7 @@ describe('EnrollCard', () => {
     expect(link).not.toBeNull();
     expect(link.getAttribute('href')).toBe('https://meta.wikimedia.org/wiki/Special:EventDetails/98765');
     expect(link.getAttribute('target')).toBe('_blank');
-    expect(link.textContent).toContain('Go to Event Center to Register');
+    expect(link.textContent).toContain('Go to Event Center to register');
 
     document.body.removeChild(container);
   });

--- a/test/components/enroll_card.spec.js
+++ b/test/components/enroll_card.spec.js
@@ -1,0 +1,55 @@
+import '../testHelper';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+if (typeof I18n !== 'undefined') {
+  I18n.translations = I18n.translations || {};
+  I18n.translations.en = I18n.translations.en || {};
+  I18n.translations.en.courses = I18n.translations.en.courses || {};
+  I18n.translations.en.courses.controlled_by_event_center = 'Enrollment in this event is controlled by Wikimedia Event Center. It cannot be joined from the Dashboard.';
+  I18n.translations.en.courses.go_to_event_center = 'Go to Event Center to Register';
+}
+
+const React = require('react');
+const { createRoot } = require('react-dom/client');
+const { act } = require('react-dom/test-utils');
+const EnrollCard = require('../../app/assets/javascripts/components/enroll/enroll_card').default;
+
+describe('EnrollCard', () => {
+  test('renders Event Center registration link when course has active event sync', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const mockCourse = {
+      title: 'Test Synced Course',
+      ended: false,
+      flags: {
+        event_sync: '98765'
+      }
+    };
+
+    act(() => {
+      createRoot(container).render(
+        React.createElement(EnrollCard, {
+          course: mockCourse,
+          user: {},
+          userRoles: {}
+        })
+      );
+    });
+
+    const header = container.querySelector('h1');
+    expect(header.textContent).toContain('Enrollment in this event is controlled by Wikimedia Event Center.');
+
+    const link = container.querySelector('p a');
+    expect(link).not.toBeNull();
+    expect(link.getAttribute('href')).toBe('https://meta.wikimedia.org/wiki/Special:EventDetails/98765');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.textContent).toContain('Go to Event Center to Register');
+
+    document.body.removeChild(container);
+  });
+});


### PR DESCRIPTION


#### Changes Done :
1. Course Overview Details (`details.jsx`): Checks for `course.flags.event_sync` (which contains the Event ID). Dynamically constructs the event URL: `https://meta.wikimedia.org/wiki/Special:EventDetails/{eventSyncId}`, Renders a read-only metadata link row: **Event Center Page**

2. Enroll Card (`enroll_card.jsx`):  Replaces the static warning with a call-to-action (CTA) button for users. Provides a prominent **Go to Event Center to Register** button linking directly to the Meta-Wiki Special page.

3. Translations (`en.yml`): Added translation strings under the `courses:` namespace for: `event_center_link`, `view_event_center_page`,`go_to_event_center`

4. Testing (`enroll_card.spec.js`): Added a new Jest unit test suite to verify that the `EnrollCard` correctly displays the Event Center warning and CTA link when `event_sync` is active.

#### Verification Results
All Jest component tests pass cleanly: `test/components/enroll_card.spec.js`, `test/components/article_viewer_legend.spec.js`, `test/components/use_authorship_highlighting.spec.js`

## Screenshots and demo
from Admin side:

https://github.com/user-attachments/assets/5d00c2b0-6980-41f9-9e86-7d06096383b3

from user side:
<img width="1027" height="822" alt="Screenshot 2026-08-23 at 8 31 10 PM" src="https://github.com/user-attachments/assets/58770186-3800-46fc-8b03-93c8496bd48a" />



addresses #6998 
please review @ragesoss @Formasitchijoh 