### PR TITLE
Scope the Article Finder search button styles so autocomplete suggestions render as a list

### DIFF
--- a/app/assets/stylesheets/modules/_article_finder.styl
+++ b/app/assets/stylesheets/modules/_article_finder.styl
@@ -35,9 +35,9 @@
     border-radius 5px 5px 5px 5px
     padding 1rem 11rem 1rem 2rem
     transition border-radius linear 0.1s
-  button:disabled
+  > button:disabled
     opacity 50%
-  button
+  > button
     position absolute
     right 0
     height 100%
@@ -69,6 +69,10 @@
     box-shadow 0px 2px 4px rgba(0, 0, 0, 0.1)
     z-index 5
     .autocomplete-item
+      display block
+      width 100%
+      text-align start
+      line-height inherit
       padding 0.5rem 2rem
       cursor pointer
     .autocomplete-item:hover


### PR DESCRIPTION
Fixes #7031

## What was wrong

`_article_finder.styl` styles the search bar's Search button with a bare `button` selector inside `.article-finder-search-bar` (position absolute, right 0, 8rem wide, purple background, white bold text). That rule predates 3d98791d, which turned the autocomplete suggestions into `<button class="autocomplete-item">` elements for accessibility. Since then every suggestion inherits the Search button styling: all of them are absolutely positioned at the same spot under the Search button, 8rem wide, purple with white text, which is the "scrambled" dropdown in the screenshot.

## The fix

- Scope the Search button rules to the direct child (`> button`, `> button:disabled`) so they no longer reach the suggestions.
- Let the suggestions render as list rows again (`display block`, `width 100%`, `text-align left`); they keep the existing padding, cursor and hover styles.

No JavaScript changes, so the Jest and ESLint suites are unaffected.

## How it was verified

Compiled the complete `main.styl` cascade (reset, utils, base, all modules) with the original and the patched partial. The diff between the two compiled stylesheets is exactly these lines. Rendering the component's markup with the full stylesheet in headless Chromium:

- before: the three suggestions are `position: absolute`, at the same coordinates, 120px wide, background `rgb(103, 110, 180)`, white text
- after: `position: static`, full width of the dropdown, stacked as rows, transparent background, regular text color, hover highlight intact

`.autocomplete-item` and `.autocomplete` are not used anywhere else in the codebase, and the only other button inside the search bar is the Search button itself.

## AI usage
I used Claude Code (Anthropic) as a coding assistant on this PR: to trace the regression to the commit that turned the autocomplete suggestions into buttons, to draft the stylesheet change, and to build the local verification harness (compiling the full Stylus cascade at the pre-regression commit, master, and this branch, then rendering the component in headless Chromium and comparing computed styles). I reviewed and tested the change myself; the before and after screenshots below come from that rendering. No user-facing text was written or changed.

## Screenshots
Before:

<img width="980" height="360" alt="Article Finder autocomplete before the fix: suggestions stacked under the Search button" src="https://github.com/user-attachments/assets/552ff1ba-b164-4224-a479-743e1cc616a5" />

After:

<img width="980" height="360" alt="Article Finder autocomplete after the fix: suggestions rendered as a list" src="https://github.com/user-attachments/assets/e36a08d2-4de9-42ce-a9a5-7cbbca12f809" />
