### PR TITLE
Fall 2026 experiment: enrollment notification, install polish, and email-link instructor opt-in

### DIFF
--- a/app/assets/javascripts/components/overview/experiment_opt_in_invitation.jsx
+++ b/app/assets/javascripts/components/overview/experiment_opt_in_invitation.jsx
@@ -25,6 +25,7 @@ const ExperimentOptInInvitation = ({ course, current_user }) => {
   // hidden | choice | install | working
   const [phase, setPhase] = useState('hidden');
   const [checked, setChecked] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const eligible = !!(course && course.id && course.research_experiment_open_to_students
     && current_user && current_user.isStudent);
@@ -76,6 +77,16 @@ const ExperimentOptInInvitation = ({ course, current_user }) => {
     }
   };
 
+  // Put the import line on the clipboard, so the student only has to paste it
+  // on the common.js edit form. If the browser withholds clipboard access, the
+  // line is still there to copy by hand.
+  const copyImportLine = () => {
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(userscript.import_line)
+      .then(() => setCopied(true))
+      .catch(logErrorMessage);
+  };
+
   // Re-read the student's common.js. Once the line is there the server stops
   // returning an install payload and the modal closes for good.
   const recheck = async () => {
@@ -104,7 +115,12 @@ const ExperimentOptInInvitation = ({ course, current_user }) => {
         <div className="experiment-opt-in__panel">
           <h2 id="experiment-opt-in-title">{copy.install_title}</h2>
           <div dangerouslySetInnerHTML={{ __html: md.render(copy.install_message || '') }} />
-          <pre className="experiment-opt-in__snippet">{userscript.import_line}</pre>
+          <div className="experiment-opt-in__snippet-row">
+            <pre className="experiment-opt-in__snippet">{userscript.import_line}</pre>
+            <button className="button experiment-opt-in__copy-button" onClick={copyImportLine}>
+              {copied ? copy.install_copied : copy.install_copy_button}
+            </button>
+          </div>
           {checked && <p className="experiment-opt-in__not-found">{copy.install_not_found}</p>}
           <div className="experiment-opt-in__actions">
             <a

--- a/app/assets/stylesheets/modules/_experiment_instructor_opt_in.styl
+++ b/app/assets/stylesheets/modules/_experiment_instructor_opt_in.styl
@@ -1,0 +1,21 @@
+// Styling for the standalone instructor opt-in page for research experiments
+// (experiments/instructor_opt_in/show.html.haml).
+.instructor-opt-in
+  margin 40px auto
+  max-width 720px
+  h1
+    font-size 1.563em
+    font-weight 300
+    margin-bottom 15px
+  .instructor-opt-in__courses
+    list-style disc
+    margin 15px 0 25px
+    padding-left 25px
+    li
+      margin-bottom 5px
+  .instructor-opt-in__status
+    color #676767
+    margin-left 10px
+  .instructor-opt-in__actions
+    display flex
+    gap 10px

--- a/app/assets/stylesheets/modules/_experiment_opt_in.styl
+++ b/app/assets/stylesheets/modules/_experiment_opt_in.styl
@@ -33,6 +33,17 @@
     padding 10px 12px
     white-space pre-wrap
     word-break break-all
+  // Row holding the import line and its copy button. The button gets a stable
+  // width so the label swap after copying does not shift the layout.
+  .experiment-opt-in__snippet-row
+    align-items center
+    display flex
+    gap 10px
+    .experiment-opt-in__snippet
+      flex 1
+    .experiment-opt-in__copy-button
+      flex-shrink 0
+      min-width 90px
   .experiment-opt-in__not-found
     font-weight bold
     margin-top 15px

--- a/app/controllers/experiments/instructor_opt_in_controller.rb
+++ b/app/controllers/experiments/instructor_opt_in_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/experiments/opt_in_experiment"
+
+module Experiments
+  # Standalone opt-in page for instructors invited by email, mirroring the
+  # assignment wizard's research-study panel for courses that never went
+  # through the wizard. The signed-in instructor's choice applies to all their
+  # eligible courses at once; see OptInExperiment#handle_instructor_opt_in.
+  #
+  # A signed-out visitor following the emailed link gets the sign-in prompt,
+  # and the NotSignedInError rescue stores the return path, so they land back
+  # here after logging in.
+  class InstructorOptInController < ApplicationController
+    before_action :require_signed_in
+    before_action :set_experiment
+
+    def show
+      @copy = @experiment.instructor_invitation_copy
+      @courses = @experiment.eligible_instructed_courses(current_user)
+      @choices = @courses.index_with { |course| @experiment.course_choice(course) }
+    end
+
+    def opt_in
+      @experiment.handle_instructor_opt_in(current_user)
+      redirect_with_notice(:opted_in_flash)
+    end
+
+    def opt_out
+      @experiment.handle_instructor_opt_out(current_user)
+      redirect_with_notice(:opted_out_flash)
+    end
+
+    private
+
+    def set_experiment
+      @experiment = OptInExperiment.find(params[:experiment_slug])
+      raise ActionController::RoutingError, 'Not Found' unless @experiment
+    end
+
+    def redirect_with_notice(copy_key)
+      # No confirmation when there was nothing to apply the choice to; the page
+      # will show its no-eligible-courses message instead.
+      if @experiment.eligible_instructed_courses(current_user).any?
+        flash[:notice] = @experiment.instructor_invitation_copy[copy_key]
+      end
+      redirect_to "/experiments/#{@experiment.slug}/instructor_optin"
+    end
+  end
+end

--- a/app/services/check_experiment_userscript.rb
+++ b/app/services/check_experiment_userscript.rb
@@ -41,10 +41,14 @@ class CheckExperimentUserscript
   end
 
   # Matched on the imported script's page title rather than the whole import
-  # line, so a student who retypes it with different quoting or spacing still
-  # counts as installed.
+  # line, with underscores and spaces treated as equivalent (as MediaWiki
+  # treats them in titles), so a student who retypes it with different quoting,
+  # spacing, or title form still counts as installed.
   def installed?
-    fetch_common_js&.include?(@experiment.userscript_marker) || false
+    content = fetch_common_js
+    return false unless content
+
+    content.tr('_', ' ').include?(@experiment.userscript_marker.tr('_', ' '))
   end
 
   def record_install

--- a/app/views/experiments/instructor_opt_in/show.html.haml
+++ b/app/views/experiments/instructor_opt_in/show.html.haml
@@ -1,0 +1,30 @@
+-# Standalone instructor opt-in page for an opt-in research experiment, reached
+-# from invitation emails. All substantive text comes from the experiment's
+-# instructor_invitation_copy, which is sourced from the assignment wizard's
+-# panel for the same experiment, so the two entry points show the same thing.
+- content_for(:title) { @copy[:title] }
+.container
+  .instructor-opt-in
+    %h1= @copy[:title]
+    -# The description is a YAML literal block, so it carries hard newlines
+    -# mid-sentence; only blank lines are real paragraph breaks.
+    .instructor-opt-in__description
+      - @copy[:description].split(/\n{2,}/).each do |paragraph|
+        %p= paragraph.tr("\n", ' ')
+    - if @courses.empty?
+      %p.instructor-opt-in__no-courses= @copy[:no_courses]
+    - else
+      %p= @copy[:course_list_intro]
+      %ul.instructor-opt-in__courses
+        - @courses.each do |course|
+          %li
+            = link_to course.title, course_slug_path(course.slug)
+            %span.instructor-opt-in__status
+              = { opted_in: 'Opted in', opted_out: 'Opted out' }[@choices[course]] || 'Undecided'
+      .instructor-opt-in__actions
+        = button_to @copy[:opt_in_label],
+                    "/experiments/#{@experiment.slug}/instructor_optin/opt_in",
+                    class: 'button dark'
+        = button_to @copy[:opt_out_label],
+                    "/experiments/#{@experiment.slug}/instructor_optin/opt_out",
+                    class: 'button'

--- a/app/workers/experiment_enrollment_worker.rb
+++ b/app/workers/experiment_enrollment_worker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/experiments/opt_in_experiment"
+
+# Notifies an opt-in experiment's external data collection server, if it has
+# one, that a student has opted in. See OptInExperiment#report_enrollment.
+class ExperimentEnrollmentWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  def self.schedule(experiment_courses_user)
+    perform_async(experiment_courses_user.id)
+  end
+
+  def perform(experiment_courses_user_id)
+    record = ExperimentCoursesUser.find_by(id: experiment_courses_user_id)
+    return unless record&.opted_in?
+
+    OptInExperiment.find(record.experiment_slug)&.report_enrollment(record)
+  end
+end

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -61,6 +61,13 @@
 # the student side off. Each experiment gets its own setting.
   fall_2026_research_student_optin: 'false'
 
+# Shared secret for announcing Fall 2026 experiment opt-ins to the study's
+# data collection server (see WickieApi); the value comes from the research
+# team and must match the server's WICKIE_ENROLL_SECRET. When left unset, no
+# enrollment notifications are sent at all — set it only on the environment
+# that is meant to feed the real study cohort.
+# wickie_enroll_secret: ''
+
 # Projects with automatic edits enabled, add as edit_<language>.<project_url>
 # edit_en.wikipedia.org: "true"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -572,6 +572,13 @@ Rails.application.routes.draw do
     get 'courses/:course_id/invitation' => 'opt_in#show'
     post ':experiment_slug/courses/:course_id/opt_in' => 'opt_in#opt_in'
     post ':experiment_slug/courses/:course_id/opt_out' => 'opt_in#opt_out'
+
+    # Standalone instructor opt-in page, reached from invitation emails sent to
+    # instructors whose courses never went through the assignment wizard. The
+    # instructor's choice applies to all their eligible courses at once.
+    get ':experiment_slug/instructor_optin' => 'instructor_opt_in#show'
+    post ':experiment_slug/instructor_optin/opt_in' => 'instructor_opt_in#opt_in'
+    post ':experiment_slug/instructor_optin/opt_out' => 'instructor_opt_in#opt_out'
   end
 
   resources :admin

--- a/lib/experiments/fall_2026_consent_form.md
+++ b/lib/experiments/fall_2026_consent_form.md
@@ -18,6 +18,8 @@
 
 - _Withdrawing:_ You may withdraw at any time by uninstalling the tool or by contacting us, after which we collect no further data, with no penalty. Once data has been combined for analysis, it is no longer possible to remove individual records.
 
+- _Consequences:_ Your decision to participate or not to participate in this research will not affect in any way your course grade or your relationship with your school or instructor.
+
 - _Risks._ This study involves minimal risk. The editing you do is your normal coursework, and your edits to Wikipedia are public regardless of the study. The main risk is a loss of confidentiality with respect to the editing activity we record, which is not otherwise public. To reduce this risk, we do not collect your name or email, we store the recorded activity on secure servers available only to the research team, we report results only in aggregate, and we never share your individual data with your course instructor.
 
 - _Benefits._ You may not receive a direct benefit from taking part. If you receive a version of the tool that shows feedback, it may help you notice and correct common problems and learn skills such as citing sources and writing in a neutral style, though whether it helps is what the study examines. Your participation will help researchers understand how to use AI to support, rather than replace, student writing.

--- a/lib/experiments/fall_2026_research_experiment.rb
+++ b/lib/experiments/fall_2026_research_experiment.rb
@@ -47,8 +47,34 @@ class Fall2026ResearchExperiment < OptInExperiment
     install_not_found: "We couldn't find the expected experiment script installed on your account."
   }.freeze
 
+  # The assignment wizard panel that presents this experiment to instructors.
+  # The standalone instructor opt-in page (reached from invitation emails)
+  # reuses its title, description, and option labels so the two entry points
+  # cannot drift apart.
+  WIZARD_PANEL = YAML.safe_load(
+    File.read("#{Rails.root}/config/wizard/researchwrite/wizard.yml")
+  ).find { |panel| panel['key'] == 'fall_2026_research_optin' }.freeze
+
+  INSTRUCTOR_INVITATION_COPY = {
+    title: WIZARD_PANEL['title'],
+    description: WIZARD_PANEL['description'],
+    opt_in_label: WIZARD_PANEL['options']
+      .find { |option| option['tag'] == "#{SLUG}_opted_in" }['title'],
+    opt_out_label: WIZARD_PANEL['options']
+      .find { |option| option['tag'] == "#{SLUG}_opted_out" }['title'],
+    course_list_intro: 'Your choice will apply to all of your Fall 2026 courses:',
+    opted_in_flash: 'Thank you! Your Fall 2026 courses are opted in to the research experiment.',
+    opted_out_flash: 'You have opted out. No experiment invitations will be shown ' \
+                     'to your students.',
+    no_courses: "You don't have any Fall 2026 courses that are eligible for this experiment."
+  }.freeze
+
   def slug
     SLUG
+  end
+
+  def instructor_invitation_copy
+    INSTRUCTOR_INVITATION_COPY
   end
 
   def eligible_course?(course)

--- a/lib/experiments/fall_2026_research_experiment.rb
+++ b/lib/experiments/fall_2026_research_experiment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/experiments/opt_in_experiment"
+require_dependency "#{Rails.root}/lib/experiments/wickie_api"
 
 # The Fall 2026 research study ("Ribeiro experiment").
 #
@@ -14,7 +15,7 @@ class Fall2026ResearchExperiment < OptInExperiment
   # The userscript students install. As a user JS page it is editable only by its
   # owner and interface admins, so the code participants run cannot be altered by
   # anyone else.
-  USERSCRIPT_PAGE = 'User:Sage_(Wiki_Ed)/fall2026experiment.js'
+  USERSCRIPT_PAGE = 'User:Sage_(Wiki_Ed)/wickie.js'
 
   USERSCRIPT_IMPORT_LINE = "importScript('#{USERSCRIPT_PAGE}');"
 
@@ -60,6 +61,20 @@ class Fall2026ResearchExperiment < OptInExperiment
   # invited yet.
   def student_invitations_open?
     Features.fall_2026_research_student_optin?
+  end
+
+  # The study's data collection server must learn of each enrollment before the
+  # student's userscript first runs: the script asks the server whether its user
+  # is a participant, and stays inert for anyone it doesn't recognize.
+  def handle_student_opt_in(courses_user)
+    record = super
+    ExperimentEnrollmentWorker.schedule(record)
+    record
+  end
+
+  def report_enrollment(experiment_courses_user)
+    WickieApi.new.enroll(username: experiment_courses_user.user.username,
+                         course_slug: experiment_courses_user.course.slug)
   end
 
   def userscript_import_line

--- a/lib/experiments/fall_2026_research_experiment.rb
+++ b/lib/experiments/fall_2026_research_experiment.rb
@@ -41,6 +41,8 @@ class Fall2026ResearchExperiment < OptInExperiment
       To enable the experiment, copy the line below, click 'Install script', paste it to your common.js page, then "Publish changes".
     INSTALL
     install_button: 'Install script',
+    install_copy_button: 'Copy',
+    install_copied: 'Copied!',
     install_verify_button: 'Verify experiment script',
     install_not_found: "We couldn't find the expected experiment script installed on your account."
   }.freeze

--- a/lib/experiments/opt_in_experiment.rb
+++ b/lib/experiments/opt_in_experiment.rb
@@ -41,9 +41,9 @@ class OptInExperiment
   # en.yml) so this ephemeral experiment text stays out of the translation
   # pipeline; the controller hands it to the React component. Returns a hash
   # with keys: :title, :message, :consent_form, :opt_in, :opt_out,
-  # :install_title, :install_message, :install_button, :install_verify_button,
-  # :install_not_found (the :message, :consent_form and :install_message values
-  # are Markdown).
+  # :install_title, :install_message, :install_button, :install_copy_button,
+  # :install_copied, :install_verify_button, :install_not_found (the :message,
+  # :consent_form and :install_message values are Markdown).
   def student_invitation_copy
     raise NotImplementedError
   end

--- a/lib/experiments/opt_in_experiment.rb
+++ b/lib/experiments/opt_in_experiment.rb
@@ -104,7 +104,47 @@ class OptInExperiment
   # after the student opts in; must be safe to retry.
   def report_enrollment(_experiment_courses_user); end
 
+  # Copy for the standalone instructor opt-in page reached from invitation
+  # emails (Experiments::InstructorOptInController). Lives here for the same
+  # reason as student_invitation_copy. Returns a hash with keys: :title,
+  # :description, :opt_in_label, :opt_out_label, :course_list_intro,
+  # :opted_in_flash, :opted_out_flash, :no_courses.
+  def instructor_invitation_copy
+    raise NotImplementedError
+  end
+
+  def eligible_instructed_courses(user)
+    user.instructed_courses.select { |course| eligible_course?(course) }
+  end
+
+  # The instructor's recorded choice for one course: :opted_in, :opted_out, or
+  # nil when they have not chosen yet.
+  def course_choice(course)
+    return :opted_in if course.tag?(opted_in_tag)
+    return :opted_out if course.tag?(opted_out_tag)
+    nil
+  end
+
+  # An instructor's choice from the standalone page applies to all their
+  # eligible courses at once, overwriting any earlier wizard choice: the tag
+  # upsert mirrors WizardTimelineManager#add_tags' exclusive-key semantics, so
+  # the two entry points remain interchangeable and the latest explicit choice
+  # always wins.
+  def handle_instructor_opt_in(user)
+    tag_instructed_courses(user, opted_in_tag)
+  end
+
+  def handle_instructor_opt_out(user)
+    tag_instructed_courses(user, opted_out_tag)
+  end
+
   private
+
+  def tag_instructed_courses(user, value)
+    eligible_instructed_courses(user).each do |course|
+      Tag.find_or_initialize_by(course:, key: tag_key).update!(tag: value)
+    end
+  end
 
   def upsert_participation(courses_user, status)
     record = ExperimentCoursesUser.find_or_initialize_by(

--- a/lib/experiments/opt_in_experiment.rb
+++ b/lib/experiments/opt_in_experiment.rb
@@ -99,6 +99,11 @@ class OptInExperiment
     :opted_out
   end
 
+  # Announce a confirmed opt-in to the experiment's external data collection
+  # server, if it has one. Called asynchronously (ExperimentEnrollmentWorker)
+  # after the student opts in; must be safe to retry.
+  def report_enrollment(_experiment_courses_user); end
+
   private
 
   def upsert_participation(courses_user, status)

--- a/lib/experiments/wickie_api.rb
+++ b/lib/experiments/wickie_api.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Client for the Fall 2026 research experiment's data collection server
+# ("wickie", source: https://github.com/humans-and-machines/wikiedu-intervention).
+# Experiment-specific; delete along with Fall2026ResearchExperiment when the
+# study ends.
+class WickieApi
+  ENROLL_URL = 'https://wickie.ink/enroll'
+
+  class EnrollmentFailed < StandardError; end
+
+  # Announces a student's opt-in so the server accepts data from their
+  # userscript. The endpoint is idempotent, so Sidekiq retries are safe.
+  #
+  # Without a configured secret this makes no request at all, so opt-ins on an
+  # environment that isn't meant to feed the study (development, test, a
+  # staging box) can never land in the real cohort.
+  def enroll(username:, course_slug:)
+    return if secret.blank?
+
+    response = post_enrollment(username:, course_slug:)
+    return if response.success?
+
+    # 5xx and network errors raise so Sidekiq retries them; a 4xx (malformed
+    # request, wrong secret) cannot succeed on retry, so it only alerts.
+    raise EnrollmentFailed, "#{response.status}: #{response.body}" if response.status >= 500
+
+    Sentry.capture_message('wickie enrollment rejected',
+                           level: 'error',
+                           extra: { status: response.status, body: response.body,
+                                    username:, course: course_slug })
+  end
+
+  private
+
+  def secret
+    ENV['wickie_enroll_secret']
+  end
+
+  def post_enrollment(username:, course_slug:)
+    conn = Faraday.new(url: ENROLL_URL,
+                       headers: { 'Content-Type' => 'application/json' })
+    conn.headers['User-Agent'] = ENV['dashboard_url'] + ' ' + Rails.env
+    conn.post('') do |req|
+      req.body = { secret:, username:, course: course_slug }.to_json
+    end
+  end
+end

--- a/spec/controllers/experiments/instructor_opt_in_controller_spec.rb
+++ b/spec/controllers/experiments/instructor_opt_in_controller_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/experiments/opt_in_experiment"
+
+describe Experiments::InstructorOptInController, type: :controller do
+  let(:slug) { Fall2026ResearchExperiment::SLUG }
+  let(:experiment) { Fall2026ResearchExperiment.new }
+  let(:instructor) { create(:user, username: 'Prof') }
+
+  def create_eligible_course(title)
+    create(:course, title:, slug: "School/#{title}_(Fall_2026)",
+                    start: Date.new(2026, 9, 1), end: Date.new(2026, 12, 15))
+  end
+
+  def instruct(course)
+    create(:courses_user, user: instructor, course:, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+  end
+
+  let!(:undecided_course) { create_eligible_course('Undecided').tap { |c| instruct(c) } }
+  let!(:opted_out_course) do
+    create_eligible_course('Opted_out').tap do |course|
+      instruct(course)
+      Tag.create!(course:, key: experiment.tag_key, tag: experiment.opted_out_tag)
+    end
+  end
+  # Eligible, but this instructor's choice must not touch someone else's course.
+  let!(:other_instructors_course) { create_eligible_course('Other') }
+
+  before do
+    allow(Features).to receive(:wiki_ed?).and_return(true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(instructor)
+  end
+
+  describe 'GET #show' do
+    it 'assigns the eligible instructed courses with their current choices' do
+      get :show, params: { experiment_slug: slug }
+      expect(response).to have_http_status(200)
+      expect(assigns(:courses)).to contain_exactly(undecided_course, opted_out_course)
+      expect(assigns(:choices)[undecided_course]).to be_nil
+      expect(assigns(:choices)[opted_out_course]).to eq(:opted_out)
+    end
+
+    it 'requires login' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil)
+      get :show, params: { experiment_slug: slug }
+      expect(response).to have_http_status(401)
+    end
+
+    it 'raises a routing error for an unknown experiment' do
+      expect { get :show, params: { experiment_slug: 'not_a_thing' } }
+        .to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  describe 'POST #opt_in' do
+    it 'opts in every eligible instructed course, overriding an earlier opt-out' do
+      post :opt_in, params: { experiment_slug: slug }
+      expect(experiment.course_choice(undecided_course)).to eq(:opted_in)
+      expect(experiment.course_choice(opted_out_course)).to eq(:opted_in)
+      expect(experiment.course_participating?(opted_out_course)).to be true
+      expect(experiment.course_choice(other_instructors_course)).to be_nil
+    end
+
+    it 'records only one tag per course, like the wizard' do
+      post :opt_in, params: { experiment_slug: slug }
+      expect(Tag.where(course: opted_out_course, key: experiment.tag_key).count).to eq(1)
+    end
+
+    it 'confirms and returns to the page' do
+      post :opt_in, params: { experiment_slug: slug }
+      expect(flash[:notice]).to eq(experiment.instructor_invitation_copy[:opted_in_flash])
+      expect(response).to redirect_to("/experiments/#{slug}/instructor_optin")
+    end
+  end
+
+  describe 'POST #opt_out' do
+    it 'opts out every eligible instructed course' do
+      post :opt_out, params: { experiment_slug: slug }
+      expect(experiment.course_choice(undecided_course)).to eq(:opted_out)
+      expect(experiment.course_choice(opted_out_course)).to eq(:opted_out)
+      expect(flash[:notice]).to eq(experiment.instructor_invitation_copy[:opted_out_flash])
+    end
+  end
+
+  context 'for a user with no eligible courses' do
+    let(:student) { create(:user, username: 'NotAnInstructor') }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(student)
+    end
+
+    it 'shows the page with no courses' do
+      get :show, params: { experiment_slug: slug }
+      expect(response).to have_http_status(200)
+      expect(assigns(:courses)).to be_empty
+    end
+
+    it 'records nothing and shows no confirmation on a posted choice' do
+      expect { post :opt_in, params: { experiment_slug: slug } }.not_to change(Tag, :count)
+      expect(flash[:notice]).to be_nil
+      expect(response).to redirect_to("/experiments/#{slug}/instructor_optin")
+    end
+  end
+end

--- a/spec/controllers/experiments/opt_in_controller_spec.rb
+++ b/spec/controllers/experiments/opt_in_controller_spec.rb
@@ -83,6 +83,12 @@ describe Experiments::OptInController, type: :controller do
       expect(record.opted_in?).to be true
     end
 
+    it 'schedules the enrollment notification to the data collection server' do
+      stub_common_js ''
+      expect(ExperimentEnrollmentWorker).to receive(:schedule)
+      post :opt_in, params: { experiment_slug: slug, course_id: course.id }
+    end
+
     it 'returns the import line to paste and a link to the edit form' do
       stub_common_js ''
       post :opt_in, params: { experiment_slug: slug, course_id: course.id }
@@ -100,6 +106,11 @@ describe Experiments::OptInController, type: :controller do
       post :opt_out, params: { experiment_slug: slug, course_id: course.id }
       record = ExperimentCoursesUser.find_by(courses_user:, experiment_slug: slug)
       expect(record.opted_out?).to be true
+    end
+
+    it 'does not notify the data collection server' do
+      expect(ExperimentEnrollmentWorker).not_to receive(:schedule)
+      post :opt_out, params: { experiment_slug: slug, course_id: course.id }
     end
   end
 

--- a/spec/features/experiment_instructor_optin_spec.rb
+++ b/spec/features/experiment_instructor_optin_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/experiments/opt_in_experiment"
+
+# Covers the standalone instructor opt-in page reached from invitation emails,
+# for instructors whose courses never went through the assignment wizard. The
+# page is server-rendered with no JavaScript, so these run on rack_test.
+describe 'research experiment instructor email-link opt-in', type: :feature do
+  let(:experiment) { Fall2026ResearchExperiment.new }
+  let(:instructor) do
+    create(:user, username: 'Alice Nakamura', permissions: User::Permissions::INSTRUCTOR)
+  end
+  let(:opt_in_path) { "/experiments/#{experiment.slug}/instructor_optin" }
+
+  before do
+    allow(Features).to receive(:wiki_ed?).and_return(true)
+  end
+
+  after { logout }
+
+  def eligible_course(title)
+    create(:course, title:, school: 'Northwestern University',
+                    slug: "Northwestern_University/#{title.tr(' ', '_')}_(Fall_2026)",
+                    start: Date.new(2026, 9, 1), end: Date.new(2026, 12, 15))
+  end
+
+  def instruct(course)
+    create(:courses_user, user: instructor, course:, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+  end
+
+  it 'asks a signed-out visitor to log in, keeping the page as the return path' do
+    visit opt_in_path
+    expect(page).to have_content('Log in')
+  end
+
+  context 'for a signed-in instructor with eligible courses' do
+    let!(:environmental_policy) { eligible_course('Environmental Policy').tap { |c| instruct(c) } }
+    let!(:media_literacy) do
+      eligible_course('Media Literacy').tap do |course|
+        instruct(course)
+        Tag.create!(course:, key: experiment.tag_key, tag: experiment.opted_out_tag)
+      end
+    end
+    # A Spring 2026 course is not part of the experiment and must not be listed.
+    let!(:spring_course) do
+      create(:course, title: 'History of Science',
+                      slug: 'Northwestern_University/History_of_Science_(Spring_2026)',
+                      start: Date.new(2026, 1, 15), end: Date.new(2026, 5, 15))
+        .tap { |c| instruct(c) }
+    end
+
+    before { login_as(instructor, scope: :user) }
+
+    it 'shows the wizard panel info and each course with its current status' do
+      visit opt_in_path
+      expect(page).to have_content('Please participate in our research experiment')
+      expect(page).to have_content('Wiki Education is working with researchers')
+      expect(page).to have_content('Environmental Policy')
+      expect(page).to have_content('Media Literacy')
+      expect(page).to have_content('Undecided')
+      expect(page).to have_content('Opted out')
+      expect(page).to have_no_content('History of Science')
+    end
+
+    it 'opts in all eligible courses, overriding an earlier opt-out' do
+      visit opt_in_path
+      click_button 'Yes, my class will participate'
+      expect(page).to have_content('Thank you! Your Fall 2026 courses are opted in')
+      expect(experiment.course_choice(environmental_policy)).to eq(:opted_in)
+      expect(experiment.course_choice(media_literacy)).to eq(:opted_in)
+      expect(experiment.course_participating?(media_literacy)).to be true
+      expect(experiment.course_choice(spring_course)).to be_nil
+    end
+
+    it 'opts out all eligible courses' do
+      visit opt_in_path
+      click_button 'No, I want to opt out'
+      expect(page).to have_content('You have opted out.')
+      expect(experiment.course_choice(environmental_policy)).to eq(:opted_out)
+      expect(experiment.course_choice(media_literacy)).to eq(:opted_out)
+    end
+  end
+
+  it 'explains when a signed-in user has no eligible courses' do
+    login_as(instructor, scope: :user)
+    visit opt_in_path
+    expect(page).to have_content("You don't have any Fall 2026 courses")
+    expect(page).to have_no_button('Yes, my class will participate')
+  end
+end

--- a/spec/features/experiment_opt_in_screenshots_spec.rb
+++ b/spec/features/experiment_opt_in_screenshots_spec.rb
@@ -81,6 +81,13 @@ describe 'Research experiment opt-in screenshots', type: :feature, js: true,
     allow_any_instance_of(WikiApi).to receive(:get_page_content).and_return(content)
   end
 
+  # Full viewport, as the student actually sees the page (unlike shoot_element,
+  # which clips to one element after growing the viewport to fit it).
+  def shoot_page(name)
+    sleep 0.6
+    page.save_screenshot(screenshot_dir.join("#{name}.png").to_s)
+  end
+
   it 'captures the instructor wizard opt-in panel' do
     TrainingModule.load_all
     stub_oauth_edit
@@ -127,9 +134,50 @@ describe 'Research experiment opt-in screenshots', type: :feature, js: true,
     expect(page).to have_css('.experiment-opt-in__snippet')
     shoot_element('.experiment-opt-in__panel', '03_student_install')
 
+    click_button 'Copy'
+    expect(page).to have_button('Copied!')
+    shoot_element('.experiment-opt-in__panel', '03b_student_install_copied')
+
     # common.js still lacks the line, so the re-check reports it as missing.
     click_button 'Verify experiment script'
     expect(page).to have_css('.experiment-opt-in__not-found')
     shoot_element('.experiment-opt-in__panel', '04_student_install_not_found')
+  end
+
+  it 'captures the consent modal in context, over the course overview' do
+    join_participating_course
+    visit "/courses/#{course.slug}"
+    expect(page).to have_css('.experiment-opt-in__panel')
+    shoot_page('02b_student_consent_in_context')
+  end
+
+  it 'captures the cleared course page once the script is verified on-wiki' do
+    join_participating_course
+    stub_common_js ''
+    visit "/courses/#{course.slug}"
+    expect(page).to have_css('.experiment-opt-in__panel')
+    click_button 'I consent'
+    expect(page).to have_css('.experiment-opt-in__snippet')
+
+    # The student has now saved the import line to their common.js, so the
+    # re-check finds it and the modal closes for good.
+    stub_common_js "#{experiment.userscript_import_line}\n"
+    click_button 'Verify experiment script'
+    expect(page).to have_no_css('.experiment-opt-in__panel')
+    shoot_page('05_student_verified_done')
+  end
+
+  it 'captures the course page after the student declines' do
+    join_participating_course
+    visit "/courses/#{course.slug}"
+    expect(page).to have_css('.experiment-opt-in__panel')
+    click_button 'No'
+    expect(page).to have_no_css('.experiment-opt-in__panel')
+    shoot_page('06_student_opted_out')
+
+    # The choice is durable: a return visit shows no invitation.
+    visit "/courses/#{course.slug}"
+    expect(page).to have_content(course.title)
+    expect(page).to have_no_css('.experiment-opt-in__panel')
   end
 end

--- a/spec/features/experiment_opt_in_screenshots_spec.rb
+++ b/spec/features/experiment_opt_in_screenshots_spec.rb
@@ -167,6 +167,27 @@ describe 'Research experiment opt-in screenshots', type: :feature, js: true,
     shoot_page('05_student_verified_done')
   end
 
+  it 'captures the instructor email-link opt-in page, before and after opting in' do
+    create(:courses_user, user: instructor, course:,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    second_course = create(:course, title: 'Media Literacy',
+                                    school: 'Northwestern University',
+                                    slug: 'Northwestern_University/Media_Literacy_(Fall_2026)',
+                                    start: Date.new(2026, 9, 1), end: Date.new(2026, 12, 15))
+    create(:courses_user, user: instructor, course: second_course,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    create(:tag, course: second_course, key: experiment.tag_key, tag: experiment.opted_out_tag)
+    login_as(instructor, scope: :user)
+
+    visit "/experiments/#{experiment.slug}/instructor_optin"
+    expect(page).to have_content('research experiment')
+    shoot_page('07_instructor_email_link_page')
+
+    click_button 'Yes, my class will participate'
+    expect(page).to have_content('Thank you!')
+    shoot_page('08_instructor_email_link_opted_in')
+  end
+
   it 'captures the course page after the student declines' do
     join_participating_course
     visit "/courses/#{course.slug}"

--- a/spec/lib/experiments/fall_2026_research_experiment_spec.rb
+++ b/spec/lib/experiments/fall_2026_research_experiment_spec.rb
@@ -55,9 +55,20 @@ describe Fall2026ResearchExperiment do
       expect(record.userscript_installed_at).to be_nil
     end
 
+    it 'schedules the enrollment notification to the data collection server' do
+      expect(ExperimentEnrollmentWorker).to receive(:schedule)
+        .with(an_instance_of(ExperimentCoursesUser))
+      experiment.handle_student_opt_in(courses_user)
+    end
+
     it 'records an opt-out' do
       experiment.handle_student_opt_out(courses_user)
       expect(experiment.participation(courses_user).opted_out?).to be true
+    end
+
+    it 'does not notify the data collection server of an opt-out' do
+      expect(ExperimentEnrollmentWorker).not_to receive(:schedule)
+      experiment.handle_student_opt_out(courses_user)
     end
 
     it 'no longer needs a response once the student has responded' do
@@ -109,6 +120,24 @@ describe Fall2026ResearchExperiment do
     # javascript content model, so a preload parameter would be ignored.
     it 'does not try to preload the edit box' do
       expect(experiment.userscript_install_url(student)).not_to include('preload')
+    end
+  end
+
+  describe '#report_enrollment' do
+    let(:student) { create(:user, username: 'Jane Doe') }
+    let(:courses_user) do
+      create(:courses_user, course: fall_2026_course, user: student,
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
+    let(:record) do
+      ExperimentCoursesUser.create!(experiment_slug: experiment.slug, courses_user:,
+                                    status: :opted_in)
+    end
+
+    it 'enrolls the student on the data collection server by username and course slug' do
+      expect_any_instance_of(WickieApi).to receive(:enroll)
+        .with(username: 'Jane Doe', course_slug: fall_2026_course.slug)
+      experiment.report_enrollment(record)
     end
   end
 

--- a/spec/lib/experiments/fall_2026_research_experiment_spec.rb
+++ b/spec/lib/experiments/fall_2026_research_experiment_spec.rb
@@ -141,6 +141,21 @@ describe Fall2026ResearchExperiment do
     end
   end
 
+  describe '#instructor_invitation_copy' do
+    let(:wizard_panel) do
+      YAML.safe_load(File.read("#{Rails.root}/config/wizard/researchwrite/wizard.yml"))
+          .find { |panel| panel['key'] == 'fall_2026_research_optin' }
+    end
+
+    it 'reuses the wizard panel title, description and option labels verbatim' do
+      copy = experiment.instructor_invitation_copy
+      expect(copy[:title]).to eq(wizard_panel['title'])
+      expect(copy[:description]).to eq(wizard_panel['description'])
+      expect(wizard_panel['options'].map { |option| option['title'] })
+        .to contain_exactly(copy[:opt_in_label], copy[:opt_out_label])
+    end
+  end
+
   describe '#userscript_marker' do
     it 'is contained in the import line, so a saved line is detected' do
       expect(experiment.userscript_import_line).to include(experiment.userscript_marker)

--- a/spec/lib/experiments/wickie_api_spec.rb
+++ b/spec/lib/experiments/wickie_api_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/experiments/wickie_api"
+
+describe WickieApi do
+  let(:username) { 'Jane Doe' }
+  let(:course_slug) { 'University_of_X/Course_Name_(Fall_2026)' }
+  let(:enroll) { described_class.new.enroll(username:, course_slug:) }
+
+  def stub_secret(value)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('wickie_enroll_secret').and_return(value)
+  end
+
+  context 'when the enrollment secret is configured' do
+    before { stub_secret 'a-real-secret' }
+
+    it 'posts the enrollment payload to the data collection server' do
+      stub = stub_request(:post, WickieApi::ENROLL_URL)
+             .with(body: { secret: 'a-real-secret', username:, course: course_slug },
+                   headers: { 'Content-Type' => 'application/json' })
+             .to_return(status: 200, body: '{"enrolled": true}')
+      enroll
+      expect(stub).to have_been_requested
+    end
+
+    it 'reports a rejected enrollment to Sentry without raising' do
+      stub_request(:post, WickieApi::ENROLL_URL).to_return(status: 401, body: 'bad secret')
+      expect(Sentry).to receive(:capture_message)
+      expect { enroll }.not_to raise_error
+    end
+
+    it 'raises on a server error, so Sidekiq will retry' do
+      stub_request(:post, WickieApi::ENROLL_URL).to_return(status: 503)
+      expect { enroll }.to raise_error(WickieApi::EnrollmentFailed)
+    end
+
+    it 'lets a connection failure propagate, so Sidekiq will retry' do
+      stub_request(:post, WickieApi::ENROLL_URL).to_raise(Faraday::ConnectionFailed)
+      expect { enroll }.to raise_error(Faraday::ConnectionFailed)
+    end
+  end
+
+  context 'when no enrollment secret is configured' do
+    before { stub_secret nil }
+
+    it 'makes no request at all' do
+      stub = stub_request(:post, WickieApi::ENROLL_URL)
+      enroll
+      expect(stub).not_to have_been_requested
+    end
+  end
+end

--- a/spec/services/check_experiment_userscript_spec.rb
+++ b/spec/services/check_experiment_userscript_spec.rb
@@ -41,6 +41,12 @@ describe CheckExperimentUserscript do
     expect(described_class.new(record, experiment).status).to eq(:installed)
   end
 
+  it 'still counts the script as installed when the title uses spaces for underscores' do
+    spaced_title = Fall2026ResearchExperiment::USERSCRIPT_PAGE.tr('_', ' ')
+    stub_common_js "importScript('#{spaced_title}');\n"
+    expect(described_class.new(record, experiment).status).to eq(:installed)
+  end
+
   it 'leaves an existing install timestamp untouched' do
     record.update!(userscript_installed_at: 3.days.ago)
     stub_common_js "#{experiment.userscript_import_line}\n"

--- a/spec/workers/experiment_enrollment_worker_spec.rb
+++ b/spec/workers/experiment_enrollment_worker_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/experiments/opt_in_experiment"
+
+describe ExperimentEnrollmentWorker do
+  let(:course) { create(:course, start: Date.new(2026, 9, 1)) }
+  let(:student) { create(:user) }
+  let(:courses_user) do
+    create(:courses_user, course:, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+
+  def create_record(status)
+    ExperimentCoursesUser.create!(experiment_slug: Fall2026ResearchExperiment::SLUG,
+                                  courses_user:, status:)
+  end
+
+  it 'reports an opted-in record to the experiment' do
+    record = create_record(:opted_in)
+    expect_any_instance_of(Fall2026ResearchExperiment)
+      .to receive(:report_enrollment).with(record)
+    described_class.new.perform(record.id)
+  end
+
+  it 'does nothing for an opted-out record' do
+    record = create_record(:opted_out)
+    expect_any_instance_of(Fall2026ResearchExperiment).not_to receive(:report_enrollment)
+    described_class.new.perform(record.id)
+  end
+
+  it 'does nothing when the record no longer exists' do
+    expect_any_instance_of(Fall2026ResearchExperiment).not_to receive(:report_enrollment)
+    described_class.new.perform(-1)
+  end
+end

--- a/test/components/experiment_opt_in_invitation.spec.js
+++ b/test/components/experiment_opt_in_invitation.spec.js
@@ -88,6 +88,8 @@ describe('ExperimentOptInInvitation', () => {
     install_title: 'Install the tool',
     install_message: 'Paste this line into your common.js.',
     install_button: 'Open my common.js',
+    install_copy_button: 'Copy it',
+    install_copied: 'On your clipboard',
     install_verify_button: "I've saved it",
     install_not_found: 'Not found yet.'
   };
@@ -113,6 +115,26 @@ describe('ExperimentOptInInvitation', () => {
     expect(container.textContent).toContain('Paste this line into your common.js.');
     const link = container.querySelector('.experiment-opt-in__actions a');
     expect(link.getAttribute('href')).toContain('action=edit');
+  });
+
+  it('copies the import line to the clipboard and says so', async () => {
+    const importLine = "importScript('User:Sage_(Wiki_Ed)/wickie.js');";
+    request.mockResolvedValue(installInvitation({
+      install_url: 'https://en.wikipedia.org/w/index.php?title=User:S/common.js&action=edit',
+      import_line: importLine
+    }));
+    const writeText = jest.fn().mockResolvedValue();
+    global.navigator.clipboard = { writeText };
+
+    const container = await renderComponent(eligibleCourse, student);
+    const copyButton = container.querySelector('.experiment-opt-in__copy-button');
+    expect(copyButton.textContent).toEqual('Copy it');
+    await act(async () => { copyButton.click(); });
+    await flush();
+
+    expect(writeText).toHaveBeenCalledWith(importLine);
+    expect(copyButton.textContent).toEqual('On your clipboard');
+    delete global.navigator.clipboard;
   });
 
   it('closes for good once a re-check finds the script installed', async () => {


### PR DESCRIPTION
## What this PR does

Completes the Dashboard side of the Fall 2026 research experiment ("wickie" study, Princeton University IRB #19959), building on the opt-in framework from #6935. Four changes:

1. **Enrollment notification**: when a student opts in, a Sidekiq job POSTs `{secret, username, course}` to the study's data collection server (`https://wickie.ink/enroll`), which must know about each enrollment before the student's userscript first runs. The endpoint's contract (idempotent, designed for retrying consent workflows) was verified against the researchers' backend source ([humans-and-machines/wikiedu-intervention](https://github.com/humans-and-machines/wikiedu-intervention), private). With no `wickie_enroll_secret` configured, no request is made at all, so non-production environments can never pollute the study cohort. All wickie-specific code lives in `Fall2026ResearchExperiment` and `lib/experiments/wickie_api.rb`, deletable together when the study ends; the worker and base-class hook are experiment-agnostic.
2. **Userscript rename + install polish**: the script page is now `User:Sage_(Wiki_Ed)/wickie.js` (matching the tool's real name), the install modal gained a Copy button for the import line, and install verification now treats underscores and spaces in the page title as equivalent, as MediaWiki does.
3. **Consent form fix**: the "Consequences" section from the IRB-approved consent document was missing from the form shown to students; added verbatim.
4. **Email-link instructor opt-in page** at `/experiments/fall_2026_research/instructor_optin`: instructors of courses that never went through the assignment wizard will be invited by email. The page shows the same information as the wizard panel (title, description, and button labels are loaded from `wizard.yml` at runtime so the two entry points cannot drift), lists the instructor's eligible Fall 2026 courses with each one's current status, and applies their choice to all of them at once by writing the same exclusive-keyed course Tags the wizard writes — so the latest explicit choice always wins, whichever entry point it came from. A signed-out visitor is prompted to log in and returned to the page afterwards.

## Go-live checklist

Everything needed to enable the student side and take the experiment live, in rough order:

**Dashboard side**
- [x] Merge this PR and deploy to production.
- [x] Set `wickie_enroll_secret` in production `application.yml` (value from the research team; must match the backend's `WICKIE_ENROLL_SECRET`) and restart, so student opt-ins are reported to wickie.ink.
- [x] Create [`User:Sage (Wiki Ed)/wickie.js`](https://en.wikipedia.org/wiki/User:Sage_(Wiki_Ed)/wickie.js) on English Wikipedia with the production build of the userscript (testing draft: [`User:TestAccount4454/wickie.js`](https://en.wikipedia.org/wiki/User:TestAccount4454/wickie.js)).
- [ ] Set `fall_2026_research_student_optin: 'true'` in production `application.yml` and restart. This opens the student invitations on participating courses — do it only after the two items above, since opting-in students are immediately shown the install step and their enrollment POSTs fire right away.
- [ ] Send the instructor invitation emails linking to `https://dashboard.wikiedu.org/experiments/fall_2026_research/instructor_optin` (email sending happens outside the Dashboard).

**Research-team side (coordinate before flipping the student flag)**
- [x] wickie.ink backend running in production mode with the matching `WICKIE_ENROLL_SECRET`.
- [ ] `WICKIE_OPEN_ENROLLMENT_COURSE` unset on their production backend (a pre-launch window that auto-enrolls unknown usernames) before any cohort students arrive.
- [ ] Recruitment materials updated: they still say the tool "will be installed automatically", which predates the pivot to student self-install after the production OAuth grant was denied.
- [ ] Reconcile the randomization-unit wording: the recruitment materials and wizard copy describe course-level assignment ("some enrolled courses receive..."), but the backend assigns arms per student, block-balanced within each course.
- [x] Confirm the doubled "While you edit..." sentence in the IRB consent document's Procedures section is a copy artifact (the Dashboard's form includes it once).

**After go-live**
- [ ] End-to-end smoke test with a test student account on a participating course: opt in, confirm the enrollment reached wickie.ink (the research team can check the participants table), install the script via the copy-button flow, and confirm "Verify experiment script" clears the modal.

## AI usage

All four commits were written by Claude Code (Fable 5) in a single working session on 2026-08-26 (first to last commit spanning about three hours), under continuous direction and review by @ragesoss, who made every design decision (userscript page name, enrollment-failure semantics, override behavior for existing wizard choices) and approved or chose every user-facing string individually — per this repo's policy, no user-facing copy was AI-invented. Claude Code wrote the code, specs, and commit messages, read the researchers' backend source to verify the `/enroll` contract before choosing retry semantics, and generated and reviewed the screenshots below. This summary and the rest of this description were also drafted by Claude Code (via the `/prepare-pr` skill) and may contain errors.

## Screenshots

**01 instructor wizard opt-in panel** _(unchanged; shown for reference)_

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/before/01_instructor_wizard_optin.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/01_instructor_wizard_optin.png) |

**02 student consent modal**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/before/02_student_consent_modal.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/02_student_consent_modal.png) |

**02b student consent modal in context, over the course overview**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/02b_student_consent_in_context.png) |

**03 student install step** _(renamed script; new Copy button)_

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/before/03_student_install.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/03_student_install.png) |

**03b student install step after copying the import line**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/03b_student_install_copied.png) |

**04 student install, script not found on re-check**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/before/04_student_install_not_found.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/04_student_install_not_found.png) |

**05 course page once the script is verified on-wiki**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/05_student_verified_done.png) |

**06 course page after the student declines**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/06_student_opted_out.png) |

**07 instructor email-link opt-in page**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/07_instructor_email_link_page.png) |

**08 instructor email-link page after opting in**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/WickieEnrollmentNotification/screenshots/after/08_instructor_email_link_opted_in.png) |

## Open questions and concerns

- A 4xx from `/enroll` (e.g. a wrong secret) is reported to Sentry and **not** retried, since retrying can't fix it. If production ever runs with a misconfigured secret, opt-ins from that window won't reach the study server until re-triggered — the endpoint is idempotent, so re-enrollment is safe, but someone has to notice the Sentry report.
- The two research-team wording issues in the checklist (stale "installed automatically" language; per-student vs. course-level randomization description) affect their IRB-facing materials, not this codebase, but the wizard/instructor-page copy mirrors their materials — if they revise the randomization description, `wizard.yml` should be updated to match, and the email-link page will pick that up automatically.
- Email sending for the instructor invitations is deliberately out of scope; the Dashboard only serves the landing page.

(PR description written by Claude Code.)
