### PR TITLE
Explain the userscript install step to opted-in students

### DIFF
--- a/app/assets/javascripts/components/overview/experiment_opt_in_invitation.jsx
+++ b/app/assets/javascripts/components/overview/experiment_opt_in_invitation.jsx
@@ -114,6 +114,12 @@ const ExperimentOptInInvitation = ({ course, current_user }) => {
       <Modal modalClass="experiment-opt-in" ariaLabelledBy="experiment-opt-in-title">
         <div className="experiment-opt-in__panel">
           <h2 id="experiment-opt-in-title">{copy.install_title}</h2>
+          {copy.install_explanation && (
+            <div
+              className="experiment-opt-in__explanation"
+              dangerouslySetInnerHTML={{ __html: md.render(copy.install_explanation) }}
+            />
+          )}
           <div dangerouslySetInnerHTML={{ __html: md.render(copy.install_message || '') }} />
           <div className="experiment-opt-in__snippet-row">
             <pre className="experiment-opt-in__snippet">{userscript.import_line}</pre>

--- a/app/assets/stylesheets/modules/_experiment_opt_in.styl
+++ b/app/assets/stylesheets/modules/_experiment_opt_in.styl
@@ -16,6 +16,10 @@
       font-size 1.563em
       font-weight 300
       margin-bottom 15px
+  // The "what this step is for" text above the install instruction; the gap
+  // keeps it from running into the instruction paragraph that follows.
+  .experiment-opt-in__explanation
+    margin-bottom 15px
   .experiment-opt-in__consent
     border 1px solid border_lt
     margin 20px 0

--- a/lib/experiments/fall_2026_research_experiment.rb
+++ b/lib/experiments/fall_2026_research_experiment.rb
@@ -19,9 +19,10 @@ class Fall2026ResearchExperiment < OptInExperiment
 
   USERSCRIPT_IMPORT_LINE = "importScript('#{USERSCRIPT_PAGE}');"
 
-  # Student-facing invitation copy, shown in a modal. `message`, `consent_form`
-  # and `install_message` are rendered as Markdown. Kept here (not in en.yml) so
-  # this ephemeral experiment text stays out of the translation pipeline.
+  # Student-facing invitation copy, shown in a modal. `message`, `consent_form`,
+  # `install_explanation` and `install_message` are rendered as Markdown. Kept
+  # here (not in en.yml) so this ephemeral experiment text stays out of the
+  # translation pipeline.
   STUDENT_INVITATION_COPY = {
     title: 'Research Study',
     message: <<~MESSAGE,
@@ -37,6 +38,11 @@ class Fall2026ResearchExperiment < OptInExperiment
     opt_in: 'I consent',
     opt_out: 'No',
     install_title: 'Install the experiment script',
+    # Shown above the step-by-step instruction, to say what this step is for
+    # before the student is handed a line of JavaScript to paste.
+    install_explanation: <<~EXPLANATION,
+      Thank you for opting in to our research project! To enable the features we're studying, you'll need to install the `wickie.js` script for your Wikipedia account. (This is the only extra step you'll need to take.)
+    EXPLANATION
     install_message: <<~INSTALL,
       To enable the experiment, copy the line below, click 'Install script', paste it to your common.js page, then "Publish changes".
     INSTALL

--- a/lib/experiments/opt_in_experiment.rb
+++ b/lib/experiments/opt_in_experiment.rb
@@ -41,9 +41,10 @@ class OptInExperiment
   # en.yml) so this ephemeral experiment text stays out of the translation
   # pipeline; the controller hands it to the React component. Returns a hash
   # with keys: :title, :message, :consent_form, :opt_in, :opt_out,
-  # :install_title, :install_message, :install_button, :install_copy_button,
-  # :install_copied, :install_verify_button, :install_not_found (the :message,
-  # :consent_form and :install_message values are Markdown).
+  # :install_title, :install_explanation, :install_message, :install_button,
+  # :install_copy_button, :install_copied, :install_verify_button,
+  # :install_not_found (the :message, :consent_form, :install_explanation and
+  # :install_message values are Markdown).
   def student_invitation_copy
     raise NotImplementedError
   end

--- a/test/components/experiment_opt_in_invitation.spec.js
+++ b/test/components/experiment_opt_in_invitation.spec.js
@@ -86,6 +86,7 @@ describe('ExperimentOptInInvitation', () => {
 
   const installCopy = {
     install_title: 'Install the tool',
+    install_explanation: 'This is **why** you are asked to do this.',
     install_message: 'Paste this line into your common.js.',
     install_button: 'Open my common.js',
     install_copy_button: 'Copy it',
@@ -115,6 +116,19 @@ describe('ExperimentOptInInvitation', () => {
     expect(container.textContent).toContain('Paste this line into your common.js.');
     const link = container.querySelector('.experiment-opt-in__actions a');
     expect(link.getAttribute('href')).toContain('action=edit');
+  });
+
+  it('explains the install step, as Markdown, above the instructions', async () => {
+    request.mockResolvedValue(installInvitation({
+      install_url: 'https://en.wikipedia.org/w/index.php?title=User:S/common.js&action=edit',
+      import_line: 'importScript("x");'
+    }));
+    const container = await renderComponent(eligibleCourse, student);
+    const explanation = container.querySelector('.experiment-opt-in__explanation');
+    expect(explanation.textContent).toContain('why you are asked to do this');
+    expect(explanation.querySelector('strong').textContent).toEqual('why');
+    const text = container.textContent;
+    expect(text.indexOf('why you are asked')).toBeLessThan(text.indexOf('Paste this line'));
   });
 
   it('copies the import line to the clipboard and says so', async () => {


### PR DESCRIPTION
## What this PR does

Students in Fall 2026 courses who opt in to the research study have to install the `wickie.js` userscript themselves, by pasting an import line into their English Wikipedia `common.js`. The modal that prompts them to do so had been a source of confusion: it opened straight onto a line of JavaScript with no context for what the step is or why it is needed.

This adds a short explanatory paragraph, written by the operator, at the top of the install modal, above the existing step-by-step instruction. The paragraph lives in the experiment's Ruby copy hash (`Fall2026ResearchExperiment::STUDENT_INVITATION_COPY`) alongside the rest of the modal text, so it stays out of the i18n pipeline like the other ephemeral experiment copy. A small stylesheet tweak gives it a bottom margin, since the base stylesheet zeroes the margin on a last-child paragraph and the two blocks otherwise ran together.

## AI usage

This PR was produced with Claude Code (Claude Fable 5.1), directed by Sage Ross. Claude Code drafted all of the code changes: the new `install_explanation` copy slot, the component rendering, the stylesheet margin, and the jest test. It also wrote the commit message, ran the tests and the screenshot harness, and drafted this description. The user-facing paragraph itself was written by the human and inserted verbatim; following the project's no-AI-copy rule, Claude Code first wired the slot with a `[PLACEHOLDER` marker and asked for wording. The human decided what to build, supplied the copy, reviewed the screenshot, and approved the result.

Scale of effort: a single commit from one short, focused session, roughly half an hour to an hour of wall-clock time. The "What this PR does" summary and other analysis in this description were also drafted by Claude Code and may contain errors.

This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

Only the install step changes. The other states captured by the harness (consent modal, instructor wizard panel, email-link page, cleared course page, opted-out page) are unchanged and omitted.

**Install step, right after the student clicks "I consent"**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/experiment-install-explanation/screenshots/before/03_student_install.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/experiment-install-explanation/screenshots/after/03_student_install.png) |

**Install step, after clicking Copy**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/experiment-install-explanation/screenshots/before/03b_student_install_copied.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/experiment-install-explanation/screenshots/after/03b_student_install_copied.png) |

**Install step, after a verify attempt that finds no script**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/experiment-install-explanation/screenshots/before/04_student_install_not_found.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/experiment-install-explanation/screenshots/after/04_student_install_not_found.png) |

## Open questions and concerns

- The existing instruction line ("To enable the experiment, copy the line below…") and the not-found message after a failed verify were left untouched. If either also contributed to the confusion, they could get the same treatment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(PR description written by Claude Code.)
