### PR TITLE
Add new `report_csv` queue

### DIFF
--- a/app/services/system_metrics.rb
+++ b/app/services/system_metrics.rb
@@ -57,7 +57,8 @@ class SystemMetrics
     'long_update' => 1.day,
     'daily_update' => 1.day,
     'constant_update' => 15.minutes,
-    'acuwt_update' => 1.day
+    'acuwt_update' => 1.day,
+    'report_csv' => 15.minutes
   }.freeze
 
   def get_queue_status(queue_name, latency)

--- a/app/workers/csv_cleanup_worker.rb
+++ b/app/workers/csv_cleanup_worker.rb
@@ -3,6 +3,7 @@ require_dependency "#{Rails.root}/lib/analytics/report_csv_store"
 
 class CsvCleanupWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'report_csv'
 
   def perform(filename)
     ReportCsvStore.delete filename

--- a/app/workers/report_csv_worker.rb
+++ b/app/workers/report_csv_worker.rb
@@ -14,7 +14,7 @@ require_dependency "#{Rails.root}/lib/analytics/system_stats_csv_builder"
 
 class ReportCsvWorker
   include Sidekiq::Worker
-  sidekiq_options queue: 'daily_update', lock: :until_executed
+  sidekiq_options queue: 'report_csv', lock: :until_executed
 
   # Generate the csv for the given source (course or campaign)
   # if type is global, then can access source as nil

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -148,6 +148,7 @@ namespace :deploy do
       'sidekiq-long', # data updates for long-running courses, which may have long queue latency
       'sidekiq-daily', # once-daily long-running data update tasks
       'sidekiq-constant', # frequently-run tasks like adding courses to the update queues
+      'sidekiq-report-csv', # user-requested CSV reports
     ]
   end
   set :sidekiq_roles, -> { :app }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1573,6 +1573,9 @@ en:
     purpose: Purpose
     queues_overview: Queues Overview
     queue: Queue
+    report_csv: Report CSV generation
+    report_csv_description: Specific queue for generating user-requested CSV reports.
+    report_csv_doc: Handles user-requested CSV reports.
     short_update: Short update
     short_update_description: Short updates process courses with fewer than 1,000 revisions.
     short_update_doc: Handles updates for small courses.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -29,3 +29,4 @@ test:
  - constant_update
  - very_long_update
  - acuwt_update
+ - report_csv

--- a/server_config/systemd/sidekiq-report-csv.service
+++ b/server_config/systemd/sidekiq-report-csv.service
@@ -1,0 +1,38 @@
+# Based on https://github.com/mperham/sidekiq/blob/master/examples/systemd/sidekiq.service
+#
+# A process dedicated to the report_csv queue: user-requested CSV reports and the
+# cleanup jobs that delete them a week later. These are the only user-facing jobs
+# in the system, so they get their own queue instead of waiting behind course
+# updates. (The host running this needs the report_csv_* env vars.)
+
+[Unit]
+Description=sidekiq-report-csv
+After=syslog.target network.target
+
+[Service]
+Type=simple
+# On the Capistrano-deployed hosts this is /var/www/dashboard/current instead,
+# with User=ragesoss and Group=project-globaleducation.
+WorkingDirectory=/home/ragesoss/WikiEduDashboard
+ExecStart=/home/ragesoss/.rvm/bin/rvm default do bundle exec sidekiq -e production --queue report_csv --concurrency 1
+User=root
+Group=root
+UMask=0002
+
+# Greatly reduce Ruby memory fragmentation and heap usage
+# https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
+Environment=MALLOC_ARENA_MAX=2
+
+# if we crash, restart
+RestartSec=1
+Restart=on-failure
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=sidekiq-report-csv
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/services/system_metrics_spec.rb
+++ b/spec/services/system_metrics_spec.rb
@@ -62,6 +62,7 @@ describe SystemMetrics do
       expect(service.get_queue_status('constant_update', 12.minutes)).to eq('Normal')
       expect(service.get_queue_status('acuwt_update', 12.hours)).to eq('Normal')
       expect(service.get_queue_status('default', 0)).to eq('Normal')
+      expect(service.get_queue_status('report_csv', 5.minutes)).to eq('Normal')
     end
 
     it 'returns Backlogged for queues exceeding threshold latency' do
@@ -72,6 +73,7 @@ describe SystemMetrics do
       expect(service.get_queue_status('constant_update', 16.minutes)).to eq('Backlogged')
       expect(service.get_queue_status('acuwt_update', 26.hours)).to eq('Backlogged')
       expect(service.get_queue_status('default', 2)).to eq('Backlogged')
+      expect(service.get_queue_status('report_csv', 1.hour)).to eq('Backlogged')
     end
   end
 


### PR DESCRIPTION
## What this PR does
This PR adds a new `report_csv` queue to put CSV generation and CSV cleanup. This is the last step for #6606.

As @Formasitchijoh [pointed out in Slack](https://wikieducation.slack.com/archives/C724RCXT7/p1787642285228759), `ReportCsvWorker` runs on the `daily_update` queue. Now that we want to move the CSV report generation to another server (I have `peony-sidekiq-medium` in mind) the easiest move is to create a new specific queue for that purpose. **Note this affects both deployments: wiki edu and peony.**

### Steps for peony

1. Copy production credentials as env variables into **1)** `peony-sidekiq-medium` (the server that process the new report_csv queue and creates and deletes the reports) and **2)** `peony-web` (the server that runs the controller code and it has to decide the report URL and check whether the report already exists). Already done :heavy_check_mark: :heavy_check_mark: 
2. Copy the new systemd unit file into `/etc/systemd/system` into `peony-sidekiq-medium` server and enable it (run `sudo systemctl daemon-reload` and `sudo systemctl enable --now sidekiq-report-csv`). I can do that right now, but I'm not sure if we would have to do it anyway manually right after deployment.

### Steps for wiki-edu

1. Copy the new system unit file into  `/etc/systemd/system` into single wiki edu server (using the right `WorkingDirectory` and `ExecStart` definitions) and enable it. I can do that.

## AI usage
Used Claude Code to discuss things.

## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
