### PR TITLE
Hide stale drafts from the unsubmitted courses list by default

### DIFF
--- a/app/controllers/unsubmitted_courses_controller.rb
+++ b/app/controllers/unsubmitted_courses_controller.rb
@@ -3,7 +3,19 @@
 class UnsubmittedCoursesController < ApplicationController
   respond_to :html
 
+  # Drafts whose start date is further in the past than this are unlikely to
+  # ever be submitted, so the default view hides them. `?all=true` shows them.
+  START_DATE_CUTOFF = 3.months
+
   def index
-    @unsubmitted_courses = Course.unsubmitted.order(created_at: :desc).includes(:tags, :instructors)
+    @show_all = params[:all].present?
+    @unsubmitted_courses = scoped_courses.order(created_at: :desc).includes(:tags, :instructors)
+  end
+
+  private
+
+  def scoped_courses
+    return Course.unsubmitted if @show_all
+    Course.unsubmitted.where(start: START_DATE_CUTOFF.ago..)
   end
 end

--- a/app/views/unsubmitted_courses/index.html.haml
+++ b/app/views/unsubmitted_courses/index.html.haml
@@ -7,6 +7,11 @@
 .container
   %section#courses
     .section-header
+      %p.unsubmitted-courses__scope
+        - if @show_all
+          %a{href: unsubmitted_courses_path}= t('courses.unsubmitted_show_recent')
+        - else
+          %a{href: unsubmitted_courses_path(all: true)}= t('courses.unsubmitted_show_all')
       .sort-select
         %select.sorts{:rel => "courses", 'aria-label': t('application.sort')}
           %option{:rel => "asc", :value => "title"}= t("courses.title")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1037,6 +1037,8 @@ en:
     training_nav: Go to training
     training_overdue: The training module "%{title}" is assigned for this course, and was due on %{date}.
     unsubmitted: Unsubmitted Courses
+    unsubmitted_show_all: Show all
+    unsubmitted_show_recent: Show recent
     untrained: Untrained
     update_stats: Update statistics
     uploads_none: This class has not contributed any images or other media files to Wikimedia Commons.

--- a/config/locales/qqq.yml
+++ b/config/locales/qqq.yml
@@ -540,6 +540,8 @@ qqq:
     training_nav: Link to go to the training page (Wiki Ed only)
     training_overdue: Training due date has passed for this course (Wiki Ed only)
     unsubmitted: Name for pseudo-campaign of unsubmitted courses (Wiki Ed only)
+    unsubmitted_show_all: Link on the unsubmitted courses page. By default the page only lists courses that started within the last three months or have not started yet; this link switches to the full list.
+    unsubmitted_show_recent: Link on the unsubmitted courses page that switches from the full list back to the default view (courses that started within the last three months or have not started yet).
     untrained: '{{Identical|Untrained}}'
     view: Label for link to a course page
     view_doc: Explanation of what 'article views' means

--- a/spec/controllers/unsubmitted_courses_controller_spec.rb
+++ b/spec/controllers/unsubmitted_courses_controller_spec.rb
@@ -6,12 +6,17 @@ describe UnsubmittedCoursesController, type: :request do
   describe '#index' do
     let!(:course) do
       create(:course, title: 'My awesome course',
-                      start: Date.civil(2016, 1, 10), end: Date.civil(2050, 1, 10))
+                      start: 1.month.ago, end: 1.year.from_now)
     end
 
     let!(:course2) do
       create(:course, title: 'course2', slug: 'foo/course2',
-                      start: Date.civil(2016, 1, 10), end: Date.civil(2016, 2, 10))
+                      start: 1.month.ago, end: 1.month.from_now)
+    end
+
+    let!(:stale_course) do
+      create(:course, title: 'Stale draft', slug: 'foo/stale',
+                      start: 4.months.ago, end: 3.months.ago)
     end
 
     it 'lists courses/programs that do not have a campaigns' do
@@ -26,6 +31,36 @@ describe UnsubmittedCoursesController, type: :request do
     it 'shows course creation date' do
       get '/unsubmitted_courses'
       expect(response.body).to include(course.created_at.strftime('%Y-%m-%d'))
+    end
+
+    it 'hides courses that started more than three months ago by default' do
+      get '/unsubmitted_courses'
+      expect(response.body).not_to include(stale_course.title)
+    end
+
+    it 'shows courses that have not started yet' do
+      upcoming = create(:course, title: 'Upcoming draft', slug: 'foo/upcoming',
+                                 start: 6.months.from_now, end: 1.year.from_now)
+      get '/unsubmitted_courses'
+      expect(response.body).to include(upcoming.title)
+    end
+
+    it 'shows every unsubmitted course when all=true' do
+      get '/unsubmitted_courses', params: { all: true }
+      expect(response.body).to include(stale_course.title)
+      expect(response.body).to include(course2.title)
+    end
+
+    it 'links to the full list from the default view' do
+      get '/unsubmitted_courses'
+      expect(Capybara.string(response.body))
+        .to have_link('Show all', href: '/unsubmitted_courses?all=true')
+    end
+
+    it 'links back to the default view from the full list' do
+      get '/unsubmitted_courses', params: { all: true }
+      expect(Capybara.string(response.body))
+        .to have_link('Show recent', href: '/unsubmitted_courses')
     end
   end
 end

--- a/spec/features/courses_by_wiki_spec.rb
+++ b/spec/features/courses_by_wiki_spec.rb
@@ -32,7 +32,8 @@ end
 describe 'unsubmitted courses page', type: :feature, js: true do
   before do
     stub_wiki_validation
-    create(:course, title: 'Draft course', submitted: false)
+    create(:course, title: 'Draft course', submitted: false,
+                    start: 1.week.ago, end: 1.year.from_now)
     login_as(create(:admin))
   end
 


### PR DESCRIPTION
## What this PR does

The Unsubmitted Courses admin page (`/unsubmitted_courses`) listed every course that was never submitted, going back to the beginning of the Dashboard. Most of those are abandoned drafts, so the list was long and the drafts actually worth following up on were buried. This PR makes the page default to unsubmitted courses whose start date is no more than three months in the past (courses that haven't started yet are included), and adds a "Show all" link that switches to the full list. The full list links back with "Show recent".

The cutoff is applied in the controller via a `START_DATE_CUTOFF` constant (3 months). `?all=true` bypasses it, following the same query-param pattern the FAQ page already uses. Two existing specs seeded unsubmitted courses with 2015/2016 start dates and were updated to use recent dates; new controller spec examples cover the cutoff, upcoming courses, the `all` bypass, and both directions of the toggle link.

## AI usage

This PR was written by Claude Code (Claude Fable 5.1) under Sage Ross's direction. Sage specified the behavior (three-month cutoff on start date, with an option to see the full list). Claude Code read the existing controller, view, `Course.unsubmitted` scope, and specs, implemented the filter, the toggle link, and the locale strings, updated the specs, captured the screenshots below, and wrote the commit message and this PR description. Sage reviewed the result via the screenshots and spec output.

The link labels "Show all" and "Show recent" are Claude Code's wording. They are two-word labels, within the project's rule on AI-written user-facing text, but see the open questions below. No other user-facing copy was added.

Scale of effort: a single commit, made in one short session (well under an hour) on 2026-09-10, with one correction cycle: two spec assertions initially failed because Haml emits single-quoted attributes, and were switched to Capybara link matchers.

The "What this PR does" summary and other analysis in this description were also drafted by Claude Code and may contain errors. This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

Seeded with four unsubmitted drafts: two recent or upcoming (start dates 6 weeks ago and 30 days from now) and two stale (started in early 2025 and fall 2024).

**01 default view** — before: all four drafts; after: only the two recent ones, with a "Show all" link

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/unsubmitted-courses-filter/screenshots/before/01_default_view.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/unsubmitted-courses-filter/screenshots/after/01_default_view.png) |

**02 full list** — after clicking "Show all"; the link becomes "Show recent"

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/unsubmitted-courses-filter/screenshots/after/02_full_list.png) |

## Open questions and concerns

- The link labels are AI-drafted. "Show recent" is slightly loose, since the default view also includes courses that haven't started yet. Alternative wording, or a short human-written note explaining the cutoff, would be easy to drop in.
- The three-month cutoff is a constant in the controller rather than anything configurable. That seemed sufficient for an admin-only page.
- `all` is treated as on for any non-blank value (so `?all=false` also shows the full list), matching how the FAQ page handles its `all` param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(PR description written by Claude Code.)
