### PR TITLE
Refresh the HECVAT, document the Cloud Firewall, and harden Oj and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,5 +181,10 @@ jobs:
       - name: Check whitespace
         run: git diff --check HEAD~1
 
+      # Fails the build when Gemfile.lock contains a gem with a published
+      # security advisory (ruby-advisory-db, refreshed on each run).
+      - name: Ruby dependency vulnerability audit
+        run: bundle exec bundle-audit check --update
+
       - name: Ruby linting
         run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,13 @@ jobs:
            ruby-version: 3.4.8
            bundler-cache: true
 
+      # Fails the build when Gemfile.lock contains a gem with a published
+      # security advisory (ruby-advisory-db, refreshed on each run). Runs
+      # before the test suites so a new advisory surfaces in the first
+      # minutes of the build, and even when a later step fails.
+      - name: Ruby dependency vulnerability audit
+        run: bundle exec bundle-audit check --update
+
       - name: setup Node
         uses: actions/setup-node@v5
         with:
@@ -180,11 +187,6 @@ jobs:
 
       - name: Check whitespace
         run: git diff --check HEAD~1
-
-      # Fails the build when Gemfile.lock contains a gem with a published
-      # security advisory (ruby-advisory-db, refreshed on each run).
-      - name: Ruby dependency vulnerability audit
-        run: bundle exec bundle-audit check --update
 
       - name: Ruby linting
         run: bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'bundler-audit', require: false
   gem 'pry-rails'
   gem 'byebug'
   gem 'rspec-rails', '6.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
     anonymous_loader (0.1.3)
       version_gem (~> 1.1, >= 1.1.14)
     ast (2.4.3)
+    auth-sanitizer (0.2.3)
+      version_gem (~> 1.1, >= 1.1.14)
     aws-eventstream (1.4.0)
     aws-partitions (1.1281.0)
     aws-sdk-core (3.254.1)
@@ -157,8 +159,6 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    auth-sanitizer (0.2.3)
-      version_gem (~> 1.1, >= 1.1.14)
     axe-core-api (4.11.3)
       dumb_delegator
       ostruct
@@ -187,6 +187,9 @@ GEM
       railties (>= 5.0)
     browser (5.3.1)
     builder (3.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     byebug (11.1.3)
     capistrano (3.20.0)
       airbrussh (>= 1.0.0)
@@ -229,7 +232,7 @@ GEM
     connection_pool (3.0.2)
     crack (0.4.5)
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)
@@ -644,7 +647,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
-    rubyzip (2.3.2)
+    rubyzip (3.6.0)
     securerandom (0.4.1)
     selenium-webdriver (4.43.0)
       base64 (~> 0.2)
@@ -764,6 +767,7 @@ DEPENDENCIES
   bootsnap
   breadcrumbs_on_rails
   browser
+  bundler-audit
   byebug
   capistrano
   capistrano-bundler

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -2,3 +2,10 @@
 
 # https://github.com/ohler55/oj/blob/develop/pages/Rails.md
 Oj.optimize_rails
+
+# Oj's default :object mode instantiates arbitrary Ruby classes from JSON keys
+# such as "^o", so Oj.load on any JSON we did not write ourselves (API responses,
+# training content read from wiki pages) would be an insecure-deserialization
+# hole. :strict mode returns only JSON-native types (Hash, Array, String, numbers,
+# booleans, nil). optimize_rails does not change this default.
+Oj.default_options = { mode: :strict }

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - [Deployment](deploy.md)
 - [Admin Guide](docs/admin_guide.md)
 - [Upgrading dependencies](upgrade_dependencies.md)
+- [Patch management](patch_management.md)
 - [Tools & Integrations](tools.md)
 - [Model diagram](../erd.pdf)
 - [Miscellaneous Credits](miscellaneous_credits.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 - [Contributing](../CONTRIBUTING.md)
 - [Development Process outline](dev_process.md)
 - [Deployment](deploy.md)
-- [Admin Guide](docs/admin_guide.md)
+- [Admin Guide](admin_guide.md)
 - [Upgrading dependencies](upgrade_dependencies.md)
 - [Patch management](patch_management.md)
 - [Tools & Integrations](tools.md)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -39,7 +39,20 @@ For detailed instructions on setting up a production server — specifically on 
 
 ## Recovery procedure
 
-1. Set up a new production server. Production apache conf and sanitized application.yml are checked in to this repo.
-2. Import SSL certs using sslmate.
-3. Create a new OAuth consumer on meta.wikimedia.org and ping a WMF developer to get it approved quickly. Add tokens to application.yml
-4. Import the lastest database backup. Recent backups are stored on the production server and also on wikiedubackups.globaleducation.eqiad.wmflabs (a virtual server on wmflabs.org).
+Owner: the CTO. The database-restore step was last exercised on 2026-09-02, when the
+weekly dump was restored onto a clone of the production server while rehearsing the
+Debian upgrade (about two and a half minutes for the 2.8 GB database).
+
+1. If the production Linode itself is intact, prefer restoring a Linode Backups snapshot
+   onto the **same** Linode: that keeps both the IPv4 and the SLAAC IPv6, which Wikimedia
+   allowlists reference. Only build a new server if the Linode is gone.
+2. Set up a new production server. The production Apache configuration and a sanitized
+   application.yml are checked in to this repo (see [`server_config/`](../server_config/SERVER_CONFIG.md)).
+3. Obtain a TLS certificate from Let's Encrypt with certbot (production uses the certbot
+   snap with the Apache authenticator, so port 80 must be reachable).
+4. If the server's IP addresses changed, update the Wikimedia-side allowlists that
+   reference them, and create a new OAuth consumer on meta.wikimedia.org if the old one
+   cannot be reused; ping a WMF developer to get it approved quickly. Add tokens to
+   application.yml.
+5. Import the latest database backup. Weekly dumps are kept on the production server in
+   `/home/dbbackup/dumps` (newest three), with off-site copies in Dropbox.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -48,6 +48,7 @@ Debian upgrade (about two and a half minutes for the 2.8 GB database).
    allowlists reference. Only build a new server if the Linode is gone.
 2. Set up a new production server. The production Apache configuration and a sanitized
    application.yml are checked in to this repo (see [`server_config/`](../server_config/SERVER_CONFIG.md)).
+   Attach the Cloud Firewall described in [`server_config/firewall.md`](../server_config/firewall.md).
 3. Obtain a TLS certificate from Let's Encrypt with certbot (production uses the certbot
    snap with the Apache authenticator, so port 80 must be reachable).
 4. If the server's IP addresses changed, update the Wikimedia-side allowlists that

--- a/docs/hecvat.md
+++ b/docs/hecvat.md
@@ -233,7 +233,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** Yes
 
-**Notes:** The Dashboard runs on a single server (Linode, Fremont CA) that hosts the web application and the database together; as the public web server it has a publicly routable IP. The database is reached locally by the co-located application and is not exposed as a separate internet-facing service.
+**Notes:** The Dashboard runs on a single server (Linode, Fremont CA) that hosts the web application and the database together; as the public web server it has a publicly routable IP. The database is reached locally by the co-located application and is not exposed as a separate internet-facing service; a network firewall admits only SSH, HTTP/HTTPS, and ICMP to the server.
 
 **DATA-02** — Is the transport of sensitive data encrypted using security protocols/algorithms (e.g., system-to-client)?
 
@@ -338,15 +338,15 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **FIDP-01** — Are you utilizing a stateful packet inspection (SPI) firewall?
 
-**Answer:** No
+**Answer:** Yes
 
-**Notes:** No firewall is configured: the documented server setup (server_config/) does not include one, and Debian ships netfilter with no active rules by default.
+**Notes:** Inbound traffic to the production server is filtered by a stateful network firewall (Akamai/Linode Cloud Firewall) applied outside the server: the default inbound policy is drop, with only SSH, HTTP/HTTPS, and ICMP permitted; outbound traffic is unrestricted. The rule set and change procedure are published in the open-source repository (server_config/firewall.md). No separate host-based firewall is configured.
 
 **FIDP-02** — Do you have a documented policy for firewall change requests?
 
-**Answer:** No
+**Answer:** Yes
 
-**Notes:** No firewall, and no documented firewall-change policy.
+**Notes:** Firewall changes follow the procedure documented in server_config/firewall.md: the rule set is maintained in the repository, planned changes are reviewed there before being applied through the hosting provider's console, and emergency changes are recorded within one business day.
 
 **FIDP-03** — Have you implemented an intrusion detection system (network-based)?
 
@@ -362,9 +362,9 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **FIDP-05** — Are audit logs available for all changes to the network, firewall, IDS, and IPS systems?
 
-**Answer:** No
+**Answer:** Yes
 
-**Notes:** No firewall/IDS/IPS systems are in place (see FIDP-01/03/04), and no dedicated audit logging of network/firewall changes is configured.
+**Notes:** Every change to the network firewall (creation, rule updates, attaching or detaching a server, enabling or disabling) is recorded in the hosting account's event history with the acting user and timestamp, retained for 90 days; the intended rule set and its history are kept in the public repository. No IDS or IPS is deployed (see FIDP-03 and FIDP-04).
 
 
 ## Vulnerability Management

--- a/docs/hecvat.md
+++ b/docs/hecvat.md
@@ -7,7 +7,7 @@
 > infrastructure details, then reviewed and confirmed by Wiki Education (Sage Ross,
 > Chief Technology Officer).
 >
-> **Last reviewed:** 2026-09-11, after the production server's operating-system upgrade.
+> **Last reviewed:** 2026-09-11.
 
 This is a Higher Education Community Vendor Assessment Toolkit (HECVAT) response for the Wiki Education Dashboard's Canvas (LTI 1.3) integration, covering the **critical ("Core") questions** — the asterisked subset EDUCAUSE recommends for a Lite-style review. (Full HECVAT 4 has 332 questions across seven tabs; this Core answers the critical and identification questions.) Answers use **Yes / No / N/A**; the Notes field is optional context.
 
@@ -67,7 +67,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** No
 
-**Notes:** Wiki Education maintains a disaster recovery plan (the recovery procedure in the open-source repository's deployment documentation, owned by the CTO), but does not test it on a fixed annual schedule. The database-restore step was most recently exercised on 2026-09-02, when the weekly backup was restored onto a clone of the production server while rehearsing the operating-system upgrade.
+**Notes:** Wiki Education maintains a disaster recovery plan (the recovery procedure in the open-source repository's deployment documentation, owned by the CTO), but does not test it on a fixed annual schedule.
 
 
 ## Assessment of Third Parties
@@ -292,7 +292,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** Yes
 
-**Notes:** The application runs on current, supported runtimes — Ruby 3.4.8 and Rails 8.1 — with maintained dependencies. The host OS is Debian 12 (bookworm), upgraded in place from Debian 11 on 2026-09-04 and covered by Debian LTS security support through June 2028; the web server, database, and cache (Apache, MariaDB, Redis) run at supported releases from the Debian and Redis package repositories. A further in-place upgrade to Debian 13 (trixie, supported through 2030) is planned.
+**Notes:** The application runs on current, supported runtimes — Ruby 3.4.8 and Rails 8.1 — with maintained dependencies. The host OS is Debian 12 (bookworm), which is under Debian security support; the web server, database, and cache (Apache, MariaDB, Redis) run at supported releases from the Debian and Redis package repositories.
 
 **APPL-04** — Does your application require access to location or GPS data?
 
@@ -392,7 +392,7 @@ _Additional Information_
 
 **Answer:** Yes
 
-**Notes:** A VPAT 2.5 (WCAG edition), report date 2026-08-19, is published at https://dashboard.wikiedu.org/accessibility. It covers the Dashboard including the views served inside Canvas through the LTI integration.
+**Notes:** A VPAT 2.5 (WCAG edition) is published at https://dashboard.wikiedu.org/accessibility; it covers the Dashboard including the views served inside Canvas through the LTI integration.
 
 **ITAC-07** — Will your company agree to meet your stated accessibility standard or WCAG 2.1 AA as part of your contractual agreement for the solution?
 

--- a/docs/hecvat.md
+++ b/docs/hecvat.md
@@ -6,6 +6,8 @@
 > with Claude Code, an AI assistant, from the public codebase and Wiki Education's
 > infrastructure details, then reviewed and confirmed by Wiki Education (Sage Ross,
 > Chief Technology Officer).
+>
+> **Last reviewed:** 2026-09-11, after the production server's operating-system upgrade.
 
 This is a Higher Education Community Vendor Assessment Toolkit (HECVAT) response for the Wiki Education Dashboard's Canvas (LTI 1.3) integration, covering the **critical ("Core") questions** — the asterisked subset EDUCAUSE recommends for a Lite-style review. (Full HECVAT 4 has 332 questions across seven tabs; this Core answers the critical and identification questions.) Answers use **Yes / No / N/A**; the Notes field is optional context.
 
@@ -65,7 +67,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** No
 
-**Notes:** Wiki Education maintains a disaster recovery plan, but it is not tested annually.
+**Notes:** Wiki Education maintains a disaster recovery plan (the recovery procedure in the open-source repository's deployment documentation, owned by the CTO), but does not test it on a fixed annual schedule. The database-restore step was most recently exercised on 2026-09-02, when the weekly backup was restored onto a clone of the production server while rehearsing the operating-system upgrade.
 
 
 ## Assessment of Third Parties
@@ -290,7 +292,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** Yes
 
-**Notes:** The application runs on current, supported runtimes — Ruby 3.4.8 and Rails 8.1.3 — with maintained dependencies. The host OS is Debian 11 (bullseye), currently under Debian LTS; note that Debian 11 LTS support ends around August 2026, so an upgrade to a newer Debian release is due to remain on a supported version.
+**Notes:** The application runs on current, supported runtimes — Ruby 3.4.8 and Rails 8.1 — with maintained dependencies. The host OS is Debian 12 (bookworm), upgraded in place from Debian 11 on 2026-09-04 and covered by Debian LTS security support through June 2028; the web server, database, and cache (Apache, MariaDB, Redis) run at supported releases from the Debian and Redis package repositories. A further in-place upgrade to Debian 13 (trixie, supported through 2030) is planned.
 
 **APPL-04** — Does your application require access to location or GPS data?
 
@@ -308,7 +310,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** Yes
 
-**Notes:** Every CI build runs static code analysis — RuboCop (Ruby) and ESLint (JavaScript). These are code-quality/style analyzers; there is no dedicated security SAST (e.g., Brakeman) in the pipeline.
+**Notes:** Every CI build runs static code analysis — RuboCop (Ruby) and ESLint (JavaScript) — and a dependency-vulnerability audit (bundler-audit against the Ruby Advisory Database) that fails the build if any gem in use has a published security advisory. The static analyzers are code-quality/style tools; there is no dedicated security SAST (e.g., Brakeman) in the pipeline.
 
 **APPL-07** — Do you have software testing processes (dynamic or static) that are established and followed?
 
@@ -371,7 +373,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** No
 
-**Notes:** Vulnerability scanning is not tied to the release process. Wiki Education does perform periodic security code audits and uses GitHub security alerts (Dependabot) to surface dependency vulnerabilities, but does not run authenticated vulnerability scans as a release gate.
+**Notes:** Vulnerability scanning is not tied to the release process. Wiki Education does perform periodic security code audits, uses GitHub security alerts (Dependabot) to surface dependency vulnerabilities, and blocks merges in CI when a gem with a published advisory is in use, but does not run authenticated vulnerability scans as a release gate.
 
 **VULN-02** — Will you provide results of application and system vulnerability scans to the institution?
 
@@ -390,7 +392,7 @@ _Additional Information_
 
 **Answer:** Yes
 
-**Notes:** A VPAT 2.5 (WCAG edition) is published at https://dashboard.wikiedu.org/accessibility.
+**Notes:** A VPAT 2.5 (WCAG edition), report date 2026-08-19, is published at https://dashboard.wikiedu.org/accessibility. It covers the Dashboard including the views served inside Canvas through the LTI integration.
 
 **ITAC-07** — Will your company agree to meet your stated accessibility standard or WCAG 2.1 AA as part of your contractual agreement for the solution?
 

--- a/docs/hecvat.md
+++ b/docs/hecvat.md
@@ -292,7 +292,7 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **Answer:** Yes
 
-**Notes:** The application runs on current, supported runtimes — Ruby 3.4.8 and Rails 8.1 — with maintained dependencies. The host OS is Debian 12 (bookworm), which is under Debian security support; the web server, database, and cache (Apache, MariaDB, Redis) run at supported releases from the Debian and Redis package repositories.
+**Notes:** The application runs on current, supported runtimes — Ruby 3.4.8 and Rails 8.1 — with maintained dependencies. The host OS is Debian 12 (bookworm), which is under Debian security support through June 2028; the web server, database, and cache (Apache, MariaDB, Redis) run at supported releases from the Debian and Redis package repositories.
 
 **APPL-04** — Does your application require access to location or GPS data?
 

--- a/docs/hecvat.md
+++ b/docs/hecvat.md
@@ -110,7 +110,9 @@ Sections such as HIPAA, PCI DSS, and Consulting Services apply only if the produ
 
 **PPPR-01** — Do you have a documented patch management process?
 
-**Answer:** No
+**Answer:** Yes
+
+**Notes:** The process is documented in the open-source repository (docs/patch_management.md). Operating-system security updates from the Debian security suite are applied automatically each day; other package updates, dependency vulnerability alerts, and runtime versions are handled in a monthly cycle that ends with recorded post-change checks; operating-system release upgrades are carried out before the running release leaves security support; and critical vulnerabilities in internet-facing components are fixed out of band. The CTO owns the process.
 
 **PPPR-02** — Can your organization comply with institutional policies on privacy and data protection with regard to users of institutional systems, if required?
 

--- a/docs/patch_management.md
+++ b/docs/patch_management.md
@@ -1,0 +1,109 @@
+# Patch management
+
+How security fixes and other updates reach the Wiki Education Dashboard's production server
+(`dashboard.wikiedu.org`) and its staging server (`dashboard-testing.wikiedu.org`). This is
+the process the HECVAT's PPPR-01 answer refers to. The Programs & Events Dashboard on
+Wikimedia Cloud runs the same code but is operated separately and is not covered here.
+
+**Owner:** the CTO. Anyone with production access may run a step; the owner is responsible
+for the cadence being kept and for deciding exceptions.
+
+## Layers and what patches each of them
+
+| Layer | Examples | How updates arrive | Cadence |
+|---|---|---|---|
+| Operating system security fixes | Debian security advisories for the kernel, OpenSSL, Apache, MariaDB, OpenSSH, and everything else installed from Debian | `unattended-upgrades`, restricted to the Debian security suite | Automatic, daily |
+| Other operating-system packages | Debian point-release updates; Redis from the redis.io repository | `apt update && apt full-upgrade` by hand | Monthly |
+| Ruby gems and JavaScript packages | Rails, Sidekiq, React, build tooling | GitHub Dependabot alerts (alerts only, no automatic PRs); `bundler-audit` fails CI when a gem in the lockfile has a published advisory | Monthly triage to zero open alerts; a failing CI build is fixed before the affected change merges |
+| Language runtimes | Ruby (installed through RVM, so not covered by apt), Node.js | Manual, following [Upgrading dependencies](upgrade_dependencies.md) | Reviewed monthly; upgraded when a security release or end-of-life approaches |
+| Operating-system release | Debian 12 → 13 and later | A written, rehearsed runbook (the 2026 upgrade rehearsed on a clone of the production Linode first) | Before the running release leaves Debian security support |
+| The application itself | The Dashboard's own code | Continuous deployment from `master` via Capistrano after code review and a green CI build | Several times a week |
+
+## Automatic security updates
+
+`unattended-upgrades` runs daily from the `apt-daily-upgrade.timer` (about 06:00 server
+time plus a random delay of up to an hour) and installs whatever the Debian security
+suite offers for the installed release. It does **not** install point-release updates or
+packages from third-party repositories, does **not** reboot, and does **not** remove
+packages; those are left to the monthly manual run so that a person is watching when they
+happen. Packages whose maintainer scripts restart their service (Apache, MariaDB) will do so
+during the automatic run; that is a few seconds of interruption for a security fix, and is
+accepted. Its log is `/var/log/unattended-upgrades/unattended-upgrades.log`.
+
+Setup on a Debian server, done once (the configuration lives in a separate file so that
+package upgrades never prompt about it):
+
+```bash
+sudo apt install -y unattended-upgrades
+
+sudo tee /etc/apt/apt.conf.d/20auto-upgrades > /dev/null <<'CONF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+CONF
+
+sudo tee /etc/apt/apt.conf.d/52unattended-upgrades-local > /dev/null <<'CONF'
+// Local policy, documented in docs/patch_management.md of the Dashboard repository:
+// apply only Debian security updates automatically. Point-release updates and the
+// redis.io repository are applied in the monthly manual run.
+#clear Unattended-Upgrade::Origins-Pattern;
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian,codename=${distro_codename},label=Debian-Security";
+        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+};
+Unattended-Upgrade::Automatic-Reboot "false";
+Unattended-Upgrade::Remove-Unused-Dependencies "false";
+CONF
+
+apt-config dump Unattended-Upgrade::Origins-Pattern      # only the two Debian-Security lines
+sudo unattended-upgrade --dry-run --debug 2>&1 | grep -E 'Allowed origins|Checking|pkgs that look like|No packages found|Packages that will be upgraded'
+systemctl list-timers 'apt-daily*' --no-pager
+```
+
+The dry run lists the allowed origins and any security updates it would install right now.
+To apply them immediately rather than waiting for the timer, `sudo unattended-upgrade -v`.
+
+## Monthly run
+
+Done by hand, at a quiet time, not on a Sunday evening (the weekly database backup runs at
+20:00). Record the date and anything notable on the office wiki's security page.
+
+1. On each server: `sudo apt update && sudo apt full-upgrade`, then `sudo apt autoremove`
+   (never `--purge`). Read what it proposes before confirming; conffile prompts are answered
+   per the notes in the most recent upgrade runbook.
+2. If a kernel or libc update was installed (`ls /boot | tail`, or `needrestart` if
+   installed), schedule a reboot: confirm `grep root= /boot/grub/grub.cfg` shows
+   `root=UUID=` first, then reboot and run the post-change checks below.
+3. In GitHub, bring the repository's Dependabot alerts to zero: upgrade, or record why an
+   alert does not apply (a `.bundler-audit.yml` ignore entry with a justification for gems).
+   AI-assisted audits are fine; a person reviews the resulting pull request.
+4. Check the horizons: the Debian release's security-support end date, Ruby and Rails
+   end-of-life dates, Node.js LTS status. Anything within six months gets a scheduled task.
+5. Post-change checks on each server: the site loads (including a database-backed page),
+   `systemctl list-units --failed` is empty, `sudo ss -tulpn | grep -Ev '127\.0\.0\.1|\[::1\]'`
+   lists only sshd (22) and Apache (80, 443), `systemctl is-enabled mariadb.socket` is
+   `disabled`, the IPv6 address check from the upgrade runbook passes, and Sentry is quiet.
+
+## Out-of-band fixes
+
+A critical vulnerability in something reachable from the internet (Apache, OpenSSH, Rails,
+the LTI or OAuth code paths) or one with a public exploit is patched as soon as it is known,
+without waiting for the monthly run. Debian security fixes for such components arrive
+automatically; application-level fixes ship through the normal deploy after CI passes.
+
+## Verification and record
+
+- The automatic run's log: `/var/log/unattended-upgrades/unattended-upgrades.log`, and
+  `apt list --upgradable` should show no security updates pending on any given day.
+- The monthly run: a dated entry on the office wiki's security page.
+- Dependency state: the GitHub Dependabot alerts page and the `bundle-audit` step in every
+  CI run.
+- Firewall and listener state after any change: the checks in
+  [`server_config/firewall.md`](../server_config/firewall.md).
+
+## Current exceptions
+
+- Staging (`dashboard-testing.wikiedu.org`) is on Debian 10, which is past end of life, and
+  is to be rebuilt on a current release. It holds no production data and sits behind the
+  same firewall rules as production.
+
+(Document written by Claude Code.)

--- a/docs/patch_management.md
+++ b/docs/patch_management.md
@@ -17,7 +17,7 @@ for the cadence being kept and for deciding exceptions.
 | Ruby gems and JavaScript packages | Rails, Sidekiq, React, build tooling | GitHub Dependabot alerts (alerts only, no automatic PRs); `bundler-audit` fails CI when a gem in the lockfile has a published advisory | Monthly triage to zero open alerts; a failing CI build is fixed before the affected change merges |
 | Language runtimes | Ruby (installed through RVM, so not covered by apt), Node.js | Manual, following [Upgrading dependencies](upgrade_dependencies.md) | Reviewed monthly; upgraded when a security release or end-of-life approaches |
 | Operating-system release | Debian 12 → 13 and later | A written, rehearsed runbook (the 2026 upgrade rehearsed on a clone of the production Linode first) | Before the running release leaves Debian security support |
-| The application itself | The Dashboard's own code | Continuous deployment from `master` via Capistrano after code review and a green CI build | Several times a week |
+| The application itself | The Dashboard's own code | Merged to `master` after code review and a green CI build, then deployed with Capistrano from the `production` branch (see [Deployment](deploy.md)) | Several times a week |
 
 ## Automatic security updates
 
@@ -81,7 +81,8 @@ Done by hand, at a quiet time, not on a Sunday evening (the weekly database back
 5. Post-change checks on each server: the site loads (including a database-backed page),
    `systemctl list-units --failed` is empty, `sudo ss -tulpn | grep -Ev '127\.0\.0\.1|\[::1\]'`
    lists only sshd (22) and Apache (80, 443), `systemctl is-enabled mariadb.socket` is
-   `disabled`, the IPv6 address check from the upgrade runbook passes, and Sentry is quiet.
+   `disabled`, the IPv6 address check from Phase 0 of
+   [`server_config/firewall.md`](../server_config/firewall.md) passes, and Sentry is quiet.
 
 ## Out-of-band fixes
 

--- a/server_config/SERVER_CONFIG.md
+++ b/server_config/SERVER_CONFIG.md
@@ -10,6 +10,12 @@ These files are the main web server configuration files:
 * `dashboard.conf` # apache config for dashboard.wikiedu.org (ie, production)
 * `dashboard-testing.conf` # apache config for dashboard-testing.wikiedu.org (ie, staging)
 
+## Network firewall
+
+Inbound traffic to the production and staging Linodes is filtered by an Akamai (Linode)
+Cloud Firewall. The rule set, the rollout runbook, and the change procedure are in
+[`firewall.md`](./firewall.md). Change the file first, then the live firewall.
+
 ## Database backup
 
 We've designed a system to perform automatic database backups periodically

--- a/server_config/firewall.md
+++ b/server_config/firewall.md
@@ -1,0 +1,343 @@
+# Network firewall for dashboard.wikiedu.org
+
+The production Dashboard runs on a single Linode (Akamai Cloud) in Fremont, CA. Until
+September 2026 it had no firewall of any kind: the host ran Debian's default empty
+netfilter rule set, and nothing filtered traffic upstream of the VM. This document is
+the design, rollout runbook, and change procedure for the **Akamai Cloud Firewall**
+attached to that Linode. It is the record the HECVAT firewall answers (FIDP-01, FIDP-02,
+FIDP-05 in `docs/hecvat.md`) point to.
+
+Status: **applied** to production and staging on 2026-09-11 (and to the rehearsal clone while it
+exists). See the "Applied" table at the end.
+
+## Why a Cloud Firewall rather than (or before) a host firewall
+
+- **It is stateful and sits outside the VM.** Akamai describes Cloud Firewalls as
+  "stateful network-based firewalls" that operate between the Linode and the internet.
+  Return traffic for connections the server opens (DNS, NTP, HTTPS to Wikimedia and the
+  other APIs, apt) is allowed automatically, so an outbound policy of ACCEPT plus a
+  default-drop inbound policy is safe.
+- **Nothing changes on the host.** No packages, no nftables rules, no reboot. Attaching
+  and detaching takes effect within seconds and is done from Cloud Manager, the Linode
+  CLI, or the API, so the rollback is a single click that does not depend on SSH working.
+- **Changes are logged for us.** Every create, rule update, attach/detach, enable/disable
+  is an event in the account's event history (`firewall_create`, `firewall_rules_update`,
+  `firewall_device_add`, `firewall_device_remove`, `firewall_enable`, `firewall_disable`,
+  `firewall_delete`) with the acting user and timestamp, retained 90 days. Together with
+  this file's git history that is the audit trail.
+- **It is free** in all regions.
+
+Akamai's own guidance is to run both a Cloud Firewall and a host firewall; for inbound
+traffic the Cloud Firewall is evaluated first. A host nftables rule set is a reasonable
+later addition (see "Later hardening") but is not needed to close the HECVAT gap, and
+doing one layer at a time keeps each change easy to reason about and to roll back.
+
+Limits that matter: 25 rules per firewall (inbound and outbound combined), 255 addresses
+per rule, 15 ports or port ranges per rule, one firewall per Linode. Rules apply to the
+public and private interfaces but not to VLAN interfaces (we have none).
+
+## Facts the design depends on
+
+Confirmed during the September 2026 OS upgrade (`.claude/debian_upgrade_plan-2026-09-01.md`
+inventory, and the live notes there) unless marked otherwise.
+
+| Fact | Consequence for the rules |
+|---|---|
+| Public IPv4 `45.79.106.114` is **static** in `/etc/network/interfaces`. | No DHCP to allow. |
+| Public IPv6 `2600:3c01::f03c:93ff:fe24:db1b` is a **SLAAC** address (`inet6 auto`, EUI-64), and Wikimedia allowlists reference it. Outbound calls to Wikimedia leave from this address. | SLAAC needs inbound ICMPv6 router advertisements and neighbor discovery. Akamai's IPv6 guide: "In order for your Linode to receive its SLAAC address, it must respond to IPv6's ping protocol" and the firewall must "allow ICMPv6". **The ICMP rule with source `::/0` is therefore mandatory**, and losing it would eventually drop the allowlisted address. |
+| Public listeners as of the Phase 0 check on 2026-09-11: `sshd` on 22, Apache on 80 and 443, and **MariaDB on `*:3306`** (all interfaces, socket held by systemd as well as `mariadbd`), reachable from the internet over IPv4. Redis (`bind 127.0.0.1 -::1`) and memcached (`-l 127.0.0.1`) are loopback-only. Before the 2026-09-04 upgrade MariaDB was on `127.0.0.1` via `bind-address` in `50-server.cnf`; bookworm's packaging stopped honoring it (see Phase 0). | Only 22, 80, 443 get inbound rules. The firewall drops 3306 from outside the moment it is attached, which is the fast mitigation; binding MariaDB back to loopback is the durable fix and is done regardless. |
+| TLS certificates come from Let's Encrypt via the certbot snap with the **Apache authenticator** (HTTP-01). | Port 80 must stay open to the whole internet; Let's Encrypt validates from multiple, unpublished addresses. |
+| `backup.sh` (weekly, Sunday 20:00) calls `https://dashboard.wikiedu.org/system/can_start_backup.json` from the server itself. | Traffic to the server's own public address is delivered over loopback and never reaches the Cloud Firewall. Unaffected. |
+| Deploys are Capistrano over SSH from a staff machine; LTI launches, Wikimedia OAuth callbacks, LTIAAS and Mailgun callbacks, the uptime monitor, and all users arrive over HTTPS. | Covered by rules 1 and 2. |
+| Outbound dependencies: Wikimedia APIs (IPv6), the replica-revision Toolforge tools, Mailgun, Sentry, Salesforce, LTIAAS, Pangram and Originality.ai, Debian and redis.io package mirrors, snapd, NTP, DNS, the Linode metadata service. | Outbound policy ACCEPT. Restricting outbound is possible later but needs every one of these enumerated first. |
+| Out-of-band access: LISH/Weblish in Cloud Manager works regardless of network rules. | The safety net if an SSH rule is ever wrong. |
+
+## The rule set
+
+The live firewall is `dashboard-web`, Cloud Firewall ID **163657050** (created 2026-09-11).
+
+Default inbound policy **DROP**. Default outbound policy **ACCEPT**. Rules are evaluated
+top to bottom; first match wins.
+
+| # | Label | Protocol | Ports | Sources | Action | Why |
+|---|---|---|---|---|---|---|
+| 1 | `allow-ssh` | TCP | 22 | `0.0.0.0/0`, `::/0` | ACCEPT | Capistrano deploys and administration. Key-based authentication only (verify in Phase 0). Kept as its own rule so the sources can be narrowed later without touching the web rule. |
+| 2 | `allow-web` | TCP | 80, 443 | `0.0.0.0/0`, `::/0` | ACCEPT | The site, and Let's Encrypt HTTP-01 validation on port 80 (Apache redirects everything else to HTTPS). |
+| 3 | `allow-icmp` | ICMP | — | `0.0.0.0/0`, `::/0` | ACCEPT | IPv6 SLAAC, neighbor discovery, path-MTU discovery, and ping-based monitoring. **Do not remove**: the Wikimedia-allowlisted IPv6 depends on it. |
+
+Everything else inbound is dropped. No outbound rules.
+
+The same firewall is attached to **staging** (`dashboard-testing.wikiedu.org`, `45.33.77.39`)
+and, while it exists, to the `dashboard-rehearsal` clone; they have the same three listeners.
+
+### As an API / Linode CLI request body
+
+Equivalent to the table above; usable with `linode-cli firewalls create` or
+`POST /v4/networking/firewalls`. Create it **without** `devices` and attach Linodes
+separately, phase by phase.
+
+```json
+{
+  "label": "dashboard-web",
+  "tags": ["dashboard"],
+  "rules": {
+    "inbound_policy": "DROP",
+    "outbound_policy": "ACCEPT",
+    "inbound": [
+      {
+        "label": "allow-ssh",
+        "description": "SSH for Capistrano deploys and administration (key-based auth only)",
+        "protocol": "TCP",
+        "ports": "22",
+        "addresses": { "ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"] },
+        "action": "ACCEPT"
+      },
+      {
+        "label": "allow-web",
+        "description": "HTTP (Let's Encrypt HTTP-01, redirect to HTTPS) and HTTPS",
+        "protocol": "TCP",
+        "ports": "80, 443",
+        "addresses": { "ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"] },
+        "action": "ACCEPT"
+      },
+      {
+        "label": "allow-icmp",
+        "description": "ICMP/ICMPv6: SLAAC and neighbor discovery for the allowlisted IPv6, PMTU, ping",
+        "protocol": "ICMP",
+        "addresses": { "ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"] },
+        "action": "ACCEPT"
+      }
+    ],
+    "outbound": []
+  }
+}
+```
+
+In Cloud Manager the same thing is: **Firewalls → Create Firewall** (label
+`dashboard-web`, no services assigned yet) → on the firewall's **Rules** tab set the
+default inbound policy to **Drop** and outbound to **Accept**, then **Add an Inbound Rule**
+three times (the SSH, HTTP and HTTPS presets exist; HTTP and HTTPS can be one custom TCP
+rule with ports `80, 443`; ICMP is a custom rule with protocol ICMP, no ports, sources
+`0.0.0.0/0` and `::/0`) → **Save Changes**. Nothing is enforced until a Linode is attached
+on the **Linodes** tab.
+
+## Rollout runbook (no-disruption path)
+
+Each phase is independently reversible. The only step that touches production is Phase 4,
+and its rollback is detaching the firewall, which takes effect in seconds and needs no
+reboot and no SSH.
+
+### Phase 0: pre-flight (on prod, run by the operator; 10 minutes)
+
+1. **Confirm the public listeners are exactly 22, 80, 443** (plus NTP, which needs no
+   inbound rule):
+
+   ```bash
+   sudo ss -tulpn | grep -Ev '127\.0\.0\.1|\[::1\]|Netid'
+   ```
+
+   Anything else bound to `0.0.0.0` or `[::]` needs a decision before Phase 4: add a rule,
+   or (better) bind it to loopback.
+
+   **Result 2026-09-11: MariaDB was listening on `*:3306`**, and a TCP connect to
+   `45.79.106.114:3306` from outside succeeded. Diagnosis (same day): bookworm's
+   `mariadb-server` enabled **`mariadb.socket`** (systemd socket activation) during the
+   upgrade. systemd creates the TCP socket on all interfaces and hands it to `mariadbd`,
+   so the daemon's `bind_address = 127.0.0.1` from `50-server.cnf` is loaded but never
+   used for the TCP listener. File permissions were fine (Debian bug #1042454 did not
+   apply). Every account in `mysql.user` is `@localhost`, so remote authentication was
+   impossible; the exposure was the unauthenticated surface only.
+
+   Fix, which restores the bullseye behavior and makes `50-server.cnf` the single source
+   of truth again (one MariaDB restart, a few seconds of database errors for the app and
+   Sidekiq; pick a quiet moment):
+
+   ```bash
+   systemctl cat mariadb.socket                 # for the record: what systemd was listening on
+   sudo systemctl disable --now mariadb.socket  # stop socket activation; survives package upgrades
+   sudo systemctl restart mariadb.service       # mariadbd now binds per 50-server.cnf
+   sudo ss -tlnp | grep 3306                    # must show only 127.0.0.1:3306
+   ls -l /run/mysqld/mysqld.sock && sudo mariadb -e 'SELECT 1'   # unix socket still there
+   systemctl is-enabled mariadb.socket          # disabled
+   ```
+
+   **Applied 2026-09-11.** After the restart `ss` showed only `127.0.0.1:3306`, the unix
+   socket and `SELECT 1` worked, `mariadb.socket` reports `disabled`, a TCP connect to
+   `45.79.106.114:3306` from outside was refused, and the site served database-backed
+   pages normally. Re-check `systemctl is-enabled mariadb.socket` after the Debian 13
+   hop, and put the `ss` listener check in every post-upgrade checklist from now on.
+2. **Confirm SSH is key-only**, since port 22 stays open to the internet:
+
+   ```bash
+   sudo sshd -T | grep -Ei '^(passwordauthentication|kbdinteractiveauthentication|permitrootlogin|pubkeyauthentication) '
+   ```
+
+   Expected: `passwordauthentication no`, `kbdinteractiveauthentication no`,
+   `permitrootlogin no` (or `prohibit-password`), `pubkeyauthentication yes`. If password
+   authentication is on, turn it off first (`/etc/ssh/sshd_config.d/`, then
+   `sudo systemctl reload ssh`) **from a session whose key login you have just tested**.
+3. **Record the address baseline** (from the upgrade plan, section 5.0):
+
+   ```bash
+   ip -6 addr show scope global | grep -c 2600:3c01::f03c:93ff:fe24:db1b   # 1
+   ip -4 addr show eth0 | grep -c 45.79.106.114                            # 1
+   curl -s -o /dev/null -w '%{local_ip}\n' https://en.wikipedia.org/       # the IPv6 above
+   ```
+4. In Cloud Manager: confirm the account has **two-factor authentication** enabled for
+   every user who can log in (the firewall is only as strong as the console that controls
+   it), and open a **Weblish** tab to the prod Linode so out-of-band access is proven
+   before anything changes.
+5. Do not schedule Phase 4 for a Sunday evening (backup cron at 20:00) or during a deploy.
+
+### Phase 1: create the firewall, attached to nothing
+
+Create `dashboard-web` from the JSON or the Cloud Manager steps above. Verify on the
+Rules tab: inbound Drop, outbound Accept, three inbound rules with both `0.0.0.0/0` and
+`::/0` on each. Nothing is enforced yet.
+
+### Phase 2: rehearse on the `dashboard-rehearsal` clone
+
+The clone is a full copy of prod with the same listeners and its own SLAAC IPv6, so it is
+the right place to prove the IPv6 behavior. Attach the firewall on the Linodes tab, then:
+
+1. SSH in (rule 1). From the laptop, with the clone's IP in `/etc/hosts` for
+   `dashboard.wikiedu.org`, load the site over HTTPS (rule 2); `curl -I http://...` should
+   redirect to HTTPS.
+2. On the clone, run the three address-check lines; the IPv6 must still be present and
+   the Wikipedia probe must still leave from it.
+3. `sudo apt update`, `redis-cli ping`, `dig +short en.wikipedia.org AAAA`, and
+   `ntpq -p` (reach column non-zero) prove outbound DNS/HTTP/NTP replies get back in.
+4. **Reboot the clone** with the firewall attached. Wait two minutes, then repeat step 2.
+   The SLAAC address arrives with the next router advertisement, which on 2026-09-04
+   took about a minute; a `0` in the first minute is not a failure. If the address is
+   still missing after five minutes, stop: the ICMP rule is not doing its job and Phase 4
+   must not proceed until that is understood.
+5. Leave it attached for at least a day, then repeat step 2 once more (the address must
+   survive router-advertisement refreshes, not just the initial one).
+
+   **Result 2026-09-11:** all of the above passed on `dashboard-rehearsal`
+   (IPv6 `2600:3c01::2000:1cff:fe90:bc91`). Two extra checks proved the ICMPv6 path
+   directly rather than by waiting: `rdisc6 -1 eth0` (package `ndisc6`) received the
+   router advertisement from `fe80::a9fe:a9fe` through the firewall, and the address's
+   `valid_lft` reset to ~5400 s afterwards; before that it had only counted down.
+   `timedatectl` showed NTP synchronized, `apt update` and `dig` worked. After
+   `sudo reboot` the address was back within two minutes and the Wikipedia probe left
+   from it. Use `rdisc6` in future instead of step 5's day-long wait.
+
+### Phase 3: staging
+
+Attach to `dashboard-testing`. Same checks as Phase 2 steps 1 to 3 (its IPv6 is not
+allowlisted anywhere, so this is mostly a second data point). It stays attached.
+
+### Phase 4: production
+
+1. Weblish tab open; Phase 0 checks done within the last day; Sentry open.
+2. Attach the firewall to the prod Linode.
+3. Within the first minute, from prod: the three address-check lines. From the laptop:
+   `ssh` in a **new** session, `curl -sI https://dashboard.wikiedu.org/ | head -1`,
+   `curl -6 -sI https://dashboard.wikiedu.org/ | head -1`, `ping -c 3 dashboard.wikiedu.org`,
+   `ping -6 -c 3 dashboard.wikiedu.org`.
+4. Over the next 15 minutes: Sentry stays quiet; the Sidekiq Web UI shows jobs completing;
+   `sudo journalctl -u sidekiq-default --since -15min` shows no connection errors; a page
+   that hits the Wikimedia API (any course's Activity tab) loads.
+5. Within the next day: `sudo certbot renew --dry-run` (snap) succeeds, proving HTTP-01
+   still reaches Apache; after the next Sunday, confirm the weekly dump landed in
+   `/home/dbbackup/dumps`.
+6. Fill in the "Applied" section below and make the HECVAT and wiki updates listed there.
+
+   **Result 2026-09-11:** attached at about 15:47 PDT. Probes from outside in the first
+   seconds after the attach still saw unlisted ports *refused* (the packets reached the
+   host); within a minute they were *dropped* (six-second timeout), which is the sign the
+   Cloud Firewall is enforcing. Allow a minute before judging. After that: 22, 80, 443
+   open; 3306 and 8080 dropped; HTTPS 200 including a database-backed page; HTTP 301 to
+   HTTPS; ping answered. On the server: IPv6 `2600:3c01::f03c:93ff:fe24:db1b` present with
+   a normal `valid_lft`, Wikipedia probe left from it, `apt update` succeeded, NTP
+   synchronized. Still to do in the following days: `sudo certbot renew --dry-run`, a
+   glance at the IPv6 `valid_lft` an hour later (it must have reset upward at least once),
+   Sentry quiet, and the Sunday dump landing in `/home/dbbackup/dumps`.
+
+**Rollback at any point**: Cloud Manager → Firewalls → `dashboard-web` → Linodes tab →
+**Remove** the Linode (or **Disable** the whole firewall). Effective within seconds; no
+reboot. If SSH is what broke, do it from Weblish or from any browser; the console does not
+depend on the rules.
+
+## Change procedure
+
+This is the firewall change policy (HECVAT FIDP-02).
+
+- **Who**: the CTO, or another Wiki Education staff member with admin access to the
+  Linode account, and no one else. Access to that account is part of the quarterly account
+  review.
+- **How, for planned changes**: update the rule table and the JSON in this file in a pull
+  request that explains the reason; after review, apply the change in Cloud Manager (or via
+  the CLI/API) so the file and the live firewall match; then note the date under "Applied".
+- **How, for emergencies** (for example an attack that needs a source range dropped):
+  apply the change in Cloud Manager first, then bring this file into line within one
+  business day.
+- **What is never done casually**: removing `allow-icmp` (the Wikimedia-allowlisted IPv6
+  depends on it); changing `allow-ssh` without an open Weblish session; setting the
+  outbound policy to DROP without first enumerating and testing every outbound dependency
+  in the facts table.
+- **Record**: the Linode account event history holds every firewall event with user and
+  timestamp for 90 days; this file's git history holds the intended state indefinitely.
+  When the two disagree, the live firewall is wrong and gets fixed to match the file, or
+  the file gets a PR explaining why the change was right.
+- **Review**: quarterly, alongside the other server and account checks; and whenever the
+  HECVAT is refreshed.
+
+## Later hardening (not part of this rollout)
+
+- **Narrow `allow-ssh`** to the staff addresses that actually deploy, once they are known
+  to be stable; Weblish remains the fallback if an address changes. Alternatively keep 22
+  open and add `fail2ban` on the host.
+- **Host firewall (nftables)** as a second layer, so the rules hold even if the Linode is
+  ever moved or the Cloud Firewall detached; also where per-service rate limits would live.
+- **Outbound restriction** to the enumerated dependencies. High effort, modest gain for a
+  server whose job is to call many third-party APIs.
+
+## After it is live: documentation updates
+
+Once Phase 4 is done and verified, make these edits so the public record matches reality:
+
+1. `docs/hecvat.md`:
+   - **FIDP-01** → Yes. Suggested note: "Inbound traffic to the production server is
+     filtered by a stateful network firewall (Akamai/Linode Cloud Firewall) applied
+     outside the server: the default inbound policy is drop, with only SSH, HTTP/HTTPS, and
+     ICMP permitted; outbound traffic is unrestricted. The rule set and change procedure
+     are published in the open-source repository (server_config/firewall.md). No separate
+     host-based firewall is configured."
+   - **FIDP-02** → Yes. Suggested note: "Firewall changes follow the procedure documented
+     in server_config/firewall.md: the rule set is maintained in the repository, planned
+     changes are reviewed there before being applied through the hosting provider's
+     console, and emergency changes are recorded within one business day."
+   - **FIDP-05** → Yes. Suggested note: "Every change to the network firewall (creation,
+     rule updates, attaching or detaching a server, enabling or disabling) is recorded in
+     the hosting account's event history with the acting user and timestamp, retained for
+     90 days; the intended rule set and its history are kept in the public repository. No
+     IDS or IPS is deployed (see FIDP-03 and FIDP-04)."
+   - **DATA-01** note, optionally append: "Inbound traffic is filtered by a network
+     firewall that admits only SSH, HTTP/HTTPS, and ICMP."
+   - Bump the **Last reviewed** date in the header.
+2. The security-status page on the office wiki: move "No firewall" from the gaps list to
+   the in-place list.
+3. `docs/deploy.md`, recovery procedure: attaching the firewall is part of standing up a
+   replacement server.
+
+## Applied
+
+| Date | Linode | Firewall ID | By | Notes |
+|---|---|---|---|---|
+| 2026-09-11 | `dashboard-rehearsal` | 163657050 | Sage Ross | Phase 2 passed incl. reboot and `rdisc6` RA test. |
+| 2026-09-11 | `dashboard-testing` (staging) | 163657050 | Sage Ross | External check: 22/80/443 open, HTTPS 200, HTTP 301 to HTTPS, unlisted port dropped (6 s timeout, not refused). |
+| 2026-09-11 | prod (`dashboard.wikiedu.org`) | 163657050 | Sage Ross | Phase 4 passed; see the result note under Phase 4. Enforcement took under a minute to propagate. |
+
+## Sources
+
+- Akamai Cloud Firewall overview (limits, cost, interfaces): https://techdocs.akamai.com/cloud-computing/docs/cloud-firewall
+- Cloud Firewall rules (fields, policies, ordering): https://techdocs.akamai.com/cloud-computing/docs/manage-firewall-rules
+- Cloud Firewall vs. Linux firewall software ("stateful network-based firewalls"; inbound order of evaluation; recommendation to use both): https://techdocs.akamai.com/cloud-computing/docs/comparing-cloud-firewalls-to-linux-firewall-software
+- IPv6 on Linodes (SLAAC requires ICMPv6 and router advertisements): https://techdocs.akamai.com/cloud-computing/docs/an-overview-of-ipv6-on-linode
+- API: create a firewall (request schema): https://techdocs.akamai.com/linode-api/reference/post-firewalls
+- API: events (firewall event types, 90-day retention): https://techdocs.akamai.com/linode-api/reference/get-events
+
+(Document written by Claude Code.)

--- a/server_config/firewall.md
+++ b/server_config/firewall.md
@@ -38,8 +38,7 @@ public and private interfaces but not to VLAN interfaces (we have none).
 
 ## Facts the design depends on
 
-Confirmed during the September 2026 OS upgrade (`.claude/debian_upgrade_plan-2026-09-01.md`
-inventory, and the live notes there) unless marked otherwise.
+Confirmed on the server during the September 2026 OS upgrade unless marked otherwise.
 
 | Fact | Consequence for the rules |
 |---|---|
@@ -176,7 +175,7 @@ reboot and no SSH.
    `permitrootlogin no` (or `prohibit-password`), `pubkeyauthentication yes`. If password
    authentication is on, turn it off first (`/etc/ssh/sshd_config.d/`, then
    `sudo systemctl reload ssh`) **from a session whose key login you have just tested**.
-3. **Record the address baseline** (from the upgrade plan, section 5.0):
+3. **Record the address baseline** (the same check used during the OS upgrade):
 
    ```bash
    ip -6 addr show scope global | grep -c 2600:3c01::f03c:93ff:fe24:db1b   # 1
@@ -243,7 +242,8 @@ allowlisted anywhere, so this is mostly a second data point). It stays attached.
 5. Within the next day: `sudo certbot renew --dry-run` (snap) succeeds, proving HTTP-01
    still reaches Apache; after the next Sunday, confirm the weekly dump landed in
    `/home/dbbackup/dumps`.
-6. Fill in the "Applied" section below and make the HECVAT and wiki updates listed there.
+6. Fill in the "Applied" section below and make the documentation updates listed under
+   "Documentation updates after go-live".
 
    **Result 2026-09-11:** attached at about 15:47 PDT. Probes from outside in the first
    seconds after the attach still saw unlisted ports *refused* (the packets reached the
@@ -295,33 +295,18 @@ This is the firewall change policy (HECVAT FIDP-02).
 - **Outbound restriction** to the enumerated dependencies. High effort, modest gain for a
   server whose job is to call many third-party APIs.
 
-## After it is live: documentation updates
+## Documentation updates after go-live
 
-Once Phase 4 is done and verified, make these edits so the public record matches reality:
+Phase 4 was verified on 2026-09-11, and the record was brought into line the same day:
 
-1. `docs/hecvat.md`:
-   - **FIDP-01** → Yes. Suggested note: "Inbound traffic to the production server is
-     filtered by a stateful network firewall (Akamai/Linode Cloud Firewall) applied
-     outside the server: the default inbound policy is drop, with only SSH, HTTP/HTTPS, and
-     ICMP permitted; outbound traffic is unrestricted. The rule set and change procedure
-     are published in the open-source repository (server_config/firewall.md). No separate
-     host-based firewall is configured."
-   - **FIDP-02** → Yes. Suggested note: "Firewall changes follow the procedure documented
-     in server_config/firewall.md: the rule set is maintained in the repository, planned
-     changes are reviewed there before being applied through the hosting provider's
-     console, and emergency changes are recorded within one business day."
-   - **FIDP-05** → Yes. Suggested note: "Every change to the network firewall (creation,
-     rule updates, attaching or detaching a server, enabling or disabling) is recorded in
-     the hosting account's event history with the acting user and timestamp, retained for
-     90 days; the intended rule set and its history are kept in the public repository. No
-     IDS or IPS is deployed (see FIDP-03 and FIDP-04)."
-   - **DATA-01** note, optionally append: "Inbound traffic is filtered by a network
-     firewall that admits only SSH, HTTP/HTTPS, and ICMP."
-   - Bump the **Last reviewed** date in the header.
-2. The security-status page on the office wiki: move "No firewall" from the gaps list to
+1. `docs/hecvat.md` (in the same pull request that added this document): **FIDP-01**,
+   **FIDP-02** and **FIDP-05** changed from No to Yes, with notes that point here; the
+   **DATA-01** note mentions the firewall; the **Last reviewed** date in the header was
+   bumped.
+2. `docs/deploy.md`, recovery procedure (same pull request): attaching the firewall is a
+   step in standing up a replacement server.
+3. The security-status page on the office wiki: "No firewall" moved from the gaps list to
    the in-place list.
-3. `docs/deploy.md`, recovery procedure: attaching the firewall is part of standing up a
-   replacement server.
 
 ## Applied
 

--- a/spec/config/oj_spec.rb
+++ b/spec/config/oj_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# config/initializers/oj.rb switches Oj from its default :object mode, which
+# instantiates arbitrary Ruby classes from "^o" keys, to :strict mode. Several
+# Oj.load call sites parse JSON the Dashboard did not write (API responses,
+# training content read from wiki pages), so this pins the security property.
+describe 'Oj initializer' do
+  it 'sets strict mode as the default' do
+    expect(Oj.default_options[:mode]).to eq(:strict)
+  end
+
+  it 'returns a plain Hash for a payload with an object-instantiation key' do
+    parsed = Oj.load('{"^o":"Object","x":1}')
+    expect(parsed).to eq('^o' => 'Object', 'x' => 1)
+  end
+
+  it 'keeps strings that begin with a colon as strings' do
+    expect(Oj.load('[":foo"]')).to eq([':foo'])
+  end
+end


### PR DESCRIPTION
## What this PR does

Refreshes the published HECVAT (`docs/hecvat.md`, served at `/hecvat`) after the production server's in-place move from Debian 11 to Debian 12 on 2026-09-04, and closes several of its "No" answers with low-disruption changes made the same day:

- **Cloud Firewall.** `server_config/firewall.md` documents the Akamai (Linode) Cloud Firewall now attached to production, staging, and the rehearsal clone: why a network firewall rather than host nftables first, the facts the rules depend on (notably that the Wikimedia-allowlisted IPv6 is a SLAAC address that needs inbound ICMPv6), the rule set (inbound drop; allow TCP 22, TCP 80+443, ICMP from all IPv4 and IPv6; outbound accept), the four-phase rollout runbook with each phase's recorded result, and the change procedure. HECVAT FIDP-01, FIDP-02 and FIDP-05 change from No to Yes and point at it. The Phase 0 listener check also found that the bookworm upgrade had enabled `mariadb.socket`, leaving MariaDB on `*:3306` reachable from the internet (all accounts were `@localhost`, so no remote login was possible); that was fixed on the server the same day and the diagnosis and post-upgrade re-check are written into the runbook.
- **Oj strict mode.** `Oj.load` ran in Oj's default `:object` mode, which instantiates arbitrary Ruby classes from `"^o"` keys, and one call site parses training-content JSON from editable Meta-Wiki pages. `config/initializers/oj.rb` now sets `mode: :strict`; every call site only ever needed plain Hash/Array output.
- **Dependency audit in CI.** `bundler-audit` runs right after Ruby setup, before the test suites, and fails the build on any gem with a published advisory. Making it green required `crass` 1.0.6 → 1.0.7 (four CSS-parsing DoS advisories) and `rubyzip` 2.3.2 → 3.6.0 (CVE-2026-85396, path traversal on extraction; the Dashboard only writes zips).
- **HECVAT facts.** APPL-03 (OS and runtimes), DOCU-02 (owner and testing cadence), ITAC-06 (VPAT scope), APPL-06 and VULN-01 (the CI audit), DATA-01 (firewall), and a "Last reviewed" line, which is deliberately the document's only date.
- **Patch management.** `docs/patch_management.md` documents how each layer is patched and on what cadence; `unattended-upgrades` is now enabled on production, restricted to the Debian security suite with no automatic reboot. HECVAT PPPR-01 changes from No to Yes.
- **Recovery procedure.** `docs/deploy.md` said sslmate and a long-gone wmflabs backup host; it now describes Let's Encrypt via certbot, the same-Linode snapshot restore that preserves the allowlisted addresses, the firewall, and the real backup locations.

Related documentation: [Akamai Cloud Firewall](https://techdocs.akamai.com/cloud-computing/docs/cloud-firewall) and its [comparison with Linux firewalls](https://techdocs.akamai.com/cloud-computing/docs/comparing-cloud-firewalls-to-linux-firewall-software) (stateful, evaluated before host rules); [IPv6 on Linodes](https://techdocs.akamai.com/cloud-computing/docs/an-overview-of-ipv6-on-linode) (SLAAC requires ICMPv6); [Debian LTS schedule](https://wiki.debian.org/LTS); [Oj modes](https://github.com/ohler55/oj/blob/develop/pages/Modes.md).

## AI usage

This PR was produced with Claude Code (Claude Fable 5.1) under Sage Ross's direction. The agent read the existing HECVAT, the Debian upgrade notes and the security-status draft, researched the Akamai firewall and Oj documentation, drafted every file change and every commit message, and ran the specs and the external network probes. Sage decided what to do, ran every command on the production server and the clone himself and pasted the output back (the agent never had shell access to production), created and attached the firewall in Cloud Manager, and reviewed the HECVAT wording. The Brakeman scan that surfaced the Oj issue was run by the agent; the judgement that it was a real gap rather than a false positive came from verifying Oj's behaviour with the app loaded.

Scale of effort: eight commits, all on 2026-09-11. Seven came from a single session of several hours, roughly half of it the interactive firewall rollout; two of those are tidy-ups after Sage's review of the HECVAT wording (no dates or planned-change narration in the notes, apart from the header's review date and the OS support window), and the seventh adds the patch-management process after Sage chose it from a list of remaining easy wins. The eighth, from a short second session, addresses the Claude Code review posted on this PR: dead documentation references, the deploy-branch description, the audit step's position in CI, a pre-existing broken README link, and a spec pinning Oj strict mode. The "What this PR does" summary and the rest of this description were also drafted by Claude Code and may contain errors. This PR description was drafted using Claude Code and the `prepare-pr` skill.

## Screenshots

No UI changes. Verification evidence instead:

Oj mode with the app loaded, before and after the initializer change:

```
$ bundle exec rails runner 'p Oj.default_options[:mode]; p Oj.load(%q({"^o":"Object","x":1}))'
:object
#<Object:0x00007f519d1519e0 @x=1>        # before

:strict
{"^o" => "Object", "x" => 1}              # after
```

Dependency audit before and after the gem bumps:

```
$ bundle-audit check --update
Name: crass    Version: 1.0.6  ...  Solution: update to '>= 1.0.7'   (x4)
Name: rubyzip  Version: 2.3.2  Criticality: High  CVE-2026-85396   Solution: update to '>= 3.4.0'
Vulnerabilities found!

$ bundle exec bundle-audit check --update
No vulnerabilities found
```

Production behind the firewall, probed from outside on 2026-09-11 (unlisted ports time out instead of being refused, which is the Cloud Firewall dropping them):

```
prod :22 -> open
prod :80 -> open
prod :443 -> open
prod :3306 -> dropped after 6.0s
prod :8080 -> dropped after 6.0s
https -> 200 in 0.146662s
DB-backed page -> 200 in 0.099658s
http redirect -> 301 -> https://dashboard.wikiedu.org/
ping -> rtt min/avg/max/mdev = 20.827/20.861/20.895/0.034 ms
```

Spec runs: the twelve spec files covering every `Oj.load` call site (127 examples, green); `spec/lib spec/models spec/services spec/helpers spec/workers spec/mailers spec/presenters` (2644 examples, one failure in `upload_importer_spec` that fails identically on master because Commons now serves thumbnails from a different host); the zip export spec (8 examples); the HECVAT page spec (7 examples).

## Open questions and concerns

- The HECVAT "Last reviewed: 2026-09-11" line asserts Wiki Education's confirmation of the revised answers; Sage should re-read the changed notes (APPL-03, DOCU-02, FIDP-01/02/05, DATA-01, ITAC-06, APPL-06, VULN-01) before this merges, since `/hecvat` is public.
- `bundler-audit` will fail CI whenever a new advisory lands for a gem in the lockfile, including cases where the Dashboard's usage is unaffected (as rubyzip's was). The escape hatch is a `.bundler-audit.yml` ignore entry with a written justification; none is needed today.
- `rubyzip` 2 → 3 is a major bump. The only use is `Zip::OutputStream.write_buffer` in `ExportTrainingModuleDraft`, whose spec passes; `selenium-webdriver` allows `< 4.0`.
- Oj strict mode is a global default. No gem in the lockfile depends on `oj`, there is no `Oj.dump` in app or lib, and the Rails encoder installed by `optimize_rails` is unaffected, so the change only touches our own `Oj.load` calls.
- Not in this PR, flagged for a decision: whether the Fall 2026 study's wickie.ink enrollment call (not yet live) and the S3-compatible CSV store belong in the HECVAT's subprocessor list (DPAI-03); Brakeman's 40 warnings (13 High, none confirmed exploitable at a glance) need a reviewed baseline before it can join CI.
- `unattended-upgrades` will restart Apache or MariaDB for a few seconds when a security update to those packages lands (around 06:00 server time). Accepted by default; a package blacklist is the one-line alternative if that ever proves disruptive.
- Operational follow-ups recorded in the runbook: `certbot renew --dry-run` on prod, a check that the IPv6 `valid_lft` resets behind the firewall, the next Sunday dump, 2FA for the other Akamai account users, `PermitRootLogin prohibit-password`, a firewall for the other Akamai-hosted servers, and rebuilding staging off Debian 10.

(PR description written by Claude Code.)

