### PR TITLE
Make Fact Verification exercise addable to timeline blocks manually

### DIFF
--- a/app/views/training/_all_modules.html.haml
+++ b/app/views/training/_all_modules.html.haml
@@ -1,5 +1,7 @@
 %ul.training-libraries.no-bullets.no-margin
   - defocus_class = @focused_library_slug ? 'training-library-defocus' : ''
+  -# A slide-less in-app exercise has no training page, so don't link it here.
+  - slideless_slugs = TrainingModule.all.select { |tm| tm.slide_slugs.empty? }.map(&:slug)
   - @libraries.each do |library|
     - next if library.exclude_from_index?
     - focus_class = @focused_library_slug == library.slug ? 'training-library-focus' : defocus_class
@@ -14,6 +16,7 @@
         %h3.included-modules-heading Included Modules:
         %ul
           - library.categories.pluck('modules').flatten.each do |training_module|
+            - next if slideless_slugs.include?(training_module['slug'])
             %li
               %a{href: "/training/#{library.slug}/#{training_module['slug']}", target: "_blank"}
                 = training_module['name']

--- a/app/views/training/show.html.haml
+++ b/app/views/training/show.html.haml
@@ -21,6 +21,7 @@
           - lib_category.modules.each do |lib_module|
             - mod = TrainingModule.find_by(slug: lib_module.slug)
             - next unless mod # On P&E Dashboard, training content is unpredictable
+            - next if mod.slide_slugs.empty? # A slide-less in-app exercise has no training page
             - pm = ::TrainingProgressManager.new(current_user, mod)
             %li
               = link_to training_module_path(@library.slug, lib_module.slug), class: 'action-card' do

--- a/spec/features/timeline_editing_spec.rb
+++ b/spec/features/timeline_editing_spec.rb
@@ -74,6 +74,30 @@ describe 'timeline editing', type: :feature, js: true do
     sleep 1
   end
 
+  it 'lets users add the fact verification exercise to an assignment block' do
+    visit "/courses/#{course_with_timeline.slug}/timeline"
+    expect(page).to have_content 'Block Title'
+
+    find('.week-1').hover
+    sleep 0.5
+    within('.week-1') do
+      find('.block__edit-block', match: :first).click
+    end
+    sleep 1
+    within(".week-1 .block-kind-#{Block::KINDS['assignment']}") do
+      within '.block__training-modules' do
+        find('input').send_keys('Fact verification', :enter)
+      end
+    end
+
+    within('.block__block-actions') { click_button 'Save' }
+
+    within ".week-1 .block-kind-#{Block::KINDS['assignment']}" do
+      expect(page).to have_content 'Fact verification'
+    end
+    sleep 1
+  end
+
   it 'lets users delete a week' do
     visit "/courses/#{course_with_timeline.slug}/timeline"
     expect(page).not_to have_content 'Add Assignment'

--- a/spec/features/training_library_spec.rb
+++ b/spec/features/training_library_spec.rb
@@ -10,4 +10,16 @@ describe 'training library overview page', type: :feature, js: true do
     expect(page).to have_content('Student Training Modules')
     expect(page).to be_axe_clean
   end
+
+  it 'does not list slide-less in-app exercise modules' do
+    visit '/training/students'
+    expect(page).to have_content('Exercise: Evaluate Wikipedia')
+    expect(page).not_to have_content('Exercise: Fact verification')
+  end
+
+  it 'does not list slide-less in-app exercise modules on the training index' do
+    visit '/training'
+    expect(page).to have_content('Exercise: Evaluate Wikipedia')
+    expect(page).not_to have_content('Exercise: Fact verification')
+  end
 end

--- a/training_content/wiki_ed/libraries/students.yml
+++ b/training_content/wiki_ed/libraries/students.yml
@@ -88,6 +88,9 @@ categories:
       - slug: evaluate-wikipedia-exercise
         name: 'Exercise: Evaluate Wikipedia'
         description: Get to know Wikipedia's standards by evaluating a Wikipedia article.
+      - slug: fact-verification-exercise
+        name: 'Exercise: Fact verification'
+        description: Fact-check a claim added to a real Wikipedia article to see if the cited source backs it up.
       - slug: 'choose-topic-exercise'
         name: 'Exercise: Choose your article'
         description: Find possible topics to work on by exploring Wikipedia.


### PR DESCRIPTION
## What this PR does

Makes the Fact Verification exercise (training module 86) addable to a timeline block manually. Until now it could only enter a timeline via the assignment wizard: the block editor's module dropdown filters classroom courses to modules in the students training library (`getAvailableTrainingModules`), and the module wasn't in any library. This PR adds it to the students library's Exercises category, which is all the dropdown needs.

Because library membership also surfaces a module on the public training pages (`/training` and `/training/students`), where a slide-less in-app exercise would link to a stub page with an empty table of contents and a dead Start button, those pages now skip modules with no slides — the same "a slide-less module has no training page" rule the timeline's `ModuleRow` already applies. A minor side effect: `find_or_default_library` now resolves module 86 to the students library instead of the `TrainingLibrary.first` fallback, which is strictly more correct for breadcrumbs and redirects.

Note for deployment: the library change takes effect after the next training content reload.

## AI usage

All code, specs, and the commit message in this PR were written by Claude Code (Fable 5) under Sage's direction. Sage reported the gap in a one-sentence prompt; Claude traced the dropdown filter to students-library membership, surfaced the design question about public-page exposure, and Sage chose the "hide slide-less modules" option from a structured question. Implementation, tests, and screenshots then proceeded without correction. All work happened in a single session on 2026-08-27 (one commit); every spec run was green on the first attempt. This PR summary and analysis were also drafted by Claude Code (via the `/prepare-pr` skill) and may contain errors.

## Screenshots

**Block editor module dropdown** — searching "Fact verification" in a classroom course's block editor:

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-manual-block-add/screenshots/before/01_block_editor_module_dropdown.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-manual-block-add/screenshots/after/01_block_editor_module_dropdown.png) |

**Block after saving** — the manually added exercise renders with the standard in-app exercise affordances:

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-manual-block-add/screenshots/before/02_block_after_save.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-manual-block-add/screenshots/after/02_block_after_save.png) |

**Students library Exercises section** — unchanged: the newly listed module is hidden from the public training pages because it has no slides:

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-manual-block-add/screenshots/before/03_students_library_exercises_section.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-manual-block-add/screenshots/after/03_students_library_exercises_section.png) |

## Open questions and concerns

- The library entry's name/description in `students.yml` don't currently render anywhere (both public display sites skip slide-less modules); they exist for consistency and in case the module page later grows a proper in-app-exercise presentation. If we'd rather list the exercise publicly with a fixed-up stub page, that's a small follow-up.
- The hide rule is generic (any module with zero slides), not specific to module 86 — intentional, but worth knowing if a future module is ever authored slides-last.

(PR description written by Claude Code.)
