### PR TITLE
Preserve instructor-chosen order of training modules in a block

### DIFF
--- a/app/models/course_data/block.rb
+++ b/app/models/course_data/block.rb
@@ -46,8 +46,13 @@ class Block < ApplicationRecord
 
   DEFAULT_POINTS = 10
 
+  # Preserves the order of training_module_ids, which is the order the
+  # instructor chose in the timeline editor. A bare `where` would come back in
+  # primary-key order. Ids with no matching module (a removed or renamed
+  # training) are skipped.
   def training_modules
-    TrainingModule.where(id: training_module_ids)
+    modules_by_id = TrainingModule.where(id: training_module_ids).index_by(&:id)
+    training_module_ids.filter_map { |id| modules_by_id[id] }
   end
 
   def date_manager

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Block do
+  describe '#training_modules' do
+    let(:first_module) do
+      create(:training_module, id: 1001, slug: 'first-module', name: 'First')
+    end
+    let(:second_module) do
+      create(:training_module, id: 1002, slug: 'second-module', name: 'Second')
+    end
+    let(:course) { create(:course) }
+    let(:week) { create(:week, course:) }
+    let(:block) do
+      create(:block, week:, training_module_ids: [second_module.id, first_module.id])
+    end
+
+    it 'returns modules in the order they were assigned to the block' do
+      expect(block.training_modules.map(&:id)).to eq([second_module.id, first_module.id])
+    end
+
+    it 'skips ids that no longer correspond to a module' do
+      block.update(training_module_ids: [second_module.id, 999_999, first_module.id])
+      expect(block.reload.training_modules.map(&:id)).to eq([second_module.id, first_module.id])
+    end
+  end
+end


### PR DESCRIPTION
## What this PR does

Fixes the display order of training modules within a timeline block. The order an instructor picks in the block editor is saved correctly in the block's serialized `training_module_ids`, but `Block#training_modules` fetched them with a bare `where(id: ...)`, which MySQL returns in primary-key order. Since both the timeline view and the edit-mode picker render from that method, modules always appeared in module-id order, and clearing and re-adding them in a new order looked like it did nothing.

`Block#training_modules` now maps the stored id array over the query result, so the saved order is what renders. Ids with no matching module (a removed or renamed training) are skipped, matching the existing `next unless tm` guard in the block jbuilder. A new `spec/models/block_spec.rb` covers both behaviors; there was no Block model spec before.

Reported directly by the operator; no GitHub issue.

## AI usage

Claude Code (Claude Fable 5.1) did the work in this PR under human direction. The operator reported the bug in a two-sentence message ("clearing the entries and then inserting them in the desired order doesn't make it happen"). Claude Code traced the path from the react-select picker through the timeline controller's permitted params to the serialized array and then to the block jbuilder, identified the unordered `where` as the only place order was lost, and confirmed it with a failing model spec before proposing the fix. The operator reviewed the diagnosis and asked for the fix to be applied, then for a commit on a new branch, then for this PR. Claude Code wrote the model change, the spec, the commit message, the disposable screenshot spec (left untracked), and this description. No corrections were needed along the way.

Scale of effort: one commit, made in a single focused session of roughly an hour from bug report to PR. Test runs: the new spec was red once before the fix (intentionally), then green; the specs for every caller of the changed method, the controller specs that serialize blocks, and the headless timeline editing feature spec all passed on their first run.

The summary above and the analysis in this description were also drafted by Claude Code and may contain errors. This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

Seeded block with `training_module_ids: [2, 1, 9, 8]`, i.e. Editing Basics, Wikipedia policies, Sandboxes and Mainspace, Adding citations. Before the fix both views show module-id order (1, 2, 8, 9) instead.

**Block as displayed on the timeline**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/preserve-training-module-order/screenshots/before/01_block_as_displayed_on_the_timeline.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/preserve-training-module-order/screenshots/after/01_block_as_displayed_on_the_timeline.png) |

**Block in edit mode with the module picker**

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/preserve-training-module-order/screenshots/before/02_block_in_edit_mode_with_module_picker.png) | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/preserve-training-module-order/screenshots/after/02_block_in_edit_mode_with_module_picker.png) |

## Open questions and concerns

- `Block#training_modules` now returns an Array rather than an ActiveRecord Relation. Every caller in `app/` and `lib/` (LTI gradebook label, LTI block progress, assignment view context, student status context, deep linkable gradables, the block jbuilder) uses only Enumerable methods, and their specs pass, but anything new that chains a query method onto it would need to change.
- The same unordered `where` pattern exists in `Course#training_modules`, which aggregates across all blocks. Order is not meaningful there, so it is left alone.
- View mode still groups a block's modules into Training / Exercise / Discussion sections, so the instructor's order applies within each section. That grouping looks intentional and is unchanged.
- The picker (react-select multi-select) has no drag-to-reorder, so remove-and-re-add remains the only way to reorder. Now that the display honors the stored order, that gesture actually works, but a drag handle would be a reasonable follow-up if reordering turns out to be common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(PR description written by Claude Code.)
