### PR TITLE
Drop the "mostly yes" / "mostly no" verdicts from the Fact Verification form

### DIFF
--- a/app/assets/javascripts/components/claim_verification_exercise/VerificationForm.jsx
+++ b/app/assets/javascripts/components/claim_verification_exercise/VerificationForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import ClaimVerificationAPI from '@components/common/ArticleViewer/claim_verification/ClaimVerificationAPI';
 import markdownIt from '~/app/assets/javascripts/utils/markdown_it';
-import { formPropType, visibleQuestions, missingRequired } from './formDefinition';
+import { formPropType, visibleQuestions, missingRequired, retiredOptions } from './formDefinition';
 
 // Step instructions are operator copy that may link out (eg to the Reliable
 // Sources policy), so they render as Markdown with bare URLs linkified and
@@ -21,18 +21,30 @@ StepInstructions.propTypes = {
   instructions: PropTypes.string.isRequired,
 };
 
+// The options to show: those offered, plus — checked but disabled — a retired
+// one when it is the student's recorded answer, so a response saved before an
+// option was dropped still reads correctly while being edited. Picking an
+// offered option replaces it; it can't be chosen again.
+const shownOptions = (question, value) => [
+  ...question.options,
+  ...retiredOptions(question)
+    .filter(option => option.value === value)
+    .map(option => ({ ...option, retired: true })),
+];
+
 // One multiple-choice question as a fieldset of radios. Both the question and
 // its options are operator copy resolved server-side, so this knows none of it.
 const ChoiceQuestion = ({ question, value, onChange }) => (
   <fieldset className="cv-form__question">
     <legend className="cv-form__question-label">{question.label}</legend>
-    {question.options.map(option => (
+    {shownOptions(question, value).map(option => (
       <label key={option.value} className="cv-form__option">
         <input
           type="radio"
           name={question.id}
           value={option.value}
           checked={value === option.value}
+          disabled={option.retired}
           onChange={() => onChange(option.value)}
         />
         <span>{option.label}</span>

--- a/app/assets/javascripts/components/claim_verification_exercise/formDefinition.js
+++ b/app/assets/javascripts/components/claim_verification_exercise/formDefinition.js
@@ -39,12 +39,17 @@ export const missingRequired = (form, answers) => (
     .map(question => question.id)
 );
 
-// How to show one stored answer: a choice's option label, or the text as typed.
-// Falls back to the raw value so an answer whose option has since been renamed
-// still displays instead of vanishing.
+// A choice question's options no longer offered but still on record, so an
+// older response's answer can be read back (and shown while being edited).
+export const retiredOptions = question => question.retired_options || [];
+
+// How to show one stored answer: a choice's option label — offered or retired —
+// or the text as typed. Falls back to the raw value so an answer whose option
+// has since been renamed still displays instead of vanishing.
 const displayValue = (question, value) => {
   if (question.type !== 'choice') { return value; }
-  return question.options.find(option => option.value === value)?.label || value;
+  return [...question.options, ...retiredOptions(question)]
+    .find(option => option.value === value)?.label || value;
 };
 
 /*
@@ -71,6 +76,10 @@ const questionPropType = PropTypes.shape({
   required: PropTypes.bool,
   visible_when: PropTypes.object,
   options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    label: PropTypes.string,
+  })),
+  retired_options: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string.isRequired,
     label: PropTypes.string,
   })),

--- a/app/views/claim_verification_responses/_form.json.jbuilder
+++ b/app/views/claim_verification_responses/_form.json.jbuilder
@@ -8,6 +8,8 @@
 #
 # `visible_when` is passed through as declared — the client applies it live as
 # the student answers, and the server applies it again on submission.
+# `retired_options` are answers no longer offered, sent labelled so a response
+# recorded with one still reads correctly.
 json.steps form.steps do |step|
   json.id step.id
   json.heading step.heading
@@ -17,6 +19,9 @@ json.steps form.steps do |step|
   json.questions step.questions do |question|
     json.call(question, :id, :type, :required, :visible_when)
     json.label question.label
-    json.options question.option_labels if question.choice?
+    if question.choice?
+      json.options question.option_labels
+      json.retired_options question.retired_option_labels
+    end
   end
 end

--- a/config/claim_verification_exercise.yml
+++ b/config/claim_verification_exercise.yml
@@ -31,6 +31,11 @@ first_step_number: 3
 #
 # `required: true` blocks submission until the question is answered. Only choice
 # questions are ever required; the free-text ones are always optional.
+#
+# `retired_options` lists a choice question's answers that are no longer offered
+# but are still on record: a response recorded with one keeps it, shows its label
+# in the summary, and stays valid if the student edits the response. Their copy
+# stays in the locales alongside the offered options'.
 steps:
   # Judged from the citation alone — this step comes before the student tries to
   # get hold of the source.
@@ -77,6 +82,10 @@ steps:
           - unsupported
           - contradicted
           - undetermined
+        # The two "mostly" verdicts were dropped for Fall 2026.
+        retired_options:
+          - mostly_supports
+          - mostly_unsupported
       - id: claim_location
         type: text
       - id: verification_notes

--- a/config/claim_verification_exercise.yml
+++ b/config/claim_verification_exercise.yml
@@ -73,9 +73,7 @@ steps:
         required: true
         options:
           - full_support
-          - mostly_supports
           - partial_support
-          - mostly_unsupported
           - unsupported
           - contradicted
           - undetermined

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1796,9 +1796,7 @@ en:
       verdict_question: "Does the source back up the claim?"
       verdict_options:
         full_support: "Yes — it explicitly supports the full claim."
-        mostly_supports: "Mostly yes — the core of the claim comes from this source."
         partial_support: "Partially — some elements of the claim come from this source, but a significant part does not."
-        mostly_unsupported: "Mostly no — the source is compatible with the claim, but doesn’t directly back it up."
         unsupported: "No — the source does not cover what the claim says."
         contradicted: "The opposite — the source actually contradicts the claim."
         undetermined: "I was unable to determine whether the claim was in the cited source."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1800,6 +1800,9 @@ en:
         unsupported: "No — the source does not cover what the claim says."
         contradicted: "The opposite — the source actually contradicts the claim."
         undetermined: "I was unable to determine whether the claim was in the cited source."
+        # Retired options: no longer offered, kept for responses recorded with them.
+        mostly_supports: "Mostly yes — the core of the claim comes from this source."
+        mostly_unsupported: "Mostly no — the source is compatible with the claim, but doesn’t directly back it up."
       claim_location_label: "If you were able to find the claim, where in the source was it located? (e.g. page number, chapter, etc…)"
       verification_notes_label: "If you were unable to verify the information, tell us more about your experience. (e.g. was the source unclear or difficult to read? Was the source unrelated to the claim? Was the citation imprecise and the source too long to reasonably consult?)"
       other_comments_label: "Any other comments about this exercise?"

--- a/lib/claim_verification/exercise_form.rb
+++ b/lib/claim_verification/exercise_form.rb
@@ -54,7 +54,8 @@ module ClaimVerification
     end
 
     # Why these answers aren't a valid submission: a required question left
-    # unanswered, or a choice answered with something the question doesn't offer.
+    # unanswered, or a choice answered with something the question doesn't take
+    # (an option it offers, or a retired one a response was recorded with).
     # Developer-facing — the client blocks invalid submissions itself.
     def errors_in(answers)
       applicable_questions(answers.to_h.stringify_keys).filter_map do |question|
@@ -67,8 +68,7 @@ module ClaimVerification
     def error_for(question, answer)
       return "#{question.id} is required" if question.required && answer.blank?
       return if answer.blank? || !question.choice?
-      "#{answer} is not an accepted answer for #{question.id}" unless
-        question.options.include?(answer)
+      "#{answer} is not an accepted answer for #{question.id}" unless question.accepts?(answer)
     end
 
     # Numbers are assigned here rather than written into the copy, counting only

--- a/lib/claim_verification/form_question.rb
+++ b/lib/claim_verification/form_question.rb
@@ -10,15 +10,18 @@ module ClaimVerification
   #
   # - id: also the key this question's answer is stored under
   # - type: 'choice' (one of `options`) or 'text' (free response)
-  # - options: the accepted answers, for a choice question
+  # - options: the answers offered, for a choice question
+  # - retired_options: answers no longer offered but still accepted, so a
+  #   response recorded with one keeps it and can still be edited
   # - required: submission is blocked until this is answered
   # - visible_when: { other question id => [answers] | true }; asked only when
   #   that earlier answer is one of those, or any answer at all (see AnswerGate)
-  FormQuestion = Data.define(:id, :type, :options, :required, :visible_when) do
+  FormQuestion = Data.define(:id, :type, :options, :retired_options, :required,
+                             :visible_when) do
     def self.from_config(config)
       new(id: config.fetch('id'), type: config.fetch('type'),
-          options: config['options'] || [], required: config['required'] || false,
-          visible_when: config['visible_when'] || {})
+          options: config['options'] || [], retired_options: config['retired_options'] || [],
+          required: config['required'] || false, visible_when: config['visible_when'] || {})
     end
 
     def choice?
@@ -35,9 +38,27 @@ module ClaimVerification
       I18n.t("claim_verification.form.#{choice? ? "#{id}_question" : "#{id}_label"}")
     end
 
+    # Whether a choice question takes this answer: one it offers, or a retired
+    # one still on record.
+    def accepts?(answer)
+      options.include?(answer) || retired_options.include?(answer)
+    end
+
     # The choice options as value/label pairs, in the order the form offers them.
     def option_labels
-      options.map do |value|
+      labelled(options)
+    end
+
+    # The retired options, labelled the same way, so the summary can still read
+    # an answer the form no longer offers.
+    def retired_option_labels
+      labelled(retired_options)
+    end
+
+    private
+
+    def labelled(values)
+      values.map do |value|
         { value:, label: I18n.t("claim_verification.form.#{id}_options.#{value}") }
       end
     end

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -180,7 +180,9 @@ describe 'Claim verification exercise', type: :feature, js: true do
         'source_appropriate' => 'appropriate',
         'meets_rs_policy' => 'generally_reliable',
         'source_access' => 'accessed',
-        'verdict' => 'partial_support',
+        # A retired verdict: no longer offered, but a response recorded with it
+        # must still read back with its label.
+        'verdict' => 'mostly_supports',
         'claim_location' => 'chapter 3',
         'verification_notes' => 'The chapter describes tool use at length, but the shellfish ' \
                                 'detail only appears in a figure caption, which took a while ' \
@@ -203,7 +205,7 @@ describe 'Claim verification exercise', type: :feature, js: true do
     within '.cv-response-pop' do
       expect(page).to have_content(sentence)
       expect(page).to have_content(
-        I18n.t('claim_verification.form.verdict_options.partial_support')
+        I18n.t('claim_verification.form.verdict_options.mostly_supports')
       )
       expect(page).to have_content('chapter 3')
     end

--- a/spec/features/claim_verification_exercise_spec.rb
+++ b/spec/features/claim_verification_exercise_spec.rb
@@ -180,7 +180,7 @@ describe 'Claim verification exercise', type: :feature, js: true do
         'source_appropriate' => 'appropriate',
         'meets_rs_policy' => 'generally_reliable',
         'source_access' => 'accessed',
-        'verdict' => 'mostly_supports',
+        'verdict' => 'partial_support',
         'claim_location' => 'chapter 3',
         'verification_notes' => 'The chapter describes tool use at length, but the shellfish ' \
                                 'detail only appears in a figure caption, which took a while ' \
@@ -203,7 +203,7 @@ describe 'Claim verification exercise', type: :feature, js: true do
     within '.cv-response-pop' do
       expect(page).to have_content(sentence)
       expect(page).to have_content(
-        I18n.t('claim_verification.form.verdict_options.mostly_supports')
+        I18n.t('claim_verification.form.verdict_options.partial_support')
       )
       expect(page).to have_content('chapter 3')
     end

--- a/spec/lib/claim_verification/exercise_form_spec.rb
+++ b/spec/lib/claim_verification/exercise_form_spec.rb
@@ -125,6 +125,12 @@ describe ClaimVerification::ExerciseForm do
         .to include(/not an accepted answer for verdict/)
     end
 
+    # An answer the exercise used to offer stays valid, so a response recorded
+    # with it can still be edited and re-saved.
+    it 'accepts a retired option as an answer' do
+      expect(form.errors_in(complete_answers.merge('verdict' => 'mostly_supports'))).to be_empty
+    end
+
     it 'does not require a question the path never asked' do
       answers = complete_answers.except('verdict').merge('source_access' => 'nonexistent')
       expect(form.errors_in(answers)).to be_empty
@@ -145,7 +151,7 @@ describe ClaimVerification::ExerciseForm do
         'steps' => [
           { 'id' => 'pick',
             'questions' => [{ 'id' => 'colour', 'type' => 'choice', 'required' => true,
-                              'options' => %w[red blue] }] },
+                              'options' => %w[red blue], 'retired_options' => %w[green] }] },
           { 'id' => 'explain', 'visible_when' => { 'colour' => ['red'] },
             'questions' => [{ 'id' => 'shade', 'type' => 'text' }] },
           { 'id' => 'note', 'visible_when' => { 'colour' => true },
@@ -164,8 +170,14 @@ describe ClaimVerification::ExerciseForm do
     end
 
     it 'validates a choice against the options the declaration gives it' do
-      expect(form.errors_in('colour' => 'green'))
+      expect(form.errors_in('colour' => 'purple'))
         .to include(/not an accepted answer for colour/)
+    end
+
+    it 'accepts a retired option without offering it' do
+      expect(form.errors_in('colour' => 'green')).to be_empty
+      expect(form.questions.first.options).not_to include('green')
+      expect(form.questions.first.retired_options).to eq(['green'])
     end
 
     it 'gates a step on the answer the declaration names' do

--- a/spec/requests/claim_verification_exercise_spec.rb
+++ b/spec/requests/claim_verification_exercise_spec.rb
@@ -80,6 +80,17 @@ describe 'Claim verification exercise', type: :request do
       expect(steps.pluck('id')).to include('evaluate_source', 'find_source', 'verify')
     end
 
+    # Options the exercise no longer offers still go out, labelled and apart from
+    # the offered ones, so a response recorded with one reads back correctly.
+    it 'sends retired options labelled, separately from the offered ones' do
+      get "/courses/#{course.slug}/verify_claim/state"
+      questions = response.parsed_body['form']['steps'].flat_map { |step| step['questions'] }
+      verdict = questions.find { |question| question['id'] == 'verdict' }
+      expect(verdict['options'].pluck('value')).not_to include('mostly_supports')
+      expect(verdict['retired_options'].pluck('value')).to include('mostly_supports')
+      expect(verdict['retired_options'].pluck('label')).to all(start_with('Mostly'))
+    end
+
     it 'is open to any signed-in user, even one not enrolled in the course' do
       outsider = create(:user, username: 'Outsider', onboarded: true)
       login_as outsider


### PR DESCRIPTION
## What this PR does

Removes the "Mostly yes" and "Mostly no" options from the Fact Verification exercise's verdict question ("Does the source back up the claim?"), leaving five: full support, partial support, unsupported, contradicted, and undetermined.

Responses already recorded with one of the dropped verdicts keep reading correctly. The form declaration in `config/claim_verification_exercise.yml` gains a `retired_options` list for answers no longer offered but still on record: the summary (student view, instructor cards, students-tab popover) shows a retired answer's label rather than its raw key, validation still accepts it so a student can edit and re-save an older response, and while editing, the retired answer shows as a checked but disabled option after the offered ones. New responses only ever see the five current options.

Follows up #7028 (the Fall 2026 curation of the claim pool), which was merged while this change was being prepared; it was originally meant to be part of that PR.

## AI usage

Claude Code made the edits and wrote the commit messages under Sage's direction: Sage specified which two options to remove and, when Claude Code flagged that already-recorded "mostly" verdicts would otherwise display as raw keys and be rejected on edit, asked for their labels to be kept. Claude Code designed the `retired_options` declaration, made the Ruby, view, config and React changes, and ran the form, model, request and browser feature specs (the feature spec records a `mostly_supports` response and reads its label back). This was two commits over about half an hour at the end of the same session that produced #7028. The summary in this description was also drafted by Claude Code and may contain errors. This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

The verdict question offers five options instead of seven. The only other visible change is when a student edits a response recorded with a dropped verdict: that verdict appears checked and disabled after the offered options.

## Open questions and concerns

- **Retired options are a small new concept** in the form declaration. It is generic (any choice question can retire an option), but the only use so far is these two verdicts.
- **Other locales.** The translatewiki-managed locales (ga, nb, nl, sk) still carry translations of the two removed keys. They are unused and left for translatewiki to reconcile, per the project's practice of editing only `en.yml`.

(PR description written by Claude Code.)
