### PR TITLE
Fix missing translation for empty alerts lists

### DIFF
--- a/app/assets/javascripts/components/alerts/admin_alerts.jsx
+++ b/app/assets/javascripts/components/alerts/admin_alerts.jsx
@@ -16,7 +16,7 @@ const AdminAlerts = () => {
   return (
     <AlertsHandler
       alertLabel={I18n.t('alerts.alert_label')}
-      noAlertsLabel={I18n.t('alerts.no_alerts')}
+      noAlertsLabel={I18n.t('alerts.no_data')}
       adminAlert={true}
     />
   );

--- a/app/assets/javascripts/components/alerts/course_alerts_list.jsx
+++ b/app/assets/javascripts/components/alerts/course_alerts_list.jsx
@@ -17,7 +17,7 @@ const CourseAlertsList = (props) => {
   return (
     <AlertsHandler
       alertLabel={I18n.t('alerts.alert_label')}
-      noAlertsLabel={I18n.t('alerts.no_alerts')}
+      noAlertsLabel={I18n.t('alerts.no_data')}
     />
   );
 };

--- a/spec/features/course_page_spec.rb
+++ b/spec/features/course_page_spec.rb
@@ -517,6 +517,12 @@ describe 'the course page', type: :feature, js: true do
         expect(page).to be_axe_clean
       end
     end
+
+    it 'shows a translated empty-state message when the course has no alerts' do
+      js_visit "/courses/#{slug}/activity/alerts"
+      expect(page).to have_content I18n.t('alerts.no_data')
+      expect(page).not_to have_content 'missing'
+    end
   end
 
   describe 'resources view' do


### PR DESCRIPTION
## What this PR does

Fixes a raw `[missing "en.alerts.no_alerts" translation]` marker that has been showing in place of the empty-state message on two alerts lists whenever there are no alerts to display:

- the course page's **Activity › Alerts** sub-tab (`/courses/:slug/activity/alerts`), which an instructor reported via screenshot
- the admin **Alerts** list (`/alerts_list`)

Commit a924bf2c4 (merged via #6559 on 2025-11-10) renamed `alerts.no_alerts` to `alerts.no_data` in `en.yml` and updated the AI-stats callers, but missed the two components above. Translatewiki followed the rename, so no locale defines the old key anymore and the marker appeared in every language. Both components now use `alerts.no_data`, which is already translated across locales.

A feature spec in `course_page_spec.rb` visits the `activity/alerts` sub-route for a course with no alerts and asserts the translated text renders with no "missing" marker, so a future key rename that misses a caller will fail CI.

## AI usage

Claude Code (Claude Fable 5.1) did the diagnosis and wrote the code. Starting from the instructor's screenshot, it located the two stale `I18n.t` calls, traced the key rename to commit a924bf2c4 with `git log -S`, and confirmed with a YAML-aware scan that no locale still defines `alerts.no_alerts`. It then made the two one-line changes, wrote the regression spec, wrote the commit message, and drafted this description. The human contribution was supplying the screenshot, choosing between the two fix options presented (reuse the existing translated `no_data` key vs. restore the original "No alerts found." copy), and directing the commit and PR.

Scale of effort: a single commit, made within about 15 minutes of the diagnosis in one session. The first version of the regression spec visited `/activity`, which redirects to `activity/recent` and never mounts the alerts list; it was corrected to `activity/alerts` and passed on the second run.

The "What this PR does" summary and other analysis here were also drafted by Claude Code and may contain errors. This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

Captured with a disposable, untracked screenshot spec. Because the change is entirely in compiled JS, the "before" pass was produced by checking out master's two components, running `yarn build`, and re-running the spec.

**Course Activity › Alerts sub-tab, no alerts**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-alerts-empty-state-translation/screenshots/before/01_course_activity_alerts_empty.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-alerts-empty-state-translation/screenshots/after/01_course_activity_alerts_empty.png) |

**Admin alerts list, no alerts**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-alerts-empty-state-translation/screenshots/before/02_admin_alerts_list_empty.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/fix-alerts-empty-state-translation/screenshots/after/02_admin_alerts_list_empty.png) |

## Open questions and concerns

- The fix reuses the generic "No data found." string rather than restoring alert-specific wording. That was a deliberate choice so the fix ships fully translated; if alert-specific copy is preferred, a `no_alerts` key would need to be re-added to `en.yml` and picked up by translatewiki.
- The repo has no `i18n-tasks` configuration, so `I18n.t` calls in JSX are never checked against the locale files. That is how this rename went unnoticed for ten months. A lightweight check that scans `app/assets/javascripts` for `I18n.t('...')` keys and verifies them against `en.yml` would catch this class of bug; left as possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(PR description written by Claude Code.)
