### PR TITLE
Curate the Fact Verification claim pool for Fall 2026

### DIFF
--- a/app/services/annotate_revision_claims.rb
+++ b/app/services/annotate_revision_claims.rb
@@ -128,16 +128,20 @@ class AnnotateRevisionClaims
 
   # The pool claims added in this revision, keyed by normalized sentence (first
   # wins when a sentence carries more than one citation), minus the claims
-  # curated out of the exercise. The exclusion is applied after each sentence's
-  # representative is picked, not in the query: a sentence with several
-  # citations has one pool row per citation, and excluding only the row the
-  # student sees would just promote the next one. What's excluded is the
-  # sentence as displayed — the thing the curators reviewed.
+  # curated out of the exercise. The exclusion removes every pool row for an
+  # excluded claim's sentence (see RolloutList.without_excluded), so excluding
+  # the row the student sees can't just promote the sentence's next row — a
+  # different citation for the same text.
   def harvested_claims
-    @harvested_claims ||= VerificationClaim.where(article_id: @article.id, mw_rev_id: @mw_rev_id)
-                                           .order(:id).each_with_object({}) do |claim, map|
+    @harvested_claims ||= ClaimVerification::RolloutList.without_excluded(pool_claims)
+                                                        .order(:id)
+                                                        .each_with_object({}) do |claim, map|
       map[normalize(claim.sentence)] ||= claim
-    end.reject { |_, claim| ClaimVerification::RolloutList.excluded?(claim.id) }
+    end
+  end
+
+  def pool_claims
+    VerificationClaim.where(article_id: @article.id, mw_rev_id: @mw_rev_id)
   end
 
   def normalize(text)

--- a/app/services/annotate_revision_claims.rb
+++ b/app/services/annotate_revision_claims.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/claim_verification/claim_citation_extractor"
+require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
 require_dependency "#{Rails.root}/lib/claim_verification/sentence_highlighter"
 
 # Renders an article at the exact revision a mainspace AiEditAlert flagged and
 # wraps — in a `cv-claim` span — only the cited sentences that were *added* in
-# that revision (the pre-harvested pool claims for this article+revision), so the
-# ArticleViewer can highlight them and let the student take one on. The full
-# revision is rendered (not the diff) so MediaWiki's real citation markers and
-# sentence positions are present; each highlighted span carries the stored
-# VerificationClaim's id and display data, so the client never re-derives them.
-# If a sentence can't be located we fall back to tagging its `[n]` marker.
+# that revision (the pre-harvested pool claims for this article+revision, less
+# any curated out via the rollout config), so the ArticleViewer can highlight
+# them and let the student take one on. The full revision is rendered (not the
+# diff) so MediaWiki's real citation markers and sentence positions are present;
+# each highlighted span carries the stored VerificationClaim's id and display
+# data, so the client never re-derives them. If a sentence can't be located we
+# fall back to tagging its `[n]` marker.
 class AnnotateRevisionClaims
   attr_reader :html, :mw_rev_id
 
@@ -125,12 +127,17 @@ class AnnotateRevisionClaims
   end
 
   # The pool claims added in this revision, keyed by normalized sentence (first
-  # wins when a sentence carries more than one citation).
+  # wins when a sentence carries more than one citation), minus the claims
+  # curated out of the exercise. The exclusion is applied after each sentence's
+  # representative is picked, not in the query: a sentence with several
+  # citations has one pool row per citation, and excluding only the row the
+  # student sees would just promote the next one. What's excluded is the
+  # sentence as displayed — the thing the curators reviewed.
   def harvested_claims
     @harvested_claims ||= VerificationClaim.where(article_id: @article.id, mw_rev_id: @mw_rev_id)
                                            .order(:id).each_with_object({}) do |claim, map|
       map[normalize(claim.sentence)] ||= claim
-    end
+    end.reject { |_, claim| ClaimVerification::RolloutList.excluded?(claim.id) }
   end
 
   def normalize(text)

--- a/app/services/relevant_claim_revisions_for_course.rb
+++ b/app/services/relevant_claim_revisions_for_course.rb
@@ -13,7 +13,8 @@ require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
 # Every one of those scopes is first narrowed to the curated rollout list
 # (config/claim_verification_rollout.yml) when one is configured, so
 # prioritization only ever reorders approved revisions and can never reach past
-# them. That list is temporary; with it absent or empty this serves the whole
+# them; claims curated out individually are left out of the counts too. The
+# revision list is temporary; with it absent or empty this serves the whole
 # pool, which is the behavior to expect once the rollout gate comes off.
 class RelevantClaimRevisionsForCourse
   Tile = Struct.new(:article, :mw_rev_id, :claim_count, :mw_rev_timestamp,

--- a/config/claim_verification_rollout.yml
+++ b/config/claim_verification_rollout.yml
@@ -238,3 +238,32 @@ excluded_claim_ids:
   - 1079  # Surrogacy in India, review claim 16 (2 citations)
   - 1085  # Surrogacy in India, review claim 21 (2 citations)
   - 1087  # Surrogacy in India, review claim 22 (2 citations)
+  #
+  # Fall 2026 review, second pass: claims whose cited source the reviewers
+  # judged not to be a good source ("Source good?" = No in the spreadsheet;
+  # 25 claims — the other 7 marked No were already excluded above).
+  - 788   # American pika, review claim 3
+  - 789   # American pika, review claim 4
+  - 792   # American pika, review claim 7
+  - 802   # American pika, review claim 17
+  - 3177  # Climate finance in the United States, review claim 6
+  - 3187  # Climate finance in the United States, review claim 15
+  - 3832  # Curly Girl Method, review claim 1
+  - 3833  # Curly Girl Method, review claim 2
+  - 4808  # Extensive farming, review claim 1
+  - 4810  # Extensive farming, review claim 3
+  - 4812  # Extensive farming, review claim 5
+  - 4816  # Extensive farming, review claim 9
+  - 4817  # Extensive farming, review claim 10
+  - 4818  # Extensive farming, review claim 11
+  - 4819  # Extensive farming, review claim 12
+  - 4834  # Extensive farming, review claim 26
+  - 4836  # Extensive farming, review claim 28
+  - 4837  # Extensive farming, review claim 29
+  - 4845  # Extensive farming, review claim 35
+  - 4867  # Extensive farming, review claim 56
+  - 4868  # Extensive farming, review claim 57
+  - 857   # Helianthus californicus, review claim 15
+  - 4727  # Sharpfin houndshark, review claim 5
+  - 4728  # Sharpfin houndshark, review claim 6
+  - 4729  # Sharpfin houndshark, review claim 7

--- a/config/claim_verification_rollout.yml
+++ b/config/claim_verification_rollout.yml
@@ -20,7 +20,8 @@
 #
 # Fall 2026 curation: after the team checked the claims of all 25 articles by
 # hand, three were removed — Honolulu Courthouse riot, CHRFAM7A and Climate of
-# Armenia — leaving 22.
+# Armenia — leaving 22. Individual claims within them are then curated out via
+# `excluded_claim_ids` at the bottom of this file.
 revisions:
 - article_id: 376975008
   mw_rev_id: 1321874993
@@ -154,3 +155,86 @@ revisions:
   tier: usable
   topic_area: sciences
   claim_count: 11
+
+# Individual claims curated out of the exercise, by VerificationClaim id — the
+# production ids, which are also the "Claim ID" column of the team's Fall 2026
+# review spreadsheet (the "review claim N" in each comment is that
+# spreadsheet's "Claim #", the viewer's position at review time; it shifts as
+# claims are removed, the id does not). Excluding a claim removes its sentence
+# from the viewer: AnnotateRevisionClaims drops the sentence the claim stands
+# for rather than promoting another pool row (a different citation) for the
+# same text, and tile claim counts leave these out. The list is subtractive —
+# append ids as the review turns up more to remove — and keeps applying once
+# the revision list above is retired.
+#
+# Fall 2026 review, first pass: sentences carrying more than one citation
+# marker in the rendered revision (66 claims). The exercise shows a
+# single source per claim, so a student can't tell which of several is meant
+# to support it.
+excluded_claim_ids:
+  - 3412  # 2011 Italian census, review claim 2 (3 citations)
+  - 3416  # 2011 Italian census, review claim 4 (2 citations)
+  - 3418  # 2011 Italian census, review claim 5 (2 citations)
+  - 3420  # 2011 Italian census, review claim 6 (2 citations)
+  - 3422  # 2011 Italian census, review claim 7 (3 citations)
+  - 3425  # 2011 Italian census, review claim 8 (2 citations)
+  - 1557  # Biodesign, review claim 3 (2 citations)
+  - 1560  # Biodesign, review claim 5 (2 citations)
+  - 3631  # Bullerengue, review claim 10 (2 citations)
+  - 5065  # Central Valley groundwater pollution, review claim 5 (3 citations)
+  - 5071  # Central Valley groundwater pollution, review claim 9 (2 citations)
+  - 5075  # Central Valley groundwater pollution, review claim 12 (2 citations)
+  - 3167  # Climate finance in the United States, review claim 1 (2 citations)
+  - 3169  # Climate finance in the United States, review claim 2 (2 citations)
+  - 3171  # Climate finance in the United States, review claim 3 (2 citations)
+  - 3173  # Climate finance in the United States, review claim 4 (2 citations)
+  - 3175  # Climate finance in the United States, review claim 5 (2 citations)
+  - 3181  # Climate finance in the United States, review claim 10 (2 citations)
+  - 3189  # Climate finance in the United States, review claim 17 (2 citations)
+  - 3191  # Climate finance in the United States, review claim 18 (2 citations)
+  - 3193  # Climate finance in the United States, review claim 19 (4 citations)
+  - 3199  # Climate finance in the United States, review claim 22 (2 citations)
+  - 3205  # Climate finance in the United States, review claim 27 (2 citations)
+  - 1408  # Diseases of poverty, review claim 11 (2 citations)
+  - 1     # Dynamical decoupling, review claim 1 (2 citations)
+  - 3     # Dynamical decoupling, review claim 2 (6 citations)
+  - 9     # Dynamical decoupling, review claim 3 (3 citations)
+  - 13    # Dynamical decoupling, review claim 5 (2 citations)
+  - 1270  # Dysthymia, review claim 1 (2 citations)
+  - 1274  # Dysthymia, review claim 2 (2 citations)
+  - 4826  # Extensive farming, review claim 19 (2 citations)
+  - 4841  # Extensive farming, review claim 33 (2 citations)
+  - 4843  # Extensive farming, review claim 34 (2 citations)
+  - 4860  # Extensive farming, review claim 50 (2 citations)
+  - 4667  # Graffiti in Los Angeles, review claim 3 (2 citations)
+  - 4670  # Graffiti in Los Angeles, review claim 5 (2 citations)
+  - 4674  # Graffiti in Los Angeles, review claim 8 (2 citations)
+  - 4677  # Graffiti in Los Angeles, review claim 10 (2 citations)
+  - 4050  # Hazardous energy, review claim 4 (2 citations)
+  - 823   # Helianthus californicus, review claim 1 (3 citations)
+  - 826   # Helianthus californicus, review claim 2 (2 citations)
+  - 828   # Helianthus californicus, review claim 3 (2 citations)
+  - 830   # Helianthus californicus, review claim 4 (2 citations)
+  - 832   # Helianthus californicus, review claim 5 (4 citations)
+  - 837   # Helianthus californicus, review claim 7 (3 citations)
+  - 840   # Helianthus californicus, review claim 8 (2 citations)
+  - 843   # Helianthus californicus, review claim 10 (3 citations)
+  - 846   # Helianthus californicus, review claim 11 (2 citations)
+  - 848   # Helianthus californicus, review claim 12 (2 citations)
+  - 850   # Helianthus californicus, review claim 13 (2 citations)
+  - 852   # Helianthus californicus, review claim 14 (5 citations)
+  - 858   # Helianthus californicus, review claim 16 (3 citations)
+  - 5636  # Immigration policy of the United States, review claim 15 (2 citations)
+  - 5639  # Immigration policy of the United States, review claim 17 (3 citations)
+  - 3482  # Immunosenescence, review claim 1 (2 citations)
+  - 3486  # Immunosenescence, review claim 4 (2 citations)
+  - 579   # Psychology of art, review claim 6 (3 citations)
+  - 582   # Psychology of art, review claim 7 (2 citations)
+  - 584   # Psychology of art, review claim 8 (2 citations)
+  - 1063  # Surrogacy in India, review claim 4 (2 citations)
+  - 1067  # Surrogacy in India, review claim 7 (2 citations)
+  - 1070  # Surrogacy in India, review claim 9 (2 citations)
+  - 1074  # Surrogacy in India, review claim 12 (2 citations)
+  - 1079  # Surrogacy in India, review claim 16 (2 citations)
+  - 1085  # Surrogacy in India, review claim 21 (2 citations)
+  - 1087  # Surrogacy in India, review claim 22 (2 citations)

--- a/config/claim_verification_rollout.yml
+++ b/config/claim_verification_rollout.yml
@@ -7,15 +7,20 @@
 # cannot reach outside this list. Emptying `revisions` or deleting this file
 # restores the full harvested pool, which is how you turn the gate off.
 #
-# Generated — do not hand-edit. Edit the verdicts in
-# docs/analytics_scripts/fact_verification_curation/fv_rollout_shortlist.csv
-# and re-run build_rollout_list.rb in that directory.
+# Originally generated from the verdicts in
+# docs/analytics_scripts/fact_verification_curation/fv_rollout_shortlist.csv by
+# build_rollout_list.rb in that directory, then hand-curated for Fall 2026 (see
+# below), so it no longer matches that script's output.
 #
 # Selection: the 468-article harvested pool was scored for source
 # accessibility and slop signals, the top 54 were reviewed by hand against
 # their diffs and fetched sources, and the 25 that came out `strong_candidate`
-# or `usable` are listed here, ranked. Four of them were flagged twice; only
+# or `usable` were listed here, ranked. Four of them were flagged twice; only
 # the revision with more claims ships. See that directory's README.md.
+#
+# Fall 2026 curation: after the team checked the claims of all 25 articles by
+# hand, three were removed — Honolulu Courthouse riot, CHRFAM7A and Climate of
+# Armenia — leaving 22.
 revisions:
 - article_id: 376975008
   mw_rev_id: 1321874993
@@ -29,12 +34,6 @@ revisions:
   tier: strong_candidate
   topic_area: health
   claim_count: 7
-- article_id: 985108653
-  mw_rev_id: 1325604815
-  title: Honolulu Courthouse riot
-  tier: strong_candidate
-  topic_area: humanities
-  claim_count: 39
 - article_id: 989847485
   mw_rev_id: 1339774149
   title: 2011 Italian census
@@ -59,12 +58,6 @@ revisions:
   tier: strong_candidate
   topic_area: social sciences
   claim_count: 40
-- article_id: 1001810019
-  mw_rev_id: 1347334965
-  title: CHRFAM7A
-  tier: strong_candidate
-  topic_area: sciences
-  claim_count: 95
 - article_id: 50875139
   mw_rev_id: 1323139167
   title: Dysthymia
@@ -89,12 +82,6 @@ revisions:
   tier: strong_candidate
   topic_area: sciences
   claim_count: 9
-- article_id: 1000416953
-  mw_rev_id: 1345648440
-  title: Climate of Armenia
-  tier: usable
-  topic_area: sciences
-  claim_count: 6
 - article_id: 1003575313
   mw_rev_id: 1347254024
   title: Hazardous energy

--- a/config/claim_verification_rollout.yml
+++ b/config/claim_verification_rollout.yml
@@ -267,3 +267,16 @@ excluded_claim_ids:
   - 4727  # Sharpfin houndshark, review claim 5
   - 4728  # Sharpfin houndshark, review claim 6
   - 4729  # Sharpfin houndshark, review claim 7
+  #
+  # Fall 2026 review, third pass: claims whose cited source is a book — the
+  # citation renders from the Cite book template, or is a book chapter cited
+  # via the generic Citation template (8 claims; 3 more book citations were
+  # already excluded above).
+  - 786   # American pika, review claim 1
+  - 796   # American pika, review claim 11
+  - 4824  # Extensive farming, review claim 17
+  - 4830  # Extensive farming, review claim 22
+  - 4875  # Extensive farming, review claim 64
+  - 4665  # Graffiti in Los Angeles, review claim 1
+  - 4679  # Graffiti in Los Angeles, review claim 11
+  - 5622  # Immigration policy of the United States, review claim 1

--- a/config/claim_verification_rollout.yml
+++ b/config/claim_verification_rollout.yml
@@ -160,10 +160,11 @@ revisions:
 # production ids, which are also the "Claim ID" column of the team's Fall 2026
 # review spreadsheet (the "review claim N" in each comment is that
 # spreadsheet's "Claim #", the viewer's position at review time; it shifts as
-# claims are removed, the id does not). Excluding a claim removes its sentence
-# from the viewer: AnnotateRevisionClaims drops the sentence the claim stands
-# for rather than promoting another pool row (a different citation) for the
-# same text, and tile claim counts leave these out. The list is subtractive —
+# claims are removed, the id does not). Excluding a claim excludes its
+# sentence: every pool row for that sentence in that revision (one per
+# citation) leaves the viewer and the tile claim counts, rather than another
+# row — a different citation for the same text — taking its place. A revision
+# with nothing left gets no tile. The list is subtractive —
 # append ids as the review turns up more to remove — and keeps applying once
 # the revision list above is retired.
 #
@@ -280,3 +281,74 @@ excluded_claim_ids:
   - 4665  # Graffiti in Los Angeles, review claim 1
   - 4679  # Graffiti in Los Angeles, review claim 11
   - 5622  # Immigration policy of the United States, review claim 1
+  #
+  # TEMPORARY — Fall 2026 review, fourth pass: claims the team has not yet
+  # evaluated ("Source good?" still blank in the spreadsheet; 66 claims).
+  # Held out only until they are reviewed: delete this whole block, or the
+  # lines for claims that have since passed review, as the review catches up.
+  - 787   # American pika, review claim 2
+  - 809   # American pika, review claim 24
+  - 810   # American pika, review claim 25
+  - 811   # American pika, review claim 26
+  - 3623  # Bullerengue, review claim 2
+  - 3624  # Bullerengue, review claim 3
+  - 3625  # Bullerengue, review claim 4
+  - 3626  # Bullerengue, review claim 5
+  - 3627  # Bullerengue, review claim 6
+  - 3628  # Bullerengue, review claim 7
+  - 3629  # Bullerengue, review claim 8
+  - 3630  # Bullerengue, review claim 9
+  - 3178  # Climate finance in the United States, review claim 7
+  - 3183  # Climate finance in the United States, review claim 11
+  - 3186  # Climate finance in the United States, review claim 14
+  - 3198  # Climate finance in the United States, review claim 21
+  - 5586  # Community health centers in the United States, review claim 1
+  - 5587  # Community health centers in the United States, review claim 2
+  - 5588  # Community health centers in the United States, review claim 3
+  - 5589  # Community health centers in the United States, review claim 4
+  - 5590  # Community health centers in the United States, review claim 5
+  - 5591  # Community health centers in the United States, review claim 6
+  - 5592  # Community health centers in the United States, review claim 7
+  - 5593  # Community health centers in the United States, review claim 8
+  - 5594  # Community health centers in the United States, review claim 9
+  - 5595  # Community health centers in the United States, review claim 10
+  - 5596  # Community health centers in the United States, review claim 11
+  - 5597  # Community health centers in the United States, review claim 12
+  - 5598  # Community health centers in the United States, review claim 13
+  - 5599  # Community health centers in the United States, review claim 14
+  - 5600  # Community health centers in the United States, review claim 15
+  - 12    # Dynamical decoupling, review claim 4
+  - 15    # Dynamical decoupling, review claim 6
+  - 16    # Dynamical decoupling, review claim 7
+  - 17    # Dynamical decoupling, review claim 8
+  - 18    # Dynamical decoupling, review claim 9
+  - 19    # Dynamical decoupling, review claim 10
+  - 1273  # Dysthymia, review claim 4
+  - 4666  # Graffiti in Los Angeles, review claim 2
+  - 4669  # Graffiti in Los Angeles, review claim 4
+  - 4672  # Graffiti in Los Angeles, review claim 6
+  - 4673  # Graffiti in Los Angeles, review claim 7
+  - 4676  # Graffiti in Los Angeles, review claim 9
+  - 4680  # Graffiti in Los Angeles, review claim 12
+  - 4681  # Graffiti in Los Angeles, review claim 13
+  - 4047  # Hazardous energy, review claim 1
+  - 4048  # Hazardous energy, review claim 2
+  - 4049  # Hazardous energy, review claim 3
+  - 4052  # Hazardous energy, review claim 5
+  - 4053  # Hazardous energy, review claim 6
+  - 5623  # Immigration policy of the United States, review claim 2
+  - 5624  # Immigration policy of the United States, review claim 3
+  - 5625  # Immigration policy of the United States, review claim 4
+  - 5626  # Immigration policy of the United States, review claim 5
+  - 5627  # Immigration policy of the United States, review claim 6
+  - 5628  # Immigration policy of the United States, review claim 7
+  - 5629  # Immigration policy of the United States, review claim 8
+  - 5630  # Immigration policy of the United States, review claim 9
+  - 5631  # Immigration policy of the United States, review claim 10
+  - 5632  # Immigration policy of the United States, review claim 11
+  - 5633  # Immigration policy of the United States, review claim 12
+  - 5634  # Immigration policy of the United States, review claim 13
+  - 5635  # Immigration policy of the United States, review claim 14
+  - 5638  # Immigration policy of the United States, review claim 16
+  - 5642  # Immigration policy of the United States, review claim 18
+  - 5643  # Immigration policy of the United States, review claim 19

--- a/lib/claim_verification/rollout_list.rb
+++ b/lib/claim_verification/rollout_list.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
 module ClaimVerification
-  # The hand-curated set of flagged revisions students may pick from, as
-  # declared in config/claim_verification_rollout.yml.
+  # The hand-curated set of flagged revisions students may pick from, and the
+  # individual claims curated out of them, as declared in
+  # config/claim_verification_rollout.yml.
   #
   # TEMPORARY. This is the initial rollout's allow-list, not the intended
   # serving strategy. While the config names any revisions, the exercise offers
   # only those, to every course; empty the list or delete the file and the full
-  # harvested pool comes back. Nothing else in the app knows the list exists —
-  # RelevantClaimRevisionsForCourse is the single point that consults it.
+  # harvested pool comes back. The per-claim exclusions are subtractive and
+  # independent of that gate, so they keep applying to the full pool once the
+  # revision list is retired. Nothing else in the app knows the list exists —
+  # RelevantClaimRevisionsForCourse (tiles and counts) and AnnotateRevisionClaims
+  # (which claims get highlighted) are the two points that consult it.
   #
-  # The unit is the (article_id, mw_rev_id) pair rather than the revision id
-  # alone: revision ids are unique within a wiki but not across them, and the
-  # pool spans wikis.
+  # The revision unit is the (article_id, mw_rev_id) pair rather than the
+  # revision id alone: revision ids are unique within a wiki but not across
+  # them, and the pool spans wikis.
   class RolloutList
     CONFIG_PATH = "#{Rails.root}/config/claim_verification_rollout.yml"
 
@@ -21,27 +25,48 @@ module ClaimVerification
         pairs.any?
       end
 
-      # The given VerificationClaim scope, narrowed to the rollout revisions —
-      # or returned untouched when no list is configured.
+      # The given VerificationClaim scope, narrowed to the rollout revisions and
+      # stripped of the excluded claims — or returned untouched when neither is
+      # configured.
       def filter(scope)
         approved = pairs
-        return scope if approved.empty?
-        scope.where(tuple_condition(approved))
+        scope = scope.where(tuple_condition(approved)) if approved.any?
+        excluded = excluded_claim_ids
+        scope = scope.where.not(id: excluded.to_a) if excluded.any?
+        scope
       end
 
       # [[article_id, mw_rev_id], ...]
       def pairs
-        # Reloaded every time outside production so curation changes land
-        # without a restart, matching ClaimVerification::ExerciseForm.
-        return load_pairs unless Rails.env.production?
-        @pairs ||= load_pairs
+        config[:pairs]
+      end
+
+      # The VerificationClaim ids curated out of the exercise, as a Set.
+      def excluded_claim_ids
+        config[:excluded_claim_ids]
+      end
+
+      def excluded?(claim_id)
+        excluded_claim_ids.include?(claim_id)
       end
 
       private
 
-      def load_pairs
-        return [] unless File.exist?(CONFIG_PATH)
-        revisions = YAML.load_file(CONFIG_PATH)['revisions'] || []
+      def config
+        # Reloaded every time outside production so curation changes land
+        # without a restart, matching ClaimVerification::ExerciseForm.
+        return load_config unless Rails.env.production?
+        @config ||= load_config
+      end
+
+      def load_config
+        return { pairs: [], excluded_claim_ids: Set.new } unless File.exist?(CONFIG_PATH)
+        yaml = YAML.load_file(CONFIG_PATH)
+        { pairs: load_pairs(yaml['revisions'] || []),
+          excluded_claim_ids: (yaml['excluded_claim_ids'] || []).map(&:to_i).to_set }
+      end
+
+      def load_pairs(revisions)
         revisions.filter_map do |revision|
           article_id = revision['article_id']
           mw_rev_id = revision['mw_rev_id']

--- a/lib/claim_verification/rollout_list.rb
+++ b/lib/claim_verification/rollout_list.rb
@@ -31,9 +31,18 @@ module ClaimVerification
       def filter(scope)
         approved = pairs
         scope = scope.where(tuple_condition(approved)) if approved.any?
+        without_excluded(scope)
+      end
+
+      # The given scope minus the excluded claims — and minus every other pool
+      # row for the same sentence in the same revision. A sentence with several
+      # citations is pooled once per citation but shown once, so what the
+      # curators reviewed and excluded is the sentence: its other rows have to
+      # go too, or they would surface in the viewer and in the tile counts.
+      def without_excluded(scope)
         excluded = excluded_claim_ids
-        scope = scope.where.not(id: excluded.to_a) if excluded.any?
-        scope
+        return scope if excluded.empty?
+        scope.where.not(excluded_sentence_exists(excluded))
       end
 
       # [[article_id, mw_rev_id], ...]
@@ -44,10 +53,6 @@ module ClaimVerification
       # The VerificationClaim ids curated out of the exercise, as a Set.
       def excluded_claim_ids
         config[:excluded_claim_ids]
-      end
-
-      def excluded?(claim_id)
-        excluded_claim_ids.include?(claim_id)
       end
 
       private
@@ -72,6 +77,16 @@ module ClaimVerification
           mw_rev_id = revision['mw_rev_id']
           [article_id, mw_rev_id] if article_id.present? && mw_rev_id.present?
         end
+      end
+
+      # EXISTS (an excluded claim with this row's article, revision and sentence).
+      def excluded_sentence_exists(excluded)
+        VerificationClaim.from('verification_claims ex')
+                         .where(ex: { id: excluded.to_a })
+                         .where('ex.article_id = verification_claims.article_id')
+                         .where('ex.mw_rev_id = verification_claims.mw_rev_id')
+                         .where('ex.sentence = verification_claims.sentence')
+                         .arel.exists
       end
 
       def tuple_condition(approved)

--- a/spec/lib/claim_verification/rollout_list_spec.rb
+++ b/spec/lib/claim_verification/rollout_list_spec.rb
@@ -37,6 +37,30 @@ describe ClaimVerification::RolloutList do
       expect(described_class.filter(scope).to_sql).to eq(scope.to_sql)
       expect(described_class.filter(scope)).to include(kept)
     end
+
+    it 'drops claims curated out of a listed revision' do
+      kept = claim(article_id: 1, mw_rev_id: 100)
+      excluded = claim(article_id: 1, mw_rev_id: 100)
+      rollout_revisions([1, 100], excluding: [excluded.id])
+      expect(described_class.filter(VerificationClaim.all)).to eq([kept])
+    end
+
+    # The exclusions outlive the revision allow-list: they still apply to the
+    # full pool once that gate is switched off.
+    it 'drops curated-out claims even with no revision list configured' do
+      kept = claim(article_id: 1, mw_rev_id: 100)
+      excluded = claim(article_id: 2, mw_rev_id: 200)
+      rollout_revisions(excluding: [excluded.id])
+      expect(described_class.filter(VerificationClaim.all)).to eq([kept])
+    end
+  end
+
+  describe '.excluded?' do
+    it 'is true only for a curated-out claim id' do
+      rollout_revisions(excluding: [42])
+      expect(described_class.excluded?(42)).to be true
+      expect(described_class.excluded?(43)).to be false
+    end
   end
 
   describe '.active?' do
@@ -64,6 +88,15 @@ describe ClaimVerification::RolloutList do
     it 'names each article exactly once' do
       article_ids = described_class.pairs.map(&:first)
       expect(article_ids.uniq.length).to eq(article_ids.length)
+    end
+
+    # Read straight from the file: the Set the class exposes would hide a claim
+    # id accidentally listed twice.
+    it 'excludes well-formed claim ids, each listed once' do
+      listed = YAML.load_file(described_class::CONFIG_PATH)['excluded_claim_ids']
+      expect(listed).to all(be_a(Integer))
+      expect(listed.uniq.length).to eq(listed.length)
+      expect(described_class.excluded_claim_ids).to eq(listed.to_set)
     end
   end
 end

--- a/spec/lib/claim_verification/rollout_list_spec.rb
+++ b/spec/lib/claim_verification/rollout_list_spec.rb
@@ -57,7 +57,7 @@ describe ClaimVerification::RolloutList do
     before { real_rollout_list }
 
     it 'parses to one (article, revision) pair per rollout article' do
-      expect(described_class.pairs.length).to eq(25)
+      expect(described_class.pairs.length).to eq(22)
       expect(described_class.pairs).to all(match([be_a(Integer), be_a(Integer)]))
     end
 

--- a/spec/lib/claim_verification/rollout_list_spec.rb
+++ b/spec/lib/claim_verification/rollout_list_spec.rb
@@ -6,8 +6,8 @@ require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
 describe ClaimVerification::RolloutList do
   let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
 
-  def claim(article_id:, mw_rev_id:)
-    VerificationClaim.create!(wiki:, article_id:, mw_rev_id:, sentence: 'A fact.')
+  def claim(article_id:, mw_rev_id:, sentence: 'A fact.')
+    VerificationClaim.create!(wiki:, article_id:, mw_rev_id:, sentence:)
   end
 
   describe '.filter' do
@@ -40,7 +40,7 @@ describe ClaimVerification::RolloutList do
 
     it 'drops claims curated out of a listed revision' do
       kept = claim(article_id: 1, mw_rev_id: 100)
-      excluded = claim(article_id: 1, mw_rev_id: 100)
+      excluded = claim(article_id: 1, mw_rev_id: 100, sentence: 'Another fact.')
       rollout_revisions([1, 100], excluding: [excluded.id])
       expect(described_class.filter(VerificationClaim.all)).to eq([kept])
     end
@@ -55,11 +55,32 @@ describe ClaimVerification::RolloutList do
     end
   end
 
-  describe '.excluded?' do
-    it 'is true only for a curated-out claim id' do
-      rollout_revisions(excluding: [42])
-      expect(described_class.excluded?(42)).to be true
-      expect(described_class.excluded?(43)).to be false
+  # A sentence with several citations is pooled once per citation; excluding
+  # the claim a student sees for it must take the sentence's other rows too.
+  describe '.without_excluded' do
+    def claim_with_sentence(sentence, article_id: 1, mw_rev_id: 100)
+      VerificationClaim.create!(wiki:, article_id:, mw_rev_id:, sentence:, ref_id: SecureRandom.hex)
+    end
+
+    it 'drops every pool row for an excluded claim\'s sentence in that revision' do
+      excluded = claim_with_sentence('Otters use tools.')
+      claim_with_sentence('Otters use tools.')
+      kept = claim_with_sentence('Otters eat urchins.')
+      rollout_revisions(excluding: [excluded.id])
+      expect(described_class.without_excluded(VerificationClaim.all)).to eq([kept])
+    end
+
+    it 'keeps the same sentence pooled from another revision' do
+      excluded = claim_with_sentence('Otters use tools.')
+      elsewhere = claim_with_sentence('Otters use tools.', mw_rev_id: 200)
+      rollout_revisions(excluding: [excluded.id])
+      expect(described_class.without_excluded(VerificationClaim.all)).to eq([elsewhere])
+    end
+
+    it 'hands back the scope untouched when nothing is excluded' do
+      rollout_revisions
+      scope = VerificationClaim.all
+      expect(described_class.without_excluded(scope).to_sql).to eq(scope.to_sql)
     end
   end
 

--- a/spec/services/annotate_revision_claims_spec.rb
+++ b/spec/services/annotate_revision_claims_spec.rb
@@ -66,6 +66,7 @@ describe AnnotateRevisionClaims do
   # config) has to remove the sentence the student would have seen, not just
   # the pool row behind it: a sentence with several citations has one pool row
   # per citation, and dropping only the displayed row would promote the next.
+  # (RolloutList.without_excluded drops the sentence's other rows as well.)
   context 'when a claim is curated out of the rollout' do
     let(:revision_html) do
       <<~HTML

--- a/spec/services/annotate_revision_claims_spec.rb
+++ b/spec/services/annotate_revision_claims_spec.rb
@@ -62,6 +62,63 @@ describe AnnotateRevisionClaims do
     expect(described_class.new(article:, mw_rev_id: 999).html).to be_nil
   end
 
+  # Curating a claim out of the exercise (excluded_claim_ids in the rollout
+  # config) has to remove the sentence the student would have seen, not just
+  # the pool row behind it: a sentence with several citations has one pool row
+  # per citation, and dropping only the displayed row would promote the next.
+  context 'when a claim is curated out of the rollout' do
+    let(:revision_html) do
+      <<~HTML
+        <p>Sea otters use rocks as tools.<sup class="reference"><a href="#cite_note-a-1">[1]</a></sup><sup class="reference"><a href="#cite_note-b-2">[2]</a></sup>
+        Otters eat urchins.<sup class="reference"><a href="#cite_note-a-1">[1]</a></sup></p>
+        <ol class="references">
+          <li id="cite_note-a-1"><span class="reference-text"><cite>
+            <a class="external" href="https://example.com/a">Riedman 1990</a></cite></span></li>
+          <li id="cite_note-b-2"><span class="reference-text"><cite>
+            <a class="external" href="https://example.com/b">Kenyon 1969</a></cite></span></li>
+        </ol>
+      HTML
+    end
+    let!(:harvested) do
+      VerificationClaim.create!(wiki:, article:, mw_rev_id:, ref_id: 'cite_note-a-1',
+                                sentence: 'Sea otters use rocks as tools.',
+                                cite_text: 'Riedman 1990', source_url: 'https://example.com/a')
+    end
+    let!(:second_citation) do
+      VerificationClaim.create!(wiki:, article:, mw_rev_id:, ref_id: 'cite_note-b-2',
+                                sentence: 'Sea otters use rocks as tools.',
+                                cite_text: 'Kenyon 1969', source_url: 'https://example.com/b')
+    end
+    let!(:kept) do
+      VerificationClaim.create!(wiki:, article:, mw_rev_id:, ref_id: 'cite_note-a-1',
+                                sentence: 'Otters eat urchins.', cite_text: 'Riedman 1990',
+                                source_url: 'https://example.com/a')
+    end
+
+    before { rollout_revisions(excluding: [harvested.id]) }
+
+    def spans
+      Nokogiri::HTML.fragment(annotate.html).css('.cv-claim')
+    end
+
+    it 'still highlights the other claims' do
+      expect(spans.map { |span| span['data-claim-id'] }).to eq([kept.id.to_s])
+    end
+
+    it 'leaves the excluded sentence unhighlighted' do
+      expect(spans.map(&:text).join(' ')).not_to include('Sea otters use rocks as tools.')
+    end
+
+    it 'does not promote the same sentence under its other citation' do
+      expect(annotate.html).not_to include(%(data-claim-id="#{second_citation.id}"))
+    end
+
+    it 'returns no html when every claim of the revision is curated out' do
+      rollout_revisions(excluding: [harvested.id, kept.id])
+      expect(annotate.html).to be_nil
+    end
+  end
+
   # A named ref like <ref name="O'Brien 2020"> renders with the apostrophe kept in
   # the cite_note id, which used to break the interpolated CSS selector that
   # located the marker (Nokogiri::CSS::SyntaxError, 500ing the endpoint).

--- a/spec/services/relevant_claim_revisions_for_course_spec.rb
+++ b/spec/services/relevant_claim_revisions_for_course_spec.rb
@@ -119,5 +119,15 @@ describe RelevantClaimRevisionsForCourse do
       rollout_revisions(excluding: [excluded.id])
       expect(described_class.new(student_course).tiles).to be_empty
     end
+
+    # The viewer shows a multi-citation sentence once; its other pool rows must
+    # not keep a tile alive (or padded) once that sentence is excluded.
+    it 'leaves the other pool rows of an excluded sentence out too' do
+      otter = article('Otter')
+      excluded = pool_claim(article: otter, rev: 10, source_course: a_course, sentence: 'One.')
+      pool_claim(article: otter, rev: 10, source_course: a_course, sentence: 'One.')
+      rollout_revisions(excluding: [excluded.id])
+      expect(described_class.new(student_course).tiles).to be_empty
+    end
   end
 end

--- a/spec/services/relevant_claim_revisions_for_course_spec.rb
+++ b/spec/services/relevant_claim_revisions_for_course_spec.rb
@@ -102,4 +102,22 @@ describe RelevantClaimRevisionsForCourse do
       expect(described_class.new(student_course).tiles).to be_empty
     end
   end
+
+  # Claims curated out individually (excluded_claim_ids in the rollout config).
+  context 'when claims are curated out of the rollout' do
+    it 'leaves them out of the tile claim count' do
+      otter = article('Otter')
+      pool_claim(article: otter, rev: 10, source_course: a_course, sentence: 'One.')
+      excluded = pool_claim(article: otter, rev: 10, source_course: a_course, sentence: 'Two.')
+      rollout_revisions([otter.id, 10], excluding: [excluded.id])
+      expect(described_class.new(student_course).tiles.map(&:claim_count)).to eq([1])
+    end
+
+    it 'offers no tile for a revision with every claim curated out' do
+      otter = article('Otter')
+      excluded = pool_claim(article: otter, rev: 10, source_course: a_course)
+      rollout_revisions(excluding: [excluded.id])
+      expect(described_class.new(student_course).tiles).to be_empty
+    end
+  end
 end

--- a/spec/support/claim_verification_rollout.rb
+++ b/spec/support/claim_verification_rollout.rb
@@ -3,19 +3,23 @@
 require_dependency "#{Rails.root}/lib/claim_verification/rollout_list"
 
 # The curated rollout allow-list (config/claim_verification_rollout.yml) names
-# real article and revision ids from the production claim pool. Left switched
-# on, it would filter away every claim a spec builds for itself, so specs run
-# with the gate off and opt in with `rollout_revisions` when they mean to
-# exercise it.
+# real article, revision and claim ids from the production claim pool. Left
+# switched on, it would filter away every claim a spec builds for itself (and
+# could exclude one by a colliding id), so specs run with the gate off and opt
+# in with `rollout_revisions` when they mean to exercise it.
 module ClaimVerificationRolloutHelper
-  # Restrict the exercise to the given [article_id, mw_rev_id] pairs.
-  def rollout_revisions(*pairs)
+  # Restrict the exercise to the given [article_id, mw_rev_id] pairs, and
+  # curate out the given claim ids.
+  def rollout_revisions(*pairs, excluding: [])
     allow(ClaimVerification::RolloutList).to receive(:pairs).and_return(pairs)
+    allow(ClaimVerification::RolloutList).to receive(:excluded_claim_ids)
+      .and_return(excluding.to_set)
   end
 
   # Read config/claim_verification_rollout.yml for real.
   def real_rollout_list
     allow(ClaimVerification::RolloutList).to receive(:pairs).and_call_original
+    allow(ClaimVerification::RolloutList).to receive(:excluded_claim_ids).and_call_original
   end
 end
 


### PR DESCRIPTION
## What this PR does

Curates the Fact Verification exercise's claim pool for the Fall 2026 iteration, based on the team's manual review of the claims in the 25 rollout articles. Three articles (Honolulu Courthouse riot, CHRFAM7A, Climate of Armenia) come off the rollout list entirely, and the rollout config gains a new `excluded_claim_ids` list that curates out individual claims by their production `VerificationClaim` id — the same ids the team's review spreadsheet now carries, so the list can keep shrinking by subtraction as the review continues. The exclusions land in four passes, each documented in the config: sentences carrying more than one citation marker (66), sources the reviewers judged not good (25), books (8), and — marked TEMPORARY, to be trimmed as the review catches up — claims not yet evaluated (66). After deploy the exercise offers 17 articles and 184 claims, down from 25 and 435.

To make exclusion by id work, `RolloutList` now applies the exclusions alongside the revision allow-list, and does so **by sentence**: a sentence with several citations is pooled once per citation but shown once, so excluding the claim a student sees also removes the sentence's other pool rows from both the viewer (`AnnotateRevisionClaims`) and the tile counts (`RelevantClaimRevisionsForCourse`). Without that, excluding a displayed claim would just promote a hidden duplicate with a different citation, and four articles would have kept a tile that opened to an article with nothing highlighted. A side effect is that tile claim counts now equal the number of highlightable claims (Helianthus californicus previously showed 39 for 17).

Part of the Fact Verification exercise work tracked in #6910.

## AI usage

Claude Code wrote essentially all of the code, config, specs and commit messages in this PR, under Sage's direction; Sage decided what to build at each step (which articles to drop, which criteria to exclude on, that filtering should be by claim id rather than a code rule, that articles left with only one to three claims should stay), and reviewed the results. Claude Code also did the analysis behind the exclusions: it reproduced the exercise viewer's claim numbering to map the spreadsheet's "Claim #" positions to production ids (the mapping was validated against a local copy of the pool and the production run's per-article counts before any ids were written), classified citations as books from the rendered revision's citation template classes, and identified multi-citation sentences with the app's own citation extractor. The production ids themselves came from a script Sage ran on the production console; the two scripts that produced and merged them are not part of this PR.

One correction during the session: Claude Code fetched the resulting CSV from the production server itself, which it should not have done; Sage said so, and it is recorded as a standing rule.

This was developed in a single session: five commits over about 35 minutes of wall-clock time on 2026-09-01, preceded by roughly an hour of analysis and spreadsheet work in the same session. The summary and analysis in this description were also drafted by Claude Code and may contain errors. This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes. The visible effect is data: fewer article tiles (17 instead of 25), tile claim counts that match the number of highlighted claims, and fewer highlighted claims per article.

## Open questions and concerns

- **Config, not code, now decides what students see.** `excluded_claim_ids` is memoized per process in production, so each change to the list takes effect on deploy. The fourth block is explicitly temporary and should be trimmed as the team finishes reviewing.
- **The `take` endpoint is unchanged.** As with the revision-level gate before this PR, it accepts any pool claim by id; students can only click highlighted claims, so this only matters for hand-crafted requests.
- **Thin articles.** Bullerengue and Dysthymia keep a single claim, and four others keep three. Sage is fine with that while the review continues.
- **The config's original generator is gone.** The header used to say "Generated — do not hand-edit" and pointed at curation scripts that are not in this repo; the file is now hand-curated and its comments say so.
- **Sentence equality in SQL** uses the column's collation (case-insensitive) rather than the annotator's whitespace normalization. Duplicate rows come from the same extractor output, so they are byte-identical in practice; the end-to-end check against a local copy of the pool matched displayed-minus-excluded counts for all 22 articles.

(PR description written by Claude Code.)
