### PR TITLE
Fix charset and test-database grants in dev setup docs and scripts

### DIFF
--- a/db_init.sh
+++ b/db_init.sh
@@ -12,13 +12,12 @@ service mysql start
 sleep 5
 
 # Init DBs
-echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
       exit" | mysql && printf "$\n[DATABSE CREATED]\n"
 
 echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
-      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
-      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
+      GRANT ALL PRIVILEGES ON \`dashboard%\`.* TO 'wiki'@'localhost';
       exit" | mysql > /dev/null && printf "\n[USER CREATED]\n"
 
 # Migrate dev and test DBs

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -1,5 +1,6 @@
-CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
 CREATE USER 'wiki'@'%' IDENTIFIED BY 'wikiedu';
-GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'%';
-GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'%';
+-- The `dashboard%` pattern also covers the numbered test databases
+-- (dashboard_testing2, ...) that parallel_tests creates from TEST_ENV_NUMBER.
+GRANT ALL PRIVILEGES ON `dashboard%`.* TO 'wiki'@'%';

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,8 +68,10 @@ If you know your way around Rails, here's the very short version. Some additiona
 5. Now **login into your database**
       *  Either create a new user using `CREATE USER 'wiki'@localhost IDENTIFIED BY 'wikiedu';`. Verify you created a new user using the command `SELECT User FROM mysql.user;`
       *  or update `database.yml` with valid credentials to connect to the database
-6. Create a new database named as `dashboard` using the command `CREATE DATABASE dashboard;`
+6. Create a new database named as `dashboard` using the command `CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;`
+      * The charset and collation must match `db/schema.rb`, which declares every table as `utf8mb4`/`utf8mb4_unicode_ci`.
       * To verify whether your database was created, use the command `SHOW DATABASES;`
+      * This bare-minimum path skips the test database and the privilege grants. See [Detailed instructions](#detailed-instructions) for the full SQL if you intend to run the test suite.
 7. Run `rake db:migrate` to migrate all database tables.
 8. Install yarn (modern)
 9. Run `yarn` to download the required javascript packages
@@ -120,14 +122,21 @@ If you know your way around Rails, here's the very short version. Some additiona
             (If you receive the error message: `Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)`
             You may have a permissions issue. Try executing: `sudo chown -R _mysql:mysql /usr/local/var/mysql` before restarting database server and logging in)
         - Windows: `C:\xampp\mysql\bin\mysql -u root`
-    - `CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
-    - `CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
-    - `CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';`
-    - `GRANT ALL PRIVILEGES ON dashboard.* TO 'wiki'@'localhost';`
-    - `GRANT ALL PRIVILEGES ON dashboard_testing.* TO 'wiki'@'localhost';`
-    - `FLUSH PRIVILEGES;` # reload privilege tables so the new user/permissions take effect
-    - `SELECT User, Host FROM mysql.user WHERE User = 'wiki';`
-    - `exit`
+    - Then run:
+
+      ```sql
+      CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+      CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+      CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
+      -- The `dashboard%` pattern also covers the numbered test databases
+      -- (dashboard_testing2, dashboard_testing3, ...) that parallel_tests
+      -- creates from TEST_ENV_NUMBER. Without it, `bin/full-suite` and the
+      -- CI `parallel_rspec` run fail when they try to create those.
+      GRANT ALL PRIVILEGES ON `dashboard%`.* TO 'wiki'@'localhost';
+      FLUSH PRIVILEGES;  -- reload privilege tables so the new permissions take effect
+      SELECT User, Host FROM mysql.user WHERE User = 'wiki';
+      exit
+      ```
 
 - Install Gems:
     - $ `gem install bundler`
@@ -153,6 +162,22 @@ If you know your way around Rails, here's the very short version. Some additiona
   - Debian: `sudo apt install redis-server`
   - OSX: `brew install redis`
   - Windows: Download [the Windows port](https://github.com/MSOpenTech/redis/releases) by the Microsoft Open Tech Group
+
+- Install Memcached:
+  - Debian: `sudo apt install memcached`
+  - OSX: `brew install memcached`
+  - `config/application.rb` sets the Rails cache to `:mem_cache_store` on
+    `localhost`, so development needs memcached running. The test environment
+    overrides this with `:null_store`, so the specs do not depend on it.
+
+- Install Google Chrome or Chromium:
+  - Debian: `sudo apt install chromium`
+  - OSX: `brew install --cask google-chrome`
+  - The Capybara feature specs in `spec/features` drive a real browser through
+    Selenium (see the driver registered in `spec/rails_helper.rb`), so a Chrome
+    or Chromium binary must be installed. You do not need to install
+    chromedriver yourself — selenium-webdriver's Selenium Manager downloads a
+    matching version on first use.
 
 - (Optional) Set up a [`post-merge`](https://git-scm.com/docs/githooks#_post_merge) hook to update all dependencies if `package.json` or `Gemfile` changes.
   - Copy `.git-hooks/pull-update-deps` to `.git/hooks/post-merge`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,8 +33,8 @@
 Then start the command line:
     - Debian: `mysql -u root -p`
     - `SET PASSWORD FOR 'root'@'localhost' = PASSWORD('mypassword')`
-    - `CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
-    - `CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;`
+    - `CREATE DATABASE dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;`
+    - `CREATE DATABASE dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;`
     - `exit`
 
 

--- a/setup/deb-setup.sh
+++ b/setup/deb-setup.sh
@@ -99,6 +99,13 @@ else
   output_line "sudo apt install -y redis-server" && print_success "${CLEAR_LINE}[+] Redis-Server installed\n"
 fi
 
+printf '[*] Installing memcached... \n'
+if which memcached > /dev/null; then
+  printf "${CLEAR_LINE}memcached already installed\n"
+else
+  output_line "sudo apt install -y memcached" && print_success "${CLEAR_LINE}[+] Memcached installed\n"
+fi
+
 printf '[*] Installing MariaDB-server... \n'
 if mysql -V | grep MariaDB > /dev/null; then
   printf "${CLEAR_LINE}MariaDB already installed\n"
@@ -129,8 +136,8 @@ else
 fi
 
 printf "[*] Creating Databases... \n"
-echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
       exit" | sudo mysql && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'
@@ -148,8 +155,7 @@ else
 
   printf '[*] Creating User for Mysql... \n'
   echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
-      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
-      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
+      GRANT ALL PRIVILEGES ON \`dashboard%\`.* TO 'wiki'@'localhost';
       exit" | sudo mysql > /dev/null && print_success "${CLEAR_LINE}[+] User created\n"
 fi
 

--- a/setup/dnf-setup.sh
+++ b/setup/dnf-setup.sh
@@ -87,6 +87,13 @@ else
   output_line "sudo dnf install -y redis" && print_success "${CLEAR_LINE}[+] Redis-Server installed\n"
 fi
 
+printf '[*] Installing memcached... \n'
+if which memcached > /dev/null; then
+  printf "${CLEAR_LINE}memcached already installed\n"
+else
+  output_line "sudo dnf install -y memcached" && print_success "${CLEAR_LINE}[+] Memcached installed\n"
+fi
+
 printf '[*] Installing MariaDB-server... \n'
 if mysql -V | grep MariaDB > /dev/null; then
   printf "${CLEAR_LINE}MariaDB already installed\n"
@@ -120,8 +127,8 @@ printf '[*] Starting MariaDB... \n'
 sudo service mariadb start
 
 printf "[*] Creating Databases... \n"
-echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
       exit" | sudo mysql && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'
@@ -139,8 +146,7 @@ else
 
   printf '[*] Creating User for Mysql... \n'
   echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
-      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
-      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
+      GRANT ALL PRIVILEGES ON \`dashboard%\`.* TO 'wiki'@'localhost';
       exit" | sudo mysql > /dev/null && print_success "${CLEAR_LINE}[+] User created\n"
 fi
 

--- a/setup/macOS-setup.sh
+++ b/setup/macOS-setup.sh
@@ -88,6 +88,13 @@ else
   output_line "brew install redis" && output_line "brew services start redis" && print_success "${CLEAR_LINE}[+] Redis-Server installed\n"
 fi
 
+printf '[*] Installing memcached... \n'
+if which memcached > /dev/null; then
+  printf "${CLEAR_LINE}memcached already installed\n"
+else
+  output_line "brew install memcached" && output_line "brew services start memcached" && print_success "${CLEAR_LINE}[+] Memcached installed\n"
+fi
+
 printf '[*] Installing MariaDB-server... \n'
 if mysql -V | grep MariaDB > /dev/null; then
   printf "${CLEAR_LINE}MariaDB already installed\n"
@@ -123,8 +130,8 @@ else
 fi
 
 printf "[*] Creating Databases... \n"
-echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+echo "CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
+      CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;
       exit" | sudo mysql && print_success "${CLEAR_LINE}[+] Databases created\n"
 
 printf '[*] Checking for Database configurations... \n'
@@ -142,8 +149,7 @@ else
 
   printf '[*] Creating User for Mysql... \n'
   echo "CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
-      GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';
-      GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';
+      GRANT ALL PRIVILEGES ON \`dashboard%\`.* TO 'wiki'@'localhost';
       exit" | sudo mysql > /dev/null && print_success "${CLEAR_LINE}[+] User created\n"
 fi
 

--- a/setup/win-setup.bat
+++ b/setup/win-setup.bat
@@ -42,11 +42,11 @@ start C:\xampp\mysql\bin\mysqld
 echo [+] XAMPP install complete!
 
 echo [*] Creating databases...
-echo CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; exit| C:\xampp\mysql\bin\mysql -u root
+echo CREATE DATABASE IF NOT EXISTS dashboard DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci; CREATE DATABASE IF NOT EXISTS dashboard_testing DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci; exit| C:\xampp\mysql\bin\mysql -u root
 echo [+] Databases created!
 
 echo [*] Creating User for Mysql...
-echo CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';GRANT ALL PRIVILEGES ON dashboard . * TO 'wiki'@'localhost';GRANT ALL PRIVILEGES ON dashboard_testing . * TO 'wiki'@'localhost';exit| C:\xampp\mysql\bin\mysql -u root
+echo CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';GRANT ALL PRIVILEGES ON `dashboard%%`.* TO 'wiki'@'localhost';exit| C:\xampp\mysql\bin\mysql -u root
 echo [+] Database user created!
 
 


### PR DESCRIPTION
## What this PR does

Fixes two defects that ran through every developer-environment setup path in the repo, both hit firsthand while standing up a working environment on a bare Debian 13 machine.

**Charset.** The documented `CREATE DATABASE` used `utf8`/`utf8_general_ci`, but `db/schema.rb` declares every table as `utf8mb4`/`utf8mb4_unicode_ci`. A database created by following the docs therefore had a default charset that disagreed with its own tables. Corrected in `docs/setup.md` (both the detailed SQL and the TL;DR, which specified no charset at all), `docs/troubleshooting.md`, all four `setup/` scripts, `db_init.sh`, and `docker/init-db.sql`.

**Test-database grants.** The docs and scripts granted privileges on `dashboard` and `dashboard_testing` only. But `bin/full-suite` runs `parallel_rspec -n 4`, CI runs `-n 3`, and `config/database.example.yml` derives test database names from `TEST_ENV_NUMBER` — so the `wiki` user could not create `dashboard_testing2` through `dashboard_testing4`. Anyone following the setup docs could not run the full test suite. Replaced the fixed pair of grants with a single wildcard grant on `` `dashboard%` ``, which covers the base databases and every numbered test database.

**Two undocumented dependencies** are now documented in `docs/setup.md`: memcached (`config/application.rb` sets the Rails cache to `:mem_cache_store` on localhost, so development needs it; the test environment overrides to `:null_store`) and Chrome/Chromium (the Capybara specs drive a real browser through the Selenium driver in `spec/rails_helper.rb`). Neither was mentioned anywhere in the setup docs, and both had to be installed by hand to get a working environment. memcached was also added to the three shell setup scripts.

Two incidental notes: the `docs/setup.md` SQL moved from a bullet list to a fenced `sql` block, because the wildcard pattern requires backtick quoting that inline Markdown code can't carry — it is also copy-pasteable now, which the bullet list was not. And `docker/init-db.sql` gained a missing trailing newline, without which its final statement can be truncated when piped to `mysql`.

No issue number; these were found by doing the setup rather than from a report.

## AI usage

The code changes, the commit message, and this description were all written by **Claude Code** (Opus 5), using the repo's own `.claude/skills/commit` and `.claude/skills/prepare-pr` workflows. Human input was direction and decisions only — five short messages totalling roughly 45 words ("set up the dev environment, tell me what to install", "apt installs complete", "prepare changes on a fresh branch to fix the problems you noted", "commit", "open a pr"). No message named a file or prescribed an approach; the specific defects, their scope, and the fixes were identified by the agent.

Scale of effort: **one commit, single session.** The session was mostly spent building the dev environment (compiling Ruby 3.4.8, installing gems, compiling assets); the documentation fixes were a shorter phase afterward.

Two things reviewers should weigh when calibrating trust in the above:

- **The agent got something wrong and had to retract it.** It initially reported a third defect — that `yarn build` exits 0 while failing, because `prepare.js` shells out to `bundle exec i18n export`. That was false. Re-tested without the `| grep | tail` wrapper that produced the original observation, `node prepare.js` exits 1, `yarn build` exits 1, and the real error prints readably. The reported exit code had been `tail`'s, not yarn's. The claim was withdrawn and `prepare.js` left untouched.
- **Scope grew mid-task.** A repo-wide grep found the same charset bug in three more files than the two originally flagged, taking the change from 5 files to 8.

Per `docs/ai_guidelines.md`, this is not an untested AI-only PR: the changes come out of a real local setup, and every claim in this PR was checked against a running MariaDB 11.8 / Rails 8.1.3.1 environment (see Screenshots). The "What this PR does" summary and the analysis above were drafted by Claude Code and may contain errors. This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

No UI changes — this PR touches only documentation and setup scripts. Per `docs/ai_guidelines.md`, here is the console verification instead.

Note on what is and isn't demonstrated: the *fixed* state is verified directly below. The *broken* state was not reproduced, because re-provisioning a restricted MySQL user requires root; instead, step 2 shows that grants are scoped to a literal pattern (a database outside the granted pattern is refused), which is what makes the old two-database grant insufficient for `dashboard_testing2`.

```console
# ── 1. Charset now matches db/schema.rb ─────────────────────────────
$ mysql -u wiki -h 127.0.0.1 -e "CREATE DATABASE dashboard_prcheck DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;"
SCHEMA_NAME		DEFAULT_CHARACTER_SET_NAME	DEFAULT_COLLATION_NAME
dashboard_prcheck	utf8mb4				utf8mb4_unicode_ci
dashboard_testing	utf8mb4				utf8mb4_unicode_ci
dashboard		utf8mb4				utf8mb4_unicode_ci

$ grep -o 'charset: "utf8mb4", collation: "utf8mb4_unicode_ci"' db/schema.rb | head -1
charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
  -> database default and table declarations now agree

# ── 2. Grants are pattern-scoped, so the old grant could not cover
#      the numbered test databases; the new one does ───────────────
$ mysql -u wiki -h 127.0.0.1 -e "SHOW GRANTS FOR CURRENT_USER();"
GRANT ALL PRIVILEGES ON `dashboard%`.* TO `wiki`@`localhost`

$ # a name OUTSIDE the granted pattern is refused (proves scoping is literal):
ERROR 1044 (42000) at line 1: Access denied for user 'wiki'@'localhost' to database 'outside_the_pattern'

$ # the names parallel_rspec -n 4 derives from TEST_ENV_NUMBER are permitted:
  OK  dashboard_testing2
  OK  dashboard_testing3
  OK  dashboard_testing4
Database (dashboard%)
dashboard
dashboard_prcheck
dashboard_testing
dashboard_testing2
dashboard_testing3
dashboard_testing4

$ # throwaway databases dropped; left with:
Database (dashboard%)
dashboard
dashboard_testing

# ── 3. Edited shell scripts still parse, and emit a literal backtick ─
$ bash -n setup/deb-setup.sh     OK
$ bash -n setup/dnf-setup.sh     OK
$ bash -n setup/macOS-setup.sh   OK
$ bash -n db_init.sh             OK
$ # what deb-setup.sh's echo actually sends to mysql:
CREATE USER 'wiki'@'localhost' IDENTIFIED BY 'wikiedu';
      GRANT ALL PRIVILEGES ON `dashboard%`.* TO 'wiki'@'localhost';
      exit
```

Also checked: `docs/setup.md` was rendered through the repo's own redcarpet to confirm the new fence becomes a `<pre><code class="sql">` block with its backticks preserved rather than swallowed as inline code. No Ruby, JS, or Stylus files are touched, so RuboCop and ESLint are unaffected (both were run clean during the session, along with Jest: 78 suites / 495 examples).

## Open questions and concerns

Three related problems were found and deliberately left out of this PR, to keep it a documentation fix:

1. **`setup/deb-setup.sh` is broken on current Debian, independent of these changes.** Line 61 calls `apt-key add`, which no longer exists on Debian 12+ / Ubuntu 22.04+, so the script dies there under `set -e`. It also installs Node 8 (EOL 2019) and Yarn 1 from the apt repo, while `package.json` pins `yarn@3.2.1` vendored via Corepack. This is arguably the most user-facing problem remaining, but fixing it means choosing a toolchain provisioning strategy (rbenv/nvm, asdf, system packages), which is a design decision rather than a docs fix. Worth its own issue.
2. **`docs/wmcloud_database_setup.md` and `docs/WMFLABS_DEPLOYMENT.md` still specify `utf8_general_ci`.** The defect is identical, but those create the *production* databases, so changing production procedure seemed like the operator's call rather than something to fold in here.
3. **Chrome/Chromium was documented but not added to the setup scripts**, unlike memcached. Installing a browser is heavier and more opinionated than a service daemon, and it is usually already present — but the inconsistency is intentional rather than an oversight, and is worth a second opinion.

One open question on the wildcard grant: `` `dashboard%` `` also matches any future database beginning with `dashboard`, which is broader than strictly necessary. The alternative is enumerating `dashboard_testing2`…`N`, but `N` varies (`bin/full-suite` uses 4, CI uses 3, and a developer can pass anything), so the wildcard seemed like the more robust choice for a dev environment. Happy to narrow it if you'd rather be explicit.

(PR description written by Claude Code.)
