### PR TITLE
Add a skill for change requests delivered as Google Doc downloads

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,7 @@ even if the current client does not automatically discover that directory:
 - Prepare a pull request: `.claude/skills/prepare-pr/SKILL.md`
 - Write browser-based feature specs: `.claude/skills/feature-spec/SKILL.md`
 - Investigate a slow or stuck course update: `.claude/skills/course-update-recon/SKILL.md`
+- Implement change requests from a downloaded Google Doc (.docx with comments and suggestions): `.claude/skills/google-doc-change-requests/SKILL.md`
 - Enter TDD mode for a session: `.claude/commands/tdd.md`
 
 ## Running tests and linting

--- a/.claude/skills/google-doc-change-requests/SKILL.md
+++ b/.claude/skills/google-doc-change-requests/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: google-doc-change-requests
+description: Turn a Google Doc of requested changes, downloaded as .docx, into an explicit change list — the visible text edits, the pending suggestions, and the decisions made in comment threads — before implementing any of it. Use this skill whenever the user hands over a .docx (or any Google Docs export) of team feedback, edits, or requested changes to copy, layout, or behavior.
+---
+
+# Google Doc change requests
+
+A Google Doc that a team has been editing carries three layers, and only one
+of them is the visible text:
+
+1. **The text** — what the page says once every pending suggestion is accepted.
+2. **Suggestions** — Google Docs "suggesting mode" edits, exported as tracked
+   changes (`w:ins` / `w:del`), each with an author and a timestamp. Some are
+   finished; some were mid-edit when the file was downloaded.
+3. **Comments** — the margin discussion, exported to `word/comments.xml`, each
+   anchored to a run of text. This is where decisions live: "editor's?",
+   "Agreed, let's point to that", "they should be routed back to pick another
+   claim", "feel free to delete".
+
+`pandoc file.docx -t gfm` gives you layer 1 only: its default
+`--track-changes=accept` applies every suggestion silently, and it drops every
+comment. Working from that output alone misses whatever the team decided in
+the margins. (It happened: four comment threads on the Fact Verification
+exercise edits were missed on the first pass in September 2026, and one
+half-finished suggestion had deleted a word from a sentence.)
+
+Work through the phases in order. Do not start implementing before Phase 3.
+
+## Phase 1: Extract all three layers
+
+Work in the session scratchpad. `<file>` is the .docx the user provided.
+
+```bash
+mkdir -p "$SCRATCH/docx"
+# 1. The final text, with images extracted (what the doc would say if every
+#    pending suggestion were accepted).
+pandoc "<file>" -t gfm --extract-media="$SCRATCH/docx" -o "$SCRATCH/docx/final.md"
+# 2. Everything inline: insertions/deletions with author and date, and comment
+#    anchors as spans. Use -t markdown (not gfm) so the spans keep attributes.
+pandoc "<file>" --track-changes=all -t markdown -o "$SCRATCH/docx/all.md"
+# 3. The ledger of comment threads (with anchored text) and suggestions.
+bin/docx-changes "<file>"
+```
+
+Read all three. `all.md` shows where each suggestion and comment sits in the
+flow; `bin/docx-changes` gives the threads with replies, authors and dates.
+If it reports no comments and no suggestions, the doc is plain and `final.md`
+is the whole story.
+
+Images: pandoc extracts them to `$SCRATCH/docx/media/`. Note each one's
+dimensions; team screenshots are usually full browser windows and will need
+cropping to the passage that makes their point (Phase 4).
+
+## Phase 2: Build the change ledger
+
+Write a ledger (a markdown table in the scratchpad, or a `.claude/` plan file
+if the work will span sessions) with one row per item, from four sources:
+
+- **Text differences** — compare `final.md` against the current copy in the
+  app (`config/locales/en.yml` etc.) and list each difference, quoting both
+  sides. Copy from the doc is applied verbatim, typos included; note a
+  suspected typo in the ledger rather than fixing it.
+- **Suggestions** — one row each, from `bin/docx-changes`. Mark any whose
+  result reads wrong (a lone deleted word, a sentence that no longer parses),
+  and any timestamped within an hour or so of the download: those may have
+  been mid-edit. Do not treat a pending suggestion as final if it garbles the
+  text; put it to the user.
+- **Comment threads** — one row each: anchored text, the thread (with
+  replies and reactions), and a classification: *decided copy change*
+  (someone agreed), *decided behavior change*, *open question* (no reply, or
+  a question nobody answered), or *note to the operator* ("feel free to
+  delete"). A behavior change is never implemented on the strength of a
+  comment alone; see Phase 3.
+- **Doc markers and omissions** — all-caps notes such as "SCREENSHOT OF
+  VERIFIED" are placement notes, not copy; the doc usually walks one path
+  through a flow, so anything in the current UI it doesn't mention (a
+  conditional question, an alternate branch) is *keep unless told*, flagged.
+
+Also note where the doc contradicts itself or its screenshots (a caption that
+quotes different wording than the screenshot shows, a link the doc says to
+replace but a sentence that still describes the old target).
+
+## Phase 3: Confirm scope before building
+
+Show the user the ledger — compactly: what will be applied verbatim, what
+needs a decision, what is being left alone. Then:
+
+- **Copy changes from the doc**, including agreed comment threads: proceed.
+- **Behavior changes and open threads**: ask, in one message that lists them
+  with a recommendation each. Different readings lead to materially different
+  work, so this is worth the round trip.
+- **Missing copy** (a heading the doc marks but doesn't write, alt text, a
+  new sentence a behavior change needs): never write it. Leave a
+  `[PLACEHOLDER - <what the copy needs to say>]` marker per CLAUDE.md, and list
+  the placeholders for the user to fill. Where an existing operator-approved
+  string already says the right thing (a button label, a link text), reuse it.
+
+## Phase 4: Implement in reviewable pieces
+
+The user usually wants to see each change on its own. Work as a series of
+small commits, one per ledger group, each with before/after screenshots:
+
+- Add a `SCREENSHOT=`-gated screenshot harness first if the feature lacks one
+  (see Strategy A in `.claude/skills/prepare-pr/SKILL.md`). Commit it as the
+  first, visually neutral commit; capture the baseline as `SCREENSHOT=00_master`.
+- After each change: `yarn build` (copy edits need the i18n export it runs),
+  then `SCREENSHOT=NN_<label> bundle exec rspec <harness spec>`; keep every
+  `tmp/screenshots/NN_<label>/` so each commit's before is the previous
+  commit's after. Delete the stray `<spec>__*.png` files the global
+  screenshot hook adds alongside.
+- Commit with the `commit` skill, `git commit --only <paths>`, so nothing
+  else in the tree rides along.
+- Images from the doc: crop to the passage that makes the point (ImageMagick
+  `-crop`; join two strips with a hairline when the point spans a page),
+  encode as WebP at native resolution, show at natural width rather than as
+  two-up thumbnails, and link each to what it shows (a permalink to the
+  article revision pictured; the source). If a screenshot can't be cropped
+  into legibility, say so and offer to retake it (a PDF viewer's find bar can
+  be reproduced headless with pdf.js + Selenium).
+- Present the iterations together: a before/after gallery per commit (an
+  Artifact, or `tmp/screenshots/gallery.html`) is what the user reviews.
+
+## Phase 5: Report
+
+Close with, in this order: what was applied (commit per ledger row), what
+was deliberately not built and why, the placeholders awaiting copy (`grep -n
+"\[PLACEHOLDER" config/locales/en.yml`), and the doc oddities preserved
+verbatim. Keep the ledger's open rows in the PR's "Open questions" section.
+
+## Gotchas
+
+- `pandoc` defaults: `--track-changes=accept`, comments dropped. Always run
+  the `--track-changes=all -t markdown` pass and `bin/docx-changes`.
+- Google Docs exports a reply as a separate comment whose range opens inside
+  the parent's; `bin/docx-changes` uses that nesting to show threads.
+- A suggestion's author and timestamp tell you who decided and when; a
+  deletion dated minutes before the download is probably unfinished.
+- Doc text and doc screenshots can disagree (the doc quoted "started"; the
+  screenshot said "launched"). Decide with the user which the app follows.
+- The live Wikipedia article behind an example may already have changed;
+  link permalinks (`oldid=`) to the revision the screenshot shows, found via
+  the revision history, not the current page.
+- Sources the team screenshotted may be paywalled (JSTOR). Link them anyway
+  when the team wants students to see where the source lives, and ask the
+  user for the file if a retake is needed.

--- a/bin/docx-changes
+++ b/bin/docx-changes
@@ -1,0 +1,192 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# List what a Google Doc exported as .docx says beyond its visible text: the
+# comment threads (with the text each is anchored to) and the pending
+# suggestions (tracked insertions and deletions, with author and date).
+#
+# Usage:
+#   bin/docx-changes "path/to/file.docx"
+#
+# Pair it with pandoc for the text itself — see
+# .claude/skills/google-doc-change-requests/SKILL.md. pandoc's default run
+# silently accepts every pending suggestion and drops every comment, which is
+# exactly what this script surfaces so nothing decided in the margins is missed.
+
+require 'zip'
+require 'nokogiri'
+require 'time'
+
+class DocxChanges
+  W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+  NS = { 'w' => W }.freeze
+  TEXT_NODES = './/w:t | .//w:delText'
+
+  Comment = Struct.new(:id, :author, :date, :text, :anchor, :parent, keyword_init: true)
+  Change = Struct.new(:kind, :author, :date, :text, :context, keyword_init: true)
+
+  def initialize(path)
+    Zip::File.open(path) do |zip|
+      @document = Nokogiri::XML(zip.read('word/document.xml'))
+      entry = zip.find_entry('word/comments.xml')
+      @comments_xml = entry && Nokogiri::XML(zip.read(entry))
+      @media = zip.entries.count { |e| e.name.start_with?('word/media/') }
+    end
+  end
+
+  def report
+    [comments_report, changes_report,
+     "Media: #{@media} embedded image(s) — extract with pandoc --extract-media."].join("\n\n")
+  end
+
+  # Comment threads, in document order: a comment whose range opens inside
+  # another's is a reply to it.
+  def comments
+    return [] unless @comments_xml
+    @comments_xml.xpath('//w:comment', NS).map do |node|
+      id = attr(node, 'id')
+      Comment.new(id:, author: attr(node, 'author'), date: attr(node, 'date'),
+                  text: paragraphs_text(node), anchor: anchors[id].strip, parent: parents[id])
+    end
+  end
+
+  # Pending suggestions, grouped per paragraph by kind, author and date (Google
+  # Docs splits one suggestion into a run per formatting change).
+  def changes
+    @document.xpath('//w:body//w:p', NS).flat_map { |para| paragraph_changes(para) }
+  end
+
+  private
+
+  def attr(node, name)
+    node.attribute_with_ns(name, W)&.value
+  end
+
+  def paragraphs_text(node)
+    node.xpath('.//w:p', NS).map { |p| p.xpath(TEXT_NODES, NS).map(&:text).join }
+        .reject(&:empty?).join("\n")
+  end
+
+  # Text under each comment's range, keyed by comment id, by walking the body's
+  # text and range markers in document order.
+  def anchors
+    walk_ranges unless @anchors
+    @anchors
+  end
+
+  def parents
+    walk_ranges unless @parents
+    @parents
+  end
+
+  def walk_ranges
+    @anchors = Hash.new { |hash, key| hash[key] = +'' }
+    @parents = {}
+    open_ids = []
+    markers = '//w:body//w:p | //w:body//w:t | //w:body//w:delText | ' \
+              '//w:body//w:commentRangeStart | //w:body//w:commentRangeEnd'
+    @document.xpath(markers, NS).each { |node| visit_range_node(node, open_ids) }
+  end
+
+  def visit_range_node(node, open_ids)
+    case node.name
+    when 'p' # a paragraph boundary inside an open range
+      open_ids.each { |id| @anchors[id] << ' ¶ ' unless @anchors[id].empty? }
+    when 'commentRangeStart'
+      id = attr(node, 'id')
+      @parents[id] = open_ids.last
+      open_ids << id
+    when 'commentRangeEnd'
+      open_ids.delete(attr(node, 'id'))
+    else
+      open_ids.each { |id| @anchors[id] << node.text }
+    end
+  end
+
+  def paragraph_changes(para)
+    # Paragraph-mark changes (inside w:rPr) carry no text; skip them.
+    nodes = para.xpath('.//w:ins | .//w:del', NS).reject { |n| n.parent.name == 'rPr' }
+    nodes = nodes.select { |n| n.xpath(TEXT_NODES, NS).any? }
+    return [] if nodes.empty?
+    context = paragraph_text(para)
+    nodes.group_by { |n| [n.name, attr(n, 'author'), attr(n, 'date')] }
+         .map { |key, group| build_change(key, group, context) }
+  end
+
+  def build_change((name, author, date), group, context)
+    text = group.map { |n| n.xpath(TEXT_NODES, NS).map(&:text).join }.join
+    Change.new(kind: name == 'ins' ? 'insertion' : 'deletion', author:, date:, text:, context:)
+  end
+
+  # The paragraph with its suggestions marked: {+inserted+} and [-deleted-].
+  def paragraph_text(para)
+    para.xpath('./w:r | ./w:ins | ./w:del | ./w:hyperlink', NS).map do |node|
+      text = node.xpath(TEXT_NODES, NS).map(&:text).join
+      case node.name
+      when 'ins' then "{+#{text}+}"
+      when 'del' then "[-#{text}-]"
+      else text
+      end
+    end.join
+  end
+
+  # ── formatting ──────────────────────────────────────────────────────────────
+
+  def comments_report
+    list = comments
+    return 'Comments: none.' if list.empty?
+    lines = ["Comments (#{list.size}; pandoc drops these unless --track-changes=all):"]
+    list.each do |comment|
+      lines << (comment.parent ? reply_line(comment) : thread_line(comment))
+    end
+    lines.join("\n")
+  end
+
+  def thread_line(comment)
+    "\n##{comment.id} #{who_when(comment)} on \"#{squeeze(comment.anchor, 120)}\"\n" \
+      "   #{comment.text.gsub("\n", "\n   ")}"
+  end
+
+  def reply_line(comment)
+    "   ↳ reply to ##{comment.parent} #{who_when(comment)}: #{comment.text.gsub("\n", ' ')}"
+  end
+
+  def changes_report
+    list = changes
+    return 'Suggestions: none (no tracked changes).' if list.empty?
+    lines = ["Suggestions (#{list.size}; pandoc's default ACCEPTS all of these silently):"]
+    list.each do |change|
+      lines << "\n- #{change.kind.upcase} #{who_when(change)}: \"#{squeeze(change.text, 160)}\"\n" \
+               "  in: #{excerpt(change)}"
+    end
+    lines.join("\n")
+  end
+
+  def who_when(item)
+    date = begin
+      Time.iso8601(item.date).utc.strftime('%Y-%m-%d %H:%M UTC')
+    rescue ArgumentError, TypeError
+      item.date
+    end
+    "[#{item.author}, #{date}]"
+  end
+
+  # The paragraph around the change, trimmed to a window when it is long.
+  def excerpt(change, width: 220)
+    context = change.context
+    return "\"#{context}\"" if context.length <= width
+    marker = change.kind == 'insertion' ? "{+#{change.text[0, 30]}" : "[-#{change.text[0, 30]}"
+    at = context.index(marker) || 0
+    from = [at - (width / 2), 0].max
+    "\"…#{context[from, width]}…\""
+  end
+
+  def squeeze(text, max)
+    flat = text.gsub(/\s+/, ' ').strip
+    flat.length > max ? "#{flat[0, max]}…" : flat
+  end
+end
+
+path = ARGV[0]
+abort 'Usage: bin/docx-changes "path/to/file.docx"' if path.nil? || !File.exist?(path)
+puts DocxChanges.new(path).report


### PR DESCRIPTION
## What this PR does

Adds a skill, `.claude/skills/google-doc-change-requests/SKILL.md`, for the recurring case where the team's requested changes arrive as a Google Doc downloaded as `.docx`. Such a document carries three layers — the visible text, pending suggestions (tracked changes with author and date), and comment threads anchored to text — and `pandoc`'s default extraction silently accepts every suggestion and drops every comment. In September 2026 that lost four comment-thread decisions and one garbled sentence on the first pass at the Fact Verification exercise edits (#7052); this skill makes the full extraction and a confirm-before-building ledger the explicit workflow.

It also adds `bin/docx-changes`, a small Ruby script (rubyzip + nokogiri, both already in the bundle) that prints the ledger's raw material from a `.docx`: every comment with author, date, anchored text and replies, and every tracked insertion/deletion grouped per paragraph, with the paragraph shown as `{+inserted+}` / `[-deleted-]` context. `.claude/CLAUDE.md` lists the skill in the shared-workflows index.

## AI usage

Claude Code (Claude Fable 5.1) wrote the skill document and the script, and this commit message and PR description, at Sage Ross's request after he noticed the missed comments; the workflow and gotchas are drawn from that session. Sage directed the work and reviewed it. One commit, written in a single short exchange on 2026-09-09.

This PR description was drafted by Claude Code using the `prepare-pr` skill; the summary above may contain errors.

## Screenshots

No UI changes. As evidence of testing, `bin/docx-changes` run against the September edits document (names of team members replaced; excerpt):

```
Comments (5; pandoc drops these unless --track-changes=all):

#0 [team member, 2026-09-01 22:28 UTC] on "author’s"
   editor's?

#1 [team member, 2026-09-01 22:48 UTC] on "https://en.wikipedia.org/wiki/Wikipedia:Reliable_sources"
   We don't typically route the student to external policy pages. Why this page instead of our internal "What's a good source?"
   https://dashboard.wikiedu.org/training/students/evaluating-articles/what-is-a-good-source
   ↳ reply to #1 [team member, 2026-09-01 23:36 UTC]: Agreed, let's point to that, great suggestion!

#3 [team member, 2026-09-01 21:28 UTC] on "No, the source does not exist. ¶ No, the source exists but I could not get access to it."
   If they choose either of these, they should be routed back to pick another claim, not just end the exercise
   …

Suggestions (22; pandoc's default ACCEPTS all of these silently):

- DELETION [team member, 2026-09-01 22:34 UTC]: "and it’s"
  in: "… you can find the cited source and read that information for yourself. This is what’s known as verifiability, [-and it’s -]one of the most critical policies behind Wikipedia’s credibility.…"

- INSERTION [team member, 2026-09-09 00:22 UTC]: "have access to"
  in: "Yes, I {+have access to+}[-got-] the source."

- … (20 more)
```

The full output listed all five comment threads and 22 suggestions, matching a manual re-extraction with `pandoc --track-changes=all`. RuboCop is clean on the script.

## Open questions and concerns

- The script reads the shapes Google Docs exports: replies are comments whose range opens inside the parent's, and there is no `commentsExtended.xml`. A `.docx` from Word may thread replies differently; the comments would still be listed, just flat.
- `pandoc` is assumed to be installed (it is not a repo dependency); the script itself needs only bundled gems.

(PR description written by Claude Code.)
