### PR TITLE
Revamp AI edit alert emails with verification-focused text

### DIFF
--- a/app/views/ai_edit_alert_mailer/instructor_mainspace_advice.html.haml
+++ b/app/views/ai_edit_alert_mailer/instructor_mainspace_advice.html.haml
@@ -94,21 +94,15 @@
                 Wikipedia).
               %p.info
                 To view the Pangram report for this text, click below:
-              %table
-                %tr
-                  %td.main-content.link-cell
-                    %a.button_link{href: @alert.pangram_url}
-                      %strong View Pangram report
+              %p.info
+                %a.link{href: @alert.pangram_url} View Pangram report
               %p.info
                 Is the Pangram report accurate? Was this a false positive? Help us
                 improve our AI detection system to get better at keeping
                 unverifiable, inaccurate AI-generated content off Wikipedia without
                 flagging authentic writing incorrectly.
-              %table
-                %tr
-                  %td.main-content.link-cell
-                    %a.button_link{href: @alert.followup_link}
-                      %strong Submit feedback on Pangram report
+              %p.info
+                %a.link{href: @alert.followup_link} Submit feedback on Pangram report
               %p.info
                 Plausible information that seems generally consistent with a cited
                 source but doesn’t seem like it actually came from there is a

--- a/app/views/ai_edit_alert_mailer/instructor_mainspace_advice.html.haml
+++ b/app/views/ai_edit_alert_mailer/instructor_mainspace_advice.html.haml
@@ -9,61 +9,68 @@
               %p.paragraph
                 = "Dear #{@greeted_users},"
               %p.paragraph
-                You've received a message with your student on copy that Pangram has
-                automatically detected that your student pasted a generative AI
-                chatbot output into a Wikipedia page, against Wiki Education's rules.
-                This message provides more details for you as the instructor. We
-                recommend keeping it in your inbox for future reference, as many
-                instructors receive multiple alerts throughout the term.
+                You’ve received a message with your student on copy that the Wiki
+                Education Dashboard has automatically detected that your student
+                may have pasted an AI chatbot output into a Wikipedia page that
+                requires further verification.
               %p.paragraph
-                The alert you received is about a mainspace edit, meaning it's visible to everyone.
-                %strong Please immediately revert the student's work if it hasn't yet been removed by Wiki Education staff or other Wikipedia editors.
-                (Their contribution will still be visible in the page history,
-                so this will just remove it from readers' views, not remove it entirely.) Please have a 1:1
-                conversation with the student to understand their perspective as soon as possible.
-              %h2.headline If your student used a generative AI tool
+                If you’d like your student to move their work live again, they need
+                to work with you to ensure the facts in their contribution can be
+                found in the sources they cite.
               %p.paragraph
-                Make sure the generative AI-written or -edited content is already out of the live Wikipedia
-                article. You may then allow the student to re-do the assignment without using AI, if that
-                fits into your course policies. Do not allow the student to move the AI content live again;
-                doing so will likely result in the student being blocked from editing.
-              %h2.headline If your student says they didn't use a generative AI tool
+                This message provides more details for you as the instructor. See
+                next steps below.
               %p.paragraph
-                Generative AI tools are particularly bad at creating text for Wikipedia that is verifiable.
-                Ideally, a reader should be able to quickly confirm the accuracy by checking the source. If
-                it's not straightforward to confirm where information came from, then the student should
-                rewrite their contribution to make the information easily verifiable (even if AI wasn't used).
-                We require the following steps to assess text if you believe your student has experienced a
-                false positive and would like to move the work live again:
-                %ol.paragraph
-                  %li Find the content your student edited. (If it's already been reverted, you can use the "View history" tab to see the last version from your student.)
-                  %li Identify a sentence or paragraph the student has cited to a source. Open the source in a separate window.
-                  %li Check the source, looking for the information from the sentence or paragraph the student cited it to.
-                  %li If you can easily verify the fact is true according to that source, move on to the next one. Plausible information that seems generally consistent with a cited source but doesn't seem like it actually came from there is a hallmark of AI-created Wikipedia content. (If the citations are not specific enough to easily verify, ask the student to add page numbers to the citations.)
-                  %li If all information the student has included is verifiable in the sources they have cited, they can move the work again. Please report this case to us as a false positive. (These are rare, so knowing when they occur helps us improve our detection).
-                  %li If any of the information fails verification, we recommend asking the student to rewrite their Wikipedia contribution in a sandbox without the help of generative AI.
+                The alert you received is about a mainspace edit, meaning it’s a
+                part of a Wikipedia article that’s visible to everyone.
+                %strong Remove the student’s work if it hasn’t been removed yet by Wiki Education staff or other Wikipedia editors.
+                (This will remove their contribution from readers’ views, but it
+                will still be accessible in the page history.)
               %p.paragraph
-                Text transformed by Grammarly and other AI copyediting tools can also trigger AI detection,
-                depending on how significantly it was transformed. Simple grammar fixes in Grammarly will not
-                typically trigger Pangram, but use of writing suggestions may. If the student says they "only
-                used Grammarly" please make sure they turn off anything but basic grammar fixes (and they
-                should ensure those don't change the meaning of the sentence, something critical for Wikipedia).
-                Other Wikipedia editors can easily improve the readability of the text if the facts are accurate
-                and precise, but AI copyediting introduces distortions in meaning, so it's untrustworthy for
-                the same reasons as chatbot output when it comes to Wikipedia.
+                Have a 1:1 conversation with the student to understand their
+                perspective as soon as possible, and to let them know their work
+                needs to be double checked for accuracy before it goes live.
+              %h2.headline Next steps
+              %ol.paragraph
+                %li
+                  Work directly with your student to ensure
+                  %u every sentence
+                  they’ve added is fully accurate and can be found in the sources they’re citing.
+                %li
+                  Locate your student’s wiki contribution. (If it’s already been
+                  removed, you will find their text in their drafting sandbox page
+                  or their outline sandbox page or you can use the "View history"
+                  tab to see the last version from your student. Reach out to your
+                  Wikipedia Expert if you have questions.)
+                %li
+                  Ask your student to identify a sentence or paragraph the student
+                  has cited to a source. Have them go to the cited source.
+                %li
+                  Ask your student to locate the information from the sentence or
+                  paragraph in the source.
+                %li
+                  If your student can easily show you the fact in the cited source,
+                  move on to the next one. (If the citations are not specific enough
+                  to easily fact-check, ask the student to add page numbers to the
+                  citations.)
+                %li
+                  Once all information the student has included is verifiable in the
+                  sources they have cited, they may move the work back to Wikipedia.
+                %li
+                  Notify your Wikipedia Expert that the work has been verified and
+                  will be added to the live article.
               %p.paragraph
-                Non-verifiable text may NOT be added back to Wikipedia; doing so will likely result in the
-                student being blocked from editing.
+                ** If any of the information cannot be found in the cited source, we
+                recommend asking the student to rewrite their Wikipedia contribution
+                in a sandbox without the help of AI. Non-verifiable text may NOT be
+                added back to Wikipedia.
+              %h2.headline About detection
               %p.paragraph
-                If you are able to verify the information the student has added, and you are confident as a
-                subject matter expert that they didn't use Grammarly or another tool that introduced
-                subtle errors in meaning, the student may move the work live again.
-                %strong
-                  Please communicate directly with the Wiki Expert assigned to your course to personally
-                  confirm your assessment that the text is accurate.
-                Your domain expertise in your course subject is critical input
-                for us, as our staff's expertise is in Wikipedia, not the content of the article your student
-                edited.
+                We use the AI detector Pangram to check Wikipedia edits for
+                AI-generated text. We use Pangram as a signal that a human must
+                verify that the information added to Wikipedia is accurate, can be
+                found in the cited source, and fully adheres to Wikipedia’s
+                verifiability policy.<sup>†</sup>
               %h2.headline Need more help?
               %p.paragraph
                 You're not alone in navigating these AI detection incidents — other instructors are also
@@ -79,6 +86,50 @@
                 %br
                 %em Wiki Education
 
+              %hr
+              %h2.info † About AI detection
+              %p.info
+                AI detectors are not foolproof, but Pangram is reliable enough to
+                catch many cases of AI-generated text (which should not be added to
+                Wikipedia).
+              %p.info
+                To view the Pangram report for this text, click below:
+              %table
+                %tr
+                  %td.main-content.link-cell
+                    %a.button_link{href: @alert.pangram_url}
+                      %strong View Pangram report
+              %p.info
+                Is the Pangram report accurate? Was this a false positive? Help us
+                improve our AI detection system to get better at keeping
+                unverifiable, inaccurate AI-generated content off Wikipedia without
+                flagging authentic writing incorrectly.
+              %table
+                %tr
+                  %td.main-content.link-cell
+                    %a.button_link{href: @alert.followup_link}
+                      %strong Submit feedback on Pangram report
+              %p.info
+                Plausible information that seems generally consistent with a cited
+                source but doesn’t seem like it actually came from there is a
+                hallmark of AI-created Wikipedia content. Text transformed by
+                Grammarly and other AI copyediting tools can also trigger AI
+                detection, depending on how significantly it was transformed. If the
+                student says they "only used Grammarly" please make sure they turn
+                it off. Other Wikipedia editors can easily improve the readability
+                of the text if the facts are accurate and precise, but AI
+                copyediting introduces distortions in meaning, so it’s untrustworthy
+                for the same reasons as chatbot output when it comes to Wikipedia.
+              %p.info
+                If you are able to verify the information the student has added, and
+                you are confident as a subject matter expert that they didn’t use
+                Grammarly or another tool that introduced subtle errors in meaning,
+                the student may move the work live again. Please communicate
+                directly with the Wiki Expert assigned to your course to personally
+                confirm your assessment that the text is accurate. Your domain
+                expertise in your course subject is critical input for us, as our
+                staff’s expertise is in Wikipedia, not the content of the article
+                your student edited.
 
 .hidden
   %p

--- a/app/views/ai_edit_alert_mailer/instructor_sandbox_advice.html.haml
+++ b/app/views/ai_edit_alert_mailer/instructor_sandbox_advice.html.haml
@@ -9,66 +9,60 @@
               %p.paragraph
                 = "Dear #{@greeted_users},"
               %p.paragraph
-                You've received a message with your student on copy that Pangram has
-                automatically detected that your student pasted a generative AI
-                chatbot output into a Wikipedia page, against Wiki Education's rules.
-                This message provides more details for you as the instructor. We
-                recommend keeping it in your inbox for future reference, as many
-                instructors receive multiple alerts throughout the term.
+                You’ve received a message with your student on copy that the Wiki
+                Education Dashboard has automatically detected that your student
+                may have pasted an AI chatbot output into their sandbox page that
+                requires further verification.
               %p.paragraph
-                The alert you received was about text in your student's sandbox. Since this text
-                is intended to be moved to the article space, it is critical that
-                none of this text was written by generative AI chatbots. Please have
-                a 1:1 conversation with the student to understand their perspective
-                as soon as possible.
-              %h2.headline If your student used a generative AI tool
+                If you’d like your student to move their work live, they need to
+                work with you to ensure the facts in their contribution can be
+                found in the sources they cite.
               %p.paragraph
-                The student must redo the assignment without using generative AI to
-                draft or edit text (even Grammarly). If they do not redo the assignment,
-                they may not move the text to Wikipedia's mainspace, and must leave it
-                in the sandbox for you to assess there.
-              %h2.headline If your student says they didn't use a generative AI tool
+                This message provides more details for you as the instructor. See
+                next steps below.
               %p.paragraph
-                Generative AI tools are particularly bad at creating text for Wikipedia that is verifiable.
-                Ideally, a reader should be able to quickly confirm the accuracy by checking the source. If
-                it's not straightforward to confirm where information came from, then the student should
-                return to their contribution to make the information easily verifiable (even if AI wasn't used).
-                We recommend the following steps to assess text:
-                %ol.paragraph
-                  %li Identify a sentence or paragraph the student has cited to a source. Open the source in a separate window.
-                  %li Check the source, looking for the information from the sentence or paragraph the student cited it to.
-                  %li If you can easily verify the fact is true according to that source, move on to the next one. Plausible information that seems generally consistent with a cited source but doesn't seem like it actually came from there is a hallmark of AI-created Wikipedia content. (If the citations are not specific enough to easily verify, ask the student to add page numbers to the citations.)
-                  %li If all information the student has included is verifiable in the sources they have cited, they can move the work live. Please report this case to us as a false positive. (These are rare, so knowing when they occur helps us improve our detection).
-                  %li If any of the information fails verification, ask the student to rewrite their Wikipedia contribution without the help of generative AI. Do not let them move information that fails verification to Wikipedia.
+                The alert you received was about text in your student’s sandbox.
+                Since this text is intended to be moved to the article space, it is
+                critical that none of this text was written by AI chatbots before
+                that happens. Have a 1:1 conversation with the student to understand
+                their perspective as soon as possible, and to let them know their
+                work needs to be double checked for accuracy before it goes live.
+              %h2.headline Next steps
+              %ol.paragraph
+                %li
+                  Work directly with your student to ensure
+                  %u every sentence
+                  they’ve added is fully accurate and can be found in the sources they’re citing.
+                %li
+                  Ask your student to identify a sentence or paragraph the student
+                  has cited to a source. Have them go to the cited source.
+                %li
+                  Ask your student to locate the information from the sentence or
+                  paragraph in the source.
+                %li
+                  If your student can easily show you the fact in the cited source,
+                  move on to the next one. (If the citations are not specific enough
+                  to easily verify, ask the student to add page numbers to the
+                  citations.)
+                %li
+                  Once all information the student has included is verifiable in the
+                  sources they have cited, then they can add their work to the live
+                  article when it is time.
+                %li
+                  Notify your Wikipedia Expert that the work has been verified and
+                  will be added to the live article.
               %p.paragraph
-                Pangram may flag edits in scenarios like:
-                %ul.paragraph
-                  %li.paragraph
-                    If a student saves an empty outline (for example, with just short
-                    bullet points or empty section headers), or includes a significant
-                    amount of non-prose text (like sentence fragments or bibliographic
-                    entries) this might trigger the AI detector. Non-prose text is a
-                    common factor in most of the confirmed false positives we've seen.
-                    In this case, please encourage the student to fill out the feedback
-                    form and indicate a false positive so we know how many occur each term.
-                  %li.paragraph
-                    Text transformed by Grammarly and other AI copyediting tools can
-                    trigger AI detection, depending on how significantly it was
-                    transformed. Simple grammar fixes in Grammarly will not typically
-                    trigger Pangram, but use of writing suggestions may. If the student
-                    says they "only used Grammarly" please make sure they turn off anything
-                    but basic grammar fixes (and they should ensure those don't change
-                    the meaning of the sentence, something critical for Wikipedia). Other
-                    Wikipedia editors can easily improve the readability of the text if
-                    the facts are accurate and precise, but AI copyediting introduces
-                    distortions in meaning, so it's untrustworthy for the same reasons
-                    as chatbot output when it comes to Wikipedia.
-                  %li.paragraph
-                    Students who copy and paste existing text from a Wikipedia article into their sandbox
-                    will occasionally have the pre-existing text flagged. In this case, they've probably
-                    discovered some extant AI slop, and your student should be highly skeptical of that
-                    content! If it's bad or they can't easily verify it from cited sources, they should
-                    delete it from the live article.
+                ** If any of the information cannot be found in the cited source, we
+                recommend asking the student to rewrite their Wikipedia contribution
+                in a sandbox without the help of generative AI. Non-verifiable text
+                may NOT be added to Wikipedia.
+              %h2.headline About detection
+              %p.paragraph
+                We use the AI detector Pangram to check Wikipedia edits for
+                AI-generated text. We use Pangram as a signal that a human must
+                verify that the information added to Wikipedia is accurate, can be
+                found in the cited source, and fully adheres to Wikipedia’s
+                verifiability policy.<sup>†</sup>
               %h2.headline Need more help?
               %p.paragraph
                 You're not alone in navigating these AI detection incidents — other instructors are also
@@ -84,6 +78,50 @@
                 %br
                 %em Wiki Education
 
+              %hr
+              %h2.info † About AI detection
+              %p.info
+                AI detectors are not foolproof, but Pangram is reliable enough to
+                catch many cases of AI-generated text (which should not be added to
+                Wikipedia).
+              %p.info
+                To view the Pangram report for this text, click below:
+              %table
+                %tr
+                  %td.main-content.link-cell
+                    %a.button_link{href: @alert.pangram_url}
+                      %strong View Pangram report
+              %p.info
+                Is the Pangram report accurate? Was this a false positive? Help us
+                improve our AI detection system to get better at keeping
+                unverifiable, inaccurate AI-generated content off Wikipedia without
+                flagging authentic writing incorrectly.
+              %table
+                %tr
+                  %td.main-content.link-cell
+                    %a.button_link{href: @alert.followup_link}
+                      %strong Submit feedback on Pangram report
+              %p.info
+                Plausible information that seems generally consistent with a cited
+                source but doesn’t seem like it actually came from there is a
+                hallmark of AI-created Wikipedia content. Text transformed by
+                Grammarly and other AI copyediting tools can also trigger AI
+                detection, depending on how significantly it was transformed. If the
+                student says they "only used Grammarly" please make sure they turn
+                it off. Other Wikipedia editors can easily improve the readability
+                of the text if the facts are accurate and precise, but AI
+                copyediting introduces distortions in meaning, so it’s untrustworthy
+                for the same reasons as chatbot output when it comes to Wikipedia.
+              %p.info
+                If you are able to verify the information the student has added, and
+                you are confident as a subject matter expert that they didn’t use
+                Grammarly or another tool that introduced subtle errors in meaning,
+                the student may move the work live again. Please communicate
+                directly with the Wiki Expert assigned to your course to personally
+                confirm your assessment that the text is accurate. Your domain
+                expertise in your course subject is critical input for us, as our
+                staff’s expertise is in Wikipedia, not the content of the article
+                your student edited.
 
 .hidden
   %p

--- a/app/views/ai_edit_alert_mailer/instructor_sandbox_advice.html.haml
+++ b/app/views/ai_edit_alert_mailer/instructor_sandbox_advice.html.haml
@@ -86,21 +86,15 @@
                 Wikipedia).
               %p.info
                 To view the Pangram report for this text, click below:
-              %table
-                %tr
-                  %td.main-content.link-cell
-                    %a.button_link{href: @alert.pangram_url}
-                      %strong View Pangram report
+              %p.info
+                %a.link{href: @alert.pangram_url} View Pangram report
               %p.info
                 Is the Pangram report accurate? Was this a false positive? Help us
                 improve our AI detection system to get better at keeping
                 unverifiable, inaccurate AI-generated content off Wikipedia without
                 flagging authentic writing incorrectly.
-              %table
-                %tr
-                  %td.main-content.link-cell
-                    %a.button_link{href: @alert.followup_link}
-                      %strong Submit feedback on Pangram report
+              %p.info
+                %a.link{href: @alert.followup_link} Submit feedback on Pangram report
               %p.info
                 Plausible information that seems generally consistent with a cited
                 source but doesn’t seem like it actually came from there is a

--- a/app/views/ai_edit_alert_mailer/student_program_email.html.haml
+++ b/app/views/ai_edit_alert_mailer/student_program_email.html.haml
@@ -36,7 +36,8 @@
                     %strong (#{@alert.user.real_name})
                   drafted for Wikipedia in the course
                   %a.link{href: @course_link}= @course.title
-                  may be AI-generated.
+                  may be AI-generated and requires further verification before it can
+                  go live on Wikipedia.
                 %p.paragraph
                   Wikipedia page:
                   %a.link{href: @alert.page_url}= @alert.article_title
@@ -44,25 +45,58 @@
                   %a.link{href: @alert.url} diff
                   )
                 %p.paragraph
+                  If you intend to move your work live, you will need to work with your
+                  instructor to ensure the facts in your draft can be found in the
+                  sources you cite. See next steps below.
+                %p.paragraph
                   Remember,
                   %strong you should NEVER copy and paste any AI-generated content into Wikipedia.
                   This includes copyediting tools like Grammarly. All text added to Wikipedia should
                   be written by a human. Make sure to never use tools like ChatGPT or Grammarly to
                   draft or edit text you’re creating for Wikipedia. We encourage you to refresh yourself on the rules for
                   %a.link{href: "https://dashboard.wikiedu.org/training/students/generative-ai"} Wikipedia and generative AI in our training.
-                %p.paragraph
-                  If you used AI to write text (including copyediting), please delete the text and re-do
-                  the work without AI text generation before you move your draft live to Wikipedia.
-                  AI-generated text will be deleted from Wikipedia.
+                %h2.headline Next steps
+                %ol.paragraph
+                  %li
+                    Work directly with your instructor to ensure
+                    %u every sentence
+                    you’ve added is fully accurate and can be found in the sources you’re citing.
+                  %li
+                    If you used AI to write text (including copyediting), please delete the
+                    text and re-do the work without AI text generation. AI-generated text
+                    will be deleted from Wikipedia.
+                  %li
+                    To verify your text to your instructor, identify a sentence or paragraph
+                    in your contribution that you have cited to a source. Go to the source.
+                  %li
+                    Read through the source to locate the sentence or paragraph where your
+                    contribution came from.
+                  %li
+                    If the citations are not specific enough to easily fact-check, add page
+                    numbers to the citations.
+                  %li
+                    If you can’t show your instructor where to find the fact in the cited
+                    source, the information fails verification and you will have to rewrite
+                    that information to be accurate and representative of what is in your
+                    cited source.
+                  %li
+                    Once you’ve worked with your instructor to ensure that all of the text
+                    is fully accurate and can be found in the cited sources, you may move
+                    the work to Wikipedia when it is time.
+                  %li
+                    Notify your Wikipedia Expert that the work has been verified and will
+                    be added to the live article.
               - if @intro_variant == :default
                 %p.paragraph
-                  The Wiki Education Dashboard detected that text
+                  = "Dear #{@alert.user.real_name || @alert.user.username},"
+                %p.paragraph
+                  The Wiki Education Dashboard detected that information
                   #{link_to @alert.user.username, "#{@course_link}/students/articles/#{@alert.user.url_encoded_username}", class: 'link'}
                   - if @alert.user.real_name
                     %strong (#{@alert.user.real_name})
                   added to Wikipedia in the course
                   %a.link{href: @course_link}= @course.title
-                  may be AI-generated.
+                  requires further verification in order to stay live on Wikipedia.
                 %p.paragraph
                   Wikipedia page:
                   %a.link{href: @alert.page_url}= @alert.article_title
@@ -70,98 +104,170 @@
                   %a.link{href: @alert.url} diff
                   )
                 %p.paragraph
-                  If you used AI to write text (including copyediting), please immediately delete the text
-                  from Wikipedia. If the text is still live in the article when your instructor or Wiki
-                  Education staff read this alert (or other Wikipedians see the text), they will delete it.
+                  If you intend to move your work live again, you will need to work with
+                  your instructor to ensure the facts in your contribution can be found
+                  in the sources you cited. See next steps below.
+                %h2.headline Next steps
+                %ol.paragraph
+                  %li
+                    Remove flagged text from the live Wikipedia article and move it back
+                    to your drafting sandbox page or your outline sandbox page. (If the
+                    text is still live in the article when your instructor or Wiki
+                    Education staff reads this alert, they will remove it.)
+                  %li
+                    Work directly with your instructor to ensure
+                    %u every sentence
+                    you’ve added is fully accurate and can be found in the sources you’re citing.
+                  %li
+                    To verify your text to your instructor, identify a sentence or paragraph
+                    in your contribution that you have cited to a source. Go to the cited source.
+                  %li
+                    Read through the source to locate the sentence or paragraph where your
+                    contribution came from.
+                  %li
+                    If the citations are not specific enough to easily fact-check, add page
+                    numbers to the citations.
+                  %li
+                    If you can’t show your instructor where to find the fact in the cited
+                    source, the information fails verification and you will have to rewrite
+                    that information to be accurate and representative of what is in your
+                    cited source.
+                  %li
+                    Once you’ve worked with your instructor to ensure that all of the text
+                    is fully accurate and can be found in the cited sources, you may move
+                    the work back to Wikipedia.
+                  %li
+                    Notify your Wikipedia Expert that the work has been verified and will
+                    be added to the live article.
+              - if @intro_variant == :exercise
+                %h2.headline Detection report
                 %p.paragraph
-                  Remember,
-                  %strong you should NEVER copy and paste any AI-generated content into Wikipedia.
-                  This includes copyediting tools like Grammarly. All text added to Wikipedia should
-                  be written by a human. Make sure to never use tools like ChatGPT or Grammarly to
-                  draft or edit text you’re creating for Wikipedia. We encourage you to refresh yourself on the rules for
-                  %a.link{href: "https://dashboard.wikiedu.org/training/students/generative-ai"} Wikipedia and generative AI in our training.
+                  We use the AI detector Pangram to check Wikipedia edits for AI-generated text.<sup>†</sup>
+                %ul.paragraph
+                  %li
+                    Pangram prediction:
+                    %strong= @alert.pangram_headline
+                  %li
+                    Fraction AI-generated:
+                    %strong= number_to_percentage @alert.fraction_ai_generated*100, precision: 0
+                  %li
+                    Fraction AI-assisted:
+                    %strong= number_to_percentage @alert.fraction_ai_assisted*100, precision: 0
+                  %li
+                    Number of ~400-word segments with AI text:
+                    %strong= @alert.predicted_ai_window_count
+                %table
+                  %tr
+                    %td.main-content.link-cell
+                      %a.button_link{href: @alert.pangram_url}
+                        %strong View Pangram report
+
+                %h2.headline= "#{@alert.user.username}: Please fill out follow-up questionnaire"
                 %p.paragraph
-                  Please work directly with your instructor to ensure every sentence you’ve added
-                  is fully accurate and verifiable. This means a reader should be able to open
-                  the source you’ve cited (with an exact page number, if applicable) and find the
-                  fact in that source. (AI-written text often attributes information to sources
-                  that are relevant but do not contain that specific fact; copyeditors like
-                  Grammarly often distort meaning.) Once your instructor has agreed that the
-                  text is fully accurate and verifiable, you may make the contribution live on
-                  Wikipedia again.
+                  Is the Pangram report accurate? Was this a false positive? Help us improve our
+                  AI detection system to get better at keeping unverifiable, inaccurate
+                  AI-generated content off Wikipedia without flagging authentic writing incorrectly.
+                %table
+                  %tr
+                    %td.main-content.link-cell
+                      %a.button_link{href: @alert.followup_link}
+                        %strong Follow-up questionnaire
+
                 %p.paragraph
-                  If you believe this is a false positive (meaning you did not use any editing
-                  or drafting tools on your text), carefully confirm that everything you've written
-                  is easy to verify in the cited sources, then follow the instructions regarding the
-                  %em questionnaire
-                  below.
-              %h2.headline Detection report
-              %p.paragraph
-                We use the AI detector Pangram to check Wikipedia edits for AI-generated text.<sup>†</sup>
-              %ul.paragraph
-                %li
-                  Pangram prediction:
-                  %strong= @alert.pangram_headline
-                %li
-                  Fraction AI-generated:
-                  %strong= number_to_percentage @alert.fraction_ai_generated*100, precision: 0
-                %li
-                  Fraction AI-assisted:
-                  %strong= number_to_percentage @alert.fraction_ai_assisted*100, precision: 0
-                %li
-                  Number of ~400-word segments with AI text:
-                  %strong= @alert.predicted_ai_window_count
-              %table
-                %tr
-                  %td.main-content.link-cell
-                    %a.button_link{href: @alert.pangram_url}
-                      %strong View Pangram report
+                  Best,
+                  %br
+                  %em Wiki Education
 
-              %h2.headline= "#{@alert.user.username}: Please fill out follow-up questionnaire"
-              %p.paragraph
-                Is the Pangram report accurate? Was this a false positive? Help us improve our
-                AI detection system to get better at keeping unverifiable, inaccurate
-                AI-generated content off Wikipedia without flagging authentic writing incorrectly.
-              %table
-                %tr
-                  %td.main-content.link-cell
-                    %a.button_link{href: @alert.followup_link}
-                      %strong Follow-up questionnaire
+                %hr
+                %h2.info † About AI detection
+                %p.info
+                  AI detectors are not foolproof, but Pangram is reliable enough to catch many cases of AI-generated text
+                  (which should not be added to Wikipedia).
+                %p.info
+                  We've found that Pangram is highly reliable when it comes to Wikipedia article prose. It is less reliable —
+                  resulting in false positives — when there are significant non-prose elements, such as bibliographic citations,
+                  bullet lists, fragmentary outlines, and other formatting-heavy content. Before analyzing an edit,
+                  the Dashboard attempts to isolate the prose portions and convert it to plaintext. The Pangram report shows
+                  this isolated plaintext, which in most cases excludes citations, Wikipedia templates, and other common non-prose
+                  elements. Let us know if significant non-prose elements remain that you suspect resulted in a false positive.
+                %p.info
+                  In broad strokes, Pangram is designed to detect the statistical fingerprint of text generated by a
+                  Large Language Model (LLM). It can't easily differentiate between text that was generated directly from a
+                  chatbot prompt versus human text that was rewritten by an LLM-driven copyediting tool or chatbot. Extensive use of
+                  an AI copyediting tool — including Grammarly — can result in text that Pangram detects as AI-generated, but such
+                  AI copyediting can also introduce factual errors and distortions of meaning, so editors should not use such tools
+                  when writing for Wikipedia. Mixed writing — where LLM-generated text and human-written text are combined —
+                  typically results in an intermediate AI assistance score in Pangram's results, roughly corresponding to the portion of
+                  the text that came from an LLM. Simple spelling or grammar fixes typically do not trigger Pangram (although
+                  LLM-driven grammar fixes still often change the intended meaning in subtle ways).
+                %p.info
+                  Pangram analyzes text in segments of approximately 400 words at a time, assigning an "AI assistance score"
+                  to each segment. (It is less reliable on very short segments.) The resulting report includes an overall
+                  prediction, as well as individual scores for each segment. Based on Wiki Education's experience so far,
+                  AI-generated text that has been significantly edited is often detected as "possibly AI" with an intermediate
+                  score, while most text copied directly from common AI tools as of late 2025 is flagged as nearly 100% AI
+                  likelihood, and most Wikipedia text with no AI involvement is flagged close to 0% AI likelihood.
+              - else
+                %h2.headline About detection
+                %p.paragraph
+                  We use the AI detector Pangram to check Wikipedia edits for AI-generated text.<sup>†</sup>
+                  We use Pangram as a signal that a human must verify that the information
+                  added to Wikipedia is accurate, can be found in the cited source, and
+                  fully adheres to Wikipedia’s verifiability policy.
+                %p.paragraph
+                  Thank you for helping us ensure that information on Wikipedia remains
+                  reliable and accurate. Feel free to reach out to your Wikipedia Expert
+                  if you have any questions.
+                %p.paragraph
+                  Best,
+                  %br
+                  %em Wiki Education
 
-              %p.paragraph
-                Best,
-                %br
-                %em Wiki Education
-
-              %hr
-              %h2.info † About AI detection
-              %p.info
-                AI detectors are not foolproof, but Pangram is reliable enough to catch many cases of AI-generated text
-                (which should not be added to Wikipedia).
-              %p.info
-                We've found that Pangram is highly reliable when it comes to Wikipedia article prose. It is less reliable —
-                resulting in false positives — when there are significant non-prose elements, such as bibliographic citations,
-                bullet lists, fragmentary outlines, and other formatting-heavy content. Before analyzing an edit,
-                the Dashboard attempts to isolate the prose portions and convert it to plaintext. The Pangram report shows
-                this isolated plaintext, which in most cases excludes citations, Wikipedia templates, and other common non-prose
-                elements. Let us know if significant non-prose elements remain that you suspect resulted in a false positive.
-              %p.info
-                In broad strokes, Pangram is designed to detect the statistical fingerprint of text generated by a
-                Large Language Model (LLM). It can't easily differentiate between text that was generated directly from a
-                chatbot prompt versus human text that was rewritten by an LLM-driven copyediting tool or chatbot. Extensive use of
-                an AI copyediting tool — including Grammarly — can result in text that Pangram detects as AI-generated, but such
-                AI copyediting can also introduce factual errors and distortions of meaning, so editors should not use such tools
-                when writing for Wikipedia. Mixed writing — where LLM-generated text and human-written text are combined —
-                typically results in an intermediate AI assistance score in Pangram's results, roughly corresponding to the portion of
-                the text that came from an LLM. Simple spelling or grammar fixes typically do not trigger Pangram (although
-                LLM-driven grammar fixes still often change the intended meaning in subtle ways).
-              %p.info
-                Pangram analyzes text in segments of approximately 400 words at a time, assigning an "AI assistance score"
-                to each segment. (It is less reliable on very short segments.) The resulting report includes an overall
-                prediction, as well as individual scores for each segment. Based on Wiki Education's experience so far,
-                AI-generated text that has been significantly edited is often detected as "possibly AI" with an intermediate
-                score, while most text copied directly from common AI tools as of late 2025 is flagged as nearly 100% AI
-                likelihood, and most Wikipedia text with no AI involvement is flagged close to 0% AI likelihood.
+                %hr
+                %h2.info † About AI detection
+                %p.info
+                  AI detectors are not foolproof, but Pangram is reliable enough to catch many cases of AI-generated text
+                  (which should not be added to Wikipedia).
+                %p.info
+                  To view the Pangram report for this text, click below:
+                %table
+                  %tr
+                    %td.main-content.link-cell
+                      %a.button_link{href: @alert.pangram_url}
+                        %strong View Pangram report
+                %p.info
+                  Is the Pangram report accurate? Was this a false positive? Help us improve our
+                  AI detection system to get better at keeping unverifiable, inaccurate
+                  AI-generated content off Wikipedia without flagging authentic writing incorrectly.
+                %table
+                  %tr
+                    %td.main-content.link-cell
+                      %a.button_link{href: @alert.followup_link}
+                        %strong Submit feedback on Pangram report
+                %p.info
+                  We've found that Pangram is highly reliable when it comes to Wikipedia article prose. It is less reliable —
+                  resulting in false positives — when there are significant non-prose elements, such as bibliographic citations,
+                  bullet lists, fragmentary outlines, and other formatting-heavy content. Before analyzing an edit,
+                  the Dashboard attempts to isolate the prose portions and convert it to plaintext. The Pangram report shows
+                  this isolated plaintext, which in most cases excludes citations, Wikipedia templates, and other common non-prose
+                  elements. Let us know if significant non-prose elements remain that you suspect resulted in a false positive.
+                %p.info
+                  In broad strokes, Pangram is designed to detect the statistical fingerprint of text generated by a
+                  Large Language Model (LLM). It can't easily differentiate between text that was generated directly from a
+                  chatbot prompt versus human text that was rewritten by an LLM-driven copyediting tool or chatbot. Extensive use of
+                  an AI copyediting tool — including Grammarly — can result in text that Pangram detects as AI-generated, but such
+                  AI copyediting can also introduce factual errors and distortions of meaning, so editors should not use such tools
+                  when writing for Wikipedia. Mixed writing — where LLM-generated text and human-written text are combined —
+                  typically results in an intermediate AI assistance score in Pangram's results, roughly corresponding to the portion of
+                  the text that came from an LLM. Simple spelling or grammar fixes typically do not trigger Pangram (although
+                  LLM-driven grammar fixes still often change the intended meaning in subtle ways).
+                %p.info
+                  Pangram analyzes text in segments of approximately 400 words at a time, assigning an "AI assistance score"
+                  to each segment. (It is less reliable on very short segments.) The resulting report includes an overall
+                  prediction, as well as individual scores for each segment. Based on Wiki Education's experience so far,
+                  AI-generated text that has been significantly edited is often detected as "possibly AI" with an intermediate
+                  score, while most text copied directly from common AI tools as of late 2025 is flagged as nearly 100% AI
+                  likelihood, and most Wikipedia text with no AI involvement is flagged close to 0% AI likelihood.
 
 .hidden
   %p

--- a/app/views/ai_edit_alert_mailer/student_program_email.html.haml
+++ b/app/views/ai_edit_alert_mailer/student_program_email.html.haml
@@ -230,20 +230,14 @@
                   (which should not be added to Wikipedia).
                 %p.info
                   To view the Pangram report for this text, click below:
-                %table
-                  %tr
-                    %td.main-content.link-cell
-                      %a.button_link{href: @alert.pangram_url}
-                        %strong View Pangram report
+                %p.info
+                  %a.link{href: @alert.pangram_url} View Pangram report
                 %p.info
                   Is the Pangram report accurate? Was this a false positive? Help us improve our
                   AI detection system to get better at keeping unverifiable, inaccurate
                   AI-generated content off Wikipedia without flagging authentic writing incorrectly.
-                %table
-                  %tr
-                    %td.main-content.link-cell
-                      %a.button_link{href: @alert.followup_link}
-                        %strong Submit feedback on Pangram report
+                %p.info
+                  %a.link{href: @alert.followup_link} Submit feedback on Pangram report
                 %p.info
                   We've found that Pangram is highly reliable when it comes to Wikipedia article prose. It is less reliable —
                   resulting in false positives — when there are significant non-prose elements, such as bibliographic citations,

--- a/spec/models/alert_types/ai_edit_alert_spec.rb
+++ b/spec/models/alert_types/ai_edit_alert_spec.rb
@@ -271,7 +271,7 @@ describe AiEditAlert do
         expect(sandbox_alert_email.body.encoded).to include('drafted for Wikipedia in the course')
         expect(sandbox_advice_email.to).to contain_exactly('instructor@example.com',
                                                             'wiki_expert@example.com')
-        expect(sandbox_advice_email.body.encoded).to include("student's sandbox")
+        expect(sandbox_advice_email.body.encoded).to include('into their sandbox page')
       end
     end
 


### PR DESCRIPTION
## What this PR does

Revamps four of the AI edit alert emails with new text prepared by Wiki Education staff in a shared planning doc. The student and instructor alerts for mainspace and sandbox-draft edits are reframed around fact verification ("requires further verification") rather than AI accusation, and each gains a step-by-step "Next steps" list. The Pangram-stats "Detection report" and follow-up questionnaire sections of the student emails are replaced by a short "About detection" section, with the **View Pangram report** and **Submit feedback on Pangram report** actions moved into the "† About AI detection" footer as small text links, de-emphasized from the original button styling to match that supplemental section; the instructor advice emails gain those two links for the first time (the feedback link goes to the same alert follow-up questionnaire as the old button).

The four affected emails (mailer previews linked):

- [student_program_ai_edit_alert_mainspace](https://dashboard.wikiedu.org/rails/mailers/ai_edit_alert_mailer/student_program_ai_edit_alert_mainspace) — the `:default` variant of `student_program_email.html.haml`
- [student_program_ai_edit_alert_sandbox_draft](https://dashboard.wikiedu.org/rails/mailers/ai_edit_alert_mailer/student_program_ai_edit_alert_sandbox_draft) — the `:sandbox` variant of the same template
- [instructor_mainspace_advice](https://dashboard.wikiedu.org/rails/mailers/ai_edit_alert_mailer/instructor_mainspace_advice)
- [instructor_sandbox_advice](https://dashboard.wikiedu.org/rails/mailers/ai_edit_alert_mailer/instructor_sandbox_advice)

Not changed: the exercise-page student and instructor emails, the generic (non-ClassroomProgramCourse) `email` template, and all email subject lines (the planning doc left the new subject heading blank). The mainspace student email now opens with a greeting addressed to the student (real name, falling back to username).

## AI usage

Claude Code did the implementation under human direction: it converted the staff-prepared planning doc (a .docx export of a Google Doc) with pandoc, mapped each draft to its mailer template/variant, and transcribed the text into HAML. The email copy itself was written by Wiki Education staff, not generated by AI. Claude Code made two wording deviations from the doc, both flagged to and approved by the human operator: adding a missing "and" in "verified and will be added" (two spots, matching the doc's own parallel sentence) and a missing "a" in "a part of a Wikipedia article" (fixed at the operator's explicit direction). Claude Code also wrote the commit message, generated the before/after screenshots below, and drafted this PR description (including the summary above), which may contain errors.

All work happened in a single session on 2026-08-26, producing two commits (the second restyling the footer's report/feedback buttons into plain text links at the operator's direction); verification consisted of the mailer unit spec, the mailer-previews feature spec (which renders every email preview), and ad-hoc rendering checks of the four emails' text and buttons — all green on the first run.

This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

Full-length before/after captures of each changed email, rendered from the mailer previews with `mailer.css` applied.

### Student alert — live article (mainspace)

| Before | After |
| --- | --- |
| ![before: student mainspace alert](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/before_student_program_ai_edit_alert_mainspace.png) | ![after: student mainspace alert](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/after_student_program_ai_edit_alert_mainspace.png) |

### Student alert — draft sandbox

| Before | After |
| --- | --- |
| ![before: student sandbox draft alert](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/before_student_program_ai_edit_alert_sandbox_draft.png) | ![after: student sandbox draft alert](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/after_student_program_ai_edit_alert_sandbox_draft.png) |

### Instructor advice — mainspace

| Before | After |
| --- | --- |
| ![before: instructor mainspace advice](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/before_instructor_mainspace_advice.png) | ![after: instructor mainspace advice](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/after_instructor_mainspace_advice.png) |

### Instructor advice — sandbox

| Before | After |
| --- | --- |
| ![before: instructor sandbox advice](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/before_instructor_sandbox_advice.png) | ![after: instructor sandbox advice](https://gist.githubusercontent.com/ragesoss/b016c45f82ba767eeef5ba640596572d/raw/411263509e2fcbec8523cb207dbc1b0c88957e12/after_instructor_sandbox_advice.png) |

## Open questions and concerns

- The planning doc adds a "Dear …" greeting to the mainspace student email but not to the sandbox one; this PR matches the doc. If that was unintentional, the sandbox variant can get the same greeting.
- The instructor emails keep the doc's literal `**`-prefixed note ("** If any of the information cannot be found…") as a footnote-style marker after the numbered list.
- Email subject lines are unchanged because the doc's "Subject heading:" field was blank; new subjects can be added if staff supply them.

(PR description written by Claude Code.)
