### PR TITLE
Add self-service copying of Available Articles between courses

### DIFF
--- a/app/assets/javascripts/actions/assignment_actions.js
+++ b/app/assets/javascripts/actions/assignment_actions.js
@@ -51,6 +51,15 @@ export const randomPeerAssignments = randomAssignments => (dispatch) => {
     .catch(response => dispatch({ type: types.API_FAIL, data: response }));
 };
 
+// Copies Available Articles from another course into this one. The response
+// carries the full refreshed assignments list, so it replaces the current one.
+export const copyAvailableArticles = opts => (dispatch) => {
+  dispatch({ type: types.LOADING_ASSIGNMENTS });
+  return API.copyAvailableArticles(opts)
+    .then(resp => dispatch({ type: types.RECEIVE_ASSIGNMENTS, data: resp }))
+    .catch(response => dispatch({ type: types.API_FAIL, data: response }));
+};
+
 export const deleteAssignment = assignment => (dispatch) => {
   return API.deleteAssignment(assignment)
     .then((resp) => {

--- a/app/assets/javascripts/components/articles/available_articles.jsx
+++ b/app/assets/javascripts/components/articles/available_articles.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 
 import AssignCell from '@components/common/AssignCell/AssignCell.jsx';
 import ConnectedAvailableArticle from './available_article.jsx';
+import CopyAvailableArticles from './copy_available_articles.jsx';
 import AvailableArticlesList from '../articles/available_articles_list.jsx';
 import MyArticlesContainer from '../overview/my_articles/containers';
 import { ASSIGNED_ROLE } from '../../constants';
@@ -25,6 +26,7 @@ const AvailableArticles = (props) => {
   }, []);
 
   let assignCell;
+  let copyCell;
   let availableArticles;
   let elements = [];
   let findingArticlesTraining;
@@ -81,6 +83,12 @@ const AvailableArticles = (props) => {
         prefix={I18n.t('users.my_assigned')}
       />
     );
+    // Same gate as the add control inside AssignCell
+    if (current_user.isInstructor || current_user.admin) {
+      copyCell = (
+        <CopyAvailableArticles course={course} course_id={course_id} current_user={current_user} />
+      );
+    }
   }
 
   const showAvailableArticles = elements.length > 0 || current_user.isAdvancedRole;
@@ -92,6 +100,7 @@ const AvailableArticles = (props) => {
           <div className="section-header__actions">
             {findingArticlesTraining}
             {assignCell}
+            {copyCell}
             <Link to={`/courses/${course_id}/article_finder`}><button className="button border small ml2">{ArticleUtils.I18n('find', project)}</button></Link>
           </div>
         </div>

--- a/app/assets/javascripts/components/articles/copy_available_articles.jsx
+++ b/app/assets/javascripts/components/articles/copy_available_articles.jsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import Select from 'react-select';
+
+import Modal from '../common/modal.jsx';
+import selectStyles from '../../styles/single_select.js';
+import API from '../../utils/api.js';
+import { fetchCoursesForUser } from '../../actions/user_courses_actions';
+import { copyAvailableArticles } from '../../actions/assignment_actions';
+
+const PREVIEW_DEBOUNCE_MS = 400;
+
+// The backend reports why a source can't be used (unknown, private, or this
+// same course) in the JSON `message`; fall back to the generic error text.
+const errorMessageFrom = (error) => {
+  try {
+    return JSON.parse(error.responseText).message;
+  } catch (e) {
+    return error.message;
+  }
+};
+
+// Button plus dialog for copying another course's Available Articles into this
+// course. The source is either one of the user's own courses (dropdown) or any
+// course URL/slug (text field). The preview shows how many articles would be
+// added, net of ones already present here; it comes from the server and
+// deliberately bypasses redux, because fetching the source's assignments
+// through the store would replace this course's list.
+const CopyAvailableArticles = ({ course, course_id, current_user }) => {
+  const dispatch = useDispatch();
+  const userCourses = useSelector(state => state.userCourses.userCourses);
+
+  const [open, setOpen] = useState(false);
+  const [selectedSlug, setSelectedSlug] = useState(null);
+  const [urlText, setUrlText] = useState('');
+  const [includeStudentAssigned, setIncludeStudentAssigned] = useState(false);
+  const [preview, setPreview] = useState(null);
+  const [previewError, setPreviewError] = useState(null);
+
+  const source = selectedSlug || urlText.trim();
+
+  useEffect(() => {
+    if (open && userCourses.length === 0) {
+      dispatch(fetchCoursesForUser(current_user.id));
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setPreview(null);
+    setPreviewError(null);
+    if (!source) return undefined;
+
+    let cancelled = false;
+    const timeout = setTimeout(() => {
+      API.previewCopyAvailableArticles({
+        course_slug: course_id, source, include_student_assigned: includeStudentAssigned
+      })
+        .then((resp) => { if (!cancelled) setPreview(resp); })
+        .catch((error) => { if (!cancelled) setPreviewError(errorMessageFrom(error)); });
+    }, PREVIEW_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+    };
+  }, [source, includeStudentAssigned]);
+
+  const options = userCourses
+    .filter(userCourse => userCourse.slug !== course.slug)
+    .map(userCourse => ({ value: userCourse.slug, label: userCourse.title }));
+  const selectedOption = options.find(option => option.value === selectedSlug) || null;
+
+  const onSelectChange = (option) => {
+    setSelectedSlug(option ? option.value : null);
+    setUrlText('');
+  };
+
+  const onUrlChange = (e) => {
+    setUrlText(e.target.value);
+    setSelectedSlug(null);
+  };
+
+  const close = () => {
+    setOpen(false);
+    setSelectedSlug(null);
+    setUrlText('');
+    setIncludeStudentAssigned(false);
+  };
+
+  const toCopy = preview ? preview.count - preview.already_present : 0;
+
+  const onCopy = () => {
+    dispatch(copyAvailableArticles({
+      course_slug: course_id, source, include_student_assigned: includeStudentAssigned
+    }));
+    close();
+  };
+
+  const button = (
+    <button id="copy-available-articles-button" className="button border small ml2" onClick={() => setOpen(true)}>
+      {I18n.t('assignments.copy_available')}
+    </button>
+  );
+
+  if (!open) return button;
+
+  return (
+    <>
+      {button}
+      <Modal modalClass="confirm-modal-overlay" ariaLabelledBy="copy-available-articles-title">
+        <div className="confirm-modal copy-available-articles">
+          <h3 id="copy-available-articles-title">{I18n.t('assignments.copy_available')}</h3>
+          <div className="copy-available-articles__field">
+            <Select
+              id="copy-available-articles-source-select"
+              inputId="copy-available-articles-source-select-input"
+              styles={selectStyles}
+              options={options}
+              value={selectedOption}
+              onChange={onSelectChange}
+              isClearable
+            />
+          </div>
+          <div className="copy-available-articles__field">
+            <input
+              id="copy-available-articles-source-url"
+              type="text"
+              placeholder={I18n.t('assignments.copy_available_url_placeholder')}
+              value={urlText}
+              onChange={onUrlChange}
+            />
+          </div>
+          <div className="copy-available-articles__field">
+            <input
+              id="copy_available_include_student_assigned"
+              type="checkbox"
+              checked={includeStudentAssigned}
+              onChange={e => setIncludeStudentAssigned(e.target.checked)}
+            />
+            <label htmlFor="copy_available_include_student_assigned">
+              {I18n.t('assignments.copy_available_include_student_assigned')}
+            </label>
+          </div>
+          <div className="copy-available-articles__preview">
+            {preview && (
+              <p>{preview.source.title}: {I18n.t('users.number_of_articles', { count: toCopy })}</p>
+            )}
+            {previewError && <p className="red">{previewError}</p>}
+          </div>
+          <div className="pop_container pull-right">
+            <button className="button ghost-button" onClick={close}>{I18n.t('application.cancel')}</button>
+            <button className="button dark" onClick={onCopy} disabled={toCopy <= 0}>
+              {I18n.t('application.confirm')}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+CopyAvailableArticles.propTypes = {
+  course: PropTypes.object.isRequired,
+  course_id: PropTypes.string.isRequired,
+  current_user: PropTypes.object.isRequired
+};
+
+export default CopyAvailableArticles;

--- a/app/assets/javascripts/components/articles/copy_available_articles.jsx
+++ b/app/assets/javascripts/components/articles/copy_available_articles.jsx
@@ -116,6 +116,7 @@ const CopyAvailableArticles = ({ course, course_id, current_user }) => {
               id="copy-available-articles-source-select"
               inputId="copy-available-articles-source-select-input"
               styles={selectStyles}
+              placeholder={I18n.t('assignments.copy_available_select_placeholder')}
               options={options}
               value={selectedOption}
               onChange={onSelectChange}

--- a/app/assets/javascripts/utils/api.js
+++ b/app/assets/javascripts/utils/api.js
@@ -149,6 +149,26 @@ const API = {
     return response.json();
   },
 
+  // Reports how many Available Articles a copy from another course would add,
+  // without changing anything.
+  async previewCopyAvailableArticles(opts) {
+    const queryString = stringify(opts);
+    const response = await request(`/copy_available_articles/preview.json?${queryString}`);
+
+    await ensureOk(response);
+    return response.json();
+  },
+
+  async copyAvailableArticles(opts) {
+    const queryString = stringify(opts);
+    const response = await request(`/copy_available_articles.json?${queryString}`, {
+      method: 'POST'
+    });
+
+    await ensureOk(response);
+    return response.json();
+  },
+
   fetch(courseId, endpoint) {
     return request(`/courses/${courseId}/${endpoint}.json`, {
       credentials: "include"

--- a/app/assets/stylesheets/modules/_copy_available_articles.styl
+++ b/app/assets/stylesheets/modules/_copy_available_articles.styl
@@ -1,0 +1,16 @@
+// Dialog for copying Available Articles from another course
+.copy-available-articles
+  text-align left
+
+  &__field
+    margin-bottom 12px
+
+    input[type="text"]
+      width 100%
+
+    input[type="checkbox"]
+      margin-right 6px
+
+  &__preview
+    min-height 1.5em
+    margin-bottom 12px

--- a/app/controllers/copy_available_articles_controller.rb
+++ b/app/controllers/copy_available_articles_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/utils/course_url_parser"
+require_dependency "#{Rails.root}/app/workers/update_assignments_worker"
+require_dependency "#{Rails.root}/app/workers/update_course_worker"
+
+#= Copies the Available Articles of one course into another
+class CopyAvailableArticlesController < ApplicationController
+  include CourseHelper
+  respond_to :json
+
+  before_action :require_signed_in
+  before_action :set_target
+  before_action :check_permissions
+  before_action :set_source
+
+  # Reports how many articles a copy would add, without changing anything.
+  def preview
+    @result = copy_available_articles(dry_run: true)
+  end
+
+  def create
+    @result = copy_available_articles
+    update_onwiki_course_and_assignments if @result.created_count.positive?
+  end
+
+  private
+
+  def copy_available_articles(dry_run: false)
+    CopyAvailableArticles.new(source: @source, target: @target,
+                              include_student_assigned: include_student_assigned?,
+                              dry_run:)
+  end
+
+  def include_student_assigned?
+    params[:include_student_assigned].to_s == 'true'
+  end
+
+  def set_target
+    @target = find_course_by_slug(params[:course_slug])
+  end
+
+  def check_permissions
+    raise NotPermittedError unless current_user.can_edit?(@target)
+  end
+
+  # The source may be given as a slug or as a pasted course URL. It must be
+  # visible to the current user under the same rules as
+  # CoursesController#protect_privacy; unknown and hidden sources both get a
+  # 404 so that the existence of a private course is not revealed.
+  def set_source
+    parser = CourseUrlParser.new(params[:source])
+    @source = parser.course
+    if @source.nil? || source_hidden?
+      render json: { message: I18n.t('error_no_course.explanation', slug: parser.slug) },
+             status: :not_found
+    elsif @source == @target
+      render json: { message: I18n.t('error.invalid_assignment') },
+             status: :unprocessable_content
+    end
+  end
+
+  def source_hidden?
+    @source.private && !current_user.nonvisitor?(@source)
+  end
+
+  def update_onwiki_course_and_assignments
+    UpdateAssignmentsWorker.schedule_edits(course: @target, editing_user: current_user)
+    UpdateCourseWorker.schedule_edits(course: @target, editing_user: current_user)
+  end
+end

--- a/app/controllers/course_clone_controller.rb
+++ b/app/controllers/course_clone_controller.rb
@@ -10,7 +10,8 @@ class CourseCloneController < ApplicationController
     check_permission
 
     campaign_slug = clone_params[:campaign_slug]
-    clone_assignments = clone_params[:copy_assignments]
+    # The frontend always sends this param as the string 'true' or 'false'.
+    clone_assignments = clone_params[:copy_assignments] == 'true'
     new_course = CourseCloneManager.new(course: @course, user: current_user, clone_assignments:,
                                         campaign_slug:).clone!
 

--- a/app/models/course_data/assignment.rb
+++ b/app/models/course_data/assignment.rb
@@ -43,6 +43,8 @@ class Assignment < ApplicationRecord
   validates :article_title, format: { with: SPECIAL_PAGE_MATCHER }
   scope :assigned, -> { where(role: 0) }
   scope :reviewing, -> { where(role: 1) }
+  # Available Articles: editing assignments not yet claimed by any user
+  scope :available, -> { where(role: 0, user_id: nil) }
 
   before_validation :set_defaults_and_normalize
   before_save :set_sandbox_url

--- a/app/services/copy_available_articles.rb
+++ b/app/services/copy_available_articles.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#= Copies the Available Articles of one course into another course, as Available
+#= Articles. Records are created directly from the source assignment's attributes,
+#= with no wiki API calls, and (article_title, wiki_id) pairs already present in
+#= the target are skipped.
+class CopyAvailableArticles
+  attr_reader :source_count, :created_count, :skipped_count
+
+  def initialize(source:, target:, include_student_assigned: false, dry_run: false)
+    @source = source
+    @target = target
+    @include_student_assigned = include_student_assigned
+    @created_count = 0
+    @skipped_count = 0
+    dry_run ? count_only : copy_all
+  end
+
+  private
+
+  # Available Articles are editing assignments (role 0) with no user. With
+  # include_student_assigned, the articles students in the source course picked
+  # are included too, which reconstructs the original pool before selections.
+  def source_scope
+    scope = @source.assignments.assigned
+    @include_student_assigned ? scope : scope.available
+  end
+
+  # Deduplicate within the source: with retain_available_articles, a claimed
+  # article exists both as the available row and as the student's copy.
+  def candidates
+    @candidates ||= source_scope.order(:id).uniq { |assignment| key_for(assignment) }
+  end
+
+  def existing_keys
+    @existing_keys ||= @target.assignments.available.pluck(:article_title, :wiki_id).to_set
+  end
+
+  def key_for(assignment)
+    [assignment.article_title, assignment.wiki_id]
+  end
+
+  def count_only
+    @source_count = candidates.size
+    @skipped_count = candidates.count { |assignment| existing_keys.include?(key_for(assignment)) }
+  end
+
+  def copy_all
+    @source_count = candidates.size
+    candidates.each do |assignment|
+      if existing_keys.include?(key_for(assignment))
+        @skipped_count += 1
+      else
+        copy(assignment)
+      end
+    end
+  end
+
+  # Non-bang create: a legacy title that no longer passes validation, or a
+  # concurrent addition caught by the uniqueness validation, is counted as
+  # skipped rather than aborting the batch.
+  def copy(assignment)
+    copied = Assignment.create(course: @target,
+                               role: Assignment::Roles::ASSIGNED_ROLE,
+                               user_id: nil,
+                               article_title: assignment.article_title,
+                               article_id: assignment.article_id,
+                               wiki_id: assignment.wiki_id,
+                               flags: { available_article: true })
+    if copied.persisted?
+      @created_count += 1
+      existing_keys << key_for(copied)
+    else
+      @skipped_count += 1
+    end
+  end
+end

--- a/app/views/copy_available_articles/create.json.jbuilder
+++ b/app/views/copy_available_articles/create.json.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+json.created @result.created_count
+json.skipped @result.skipped_count
+json.source do
+  json.id @source.id
+  json.slug @source.slug
+  json.title pretty_course_title(@source)
+end
+# Same shape as /courses/:slug/assignments.json, so the frontend can replace
+# its assignments list directly from this response.
+json.course do
+  json.partial! 'courses/assignments', course: @target
+end

--- a/app/views/copy_available_articles/preview.json.jbuilder
+++ b/app/views/copy_available_articles/preview.json.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.source do
+  json.id @source.id
+  json.slug @source.slug
+  json.title pretty_course_title(@source)
+end
+json.count @result.source_count
+json.already_present @result.skipped_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -436,6 +436,7 @@ en:
     confirm_deletion: Are you sure you want to delete this assignment?
     copy_available: Import from another course
     copy_available_url_placeholder: course URL
+    copy_available_select_placeholder: Select a course
     copy_available_include_student_assigned: Include assigned articles?
     delete: Remove and Delete
     editors: Assigned to

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,6 +434,9 @@ en:
     confirm_add_available: Are you sure you want to add %{title}?
     confirm_addition: Are you sure you want to assign %{title} to %{username}?
     confirm_deletion: Are you sure you want to delete this assignment?
+    copy_available: Import from another course
+    copy_available_url_placeholder: course URL
+    copy_available_include_student_assigned: Include assigned articles?
     delete: Remove and Delete
     editors: Assigned to
     change_sandbox_url: Change sandbox

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,8 @@ Rails.application.routes.draw do
   patch '/assignments/:id/update_sandbox_url' => 'assignments#update_sandbox_url'
   put '/assignments/:assignment_id/claim' => 'assignments#claim'
   post '/assignments/assign_reviewers_randomly' => 'assignments#assign_reviewers_randomly'
+  get 'copy_available_articles/preview' => 'copy_available_articles#preview'
+  post 'copy_available_articles' => 'copy_available_articles#create'
 
   get 'mass_enrollment/:course_id'  => 'mass_enrollment#index',
       constraints: { course_id: /.*/ }

--- a/lib/course_clone_manager.rb
+++ b/lib/course_clone_manager.rb
@@ -70,15 +70,7 @@ class CourseCloneManager
   end
 
   def copy_assignments
-    @course.assignments.where(user_id: nil).each do |assignment|
-      Assignment.create(
-        role: 0,
-        article_title: assignment.article_title,
-        article_id: assignment.article_id,
-        wiki_id: assignment.wiki_id,
-        course_id: @clone.id
-      )
-    end
+    CopyAvailableArticles.new(source: @course, target: @clone)
   end
 
   def duplicate_timeline

--- a/lib/utils/course_url_parser.rb
+++ b/lib/utils/course_url_parser.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#= Resolves a course from a pasted Dashboard course URL, a `courses/...` path,
+#= or a bare course slug.
+class CourseUrlParser
+  # Course slugs have exactly two path segments: School/Title_(Term).
+  # Anything after them (a tab such as /articles/available, a query string) is ignored.
+  COURSE_PATH_MATCHER = %r{(?:\A|/)courses/(?<slug>[^/?#]+/[^/?#]+)}
+
+  def initialize(input)
+    @input = input.to_s.strip
+  end
+
+  def slug
+    return if @input.empty?
+    match = @input.match(COURSE_PATH_MATCHER)
+    raw_slug = match ? match[:slug] : bare_slug
+    # Pasted URLs carry percent-encoded parentheses. Only %XX escapes are decoded,
+    # so a literal '+' in a slug is preserved.
+    URI::DEFAULT_PARSER.unescape(raw_slug.delete_suffix('.json'))
+  end
+
+  def course
+    return unless slug
+    Course.find_by(slug:)
+  end
+
+  private
+
+  def bare_slug
+    @input.delete_prefix('/').delete_suffix('/')
+  end
+end

--- a/spec/controllers/copy_available_articles_controller_spec.rb
+++ b/spec/controllers/copy_available_articles_controller_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CopyAvailableArticlesController, type: :request do
+  let(:user) { create(:user) }
+  let(:target) { create(:course, slug: 'School/Target_(Term)') }
+  let(:source) { create(:course, slug: 'School/Source_(Term)') }
+  let(:student) { create(:user, username: 'Student') }
+  let(:params) { { course_slug: target.slug, source: source.slug, format: :json } }
+  let(:response_body) { Oj.load(response.body) }
+
+  def enroll(enrolled_user, course, role)
+    create(:courses_user, user: enrolled_user, course:, role:)
+  end
+
+  before do
+    stub_wiki_validation
+    create(:assignment, course: source, user_id: nil, role: 0, wiki_id: 1,
+                        article_title: 'Alpha_article', flags: { available_article: true })
+    create(:assignment, course: source, user: student, role: 0, wiki_id: 1,
+                        article_title: 'Beta_article')
+    allow(UpdateAssignmentsWorker).to receive(:schedule_edits)
+    allow(UpdateCourseWorker).to receive(:schedule_edits)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
+
+  describe 'authorization on the target course' do
+    it 'returns 401 when not signed in' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil)
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(401)
+      expect(target.assignments).to be_empty
+    end
+
+    it 'returns 401 for a student of the target course' do
+      enroll(user, target, CoursesUsers::Roles::STUDENT_ROLE)
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(401)
+      expect(target.assignments).to be_empty
+    end
+
+    it 'allows an instructor of the target course' do
+      enroll(user, target, CoursesUsers::Roles::INSTRUCTOR_ROLE)
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(200)
+      expect(target.assignments.available.pluck(:article_title)).to eq(['Alpha_article'])
+    end
+
+    it 'allows an admin who is not enrolled' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user)
+        .and_return(create(:admin))
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns 404 for an unknown target course' do
+      post '/copy_available_articles', params: params.merge(course_slug: 'School/Nope_(Term)')
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'source course rules' do
+    before { enroll(user, target, CoursesUsers::Roles::INSTRUCTOR_ROLE) }
+
+    it 'accepts a public source the user is not enrolled in' do
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(200)
+    end
+
+    it 'accepts the source as a pasted course URL' do
+      url = "https://dashboard.wikiedu.org/courses/#{source.slug}/articles/available"
+      post '/copy_available_articles', params: params.merge(source: url)
+      expect(response.status).to eq(200)
+      expect(target.assignments.count).to eq(1)
+    end
+
+    it 'returns 404 for a private source the user is not a member of' do
+      source.update(private: true)
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(404)
+      expect(response_body['message'])
+        .to eq(I18n.t('error_no_course.explanation', slug: source.slug))
+      expect(target.assignments).to be_empty
+    end
+
+    it 'accepts a private source the user is enrolled in' do
+      source.update(private: true)
+      enroll(user, source, CoursesUsers::Roles::INSTRUCTOR_ROLE)
+      post '/copy_available_articles', params: params
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns 404 for an unknown source' do
+      post '/copy_available_articles', params: params.merge(source: 'School/Nope_(Term)')
+      expect(response.status).to eq(404)
+    end
+
+    it 'returns 422 when the source is the target course' do
+      post '/copy_available_articles', params: params.merge(source: target.slug)
+      expect(response.status).to eq(422)
+      expect(response_body['message']).to eq(I18n.t('error.invalid_assignment'))
+    end
+  end
+
+  describe '#create' do
+    before { enroll(user, target, CoursesUsers::Roles::INSTRUCTOR_ROLE) }
+
+    it 'includes student-assigned articles when include_student_assigned is true' do
+      post '/copy_available_articles', params: params.merge(include_student_assigned: 'true')
+      expect(target.assignments.available.pluck(:article_title))
+        .to contain_exactly('Alpha_article', 'Beta_article')
+    end
+
+    it 'responds with the counts and the refreshed assignments list' do
+      post '/copy_available_articles', params: params
+      expect(response_body['created']).to eq(1)
+      expect(response_body['skipped']).to eq(0)
+      expect(response_body['source']['slug']).to eq(source.slug)
+      expect(response_body['course']['assignments'].map { |a| a['article_title'] })
+        .to eq(['Alpha article'])
+    end
+
+    it 'schedules the on-wiki course and assignment updates once' do
+      expect(UpdateAssignmentsWorker).to receive(:schedule_edits)
+        .with(course: target, editing_user: user).once
+      expect(UpdateCourseWorker).to receive(:schedule_edits)
+        .with(course: target, editing_user: user).once
+      post '/copy_available_articles', params: params
+    end
+
+    it 'does not schedule on-wiki updates when nothing was copied' do
+      create(:assignment, course: target, user_id: nil, role: 0, wiki_id: 1,
+                          article_title: 'Alpha_article', flags: { available_article: true })
+      expect(UpdateAssignmentsWorker).not_to receive(:schedule_edits)
+      post '/copy_available_articles', params: params
+      expect(response_body['skipped']).to eq(1)
+    end
+  end
+
+  describe '#preview' do
+    before { enroll(user, target, CoursesUsers::Roles::INSTRUCTOR_ROLE) }
+
+    it 'reports the counts without creating anything' do
+      create(:assignment, course: target, user_id: nil, role: 0, wiki_id: 1,
+                          article_title: 'Alpha_article', flags: { available_article: true })
+      get '/copy_available_articles/preview', params: params.merge(include_student_assigned: 'true')
+      expect(response.status).to eq(200)
+      expect(response_body['count']).to eq(2)
+      expect(response_body['already_present']).to eq(1)
+      expect(response_body['source']['title']).to include(source.title)
+      expect(target.assignments.count).to eq(1)
+    end
+  end
+end

--- a/spec/controllers/course_clone_controller_spec.rb
+++ b/spec/controllers/course_clone_controller_spec.rb
@@ -30,6 +30,22 @@ describe CourseCloneController, type: :request do
           post "/clone_course/#{course.id}", params: { format: :html, id: course.id }
         end
       end
+
+      it 'does not copy assignments when copy_assignments is the string "false"' do
+        expect(CourseCloneManager).to receive(:new)
+          .with(hash_including(clone_assignments: false)).and_call_original
+        expect_any_instance_of(CourseCloneManager).to receive(:clone!)
+        post "/clone_course/#{course.id}",
+             params: { format: :json, id: course.id, copy_assignments: 'false' }
+      end
+
+      it 'copies assignments when copy_assignments is the string "true"' do
+        expect(CourseCloneManager).to receive(:new)
+          .with(hash_including(clone_assignments: true)).and_call_original
+        expect_any_instance_of(CourseCloneManager).to receive(:clone!)
+        post "/clone_course/#{course.id}",
+             params: { format: :json, id: course.id, copy_assignments: 'true' }
+      end
     end
 
     context 'when the user is not the original instructor' do

--- a/spec/features/copy_available_articles_spec.rb
+++ b/spec/features/copy_available_articles_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Copying Available Articles from another course', :js, type: :feature do
+  let(:instructor) do
+    create(:user, username: 'Professor Sage', wiki_token: 'foo', wiki_secret: 'bar')
+  end
+  let(:target) do
+    create(:course, slug: 'University/Target_(Term)', title: 'Target', school: 'University',
+                    term: 'Term', submitted: true)
+  end
+  let(:source) do
+    create(:course, slug: 'University/Source_(Term)', title: 'Source', school: 'University',
+                    term: 'Term', submitted: true)
+  end
+
+  before do
+    [target, source].each do |course|
+      course.campaigns << Campaign.first
+      create(:courses_user, user: instructor, course:, role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    end
+    %w[Source_article_one Source_article_two].each do |title|
+      create(:assignment, course: source, user_id: nil, role: 0, wiki_id: 1,
+                          article_title: title, flags: { available_article: true })
+    end
+    login_as(instructor, scope: :user)
+    stub_oauth_edit
+    stub_raw_action
+    stub_info_query
+  end
+
+  def open_copy_dialog
+    visit "/courses/#{target.slug}/articles/available"
+    find('#copy-available-articles-button').click
+  end
+
+  it 'copies the source course Available Articles after showing a preview' do
+    open_copy_dialog
+    fill_in 'copy-available-articles-source-url',
+            with: "http://localhost/courses/#{source.slug}/articles/available"
+    expect(page).to have_css('.copy-available-articles__preview p', text: '2 articles')
+    find('.copy-available-articles .button.dark').click
+    expect(page).to have_content 'Source article one'
+    expect(page).to have_content 'Source article two'
+    expect(target.assignments.available.count).to eq(2)
+  end
+
+  it 'previews only the articles not already present' do
+    create(:assignment, course: target, user_id: nil, role: 0, wiki_id: 1,
+                        article_title: 'Source_article_one', flags: { available_article: true })
+    open_copy_dialog
+    fill_in 'copy-available-articles-source-url', with: source.slug
+    # The preview names the source with its full 'School - Title (Term)' title
+    expect(page).to have_css('.copy-available-articles__preview p',
+                             text: /Source \(Term\): 1 article$/)
+  end
+end

--- a/spec/features/course_cloning_spec.rb
+++ b/spec/features/course_cloning_spec.rb
@@ -48,7 +48,8 @@ describe 'cloning a course', js: true do
   let!(:tag) { create(:tag, tag: 'cloneable', course_id: course.id) }
   let!(:assignment) do
     create(:assignment, course_id: course.id, user_id: user.id, id: 123)
-    create(:assignment, course_id: course.id, id: 12345)
+    # An Available Article: an editing assignment (role 0) with no user
+    create(:assignment, course_id: course.id, id: 12345, role: 0)
   end
 
   it 'copies relevant attributes of an existing course' do

--- a/spec/lib/course_clone_manager_spec.rb
+++ b/spec/lib/course_clone_manager_spec.rb
@@ -183,4 +183,24 @@ describe CourseCloneManager do
       expect(clone.wikis.include?(wikidata)).to be true
     end
   end
+  context 'when clone_assignments is true' do
+    before do
+      create(:assignment, course_id: 1, user_id: nil, role: 0, wiki_id: 1,
+                          article_title: 'Available_one', flags: { available_article: true })
+      create(:assignment, course_id: 1, user_id: 2, role: 0, wiki_id: 1,
+                          article_title: 'Claimed_one')
+      described_class.new(course: Course.find(1), user: User.find(1),
+                          clone_assignments: true).clone!
+    end
+
+    it 'copies the available articles as available articles' do
+      copied = clone.assignments.find_by(article_title: 'Available_one')
+      expect(copied.user_id).to be_nil
+      expect(copied.flags[:available_article]).to be(true)
+    end
+
+    it 'does not copy articles assigned to students' do
+      expect(clone.assignments.where(article_title: 'Claimed_one')).to be_empty
+    end
+  end
 end

--- a/spec/lib/course_url_parser_spec.rb
+++ b/spec/lib/course_url_parser_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/utils/course_url_parser"
+
+describe CourseUrlParser do
+  let!(:course) { create(:course, slug: 'School/Course_(Term)') }
+
+  it 'resolves a bare slug' do
+    expect(described_class.new('School/Course_(Term)').course).to eq(course)
+  end
+
+  it 'resolves a full course URL that continues past the slug' do
+    url = 'https://dashboard.wikiedu.org/courses/School/Course_(Term)/articles/available'
+    expect(described_class.new(url).course).to eq(course)
+  end
+
+  it 'resolves a URL with percent-encoded parentheses and a query string' do
+    url = 'https://dashboard.wikiedu.org/courses/School/Course_%28Term%29?enroll=abc'
+    expect(described_class.new(url).course).to eq(course)
+  end
+
+  it 'resolves a courses/ path without a host, ignoring a .json suffix' do
+    expect(described_class.new('/courses/School/Course_(Term).json').course).to eq(course)
+  end
+
+  it 'tolerates surrounding whitespace and slashes around a slug' do
+    expect(described_class.new("  /School/Course_(Term)/ \n").course).to eq(course)
+  end
+
+  it 'returns nil for an unknown slug' do
+    expect(described_class.new('School/Other_(Term)').course).to be_nil
+  end
+
+  it 'returns nil for nil input' do
+    expect(described_class.new(nil).course).to be_nil
+  end
+
+  it 'returns nil for blank input' do
+    expect(described_class.new('   ').course).to be_nil
+  end
+end

--- a/spec/services/copy_available_articles_spec.rb
+++ b/spec/services/copy_available_articles_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/importers/article_importer"
+
+describe CopyAvailableArticles do
+  let(:source) { create(:course, slug: 'School/Source_(Term)') }
+  let(:target) { create(:course, slug: 'School/Target_(Term)') }
+  let(:student) { create(:user, username: 'Student') }
+  let(:es_wiki) { create(:wiki, language: 'es', project: 'wikipedia') }
+
+  def add_available(course, title, wiki_id: 1, article_id: nil)
+    create(:assignment, course:, user_id: nil, role: 0, wiki_id:, article_id:,
+                        article_title: title, flags: { available_article: true })
+  end
+
+  def add_claimed(course, title, wiki_id: 1)
+    create(:assignment, course:, user: student, role: 0, wiki_id:, article_title: title)
+  end
+
+  before { stub_wiki_validation }
+
+  describe 'default copy' do
+    before do
+      add_available(source, 'Alpha_article', article_id: 5)
+      add_claimed(source, 'Beta_article')
+    end
+
+    it 'copies only unclaimed Available Articles' do
+      described_class.new(source:, target:)
+      expect(target.assignments.pluck(:article_title)).to eq(['Alpha_article'])
+    end
+
+    it 'creates the copy as an Available Article with the source attributes' do
+      described_class.new(source:, target:)
+      copied = target.assignments.first
+      expect(copied.user_id).to be_nil
+      expect(copied.role).to eq(Assignment::Roles::ASSIGNED_ROLE)
+      expect(copied.flags[:available_article]).to be(true)
+      expect(copied.article_id).to eq(5)
+      expect(copied.wiki_id).to eq(1)
+    end
+
+    it 'reports the counts' do
+      service = described_class.new(source:, target:)
+      expect([service.source_count, service.created_count, service.skipped_count]).to eq([1, 1, 0])
+    end
+
+    it 'does not call the wiki API' do
+      expect(ArticleImporter).not_to receive(:new)
+      described_class.new(source:, target:)
+    end
+  end
+
+  describe 'include_student_assigned' do
+    it 'also copies articles students were assigned, as Available Articles' do
+      add_available(source, 'Alpha_article')
+      add_claimed(source, 'Beta_article')
+      described_class.new(source:, target:, include_student_assigned: true)
+      expect(target.assignments.available.pluck(:article_title))
+        .to contain_exactly('Alpha_article', 'Beta_article')
+    end
+
+    it 'deduplicates an article present both as available and as claimed' do
+      add_available(source, 'Alpha_article')
+      add_claimed(source, 'Alpha_article')
+      service = described_class.new(source:, target:, include_student_assigned: true)
+      expect(service.source_count).to eq(1)
+      expect(target.assignments.count).to eq(1)
+    end
+
+    it 'excludes peer review assignments' do
+      create(:assignment, course: source, user: student, role: 1, wiki_id: 1,
+                          article_title: 'Reviewed_article')
+      described_class.new(source:, target:, include_student_assigned: true)
+      expect(target.assignments).to be_empty
+    end
+  end
+
+  describe 'articles already in the target' do
+    before do
+      add_available(source, 'Alpha_article')
+      add_available(source, 'Gamma_article')
+      add_available(target, 'Alpha_article')
+    end
+
+    it 'skips them and reports them as skipped' do
+      service = described_class.new(source:, target:)
+      expect(target.assignments.pluck(:article_title))
+        .to contain_exactly('Alpha_article', 'Gamma_article')
+      expect([service.created_count, service.skipped_count]).to eq([1, 1])
+    end
+
+    it 'treats the same title on a different wiki as a different article' do
+      add_available(source, 'Alpha_article', wiki_id: es_wiki.id)
+      described_class.new(source:, target:)
+      expect(target.assignments.where(article_title: 'Alpha_article').pluck(:wiki_id))
+        .to contain_exactly(1, es_wiki.id)
+    end
+
+    it 'reports counts without writing anything on a dry run' do
+      service = described_class.new(source:, target:, dry_run: true)
+      expect([service.source_count, service.skipped_count, service.created_count]).to eq([2, 1, 0])
+      expect(target.assignments.count).to eq(1)
+    end
+  end
+
+  it 'skips a title that no longer passes validation instead of raising' do
+    assignment = add_available(source, 'Alpha_article')
+    assignment.update_column(:article_title, 'Special:Contributions') # rubocop:disable Rails/SkipsModelValidations
+    service = described_class.new(source:, target:)
+    expect(service.skipped_count).to eq(1)
+    expect(target.assignments).to be_empty
+  end
+end

--- a/test/actions/assignment_actions.spec.js
+++ b/test/actions/assignment_actions.spec.js
@@ -1,5 +1,5 @@
 import '../testHelper';
-import { addAssignment, deleteAssignment } from '../../app/assets/javascripts/actions/assignment_actions.js';
+import { addAssignment, copyAvailableArticles, deleteAssignment } from '../../app/assets/javascripts/actions/assignment_actions.js';
 import * as requestModule from '../../app/assets/javascripts/utils/request';
 
 
@@ -32,6 +32,29 @@ describe('AssignmentActions', () => {
         .then(() => {
           const assignmentsAfterDelete = reduxStore.getState().assignments.assignments;
           expect(assignmentsAfterDelete.length).toBe(0);
+          done();
+        });
+    }
+  );
+
+  test(
+    '.copyAvailableArticles replaces the assignments list with the response',
+    (done) => {
+      const copyResponse = {
+        created: 2,
+        skipped: 1,
+        course: { assignments: [{ id: 7, article_title: 'Copied', user_id: null, role: 0 }] }
+      };
+      requestModule.default.restore();
+      sinon.stub(requestModule, 'default').resolves(
+        { status: 200, ok: true, json: sinon.fake.returns(copyResponse) }
+      );
+      const opts = { course_slug: 'School/Target_(Term)', source: 'School/Source_(Term)', include_student_assigned: false };
+      copyAvailableArticles(opts)(reduxStore.dispatch)
+        .then(() => {
+          const state = reduxStore.getState();
+          expect(state.assignments.assignments.map(a => a.article_title)).toEqual(['Copied']);
+          expect(state.assignments.loading).toBe(false);
           done();
         });
     }

--- a/test/components/available_articles.spec.js
+++ b/test/components/available_articles.spec.js
@@ -69,6 +69,16 @@ describe('AvailableArticles', () => {
     expect(fetchAssignments).toHaveBeenCalledWith(course.slug);
   });
 
+  test('shows the copy-from-another-course control to instructors', () => {
+    const container = renderTab({ id: 1, isStudent: false, isAdvancedRole: true, isInstructor: true, admin: false }, jest.fn());
+    expect(container.querySelector('#copy-available-articles-button')).not.toBeNull();
+  });
+
+  test('hides the copy-from-another-course control from students', () => {
+    const container = renderTab({ id: 999, isStudent: true, isAdvancedRole: false, isInstructor: false, admin: false }, jest.fn());
+    expect(container.querySelector('#copy-available-articles-button')).toBeNull();
+  });
+
   test('renders not-yet-created (red link) available articles for a student', () => {
     const container = renderTab({ id: 999, isStudent: true, isAdvancedRole: false, admin: false }, jest.fn());
     expect(container.innerHTML).toContain('Existing Article');

--- a/test/components/copy_available_articles.spec.js
+++ b/test/components/copy_available_articles.spec.js
@@ -1,0 +1,109 @@
+import '../testHelper';
+
+// jsdom test env lacks TextEncoder/TextDecoder which react-dom needs
+const { TextEncoder, TextDecoder } = require('util');
+
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const React = require('react');
+const { createRoot } = require('react-dom/client');
+const { act } = require('react-dom/test-utils');
+const { Provider } = require('react-redux');
+const { createStore, applyMiddleware } = require('redux');
+const thunk = require('redux-thunk').default;
+const reducer = require('../../app/assets/javascripts/reducers').default;
+const { RECEIVE_USER_COURSES } = require('../../app/assets/javascripts/constants');
+const API = require('../../app/assets/javascripts/utils/api.js').default;
+const CopyAvailableArticles = require('../../app/assets/javascripts/components/articles/copy_available_articles').default;
+
+const course = {
+  id: 1,
+  slug: 'School/Alpha_(Term)',
+  title: 'Alpha course',
+  home_wiki: { id: 1, project: 'wikipedia', language: 'en' }
+};
+const instructor = { id: 1, isInstructor: true, admin: false };
+const userCourses = [
+  { id: 1, slug: course.slug, title: 'Alpha course' },
+  { id: 2, slug: 'School/Beta_(Term)', title: 'Beta course' }
+];
+
+// React only picks up programmatic value changes that go through the native setter.
+const typeInto = (input, value) => {
+  const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), 'value').set;
+  setter.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+};
+
+const renderDialog = () => {
+  const store = createStore(reducer, applyMiddleware(thunk));
+  store.dispatch({ type: RECEIVE_USER_COURSES, payload: { data: { courses: userCourses } } });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(
+      React.createElement(Provider, { store },
+        React.createElement(CopyAvailableArticles, {
+          course, course_id: course.slug, current_user: instructor
+        }))
+    );
+  });
+  act(() => { container.querySelector('#copy-available-articles-button').click(); });
+  return container;
+};
+
+describe('CopyAvailableArticles', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('lists the user\'s other courses as sources, excluding this course', () => {
+    const container = renderDialog();
+    const selectInput = container.querySelector('#copy-available-articles-source-select-input');
+    act(() => {
+      selectInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+    expect(container.innerHTML).toContain('Beta course');
+    expect(container.innerHTML).not.toContain('Alpha course');
+  });
+
+  test('keeps the copy button disabled until a preview arrives, then enables it', async () => {
+    const preview = jest.spyOn(API, 'previewCopyAvailableArticles').mockResolvedValue({
+      source: { id: 2, slug: 'School/Beta_(Term)', title: 'Beta course' }, count: 3, already_present: 1
+    });
+    const container = renderDialog();
+    const copyButton = container.querySelector('.copy-available-articles .button.dark');
+    expect(copyButton.disabled).toBe(true);
+
+    act(() => { typeInto(container.querySelector('#copy-available-articles-source-url'), 'School/Beta_(Term)'); });
+    await act(async () => { jest.advanceTimersByTime(400); });
+
+    expect(preview).toHaveBeenCalledWith({
+      course_slug: course.slug, source: 'School/Beta_(Term)', include_student_assigned: false
+    });
+    // 3 in the source, 1 already here: 2 would be added
+    expect(container.querySelector('.copy-available-articles__preview p').textContent)
+      .toBe('Beta course: 2 articles');
+    expect(copyButton.disabled).toBe(false);
+  });
+
+  test('shows the server message when the source cannot be used', async () => {
+    const error = new Error('Not Found');
+    error.responseText = JSON.stringify({ message: 'No such course' });
+    jest.spyOn(API, 'previewCopyAvailableArticles').mockRejectedValue(error);
+    const container = renderDialog();
+
+    act(() => { typeInto(container.querySelector('#copy-available-articles-source-url'), 'School/Nope_(Term)'); });
+    await act(async () => { jest.advanceTimersByTime(400); });
+
+    expect(container.querySelector('.copy-available-articles__preview .red').textContent).toBe('No such course');
+    expect(container.querySelector('.copy-available-articles .button.dark').disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## What this PR does

Adds a self-service way for instructors to reuse a previous course's Available Articles list. On the Articles tab → Available Articles, a new **Import from another course** button opens a dialog where the instructor picks one of their other courses from a dropdown (or pastes any course URL), optionally ticks **Include assigned articles?** to also bring over the articles students in that course were assigned, sees how many articles would be added (net of ones already present in this course), and confirms. Everything lands as Available Articles in the current course.

Until now the only options were the clone-time "Clone Available Articles list" checkbox (new courses only) or the console script in `docs/course_update_scripts/copy_assignments.rb`.

Implementation notes:

- `CopyAvailableArticles` service creates the records directly from the source rows (`article_title`/`article_id`/`wiki_id`, `flags: {available_article: true}`) — no `AssignmentManager`, so no per-title wiki API import. It dedupes by `(article_title, wiki_id)` against the target and within the source, and uses non-bang `create` so a legacy title that no longer validates (or a concurrent add) is counted as skipped rather than aborting the batch. `dry_run:` powers the preview.
- `CopyAvailableArticlesController` exposes `GET /copy_available_articles/preview.json` and `POST /copy_available_articles.json`. The target requires `can_edit?`; the source must be non-private or the user must be a member — the same visibility rule as `/courses/:slug/assignments.json`. Unknown and hidden sources both get the existing "No such course … exists." 404 so a private course's existence isn't revealed.
- `CourseUrlParser` (in `lib/utils`) resolves a bare slug, a `courses/…` path, or a full pasted course URL.
- New `Assignment.available` scope (`role: 0, user_id: nil`).
- The clone path (`CourseCloneManager#copy_assignments`) now delegates to the same service, so cloned Available Articles carry the `available_article` flag that the Remove button's unclaim-vs-destroy logic depends on. This also surfaced and fixes a pre-existing bug: the frontend always sends `copy_assignments` as the string `'true'`/`'false'`, and `'false'` was truthy, so every clone copied the articles regardless of the checkbox.
- Frontend: `copy_available_articles.jsx` mounted in `available_articles.jsx` behind the same `isInstructor || admin` gate as the add control. The preview is fetched straight into component state rather than through redux, because `fetchAssignments(sourceSlug)` would replace this course's list. Three new i18n strings; everything else reuses existing ones (`users.number_of_articles`, `error_no_course.explanation`, `error.invalid_assignment`, `application.confirm`/`cancel`).

Specs: service, parser, request spec (auth matrix, source visibility, checkbox, worker scheduling, preview), clone-manager `clone_assignments: true` (previously uncovered), clone-controller string param, a feature spec on the Articles tab, and Jest specs for the component, the gating, and the redux action.

## AI usage

This PR was built with Claude Code under Sage Ross's direction. Claude Code drafted all of the code, specs, the Stylus module, and the commit message, and ran the test suites. Sage asked for an overview of existing article-copying support, requested an implementation plan, decided the three product questions the plan surfaced (which articles to copy — unclaimed by default with an opt-in for student-assigned ones; which sources are allowed — own courses plus any course by URL; copy-all with a count preview rather than per-article selection), approved the plan, and then steered the result: cutting the user-facing message surface from 22 strings to 3 by reusing existing strings and dropping non-essential ones, ruling out Wikidata-specific wording, choosing the generic "Invalid assignment" error, and writing all three new strings.

Scale of effort: a single commit, developed in one Claude Code session of a few hours on 2026-09-03. Planning used plan mode with three exploration subagents and one design subagent; implementation went through one build pass and two simplification rounds driven by Sage's review. Tests were run about ten times; the Ruby specs needed one fix (a missing `require`) and the feature spec one corrected expectation.

The summary above and the rest of this description were also drafted by Claude Code and may contain errors. This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

Before: the feature did not exist — the Available Articles header had only "How to find an article", "Add available articles", and "Find Articles".

After:

**1. Available Articles header with the new button**

![Available Articles header showing the Import from another course button](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/copy-available-articles/screenshots/after/01_available_articles_with_import_button.png)

**2. The import dialog**

![Import dialog with course dropdown, course URL field, and Include assigned articles checkbox](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/copy-available-articles/screenshots/after/02_import_dialog.png)

**3. Choosing a source course from the instructor's other courses**

![Dropdown open listing the instructor's other course](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/copy-available-articles/screenshots/after/03_choosing_a_source_course.png)

**4. Preview of what would be added**

![Preview line reading Northwestern University - History of Science Fall 2025: 5 articles, with OK enabled](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/copy-available-articles/screenshots/after/04_preview_count.png)

**5. After confirming**

![Available Articles list populated with the five imported titles](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/copy-available-articles/screenshots/after/05_articles_imported.png)

## Open questions and concerns

- **Message surface is deliberately minimal.** The same-course error reuses "Invalid assignment", the not-found error reuses "No such course … exists.", and the confirm button is the generic "OK". There's no Wikidata-specific wording ("articles" will show on Wikidata courses too) — accepted as unlikely to matter for this feature.
- **Source visibility.** Anyone who can edit the target can import from any course they could already read `assignments.json` for, including by pasting a URL for a course they aren't enrolled in. That matches existing data exposure, but it does mean admins/staff can pull lists across instructors without the console.
- **Clone-path behaviour change.** Cloned Available Articles now get `flags[:available_article]`, and the `'false'` bug fix means clones will stop copying articles when the checkbox is unticked — which is what the UI always claimed. Bundled here because the fix fell out of delegating to the shared service; happy to split it out if preferred.
- **Synchronous copy.** Roughly three queries per row; hundreds of articles complete in a few seconds. No upper bound is enforced.
- The screenshot spec (`spec/features/copy_available_articles_screenshots_spec.rb`) is disposable and not committed.

(PR description written by Claude Code.)
