### PR TITLE
Lock course flag writes and surface Event Center sync failures

### DIFF
--- a/app/controllers/wikimedia_event_center_controller.rb
+++ b/app/controllers/wikimedia_event_center_controller.rb
@@ -26,6 +26,7 @@ class WikimediaEventCenterController < ApplicationController
   #   already_in_use - The course already has participants, so it can't be linked to the event
   #   sync_already_enabled - The course is already linked to an event
   #   missing_event_id - No Event Center ID ("event_id") was provided.
+  #   course_not_saved - The link could not be saved, so the course is not linked to the event.
   def confirm_event_sync
     verify_secret { return }
     set_course { return }
@@ -95,6 +96,7 @@ class WikimediaEventCenterController < ApplicationController
   def set_course
     @course = Course.find_by!(slug: params[:course_slug])
   rescue ActiveRecord::RecordNotFound => e
+    report_sync_failure('course_not_found')
     render json: { error: e.message, error_code: 'course_not_found' }, status: :not_found
     yield
   end
@@ -122,25 +124,49 @@ class WikimediaEventCenterController < ApplicationController
     return if params[:dry_run]
     raise MissingEventIdError unless params[:event_id].present?
 
-    @course.flags[:event_sync] = params[:event_id]
-    @course.save
+    # The extension keeps the link only if we report success, so a save that
+    # does not persist must be an error here, not a silent no-op. add_flag
+    # also takes a row lock, so a concurrent flags write elsewhere cannot
+    # drop the link before it is ever read.
+    raise CourseNotSavedError unless @course.add_flag(key: :event_sync, value: params[:event_id])
   rescue AlreadyInUseError, SyncAlreadyEnabledError, MissingEventIdError => e
     render json: { error: e.message, error_code: e.code }, status: :conflict
     yield
+  rescue CourseNotSavedError => e
+    render_failed_save(e)
+    yield
+  end
+
+  def render_failed_save(error)
+    report_sync_failure(error.code, level: 'error')
+    render json: { error: error.message, error_code: error.code }, status: :internal_server_error
   end
 
   def disable_event_sync
     return if params[:dry_run]
 
-    @course.flags.delete(:event_sync)
-    @course.save
+    @course.remove_flag(:event_sync)
   end
 
   def verify_event_sync
     raise SyncNotEnabledError unless @course.flags[:event_sync] == params[:event_id]
   rescue SyncNotEnabledError => e
+    report_sync_failure(e.code)
     render json: { error: e.message, error_code: e.code }, status: :conflict
     yield
+  end
+
+  # These responses are rendered rather than raised, so without this the
+  # participant sees the extension's message and the Dashboard records nothing
+  # at all. Usernames are deliberately left out: the course may be private.
+  def report_sync_failure(error_code, level: 'info')
+    Sentry.capture_message("Event Center sync failed: #{error_code}",
+                           level:,
+                           extra: { action: action_name,
+                                    course_slug: params[:course_slug],
+                                    event_id: params[:event_id],
+                                    stored_event_id: @course&.flags&.dig(:event_sync),
+                                    dry_run: params[:dry_run] })
   end
 
   def add_or_remove_participants
@@ -238,6 +264,16 @@ class WikimediaEventCenterController < ApplicationController
 
     def message
       'An Event Center event ID is requred.'
+    end
+  end
+
+  class CourseNotSavedError < StandardError
+    def code
+      'course_not_saved'
+    end
+
+    def message
+      'The event link could not be saved.'
     end
   end
 end

--- a/app/controllers/wikimedia_event_center_controller.rb
+++ b/app/controllers/wikimedia_event_center_controller.rb
@@ -48,11 +48,12 @@ class WikimediaEventCenterController < ApplicationController
   #   invalid_secret - The shared secret doesn't match
   #   course_not_found - A Course with the provided slug doesn't exist
   #   sync_not_enabled - This Course isn't linked to the Event Center event (based on event_id)
+  #   course_not_saved - The unlink could not be saved, so the course is still linked to the event.
   def unsync_event
     verify_secret { return }
     set_course { return }
     verify_event_sync { return }
-    disable_event_sync
+    disable_event_sync { return }
     render json: { success: true }
   end
 
@@ -145,7 +146,13 @@ class WikimediaEventCenterController < ApplicationController
   def disable_event_sync
     return if params[:dry_run]
 
-    @course.remove_flag(:event_sync)
+    # Same reasoning as enable_event_sync: the extension drops its side of the
+    # link on success, so reporting success while the flag stays behind would
+    # leave the course permanently unlinkable.
+    raise CourseNotSavedError unless @course.remove_flag(:event_sync)
+  rescue CourseNotSavedError => e
+    render_failed_save(e)
+    yield
   end
 
   def verify_event_sync

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -494,9 +494,25 @@ class Course < ApplicationRecord
     word_count / user_count
   end
 
+  # Flags live in one serialized column, so every save rewrites the whole hash.
+  # A stale Course object that sets one flag and saves silently drops any flag
+  # another process wrote in the meantime; that is how an Event Center link can
+  # vanish minutes after it was confirmed (T437639). These two methods reload
+  # under a row lock before writing, so a single-flag change never clobbers the
+  # rest. They return the result of `save`, and raise if the receiver has
+  # unsaved changes, because `with_lock` refuses to reload over them.
   def add_flag(key:, value: true)
-    flags[key] = value
-    save
+    with_lock do
+      flags[key] = value
+      save
+    end
+  end
+
+  def remove_flag(key)
+    with_lock do
+      flags.delete(key)
+      save
+    end
   end
 
   # Overridden for some course types

--- a/lib/data_cycle/course_queue_sorting.rb
+++ b/lib/data_cycle/course_queue_sorting.rb
@@ -62,9 +62,12 @@ module CourseQueueSorting
   end
 
   def update_longest_update_time(course)
-    return unless longest_recent_update_time(course).to_i >= longest_update_time(course).to_i
+    longest = longest_recent_update_time(course)
+    return unless longest.to_i >= longest_update_time(course).to_i
+    # This runs for every course on every scheduler pass and add_flag takes a
+    # row lock, so only write when the value actually changes.
+    return if longest == longest_update_time(course)
 
-    course.flags[:longest_update] = longest_recent_update_time(course)
-    course.save
+    course.add_flag(key: :longest_update, value: longest)
   end
 end

--- a/lib/data_cycle/schedule_course_updates.rb
+++ b/lib/data_cycle/schedule_course_updates.rb
@@ -50,11 +50,11 @@ class ScheduleCourseUpdates
       log_message "Set course #{course.slug} to queue #{queue}"
       CourseDataUpdateWorker.update_course(course_id: course.id, queue:)
 
-      # if course isn't updated before, add first update flags
+      # if course isn't updated before, add first update flags.
+      # This course object was loaded at the start of the pass, so write the
+      # flag through add_flag rather than saving the stale copy wholesale.
       next if course.flags[:first_update] || course.flags['update_logs']
-      first_update = first_update_flags(course)
-      course.flags[:first_update] = first_update
-      course.save
+      course.add_flag(key: :first_update, value: first_update_flags(course))
     end
   end
 

--- a/spec/controllers/wikimedia_event_center_controller_spec.rb
+++ b/spec/controllers/wikimedia_event_center_controller_spec.rb
@@ -78,6 +78,18 @@ describe WikimediaEventCenterController, type: :request do
         response_json = JSON.parse(response.body)
         expect(response_json['error_code']).to eq('course_not_found')
       end
+
+      it 'reports the failure to Sentry without any usernames' do
+        allow(Sentry).to receive(:capture_message)
+        subject
+        expect(Sentry).to have_received(:capture_message) do |message, options|
+          expect(message).to eq('Event Center sync failed: course_not_found')
+          expect(options[:level]).to eq('info')
+          expect(options[:extra]).to include(action: 'confirm_event_sync',
+                                             course_slug: 'not-a-course')
+          expect(options[:extra].to_s).not_to include(organizer.username)
+        end
+      end
     end
 
     context 'when the organizer is not part of the course' do
@@ -112,6 +124,22 @@ describe WikimediaEventCenterController, type: :request do
         subject
         response_json = JSON.parse(response.body)
         expect(response_json['error_code']).to eq('sync_already_enabled')
+      end
+    end
+
+    context 'when the link cannot be saved' do
+      before do
+        allow_any_instance_of(Course).to receive(:save).and_return(false)
+        allow(Sentry).to receive(:capture_message)
+      end
+
+      it 'returns an error instead of reporting success' do
+        subject
+        expect(response).to have_http_status(:internal_server_error)
+        expect(JSON.parse(response.body)['error_code']).to eq('course_not_saved')
+        expect(course.reload.flags[:event_sync]).to be_nil
+        expect(Sentry).to have_received(:capture_message)
+          .with('Event Center sync failed: course_not_saved', hash_including(level: 'error'))
       end
     end
   end
@@ -245,6 +273,21 @@ describe WikimediaEventCenterController, type: :request do
         subject
         response_json = JSON.parse(response.body)
         expect(response_json['error_code']).to eq('sync_not_enabled')
+      end
+
+      it 'reports both event IDs to Sentry without any usernames' do
+        allow(Sentry).to receive(:capture_message)
+        subject
+        expect(Sentry).to have_received(:capture_message) do |message, options|
+          expect(message).to eq('Event Center sync failed: sync_not_enabled')
+          expect(options[:level]).to eq('info')
+          expect(options[:extra]).to include(action: 'update_event_participants',
+                                             course_slug: course.slug,
+                                             event_id: '54321',
+                                             stored_event_id: '12345')
+          expect(options[:extra].to_s).not_to include('Ragesoss')
+          expect(options[:extra].to_s).not_to include(organizer.username)
+        end
       end
     end
   end

--- a/spec/controllers/wikimedia_event_center_controller_spec.rb
+++ b/spec/controllers/wikimedia_event_center_controller_spec.rb
@@ -180,6 +180,22 @@ describe WikimediaEventCenterController, type: :request do
         expect(course.reload.flags[:event_sync]).to eq('12345')
       end
     end
+
+    context 'when the unlink cannot be saved' do
+      before do
+        allow_any_instance_of(Course).to receive(:save).and_return(false)
+        allow(Sentry).to receive(:capture_message)
+      end
+
+      it 'returns an error instead of reporting success' do
+        subject
+        expect(response).to have_http_status(:internal_server_error)
+        expect(JSON.parse(response.body)['error_code']).to eq('course_not_saved')
+        expect(course.reload.flags[:event_sync]).to eq('12345')
+        expect(Sentry).to have_received(:capture_message)
+          .with('Event Center sync failed: course_not_saved', hash_including(level: 'error'))
+      end
+    end
   end
 
   describe '#update_event_participants' do

--- a/spec/lib/data_cycle/course_queue_sorting_spec.rb
+++ b/spec/lib/data_cycle/course_queue_sorting_spec.rb
@@ -139,4 +139,28 @@ describe CourseQueueSorting do
       end
     end
   end
+
+  describe '#update_longest_update_time' do
+    let(:seven_second_log) do
+      { 1 => { 'start_time' => Time.zone.parse('2026-09-08 19:00:00'),
+               'end_time' => Time.zone.parse('2026-09-08 19:00:07') } }
+    end
+
+    it 'records the longest recent update without clobbering other flags' do
+      course = create(:course, flags: { 'update_logs' => seven_second_log })
+      stale_copy = Course.find(course.id)
+      course.add_flag(key: :event_sync, value: 4563)
+
+      subject.update_longest_update_time(stale_copy)
+
+      expect(course.reload.flags).to include(event_sync: 4563, longest_update: 7)
+    end
+
+    it 'does not save when the value is unchanged' do
+      course = create(:course, flags: { 'update_logs' => seven_second_log, longest_update: 7 })
+      expect(course).not_to receive(:save)
+
+      subject.update_longest_update_time(course)
+    end
+  end
 end

--- a/spec/lib/data_cycle/schedule_course_updates_spec.rb
+++ b/spec/lib/data_cycle/schedule_course_updates_spec.rb
@@ -105,4 +105,24 @@ describe ScheduleCourseUpdates do
       end
     end
   end
+
+  describe 'writing first update flags' do
+    let!(:course) do
+      create(:course, start: 1.day.ago, end: 2.months.from_now, slug: 'New/Course')
+    end
+
+    it 'keeps a flag another process wrote after the course was loaded' do
+      # The scheduler loads every course before its loop starts. Here another
+      # process (the Event Center link) writes to the same flags column in the
+      # gap between that load and the first_update write.
+      allow(CourseDataUpdateWorker).to receive(:update_course) do |course_id:, **|
+        Course.find(course_id).add_flag(key: :event_sync, value: 4563)
+      end
+
+      described_class.new
+
+      expect(course.reload.flags[:event_sync]).to eq(4563)
+      expect(course.flags[:first_update]).to include(queue_name: 'medium_update')
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1026,4 +1026,35 @@ describe Course, type: :model do
       expect(build(:course, start: Date.new(2026, 12, 1)).inferred_term).to eq('spring_2027')
     end
   end
+
+  describe '#add_flag' do
+    let(:course) { create(:course, flags: { existing: true }) }
+
+    it 'keeps flags written by another process since the course was loaded' do
+      stale_copy = Course.find(course.id)
+      course.add_flag(key: :event_sync, value: 4563)
+      stale_copy.add_flag(key: :first_update, value: { queue_name: 'medium_update' })
+      expect(course.reload.flags).to include(existing: true,
+                                             event_sync: 4563,
+                                             first_update: { queue_name: 'medium_update' })
+    end
+
+    it 'returns false and writes nothing when the course is invalid' do
+      allow(course).to receive(:valid?).and_return(false)
+      expect(course.add_flag(key: :event_sync, value: 4563)).to be(false)
+      expect(course.reload.flags).not_to have_key(:event_sync)
+    end
+  end
+
+  describe '#remove_flag' do
+    let(:course) { create(:course, flags: { event_sync: 4563 }) }
+
+    it 'removes only the given flag, keeping flags written by another process' do
+      stale_copy = Course.find(course.id)
+      course.add_flag(key: :longest_update, value: 3)
+      stale_copy.remove_flag(:event_sync)
+      expect(course.reload.flags).to include(longest_update: 3)
+      expect(course.flags).not_to have_key(:event_sync)
+    end
+  end
 end


### PR DESCRIPTION
## What this PR does

Follow-up to #7056 for [T437639](https://phabricator.wikimedia.org/T437639), where participants registering for Wikimedia Event Registration events linked to the Programs & Events Dashboard are blocked with "not connected to this event" errors.

A new report on the task pointed at a course that had not appeared in any log. Checking it on the production console showed a valid course, one facilitator, zero participants, and no `event_sync` flag at all, while the CampaignEvents extension had recorded the link. The extension only stores a link after the Dashboard returns success (see [WikiEduDashboard.php](https://github.com/wikimedia/mediawiki-extensions-CampaignEvents/blob/master/src/TrackingTool/Tool/WikiEduDashboard.php) and [TrackingToolEventWatcher.php](https://github.com/wikimedia/mediawiki-extensions-CampaignEvents/blob/master/src/TrackingTool/TrackingToolEventWatcher.php)), so the Dashboard either reported success without persisting the flag or persisted it and then lost it. The delete-and-recreate mechanism fixed in #7056 does not apply: the course was never deleted. Three changes close the remaining gaps.

**Flag writes reload under a row lock.** Course flags live in one serialized column, so every save rewrites the whole hash, and a stale Course object that sets one flag silently drops any flag another process wrote in the meantime. `Course#add_flag` now reloads under `with_lock` before writing, and a new `remove_flag` does the same for deletion. The Event Center controller and the two flag writers in the update scheduler use them. The scheduler is the leading suspect for the lost flag: it loads every current course before its loop and only then iterates, and in the reported case its first-update write landed on the course at 19:45:19 UTC, thirty-seven seconds after the course was created and right when the organizer would have been linking the event. The longest-update writer now also skips the write when the value is unchanged, since it runs for every course on every pass.

**A failed save is no longer reported as success.** The confirm endpoint ignored the return value of `save`. It now returns a 500 with a new `course_not_saved` error code and reports to Sentry at error level, so the extension drops the link instead of keeping one the Dashboard never stored.

**Sync failures are visible.** The `course_not_found` and `sync_not_enabled` responses are rendered rather than raised, so they never reached Sentry; that is why the reported course was invisible to the original investigation. They now send an info-level Sentry message with the action, course slug, requested event ID, stored event ID, and dry-run flag. Usernames are deliberately excluded because linked courses can be private.

## AI usage

This PR was produced with Claude Code (Claude Fable 5.1) under human direction. The agent did the investigation: it fetched the Phabricator update, established through the Dashboard's slug-existence endpoint that the reported course exists and is private rather than deleted, scanned Event Registration events through the CampaignEvents REST API to locate the linked event and to check every other linked course, confirmed from Sentry's course-deletion log that the course was never deleted, read the extension source to establish when it persists a link, and reviewed every code path that writes the flags hash. It proposed the three changes, and after the human's go-ahead wrote the code, the specs, the commit message, and this description.

The human ran the diagnostic queries on the production console and pasted the results, decided which of the proposed changes to implement, and reviewed the diff. One correction during the work: the agent's first console snippet would have printed a facilitator's username from a private course; the human pointed this out, the snippet was reworked to roles, counts, and timestamps, and the same rule shaped the Sentry logging in this PR.

Scale of effort: a single commit from one session, roughly two hours of investigation followed by about fifteen minutes of implementation. RuboCop flagged one ABC-size offense, fixed by extracting a helper; the specs were green on the first run. The "What this PR does" section and the rest of this description were drafted by Claude Code and may contain errors.

This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

No UI changes.

## Open questions and concerns

- The scheduler overwrite is the leading suspect for the reported course, not a proven cause. The Apache access log for the confirm call on 2026-09-08 between 19:44 and 19:55 UTC would settle it. The changes here are worthwhile either way, since they remove the whole class of lost-flag writes and make future failures observable.
- `add_flag` and `remove_flag` now take a row lock, and `with_lock` raises if the receiver has unsaved changes. Every current caller passes a clean object, and the model comment says so, but new callers need to know.
- `course_not_saved` is a new error code the extension does not recognize, so it maps to the extension's generic "unknown error" message. That is acceptable because the link is dropped either way, but WMF could add a specific message if they want one.
- The new info-level Sentry messages will include some expected cases, such as the extension unlinking a course that was already deleted. The `action` field distinguishes them.
- `update_longest_update_time` no longer writes a nil `longest_update` key onto courses that have no update logs yet. Nothing reads that key expecting it to exist.
- For organizers hit by this today, removing and re-adding the Dashboard link in Event Registration repairs the state as long as the course still has no participants. That is worth passing along on the task.

(PR description written by Claude Code.)
