### PR TITLE
Update admin docs with new sidekiq-report-csv

### DIFF
--- a/docs/WMCLOUD_SETUP/object_storage.md
+++ b/docs/WMCLOUD_SETUP/object_storage.md
@@ -11,7 +11,7 @@ These are notes about how we set up object storage for storing reports CSV files
 * Grant anonymous GetObject access to that container, with no ListBucket access. This allows every user to download their report while preventing them from seeing all the existing reports.
 
 ### Set up ENV vars
-* Use the container name and S3-compatible aws credentials to set the following env vars on the corresponding server.
+* Use the container name and S3-compatible aws credentials to set the following env vars on the corresponding servers (for example: peony-web for serving the downloads and peony-sidekiq-medium for generating them).
 
 ```
 # Credentials for storing CSV exports in S3-compatible object storage.

--- a/docs/WMCLOUD_SETUP/web_server.md
+++ b/docs/WMCLOUD_SETUP/web_server.md
@@ -108,7 +108,7 @@ These are notes from setting up a fresh web server on the newest Debian, July 2,
 
 - Add systemd services for the app's sidekiq processes. Only the lightest queue belongs on the web server; the rest should be on separate Sidekiq servers.
   - `default` is light enough to share the web server, but note that it is load-bearing for the entire update pipeline: it runs `ScheduleCourseUpdatesWorker`, so if nothing is consuming the `default` queue, no course updates get scheduled on *any* server and every other Sidekiq host drains its queue and goes idle. When diagnosing a system-wide stall, check this first.
-  - Do **not** run `daily` on the web server. It carries the heaviest jobs in the system — `ImportRatingsWorker`, which sweeps all articles, and `ReportCsvWorker`, which builds campaign and system-wide CSV exports — and has been observed at over 1 GB resident while competing with the web application for the same RAM. See #6990.
+  - Do **not** run `daily` on the web server. It carries one of the heaviest jobs in the system — `ImportRatingsWorker`, which sweeps all articles — and has been observed at over 1 GB resident while competing with the web application for the same RAM. See #6990.
   - `constant` runs on a separate Sidekiq server in the current P&E Dashboard setup, notwithstanding what earlier versions of these notes said.
   - copy the .service files from `server_config/systemd` into the systemd directory ( `/etc/systemd/system` on Debian)
     - Change the user and group lines to match the user who owns the deployment process (and one of their groups)

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -42,8 +42,8 @@ Below is a breakdown of the key servers and their roles within the infrastructur
 
 2. **Sidekiq Servers**: These dedicated servers handle the other Sidekiq processes to isolate bottlenecks and failures:  
    - **`peony-sidekiq.globaleducation.eqiad1.wikimedia.cloud`**: Hosts `sidekiq-long` for long-running course updates with higher queue latency, as well as `sidekiq-constant`.
-   - **`peony-sidekiq-medium.globaleducation.eqiad1.wikimedia.cloud`**: Hosts `sidekiq-medium` for typical course updates.  
-   - **`peony-sidekiq-3.globaleducation.eqiad1.wikimedia.cloud`**: Hosts `sidekiq-short` for short-running course updates.
+   - **`peony-sidekiq-medium.globaleducation.eqiad1.wikimedia.cloud`**: Hosts `sidekiq-medium` for typical course updates, as well as `sidekiq-report-csv` for generating and deleting user-requested CSV reports.
+   - **`peony-sidekiq-short.globaleducation.eqiad1.wikimedia.cloud`**: Hosts `sidekiq-short` for short-running course updates.
 
 3. **Database Server**  
    - **`peony-database.globaleducation.eqiad1.wikimedia.cloud`**: Stores program, user, and revision data. It supports the dashboard’s data queries and updates.


### PR DESCRIPTION
## What this PR does
This PR updates some docs. Now that we moved CSV report generation and deletion out of the `daily_update` queue, and out of the `web-server` for peony, we have to update some docs.

## Open questions and concerns
`docs/WMCLOUD_SETUP/web_server.md` still says that we shouldn't run daily queue on the web server. Note that, while #6606 got closed, daily queue still runs on the web-server.

>  - Do **not** run `daily` on the web server. It carries one of the heaviest jobs in the system — `ImportRatingsWorker`, which sweeps all articles — and has been observed at over 1 GB resident while competing with the web application for the same RAM. See #6990.