### PR TITLE
Update article ratings once a week

### DIFF
--- a/app/workers/daily_update/import_ratings_worker.rb
+++ b/app/workers/daily_update/import_ratings_worker.rb
@@ -7,6 +7,6 @@ class ImportRatingsWorker
   sidekiq_options lock: :until_executed
 
   def perform
-    RatingImporter.update_all_ratings
+    RatingImporter.update_outdated_ratings
   end
 end

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -65,7 +65,7 @@ class DailyUpdate
     log_message 'Finding articles that match assignment titles'
     FindAssignmentsWorker.set(queue: QUEUE).perform_async
 
-    log_message 'Updating ratings for all articles'
+    log_message 'Updating outdated article ratings'
     ImportRatingsWorker.set(queue: QUEUE).perform_async
   end
 

--- a/lib/importers/rating_importer.rb
+++ b/lib/importers/rating_importer.rb
@@ -16,16 +16,22 @@ class RatingImporter
   # Minimum interval between on-demand rating refreshes for a single article.
   RATING_UPDATE_COOLDOWN = 5.minutes
 
-  def self.update_all_ratings
+  # How long a rating stays fresh before the daily update refetches it.
+  RATING_REFRESH_INTERVAL = 1.week
+
+  def self.update_outdated_ratings
     # Since the rating scraper is only based on the English Wikipedia 1.0 rating
     # system, we only include articles from en.wiki.
     # If we develop scrapers for other languages that also keep track of ratings
     # via talk page templates, this will need to be overhauled.
     wiki_id = en_wiki.id
-    articles = Article.current.live
-                      .namespace(0)
-                      .where(wiki_id:)
-                      .find_in_batches(batch_size: API_MAX_TITLES)
+    current_articles = Article.current.live
+                              .namespace(0)
+                              .where(wiki_id:)
+    articles = current_articles
+               .where(rating_updated_at: nil)
+               .or(current_articles.where(rating_updated_at: ...RATING_REFRESH_INTERVAL.ago))
+               .find_in_batches(batch_size: API_MAX_TITLES)
     update_ratings(articles)
   end
 

--- a/lib/importers/rating_importer.rb
+++ b/lib/importers/rating_importer.rb
@@ -13,10 +13,8 @@ class RatingImporter
   # visual mappings in ArticleHelper.
   SUPPORTED_LANGUAGES = %w[en ar fr hu tr zh].freeze
 
-  # Minimum interval between on-demand rating refreshes for a single article.
-  RATING_UPDATE_COOLDOWN = 5.minutes
-
-  # How long a rating stays fresh before the daily update refetches it.
+  # How long a rating stays fresh before it is fetched again, both by the daily
+  # update and by on-demand refreshes for a single article.
   RATING_REFRESH_INTERVAL = 1.week
 
   def self.update_outdated_ratings
@@ -55,7 +53,7 @@ class RatingImporter
 
     # Skip if the rating was refreshed very recently to avoid excessive load.
     if article.rating_updated_at.present? &&
-       article.rating_updated_at > RATING_UPDATE_COOLDOWN.ago
+       article.rating_updated_at > RATING_REFRESH_INTERVAL.ago
       return
     end
     update_ratings([[article]])

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -19,7 +19,7 @@ describe DailyUpdate do
       worker_double = class_double(WikiDiscouragedArticleWorker)
       expect(UserImporter).to receive(:update_users)
       expect(AssignedArticleImporter).to receive(:import_articles_for_assignments)
-      expect(RatingImporter).to receive(:update_all_ratings)
+      expect(RatingImporter).to receive(:update_outdated_ratings)
       expect(UploadImporter).to receive(:find_deleted_files)
       expect_any_instance_of(OverdueTrainingAlertManager).to receive(:create_alerts)
       expect_any_instance_of(MainspaceAiFollowupManager).to receive(:generate_followup_alerts)

--- a/spec/lib/importers/rating_importer_spec.rb
+++ b/spec/lib/importers/rating_importer_spec.rb
@@ -32,7 +32,32 @@ describe RatingImporter do
     end
   end
 
-  describe '.update_all_ratings and .update_new_ratings' do
+  describe '.update_outdated_ratings' do
+    it 'only fetches ratings for articles with no rating or a stale one' do
+      course = create(:course,
+                      id: 1,
+                      title: 'Basket Weaving',
+                      start: '2015-01-01'.to_date,
+                      end: '2030-05-01'.to_date)
+      fresh = create(:article, title: 'Selfie', namespace: 0,
+                               rating_updated_at: 1.day.ago)
+      stale = create(:article, title: 'Six Flags AstroWorld', namespace: 0,
+                               rating_updated_at: 2.weeks.ago)
+      never_rated = create(:article, title: 'Wikipedia', namespace: 0,
+                                     rating_updated_at: nil)
+      course.articles << [fresh, stale, never_rated]
+
+      requested_titles = []
+      allow(described_class).to receive(:update_ratings) do |article_groups|
+        requested_titles = article_groups.flat_map { |articles| articles.map(&:title) }
+      end
+
+      described_class.update_outdated_ratings
+      expect(requested_titles).to contain_exactly('Six_Flags_AstroWorld', 'Wikipedia')
+    end
+  end
+
+  describe '.update_outdated_ratings and .update_new_ratings' do
     it 'gets latest ratings for articles' do
       VCR.use_cassette 'article/update_ratings' do
         course = create(:course,
@@ -60,7 +85,7 @@ describe RatingImporter do
                           title: 'A Clash of Kings',
                           namespace: 0)
         course.articles << article2
-        described_class.update_all_ratings
+        described_class.update_outdated_ratings
         expect(possible_ratings).to include Article.find(2).rating
       end
     end


### PR DESCRIPTION
## What this PR does
`ImportRatingsWorker` re-fetched the rating of every current, live, mainspace en.wiki article on every daily update, regardless of when that rating was last checked. On the P&E Dashboard it has been taking ~11 hours per run during the last 20 days. Today, we have 293,103 current, live, mainspace en.wiki articles, compared to one year ago that we had 157,683 articles.

`RatingImporter.update_all_ratings` is renamed to `update_outdated_ratings` and now only selects articles whose `rating_updated_at` is `NULL` or older than one week (`RATING_REFRESH_INTERVAL`).

The second commit drops `RATING_UPDATE_COOLDOWN` (5 minutes) and reuses `RATING_REFRESH_INTERVAL` in `update_rating_for_article`, so there is a single answer to "how stale is an acceptable rating?". That method has exactly one caller — `AssignmentManager#create_assignment` — where it runs synchronously in the web request. For en.wiki the longer window changes nothing in practice, since the daily sweep now guarantees no rating is more than a week old; it only affects the other wikis in `SUPPORTED_LANGUAGES` (ar, fr, hu, tr, zh), where a repeat assignment of the same article within a week now reuses the existing rating instead of refetching it.

## AI usage

The code changes and the new `.update_outdated_ratings` spec were drafted by Claude Code under the user's direction. The user set the direction throughout: she decided to start with a staleness filter rather than a larger redesign, chose the one-week interval, asked for the `.or` form instead of a raw SQL fragment, identified that `RATING_UPDATE_COOLDOWN` was redundant and asked for it to be removed, and fixed the new spec herself when it failed (the article factory stores underscored titles). The commit messages are the user's own.

## Screenshots

No UI changes.

## Open questions and concerns

- Every article currently has a `rating_updated_at` from a recent full sweep, so the first few runs after deploy will be nearly empty and the backlog will arrive as a spike about a week later rather than spreading evenly. Adding jitter to the interval per article would smooth that out if it turns out to matter.
- There is no index on `rating_updated_at`; the new condition is evaluated over the same `Article.current` join the query already performed, so this hasn't been treated as a problem yet.
- Follow-up worth considering: `page_assessments` is available on the Wiki Replicas, and its rows are only written when a rating actually changes. Reading `pa_class` directly from the replicas would replace the serial 50-titles-per-request API walk entirely, for all six supported languages rather than just en.wiki.

(PR description written by Claude Code.)
