### PR TITLE
Fix ARIA compliance for dashboard info tooltip (#6095)

### DIFF
--- a/app/assets/stylesheets/modules/_tooltips.styl
+++ b/app/assets/stylesheets/modules/_tooltips.styl
@@ -5,6 +5,10 @@
     .tooltip
       opacity 1
       top 110%
+  &:focus-within
+  .tooltip
+    opacity 1
+    top 110%
   .tooltip-indicator
     &:after
       font-family 'icons'

--- a/app/assets/stylesheets/modules/_tooltips.styl
+++ b/app/assets/stylesheets/modules/_tooltips.styl
@@ -6,9 +6,9 @@
       opacity 1
       top 110%
   &:focus-within
-  .tooltip
-    opacity 1
-    top 110%
+    .tooltip
+      opacity 1
+      top 110%
   .tooltip-indicator
     &:after
       font-family 'icons'

--- a/app/views/dashboard/_open_course_creation.html.haml
+++ b/app/views/dashboard/_open_course_creation.html.haml
@@ -1,6 +1,6 @@
 %div.instructions.tooltip-trigger
-  %img{:src => "/assets/images/info.svg", :alt => "tooltip default logo"}
-  %div.tooltip.large
+  %img{:src => "/assets/images/info.svg", alt: "", tabindex: "0", role: "button", "aria-label": "More information", "aria-describedby": "course-creation-tooltip"}
+  %div.tooltip.large#course-creation-tooltip{role: "tooltip"}
     %p= t("dashboard.about_programs")
     %br
     %p= t("dashboard.about_creating_programs")

--- a/app/views/dashboard/_open_course_creation.html.haml
+++ b/app/views/dashboard/_open_course_creation.html.haml
@@ -1,5 +1,5 @@
 %div.instructions.tooltip-trigger
-  %img{:src => "/assets/images/info.svg", alt: "", tabindex: "0", role: "button", "aria-label": "More information", "aria-describedby": "course-creation-tooltip"}
+  %img{src: "/assets/images/info.svg", alt: "", tabindex: "0", "aria-label": t("dashboard.tooltip.aria_label"), "aria-describedby": "course-creation-tooltip"}
   %div.tooltip.large#course-creation-tooltip{role: "tooltip"}
     %p= t("dashboard.about_programs")
     %br

--- a/app/views/dashboard/_open_course_creation.html.haml
+++ b/app/views/dashboard/_open_course_creation.html.haml
@@ -1,5 +1,5 @@
 %div.instructions.tooltip-trigger
-  %img{src: "/assets/images/info.svg", alt: t("dashboard.tooltip.aria_label"), tabindex: "0", "aria-describedby": "course-creation-tooltip"}
+  %img{src: "/assets/images/info.svg", alt: t("dashboard.tooltip.alt"), tabindex: "0", "aria-describedby": "course-creation-tooltip"}
   %div.tooltip.large#course-creation-tooltip{role: "tooltip"}
     %p= t("dashboard.about_programs")
     %br

--- a/app/views/dashboard/_open_course_creation.html.haml
+++ b/app/views/dashboard/_open_course_creation.html.haml
@@ -1,5 +1,5 @@
 %div.instructions.tooltip-trigger
-  %img{src: "/assets/images/info.svg", alt: "", tabindex: "0", "aria-label": t("dashboard.tooltip.aria_label"), "aria-describedby": "course-creation-tooltip"}
+  %img{src: "/assets/images/info.svg", alt: t("dashboard.tooltip.aria_label"), tabindex: "0", "aria-describedby": "course-creation-tooltip"}
   %div.tooltip.large#course-creation-tooltip{role: "tooltip"}
     %p= t("dashboard.about_programs")
     %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,8 @@ en:
       If you are running a single, independent event, you can create a
       Program now. If your event is part of something bigger, find or create the
       Campaign for it. Then you can create a new Program from the Campaign page.
+    tooltip:
+      aria_label: More information
   home:
     explore: Explore
     log_in: Log in with Wikipedia

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,7 +137,7 @@ en:
       Program now. If your event is part of something bigger, find or create the
       Campaign for it. Then you can create a new Program from the Campaign page.
     tooltip:
-      aria_label: More information
+      alt: More information
   home:
     explore: Explore
     log_in: Log in with Wikipedia


### PR DESCRIPTION
## What this PR does
Fixes #6095. The information "i" icon on the Dashboard page (rendered by `_open_course_creation.html.haml`) displayed a tooltip on hover, but the tooltip content was never announced by screen readers like NVDA.

Root cause: the tooltip trigger was a non-focusable `<div>`/`<img>` pair with no ARIA relationship to the tooltip text, and the CSS only revealed the tooltip on `:hover`. Keyboard and screen reader users had no way to reach or hear it.

Changes:
- Made the info icon keyboard-focusable (`tabindex="0"`, `role="button"`)
- Added `aria-label` on the icon and `aria-describedby` linking it to the tooltip text
- Gave the tooltip container a unique `id` and `role="tooltip"`
- Added a `:focus-within` rule in `_tooltips.styl` alongside the existing `:hover` rule, so the tooltip also appears for keyboard users
- Changed the icon's `alt` text to empty, since the description is now conveyed via `aria-describedby` instead

## AI usage
I used Claude (Anthropic) throughout this fix. Specifically:
- Asked it to help me locate the relevant files in the codebase, since I wasn't familiar with the project structure
- Asked it to explain the WAI-ARIA pattern for accessible tooltips (focusable trigger + `aria-describedby` + `role="tooltip"`), since I hadn't written accessibility fixes like this before
- Asked it to walk me through Haml syntax line by line, since this was my first time writing Haml
- I wrote and tested the actual code changes myself, and reviewed each suggestion before applying it rather than pasting a generated diff wholesale

## Open questions and concerns
- I used `role="button"` on the `<img>` to make it focusable and announce as interactive. If maintainers prefer, this could instead be refactored into a real `<button>` element wrapping the icon, which would be more semantically correct but touches more of the surrounding markup/CSS. Happy to go that route if preferred.