### PR TITLE
Make bin/open-pr safe to run without a terminal

### DIFF
--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -194,7 +194,11 @@ End the entire description with this exact line as its final line, after the
 Run `code tmp/pr_description.md` to open the file in VS Code and tell the user to press
 Ctrl+Shift+V to preview it with screenshots rendered locally.
 
-When ready to publish, run `bin/open-pr` once. It will:
+When ready to publish, run `bin/open-pr "<PR title>"` once, passing the title
+explicitly: the commit subject for a single-commit branch, otherwise a title you
+draft from the "What this PR does" section. (Without an argument the script
+prompts on a terminal, and falls back to the last commit subject when there is
+no terminal to prompt — agents never have one.) It will:
 
 1. Find each `screenshots/…` reference in `tmp/pr_description.md`.
 2. Build an orphan commit containing those files and force-push it to

--- a/bin/open-pr
+++ b/bin/open-pr
@@ -11,8 +11,9 @@
 # pass — no manual drag-and-drop step.
 #
 # Usage:
-#   bin/open-pr              # prompts for PR title on first run
-#   bin/open-pr "My title"   # pass title as argument
+#   bin/open-pr "My title"   # pass title as argument (recommended)
+#   bin/open-pr              # at a terminal, prompts for the title; otherwise
+#                            # (agents, CI, pipes) uses the last commit subject
 #
 # Authentication (tried in order):
 #   1. GITHUB_TOKEN env var
@@ -105,7 +106,8 @@ def api_patch(path, payload)
 end
 
 def find_existing_pr(branch)
-  results = api_get("/repos/#{OWNER}/#{REPO}/pulls?head=#{OWNER}:#{branch}&base=#{BASE_BRANCH}&state=open")
+  query = "head=#{OWNER}:#{branch}&base=#{BASE_BRANCH}&state=open"
+  results = api_get("/repos/#{OWNER}/#{REPO}/pulls?#{query}")
   results.first
 end
 
@@ -162,6 +164,20 @@ def capture_git(args, index_path)
   out
 end
 
+# Resolve the PR title before anything with side effects happens. Only prompt
+# when a human is at a terminal; a non-interactive caller (an agent, CI, a pipe)
+# has no stdin to answer with, so it gets the last commit subject.
+def resolve_title(arg)
+  return arg unless arg.nil? || arg.empty?
+
+  default = `git log -1 --pretty=%s`.strip
+  return default unless $stdin.tty?
+
+  print "PR title [#{default}]: "
+  input = $stdin.gets&.strip
+  input.nil? || input.empty? ? default : input
+end
+
 def rewrite_description(body, local_paths, branch)
   base = "https://raw.githubusercontent.com/#{OWNER}/#{REPO}/#{branch}"
   local_paths.each do |path|
@@ -183,6 +199,11 @@ abort 'Could not determine current branch.' if branch.empty?
 description = File.read(DESC_PATH)
 local_paths = extract_local_paths(description)
 
+# Settle the title (which may prompt) before pushing anything, so an aborted
+# run never leaves a half-finished state behind.
+existing_pr = find_existing_pr(branch)
+title = resolve_title(ARGV[0]) unless existing_pr
+
 if local_paths.any?
   screenshot_branch = "pr-screenshots/#{branch}"
   puts "Uploading #{local_paths.length} screenshot(s) to #{screenshot_branch}..."
@@ -191,8 +212,6 @@ if local_paths.any?
   puts "  → raw URLs: https://raw.githubusercontent.com/#{OWNER}/#{REPO}/#{screenshot_branch}/"
 end
 
-existing_pr = find_existing_pr(branch)
-
 if existing_pr
   pr_number = existing_pr['number']
   pr_url    = existing_pr['html_url']
@@ -200,14 +219,6 @@ if existing_pr
   api_patch("/repos/#{OWNER}/#{REPO}/pulls/#{pr_number}", { body: description })
   puts "  → #{pr_url}"
 else
-  title = ARGV[0]
-  if title.nil? || title.empty?
-    last_commit = `git log -1 --pretty=%s`.strip
-    print "PR title [#{last_commit}]: "
-    input = $stdin.gets&.strip
-    title = input.empty? ? last_commit : input
-  end
-
   puts "Creating draft PR on #{OWNER}/#{REPO} (#{branch} → #{BASE_BRANCH})..."
   _code, pr = api_post(
     "/repos/#{OWNER}/#{REPO}/pulls",


### PR DESCRIPTION
## What this PR does

Makes `bin/open-pr` — the last step of the `/prepare-pr` skill — safe to run without a terminal.

When no title argument was given, the script prompted `PR title [...]:` and read the answer with `$stdin.gets`. Any non-interactive caller (Claude Code, a CI job, a pipe) has no stdin to answer with, so `gets` returned nil and the script died with `undefined method 'empty?' for nil` — after it had already force-pushed the `pr-screenshots/<branch>` orphan branch, but before creating the PR. This kept tripping up agent sessions, most recently while opening #7035.

Changes:

- `bin/open-pr`: title handling moves into `resolve_title`. An explicit argument wins; otherwise the last commit subject is the default, and the interactive prompt appears only when `$stdin.tty?`. The title (and the existing-PR lookup it depends on) is now resolved *before* the screenshots push, so an aborted run can no longer leave the orphan branch pushed with no PR behind it. The usage comment recommends passing the title. The one pre-existing over-long line in `find_existing_pr` is wrapped so the script lints clean.
- `.claude/skills/prepare-pr/SKILL.md`: Phase 4 now tells the agent to run `bin/open-pr "<PR title>"` with an explicit title — the commit subject for a single-commit branch, otherwise a title drafted from the "What this PR does" section — and explains the non-terminal fallback. The script no longer crashes without it, but the commit subject isn't always the right title for a multi-commit branch, so agents shouldn't lean on the silent default.

## AI usage

Claude Code drafted both changes and the commit message under Sage Ross's direction. Sage asked what a durable fix would be after hitting the crash again in the same session, accepted the three proposed changes (non-interactive-safe title, skill instruction, resolve-before-push), and asked for them on a separate branch.

Scale of effort: one commit, a few minutes of work inside a longer Claude Code session on 2026-09-03. Verification was `ruby -c`, RuboCop, and an isolated run of `resolve_title` under closed stdin, piped non-TTY input, and an explicit argument. The script was not exercised end to end beforehand because that would have created a real PR — this PR itself was then opened with the fixed script from this branch, title passed as an argument.

This description was drafted by Claude Code and may contain errors. This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes.

## Open questions and concerns

- Ordering change: `find_existing_pr` now runs before the screenshot push. Same number of API calls, but if GitHub auth is missing the script now aborts before pushing anything, which seems strictly better.
- The commit-subject fallback exists so a non-interactive run never blocks; the skill still instructs agents to pass a title explicitly.

(PR description written by Claude Code.)
