### PR TITLE
Guard WikiApi#retry_after_seconds against responses without headers

### DIFF
--- a/lib/wiki_api.rb
+++ b/lib/wiki_api.rb
@@ -154,12 +154,14 @@ class WikiApi
   end
 
   # Returns the integer seconds requested by the server's Retry-After header,
-  # or nil if the header is absent / unparseable / the gem version in use
-  # doesn't expose the response on HttpError. Wikimedia uses delay-seconds;
-  # HTTP-date form (RFC 7231) is not parsed.
+  # or nil if the header is absent / unparseable / the error's response object
+  # doesn't expose headers (e.g. MediawikiApi::ApiError wraps a Response that
+  # delegates only :status and :success?, not :headers).
+  # Wikimedia uses delay-seconds; HTTP-date form (RFC 7231) is not parsed.
   def retry_after_seconds(error)
-    return nil unless error.respond_to?(:response) && error.response
-    raw = error.response.headers['Retry-After']
+    response = error.try(:response)
+    return nil unless response.respond_to?(:headers)
+    raw = response.headers['Retry-After']
     Integer(raw) if raw.present?
   rescue ArgumentError, TypeError
     nil

--- a/spec/lib/wiki_api_spec.rb
+++ b/spec/lib/wiki_api_spec.rb
@@ -384,4 +384,45 @@ describe WikiApi do
       end
     end
   end
+
+  describe '#query with a MediawikiApi::ApiError (no interception block)' do
+    before { stub_wiki_validation }
+
+    # MediawikiApi::Client#send_request raises ApiError for HTTP 200 responses
+    # that carry a mediawiki-api-error header (e.g. baduser, badtitle).
+    # ApiError#response is a MediawikiApi::Response, which does NOT delegate
+    # :headers — so retry_after_seconds must not call .headers on it.
+    def baduser_error
+      body = { 'error' => { 'code' => 'baduser',
+                             'info' => 'Invalid value for user parameter.' } }
+      faraday = Faraday::Response.new(
+        status: 200, body: body.to_json,
+        response_headers: { 'mediawiki-api-error' => 'baduser' }
+      )
+      MediawikiApi::ApiError.new(MediawikiApi::Response.new(faraday, ['error']))
+    end
+
+    it 'returns nil instead of raising NoMethodError' do
+      allow_any_instance_of(MediawikiApi::Client)
+        .to receive(:query) { raise baduser_error }
+      wiki = Wiki.get_or_create(language: 'en', project: 'wikipedia')
+      expect(described_class.new(wiki).query(list: 'usercontribs',
+                                             ucuser: %w[A B])).to be_nil
+    end
+  end
+
+  describe '#retry_after_seconds' do
+    before { stub_wiki_validation }
+
+    it 'parses Retry-After from a real HttpError' do
+      faraday = Faraday::Response.new(
+        status: 429, body: '{}',
+        response_headers: { 'Retry-After' => '7' }
+      )
+      wiki = Wiki.get_or_create(language: 'en', project: 'wikipedia')
+      api = described_class.new(wiki)
+      expect(api.send(:retry_after_seconds,
+                      MediawikiApi::HttpError.new(faraday))).to eq(7)
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does
Fixes #7033 

`WikiApi#retry_after_seconds` raises `NoMethodError` when handed a `MediawikiApi::ApiError`, causing the exception to escape `WikiApi#mediawiki`'s rescue block instead of logging the error and returning `nil`.

### Mechanism & Root Cause
1. `WikiApi#mediawiki` catches `StandardError`, retries up to 3 times, and then builds Sentry context using `rate_limit_sentry_extra(e)`.
2. `rate_limit_sentry_extra(e)` calls `retry_after_seconds(e)` to extract any HTTP `Retry-After` header.
3. `MediawikiApi::ApiError` (raised on HTTP 200 responses carrying MediaWiki API error payloads like `baduser` or `badtitle`) wraps a `MediawikiApi::Response` object. Unlike `MediawikiApi::HttpError` (which wraps `Faraday::Response`), `MediawikiApi::Response` delegates only `:status` and `:success?` — it does **not** implement or delegate `:headers`.
4. Calling `error.response.headers` on an `ApiError` throws `NoMethodError: undefined method 'headers' for #<MediawikiApi::Response:...>`, causing an unhandled exception for callers that expect `WikiApi#query` to return `nil` on failure.

### Changes Made
- Added a `respond_to?(:headers)` guard in `WikiApi#retry_after_seconds` (`lib/wiki_api.rb`).
- Added unit specs in `spec/lib/wiki_api_spec.rb` to verify `MediawikiApi::ApiError` returns `nil` without raising, and `MediawikiApi::HttpError` correctly parses `Retry-After`.

## AI usage
Used Google Antigravity AI agent to analyze the `MediawikiApi::Response` method delegations and write unit test case.

## Screenshots
N/A (backend error handling fix in `lib/wiki_api.rb`, no UI changes)

