### PR TITLE
Speed up articles courses cache updates.

### DIFF
--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -87,7 +87,7 @@ class ArticlesCourses < ApplicationRecord
   end
 
   def self.update_required_caches_from_timeslices(course)
-    ArticlesCourses.where(article_id: articles_courses_to_update(course))
+    ArticlesCourses.where(course:, article_id: articles_courses_to_update(course))
                    .find_each(&:update_cache_from_timeslices)
   end
 

--- a/app/models/course_data/articles_courses.rb
+++ b/app/models/course_data/articles_courses.rb
@@ -21,6 +21,7 @@
 
 require_dependency "#{Rails.root}/lib/timeslice_manager"
 require_dependency "#{Rails.root}/lib/cumulative_diff_url_builder"
+require_dependency "#{Rails.root}/lib/articles_courses_cache_manager"
 
 #= ArticlesCourses is a join model between Article and Course.
 #= It represents a mainspace Wikipedia article that has been worked on by a
@@ -28,10 +29,6 @@ require_dependency "#{Rails.root}/lib/cumulative_diff_url_builder"
 class ArticlesCourses < ApplicationRecord
   belongs_to :article
   belongs_to :course
-
-  has_many :article_course_timeslices, lambda { |articles_courses|
-                                         where article: articles_courses.article
-                                       }, through: :course
 
   scope :live, -> { joins(:article).where(articles: { deleted: false }).distinct }
   scope :new_article, -> { where(new_article: true) }
@@ -48,15 +45,6 @@ class ArticlesCourses < ApplicationRecord
   ####################
   def cumulative_diff_url
     CumulativeDiffUrlBuilder.new(self).url
-  end
-
-  def update_cache_from_timeslices
-    self.character_sum = article_course_timeslices.sum(&:character_sum)
-    self.references_count = article_course_timeslices.sum(&:references_count)
-    self.user_ids = article_course_timeslices.sum([], &:user_ids).uniq
-    self.new_article = article_course_timeslices.any?(&:new_article)
-    self.first_revision = article_course_timeslices.minimum(:first_revision)
-    save
   end
 
   #################
@@ -87,12 +75,13 @@ class ArticlesCourses < ApplicationRecord
   end
 
   def self.update_required_caches_from_timeslices(course)
-    ArticlesCourses.where(course:, article_id: articles_courses_to_update(course))
-                   .find_each(&:update_cache_from_timeslices)
+    update_all_caches_from_timeslices(
+      where(course:, article_id: articles_courses_to_update(course))
+    )
   end
 
   def self.update_all_caches_from_timeslices(articles_courses)
-    articles_courses.find_each(&:update_cache_from_timeslices)
+    ArticlesCoursesCacheManager.new(articles_courses).update_caches_from_timeslices
   end
 
   # Creates missing ArticlesCourses records for the given course revisions whose

--- a/lib/articles_courses_cache_manager.rb
+++ b/lib/articles_courses_cache_manager.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#= Service for updating the counts that are cached on ArticlesCourses objects
+class ArticlesCoursesCacheManager
+  BATCH_SIZE = 1000
+  UPDATED_FIELDS = %i[character_sum references_count user_ids new_article
+                      first_revision updated_at].freeze
+  # Values for an articles_courses record whose timeslices are all gone.
+  EMPTY_CACHE = { character_sum: 0, references_count: 0, user_ids: [],
+                  new_article: false, first_revision: nil }.freeze
+
+  def initialize(articles_courses)
+    @articles_courses = articles_courses
+  end
+
+  # Recalculates the cached fields from the article course timeslices, aggregating
+  # them in SQL and writing every record of a batch with a single upsert.
+  def update_caches_from_timeslices
+    @articles_courses.pluck(:id, :course_id, :article_id)
+                     .each_slice(BATCH_SIZE) { |batch| write_caches(batch) }
+  end
+
+  private
+
+  # Takes [id, course_id, article_id] triples and writes their recalculated caches.
+  def write_caches(records)
+    stats = timeslice_stats(records)
+    now = Time.zone.now
+    rows = records.map do |id, course_id, article_id|
+      { id:, course_id:, article_id:, updated_at: now,
+        **(stats[[course_id, article_id]] || EMPTY_CACHE) }
+    end
+    ArticlesCourses.upsert_all(rows, update_only: UPDATED_FIELDS)
+  end
+
+  # Returns { [course_id, article_id] => cache values }. Timeslices are queried per
+  # course so that the article_course_timeslices unique index applies.
+  def timeslice_stats(records)
+    stats = {}
+    records.group_by { |_id, course_id, _article_id| course_id }
+           .each do |course_id, triples|
+      stats.merge!(stats_for_course(course_id, triples.map(&:last)))
+    end
+    stats
+  end
+
+  def stats_for_course(course_id, article_ids)
+    timeslices = ArticleCourseTimeslice.where(course_id:, article_id: article_ids)
+    stats = aggregated_stats(timeslices)
+    user_ids_by_article(timeslices).each { |id, user_ids| stats[id][:user_ids] = user_ids }
+    stats.transform_keys { |article_id| [course_id, article_id] }
+  end
+
+  # SQL aggregates for every cached field but user_ids, keyed by article id.
+  def aggregated_stats(timeslices)
+    timeslices.group(:article_id)
+              .pluck(:article_id, 'SUM(character_sum)', 'SUM(references_count)',
+                     'MAX(new_article)', 'MIN(first_revision)')
+              .to_h do |article_id, chars, refs, new_article, first_revision|
+                [article_id,
+                 { character_sum: chars.to_i, references_count: refs.to_i,
+                   new_article: new_article.to_i.positive?, first_revision:,
+                   user_ids: [] }]
+              end
+  end
+
+  # user_ids is a serialized array, so it cannot be aggregated in SQL.
+  def user_ids_by_article(timeslices)
+    timeslices.pluck(:article_id, :user_ids)
+              .group_by(&:first)
+              .transform_values { |pairs| pairs.flat_map(&:last).uniq }
+  end
+end

--- a/spec/lib/articles_courses_cache_manager_spec.rb
+++ b/spec/lib/articles_courses_cache_manager_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/articles_courses_cache_manager"
+
+describe ArticlesCoursesCacheManager do
+  let(:article) { create(:article) }
+  let(:course) { create(:course, start: '2024-06-16', end: '2024-08-16') }
+
+  describe '#update_caches_from_timeslices' do
+    let(:articles_course) { create(:articles_course, article:, course:) }
+
+    before do
+      articles_course
+      create(:article_course_timeslice, article:, course:,
+             start: '2024-07-06', end: '2024-07-07',
+             character_sum: 9000, references_count: 4, user_ids: [2, 3],
+             first_revision: '2024-07-06 03:45:04')
+      create(:article_course_timeslice, article:, course:,
+             start: '2024-07-07', end: '2024-07-08',
+             character_sum: 12, references_count: 5, user_ids: [2, 4],
+             new_article: true, first_revision: '2024-07-07 20:10:24')
+      # Empty timeslice, which should not count towards the stats.
+      create(:article_course_timeslice, article:, course:,
+             start: '2024-06-25', end: '2024-06-26',
+             character_sum: 0, references_count: 0, user_ids: nil, first_revision: nil)
+
+      described_class.new(ArticlesCourses.where(course:)).update_caches_from_timeslices
+    end
+
+    it 'sums the character sum of every timeslice' do
+      expect(articles_course.reload.character_sum).to eq(9012)
+    end
+
+    it 'sums the references count of every timeslice' do
+      expect(articles_course.reload.references_count).to eq(9)
+    end
+
+    it 'merges the user ids of every timeslice, without duplicates' do
+      expect(articles_course.reload.user_ids).to match_array([2, 3, 4])
+    end
+
+    it 'does not pick up nil user ids from empty timeslices' do
+      expect(articles_course.reload.user_ids).not_to include(nil)
+    end
+
+    it 'marks the article as new when any timeslice is new' do
+      expect(articles_course.reload.new_article).to be true
+    end
+
+    it 'takes the earliest first revision' do
+      expect(articles_course.reload.first_revision).to eq('2024-07-06 03:45:04')
+    end
+  end
+
+  describe '#update_caches_from_timeslices with no timeslices' do
+    let(:articles_course) do
+      create(:articles_course, article:, course:, character_sum: 999, references_count: 5,
+             user_ids: [7], new_article: true, first_revision: '2024-07-01')
+    end
+
+    before do
+      articles_course
+      described_class.new(ArticlesCourses.where(course:)).update_caches_from_timeslices
+    end
+
+    it 'resets the cached values' do
+      expect(articles_course.reload).to have_attributes(character_sum: 0, references_count: 0,
+                                                        user_ids: [], new_article: false,
+                                                        first_revision: nil)
+    end
+  end
+
+  describe '#update_caches_from_timeslices for two courses sharing an article' do
+    let(:other_course) do
+      create(:course, slug: 'Other/Course', start: '2024-06-16', end: '2024-08-16')
+    end
+
+    before do
+      create(:articles_course, article:, course:)
+      create(:articles_course, article:, course: other_course)
+      create(:article_course_timeslice, article:, course:,
+             start: '2024-07-11', end: '2024-07-12', character_sum: 500)
+      create(:article_course_timeslice, article:, course: other_course,
+             start: '2024-07-11', end: '2024-07-12', character_sum: 900)
+
+      described_class.new(ArticlesCourses.all).update_caches_from_timeslices
+    end
+
+    it 'gives the course the totals of its own timeslices' do
+      expect(ArticlesCourses.find_by(course:).character_sum).to eq(500)
+    end
+
+    it 'gives the other course the totals of its own timeslices' do
+      expect(ArticlesCourses.find_by(course: other_course).character_sum).to eq(900)
+    end
+  end
+
+  describe '#update_caches_from_timeslices across several batches' do
+    let(:article2) { create(:article, title: 'Second Article') }
+    let(:article3) { create(:article, title: 'Third Article') }
+
+    before do
+      stub_const('ArticlesCoursesCacheManager::BATCH_SIZE', 2)
+      [article, article2, article3].each_with_index do |current_article, index|
+        create(:articles_course, article: current_article, course:)
+        create(:article_course_timeslice, article: current_article, course:,
+               start: '2024-07-11', end: '2024-07-12', character_sum: (index + 1) * 100)
+      end
+
+      described_class.new(ArticlesCourses.where(course:)).update_caches_from_timeslices
+    end
+
+    it 'updates the records of every batch' do
+      sums = ArticlesCourses.where(course:).pluck(:article_id, :character_sum).to_h
+      expect(sums).to eq(article.id => 100, article2.id => 200, article3.id => 300)
+    end
+  end
+end

--- a/spec/models/articles_courses_spec.rb
+++ b/spec/models/articles_courses_spec.rb
@@ -100,6 +100,33 @@ describe ArticlesCourses, type: :model do
     end
   end
 
+  describe '.update_required_caches_from_timeslices' do
+    let(:other_course) do
+      create(:course, slug: 'Other/Course', start: '2024-06-16', end: '2024-08-16')
+    end
+
+    before do
+      create(:articles_course, article:, course:)
+      create(:articles_course, article:, course: other_course)
+      course.flags['update_logs'] = { 1 => { 'end_time' => '2024-07-10'.to_datetime } }
+      course.save
+      create(:article_course_timeslice, article:, course:,
+             start: '2024-07-11', end: '2024-07-12', character_sum: 500)
+      create(:article_course_timeslice, article:, course: other_course,
+             start: '2024-07-11', end: '2024-07-12', character_sum: 900)
+    end
+
+    it 'updates the caches for the given course' do
+      described_class.update_required_caches_from_timeslices(course)
+      expect(described_class.find_by(course:).character_sum).to eq(500)
+    end
+
+    it 'does not update the caches for other courses sharing the same article' do
+      described_class.update_required_caches_from_timeslices(course)
+      expect(described_class.find_by(course: other_course).character_sum).to eq(0)
+    end
+  end
+
   describe '.update_from_course_revisions' do
     let(:article2) { create(:article, title: 'Second Article', namespace: 0, wiki_id: 2) }
     let(:article3) { create(:article, title: 'Third Article', namespace: 0) }

--- a/spec/models/visiting_scholarship_spec.rb
+++ b/spec/models/visiting_scholarship_spec.rb
@@ -138,7 +138,7 @@ describe VisitingScholarship, type: :model do
   describe '#scoped_article?' do
     before do
       create(:article, title: 'Category_article')
-      create(:article, title: 'Unassigned_article', mw_page_id: 400)
+      unassigned_article
       create(:assignment, course:, article:, article_title: article.title, wiki:)
       create(:categories_courses, course:, category:)
     end
@@ -146,22 +146,27 @@ describe VisitingScholarship, type: :model do
     let(:wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
     let(:course) { create(:visiting_scholarship, start: '2018-01-01', end: '2018-12-31') }
     let(:category) { create(:category, wiki:, article_titles: ['Category_article']) }
-    let(:article) { create(:article, title: 'Assigned_article', mw_page_id: 345) }
+    let(:article) { create(:article, title: 'Assigned_article') }
+    let(:unassigned_article) { create(:article, title: 'Unassigned_article') }
+    # scoped_article? only checks the mw_page_id against the assigned articles, so any
+    # sum of two ids is high enough to be absent from that list.
+    let(:unused_mw_page_id) { article.mw_page_id + unassigned_article.mw_page_id }
 
     it 'does not consider articles in categories as scoped articles' do
-      expect(course.scoped_article?(wiki, 'Category_article', 90)).to eq(false)
+      expect(course.scoped_article?(wiki, 'Category_article', unused_mw_page_id)).to eq(false)
     end
 
     it 'considers assigned articles as scoped articles even though the title changed' do
-      expect(course.scoped_article?(wiki, 'assigned article', 345)).to eq(true)
+      expect(course.scoped_article?(wiki, 'assigned article', article.mw_page_id)).to eq(true)
     end
 
     it 'considers assigned articles as scoped articles based on title' do
-      expect(course.scoped_article?(wiki, 'Assigned_article', 340)).to eq(true)
+      expect(course.scoped_article?(wiki, 'Assigned_article', unused_mw_page_id)).to eq(true)
     end
 
     it 'returns false for unassigned articles' do
-      expect(course.scoped_article?(wiki, 'Unassigned_article', 400)).to eq(false)
+      expect(course.scoped_article?(wiki, 'Unassigned_article', unassigned_article.mw_page_id))
+        .to eq(false)
     end
   end
 end

--- a/spec/services/update_course_wiki_timeslices_spec.rb
+++ b/spec/services/update_course_wiki_timeslices_spec.rb
@@ -80,18 +80,17 @@ describe UpdateCourseWikiTimeslices do
 
         # Check caches for mw_page_id 6901525
         article = Article.find_by(mw_page_id: 6901525)
-        # The article course exists
-        article_course = ArticlesCourses.find_by(article_id: article.id)
 
+        article_course_timeslices = ArticleCourseTimeslice.where(course:, article:)
         # Article course timeslice record was created for mw_page_id 6901525
         # timeslices for 2018-11-24 was created
-        expect(article_course.article_course_timeslices.count).to eq(1)
-        expect(article_course.article_course_timeslices.first.start).to eq('2018-11-24')
+        expect(article_course_timeslices.count).to eq(1)
+        expect(article_course_timeslices.first.start).to eq('2018-11-24')
         # Article course timeslices caches were updated
-        expect(article_course.article_course_timeslices.first.character_sum).to eq(427)
-        expect(article_course.article_course_timeslices.first.references_count).to eq(-2)
-        expect(article_course.article_course_timeslices.first.user_ids).to eq([user.id])
-        expect(article_course.article_course_timeslices.first.first_revision)
+        expect(article_course_timeslices.first.character_sum).to eq(427)
+        expect(article_course_timeslices.first.references_count).to eq(-2)
+        expect(article_course_timeslices.first.user_ids).to eq([user.id])
+        expect(article_course_timeslices.first.first_revision)
           .to eq('2018-11-24 04:49:31')
       end
 


### PR DESCRIPTION
## What this PR does

Speeds up the ArticlesCourses cache phase of a course update.
I did an experiment for course [Coordinate_Me_2026_NL ACUWT](https://outreachdashboard.wmflabs.org/courses/Test/TEST_Coordinate_Me_2026_NL_ACUWT/home)  (~6,000 articles) and deleted a user. For the update that catches the user deletion, the article course cache update phase was taking **6h 44m of a 7h 25m update — 91% of the total**, measured with the `debug_updates` flag.

| phase | duration |
|---|---|
| everything up to reaggregation | 2m 40s |
| timeslices reaggregated (125) | 37m 41s |
| **ArticlesCourses caches** | **6h 44m 47s** |
| CoursesUsers caches, course cache | 3s |

See raw debug updates:
```
{
0_start: 2026-09-04 22:10:10 UTC,
1_uploads_imported: 2026-09-04 22:12:07 UTC,
2_categories_updated: 2026-09-04 22:12:07 UTC,
3_article_namespaces_updated: 2026-09-04 22:12:08 UTC,
4_timeslices_adjusted: 2026-09-04 22:12:19 UTC,
5_timeslices_reprocessed_40: 2026-09-04 22:12:19 UTC,
6_acuwt_timeslices_reprocessed_40: 2026-09-04 22:12:21 UTC,
7_timeslices_processed_40: 2026-09-04 22:12:50 UTC,
8_timeslices_reaggregated_40: 2026-09-04 22:50:31 UTC,
9_average_pageviews_updated: 2026-09-04 22:50:31 UTC,
10_articles_courses_updated: 2026-09-05 05:35:18 UTC,
11_courses_users_updated: 2026-09-05 05:35:20 UTC,
12_course_cache_updated: 2026-09-05 05:35:21 UTC
}
```

This hits ACUWT courses specifically. `ArticleCourseTimeslice.bulk_update_from_acuwt`
bumps `updated_at` for every article in a reaggregated window, changed or not, so
`articles_courses_to_update` returns nearly every article in the course. The legacy path
writes ACT rows through `save`, whose partial writes only touch genuinely changed
articles. Courses that add and remove users daily, like the Coordinate Me series,
reaggregate constantly.


Two problems:

1. `ArticlesCourses.update_required_caches_from_timeslices` looked up records by
   `article_id` with no `course_id` filter, so it recomputed the caches of *every* course
   sharing those articles. On a P&E course whose articles are widely tracked this is a
   large multiplier — measured at 2× on a small course, and unbounded in general.
2. `ArticlesCourses#update_cache_from_timeslices` cost three queries per record: an
   `Article` load forced by the `article_course_timeslices` association lambda, a load of
   every timeslice as an ActiveRecord object, and a separate `MIN(first_revision)` round
   trip.

The aggregation now lives in `ArticlesCoursesCacheManager`, mirroring the existing
`CourseCacheManager`. It aggregates in SQL and writes each batch of 1000 records with one
`upsert_all`, following the pattern already used by
`ArticleCourseTimeslice.bulk_update_from_acuwt`. The unused instance method and the
`article_course_timeslices` association are removed.

Measured locally on course `Open Data Day Taiwan 2026`: **68 queries / ~813 ms → 5
queries / ~26 ms**. Cached values are unchanged; the one difference is that `upsert_all`
bumps `updated_at` unconditionally, where partial writes previously skipped no-op updates.

## AI usage

Claude Code did the analysis and wrote most of the code. It read the cache-update path,
identified the two problems above from a `pry` log the user captured on production data,
proposed the bulk-SQL design, and drafted `lib/articles_courses_cache_manager.rb`, the
model changes, and the specs.

The user directed the work throughout: chose which problems to pursue and in what order,
made the scoping fix in `c0af3a37d` herself, decided to defer the specs until the code had
been measured on production, created the manager file, and ran every test and lint pass.
Claude Code ran no specs in these sessions. Two of Claude Code's suggestions were dropped
after the user's production logs contradicted them — a `save if changed?` optimization
(Rails' partial writes already skip unchanged records) and an estimate attributing a
6½-hour update to a phase that the user's own comparison against the non-ACUWT branch
showed was elsewhere.

## Screenshots

No UI changes.

## Open questions and concerns

- `BATCH_SIZE = 1000` counts ArticlesCourses records, not timeslices. `user_ids` is a
  serialized array so it cannot be aggregated in SQL and is merged in Ruby, which means
  the pluck behind it returns one row per timeslice. On a course with heavy timeslice
  splitting, one batch could pull far more rows than intended; the constant may want
  lowering. Not yet measured on such a course.
- `upsert_all` skips validations and callbacks. `ArticlesCourses` has none on these
  columns, and `bulk_update_from_acuwt` already makes the same tradeoff on the same kind
  of data, but it is worth a reviewer's eye.
- `updated_at` is now written on every pass. Nothing in `app` or `lib` reads that column.
  Dropping it from `UPDATED_FIELDS` would restore the old "skip unchanged rows" behavior
  at the cost of the timestamp going stale.
- Not addressed here: `UpdateCourseStats#update_caches` wraps all three cache phases in a
  single `ActiveRecord::Base.transaction`, so a large course holds row locks and grows the
  undo log for the whole phase. Worth a follow-up.

(PR description written by Claude Code.)

