### PR TITLE
Clean up only the report CSVs each spec wrote, not the shared directory

### DIFF
--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -2,17 +2,13 @@
 
 require 'rails_helper'
 
-describe ReportsController, type: :request do
+describe ReportsController, :report_csv_files, type: :request do
   let(:user) { create(:user) }
   let(:course) { create(:course, id: 1, slug: 'foo/bar_(baz)') }
   let(:campaign) { create(:campaign) }
 
   before do
     campaign.courses << course
-  end
-
-  after do
-    FileUtils.remove_dir('public/system/analytics') if File.directory?('public/system/analytics')
   end
 
   describe 'authenticated course CSV endpoints' do

--- a/spec/controllers/system_csv_spec.rb
+++ b/spec/controllers/system_csv_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ReportsController, '#system_csv', type: :request do
+describe ReportsController, '#system_csv', :report_csv_files, type: :request do
   let(:admin) { create(:admin) }
   let(:user) { create(:user) }
   let(:en_wiki) { Wiki.get_or_create(language: 'en', project: 'wikipedia') }
@@ -18,10 +18,6 @@ describe ReportsController, '#system_csv', type: :request do
 
   before do
     stub_wiki_validation
-  end
-
-  after do
-    FileUtils.remove_dir('public/system/analytics') if File.directory?('public/system/analytics')
   end
 
   context 'when not signed in' do

--- a/spec/controllers/system_daily_stats_csv_spec.rb
+++ b/spec/controllers/system_daily_stats_csv_spec.rb
@@ -2,17 +2,13 @@
 
 require 'rails_helper'
 
-describe ReportsController, '#system_daily_stats_csv', type: :request do
+describe ReportsController, '#system_daily_stats_csv', :report_csv_files, type: :request do
   let(:admin) { create(:admin) }
   let(:user) { create(:user) }
 
   let!(:stat) do
     create(:system_stat, snapshot_date: 5.days.ago.to_date,
                          total_edits: 800)
-  end
-
-  after do
-    FileUtils.remove_dir('public/system/analytics') if File.directory?('public/system/analytics')
   end
 
   context 'when not signed in' do

--- a/spec/support/report_csv_files.rb
+++ b/spec/support/report_csv_files.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Request specs that exercise the real CSV export pipeline write report files into
+# public/system/analytics, a directory that every parallel_rspec process shares. A
+# spec must therefore only ever remove the files it wrote itself: deleting the whole
+# directory pulls another process's report out from under it between the write and
+# the request that expects to find it, which showed up in CI as intermittent
+# "expected ready, got generating" failures (#7040).
+#
+# Tag an example group with `:report_csv_files` to record each file written through
+# ReportCsvStore during an example and delete exactly those files afterwards.
+RSpec.configure do |config|
+  config.before(:each, :report_csv_files) do
+    @report_csv_files_written = []
+    allow(ReportCsvStore).to receive(:write).and_wrap_original do |original, filename, data|
+      @report_csv_files_written << filename
+      original.call(filename, data)
+    end
+  end
+
+  config.after(:each, :report_csv_files) do
+    @report_csv_files_written.each do |filename|
+      ReportCsvStore.delete(filename) if ReportCsvStore.exists?(filename)
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does

Fixes #7040.

CI runs the suite as three `parallel_rspec` processes that share one filesystem. Three request specs that exercise the real CSV export pipeline (`system_csv_spec`, `system_daily_stats_csv_spec`, `reports_controller_spec`) each had an `after` hook that deleted the entire `public/system/analytics` directory. When one process's cleanup ran between another process's CSV write and the follow-up request that expects to find the file, the controller reported `generating` again and the example failed. On CI this surfaced as intermittent `expected: "ready" / got: "generating"` failures in `system_csv_spec`, most recently on both runs of #7039 while master passed on the same base commit.

The fix keeps each spec's cleanup to the files it actually wrote:

- New `spec/support/report_csv_files.rb` adds a `:report_csv_files` tag. Before each tagged example it wraps `ReportCsvStore.write` to record every filename written; afterwards it deletes exactly those files through the store.
- The three specs carry the tag instead of the directory-wide hooks. No production code changes.

Verification, running the three spec files under `parallel_rspec -n 3` locally (one file per process, as on CI):

| | Old hooks | This branch |
|---|---|---|
| Single process, all four CSV specs | not run | 57 examples, 0 failures |
| Parallel run 1 | 3 failures | 0 failures |
| Parallel run 2 | 3 failures | 0 failures |
| Parallel run 3 | 6 failures | 0 failures |

The old-hook runs also exposed two more symptoms of the same race beyond the one seen on CI: `not a redirect! 200 OK` in `reports_controller_spec` when a course CSV vanished before its download redirect, and an `Errno::ENOTEMPTY` raised by a cleanup hook itself while another process was writing into the directory.

## AI usage

Claude Code did the diagnosis, opened #7040, and wrote the fix and the commit message, under direction from @ragesoss. The human contributions were the request to find out why CI was failing (with the guess that it was unrelated to the PR being tested), the request to file the issue, the go-ahead to build the fix, and the request to commit and open this PR. Four short messages in total, about forty words.

Claude confirmed the mechanism before changing anything by running the spec locally while a background loop deleted the directory, which reproduced the exact CI failure, and by checking that master passed on the same base commit before and after the failing runs. To verify the fix the way CI runs, it created the two extra local test databases that `parallel_rspec` needs and ran the three files in three processes against both the old hooks and the fix, three times each.

Scale of effort: a single commit, made in one sitting, as a continuation of the session that produced #7039.

The "What this PR does" summary and the rest of this description were also drafted by Claude Code and may contain errors. This PR description was drafted using a Claude Code skill (`/prepare-pr`).

## Screenshots

No UI changes.

## Open questions and concerns

- The tracking wraps `ReportCsvStore.write` with rspec-mocks in a global `before` hook. A tagged spec that itself stubs `ReportCsvStore.write` would override the tracking and skip cleanup for that example. None do today, and the two existing stubs in `reports_controller_spec` are on `exists?` and `url_for`, which are unaffected.
- Behaviour on a stale file left behind by an aborted run is unchanged: the old hooks only cleaned up *after* examples too, so neither version guards against it.
- An empty `public/system/analytics` directory now remains after a run instead of being removed. It is gitignored (`/public/system`).
- `parallel_rspec` was introduced in April and the directory-wide hooks arrived with the system CSV exports in July and August, so the race has been latent for about a month.

(PR description written by Claude Code.)
