### PR TITLE
Add screen reader edit boundary announcements and hide highlight token spans

### DIFF
--- a/app/assets/javascripts/components/common/ArticleViewer/components/ParsedArticle.jsx
+++ b/app/assets/javascripts/components/common/ArticleViewer/components/ParsedArticle.jsx
@@ -5,10 +5,93 @@ import PropTypes from 'prop-types';
 const httpLinkMatcher = /(<a href="http)/g;
 const blankTargetLink = '<a target="_blank" href="http';
 
+const processAuthorshipHtml = (html) => {
+  if (!html || typeof window === 'undefined' || !window.DOMParser) return html;
+
+  try {
+    const parser = new window.DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+
+    const spans = Array.from(doc.querySelectorAll('span.editor-token'));
+    const isTargetSpan = (span) => {
+      const classList = span.className || '';
+      const hasHighlightClass = /user-highlight-\d+/.test(classList);
+      const hasTitle = span.hasAttribute('title') && span.getAttribute('title').trim() !== '';
+      return hasHighlightClass && hasTitle;
+    };
+
+    const targetSpans = spans.filter(isTargetSpan);
+    if (targetSpans.length === 0) return html;
+
+    const areContiguous = (spanA, spanB) => {
+      if (spanA.parentNode !== spanB.parentNode) return false;
+      if (spanA.getAttribute('title') !== spanB.getAttribute('title')) return false;
+
+      let next = spanA.nextSibling;
+      while (next && next !== spanB) {
+        if (next.nodeType === 3) { // Node.TEXT_NODE
+          if (next.nodeValue.trim() !== '') return false;
+        } else {
+          return false;
+        }
+        next = next.nextSibling;
+      }
+      return next === spanB;
+    };
+
+    const groups = [];
+    let currentGroup = [];
+
+    targetSpans.forEach((span) => {
+      if (currentGroup.length === 0) {
+        currentGroup.push(span);
+      } else {
+        const lastSpan = currentGroup[currentGroup.length - 1];
+        if (areContiguous(lastSpan, span)) {
+          currentGroup.push(span);
+        } else {
+          groups.push(currentGroup);
+          currentGroup = [span];
+        }
+      }
+    });
+    if (currentGroup.length > 0) {
+      groups.push(currentGroup);
+    }
+
+    groups.forEach((group) => {
+      const editorName = group[0].getAttribute('title');
+
+      const firstSpan = group[0];
+      const startSpan = doc.createElement('span');
+      startSpan.className = 'screen-reader';
+      startSpan.textContent = `Edited by ${editorName}`;
+      firstSpan.parentNode.insertBefore(startSpan, firstSpan);
+
+      const lastSpan = group[group.length - 1];
+      const endSpan = doc.createElement('span');
+      endSpan.className = 'screen-reader';
+      endSpan.textContent = 'End edit';
+      lastSpan.parentNode.insertBefore(endSpan, lastSpan.nextSibling);
+
+      group.forEach((span) => {
+        span.setAttribute('aria-hidden', 'true');
+        span.setAttribute('role', 'presentation');
+      });
+    });
+
+    return doc.body.innerHTML;
+  } catch (error) {
+    console.error('Failed to parse or process authorship HTML:', error);
+    return html;
+  }
+};
+
 export const ParsedArticle = ({ html, onInnerHTMLClick, onInnerHTMLKeyDown }) => {
   // This sets `target="_blank"` for all of the non-anchor links in the article HTML,
   // so that clicking one will open it in a new tab.
   const articleHTML = html?.replace(httpLinkMatcher, blankTargetLink);
+  const processedHTML = processAuthorshipHtml(articleHTML);
 
   // `onInnerHTMLClick`/`onInnerHTMLKeyDown` let a highlight feature respond to
   // clicks and keyboard activation on the injected HTML (e.g. claim verification
@@ -24,7 +107,7 @@ export const ParsedArticle = ({ html, onInnerHTMLClick, onInnerHTMLKeyDown }) =>
       className="parsed-article"
       onClick={onInnerHTMLClick}
       onKeyDown={onInnerHTMLKeyDown}
-      dangerouslySetInnerHTML={{ __html: articleHTML }}
+      dangerouslySetInnerHTML={{ __html: processedHTML }}
     />
   );
 };

--- a/test/components/parsed_article.spec.js
+++ b/test/components/parsed_article.spec.js
@@ -1,0 +1,68 @@
+import '../testHelper';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const React = require('react');
+const { createRoot } = require('react-dom/client');
+const { act } = require('react-dom/test-utils');
+const ParsedArticle = require('../../app/assets/javascripts/components/common/ArticleViewer/components/ParsedArticle').default;
+
+describe('ParsedArticle Screen Reader Boundaries', () => {
+  test('groups contiguous editor highlight spans and injects screen reader announcement spans', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    // Contiguous spans by UserA, followed by a span by UserB, and a non-highlighted span
+    const mockHtml = `
+      <p>
+        hello
+        <span class="editor-token token-editor-123 user-highlight-1" title="UserA">world</span>
+        <span class="editor-token token-editor-123 user-highlight-1" title="UserA">wide</span>
+        web
+        <span class="editor-token token-editor-456 user-highlight-2" title="UserB">page</span>
+        <span class="some-other-span">untouched</span>
+      </p>
+    `;
+
+    act(() => {
+      createRoot(container).render(
+        React.createElement(ParsedArticle, { html: mockHtml })
+      );
+    });
+
+    const parsedArticleDiv = container.querySelector('.parsed-article');
+    expect(parsedArticleDiv).not.toBeNull();
+
+    // Check screen reader start/end boundary elements for UserA
+    const srSpans = parsedArticleDiv.querySelectorAll('span.screen-reader');
+    expect(srSpans.length).toBe(4);
+
+    expect(srSpans[0].textContent).toBe('Edited by UserA');
+    expect(srSpans[1].textContent).toBe('End edit');
+    expect(srSpans[2].textContent).toBe('Edited by UserB');
+    expect(srSpans[3].textContent).toBe('End edit');
+
+    // Check that individual target token spans have aria-hidden and role="presentation"
+    const userASpans = parsedArticleDiv.querySelectorAll('span.user-highlight-1');
+    expect(userASpans.length).toBe(2);
+    userASpans.forEach((span) => {
+      expect(span.getAttribute('aria-hidden')).toBe('true');
+      expect(span.getAttribute('role')).toBe('presentation');
+    });
+
+    const userBSpan = parsedArticleDiv.querySelector('span.user-highlight-2');
+    expect(userBSpan.getAttribute('aria-hidden')).toBe('true');
+    expect(userBSpan.getAttribute('role')).toBe('presentation');
+
+    // Verify non-highlighted element remains untouched (no aria-hidden or role)
+    const untouchedSpan = parsedArticleDiv.querySelector('.some-other-span');
+    expect(untouchedSpan.getAttribute('aria-hidden')).toBeNull();
+    expect(untouchedSpan.getAttribute('role')).toBeNull();
+    expect(untouchedSpan.textContent).toBe('untouched');
+
+    document.body.removeChild(container);
+  });
+});


### PR DESCRIPTION
Eliminate confusing word-by-word screen reader announcements of editor highlight spans during authorship highlighting. Dynamically announce edit boundaries using visually hidden screen reader text while suppressing individual token span announcements.

#### Proposed Changes
1. HTML Processing (`ParsedArticle.jsx`):
   - Added `processAuthorshipHtml` to parse and process the article HTML string on the client side using `DOMParser`.
   - Filters `span.editor-token` elements with active `user-highlight-*` classes and editor name titles.
   - Groups contiguous editor spans by checking parent node matching, editor name equality, and whitespace-only text node transitions.
   - Injects boundary announcement spans:
     - `<span class="screen-reader">Edited by [Name]</span>` at the start of an edit block.
     - `<span class="screen-reader">End edit</span>` at the end of an edit block.
   - Appends `aria-hidden="true"` and `role="presentation"` to individual token spans.

2. Unit Tests (`parsed_article.spec.js`):
   - Added a new Jest test suite verifying contiguous span grouping, screen-reader boundary injection, and aria-hidden token masking.

#### Verification Results
All related component unit tests pass cleanly:


`npx jest test/components/parsed_article.spec.js test/components/article_viewer_legend.spec.js test/components/use_authorship_highlighting.spec.js `
