### PR TITLE
Cut production AI detection over to Pangram 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ stats.json
 # Wikipedia diff URLs with AI-detection scores, and this repo is public; the
 # scripts and their READMEs are committed, the data they read and write is not.
 docs/analytics_scripts/**/*.csv
+# pangram_cutover.py imports analyze.py, so running it compiles a cache there.
+docs/analytics_scripts/**/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ stats.json
 !/fixtures/vcr_cassettes/cached/*
 /backups/
 .ltiaas
+
+# Research data exports under docs/analytics_scripts stay local. Rows pair public
+# Wikipedia diff URLs with AI-detection scores, and this repo is public; the
+# scripts and their READMEs are committed, the data they read and write is not.
+docs/analytics_scripts/**/*.csv

--- a/app/controllers/revision_ai_scores_stats_controller.rb
+++ b/app/controllers/revision_ai_scores_stats_controller.rb
@@ -29,12 +29,14 @@ class RevisionAiScoresStatsController < ApplicationController
     @scores_with_likelihood = @scores.where.not(avg_ai_likelihood: nil)
   end
 
+  # A failed check is stored as a row with nil likelihoods, so the distributions
+  # read the scored rows rather than every row.
   def set_avg_likelihoods
-    @avg_likelihoods = @scores.map { |s| { value: s.avg_ai_likelihood } }
+    @avg_likelihoods = @scores_with_likelihood.map { |s| { value: s.avg_ai_likelihood } }
   end
 
   def set_max_likelihoods
-    @max_likelihoods = @scores.map { |s| { value: s.max_ai_likelihood } }
+    @max_likelihoods = @scores_with_likelihood.map { |s| { value: s.max_ai_likelihood } }
   end
 
   # Sets an array of hashes with date, namespace, and count for historical scores.
@@ -86,6 +88,10 @@ class RevisionAiScoresStatsController < ApplicationController
   # Given arrays of possible namespaces and bins, and a partial array of hashes, returns a complete
   # array of hashes that includes all dates, namespaces and bins based on the partial one.
   def complete_hash(namespaces, bins, partial_stats)
+    # No rows means no date range to fill in. Reachable when every production row
+    # is a failed check, which carries no likelihood to bin.
+    return [] if partial_stats.empty?
+
     start_date = partial_stats.keys.map(&:first).min
     end_date   = partial_stats.keys.map(&:first).max
 

--- a/app/mailer_previews/ai_edit_alert_mailer_preview.rb
+++ b/app/mailer_previews/ai_edit_alert_mailer_preview.rb
@@ -64,17 +64,19 @@ class AiEditAlertMailerPreview < ActionMailer::Preview
 
   def example_alert_details(title)
     { article_title: title,
-      pangram_prediction: 'We are confident that this document is fully AI-generated',
-      headline_result: 'Fully AI Generated',
-      average_ai_likelihood: 0.974378,
-      max_ai_likelihood: 1.0,
+      pangram_prediction: 'We believe that this entire text is AI.',
+      headline_result: 'AI Generated',
+      average_ai_likelihood: 0.99999607,
+      max_ai_likelihood: 0.99999607,
       fraction_human_content: 0.0,
       fraction_ai_content: 1.0,
       fraction_mixed_content: 0.0,
-      window_likelihoods: [1.0, 0.9982278487261604, 0.9959831237792969],
-      predicted_ai_window_count: 3,
+      window_likelihoods: [0.99999607],
+      predicted_ai_window_count: 1,
       pangram_share_link: 'https://www.pangram.com/history/88ba317f-8572-4000-911f-2aa8fbea68fa',
-      pangram_version: '3.0',
+      pangram_version: '4.0',
+      humanized_window_count: 0,
+      max_humanizer_score: 0.00444,
       prior_alert_count_for_course: 0 }
   end
 

--- a/app/mailer_previews/scholars_ai_edit_alert_mailer_preview.rb
+++ b/app/mailer_previews/scholars_ai_edit_alert_mailer_preview.rb
@@ -31,17 +31,19 @@ class ScholarsAiEditAlertMailerPreview < ActionMailer::Preview
 
   def example_alert_details(title)
     { article_title: title,
-      pangram_prediction: 'We are confident that this document is fully AI-generated',
-      headline_result: 'Fully AI Generated',
-      average_ai_likelihood: 0.974378,
-      max_ai_likelihood: 1.0,
+      pangram_prediction: 'We believe that this entire text is AI.',
+      headline_result: 'AI Generated',
+      average_ai_likelihood: 0.99999607,
+      max_ai_likelihood: 0.99999607,
       fraction_human_content: 0.0,
       fraction_ai_content: 1.0,
       fraction_mixed_content: 0.0,
-      window_likelihoods: [1.0, 0.9982278487261604, 0.9959831237792969],
-      predicted_ai_window_count: 3,
+      window_likelihoods: [0.99999607],
+      predicted_ai_window_count: 1,
       pangram_share_link: 'https://www.pangram.com/history/88ba317f-8572-4000-911f-2aa8fbea68fa',
-      pangram_version: '3.0',
+      pangram_version: '4.0',
+      humanized_window_count: 0,
+      max_humanizer_score: 0.00444,
       prior_alert_count_for_course: 0 }
   end
 end

--- a/app/services/build_ai_detection_sample_from_recent_scores.rb
+++ b/app/services/build_ai_detection_sample_from_recent_scores.rb
@@ -8,8 +8,10 @@
 class BuildAiDetectionSampleFromRecentScores < BuildAiDetectionSample
   BANDS = { 'low' => 0.0...0.5, 'mid' => 0.5...0.9, 'high' => 0.9..1.0 }.freeze
 
+  # check_type defaults to whichever detector production alerting currently uses,
+  # so the default follows a cutover instead of silently sampling the old one.
   def initialize(sample_name:, per_band: 40, since: 30.days.ago,
-                 check_type: RevisionAiScore::PANGRAM_V3_KEY, verbose: false)
+                 check_type: CheckRevisionWithPangram::DETECTOR_KEY, verbose: false)
     super(sample_name:, verbose:)
     BANDS.each do |band, range|
       candidates(range, since, check_type).limit(per_band).each { |score| add_score(score, band) }

--- a/app/services/check_revision_with_pangram.rb
+++ b/app/services/check_revision_with_pangram.rb
@@ -26,7 +26,7 @@ class CheckRevisionWithPangram
     return unless fetch_pangram_inference
 
     parse_pangram_response
-    create_revision_ai_score
+    record_successful_check
 
     generate_alert if ai_likely?
   end
@@ -68,36 +68,64 @@ class CheckRevisionWithPangram
   # attempt is recorded, as a row with nil avg_ai_likelihood, which already means
   # "check this revision again" to already_checked?. A failure that a retry could
   # clear is re-raised for Sidekiq to retry, bounded in AiDetectionWorker; one that
-  # a retry would only re-bill is swallowed here.
+  # a retry would only re-bill is swallowed here and reported to Sentry instead,
+  # since a swallowed failure leaves nothing in the Sidekiq dead set to notice.
   def fetch_pangram_inference
     @pangram_result = detector.client.inference @plain_text
   rescue *AiDetector.recoverable_errors => e
     record_failed_check(e)
     raise unless terminal_failure?(e)
 
+    report_terminal_failure(e)
     nil
   end
 
-  # A request the API refused (malformed, out of credit) and a task the API itself
-  # finished in a failed stage will fail the same way however often they are sent.
+  # 4xx statuses a later attempt could clear: the request itself was acceptable,
+  # it just arrived at a bad moment. Every other 4xx is a refusal — malformed
+  # request, bad key, exhausted credits, oversized text — that will repeat.
+  RETRYABLE_STATUSES = [408, 429].freeze
+
+  # A request the API refused and a task the API itself finished in a failed stage
+  # will fail the same way however often they are sent.
   def terminal_failure?(error)
     case error
-    when PangramApi::RequestError then error.status.to_i.between?(400, 499)
+    when PangramApi::RequestError then refused_status?(error.status.to_i)
     when PangramApi::TaskFailed then true
     else false
     end
   end
 
+  def refused_status?(status)
+    status.between?(400, 499) && RETRYABLE_STATUSES.exclude?(status)
+  end
+
+  # Nothing retries a terminal failure, so this is the only operator-facing signal
+  # that checks are failing. Exhausted credits stop production alerting entirely.
+  def report_terminal_failure(error)
+    Sentry.capture_exception(error, level: 'warning',
+                                    extra: { revision_id: @mw_rev_id,
+                                             course_id: @course_id,
+                                             detector: DETECTOR_KEY })
+  end
+
   # already_checked? guarantees no successful production row exists for this
   # revision, so repeated failures update one row instead of accumulating.
   def record_failed_check(error)
-    score = RevisionAiScore.find_or_initialize_by(
+    production_score.update!(
+      course_id: @course_id, user_id: @user_id, revision_datetime: @rev_datetime,
+      avg_ai_likelihood: nil, max_ai_likelihood: nil,
+      details: { 'error' => error.class.name, 'message' => error.message }
+    )
+  end
+
+  # The one production row for this revision under this detector. A retryable
+  # failure records itself here first, so a later success must update that row
+  # rather than add a second one alongside it.
+  def production_score
+    RevisionAiScore.find_or_initialize_by(
       revision_id: @mw_rev_id, wiki_id: @wiki.id, article_id: @article.id,
       check_type: DETECTOR_KEY, check_origin: RevisionAiScore::COURSE_UPDATE_ORIGIN
     )
-    score.update(course_id: @course_id, user_id: @user_id, revision_datetime: @rev_datetime,
-                 avg_ai_likelihood: nil, max_ai_likelihood: nil,
-                 details: { 'error' => error.class.name, 'message' => error.message })
   end
 
   def parse_pangram_response
@@ -129,18 +157,14 @@ class CheckRevisionWithPangram
     AiEditAlert.exists?(revision_id: @mw_rev_id)
   end
 
-  # Imports data into the RevisionAiScores table
-  def create_revision_ai_score
-    RevisionAiScore.create(revision_id: @mw_rev_id,
-                           wiki_id: @wiki.id,
-                           article_id:  @article.id,
-                           course_id: @course_id,
-                           user_id: @user_id,
-                           revision_datetime: @rev_datetime,
-                           avg_ai_likelihood: @parser.average_ai_likelihood,
-                           max_ai_likelihood: @parser.max_ai_likelihood,
-                           details: @parser.clean_result,
-                           check_type: DETECTOR_KEY,
-                           check_origin: RevisionAiScore::COURSE_UPDATE_ORIGIN)
+  # Imports the scored result into the RevisionAiScores table, over any failure row
+  # an earlier attempt at this revision left behind.
+  def record_successful_check
+    production_score.update!(course_id: @course_id,
+                             user_id: @user_id,
+                             revision_datetime: @rev_datetime,
+                             avg_ai_likelihood: @parser.average_ai_likelihood,
+                             max_ai_likelihood: @parser.max_ai_likelihood,
+                             details: @parser.clean_result)
   end
 end

--- a/app/services/check_revision_with_pangram.rb
+++ b/app/services/check_revision_with_pangram.rb
@@ -4,7 +4,7 @@ require_dependency "#{Rails.root}/lib/ai/ai_detector"
 
 class CheckRevisionWithPangram
   # The detector used for production alerting. Changing this key is the cutover.
-  DETECTOR_KEY = RevisionAiScore::PANGRAM_V3_KEY
+  DETECTOR_KEY = RevisionAiScore::PANGRAM_V4_KEY
 
   def initialize(attrs)
     @wiki = Wiki.find attrs['wiki_id']
@@ -23,7 +23,8 @@ class CheckRevisionWithPangram
     # Skip the API call if the plain text is too short.
     return if @plain_text.nil?
     return if @plain_text.length < MIN_PLAIN_TEXT_LENGTH
-    fetch_pangram_inference
+    return unless fetch_pangram_inference
+
     parse_pangram_response
     create_revision_ai_score
 
@@ -43,11 +44,19 @@ class CheckRevisionWithPangram
   # where the details field is not nil.
   # A nil avg_ai_likelihood field may indicate an error occurred when calling the API, so we want
   # to retrieve it again.
+  # Only production rows count. Detector comparison samples and the admin AI tools page write
+  # rows for revisions production may not have checked yet, and without this filter such a row
+  # would suppress the production check and its alert. check_type is deliberately not filtered:
+  # a revision already scored with Pangram 3 stays checked and is not re-billed under Pangram 4.
+  # NULL is included because check_origin was added in March 2026 and never backfilled; every
+  # earlier row with an article_id came from a production check.
+  PRODUCTION_ORIGINS = [nil, RevisionAiScore::COURSE_UPDATE_ORIGIN].freeze
   def already_checked?
     RevisionAiScore.where(
       revision_id: @mw_rev_id,
       wiki_id: @wiki.id,
-      article_id: @article.id
+      article_id: @article.id,
+      check_origin: PRODUCTION_ORIGINS
     ).where.not(avg_ai_likelihood: nil).exists?
   end
 
@@ -55,8 +64,40 @@ class CheckRevisionWithPangram
     AiDetector.for(DETECTOR_KEY)
   end
 
+  # Returns the raw detector result, or nil when the call failed. Either way the
+  # attempt is recorded, as a row with nil avg_ai_likelihood, which already means
+  # "check this revision again" to already_checked?. A failure that a retry could
+  # clear is re-raised for Sidekiq to retry, bounded in AiDetectionWorker; one that
+  # a retry would only re-bill is swallowed here.
   def fetch_pangram_inference
     @pangram_result = detector.client.inference @plain_text
+  rescue *AiDetector.recoverable_errors => e
+    record_failed_check(e)
+    raise unless terminal_failure?(e)
+
+    nil
+  end
+
+  # A request the API refused (malformed, out of credit) and a task the API itself
+  # finished in a failed stage will fail the same way however often they are sent.
+  def terminal_failure?(error)
+    case error
+    when PangramApi::RequestError then error.status.to_i.between?(400, 499)
+    when PangramApi::TaskFailed then true
+    else false
+    end
+  end
+
+  # already_checked? guarantees no successful production row exists for this
+  # revision, so repeated failures update one row instead of accumulating.
+  def record_failed_check(error)
+    score = RevisionAiScore.find_or_initialize_by(
+      revision_id: @mw_rev_id, wiki_id: @wiki.id, article_id: @article.id,
+      check_type: DETECTOR_KEY, check_origin: RevisionAiScore::COURSE_UPDATE_ORIGIN
+    )
+    score.update(course_id: @course_id, user_id: @user_id, revision_datetime: @rev_datetime,
+                 avg_ai_likelihood: nil, max_ai_likelihood: nil,
+                 details: { 'error' => error.class.name, 'message' => error.message })
   end
 
   def parse_pangram_response

--- a/app/workers/ai_detection_worker.rb
+++ b/app/workers/ai_detection_worker.rb
@@ -4,7 +4,10 @@ require_dependency "#{Rails.root}/app/services/check_revision_with_pangram"
 
 class AiDetectionWorker
   include Sidekiq::Worker
-  sidekiq_options lock: :until_executed
+  # A detector call bills on every attempt, so retries are bounded well below
+  # Sidekiq's default of 25. CheckRevisionWithPangram does not raise for failures
+  # a retry cannot clear, so those never consume an attempt.
+  sidekiq_options lock: :until_executed, retry: 3
 
   def self.schedule_check(wiki:, revision:, course:)
     # revision object is a RevisionOnMemory and sidekiq good practices

--- a/docs/analytics_scripts/ai_usage_research/detector_comparison/README.md
+++ b/docs/analytics_scripts/ai_usage_research/detector_comparison/README.md
@@ -173,6 +173,28 @@ detector's verdict, a list of self-reported false positives a detector still fla
 a human to confirm, never taken as truth), a slope chart for `--pair-by`, a wide CSV of
 max scores, and `summary.md` with the tables.
 
+### Cutover questions
+
+`pangram_cutover.py` answers what changes for production alerting if the detector behind
+`CheckRevisionWithPangram` moves from one registry key to another. It needs a sample built
+by `BuildAiDetectionSampleFromRecentScores` (its units carry the production score and band
+in `metadata`) and the production population per band, which defaults to the September
+2026 preflight counts:
+
+```sh
+.venv/bin/python pangram_cutover.py ~/detector_comparison_2026-09.csv --out ~/detector_results/cutover \
+    --old "Pangram 3" --new "Pangram 4" --recent-sample recent_2026_09 \
+    --population low=12558 mid=770 high=1305 --checks-per-month 2400
+```
+
+Output: positive rate per production band for both detectors, reweighted into a projected
+alert rate (and alerts per month when `--checks-per-month` is given); the old detector's
+fresh score against the stored production score, which measures run-to-run noise; threshold
+transitions (both positive, old only, new only, neither) per sample and old model version;
+humanized-window counts and the score distribution per document label; words per window for
+each detector; baseline false-positive rate per model version; and `cutover_summary.md`
+with the tables.
+
 ## Adding a detector
 
 1. A client class in `lib/` with `#inference(text)` returning the parsed response, raising

--- a/docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/analyze.py
+++ b/docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/analyze.py
@@ -458,7 +458,9 @@ def rate(series):
 def markdown(table):
     if table is None or table.empty:
         return "_none_\n"
-    return table.to_markdown(index=False, floatfmt=".3f") + "\n"
+    # Object dtype keeps integer counts as integers; an all-numeric frame would otherwise
+    # reach tabulate as one float array and print 58 as 58.000.
+    return table.astype(object).to_markdown(index=False, floatfmt=".3f") + "\n"
 
 
 def main():

--- a/docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/pangram_cutover.py
+++ b/docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/pangram_cutover.py
@@ -46,6 +46,7 @@ BANDS = ["low", "mid", "high"]
 BAND_LABELS = {"low": "low (< 0.5)", "mid": "mid (0.5–0.9)", "high": "high (≥ 0.9)"}
 # Production Pangram 3 checks since 2026-01-01 by band, from the 2026-09-04 preflight.
 DEFAULT_POPULATION = {"low": 12558, "mid": 770, "high": 1305}
+DEFAULT_POPULATION_DATE = "2026-09-04"
 # Document labels take the palette slots after the detectors so a label keeps its hue
 # across charts. The pink slot is under 3:1 on the light surface, so label lines are
 # always direct-labeled and every label chart has a table beside it in the summary.
@@ -64,14 +65,23 @@ def parse_metadata(value):
 
 
 def parse_population(items):
+    """Band counts and their shares, plus which bands came from --population.
+
+    Partial input is merged over DEFAULT_POPULATION, so a fresh count for one band
+    is combined with preflight counts for the others. The headline output of this
+    script is a rate reweighted by these shares, so the provenance of each band
+    travels with them and is printed in the summary.
+    """
     population = dict(DEFAULT_POPULATION)
+    given = set()
     for item in items or []:
         band, _, count = item.partition("=")
         if band not in BANDS or not count.isdigit():
             sys.exit(f"--population expects band=count with band in {BANDS}, got {item!r}")
         population[band] = int(count)
+        given.add(band)
     total = sum(population.values())
-    return population, {band: population[band] / total for band in BANDS}
+    return population, {band: population[band] / total for band in BANDS}, given
 
 
 def per_detector(df, detector):
@@ -363,7 +373,8 @@ def main():
     parser.add_argument("--recent-sample", default="recent_2026_09",
                         help="sample built by BuildAiDetectionSampleFromRecentScores (has band metadata)")
     parser.add_argument("--population", nargs="*", metavar="BAND=COUNT",
-                        help="production checks per band for reweighting; defaults to the 2026-09-04 preflight")
+                        help="production checks per band for reweighting; any band left out "
+                             "keeps its 2026-09-04 preflight count, marked [default] in the summary")
     parser.add_argument("--checks-per-month", type=float,
                         help="production checks per month, to express projected rates as alerts per month")
     parser.add_argument("--baseline-provenance", default="pre_llm_term")
@@ -377,7 +388,7 @@ def main():
     meta = df["metadata"].map(parse_metadata)
     df["band"] = meta.map(lambda m: m.get("band"))
     df["source_max"] = pd.to_numeric(meta.map(lambda m: m.get("source_max_ai_likelihood")), errors="coerce")
-    population, shares = parse_population(args.population)
+    population, shares, given_bands = parse_population(args.population)
     detectors = [args.old, args.new]
     recent = df[df["sample_name"] == args.recent_sample] if args.recent_sample else df[df["band"].notna()]
 
@@ -408,7 +419,13 @@ def main():
 
     baseline = baseline_by_version(df)
 
-    population_text = ", ".join(f"{b} {population[b]:,} ({shares[b]:.1%})" for b in BANDS)
+    population_text = ", ".join(
+        f"{b} {population[b]:,} ({shares[b]:.1%}){'' if b in given_bands else ' [default]'}"
+        for b in BANDS
+    )
+    if given_bands and given_bands != set(BANDS):
+        print(f"--population supplied for {sorted(given_bands)}; "
+              f"{sorted(set(BANDS) - given_bands)} use the {DEFAULT_POPULATION_DATE} preflight counts.")
     summary = [
         "# Detector cutover analysis\n",
         f"Source: `{args.export_csv}`; old detector: {args.old}; new detector: {args.new}; "

--- a/docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/pangram_cutover.py
+++ b/docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/pangram_cutover.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Detector cutover analysis on a long-format export from ExportAiDetectionComparison.
+
+    python pangram_cutover.py export.csv --out results/cutover [--threshold 0.9]
+                              [--old "Pangram 3"] [--new "Pangram 4"]
+                              [--recent-sample recent_2026_09]
+                              [--population low=12558 mid=770 high=1305]
+                              [--checks-per-month 600]
+
+Companion to analyze.py for the questions that decide whether production alerting can
+move from one detector (--old) to another (--new). analyze.py compares detectors on
+equal terms; this script asks what changes for the alert pipeline:
+
+1. Positive rate per production score band on the recent sample, reweighted by the
+   production population of each band (--population, counts of production checks) into
+   a projected alert rate for each detector, and per month with --checks-per-month.
+2. Reproducibility of the old detector: its fresh score against the production score
+   stored in the unit's metadata (source_max_ai_likelihood). Run-to-run noise bounds how
+   much old-vs-new difference is meaningful.
+3. Transitions at the threshold (both positive, old only, new only, neither) per sample
+   and old model version.
+4. Signals only the new detector reports: humanized windows, and the score distribution
+   of each document label (whether "Mixed" stays under the threshold).
+5. Window geometry: words per window for each detector.
+6. Baseline false-positive rate per detector and model version.
+
+Positive means max window score above --threshold, the production rule. Failed rows
+and rows without a score are dropped as in analyze.py. Writes CSVs, PNG charts and
+cutover_summary.md to --out.
+"""
+import argparse
+import json
+import pathlib
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import analyze as az  # noqa: E402
+
+BANDS = ["low", "mid", "high"]
+BAND_LABELS = {"low": "low (< 0.5)", "mid": "mid (0.5–0.9)", "high": "high (≥ 0.9)"}
+# Production Pangram 3 checks since 2026-01-01 by band, from the 2026-09-04 preflight.
+DEFAULT_POPULATION = {"low": 12558, "mid": 770, "high": 1305}
+# Document labels take the palette slots after the detectors so a label keeps its hue
+# across charts. The pink slot is under 3:1 on the light surface, so label lines are
+# always direct-labeled and every label chart has a table beside it in the summary.
+LABEL_COLORS = {"AI": az.PALETTE[4], "Mixed": az.PALETTE[5], "Human": az.PALETTE[6]}
+REFERENCE_WORDS_PER_WINDOW = 400  # the segment size the alert emails describe
+
+
+def parse_metadata(value):
+    if not isinstance(value, str) or not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def parse_population(items):
+    population = dict(DEFAULT_POPULATION)
+    for item in items or []:
+        band, _, count = item.partition("=")
+        if band not in BANDS or not count.isdigit():
+            sys.exit(f"--population expects band=count with band in {BANDS}, got {item!r}")
+        population[band] = int(count)
+    total = sum(population.values())
+    return population, {band: population[band] / total for band in BANDS}
+
+
+def per_detector(df, detector):
+    """One row per unit for a detector; a re-scored unit keeps its latest row."""
+    return df[df["check_type"] == detector].sort_values("score_id").drop_duplicates("unit_id", keep="last")
+
+
+# 1. Positive rate per band, reweighted by the production population.
+
+def band_table(recent, old, new, shares):
+    rows = []
+    for band in BANDS:
+        units = recent[recent["band"] == band]
+        o = per_detector(units, old)["positive"]
+        n = per_detector(units, new)["positive"]
+        rows.append({"band": band, "population_share": round(shares[band], 3),
+                     "old_units": len(o), "old_rate": az.rate(o),
+                     "new_units": len(n), "new_rate": az.rate(n),
+                     "new_minus_old": None if o.empty or n.empty else round(float(n.mean() - o.mean()), 3)})
+    return pd.DataFrame(rows)
+
+
+def projection_table(table, shares, old, new, checks_per_month):
+    def weighted(column):
+        pairs = [(shares[b], r) for b, r in zip(table["band"], table[column]) if pd.notna(r)]
+        return sum(s * r for s, r in pairs) if pairs else None
+
+    rows = [{"detector": "production stored scores (band shares)", "projected_positive_rate": round(shares["high"], 4)},
+            {"detector": f"{old} (fresh)", "projected_positive_rate": weighted("old_rate")},
+            {"detector": f"{new} (fresh)", "projected_positive_rate": weighted("new_rate")}]
+    for row in rows:
+        rate = row["projected_positive_rate"]
+        row["projected_positive_rate"] = None if rate is None else round(rate, 4)
+        if checks_per_month is not None and rate is not None:
+            row["projected_per_month"] = round(rate * checks_per_month, 1)
+    old_rate, new_rate = rows[1]["projected_positive_rate"], rows[2]["projected_positive_rate"]
+    ratio = None if not old_rate or new_rate is None else round(new_rate / old_rate, 3)
+    return pd.DataFrame(rows), ratio
+
+
+def chart_band_rates(table, old, new, out):
+    fig, ax = plt.subplots(figsize=(6.5, 4), facecolor=az.SURFACE)
+    positions = range(len(BANDS))
+    width = 0.36
+    for offset, detector, column in ((-width / 2, old, "old_rate"), (width / 2, new, "new_rate")):
+        values = [0 if pd.isna(v) else float(v) for v in table[column]]
+        bars = ax.bar([p + offset for p in positions], values, width=width - 0.03,
+                      color=az.color_for(detector), label=detector)
+        for bar, value in zip(bars, table[column]):
+            if pd.isna(value):
+                continue
+            ax.annotate(f"{value:.0%}", (bar.get_x() + bar.get_width() / 2, bar.get_height()),
+                        xytext=(0, 3), textcoords="offset points", ha="center", fontsize=9, color=az.INK)
+    ax.set_xticks(list(positions))
+    ax.set_xticklabels([BAND_LABELS[b] for b in BANDS])
+    ax.set_ylim(0, 1.1)
+    ax.set_ylabel("share of units above threshold", color=az.INK_SOFT)
+    ax.set_xlabel("production score band of the same edit", color=az.INK_SOFT)
+    ax.set_title("Positive rate by production score band", loc="left", color=az.INK, fontsize=12)
+    ax.legend(frameon=False, fontsize=9, labelcolor=az.INK, loc="upper left")
+    az.style(ax, percent=True)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+
+
+# 2. Reproducibility of the old detector against the stored production score.
+
+def reproducibility(recent, old, threshold):
+    d = per_detector(recent, old)
+    d = d[d["source_max"].notna()].copy()
+    if d.empty:
+        return pd.DataFrame(), pd.DataFrame()
+    d["diff"] = d["max_score"] - d["source_max"]
+    d["abs_diff"] = d["diff"].abs()
+    d["source_positive"] = d["source_max"] > threshold
+    d["crossed"] = d["positive"] != d["source_positive"]
+    stats = pd.DataFrame([{
+        "units": len(d),
+        "mean_abs_diff": round(float(d["abs_diff"].mean()), 4),
+        "median_abs_diff": round(float(d["abs_diff"].median()), 4),
+        "p95_abs_diff": round(float(d["abs_diff"].quantile(0.95)), 4),
+        "max_abs_diff": round(float(d["abs_diff"].max()), 4),
+        "share_abs_diff_over_0_1": round(float((d["abs_diff"] > 0.1).mean()), 3),
+        "crossed_threshold": int(d["crossed"].sum()),
+        "crossed_up": int((d["positive"] & ~d["source_positive"]).sum()),
+        "crossed_down": int((~d["positive"] & d["source_positive"]).sum()),
+        "pearson_r": round(float(d["max_score"].corr(d["source_max"])), 4),
+    }])
+    per_unit = (d[["unit_id", "url", "band", "source_max", "max_score", "diff", "crossed", "report_url"]]
+                .rename(columns={"max_score": "fresh_max"})
+                .sort_values("diff", key=lambda s: s.abs(), ascending=False))
+    return stats, per_unit
+
+
+def chart_reproducibility(per_unit, old, threshold, out):
+    fig, ax = plt.subplots(figsize=(5.5, 5.5), facecolor=az.SURFACE)
+    ax.plot([0, 1], [0, 1], color=az.GRID, linewidth=1)
+    ax.scatter(per_unit["source_max"], per_unit["fresh_max"], s=36, color=az.color_for(old), alpha=0.7,
+               edgecolors=az.SURFACE, linewidths=1)
+    for line in (ax.axhline, ax.axvline):
+        line(threshold, color=az.INK_SOFT, linewidth=1, linestyle=":")
+    ax.set_xlim(-0.02, 1.02)
+    ax.set_ylim(-0.02, 1.02)
+    ax.set_xlabel("production max window score (stored)", color=az.INK_SOFT)
+    ax.set_ylabel("fresh max window score", color=az.INK_SOFT)
+    ax.set_title(f"{old}: fresh vs stored production score (n={len(per_unit)})",
+                 loc="left", color=az.INK, fontsize=11)
+    az.style(ax)
+    ax.xaxis.grid(True, color=az.GRID, linewidth=0.8)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+
+
+# 3. Transitions at the threshold.
+
+def transitions(df, old, new):
+    o = per_detector(df, old).set_index("unit_id")
+    n = per_detector(df, new).set_index("unit_id")
+    both = o.index.intersection(n.index)
+    if both.empty:
+        return pd.DataFrame()
+    frame = pd.DataFrame({"sample_name": o.loc[both, "sample_name"],
+                          "old_model_version": o.loc[both, "model_version"].fillna("").astype(str),
+                          "old": o.loc[both, "positive"].astype(bool), "new": n.loc[both, "positive"].astype(bool)})
+    rows = []
+    groups = list(frame.groupby(["sample_name", "old_model_version"], sort=True)) + [(("all samples", ""), frame)]
+    for (sample, version), g in groups:
+        rows.append({"sample_name": sample, "old_model_version": version, "units": len(g),
+                     "both_positive": int((g["old"] & g["new"]).sum()),
+                     "old_only": int((g["old"] & ~g["new"]).sum()),
+                     "new_only": int((~g["old"] & g["new"]).sum()),
+                     "neither": int((~g["old"] & ~g["new"]).sum())})
+    return pd.DataFrame(rows)
+
+
+# 4. Signals only the new detector reports.
+
+def humanizer_tables(df, new):
+    d = per_detector(df, new).copy()
+    d["humanized_window_count"] = pd.to_numeric(d["humanized_window_count"], errors="coerce")
+    d["max_humanizer_score"] = pd.to_numeric(d["max_humanizer_score"], errors="coerce")
+    reported = d[d["humanized_window_count"].notna()]
+    if reported.empty:
+        return pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
+    per_sample = (reported.groupby("sample_name")
+                  .agg(units=("unit_id", "size"),
+                       humanized_units=("humanized_window_count", lambda s: int((s > 0).sum())),
+                       humanized_windows=("humanized_window_count", lambda s: int(s.sum())),
+                       max_humanizer_score=("max_humanizer_score", "max"))
+                  .reset_index())
+    scores = reported["max_humanizer_score"].dropna()
+    distribution = pd.DataFrame([{"units": len(scores),
+                                  "median": round(float(scores.median()), 4),
+                                  "p90": round(float(scores.quantile(0.9)), 4),
+                                  "p99": round(float(scores.quantile(0.99)), 4),
+                                  "max": round(float(scores.max()), 4)}]) if not scores.empty else pd.DataFrame()
+    flagged = reported[reported["humanized_window_count"] > 0]
+    units = flagged[["sample_name", "unit_id", "url", "ground_truth", "provenance", "max_score",
+                     "humanized_window_count", "max_humanizer_score", "report_url"]]
+    return per_sample, distribution, units.sort_values("max_humanizer_score", ascending=False)
+
+
+def label_table(df, detectors):
+    rows = []
+    for detector in detectors:
+        d = per_detector(df, detector)
+        d = d.assign(label=d["label"].fillna("(none)").astype(str),
+                     fraction_mixed=pd.to_numeric(d["fraction_mixed"], errors="coerce"))
+        for label, g in d.groupby("label", sort=True):
+            rows.append({"detector": detector, "label": label, "units": len(g),
+                         "share_above_threshold": az.rate(g["positive"]),
+                         "median_max_score": round(float(g["max_score"].median()), 3),
+                         "p90_max_score": round(float(g["max_score"].quantile(0.9)), 3),
+                         "max_max_score": round(float(g["max_score"].max()), 3),
+                         "mean_fraction_mixed": None if g["fraction_mixed"].isna().all()
+                         else round(float(g["fraction_mixed"].mean()), 3)})
+    return pd.DataFrame(rows)
+
+
+def chart_label_distributions(df, detectors, threshold, out):
+    fig, axes = plt.subplots(1, len(detectors), figsize=(4.5 * len(detectors), 4), sharey=True,
+                             facecolor=az.SURFACE, squeeze=False)
+    for ax, detector in zip(axes[0], detectors):
+        d = per_detector(df, detector)
+        labels = sorted(d["label"].fillna("(none)").astype(str).unique(),
+                        key=lambda l: (list(LABEL_COLORS).index(l) if l in LABEL_COLORS else 99, l))
+        placed = []  # (x, y) of direct labels already drawn on this panel
+        for label in labels:
+            subset = d[d["label"].fillna("(none)").astype(str) == label]["max_score"]
+            if subset.empty:
+                continue
+            xs, ys = az.ecdf(subset)
+            color = LABEL_COLORS.get(label, az.PALETTE[-1])
+            ax.step(xs, ys, where="post", color=color, linewidth=2, label=f"{label} (n={len(subset)})")
+            # Direct label beside the curve at its median. Labels usually live in different
+            # score ranges; when two curves share one, the later label is stacked above.
+            median_x = float(subset.median())
+            left_side = median_x > 0.8
+            y = 0.5
+            for px, py in placed:
+                if abs(px - median_x) < 0.2 and abs(py - y) < 0.08:
+                    y = py + 0.09
+            placed.append((median_x, y))
+            ax.annotate(label, (median_x, y), xytext=(-8 if left_side else 8, 0), textcoords="offset points",
+                        ha="right" if left_side else "left", va="center", fontsize=8, color=az.INK)
+        ax.axvline(threshold, color=az.INK_SOFT, linewidth=1, linestyle=":")
+        ax.set_title(f"{detector}: max score by document label", loc="left", fontsize=10, color=az.INK)
+        ax.set_xlabel("max window score", color=az.INK_SOFT)
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, 1.08)
+        ax.legend(frameon=False, fontsize=8, loc="upper left", labelcolor=az.INK)
+        az.style(ax, percent=True)
+    axes[0][0].set_ylabel("share of units at or below score", color=az.INK_SOFT)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+
+
+# 5. Window geometry.
+
+def window_geometry(df, detectors):
+    frames = []
+    rows = []
+    for detector in detectors:
+        d = per_detector(df, detector).copy()
+        d["window_count"] = pd.to_numeric(d["window_count"], errors="coerce")
+        d = d[(d["window_count"] > 0) & d["word_count"].notna()]
+        if d.empty:
+            continue
+        d["words_per_window"] = d["word_count"] / d["window_count"]
+        frames.append(d)
+        rows.append({"detector": detector, "units": len(d),
+                     "median_words_per_window": round(float(d["words_per_window"].median()), 1),
+                     "q1_words_per_window": round(float(d["words_per_window"].quantile(0.25)), 1),
+                     "q3_words_per_window": round(float(d["words_per_window"].quantile(0.75)), 1),
+                     "single_window_share": az.rate(d["window_count"] == 1),
+                     "median_window_count": float(d["window_count"].median())})
+    geometry = pd.concat(frames) if frames else pd.DataFrame()
+    return pd.DataFrame(rows), geometry
+
+
+def chart_window_geometry(geometry, detectors, out):
+    fig, ax = plt.subplots(figsize=(6.5, 4.5), facecolor=az.SURFACE)
+    x_max = float(geometry["word_count"].quantile(0.99))
+    for detector in detectors:
+        d = geometry[(geometry["check_type"] == detector) & (geometry["word_count"] <= x_max)]
+        if d.empty:
+            continue
+        ax.scatter(d["word_count"], d["window_count"], s=24, color=az.color_for(detector), alpha=0.6,
+                   edgecolors=az.SURFACE, linewidths=0.8, label=f"{detector} (n={len(d)})")
+    ax.plot([0, x_max], [0, x_max / REFERENCE_WORDS_PER_WINDOW], color=az.INK_SOFT, linewidth=1, linestyle=":")
+    ax.annotate(f"{REFERENCE_WORDS_PER_WINDOW} words per window", (x_max, x_max / REFERENCE_WORDS_PER_WINDOW),
+                xytext=(-4, 4), textcoords="offset points", ha="right", fontsize=8, color=az.INK_SOFT)
+    ax.set_xlim(0, x_max * 1.02)
+    ax.set_ylim(0, None)
+    ax.set_xlabel("words sent (units above the 99th percentile omitted)", color=az.INK_SOFT)
+    ax.set_ylabel("windows returned", color=az.INK_SOFT)
+    ax.set_title("Window geometry", loc="left", color=az.INK, fontsize=12)
+    ax.legend(frameon=False, fontsize=9, labelcolor=az.INK, loc="upper left")
+    az.style(ax)
+    ax.xaxis.grid(True, color=az.GRID, linewidth=0.8)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+
+
+# 6. Baseline false positives by model version.
+
+def baseline_by_version(df):
+    base = df[df["baseline"]]
+    rows = []
+    for (detector, version), g in base.groupby(["check_type", base["model_version"].fillna("").astype(str)], sort=True):
+        rows.append({"detector": detector, "model_version": version, "baseline_units": len(g),
+                     "false_positives": int(g["positive"].sum()), "false_positive_rate": az.rate(g["positive"]),
+                     "p99_max_score": round(float(g["max_score"].quantile(0.99)), 3),
+                     "max_max_score": round(float(g["max_score"].max()), 3)})
+    return pd.DataFrame(rows)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("export_csv")
+    parser.add_argument("--out", default="results/cutover")
+    parser.add_argument("--threshold", type=float, default=0.9)
+    parser.add_argument("--old", default="Pangram 3", help="detector production alerting uses now")
+    parser.add_argument("--new", default="Pangram 4", help="detector it would move to")
+    parser.add_argument("--recent-sample", default="recent_2026_09",
+                        help="sample built by BuildAiDetectionSampleFromRecentScores (has band metadata)")
+    parser.add_argument("--population", nargs="*", metavar="BAND=COUNT",
+                        help="production checks per band for reweighting; defaults to the 2026-09-04 preflight")
+    parser.add_argument("--checks-per-month", type=float,
+                        help="production checks per month, to express projected rates as alerts per month")
+    parser.add_argument("--baseline-provenance", default="pre_llm_term")
+    args = parser.parse_args()
+
+    out = pathlib.Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    df, failed = az.load(args.export_csv, None, None, args.baseline_provenance, args.threshold, "max")
+    if df.empty:
+        sys.exit("no scored rows")
+    meta = df["metadata"].map(parse_metadata)
+    df["band"] = meta.map(lambda m: m.get("band"))
+    df["source_max"] = pd.to_numeric(meta.map(lambda m: m.get("source_max_ai_likelihood")), errors="coerce")
+    population, shares = parse_population(args.population)
+    detectors = [args.old, args.new]
+    recent = df[df["sample_name"] == args.recent_sample] if args.recent_sample else df[df["band"].notna()]
+
+    bands = band_table(recent, args.old, args.new, shares)
+    bands.to_csv(out / "band_rates.csv", index=False)
+    projection, ratio = projection_table(bands, shares, args.old, args.new, args.checks_per_month)
+    if bands[["old_rate", "new_rate"]].notna().any().any():
+        chart_band_rates(bands, args.old, args.new, out / "band_rates.png")
+
+    repro_stats, repro_units = reproducibility(recent, args.old, args.threshold)
+    if not repro_units.empty:
+        repro_units.to_csv(out / "reproducibility.csv", index=False)
+        chart_reproducibility(repro_units, args.old, args.threshold, out / "reproducibility.png")
+
+    moves = transitions(df, args.old, args.new)
+    moves.to_csv(out / "transitions.csv", index=False)
+
+    humanized_by_sample, humanizer_distribution, humanized_units = humanizer_tables(df, args.new)
+    humanized_units.to_csv(out / "humanized_units.csv", index=False)
+    labels = label_table(df, detectors)
+    if not labels.empty:
+        chart_label_distributions(df, [d for d in detectors if (df["check_type"] == d).any()],
+                                  args.threshold, out / "label_score_distributions.png")
+
+    geometry_table, geometry = window_geometry(df, detectors)
+    if not geometry.empty:
+        chart_window_geometry(geometry, detectors, out / "window_geometry.png")
+
+    baseline = baseline_by_version(df)
+
+    population_text = ", ".join(f"{b} {population[b]:,} ({shares[b]:.1%})" for b in BANDS)
+    summary = [
+        "# Detector cutover analysis\n",
+        f"Source: `{args.export_csv}`; old detector: {args.old}; new detector: {args.new}; "
+        f"positive rule: max window score > {args.threshold}; scored rows: {len(df)}; failed rows dropped: {failed}.\n",
+        f"\n## 1. Positive rate by production band (sample `{args.recent_sample}`)\n",
+        f"Population weights (production checks per band): {population_text}.\n\n",
+        az.markdown(bands),
+        "\nProjected positive rate over the production population, and the ratio of new to old:\n\n",
+        az.markdown(projection),
+        f"\nnew / old ratio: {ratio}\n" if ratio is not None else "",
+        f"\n## 2. {args.old} reproducibility (fresh vs stored production score)\n",
+        az.markdown(repro_stats),
+        f"{len(repro_units)} units in reproducibility.csv, largest differences first.\n" if not repro_units.empty else "",
+        "\n## 3. Transitions at the threshold\n", az.markdown(moves),
+        f"\n## 4. Signals only {args.new} reports\n",
+        "\nHumanized windows per sample:\n\n", az.markdown(humanized_by_sample),
+        "\nDistribution of max humanizer score across units that report one:\n\n", az.markdown(humanizer_distribution),
+        f"\n{len(humanized_units)} units with at least one humanized window in humanized_units.csv.\n",
+        "\nScore distribution by document label:\n\n", az.markdown(labels),
+        "\n## 5. Window geometry\n", az.markdown(geometry_table),
+        "\n## 6. Baseline false positives by model version\n", az.markdown(baseline),
+        "\nCharts: band_rates.png, reproducibility.png, label_score_distributions.png, window_geometry.png. "
+        "Data: band_rates.csv, reproducibility.csv, transitions.csv, humanized_units.csv.\n",
+    ]
+    (out / "cutover_summary.md").write_text("".join(summary))
+    print("\n".join(str(p) for p in sorted(out.iterdir())))
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/requests/revision_ai_scores_stats_spec.rb
+++ b/spec/requests/revision_ai_scores_stats_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the JSON the stats page graphs read. A failed detector check is stored as
+# a production row with nil likelihoods, so the distributions must not carry it.
+describe 'revision AI scores stats JSON', type: :request do
+  let(:admin) { create(:admin) }
+  let(:wiki) { Wiki.get_or_create(project: 'wikipedia', language: 'en') }
+  let(:course) { create(:course) }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, title: 'Hockey') }
+
+  before { login_as admin }
+
+  def json
+    get '/revision_ai_scores_stats.json'
+    JSON.parse(response.body)
+  end
+
+  it 'includes a scored production row in both distributions' do
+    create(:revision_ai_score, revision_id: 1, wiki_id: wiki.id, course_id: course.id,
+           user_id: user.id, article:, avg_ai_likelihood: 0.3, max_ai_likelihood: 0.4,
+           check_origin: RevisionAiScore::COURSE_UPDATE_ORIGIN)
+
+    expect(json['avg_likelihoods']).to eq([{ 'value' => 0.3 }])
+    expect(json['max_likelihoods']).to eq([{ 'value' => 0.4 }])
+  end
+
+  it 'renders with no scored rows at all' do
+    expect(json['avg_likelihoods']).to eq([])
+    expect(json['historical_scores_by_namespace']).to eq([])
+  end
+
+  it 'omits a failed check, which has no likelihood to distribute' do
+    create(:revision_ai_score, revision_id: 2, wiki_id: wiki.id, course_id: course.id,
+           user_id: user.id, article:, avg_ai_likelihood: nil, max_ai_likelihood: nil,
+           check_origin: RevisionAiScore::COURSE_UPDATE_ORIGIN,
+           details: { 'error' => 'PangramApi::RequestError', 'message' => 'out of credit' })
+
+    expect(json['avg_likelihoods']).to eq([])
+    expect(json['max_likelihoods']).to eq([])
+  end
+end

--- a/spec/services/build_ai_detection_sample_from_recent_scores_spec.rb
+++ b/spec/services/build_ai_detection_sample_from_recent_scores_spec.rb
@@ -9,10 +9,13 @@ describe BuildAiDetectionSampleFromRecentScores do
   let(:campaign) { create(:campaign, slug: 'fall_2026') }
   let(:article) { create(:article, namespace: 2, wiki_id: enwiki.id) }
 
+  # The builder samples whichever detector production alerting uses, so these
+  # rows follow that constant rather than naming a model that may be cut over.
   def production_score(rev_id, max, created_at: 1.day.ago, origin: 'course_update')
     RevisionAiScore.create!(revision_id: rev_id, wiki_id: enwiki.id, article_id: article.id,
                             course_id: course.id, max_ai_likelihood: max, avg_ai_likelihood: max,
-                            check_type: 'Pangram 3', check_origin: origin, created_at:)
+                            check_type: CheckRevisionWithPangram::DETECTOR_KEY,
+                            check_origin: origin, created_at:)
   end
 
   before do
@@ -37,8 +40,10 @@ describe BuildAiDetectionSampleFromRecentScores do
     expect(unit).to have_attributes(article_id: article.id, course_id: course.id,
                                     campaign_slug: 'fall_2026', namespace: 2, diff_mode: true,
                                     url: 'https://en.wikipedia.org/w/index.php?diff=103')
-    expect(unit.metadata).to include('band' => 'high', 'source_max_ai_likelihood' => 0.95,
-                                     'source_check_type' => 'Pangram 3')
+    expect(unit.metadata).to include(
+      'band' => 'high', 'source_max_ai_likelihood' => 0.95,
+      'source_check_type' => CheckRevisionWithPangram::DETECTOR_KEY
+    )
   end
 
   it 'limits each band to per_band units' do

--- a/spec/services/check_revision_with_pangram_spec.rb
+++ b/spec/services/check_revision_with_pangram_spec.rb
@@ -436,6 +436,61 @@ describe CheckRevisionWithPangram do
 
       expect(RevisionAiScore.where.not(avg_ai_likelihood: nil).count).to eq(1)
     end
+
+    it 'scores over the failure row rather than adding a second row' do
+      allow_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::TaskTimeout, 'task 1 unfinished after 60s')
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.to raise_error(PangramApi::TaskTimeout)
+
+        allow_any_instance_of(PangramApi).to receive(:inference)
+          .and_return(simplified_pangram_response)
+        described_class.new(attrs)
+      end
+
+      expect(RevisionAiScore.count).to eq(1)
+      expect(RevisionAiScore.last.avg_ai_likelihood).not_to be_nil
+    end
+
+    it 're-raises a rate limit so the worker retries it' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(429, 'too many requests'))
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.to raise_error(PangramApi::RequestError)
+      end
+    end
+
+    it 're-raises a request timeout so the worker retries it' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(408, 'request timeout'))
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.to raise_error(PangramApi::RequestError)
+      end
+    end
+
+    it 'reports a terminal failure to Sentry, which nothing else would surface' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(402, 'out of credit'))
+      expect(Sentry).to receive(:capture_exception)
+        .with(instance_of(PangramApi::RequestError), hash_including(level: 'warning'))
+
+      VCR.use_cassette 'pangram_2' do
+        described_class.new(attrs)
+      end
+    end
+
+    it 'does not report a retryable failure to Sentry, which Sidekiq reports' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(503, 'unavailable'))
+      expect(Sentry).not_to receive(:capture_exception)
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.to raise_error(PangramApi::RequestError)
+      end
+    end
   end
 
   context 'when the revision has empty plain text' do

--- a/spec/services/check_revision_with_pangram_spec.rb
+++ b/spec/services/check_revision_with_pangram_spec.rb
@@ -8,10 +8,11 @@ describe CheckRevisionWithPangram do
   let(:user) { create(:user) }
   # Based on https://en.wikipedia.org/w/index.php?title=User:100110Z/Five-a-side_football&oldid=1327139425
   let(:simplified_pangram_response) do
-    { 'text' => 'example',
-      'version' => '3.0',
-      'headline' => 'Fully AI Generated',
-      'prediction' => 'We are confident that this document is fully AI-generated',
+    { 'stage' => 'STAGE_SUCCESS',
+      'text' => 'example',
+      'version' => '4.0',
+      'headline' => 'AI Generated',
+      'prediction' => 'We believe that this entire text is AI.',
       'prediction_short' => 'AI',
       'fraction_ai' => 1.0,
       'fraction_ai_assisted' => 0.0,
@@ -27,7 +28,9 @@ describe CheckRevisionWithPangram do
            'start_index' => 0,
            'end_index' => 2281,
            'word_count' => 359,
-           'token_length' => 483 },
+           'token_length' => 483,
+           'is_humanized' => false,
+           'humanizer_score' => 0.00444 },
          { 'text' => 'second window',
            'label' => 'AI-Generated',
            'ai_assistance_score' => 0.9982278487261604,
@@ -35,7 +38,9 @@ describe CheckRevisionWithPangram do
            'start_index' => 2281,
            'end_index' => 4737,
            'word_count' => 358,
-           'token_length' => 476 },
+           'token_length' => 476,
+           'is_humanized' => false,
+           'humanizer_score' => 0.0021 },
          { 'text' => 'third window',
            'label' => 'AI-Generated',
            'ai_assistance_score' => 0.9959831237792969,
@@ -43,13 +48,16 @@ describe CheckRevisionWithPangram do
            'start_index' => 4737,
            'end_index' => 5202,
            'word_count' => 72,
-           'token_length' => 94 }],
+           'token_length' => 94,
+           'is_humanized' => false,
+           'humanizer_score' => 0.0 }],
       'dashboard_link' => 'https://www.pangram.com/history/7980768b-0b15-4d42-ad62-30ba8cf0e92f' }
   end
   let(:stored_simplified_pangram_response) do
-    { 'version' => '3.0',
-      'headline' => 'Fully AI Generated',
-      'prediction' => 'We are confident that this document is fully AI-generated',
+    { 'stage' => 'STAGE_SUCCESS',
+      'version' => '4.0',
+      'headline' => 'AI Generated',
+      'prediction' => 'We believe that this entire text is AI.',
       'prediction_short' => 'AI',
       'fraction_ai' => 1.0,
       'fraction_ai_assisted' => 0.0,
@@ -64,21 +72,27 @@ describe CheckRevisionWithPangram do
            'start_index' => 0,
            'end_index' => 2281,
            'word_count' => 359,
-           'token_length' => 483 },
+           'token_length' => 483,
+           'is_humanized' => false,
+           'humanizer_score' => 0.00444 },
          { 'label' => 'AI-Generated',
            'ai_assistance_score' => 0.9982278487261604,
            'confidence' => 'High',
            'start_index' => 2281,
            'end_index' => 4737,
            'word_count' => 358,
-           'token_length' => 476 },
+           'token_length' => 476,
+           'is_humanized' => false,
+           'humanizer_score' => 0.0021 },
          { 'label' => 'AI-Generated',
            'ai_assistance_score' => 0.9959831237792969,
            'confidence' => 'High',
            'start_index' => 4737,
            'end_index' => 5202,
            'word_count' => 72,
-           'token_length' => 94 }],
+           'token_length' => 94,
+           'is_humanized' => false,
+           'humanizer_score' => 0.0 }],
       'dashboard_link' => 'https://www.pangram.com/history/7980768b-0b15-4d42-ad62-30ba8cf0e92f' }
   end
   let(:timestamp) { 5.minutes.ago.to_i }
@@ -127,7 +141,7 @@ describe CheckRevisionWithPangram do
       expect(RevisionAiScore.count).to eq(1)
       expect(RevisionAiScore.last.article_id).to eq(sandbox_article.id)
       expect(RevisionAiScore.last.details).to eq(stored_simplified_pangram_response)
-      expect(RevisionAiScore.last.check_type).to eq('Pangram 3')
+      expect(RevisionAiScore.last.check_type).to eq('Pangram 4')
       expect(RevisionAiScore.last.check_origin).to eq('course_update')
     end
   end
@@ -165,7 +179,7 @@ describe CheckRevisionWithPangram do
       expect(RevisionAiScore.last.avg_ai_likelihood).to be_between(0, 1)
       expect(RevisionAiScore.last.max_ai_likelihood).to eq(1.0)
       expect(RevisionAiScore.last.details).to eq(stored_simplified_pangram_response)
-      expect(RevisionAiScore.last.check_type).to eq('Pangram 3')
+      expect(RevisionAiScore.last.check_type).to eq('Pangram 4')
       expect(RevisionAiScore.last.check_origin).to eq('course_update')
     end
   end
@@ -244,7 +258,16 @@ describe CheckRevisionWithPangram do
     let!(:revision_ai_score) do
       create(:revision_ai_score, revision_id: live_article_revision_id,
              wiki_id: en_wiki.id, course:, user:, article: live_article,
-             details: stored_simplified_pangram_response, avg_ai_likelihood: 0.5)
+             details: stored_simplified_pangram_response, avg_ai_likelihood: 0.5,
+             check_origin: RevisionAiScore::COURSE_UPDATE_ORIGIN)
+    end
+    let(:attrs) do
+      { 'mw_rev_id' => live_article_revision_id,
+        'wiki_id' => en_wiki.id,
+        'article_id' => live_article.id,
+        'course_id' => course.id,
+        'user_id' => user.id,
+        'revision_timestamp' => timestamp }
     end
 
     it 'returns prematurely if the record is found' do
@@ -287,6 +310,131 @@ describe CheckRevisionWithPangram do
 
       expect(RevisionAiScore.count).to eq(2)
       expect(RevisionAiScore.last.avg_ai_likelihood).not_to be_nil
+    end
+
+    it 'still counts as checked when the row is from an earlier detector' do
+      revision_ai_score.update(check_type: RevisionAiScore::PANGRAM_V3_KEY)
+      expect_any_instance_of(described_class).not_to receive(:check)
+
+      described_class.new(attrs)
+    end
+
+    it 'still counts as checked when the row predates the check_origin field' do
+      revision_ai_score.update(check_origin: nil)
+      expect_any_instance_of(described_class).not_to receive(:check)
+
+      described_class.new(attrs)
+    end
+
+    it 'ignores a detector comparison row, which production never scored' do
+      revision_ai_score.update(check_origin: RevisionAiScore::DETECTOR_COMPARISON_ORIGIN)
+      expect_any_instance_of(described_class).to receive(:check)
+
+      described_class.new(attrs)
+    end
+
+    it 'ignores an admin AI tools row' do
+      revision_ai_score.update(check_origin: RevisionAiScore::AI_TOOL_ORIGIN)
+      expect_any_instance_of(described_class).to receive(:check)
+
+      described_class.new(attrs)
+    end
+  end
+
+  context 'when the detector call fails' do
+    let(:attrs) do
+      { 'mw_rev_id' => live_article_revision_id,
+        'wiki_id' => en_wiki.id,
+        'article_id' => live_article.id,
+        'course_id' => course.id,
+        'user_id' => user.id,
+        'revision_timestamp' => timestamp }
+    end
+
+    it 'records the failure without retrying a request the API refused' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(402, 'out of credit'))
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.not_to raise_error
+      end
+
+      score = RevisionAiScore.last
+      expect(score.avg_ai_likelihood).to be_nil
+      expect(score.check_type).to eq('Pangram 4')
+      expect(score.check_origin).to eq('course_update')
+      expect(score.details['error']).to eq('PangramApi::RequestError')
+    end
+
+    it 'records the failure without retrying a task the API failed' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::TaskFailed, 'task 1 failed')
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.not_to raise_error
+      end
+
+      expect(RevisionAiScore.last.details['error']).to eq('PangramApi::TaskFailed')
+    end
+
+    it 're-raises a timeout so the worker retries it' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::TaskTimeout, 'task 1 unfinished after 60s')
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.to raise_error(PangramApi::TaskTimeout)
+      end
+
+      expect(RevisionAiScore.last.avg_ai_likelihood).to be_nil
+    end
+
+    it 're-raises a server error so the worker retries it' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(503, 'unavailable'))
+
+      VCR.use_cassette 'pangram_2' do
+        expect { described_class.new(attrs) }.to raise_error(PangramApi::RequestError)
+      end
+
+      expect(RevisionAiScore.last.avg_ai_likelihood).to be_nil
+    end
+
+    it 'does not generate an alert' do
+      expect_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(402, 'out of credit'))
+
+      VCR.use_cassette 'pangram_2' do
+        described_class.new(attrs)
+      end
+
+      expect(AiEditAlert.count).to eq(0)
+    end
+
+    it 'updates the one failed row rather than adding another' do
+      allow_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(402, 'out of credit'))
+
+      VCR.use_cassette 'pangram_2' do
+        described_class.new(attrs)
+        described_class.new(attrs)
+      end
+
+      expect(RevisionAiScore.count).to eq(1)
+    end
+
+    it 'leaves the revision open to a later successful check' do
+      allow_any_instance_of(PangramApi).to receive(:inference)
+        .and_raise(PangramApi::RequestError.new(402, 'out of credit'))
+
+      VCR.use_cassette 'pangram_2' do
+        described_class.new(attrs)
+
+        allow_any_instance_of(PangramApi).to receive(:inference)
+          .and_return(simplified_pangram_response)
+        described_class.new(attrs)
+      end
+
+      expect(RevisionAiScore.where.not(avg_ai_likelihood: nil).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
## What this PR does

Cuts production AI-detection alerting over from Pangram 3 to Pangram 4, and commits the
analysis script that produced the evidence for the decision.

Pangram is shutting down the v3 API on **30 September 2026**. Phase 0 (#7034, merged and
deployed 4 September) built the v4 async client, response parser and detector registry
entry. Phase 1 scored six samples (2,637 units) under both models and compared them. This
PR is the cutover itself, plus the `pangram_cutover.py` analysis script that Phase 1 used.

The cutover is deliberately as close to no-change as possible: the alert rule
(`max_ai_likelihood > 0.9`), the AI-Assisted and humanizer handling, the alert detail
readers and every email template are untouched. The only intended difference is the score
shift between models.

**Commit 1 — analysis tooling.** `docs/analytics_scripts/ai_usage_research/detector_comparison/analysis/pangram_cutover.py`
is a companion to the existing `analyze.py`. Where `analyze.py` compares detectors on equal
terms, this one answers what changes for the alert pipeline: positive rate per production
score band reweighted to the production population, the old detector's reproducibility
against its own stored scores, threshold transitions per model version, v4-only signals
(humanized windows, score distribution per document label), window geometry, and baseline
false positives per model version. It imports `analyze.py` for palette, loading and table
rendering so both scripts' output stays one system. Also: a shared fix in `analyze.py`
(all-numeric tables printed integer counts as `58.000`), a README section, and a
`docs/analytics_scripts/**/*.csv` gitignore rule — the exports pair public Wikipedia diff
URLs with AI-likelihood scores, and this repo is public, so the data stays local while the
scripts are committed.

**Commit 2 — the cutover.**

- `CheckRevisionWithPangram::DETECTOR_KEY` moves to `PANGRAM_V4_KEY`. Phase 1 projects the
  alert rate at 9.5% under v4 against 10.8% actual production since May, with 0 false
  positives on 587 pre-ChatGPT baseline units.
- `already_checked?` now filters `check_origin` to `[nil, COURSE_UPDATE_ORIGIN]`. Without
  it, a detector-comparison row on a revision production had not yet checked would suppress
  the production check and its alert — which is why no revision from a running course could
  be sampled until now. `NULL` is included because the column was added in March 2026 and
  never backfilled: every earlier row carrying an `article_id` came from a production check,
  and excluding `NULL` would re-bill each pre-March revision that gets re-queued.
  `RevisionAiScoresStatsController#set_scores` already treats `NULL` the same way.
  `check_type` is deliberately *not* filtered, so revisions already scored under v3 stay
  checked rather than being re-billed under v4.
- Detector failures are now recorded rather than only raised. Each failure writes a
  `RevisionAiScore` row with nil `avg_ai_likelihood` — which `already_checked?` has always
  read as "check this revision again" — and only failures a retry could clear are re-raised.
  Terminal, so swallowed: a 4xx `RequestError` (malformed request, exhausted credits) and
  `TaskFailed`. Retryable, so re-raised: 5xx, `TaskTimeout`, Faraday and JSON errors.
- `AiDetectionWorker` gets `retry: 3` instead of Sidekiq's default 25. The async v4 endpoint
  adds failure modes and every attempt bills, so 25 attempts on a persistent failure was the
  expensive case.
- Both AI-edit-alert mailer previews move to the v4 `details` shape, taken from the
  3 September live probe rather than invented: one window, headline "AI Generated",
  prediction "We believe that this entire text is AI.", version 4.0, plus the
  `humanized_window_count` and `max_humanizer_score` keys the parser adds for v4. One window
  is the representative case — Phase 1 found v4 returns a single window for 79% of units.
  No email copy changed; the previews only feed it different data.
- `BuildAiDetectionSampleFromRecentScores` hardcoded the v3 key as its `check_type` default,
  so a post-cutover recent-scores sample would have silently sampled the retired detector.
  It now defaults to `CheckRevisionWithPangram::DETECTOR_KEY`.

Pangram 3 stays in the registry and `PangramApi.v3` stays callable, so last-chance v3 scoring
still works before the 30 September shutdown. Removing both is a follow-up after that date.

Relevant external documentation: [Pangram 4 migration guide](https://www.pangram.com/blog/pangram-4-migration-guide),
[Pangram REST API docs](https://pangram.readthedocs.io/en/stable/api/rest.html).

## AI usage

Both commits were written by Claude Code (Opus 5) under my direction, and it drafted both
commit messages and this PR description. Each commit carries a
`Co-Authored-By: Claude Opus 5` trailer and a `(Commit message written by Claude Code.)`
marker, and the commit bodies have `## Process` sections with more detail.

What the AI did: wrote `pangram_cutover.py` and tested it against a synthetic export before
the real one existed; implemented the cutover against a specification I had settled earlier;
wrote the new specs; and drafted the prose. What I contributed: the operator decisions that
constrain the cutover (keep the 0.9 rule, no AI-Assisted or humanizer alerting, leave email
copy alone — all decided 3 September, before any of this code), the Phase 1 data collection
runs in the production console, the design in the migration plan and runbook, the decision
to pull the cutover forward from the planned 15–19 September window, and review.

Two changes here came from the AI reading the code rather than from my specification, and
both deserve a reviewer's attention: the `[nil, COURSE_UPDATE_ORIGIN]` treatment of legacy
rows (my runbook said `COURSE_UPDATE_ORIGIN` alone, which would have re-billed pre-March
revisions), and the `BuildAiDetectionSampleFromRecentScores` default. The classification of
`TaskFailed` as terminal rather than retryable is a judgment call, not something the data
settles — see Open questions.

Scale of effort: two commits inside a single session on 9 September, about 17 minutes apart.
That is a small amount of human time on the *code*, and it should be read against a much
larger amount of prior human-directed work: the migration plan and runbook (3–4 September),
Phase 0 in #7034, and the Phase 1 scoring runs and analysis (5 September), which is where
the design decisions and the evidence actually come from.

The "What this PR does" summary and the analysis above were also drafted by Claude Code and
may contain errors. This PR description was drafted using Claude Code and the `prepare-pr`
skill.

## Screenshots

No UI changes. The alert emails render identically; only the sample data behind the mailer
previews changed, and the preview pages at `/mailer_previews` are the place to see that.

## Open questions and concerns

- **`TaskFailed` is treated as terminal.** A task the API itself finished in a failed stage
  is not retried, on the reasoning that resubmission is unlikely to succeed and every
  attempt bills. If `STAGE_FAILED` turns out to be transient in practice, this should move
  to the retryable list. We have no production v4 failure data yet either way.
- **`retry: 3`** is a guess at "bounded". The two LTI workers in this codebase use `retry: 5`.
- **Email copy is now known to be inaccurate.** Phase 1 found the median v3 window is 256
  words and v4 usually returns one window for the whole edit, so the emails' "Number of
  ~400-word segments with AI text" and "segments of approximately 400 words" no longer
  describe either model. This is deliberately out of scope — the copy is operator-written —
  but it should be revised soon.
- **Parked for after cutover, with Phase 1 data in hand:** under v4, `max window > 0.9` is a
  whole-text score for 79% of units and 27% of documents Pangram labels AI-generated fall
  below it, so whether to alert on the label, a lower max, or `windows_above_0_9` is a real
  rule decision. Humanizer flagging (13% of units, none in the human baseline) is also
  parked.
- **Pangram silently changed the v3 model in May 2026** (3.2 → 3.3.2 on 18 May, found during
  Phase 1). Expect the same from v4 point releases and watch the recorded `model_version`.
- **Follow-up after 30 September:** remove `PANGRAM_V3_KEY` from the registry and delete
  `PangramApi.v3`, keeping the constant for historical rows.

(PR description written by Claude Code.)
