### PR TITLE
Refuse to delete or rename event-linked courses; tolerate sync races

### DIFF
--- a/app/assets/javascripts/components/overview/available_actions.jsx
+++ b/app/assets/javascripts/components/overview/available_actions.jsx
@@ -113,9 +113,18 @@ const AvailableActions = ({ course, current_user, updateCourse, courseCreationNo
     }
     // If course is not published, show the 'delete' button to instructors and admins.
     if ((user.isAdvancedRole || user.admin) && (!course.published || !Features.wikiEd)) {
+      // Deleting a course that is linked to a Wikimedia Event Registration event
+      // would break registration for that event, so the server refuses it.
+      const linkedToEvent = Boolean(course.flags.event_sync);
+      let deleteTitle;
+      if (linkedToEvent) {
+        deleteTitle = I18n.t('courses.error.event_sync_delete');
+      } else if (Features.wikiEd) {
+        deleteTitle = I18n.t('courses.delete_course_instructions');
+      }
       controls.push((
-        <div title={Features.wikiEd ? I18n.t('courses.delete_course_instructions') : undefined} key="delete" className="available-action">
-          <button className="button danger" onClick={deleteCourseFunc}>
+        <div title={deleteTitle} key="delete" className="available-action">
+          <button className={linkedToEvent ? 'button danger disabled' : 'button danger'} onClick={deleteCourseFunc} disabled={linkedToEvent}>
             {CourseUtils.i18n('delete_course', course.string_prefix)}
           </button>
         </div>

--- a/app/controllers/courses/delete_from_campaign_controller.rb
+++ b/app/controllers/courses/delete_from_campaign_controller.rb
@@ -8,6 +8,9 @@ class Courses::DeleteFromCampaignController < CoursesController
     if @course.campaigns.size > 1
       remove_course_from_campaign_but_not_deleted
     else
+      # Removing the only campaign deletes the course, which is refused for
+      # event-linked courses. See CoursesController#reject_deletion_of_event_synced_course.
+      reject_deletion_of_event_synced_course { return }
       remove_and_delete_course_from_campaign
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -46,8 +46,9 @@ class CoursesController < ApplicationController
 
   def update
     validate
-    handle_course_announcement(@course.instructors.first)
     slug_from_params if should_set_slug?
+    reject_rename_of_event_synced_course { return }
+    handle_course_announcement(@course.instructors.first)
     @course.update update_params
     update_courses_wikis
     update_course_wiki_namespaces
@@ -63,6 +64,7 @@ class CoursesController < ApplicationController
 
   def destroy
     validate
+    reject_deletion_of_event_synced_course { return }
     DeleteCourseWorker.schedule_deletion(course: @course, current_user:)
     render json: { success: true }
   end
@@ -313,6 +315,24 @@ class CoursesController < ApplicationController
     slug << "_(#{course[:term]})" if course[:term].present?
 
     course[:slug] = slug.tr(' ', '_')
+  end
+
+  # Courses linked to a Wikimedia Event Registration event are looked up by slug
+  # by the CampaignEvents extension, which has no way to learn that the course
+  # went away. Deleting or renaming one silently breaks registration for that
+  # event (see https://phabricator.wikimedia.org/T437639), so refuse until the
+  # organizer unlinks the event first.
+  def reject_deletion_of_event_synced_course
+    return unless @course.controlled_by_event_center?
+    render json: { message: I18n.t('courses.error.event_sync_delete') }, status: :conflict
+    yield
+  end
+
+  def reject_rename_of_event_synced_course
+    return unless @course.controlled_by_event_center?
+    return unless params[:course][:slug].present? && params[:course][:slug] != @course.slug
+    render json: { message: I18n.t('courses.error.event_sync_rename') }, status: :conflict
+    yield
   end
 
   def ensure_passcode_set

--- a/app/services/join_course.rb
+++ b/app/services/join_course.rb
@@ -23,7 +23,7 @@ class JoinCourse
 
   def process_join_request
     validate_request { return }
-    create_courses_user
+    create_courses_user { return }
     update_course_user_count
     # This needs to use string keys because it is used in Sidekiq arguments.
     @result = { 'success' => 'User added to course.' }
@@ -91,6 +91,12 @@ class JoinCourse
       real_name: @real_name,
       role_description: @role_description
     )
+  rescue ActiveRecord::RecordNotUnique
+    # A concurrent request enrolled this user in the same role between the
+    # user_already_enrolled? check and the insert. This happens when Wikimedia
+    # Event Registration sends two overlapping participant syncs for one course.
+    @result = { 'failure' => 'cannot_join_twice' }
+    yield
   end
 
   def update_course_user_count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -856,6 +856,8 @@ en:
       duplicate_course_slug: "The URL %{slug} is already taken. Please change the title, school, or term."
       invalid_slug: Blank school/title for course.
       duplicate_slug: "Another program called %{slug} already exists."
+      event_sync_delete: This page is linked to Wikimedia Event Registration and cannot be deleted.
+      event_sync_rename: This page is linked to Wikimedia Event Registration and cannot be renamed.
     expected_students: Expected Students
     features_feedback: "Automated Suggestions:"
     feedback: Feedback

--- a/spec/controllers/courses/delete_from_campaign_controller_spec.rb
+++ b/spec/controllers/courses/delete_from_campaign_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Courses::DeleteFromCampaignController, type: :request do
+  let(:slug) { 'Wikipedia_Fellows/Basket-weaving_fellows_(summer_2018)' }
+  let(:flags) { {} }
+  let!(:course) { create(:course, slug:, flags:) }
+  let!(:campaign) { create(:campaign, title: 'Spring 2016') }
+  let!(:campaigns_course) { create(:campaigns_course, course:, campaign:) }
+  let(:user) { create(:admin) }
+  let(:query) do
+    { campaign_title: campaign.title, campaign_id: campaign.id, campaign_slug: campaign.slug }
+  end
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:user_signed_in?).and_return(true)
+  end
+
+  describe '#delete_course_from_campaign' do
+    context 'when the course is only in this campaign' do
+      it 'removes the course from the campaign and schedules deletion' do
+        expect(DeleteCourseWorker).to receive(:schedule_deletion).once
+        delete "/courses/#{course.slug}.json/delete_from_campaign", params: query
+        expect(response).to redirect_to(programs_campaign_path(campaign.slug))
+        expect(CampaignsCourses.exists?(campaigns_course.id)).to be(false)
+      end
+    end
+
+    context 'when the course is also in another campaign' do
+      let!(:other_campaign) { create(:campaign_two) }
+      let!(:other_campaigns_course) { create(:campaigns_course, course:, campaign: other_campaign) }
+
+      it 'removes the course from this campaign only and does not delete it' do
+        expect(DeleteCourseWorker).not_to receive(:schedule_deletion)
+        delete "/courses/#{course.slug}.json/delete_from_campaign", params: query
+        expect(response).to redirect_to(programs_campaign_path(campaign.slug))
+        expect(CampaignsCourses.exists?(campaigns_course.id)).to be(false)
+        expect(CampaignsCourses.exists?(other_campaigns_course.id)).to be(true)
+      end
+    end
+
+    context 'when the course is linked to a Wikimedia Event Registration event' do
+      let(:flags) { { event_sync: 4296 } }
+
+      it 'refuses to delete the course and leaves it in the campaign' do
+        expect(DeleteCourseWorker).not_to receive(:schedule_deletion)
+        delete "/courses/#{course.slug}.json/delete_from_campaign", params: query
+        expect(response).to have_http_status(:conflict)
+        expect(response.parsed_body['message']).to eq(I18n.t('courses.error.event_sync_delete'))
+        expect(CampaignsCourses.exists?(campaigns_course.id)).to be(true)
+        expect(Course.exists?(course.id)).to be(true)
+      end
+
+      context 'when the course is also in another campaign' do
+        let!(:other_campaigns_course) do
+          create(:campaigns_course, course:, campaign: create(:campaign_two))
+        end
+
+        it 'still allows removing it from one campaign, since that does not delete it' do
+          expect(DeleteCourseWorker).not_to receive(:schedule_deletion)
+          delete "/courses/#{course.slug}.json/delete_from_campaign", params: query
+          expect(response).to redirect_to(programs_campaign_path(campaign.slug))
+          expect(CampaignsCourses.exists?(campaigns_course.id)).to be(false)
+        end
+      end
+    end
+
+    context 'when the user cannot edit the course' do
+      let(:user) { create(:user) }
+
+      it 'does not remove or delete anything' do
+        expect(DeleteCourseWorker).not_to receive(:schedule_deletion)
+        delete "/courses/#{course.slug}.json/delete_from_campaign", params: query
+        expect(response).to have_http_status(:unauthorized)
+        expect(CampaignsCourses.exists?(campaigns_course.id)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -111,6 +111,17 @@ describe CoursesController, type: :request do
         expect(Course.find_by(slug: course.slug)).to be_nil
       end
     end
+
+    context 'when the course is linked to a Wikimedia Event Registration event' do
+      before { course.update!(flags: { event_sync: 4296 }) }
+
+      it 'refuses to delete the course' do
+        expect(DeleteCourseWorker).not_to receive(:schedule_deletion)
+        delete "/courses/#{course.slug}", params: { id: "#{course.slug}.json" }, as: :json
+        expect(response).to have_http_status(:conflict)
+        expect(Course.find_by(slug: course.slug)).to be_present
+      end
+    end
   end
 
   describe '#update' do
@@ -145,6 +156,25 @@ describe CoursesController, type: :request do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       allow_any_instance_of(ApplicationController).to receive(:user_signed_in?).and_return(true)
       allow_any_instance_of(WikiCourseEdits).to receive(:update_course)
+    end
+
+    context 'when the course is linked to a Wikimedia Event Registration event' do
+      before { course.update!(flags: { event_sync: 4296 }) }
+
+      it 'refuses to change the slug' do
+        params = { id: course.slug, course: course_params }
+        put "/courses/#{course.slug}", params: params, as: :json
+        expect(response).to have_http_status(:conflict)
+        expect(course.reload.slug).to eq(slug_params)
+        expect(course.description).not_to eq('New description')
+      end
+
+      it 'still saves other changes when the slug is unchanged' do
+        params = { id: course.slug, course: { description: 'New description' } }
+        put "/courses/#{course.slug}", params: params, as: :json
+        expect(response).to have_http_status(:ok)
+        expect(course.reload.description).to eq('New description')
+      end
     end
 
     it 'does not post the details to the announcement page or the userpage' do

--- a/spec/controllers/wikimedia_event_center_controller_spec.rb
+++ b/spec/controllers/wikimedia_event_center_controller_spec.rb
@@ -214,6 +214,29 @@ describe WikimediaEventCenterController, type: :request do
       end
     end
 
+    context 'when an overlapping sync already enrolled a participant' do
+      let(:usernames) { ['RandomUser'] }
+
+      before do
+        JoinCourse.new(course:, user: non_organizer,
+                       role: CoursesUsers::Roles::STUDENT_ROLE, event_sync: true)
+        # Simulate the race: this request read the roster and ran the enrollment
+        # checks before the other request's insert committed, so only the
+        # database's unique index catches the duplicate.
+        allow_any_instance_of(Course).to receive(:students).and_return(User.none)
+        allow(CoursesUsers).to receive(:exists?).and_return(false)
+        allow_any_instance_of(CoursesUsers).to receive(:valid?).and_return(true)
+      end
+
+      it 'succeeds without duplicating the enrollment' do
+        subject
+        expect(response).to have_http_status(:ok)
+        enrollments = CoursesUsers.where(course:, user: non_organizer,
+                                         role: CoursesUsers::Roles::STUDENT_ROLE)
+        expect(enrollments.count).to eq(1)
+      end
+    end
+
     context 'when the course is already synced to another event' do
       let(:event_id) { '54321' }
       let(:usernames) { ['Ragesoss'] }

--- a/spec/services/join_course_spec.rb
+++ b/spec/services/join_course_spec.rb
@@ -142,6 +142,26 @@ describe JoinCourse do
     end
   end
 
+  context 'when a concurrent request enrolls the user first' do
+    let(:course) { editathon }
+
+    before do
+      # Simulate the race: both the enrollment check and the model's uniqueness
+      # validation ran before the other request committed, so only the database's
+      # unique index catches the duplicate.
+      create(:courses_user, course:, user: second_user, role: CoursesUsers::Roles::STUDENT_ROLE)
+      allow(CoursesUsers).to receive(:exists?).and_return(false)
+      allow_any_instance_of(CoursesUsers).to receive(:valid?).and_return(true)
+    end
+
+    it 'reports a repeat join instead of raising' do
+      result = described_class.new(course:, user: second_user,
+                                   role: CoursesUsers::Roles::STUDENT_ROLE).result
+      expect(result['failure']).to eq('cannot_join_twice')
+      expect(CoursesUsers.where(course:, user: second_user).count).to eq(1)
+    end
+  end
+
   context 'for a disallowed user' do
     let(:course) { basic_course }
     let(:disallowed_user) { create(:user, username: 'DisallowedBot') }


### PR DESCRIPTION
## What this PR does

Two fixes for the Programs & Events Dashboard's integration with Wikimedia Event Registration, prompted by [T437639](https://phabricator.wikimedia.org/T437639), where participants registering for events linked to the Dashboard were blocked with "not connected to this event" and "unknown error" messages.

**Refuse to delete or rename an event-linked course.** The CampaignEvents extension looks the course up by slug on every registration and has no way to learn that the course went away. When an organizer deletes a linked course and recreates it under the same slug, the event ends up pointing at a course that was never linked, and every registration fails the extension's dry-run validation. That is exactly what happened to event 4296: the linked course was deleted on 2026-08-14 at 07:47 UTC and recreated three minutes later. `CoursesController#destroy` and `#update` now return 409 with a message when the course has an `event_sync` flag and the action would delete it or change its slug. The Delete button on the course page renders disabled with the same message as its tooltip. Updates that leave the slug alone still go through.

**Tolerate overlapping participant syncs.** The extension sends the full roster after every registration. Two overlapping syncs for the same course both pass the already-enrolled check and the model's uniqueness validation before either commits, and the loser 500s on the database's unique index (Sentry PEONY-2QH, four occurrences since 2026-08-25). `JoinCourse` now rescues `ActiveRecord::RecordNotUnique` and reports it as the existing `cannot_join_twice` failure, so the request completes and the remaining participants are still processed.

Relevant extension code: [WikiEduDashboard.php](https://github.com/wikimedia/mediawiki-extensions-CampaignEvents/blob/master/src/TrackingTool/Tool/WikiEduDashboard.php) in the CampaignEvents extension, which maps the Dashboard's `sync_not_enabled` and `course_not_found` codes to the messages participants see.

## AI usage

This PR was produced with Claude Code (Claude Fable 5.1) under human direction. The agent did the investigation behind it: it mapped the extension's error messages to Dashboard error codes by reading the CampaignEvents source, scanned recent Event Registration events through the CampaignEvents REST API and compared each linked course's stored event ID with the real one, and used Sentry's course-deletion log messages to reconstruct the delete-and-recreate sequence and to find the duplicate-key crash. It then wrote the code, the specs, and the commit message. The human decided what to fix, chose to include the rename guard, supplied both user-facing strings verbatim, and reviewed the diff.

One correction during the work: the first version of the race specs passed without exercising the rescue, because the model's uniqueness validation stopped the duplicate before the database did. The agent found this with a `rails runner` reproduction and adjusted the specs to stub the validation so that only the unique index catches the duplicate, matching production.

Scale of effort: a single commit, written in one session of roughly an hour of implementation after about an hour and a half of investigation. The "What this PR does" section and the rest of this description were also drafted by Claude Code and may contain errors.

This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

The Actions panel on an event-linked course, viewed by a facilitator. The tooltip on the disabled button is a native `title` attribute and does not appear in the screenshot.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-event-sync-guards/screenshots/before/01_event_linked_course_actions.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-event-sync-guards/screenshots/after/01_event_linked_course_actions.png) |

## Open questions and concerns

- The rename guard is a backstop. The details panel already locks title, institution, and term for linked courses, so it should only fire on a stale page or a direct API call.
- The race fix makes each insert safe but does not serialize syncs per course, so two interleaved syncs can still apply adds and removes in either order. Each sync carries the full roster, so the next one converges. A per-course lock felt like more machinery than the observed problem warrants.
- The Dashboard still has no way to tell the extension that a link is gone. A linked course that was deleted before this change leaves its event blocked with a "does not exist" error until the organizer unlinks it in Event Registration. I have raised on the Phabricator task whether the extension should treat that case as a desync rather than a hard failure.
- The screenshot spec (`spec/features/event_sync_delete_button_screenshots_spec.rb`) is disposable and not committed.

(PR description written by Claude Code.)
