### PR TITLE
Fix failing specs in CI

### DIFF
--- a/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
+++ b/spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb
@@ -43,15 +43,40 @@ describe DeUserfyingEditAlertMonitor do
   end
 
   describe '.edits' do
-    it 'checks keys' do
-      VCR.use_cassette 'recent_changes' do
-        fedit = mntor.edits.first
-        expect(fedit.dig('logparams', 'target_title')).not_to be_nil
-        expect(fedit.dig('user')).not_to be_nil
-        expect(fedit.dig('revid')).not_to be_nil
-        expect(fedit.dig('pageid')).not_to be_nil
-        expect(fedit.dig('logid')).not_to be_nil
-        expect(fedit.dig('timestamp')).not_to be_nil
+    let(:api) { instance_double(WikiApi) }
+    let(:response) { OpenStruct.new(data: { 'recentchanges' => recentchanges }) }
+
+    before do
+      allow(WikiApi).to receive(:new).and_return(api)
+      allow(api).to receive(:query).and_return(response)
+    end
+
+    context 'when no recent change carries the de-userfying tag' do
+      let(:recentchanges) { [] }
+
+      it 'returns no edits' do
+        expect(mntor.edits).to be_empty
+      end
+    end
+
+    context 'when a page was moved out of user space' do
+      let(:recentchanges) do
+        [{ 'type' => 'log', 'ns' => 2, 'title' => 'User:Alice/sandbox',
+           'pageid' => 111, 'revid' => 12, 'logid' => 99, 'user' => 'Alice',
+           'timestamp' => '2026-09-01T12:00:00Z', 'tags' => ['de-userfying'],
+           'logparams' => { 'target_title' => 'my title 1' } }]
+      end
+
+      it 'keeps the keys the monitor relies on' do
+        expect(mntor.edits.first).to include(
+          'user' => 'Alice', 'revid' => 12, 'pageid' => 111, 'logid' => 99,
+          'timestamp' => '2026-09-01T12:00:00Z', 'title' => 'User:Alice/sandbox',
+          'logparams' => { 'target_title' => 'my title 1' }
+        )
+      end
+
+      it 'drops the keys the monitor does not use' do
+        expect(mntor.edits.first.keys).not_to include('type', 'ns', 'tags')
       end
     end
   end

--- a/spec/lib/importers/upload_importer_spec.rb
+++ b/spec/lib/importers/upload_importer_spec.rb
@@ -87,7 +87,7 @@ describe UploadImporter do
       VCR.use_cassette 'commons/import_urls_in_batches' do
         described_class.import_urls_in_batches([CommonsUpload.find(543972)])
         peas_photo = CommonsUpload.find(543972)
-        expect(peas_photo.thumburl[0...24]).to eq('https://upload.wikimedia')
+        expect(peas_photo.thumburl[0...23]).to eq('https://thumb.wikimedia')
       end
     end
   end


### PR DESCRIPTION
## What this PR does
This PR fixes the two current failing specs in CI:

```
  1) DeUserfyingEditAlertMonitor.edits checks keys
     Failure/Error: expect(fedit.dig('logparams', 'target_title')).not_to be_nil

     NoMethodError:
       undefined method 'dig' for nil
     # ./spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb:49:in 'block (4 levels) in <top (required)>'
     # ./spec/lib/alerts/de_userfying_edit_alert_monitor_spec.rb:47:in 'block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:78:in 'block (2 levels) in <top (required)>'

  2) UploadImporter.import_urls_in_batches finds and saves Commons thumbnail urls
     Failure/Error: expect(peas_photo.thumburl[0...24]).to eq('https://upload.wikimedia/')

       expected: "https://upload.wikimedia/"
            got: "https://thumb.wikimedia./"

       (compared using ==)
     # ./spec/lib/importers/upload_importer_spec.rb:90:in 'block (4 levels) in <top (required)>'
     # ./spec/lib/importers/upload_importer_spec.rb:87:in 'block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:78:in 'block (2 levels) in <top (required)>'
```

`DeUserfyingEditAlertMonitor` spec fails because the `recentchanges` response (de-userfying for the last 30 days) returns empty right now. The proposed solution is to avoid doing real requests (stop using VCR cassettes) and mock the response for both cases: no recent changes, existing recent changes.

`UploadImporter` spec fails because the `thumburl` field now (inside `imageinfo`) has a thumb (not upload) url domain. The proposed solution is just to update the expected URL in the specs. I don't think the domain would change soon, so this should be enough.

## AI usage
Discussed with Claude Code.


## Open questions and concerns
< anything you learned that you want to share, or questions you're wondering about related to this PR >
