### PR TITLE
Move Fact verification block after Evaluate Wikipedia

### DIFF
--- a/config/wizard/researchwrite/content.yml
+++ b/config/wizard/researchwrite/content.yml
@@ -90,13 +90,6 @@ essentials:
             Learn about Generative AI in the Wikipedia context and why you should NEVER copy and paste AI-generated text into Wikipedia.
           </p>
       -
-        if: fact_verification
-        title: Fact verification
-        kind: 1
-        training_module_ids: [86] # Exercise: Fact verification
-        content: |
-
-      -
         if: sources_and_plagiarism_discussion
         title: "Discussion"
         kind: 0
@@ -111,6 +104,13 @@ essentials:
         title: Evaluate Wikipedia
         kind: 1
         training_module_ids: [28,7,34] # How to edit, Evaluate an article, Exercise: Evaluate Wikipedia
+        content: |
+
+      -
+        if: fact_verification
+        title: Fact verification
+        kind: 1
+        training_module_ids: [86] # Exercise: Fact verification
         content: |
 
       -

--- a/docs/cleanup_scripts/reorder_fact_verification_blocks.rb
+++ b/docs/cleanup_scripts/reorder_fact_verification_blocks.rb
@@ -34,9 +34,13 @@ def move_fact_verification_blocks(dry_run: true, only_unended: true)
     end
 
     week = fv.week
+    # Read the week fresh from the database rather than via `week.blocks`:
+    # candidates in the same week share one preloaded Week instance (Block
+    # default_scope), so its association cache would hand a second candidate
+    # the stale `order` values from before the first one was moved.
     # `order` is not unique within a week in real data, so break ties by id to
     # read the current sequence deterministically.
-    blocks = week.blocks.to_a.sort_by { |b| [b.order.to_i, b.id] }
+    blocks = Block.where(week_id: week.id).to_a.sort_by { |b| [b.order.to_i, b.id] }
     # First Evaluate block wins, in case a week somehow has more than one.
     eval_block = blocks.find { |b| (mods.call(b) & eval_modules).any? }
     next report[:not_same_week] << course.slug if eval_block.nil?
@@ -54,9 +58,9 @@ def move_fact_verification_blocks(dry_run: true, only_unended: true)
     # after a drag. update_column because `order` has no validations, nothing
     # derives a date from it (BlockDateManager keys off week.order), and it
     # skips the LTI line-item sync callback, which a pure reorder doesn't affect.
-    reordered.each_with_index do |b, i|
-      b.update_column(:order, i) unless b.order == i
-    end
+    # Every row is written unconditionally: `fv` itself may carry an in-memory
+    # `order` left stale by an earlier candidate in the same week.
+    reordered.each_with_index { |b, i| b.update_column(:order, i) }
   end
 
   puts dry_run ? "\n=== DRY RUN — nothing written ===" : "\n=== WROTE CHANGES ==="

--- a/docs/cleanup_scripts/reorder_fact_verification_blocks.rb
+++ b/docs/cleanup_scripts/reorder_fact_verification_blocks.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# One-off console script. Where a course already has the Fact verification
+# exercise block and the Evaluate Wikipedia block in the SAME week, move the
+# Fact verification block to sit immediately after the Evaluate Wikipedia block.
+#
+#   move_fact_verification_blocks                    # dry run, reports only
+#   move_fact_verification_blocks(dry_run: false)    # actually writes
+
+def move_fact_verification_blocks(dry_run: true, only_unended: true)
+  fv_module = 86           # Exercise: Fact verification
+  eval_modules = [34, 57]  # Exercise: Evaluate Wikipedia (+ the professional variant)
+  mods = ->(block) { block.training_module_ids.map(&:to_i) }
+  report = Hash.new { |h, k| h[k] = [] }
+
+  # training_module_ids is a serialized YAML array, so prefilter on the stored
+  # text in SQL and confirm in Ruby.
+  candidates = Block.where('training_module_ids LIKE ?', "%- #{fv_module}\n%")
+                    .select { |b| mods.call(b).include?(fv_module) }
+
+  candidates.each do |fv|
+    course = fv.course
+    next report[:no_course] << "block #{fv.id}" if course.nil?
+    if only_unended && course.end.present? && course.end < Time.zone.now
+      next report[:course_ended] << course.slug
+    end
+
+    # A block carrying the FV exercise alongside other modules is somebody's
+    # hand-merged block; moving it would drag unrelated content along with it,
+    # so report and leave it alone.
+    unless mods.call(fv) == [fv_module]
+      key = (mods.call(fv) & eval_modules).any? ? :merged_with_eval : :merged_with_other
+      next report[key] << "#{course.slug} — block #{fv.id} #{fv.title.inspect} #{mods.call(fv)}"
+    end
+
+    week = fv.week
+    # `order` is not unique within a week in real data, so break ties by id to
+    # read the current sequence deterministically.
+    blocks = week.blocks.to_a.sort_by { |b| [b.order.to_i, b.id] }
+    # First Evaluate block wins, in case a week somehow has more than one.
+    eval_block = blocks.find { |b| (mods.call(b) & eval_modules).any? }
+    next report[:not_same_week] << course.slug if eval_block.nil?
+    next report[:already_after] << course.slug if blocks.index(fv) > blocks.index(eval_block)
+
+    reordered = blocks - [fv]
+    reordered.insert(reordered.index(eval_block) + 1, fv)
+
+    report[:moved] << "#{course.slug} (week #{week.order}): " +
+                      reordered.map { |b| b == fv ? "[#{b.title}]" : b.title.to_s }.join(' -> ')
+
+    next if dry_run
+
+    # Renumber the week contiguously, the same way the timeline editor does
+    # after a drag. update_column because `order` has no validations, nothing
+    # derives a date from it (BlockDateManager keys off week.order), and it
+    # skips the LTI line-item sync callback, which a pure reorder doesn't affect.
+    reordered.each_with_index do |b, i|
+      b.update_column(:order, i) unless b.order == i
+    end
+  end
+
+  puts dry_run ? "\n=== DRY RUN — nothing written ===" : "\n=== WROTE CHANGES ==="
+  report.each do |key, entries|
+    puts "\n#{key} (#{entries.size})"
+    entries.each { |e| puts "  #{e}" }
+  end
+  nil
+end


### PR DESCRIPTION
## What this PR does

Moves the Fact verification exercise block on the research-write timeline so it comes
**after** the Evaluate Wikipedia block instead of before it. Students meet verifiability
after they have evaluated an article, which is the more natural teaching order.

Two parts:

1. `config/wizard/researchwrite/content.yml` — the `fact_verification` block moves out of
   week two and into week three, immediately after Evaluate Wikipedia. That file is
   chronological, so its position in the file *is* the ordering; the block itself is
   unchanged. This affects newly generated timelines only.
2. `docs/cleanup_scripts/reorder_fact_verification_blocks.rb` — a one-off console script
   that applies the same reordering to existing courses, but only where the two blocks
   already sit in the same week (which happens on compressed timelines, where the wizard
   folds several content weeks into one).

Note the knock-on effect visible in the screenshots below: because the exercise now sits a
week later, its calculated due date moves out by a week too (Sep 19 → Sep 26 in the example
course). That follows from `BlockDateManager` deriving dates from `week.order`, and reads as
desirable here — students get the extra week — but it is worth a second opinion.

### About the cleanup script

The design is shaped by what the production data actually looks like:

- Blocks are matched by **training module id** (86 for Fact verification, 34/57 for Evaluate
  Wikipedia and its professional variant), not by title, because instructors rename blocks.
- A block whose module list is anything other than exactly `[86]` is somebody's hand-merged
  block. Moving one would drag unrelated content along, so those are **reported and skipped**
  rather than moved. This is not a rare edge case: in a June production dump, *both* blocks
  carrying module 86 were of this kind — one instructor had merged the exercise into their
  Evaluate Wikipedia block, another into their Generative AI block.
- `order` is **not unique within a week** in real data (1,581 duplicate `(week_id, order)`
  pairs in that dump, occurring right up to 2026-06), so the script reads the current
  sequence with an id tie-break and renumbers the whole week contiguously on write — which
  is what `reducers/timeline.js` already does after a drag in the timeline editor.
- It moves the block to immediately after Evaluate rather than swapping the two `order`
  values. A swap would fling the Evaluate block backwards past anything sitting between them.
- Writes use `update_column`: `order` has no validations, nothing derives a date from block
  order, and it skips the LTI line-item sync callback, which a pure reorder does not affect.
- Dry run by default, and idempotent — a second run reports `already_after` and writes nothing.

## AI usage

The code, the commit message, and this description were all written by **Claude Code**
(Opus 5) under my direction. The commit carries a `Co-Authored-By` trailer and a
`(Commit message written by Claude Code.)` marker.

What I contributed was direction and the decisions about what to build: that the block should
move after Evaluate Wikipedia, and that the production cleanup should apply *only* where the
two blocks already share a week. What Claude Code contributed was the implementation, plus
the data characterization that shaped the script — it queried a local production dump and
found the duplicate `order` values and the hand-merged blocks described above, both of which
changed the design. I also flagged mid-session that the dump might be too old to contain
useful examples, which was correct: its newest block predates the exercise's wizard rollout
by three days and it contains no standalone Fact verification blocks at all, so the script
was exercised against a synthetic block instead.

Scale of effort: one commit, made within a single session of roughly half an hour on
2026-09-09. This was not a long iterative effort, and the human review time behind it is
correspondingly modest — please read the cleanup script on that basis rather than assuming
it has been through several rounds of scrutiny.

The "What this PR does" summary and the analysis above were also drafted by Claude Code and
may contain errors. This description was prepared using Claude Code and the `prepare-pr` skill.

## Screenshots

Weeks 2 and 3 of a generated 12-week research-write timeline (the other weeks are unchanged
and hidden for legibility):

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-timeline-order/screenshots/before/01_weeks_two_and_three.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fact-verification-timeline-order/screenshots/after/01_weeks_two_and_three.png) |

The screenshot spec that produced these is intentionally not committed — it is a throwaway
that drives `WizardTimelineManager` directly and clips to the two weeks that change.

## Open questions and concerns

- **The due date shift** described above is a side effect of the move rather than something
  explicitly asked for. It looks right, but say so if it isn't.
- **The cleanup script's skip list may well be longer than its move list.** Based on the dump,
  hand-merged blocks may outnumber the standalone blocks the script can safely move. Anything
  it reports under `merged_with_other` needs a human decision, since the exercise is sitting
  inside an unrelated block there. Read the dry-run output before letting it write.
- **The script has no spec**, consistent with the rest of `docs/cleanup_scripts/`. It was
  verified by running it against a production-dump-loaded development database inside
  transactions that were rolled back: dry run writes nothing, the live run produces the
  expected sequence, duplicate `order` ties resolve correctly, and a repeat run is a no-op.
  Files under `docs/` are also excluded from RuboCop, so it is not linted.
- **The Ruby suite has not been run on this branch.** `course_creation_spec`'s
  `expected_course_blocks` count should be unaffected, since the content change is a pure
  move within one file, but that is reasoning rather than a green run — CI will settle it.
- Existing courses keep the old ordering until someone runs the script; nothing here
  backfills automatically.

(PR description written by Claude Code.)
