### PR TITLE
Add Scholars & Scientists retention report card page

### DIFF
--- a/app/assets/stylesheets/modules/_report_cards.styl
+++ b/app/assets/stylesheets/modules/_report_cards.styl
@@ -1,0 +1,44 @@
+// Admin-only Scholars & Scientists report cards (/report_cards).
+.report-card
+  &__legend
+    max-width 800px
+
+  &__scroll
+    overflow-x auto
+    margin-bottom 40px
+
+  &__table
+    min-width 2200px
+
+    thead th,
+    tbody td
+      padding 8px 10px
+      font-size 13px
+
+    thead th
+      vertical-align bottom
+      min-width 90px
+      max-width 150px
+      white-space normal
+
+    th.report-card__group
+      text-align center
+      font-size 15px
+      border-bottom 2px solid #ddd
+
+  &__title
+    min-width 180px
+
+  &__number
+    text-align right
+
+  td.report-card__number
+    white-space nowrap
+
+  &__pending
+    color #999
+    font-style italic
+
+  &__totals td
+    font-weight bold
+    border-top 2px solid #ddd

--- a/app/assets/stylesheets/modules/_report_cards.styl
+++ b/app/assets/stylesheets/modules/_report_cards.styl
@@ -39,6 +39,9 @@
     color #999
     font-style italic
 
+  &__not-applicable
+    color #999
+
   &__totals td
     font-weight bold
     border-top 2px solid #ddd

--- a/app/controllers/report_cards_controller.rb
+++ b/app/controllers/report_cards_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/retention_report_card"
+
+# Admin-only report cards for Scholars & Scientists (FellowsCohort) courses, one
+# per campaign, built from the RetentionStat rows UpdateRetentionStatsWorker and
+# the retention_stats:backfill task store. Wiki Education Dashboard only: the
+# program, and the daily job that computes the rows, exist only there.
+class ReportCardsController < ApplicationController
+  layout 'admin'
+  before_action :require_wiki_ed
+  before_action :require_admin_permissions
+
+  # Campaigns with at least one computed Scholars & Scientists course, newest
+  # first. Derived from stored data, so a campaign appears only once its courses
+  # have been computed.
+  def index
+    @campaigns = Campaign.joins(courses: :retention_stats)
+                         .where(courses: { type: 'FellowsCohort' })
+                         .select('campaigns.*, COUNT(DISTINCT courses.id) AS courses_count')
+                         .group('campaigns.id')
+                         .order(Arel.sql('MAX(courses.start) DESC'))
+  end
+
+  def show
+    campaign = Campaign.find_by(slug: params[:campaign_slug])
+    raise ActionController::RoutingError, 'Not Found' unless campaign
+
+    @report_card = RetentionReportCard.new(campaign)
+    respond_to do |format|
+      format.html
+      format.csv { send_data @report_card.to_csv, filename: csv_filename(campaign) }
+    end
+  end
+
+  private
+
+  def require_wiki_ed
+    raise ActionController::RoutingError, 'Not Found' unless Features.wiki_ed?
+  end
+
+  def csv_filename(campaign)
+    "report-card-#{campaign.slug}-#{Time.zone.today}.csv".tr('/', '-')
+  end
+end

--- a/app/helpers/report_cards_helper.rb
+++ b/app/helpers/report_cards_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ReportCardsHelper
+  # A numeric report card cell: formatted per the column, or the "pending"
+  # marker when the figure is not available yet.
+  def report_card_cell(value, format)
+    return tag.span(t('report_cards.pending'), class: 'report-card__pending') if value.nil?
+
+    case format
+    when :integer then number_with_delimiter(value)
+    when :decimal then number_with_precision(value, precision: 1)
+    when :percent then "#{number_with_precision(value, precision: 1)}%"
+    else value
+    end
+  end
+end

--- a/app/helpers/report_cards_helper.rb
+++ b/app/helpers/report_cards_helper.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
 module ReportCardsHelper
-  # A numeric report card cell: formatted per the column, or the "pending"
-  # marker when the figure is not available yet.
-  def report_card_cell(value, format)
-    return tag.span(t('report_cards.pending'), class: 'report-card__pending') if value.nil?
+  # A numeric report card cell: the row's figure for the column, formatted per
+  # the column; the "pending" marker when the figure has not been computed yet;
+  # the not-applicable marker when it has been reached but there was nobody to
+  # count, so it never will be.
+  def report_card_cell(row, column)
+    value = row.public_send(column.key)
+    return empty_report_card_cell(row, column) if value.nil?
 
-    case format
+    case column.format
     when :integer then number_with_delimiter(value)
     when :decimal then number_with_precision(value, precision: 1)
     when :percent then "#{number_with_precision(value, precision: 1)}%"
     else value
+    end
+  end
+
+  private
+
+  def empty_report_card_cell(row, column)
+    if row.reached?(column.stage)
+      tag.span(t('report_cards.not_applicable'), class: 'report-card__not-applicable')
+    else
+      tag.span(t('report_cards.pending'), class: 'report-card__pending')
     end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -82,6 +82,7 @@ class Course < ApplicationRecord
            foreign_key: 'project_id',
            dependent: :destroy
   has_one :course_stat, class_name: 'CourseStat', dependent: :destroy
+  has_many :retention_stats, dependent: :destroy
 
   #########################
   # Activity by the users #

--- a/app/models/retention_stat.rb
+++ b/app/models/retention_stat.rb
@@ -32,17 +32,18 @@ class RetentionStat < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :course_id }
 
-  # Whether the course's rows lag behind what can be computed now: there are
-  # none yet, a metric window has closed since they were computed, or the
-  # roster has changed. Nothing is due before the first checkpoint, a day after
-  # the course ends.
+  # Whether the course's rows lag behind what can be computed now: a metric
+  # window has closed since they were computed, or they no longer match the
+  # roster (which is also what makes a course with students and no rows due, and
+  # a course with neither not due). Nothing is due before the first checkpoint,
+  # a day after the course ends.
   def self.update_due?(course, now: Time.zone.now)
     current_stage = RetentionStudentStats.stage(course, now)
     return false if current_stage.zero?
 
     rows = where(course_id: course.id)
-    return true if rows.none?
-    return true if RetentionStudentStats.stage(course, rows.minimum(:computed_at)) < current_stage
+    computed_at = rows.minimum(:computed_at)
+    return true if computed_at && RetentionStudentStats.stage(course, computed_at) < current_stage
 
     rows.pluck(:user_id).sort != course.students.pluck(:id).sort
   end

--- a/app/models/retention_stat.rb
+++ b/app/models/retention_stat.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: retention_stats
+#
+#  id                   :bigint           not null, primary key
+#  course_id            :integer          not null
+#  user_id              :integer          not null
+#  sessions_during      :integer          default(0), not null
+#  days_to_return       :integer
+#  sessions_after       :integer
+#  edits_60_90          :integer
+#  prior_edit_count     :integer          default(0), not null
+#  long_term_wikipedian :boolean          default(FALSE), not null
+#  prior_course_count   :integer          default(0), not null
+#  computed_at          :datetime         not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+
+require_dependency "#{Rails.root}/lib/analytics/retention_student_stats"
+
+# One student's retention metrics for one Scholars & Scientists course, as
+# computed by RetentionStudentStats and stored by UpdateCourseRetentionStats.
+# The report card (RetentionReportCard) is built from these rows.
+#
+# A post-course metric is nil until its window has closed. `computed_at` records
+# when the row was computed, which is what says which windows had closed by then.
+class RetentionStat < ApplicationRecord
+  belongs_to :course
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :course_id }
+
+  # Whether the course's rows lag behind what can be computed now: there are
+  # none yet, a metric window has closed since they were computed, or the
+  # roster has changed. Nothing is due before the first checkpoint, a day after
+  # the course ends.
+  def self.update_due?(course, now: Time.zone.now)
+    current_stage = RetentionStudentStats.stage(course, now)
+    return false if current_stage.zero?
+
+    rows = where(course_id: course.id)
+    return true if rows.none?
+    return true if RetentionStudentStats.stage(course, rows.minimum(:computed_at)) < current_stage
+
+    rows.pluck(:user_id).sort != course.students.pluck(:id).sort
+  end
+
+  # Had already taken an earlier course when this one began.
+  def returning?
+    prior_course_count.positive?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,7 @@ class User < ApplicationRecord
   has_many :training_modules_users, class_name: 'TrainingModulesUsers'
   has_one :user_profile, dependent: :destroy
   has_many :lti_contexts, dependent: :destroy
+  has_many :retention_stats, dependent: :destroy
 
   has_many :assignment_suggestions
 

--- a/app/services/update_course_retention_stats.rb
+++ b/app/services/update_course_retention_stats.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/retention_student_stats"
+
+# Computes a course's per-student retention metrics (RetentionStudentStats) and
+# stores them as its RetentionStat rows, replacing whatever was stored before.
+# UpdateRetentionStatsWorker runs this once per checkpoint for recently ended
+# Scholars & Scientists courses; the retention_stats:backfill task runs it for
+# historical ones.
+class UpdateCourseRetentionStats
+  attr_reader :stats
+
+  def initialize(course, now: Time.zone.now)
+    @course = course
+    @now = now
+    @stats = RetentionStudentStats.new(course, now:).stats
+    store
+  end
+
+  private
+
+  # The metrics are all computed before anything is deleted, so an API failure
+  # leaves the previous rows in place. Deleting through the class rather than the
+  # association keeps the course's association from being cached as empty.
+  def store
+    RetentionStat.transaction do
+      RetentionStat.where(course_id: @course.id).delete_all
+      RetentionStat.insert_all(rows) if rows.any?
+    end
+    @course.retention_stats.reset
+  end
+
+  def rows
+    @rows ||= @stats.map do |s|
+      {
+        course_id: @course.id,
+        user_id: s[:user_id],
+        sessions_during: s[:sessions_during],
+        days_to_return: s[:days_to_return],
+        sessions_after: s[:sessions_after],
+        edits_60_90: s[:edits_60_90],
+        prior_edit_count: s[:prior_edit_count],
+        long_term_wikipedian: s[:long_term],
+        prior_course_count: s[:prior_courses],
+        computed_at: @now
+      }
+    end
+  end
+end

--- a/app/services/update_course_retention_stats.rb
+++ b/app/services/update_course_retention_stats.rb
@@ -19,8 +19,9 @@ class UpdateCourseRetentionStats
 
   private
 
-  # The metrics are all computed before anything is deleted, so an API failure
-  # leaves the previous rows in place. Deleting through the class rather than the
+  # The metrics are all computed before anything is deleted, so a failed fetch
+  # (RetentionFetchError, raised from the constructor) leaves the previous rows in
+  # place and the course still due. Deleting through the class rather than the
   # association keeps the course's association from being cached as empty.
   def store
     RetentionStat.transaction do

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -58,3 +58,6 @@
           %a{href: '/usage'} Usage stats
         %li
           %a{href: '/system_stats'} System & Facilitator Stats
+        - if Features.wiki_ed?
+          %li
+            %a{href: '/report_cards'} Scholars & Scientists report cards

--- a/app/views/report_cards/_row.html.haml
+++ b/app/views/report_cards/_row.html.haml
@@ -10,4 +10,4 @@
     - elsif column.format == :text
       %td= value
     - else
-      %td.report-card__number= report_card_cell(value, column.format)
+      %td.report-card__number= report_card_cell(row, column)

--- a/app/views/report_cards/_row.html.haml
+++ b/app/views/report_cards/_row.html.haml
@@ -1,0 +1,13 @@
+%tr{class: (row.total? ? 'report-card__totals' : nil)}
+  - RetentionReportCard::COLUMNS.each do |column|
+    - value = row.public_send(column.key)
+    - if column.key == :title
+      %td.report-card__title
+        - if row.course
+          = link_to value, "/courses/#{row.course.slug}"
+        - else
+          = value
+    - elsif column.format == :text
+      %td= value
+    - else
+      %td.report-card__number= report_card_cell(value, column.format)

--- a/app/views/report_cards/index.html.haml
+++ b/app/views/report_cards/index.html.haml
@@ -1,0 +1,20 @@
+- content_for :before_title, "#{t('report_cards.title')} — "
+
+%header.main-page
+  .container
+    %h1= t('report_cards.title')
+
+.container.report-cards
+  - if @campaigns.empty?
+    %p= t('report_cards.empty')
+  - else
+    %table.table
+      %thead
+        %tr
+          %th= t('report_cards.campaign')
+          %th= t('report_cards.courses')
+      %tbody
+        - @campaigns.each do |campaign|
+          %tr
+            %td= link_to campaign.title, "/report_cards/#{campaign.slug}"
+            %td= campaign.courses_count

--- a/app/views/report_cards/show.html.haml
+++ b/app/views/report_cards/show.html.haml
@@ -1,0 +1,25 @@
+- content_for :before_title, "#{@report_card.campaign.title} — "
+
+%header.main-page
+  .container
+    %h1= @report_card.campaign.title
+    %p.subtitle= t('report_cards.subtitle')
+
+.container.report-card
+  %p.report-card__legend= t('report_cards.legend')
+  %p
+    %a.button.dark{href: "/report_cards/#{@report_card.campaign.slug}.csv"}= t('report_cards.download_csv')
+  .report-card__scroll
+    %table.table.report-card__table
+      %thead
+        %tr
+          - @report_card.groups.each do |group, span|
+            %th.report-card__group{colspan: span}= t("report_cards.groups.#{group}")
+        %tr
+          - RetentionReportCard::COLUMNS.each do |column|
+            %th{class: (column.format == :text ? nil : 'report-card__number')}
+              = t("report_cards.columns.#{column.key}")
+      %tbody
+        - @report_card.rows.each do |row|
+          = render 'row', row: row
+        = render 'row', row: @report_card.totals

--- a/app/workers/daily_update/update_retention_stats_worker.rb
+++ b/app/workers/daily_update/update_retention_stats_worker.rb
@@ -24,7 +24,18 @@ class UpdateRetentionStatsWorker
     now = Time.zone.now
     FellowsCohort.where(end: (now - LIFECYCLE)..now).find_each do |course|
       next unless RetentionStat.update_due?(course, now:)
-      UpdateCourseRetentionStats.new(course, now:)
+      update(course, now)
     end
+  end
+
+  private
+
+  # A course whose usercontribs fetch failed keeps whatever rows it had and is
+  # still due tomorrow, so the next daily run tries it again; the courses after
+  # it in the loop are not held up.
+  def update(course, now)
+    UpdateCourseRetentionStats.new(course, now:)
+  rescue RetentionFetchError => e
+    Sentry.capture_exception(e, extra: { course: course.slug })
   end
 end

--- a/app/workers/daily_update/update_retention_stats_worker.rb
+++ b/app/workers/daily_update/update_retention_stats_worker.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/retention_student_stats"
+require_dependency "#{Rails.root}/app/services/update_course_retention_stats"
+
+# Keeps RetentionStat rows current for recently ended Scholars & Scientists
+# (FellowsCohort) courses. Enqueued by DailyUpdate on the Wiki Education
+# Dashboard only.
+#
+# Scope is by course type, never by campaign: student-program courses are never
+# considered. And only courses still inside their checkpoint lifecycle are: a
+# course is recomputed at most once per checkpoint (end + 1, + 31 and + 91
+# days), so on most days there is nothing to do. Older courses are reached only
+# by the retention_stats:backfill rake task, one campaign at a time.
+class UpdateRetentionStatsWorker
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executed
+
+  # The last checkpoint falls 91 days after a course ends; the extra month
+  # covers daily runs that were skipped or failed around it.
+  LIFECYCLE = (RetentionStudentStats::CHECKPOINT_DAYS.last + 30).days
+
+  def perform
+    now = Time.zone.now
+    FellowsCohort.where(end: (now - LIFECYCLE)..now).find_each do |course|
+      next unless RetentionStat.update_due?(course, now:)
+      UpdateCourseRetentionStats.new(course, now:)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1422,6 +1422,41 @@ en:
       overview stats, like 'Articles Edited', 'Total Edits', 'Words Added', etc. Hence, only
       track the namespaces that your program aims to improve.
 
+  report_cards:
+    title: Report cards
+    subtitle: Scholars & Scientists report card
+    campaign: Campaign
+    courses: Courses
+    download_csv: Download CSV
+    pending: pending
+    total: Total
+    empty: "no stats computed"
+    legend: "Long-term Wikipedians (500+ edits before the course) are counted under Participants but left out of every other figure. Cells marked pending fill in 31 and 91 days after a course ends."
+    groups:
+      general: General
+      during: During the course
+      after: After the course
+    columns:
+      number: "#"
+      title: Course
+      instructors: Instructor
+      participants: Participants
+      long_term_wikipedians: "…of which is a long-term Wikipedian (500+ edits)"
+      sessions_during: Editing sessions
+      avg_sessions_during: Average editing sessions per participant
+      zero_edit_participants: Participants with no edits
+      uploads: Total number of uploads
+      avg_uploads: Average number of uploads per participant
+      words: Total number of words added
+      avg_words: Average amount of words per participant
+      editors_after_course: Participants who edited in 30 days after course
+      pct_active_editors_after: Percentage of active participants who made 1+ edit within 30 days after course
+      avg_days_to_return: Days to first independent edit
+      avg_sessions_after: Average editing sessions 30 days after course
+      any_survival_edits: Participants with 1+ edits between days 60 and 90 after course end
+      any_survival_edits_returning: "…of which took a prior course"
+      survivors: Participants with 5+ edits between days 60 and 90 after course end
+      survivors_returning: "…of which took a prior course"
   recent_activity:
     active_courses: Article is active in
     article_title: Title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1429,6 +1429,7 @@ en:
     courses: Courses
     download_csv: Download CSV
     pending: pending
+    not_applicable: "—"
     total: Total
     empty: "no stats computed"
     legend: "Long-term Wikipedians (500+ edits before the course) are counted under Participants but left out of every other figure. Cells marked pending fill in 31 and 91 days after a course ends."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -330,6 +330,9 @@ Rails.application.routes.draw do
   get 'system_stats' => 'system_stats#index'
   get 'system_stats/wiki_trends' => 'system_stats#wiki_trends'
   get 'system_stats/facilitators' => 'system_stats#facilitators'
+  # Scholars & Scientists report cards (admin-only, Wiki Education Dashboard only)
+  get 'report_cards' => 'report_cards#index'
+  get 'report_cards/:campaign_slug' => 'report_cards#show'
 
   # Reports generated in background
   # Course reports

--- a/db/migrate/20260911120000_create_retention_stats.rb
+++ b/db/migrate/20260911120000_create_retention_stats.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Per-student retention metrics for Scholars & Scientists (FellowsCohort)
+# courses, computed from the live usercontribs API by RetentionStudentStats and
+# stored so the report card page never has to fetch them on request.
+class CreateRetentionStats < ActiveRecord::Migration[8.1]
+  def change
+    create_table :retention_stats, charset: 'utf8mb4', collation: 'utf8mb4_unicode_ci' do |t|
+      t.integer :course_id, null: false
+      t.integer :user_id, null: false
+      t.integer :sessions_during, null: false, default: 0
+      t.integer :days_to_return
+      t.integer :sessions_after
+      t.integer :edits_60_90
+      t.integer :prior_edit_count, null: false, default: 0
+      t.boolean :long_term_wikipedian, null: false, default: false
+      t.integer :prior_course_count, null: false, default: 0
+      t.datetime :computed_at, null: false
+      t.timestamps
+    end
+    add_index :retention_stats, %i[course_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_04_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_120000) do
   create_table "admin_course_notes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "courses_id"
     t.string "title"
@@ -575,6 +575,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_04_120000) do
     t.string "email"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "retention_stats", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "course_id", null: false
+    t.integer "user_id", null: false
+    t.integer "sessions_during", default: 0, null: false
+    t.integer "days_to_return"
+    t.integer "sessions_after"
+    t.integer "edits_60_90"
+    t.integer "prior_edit_count", default: 0, null: false
+    t.boolean "long_term_wikipedian", default: false, null: false
+    t.integer "prior_course_count", default: 0, null: false
+    t.datetime "computed_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id", "user_id"], name: "index_retention_stats_on_course_id_and_user_id", unique: true
   end
 
   create_table "revision_ai_scores", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/lib/analytics/retention_fetch_error.rb
+++ b/lib/analytics/retention_fetch_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Raised by RetentionStudentStats and RetentionParticipantHistory when a
+# usercontribs request gives no answer. WikiApi has already retried it and
+# logged the failure; what matters here is that a student whose edits could not
+# be fetched is not reported (or, worse, stored) as somebody who never edited.
+class RetentionFetchError < StandardError
+  def initialize(username, wiki)
+    super("Could not fetch #{username}'s contributions from #{wiki.domain}")
+  end
+end

--- a/lib/analytics/retention_metrics.rb
+++ b/lib/analytics/retention_metrics.rb
@@ -59,7 +59,9 @@ class RetentionMetrics
 
   # Editors after the course as a percentage of those who edited during it
   # (the spreadsheet's `M / (D − H)`), over the rows whose return window has
-  # closed. nil when nobody edited during the course.
+  # closed. nil when nobody edited during the course. The numerator is not
+  # limited to the denominator's editors, so a participant who edited only after
+  # the course can push this past 100%, as it does in the spreadsheet.
   def pct_active_editors_after
     rows = computed(:sessions_after)
     active = rows.count { |s| s.sessions_during.positive? }

--- a/lib/analytics/retention_metrics.rb
+++ b/lib/analytics/retention_metrics.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/retention_summary_block"
+
+# Aggregates stored RetentionStat rows — one course's, or a whole campaign's —
+# into the figures the report card shows.
+#
+# Long-term Wikipedians (500+ edits before the course) are counted in
+# `participants` and `long_term_wikipedians` and left out of everything else,
+# the same rule RetentionSummaryBlock applies to the CSV: an established editor
+# who keeps editing is not a retention outcome.
+#
+# Each post-course metric is aggregated over the rows where it has been computed
+# (its window had closed when the row was stored) and is nil when there are
+# none, so a course still inside a window shows a blank rather than a zero. For
+# a single course every row was computed at once, so that is all-or-nothing;
+# for a campaign it means "over the courses that have got that far".
+class RetentionMetrics
+  SURVIVAL_THRESHOLD = RetentionSummaryBlock::SURVIVAL_THRESHOLD
+
+  def initialize(stats)
+    @stats = stats.to_a
+    @counted = @stats.reject(&:long_term_wikipedian)
+  end
+
+  def participants
+    @stats.size
+  end
+
+  # nil rather than 0 when nothing has been computed: the count is unknown.
+  def long_term_wikipedians
+    return nil if @stats.empty?
+    @stats.count(&:long_term_wikipedian)
+  end
+
+  def counted_participants
+    @counted.size
+  end
+
+  def sessions_during
+    return nil if @counted.empty?
+    @counted.sum(&:sessions_during)
+  end
+
+  def avg_sessions_during
+    average(@counted.map(&:sessions_during))
+  end
+
+  def zero_edit_participants
+    return nil if @counted.empty?
+    @counted.count { |s| s.sessions_during.zero? }
+  end
+
+  def editors_after_course
+    rows = computed(:sessions_after)
+    return nil if rows.empty?
+    rows.count { |s| s.sessions_after.positive? }
+  end
+
+  # Editors after the course as a percentage of those who edited during it
+  # (the spreadsheet's `M / (D − H)`), over the rows whose return window has
+  # closed. nil when nobody edited during the course.
+  def pct_active_editors_after
+    rows = computed(:sessions_after)
+    active = rows.count { |s| s.sessions_during.positive? }
+    return nil if active.zero?
+    (rows.count { |s| s.sessions_after.positive? } * 100.0 / active).round(1)
+  end
+
+  def avg_days_to_return
+    average(computed(:days_to_return).map(&:days_to_return))
+  end
+
+  def avg_sessions_after
+    average(computed(:sessions_after).map(&:sessions_after))
+  end
+
+  def any_survival_edits
+    survival_count(1)
+  end
+
+  def any_survival_edits_returning
+    survival_count(1, returning: true)
+  end
+
+  def survivors
+    survival_count(SURVIVAL_THRESHOLD)
+  end
+
+  def survivors_returning
+    survival_count(SURVIVAL_THRESHOLD, returning: true)
+  end
+
+  private
+
+  # Counted rows for which `metric` has been computed.
+  def computed(metric)
+    @counted.select { |s| s.public_send(metric) }
+  end
+
+  def survival_count(threshold, returning: false)
+    rows = computed(:edits_60_90)
+    return nil if rows.empty?
+    rows = rows.select(&:returning?) if returning
+    rows.count { |s| s.edits_60_90 >= threshold }
+  end
+
+  def average(values)
+    return nil if values.empty?
+    (values.sum.to_f / values.size).round(1)
+  end
+end

--- a/lib/analytics/retention_participant_history.rb
+++ b/lib/analytics/retention_participant_history.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/wiki_api"
+require_dependency "#{Rails.root}/lib/analytics/retention_fetch_error"
 
 # What a participant had already done before the course being reported on began:
 # how much they had edited, and whether they had already taken an earlier course.
@@ -70,14 +71,15 @@ class RetentionParticipantHistory
   end
 
   # Edits on one wiki before the course start, paginated until `limit` of them
-  # have been counted (or the user's contributions run out).
+  # have been counted (or the user's contributions run out). A nil response is a
+  # failed fetch, which must not pass for an editor with no history.
   def prior_edits_on(wiki, limit)
     api = WikiApi.new(wiki)
     count = 0
     continue = {}
     loop do
       response = api.query(prior_contribs_query.merge(continue))
-      break unless response
+      raise RetentionFetchError.new(@user.username, wiki) unless response
       count += (response.data['usercontribs'] || []).count
       break if count >= limit
       continue = response['continue']

--- a/lib/analytics/retention_predictors_csv_builder.rb
+++ b/lib/analytics/retention_predictors_csv_builder.rb
@@ -1,61 +1,30 @@
 # frozen_string_literal: true
 
-require_dependency "#{Rails.root}/lib/wiki_api"
-require_dependency "#{Rails.root}/lib/analytics/retention_participant_history"
+require_dependency "#{Rails.root}/lib/analytics/retention_student_stats"
 require_dependency "#{Rails.root}/lib/analytics/retention_summary_block"
 require 'csv'
 
 # Builds the "Retention predictors" CSV report for a course (currently the
-# Scholars & Scientists / FellowsCohort program).
+# Scholars & Scientists / FellowsCohort program): a per-course summary block
+# followed by a per-student detail block, from the metrics RetentionStudentStats
+# computes (see there for what each metric means and when it becomes final).
 #
-# The report combines a per-course summary block with a per-student detail
-# block in a single CSV. Metrics (edits an hour or more apart count as distinct
-# "sessions"; edits closer together are lumped into one session):
-#
-#   1. Editing sessions during the course (course.start..course.end).
-#   2. Days from course end to the student's first independent edit in the 30
-#      days after the course. Capped/defaulted to 30 when they do not return
-#      (smaller is better).
-#   3. Editing sessions in the 30 days after the course ends.
-#   4. Edits in the 30-day window that begins 60 days after the course ends
-#      (course.end+60..course.end+90); a "survivor" made at least 5 such edits.
-#
-# The summary block also reports two aggregate conveniences derived from the
-# per-student metrics above: the count of participants with zero editing sessions
-# during the course, and the count of participants who edited in the 30 days
-# after it ended.
-#
-# Every participant is additionally classified by RetentionParticipantHistory as
-# a long-term Wikipedian (500+ edits before the course), a returning participant
-# (had already taken an earlier course), or neither. That classification decides
-# how the summary block aggregates them; see RetentionSummaryBlock. The detail
-# block reports all three groups alike, so an excluded participant is still
-# visible as somebody who took part.
-#
-# Metrics are computed on each student's combined cross-wiki edit timeline, from
-# the live MediaWiki usercontribs API (all namespaces), which is why the report
-# has no dependency on stored revision data.
-#
-# A metric's window can only be read once real-world time has passed the window
-# plus a one-day buffer: metrics 2 and 3 fill in 31 days after the course ends,
-# metric 4 fills in 91 days after. Cells (and the summary aggregates that depend
-# on them) are left blank until then, so every reported value is final.
+# The summary block aggregates by participant history — long-term Wikipedians
+# excluded, returning participants in a column of their own; see
+# RetentionSummaryBlock. The detail block reports all three groups alike, so an
+# excluded participant is still visible as somebody who took part.
 class RetentionPredictorsCsvBuilder
-  SESSION_GAP = 1.hour
-  RETURN_WINDOW_DAYS = 30
-  SURVIVAL_START_DAY = 60
-  SURVIVAL_END_DAY = 90
-  REPORTING_BUFFER_DAYS = 1
+  DETAIL_HEADERS = ['username', 'sessions during course', 'days to first independent edit',
+                    'sessions in 30 days after course', 'edits in days 60-90',
+                    'edits before course', 'long-term Wikipedian (500+ edits)',
+                    'prior courses', 'prior course slugs'].freeze
 
   def initialize(course)
     @course = course
-    @wikis = course.wikis.to_a
-    @students = course.students.to_a.sort_by(&:username)
-    @now = Time.zone.now
   end
 
   def generate_csv
-    stats = @students.map { |student| student_stats(student) }
+    stats = RetentionStudentStats.new(@course).stats
     CSV.generate do |csv|
       RetentionSummaryBlock.new(stats).rows.each { |row| csv << row }
       csv << []
@@ -65,124 +34,11 @@ class RetentionPredictorsCsvBuilder
 
   private
 
-  DETAIL_HEADERS = ['username', 'sessions during course', 'days to first independent edit',
-                    'sessions in 30 days after course', 'edits in days 60-90',
-                    'edits before course', 'long-term Wikipedian (500+ edits)',
-                    'prior courses', 'prior course slugs'].freeze
-
-  def student_stats(student)
-    times = combined_edit_times(student.username).sort
-    history = RetentionParticipantHistory.new(@course, student, @wikis)
-    edit_metrics(student.username, times).merge(history_columns(history))
-  end
-
-  def edit_metrics(username, times)
-    {
-      username:,
-      sessions_during: count_sessions(times.select { |t| t <= @course.end }),
-      days_to_return: days_to_return(times),
-      sessions_after: sessions_after(times),
-      edits_60_90: edits_in_survival_window(times)
-    }
-  end
-
-  def history_columns(history)
-    {
-      prior_edits: history.prior_edit_count_label,
-      long_term: history.long_term_wikipedian?,
-      returning: history.returning?,
-      prior_courses: history.prior_courses.size,
-      prior_course_slugs: history.prior_course_slugs
-    }
-  end
-
   def detail_rows(stats)
     rows = stats.map do |s|
       [s[:username], s[:sessions_during], s[:days_to_return], s[:sessions_after], s[:edits_60_90],
        s[:prior_edits], (s[:long_term] ? 'yes' : nil), s[:prior_courses], s[:prior_course_slugs]]
     end
     [['Per-student detail'], DETAIL_HEADERS, *rows]
-  end
-
-  # Days from course end to the first edit in the 30-day return window, floored
-  # to whole days. Defaults to the window length (30) when the student does not
-  # return. Blank (nil) until the window has closed.
-  def days_to_return(times)
-    return nil unless return_window_available?
-    first = return_window(times).min
-    return RETURN_WINDOW_DAYS if first.nil?
-    ((first - @course.end) / 1.day.to_i).floor
-  end
-
-  def sessions_after(times)
-    return nil unless return_window_available?
-    count_sessions(return_window(times))
-  end
-
-  def edits_in_survival_window(times)
-    return nil unless survival_window_available?
-    window = survival_window
-    times.count { |t| window.cover?(t) }
-  end
-
-  # Edits strictly after the course end, through the RETURN_WINDOW_DAYS cutoff.
-  def return_window(times)
-    cutoff = @course.end + RETURN_WINDOW_DAYS.days
-    times.select { |t| t > @course.end && t <= cutoff }
-  end
-
-  def survival_window
-    (@course.end + SURVIVAL_START_DAY.days)..(@course.end + SURVIVAL_END_DAY.days)
-  end
-
-  def return_window_available?
-    @now >= @course.end + (RETURN_WINDOW_DAYS + REPORTING_BUFFER_DAYS).days
-  end
-
-  def survival_window_available?
-    @now >= @course.end + (SURVIVAL_END_DAY + REPORTING_BUFFER_DAYS).days
-  end
-
-  # Number of distinct editing sessions: a new session starts whenever the gap
-  # since the previous edit is at least SESSION_GAP.
-  def count_sessions(times)
-    return 0 if times.empty?
-    sessions = 1
-    times.sort.each_cons(2) { |earlier, later| sessions += 1 if later - earlier >= SESSION_GAP }
-    sessions
-  end
-
-  # A student's edit timestamps across every tracked wiki, merged into one
-  # timeline (sessions and returns count regardless of which wiki they land on).
-  def combined_edit_times(username)
-    @wikis.flat_map { |wiki| edit_times(username, wiki) }
-  end
-
-  # All of a user's edit timestamps on a wiki since the course start, fetched
-  # from the usercontribs API and paginated until exhausted.
-  def edit_times(username, wiki)
-    api = WikiApi.new(wiki)
-    times = []
-    continue = {}
-    loop do
-      response = api.query(usercontribs_query(username).merge(continue))
-      break unless response
-      contribs = response.data['usercontribs'] || []
-      times.concat(contribs.map { |c| Time.zone.parse(c['timestamp']) })
-      continue = response['continue']
-      break unless continue
-    end
-    times
-  end
-
-  def usercontribs_query(username)
-    {
-      list: 'usercontribs',
-      ucuser: username,
-      ucstart: Time.zone.now.strftime('%Y%m%d%H%M%S'),
-      ucend: @course.start.strftime('%Y%m%d%H%M%S'),
-      ucprop: 'timestamp',
-      uclimit: 'max'
-    }
   end
 end

--- a/lib/analytics/retention_report_card.rb
+++ b/lib/analytics/retention_report_card.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/retention_report_card_row"
+require 'csv'
+
+# The report card for a campaign's Scholars & Scientists courses: one row per
+# FellowsCohort course, oldest first, plus a totals row, in the columns of the
+# staff spreadsheet this page replaces. Built entirely from stored data (courses
+# columns and RetentionStat rows); nothing is fetched on request.
+class RetentionReportCard
+  Column = Struct.new(:group, :key, :format)
+
+  # Column keys double as RetentionReportCardRow methods and as the locale keys
+  # of the headers (report_cards.columns.*).
+  COLUMNS = [
+    Column.new(:general, :number, :text),
+    Column.new(:general, :title, :text),
+    Column.new(:general, :instructors, :text),
+    Column.new(:during, :participants, :integer),
+    Column.new(:during, :long_term_wikipedians, :integer),
+    Column.new(:during, :sessions_during, :integer),
+    Column.new(:during, :avg_sessions_during, :decimal),
+    Column.new(:during, :zero_edit_participants, :integer),
+    Column.new(:during, :uploads, :integer),
+    Column.new(:during, :avg_uploads, :decimal),
+    Column.new(:during, :words, :integer),
+    Column.new(:during, :avg_words, :integer),
+    Column.new(:after, :editors_after_course, :integer),
+    Column.new(:after, :pct_active_editors_after, :percent),
+    Column.new(:after, :avg_days_to_return, :decimal),
+    Column.new(:after, :avg_sessions_after, :decimal),
+    Column.new(:after, :any_survival_edits, :integer),
+    Column.new(:after, :any_survival_edits_returning, :integer),
+    Column.new(:after, :survivors, :integer),
+    Column.new(:after, :survivors_returning, :integer)
+  ].freeze
+
+  attr_reader :campaign, :rows, :totals
+
+  def initialize(campaign)
+    @campaign = campaign
+    courses = campaign.courses.where(type: 'FellowsCohort')
+                      .includes(:instructors, :retention_stats).order(:start).to_a
+    @rows = courses.each_with_index.map do |course, index|
+      RetentionReportCardRow.new([course], number: index + 1)
+    end
+    @totals = RetentionReportCardRow.new(courses)
+  end
+
+  # Column groups and how many columns each spans, for the two-level header.
+  def groups
+    COLUMNS.group_by(&:group).transform_values(&:size)
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      csv << COLUMNS.map { |column| I18n.t("report_cards.columns.#{column.key}") }
+      (rows + [totals]).each do |row|
+        csv << COLUMNS.map { |column| row.public_send(column.key) }
+      end
+    end
+  end
+end

--- a/lib/analytics/retention_report_card.rb
+++ b/lib/analytics/retention_report_card.rb
@@ -8,7 +8,11 @@ require 'csv'
 # staff spreadsheet this page replaces. Built entirely from stored data (courses
 # columns and RetentionStat rows); nothing is fetched on request.
 class RetentionReportCard
-  Column = Struct.new(:group, :key, :format)
+  # `stage` is the checkpoint (RetentionStudentStats.stage) at which the figure
+  # becomes final: 1 for the during-course figures, 2 for the 30-day ones, 3 for
+  # the survival ones. The page uses it to tell a pending cell from one that
+  # will never fill in (RetentionReportCardRow#reached?).
+  Column = Struct.new(:group, :key, :format, :stage)
 
   # Column keys double as RetentionReportCardRow methods and as the locale keys
   # of the headers (report_cards.columns.*).
@@ -16,23 +20,23 @@ class RetentionReportCard
     Column.new(:general, :number, :text),
     Column.new(:general, :title, :text),
     Column.new(:general, :instructors, :text),
-    Column.new(:during, :participants, :integer),
-    Column.new(:during, :long_term_wikipedians, :integer),
-    Column.new(:during, :sessions_during, :integer),
-    Column.new(:during, :avg_sessions_during, :decimal),
-    Column.new(:during, :zero_edit_participants, :integer),
-    Column.new(:during, :uploads, :integer),
-    Column.new(:during, :avg_uploads, :decimal),
-    Column.new(:during, :words, :integer),
-    Column.new(:during, :avg_words, :integer),
-    Column.new(:after, :editors_after_course, :integer),
-    Column.new(:after, :pct_active_editors_after, :percent),
-    Column.new(:after, :avg_days_to_return, :decimal),
-    Column.new(:after, :avg_sessions_after, :decimal),
-    Column.new(:after, :any_survival_edits, :integer),
-    Column.new(:after, :any_survival_edits_returning, :integer),
-    Column.new(:after, :survivors, :integer),
-    Column.new(:after, :survivors_returning, :integer)
+    Column.new(:during, :participants, :integer, 1),
+    Column.new(:during, :long_term_wikipedians, :integer, 1),
+    Column.new(:during, :sessions_during, :integer, 1),
+    Column.new(:during, :avg_sessions_during, :decimal, 1),
+    Column.new(:during, :zero_edit_participants, :integer, 1),
+    Column.new(:during, :uploads, :integer, 1),
+    Column.new(:during, :avg_uploads, :decimal, 1),
+    Column.new(:during, :words, :integer, 1),
+    Column.new(:during, :avg_words, :integer, 1),
+    Column.new(:after, :editors_after_course, :integer, 2),
+    Column.new(:after, :pct_active_editors_after, :percent, 2),
+    Column.new(:after, :avg_days_to_return, :decimal, 2),
+    Column.new(:after, :avg_sessions_after, :decimal, 2),
+    Column.new(:after, :any_survival_edits, :integer, 3),
+    Column.new(:after, :any_survival_edits_returning, :integer, 3),
+    Column.new(:after, :survivors, :integer, 3),
+    Column.new(:after, :survivors_returning, :integer, 3)
   ].freeze
 
   attr_reader :campaign, :rows, :totals

--- a/lib/analytics/retention_report_card_row.rb
+++ b/lib/analytics/retention_report_card_row.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/analytics/retention_metrics"
+require_dependency "#{Rails.root}/lib/analytics/retention_student_stats"
 
 # One line of a RetentionReportCard: a single course, or the totals line over
 # every course in the campaign. Figures that come from the courses table
 # (participants, uploads, words) are summed over the courses; the retention
 # figures come from RetentionMetrics over the courses' stored RetentionStat
-# rows. Every column method returns nil where the figure is not available yet.
+# rows. Every column method returns nil where the figure is not available: not
+# computed yet, or nobody to count (see #reached?).
 class RetentionReportCardRow
   attr_reader :courses, :number
 
@@ -24,6 +26,15 @@ class RetentionReportCardRow
 
   def total?
     number.nil?
+  end
+
+  # Whether the figures that become final at `stage` (see
+  # RetentionStudentStats.stage) have been computed for at least one of the
+  # row's courses. A nil figure at a stage the row has reached is undefined
+  # (nobody edited during the course, or every participant is a long-term
+  # Wikipedian) rather than pending: it will not fill in later.
+  def reached?(stage)
+    courses.any? { |course| computed_stage(course) >= stage }
   end
 
   def course
@@ -60,15 +71,21 @@ class RetentionReportCardRow
   end
 
   def avg_words
-    per_participant(words)&.round
+    per_participant(words, precision: 0)
   end
 
   private
 
+  # The checkpoint a course's stored rows were computed at; 0 when there are none.
+  def computed_stage(course)
+    computed_at = course.retention_stats.map(&:computed_at).min
+    computed_at ? RetentionStudentStats.stage(course, computed_at) : 0
+  end
+
   # Uploads and words are course totals that include every student's work, so
   # they are spread over every participant, not just the counted ones.
-  def per_participant(total)
+  def per_participant(total, precision: 1)
     return nil if participants.zero?
-    (total.to_f / participants).round(1)
+    (total.to_f / participants).round(precision)
   end
 end

--- a/lib/analytics/retention_report_card_row.rb
+++ b/lib/analytics/retention_report_card_row.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/analytics/retention_metrics"
+
+# One line of a RetentionReportCard: a single course, or the totals line over
+# every course in the campaign. Figures that come from the courses table
+# (participants, uploads, words) are summed over the courses; the retention
+# figures come from RetentionMetrics over the courses' stored RetentionStat
+# rows. Every column method returns nil where the figure is not available yet.
+class RetentionReportCardRow
+  attr_reader :courses, :number
+
+  def initialize(courses, number: nil)
+    @courses = courses
+    @number = number
+    @metrics = RetentionMetrics.new(courses.flat_map(&:retention_stats))
+  end
+
+  delegate :long_term_wikipedians, :sessions_during, :avg_sessions_during,
+           :zero_edit_participants, :editors_after_course, :pct_active_editors_after,
+           :avg_days_to_return, :avg_sessions_after, :any_survival_edits,
+           :any_survival_edits_returning, :survivors, :survivors_returning,
+           to: :@metrics
+
+  def total?
+    number.nil?
+  end
+
+  def course
+    courses.first unless total?
+  end
+
+  def title
+    total? ? I18n.t('report_cards.total') : course.title
+  end
+
+  # Every instructor by real name (username when there is none); the Dashboard
+  # has no notion of which one led the course.
+  def instructors
+    return nil if total?
+    course.instructors.map { |user| user.real_name.presence || user.username }.sort.join(', ')
+  end
+
+  # Until a course's stats have been computed its stored rows are empty, so its
+  # cached student count stands in.
+  def participants
+    courses.sum { |c| c.retention_stats.any? ? c.retention_stats.size : c.user_count }
+  end
+
+  def uploads
+    courses.sum(&:upload_count)
+  end
+
+  def avg_uploads
+    per_participant(uploads)
+  end
+
+  def words
+    courses.sum(&:word_count)
+  end
+
+  def avg_words
+    per_participant(words)&.round
+  end
+
+  private
+
+  # Uploads and words are course totals that include every student's work, so
+  # they are spread over every participant, not just the counted ones.
+  def per_participant(total)
+    return nil if participants.zero?
+    (total.to_f / participants).round(1)
+  end
+end

--- a/lib/analytics/retention_student_stats.rb
+++ b/lib/analytics/retention_student_stats.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require_dependency "#{Rails.root}/lib/wiki_api"
+require_dependency "#{Rails.root}/lib/analytics/retention_participant_history"
+
+# Computes the per-student retention metrics for a course (currently the
+# Scholars & Scientists / FellowsCohort program). RetentionPredictorsCsvBuilder
+# turns them into the on-demand CSV; UpdateCourseRetentionStats stores them as
+# RetentionStat rows for the report card.
+#
+# Metrics (edits an hour or more apart count as distinct "sessions"; edits
+# closer together are lumped into one session):
+#
+#   1. Editing sessions during the course (course.start..course.end).
+#   2. Days from course end to the student's first independent edit in the 30
+#      days after the course. Capped/defaulted to 30 when they do not return
+#      (smaller is better).
+#   3. Editing sessions in the 30 days after the course ends.
+#   4. Edits in the 30-day window that begins 60 days after the course ends
+#      (course.end+60..course.end+90); a "survivor" made at least 5 such edits.
+#
+# Every participant is additionally classified by RetentionParticipantHistory as
+# a long-term Wikipedian (500+ edits before the course), a returning participant
+# (had already taken an earlier course), or neither. Consumers decide what to do
+# with that; see RetentionSummaryBlock and RetentionMetrics.
+#
+# Metrics are computed on each student's combined cross-wiki edit timeline, from
+# the live MediaWiki usercontribs API (all namespaces), which is why they have
+# no dependency on stored revision data.
+#
+# A metric's window can only be read once real-world time has passed the window
+# plus a one-day buffer: metrics 2 and 3 fill in 31 days after the course ends,
+# metric 4 fills in 91 days after. Until then they are nil, so every reported
+# value is final.
+class RetentionStudentStats
+  SESSION_GAP = 1.hour
+  RETURN_WINDOW_DAYS = 30
+  SURVIVAL_START_DAY = 60
+  SURVIVAL_END_DAY = 90
+  REPORTING_BUFFER_DAYS = 1
+
+  # Days after course end at which each successive metric becomes final:
+  # during-course sessions, then the return window, then the survival window.
+  CHECKPOINT_DAYS = [
+    REPORTING_BUFFER_DAYS,
+    RETURN_WINDOW_DAYS + REPORTING_BUFFER_DAYS,
+    SURVIVAL_END_DAY + REPORTING_BUFFER_DAYS
+  ].freeze
+  FINAL_STAGE = CHECKPOINT_DAYS.size
+
+  # How many checkpoints the course has passed as of `at`: 0 while nothing is
+  # final yet, FINAL_STAGE once every metric is. Nothing changes after that.
+  def self.stage(course, at = Time.zone.now)
+    CHECKPOINT_DAYS.count { |days| at >= course.end + days.days }
+  end
+
+  attr_reader :stats
+
+  def initialize(course, now: Time.zone.now)
+    @course = course
+    @wikis = course.wikis.to_a
+    @students = course.students.to_a.sort_by(&:username)
+    @now = now
+    @stats = @students.map { |student| student_stats(student) }
+  end
+
+  private
+
+  def student_stats(student)
+    times = combined_edit_times(student.username).sort
+    history = RetentionParticipantHistory.new(@course, student, @wikis)
+    { user_id: student.id }.merge(edit_metrics(student.username, times), history_columns(history))
+  end
+
+  def edit_metrics(username, times)
+    {
+      username:,
+      sessions_during: count_sessions(times.select { |t| t <= @course.end }),
+      days_to_return: days_to_return(times),
+      sessions_after: sessions_after(times),
+      edits_60_90: edits_in_survival_window(times)
+    }
+  end
+
+  def history_columns(history)
+    {
+      prior_edit_count: history.prior_edit_count,
+      prior_edits: history.prior_edit_count_label,
+      long_term: history.long_term_wikipedian?,
+      returning: history.returning?,
+      prior_courses: history.prior_courses.size,
+      prior_course_slugs: history.prior_course_slugs
+    }
+  end
+
+  # Days from course end to the first edit in the 30-day return window, floored
+  # to whole days. Defaults to the window length (30) when the student does not
+  # return. Blank (nil) until the window has closed.
+  def days_to_return(times)
+    return nil unless return_window_available?
+    first = return_window(times).min
+    return RETURN_WINDOW_DAYS if first.nil?
+    ((first - @course.end) / 1.day.to_i).floor
+  end
+
+  def sessions_after(times)
+    return nil unless return_window_available?
+    count_sessions(return_window(times))
+  end
+
+  def edits_in_survival_window(times)
+    return nil unless survival_window_available?
+    window = survival_window
+    times.count { |t| window.cover?(t) }
+  end
+
+  # Edits strictly after the course end, through the RETURN_WINDOW_DAYS cutoff.
+  def return_window(times)
+    cutoff = @course.end + RETURN_WINDOW_DAYS.days
+    times.select { |t| t > @course.end && t <= cutoff }
+  end
+
+  def survival_window
+    (@course.end + SURVIVAL_START_DAY.days)..(@course.end + SURVIVAL_END_DAY.days)
+  end
+
+  def return_window_available?
+    @now >= @course.end + CHECKPOINT_DAYS[1].days
+  end
+
+  def survival_window_available?
+    @now >= @course.end + CHECKPOINT_DAYS[2].days
+  end
+
+  # Number of distinct editing sessions: a new session starts whenever the gap
+  # since the previous edit is at least SESSION_GAP.
+  def count_sessions(times)
+    return 0 if times.empty?
+    sessions = 1
+    times.sort.each_cons(2) { |earlier, later| sessions += 1 if later - earlier >= SESSION_GAP }
+    sessions
+  end
+
+  # A student's edit timestamps across every tracked wiki, merged into one
+  # timeline (sessions and returns count regardless of which wiki they land on).
+  def combined_edit_times(username)
+    @wikis.flat_map { |wiki| edit_times(username, wiki) }
+  end
+
+  # All of a user's edit timestamps on a wiki from the course start through the
+  # end of the survival window, fetched from the usercontribs API and paginated
+  # until exhausted.
+  def edit_times(username, wiki)
+    api = WikiApi.new(wiki)
+    times = []
+    continue = {}
+    loop do
+      response = api.query(usercontribs_query(username).merge(continue))
+      break unless response
+      contribs = response.data['usercontribs'] || []
+      times.concat(contribs.map { |c| Time.zone.parse(c['timestamp']) })
+      continue = response['continue']
+      break unless continue
+    end
+    times
+  end
+
+  # Nothing after the survival window is ever used, so the fetch stops there
+  # rather than at the present. That keeps a years-old course from walking every
+  # edit its students have made since.
+  def timeline_end
+    [@course.end + SURVIVAL_END_DAY.days, @now].min
+  end
+
+  def usercontribs_query(username)
+    {
+      list: 'usercontribs',
+      ucuser: username,
+      ucstart: timeline_end.strftime('%Y%m%d%H%M%S'),
+      ucend: @course.start.strftime('%Y%m%d%H%M%S'),
+      ucprop: 'timestamp',
+      uclimit: 'max'
+    }
+  end
+end

--- a/lib/analytics/retention_student_stats.rb
+++ b/lib/analytics/retention_student_stats.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_dependency "#{Rails.root}/lib/wiki_api"
+require_dependency "#{Rails.root}/lib/analytics/retention_fetch_error"
 require_dependency "#{Rails.root}/lib/analytics/retention_participant_history"
 
 # Computes the per-student retention metrics for a course (currently the
@@ -32,6 +33,9 @@ require_dependency "#{Rails.root}/lib/analytics/retention_participant_history"
 # plus a one-day buffer: metrics 2 and 3 fill in 31 days after the course ends,
 # metric 4 fills in 91 days after. Until then they are nil, so every reported
 # value is final.
+#
+# A usercontribs request that fails after WikiApi's retries raises
+# RetentionFetchError rather than being read as "no edits".
 class RetentionStudentStats
   SESSION_GAP = 1.hour
   RETURN_WINDOW_DAYS = 30
@@ -149,14 +153,15 @@ class RetentionStudentStats
 
   # All of a user's edit timestamps on a wiki from the course start through the
   # end of the survival window, fetched from the usercontribs API and paginated
-  # until exhausted.
+  # until exhausted. WikiApi#query returns nil once its retries are exhausted;
+  # that is a failed fetch (of any page), not an empty timeline.
   def edit_times(username, wiki)
     api = WikiApi.new(wiki)
     times = []
     continue = {}
     loop do
       response = api.query(usercontribs_query(username).merge(continue))
-      break unless response
+      raise RetentionFetchError.new(username, wiki) unless response
       contribs = response.data['usercontribs'] || []
       times.concat(contribs.map { |c| Time.zone.parse(c['timestamp']) })
       continue = response['continue']

--- a/lib/data_cycle/daily_update.rb
+++ b/lib/data_cycle/daily_update.rb
@@ -8,6 +8,7 @@ require_dependency "#{Rails.root}/app/workers/daily_update/overdue_training_aler
 require_dependency "#{Rails.root}/app/workers/daily_update/salesforce_sync_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/wiki_discouraged_article_worker"
 require_dependency "#{Rails.root}/app/workers/daily_update/mainspace_ai_followup_worker"
+require_dependency "#{Rails.root}/app/workers/daily_update/update_retention_stats_worker"
 
 require_dependency "#{Rails.root}/lib/data_cycle/batch_update_logging"
 require_dependency "#{Rails.root}/lib/automated_emails/term_recap_email_scheduler"
@@ -37,6 +38,7 @@ class DailyUpdate
     send_term_recap_emails if Features.wiki_ed?
     generate_overdue_training_alerts if Features.wiki_ed?
     generate_mainspace_ai_followup_alerts if Features.wiki_ed?
+    update_retention_stats if Features.wiki_ed?
     push_course_data_to_salesforce if Features.wiki_ed?
     enqueue_system_stat_update
     log_end_of_update 'Daily update finished.'
@@ -106,6 +108,11 @@ class DailyUpdate
   ###############
   # Stats       #
   ###############
+  def update_retention_stats
+    log_message 'Updating retention stats for recently ended Scholars & Scientists courses'
+    UpdateRetentionStatsWorker.set(queue: QUEUE).perform_async
+  end
+
   def enqueue_system_stat_update
     log_message 'Enqueuing system stats snapshot'
     SystemStatUpdateWorker.set(queue: QUEUE).perform_async

--- a/lib/tasks/retention_stats.rake
+++ b/lib/tasks/retention_stats.rake
@@ -14,8 +14,12 @@ namespace :retention_stats do
         puts "  skip  #{course.slug} (already current)"
         next
       end
-      UpdateCourseRetentionStats.new(course)
-      puts "  done  #{course.slug} (#{course.retention_stats.count} students)"
+      begin
+        UpdateCourseRetentionStats.new(course)
+        puts "  done  #{course.slug} (#{course.retention_stats.count} students)"
+      rescue RetentionFetchError => e
+        puts "  FAIL  #{course.slug}: #{e.message} (rerun the task to retry)"
+      end
     end
   end
 end

--- a/lib/tasks/retention_stats.rake
+++ b/lib/tasks/retention_stats.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :retention_stats do
+  desc 'Compute and store retention stats for the Scholars & Scientists courses in one campaign'
+  task :backfill, [:campaign_slug] => :environment do |_task, args|
+    abort 'Usage: rake retention_stats:backfill[campaign_slug]' if args[:campaign_slug].blank?
+    campaign = Campaign.find_by(slug: args[:campaign_slug])
+    abort "No campaign with slug #{args[:campaign_slug]}" unless campaign
+
+    courses = campaign.courses.where(type: 'FellowsCohort').order(:start)
+    puts "#{courses.count} Scholars & Scientists courses in #{campaign.slug}"
+    courses.each do |course|
+      unless RetentionStat.update_due?(course)
+        puts "  skip  #{course.slug} (already current)"
+        next
+      end
+      UpdateCourseRetentionStats.new(course)
+      puts "  done  #{course.slug} (#{course.retention_stats.count} students)"
+    end
+  end
+end

--- a/spec/controllers/report_cards_controller_spec.rb
+++ b/spec/controllers/report_cards_controller_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ReportCardsController, type: :request do
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+  let(:campaign) { create(:campaign, title: 'Scholars and Scientists 2025-26', slug: 'ss_2025_26') }
+  let(:course) do
+    create(:course, type: 'FellowsCohort', slug: 'S/course', title: 'Report card course',
+                    start: 200.days.ago, end: 120.days.ago)
+  end
+  let(:student) { create(:user, username: 'student') }
+
+  before do
+    campaign.courses << course
+    create(:courses_user, course:, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+    create(:retention_stat, course:, user: student, sessions_during: 3, days_to_return: 10,
+                            sessions_after: 2, edits_60_90: 6)
+  end
+
+  context 'as an admin' do
+    before { login_as admin }
+
+    it 'lists the campaigns that have report card data' do
+      create(:campaign, title: 'Empty campaign', slug: 'empty')
+      get '/report_cards'
+      expect(response.body).to include('Scholars and Scientists 2025-26')
+      expect(response.body).not_to include('Empty campaign')
+    end
+
+    it 'renders the report card for a campaign' do
+      get "/report_cards/#{campaign.slug}"
+      expect(response.body).to include('Report card course')
+      expect(response.body).to include('Participants who edited in 30 days after course')
+    end
+
+    it 'downloads the report card as CSV' do
+      get "/report_cards/#{campaign.slug}.csv"
+      expect(response.content_type).to include('text/csv')
+      expect(response.body).to include('Report card course')
+    end
+
+    it 'is not found for an unknown campaign' do
+      get '/report_cards/no_such_campaign'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'does not exist on the Programs & Events Dashboard' do
+      allow(Features).to receive(:wiki_ed?).and_return(false)
+      get '/report_cards'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'as a non-admin' do
+    before { login_as user }
+
+    it 'is not authorized' do
+      get "/report_cards/#{campaign.slug}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'when signed out' do
+    it 'is not authorized' do
+      get '/report_cards'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/factories/retention_stats.rb
+++ b/spec/factories/retention_stats.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: retention_stats
+#
+#  id                   :bigint           not null, primary key
+#  course_id            :integer          not null
+#  user_id              :integer          not null
+#  sessions_during      :integer          default(0), not null
+#  days_to_return       :integer
+#  sessions_after       :integer
+#  edits_60_90          :integer
+#  prior_edit_count     :integer          default(0), not null
+#  long_term_wikipedian :boolean          default(FALSE), not null
+#  prior_course_count   :integer          default(0), not null
+#  computed_at          :datetime         not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+
+FactoryBot.define do
+  factory :retention_stat do
+    course
+    user
+    sessions_during { 0 }
+    prior_edit_count { 0 }
+    long_term_wikipedian { false }
+    prior_course_count { 0 }
+    computed_at { Time.zone.now }
+  end
+end

--- a/spec/features/report_cards_spec.rb
+++ b/spec/features/report_cards_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Scholars & Scientists report cards', type: :feature, js: true do
+  let(:admin) { create(:admin) }
+  let(:campaign) { create(:campaign, title: 'Scholars and Scientists 2025-26', slug: 'ss_2025_26') }
+  let(:instructor) { create(:user, username: 'Wkent', real_name: 'Will Kent') }
+  let(:finished) do
+    create(:course, type: 'FellowsCohort', slug: 'Wiki_Education/250_by_2026-4_(Summer_2025)',
+                    title: '250 by 2026-4', start: 200.days.ago, end: 120.days.ago,
+                    upload_count: 4, character_sum: 95_544)
+  end
+  let(:pending) do
+    create(:course, type: 'FellowsCohort', slug: 'Wiki_Education/250_by_2026-12',
+                    title: '250 by 2026-12', start: 80.days.ago, end: 20.days.ago, user_count: 16)
+  end
+
+  before do
+    campaign.courses << [finished, pending]
+    create(:courses_user, course: finished, user: instructor,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    s1, s2 = %w[s1 s2].map { |name| create(:user, username: name) }
+    create(:retention_stat, course: finished, user: s1, sessions_during: 5, days_to_return: 12,
+                            sessions_after: 1, edits_60_90: 8)
+    create(:retention_stat, course: finished, user: s2, sessions_during: 0, days_to_return: 30,
+                            sessions_after: 0, edits_60_90: 0)
+  end
+
+  describe 'as an admin' do
+    before { login_as(admin) }
+
+    it 'shows a campaign report card from the index' do
+      visit '/report_cards'
+      click_link 'Scholars and Scientists 2025-26'
+      expect(page).to have_content 'During the course'
+
+      within('tbody tr', text: '250 by 2026-4') do
+        expect(page).to have_content 'Will Kent'
+        expect(page).to have_content '18,462' # words added
+        expect(page).to have_content '2.5' # average sessions per participant
+        expect(page).to have_link '250 by 2026-4',
+                                  href: '/courses/Wiki_Education/250_by_2026-4_(Summer_2025)'
+      end
+      within('tbody tr', text: '250 by 2026-12') do
+        expect(page).to have_content '16'
+        expect(page).to have_content 'pending'
+      end
+      within('tbody tr', text: 'Total') do
+        expect(page).to have_content '18'
+      end
+      expect(page).to have_link 'Download CSV', href: '/report_cards/ss_2025_26.csv'
+    end
+  end
+
+  describe 'as a non-admin' do
+    before { login_as(create(:user)) }
+
+    it 'is refused' do
+      visit '/report_cards'
+      expect(page).to have_content 'Only administrators may do that.'
+    end
+  end
+end

--- a/spec/features/report_cards_spec.rb
+++ b/spec/features/report_cards_spec.rb
@@ -15,9 +15,13 @@ describe 'Scholars & Scientists report cards', type: :feature, js: true do
     create(:course, type: 'FellowsCohort', slug: 'Wiki_Education/250_by_2026-12',
                     title: '250 by 2026-12', start: 80.days.ago, end: 20.days.ago, user_count: 16)
   end
+  let(:veterans) do
+    create(:course, type: 'FellowsCohort', slug: 'Wiki_Education/Veterans_Workshop',
+                    title: 'Veterans Workshop', start: 190.days.ago, end: 110.days.ago)
+  end
 
   before do
-    campaign.courses << [finished, pending]
+    campaign.courses << [finished, pending, veterans]
     create(:courses_user, course: finished, user: instructor,
                           role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
     s1, s2 = %w[s1 s2].map { |name| create(:user, username: name) }
@@ -25,6 +29,10 @@ describe 'Scholars & Scientists report cards', type: :feature, js: true do
                             sessions_after: 1, edits_60_90: 8)
     create(:retention_stat, course: finished, user: s2, sessions_during: 0, days_to_return: 30,
                             sessions_after: 0, edits_60_90: 0)
+    # The only participant is a long-term Wikipedian, so nothing is left to count.
+    create(:retention_stat, course: veterans, user: create(:user, username: 'vet'),
+                            sessions_during: 9, days_to_return: 1, sessions_after: 4,
+                            edits_60_90: 30, long_term_wikipedian: true)
   end
 
   describe 'as an admin' do
@@ -46,8 +54,13 @@ describe 'Scholars & Scientists report cards', type: :feature, js: true do
         expect(page).to have_content '16'
         expect(page).to have_content 'pending'
       end
+      within('tbody tr', text: 'Veterans Workshop') do
+        expect(page).to have_css('td', exact_text: '1', count: 2) # participants, long-term
+        expect(page).to have_css('.report-card__not-applicable')
+        expect(page).not_to have_content 'pending'
+      end
       within('tbody tr', text: 'Total') do
-        expect(page).to have_content '18'
+        expect(page).to have_css('td', exact_text: '19') # participants across the courses
       end
       expect(page).to have_link 'Download CSV', href: '/report_cards/ss_2025_26.csv'
     end

--- a/spec/helpers/report_cards_helper_spec.rb
+++ b/spec/helpers/report_cards_helper_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/retention_report_card"
+
+describe ReportCardsHelper, type: :helper do
+  describe '#report_card_cell' do
+    let(:column) { RetentionReportCard::COLUMNS.find { |c| c.key == :pct_active_editors_after } }
+
+    def row_with(value, reached:)
+      instance_double(RetentionReportCardRow, pct_active_editors_after: value, reached?: reached)
+    end
+
+    it 'formats a figure per the column' do
+      expect(report_card_cell(row_with(66.666, reached: true), column)).to eq('66.7%')
+    end
+
+    it 'marks a figure the row has not reached yet as pending' do
+      cell = report_card_cell(row_with(nil, reached: false), column)
+      expect(cell).to have_css('span.report-card__pending', text: 'pending')
+    end
+
+    it 'marks a figure the row has reached but has nobody to count as not applicable' do
+      cell = report_card_cell(row_with(nil, reached: true), column)
+      expect(cell).to have_css('span.report-card__not-applicable', text: '—')
+    end
+  end
+end

--- a/spec/lib/analytics/retention_metrics_spec.rb
+++ b/spec/lib/analytics/retention_metrics_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/retention_metrics"
+
+describe RetentionMetrics do
+  def stat(**attrs)
+    RetentionStat.new(**attrs)
+  end
+
+  context 'with a fully computed course' do
+    subject(:metrics) { described_class.new(stats) }
+
+    let(:stats) do
+      [
+        # first-course participant who survived
+        stat(sessions_during: 4, days_to_return: 10, sessions_after: 2, edits_60_90: 6),
+        # returning participant with a single edit in the survival window
+        stat(sessions_during: 2, days_to_return: 30, sessions_after: 0, edits_60_90: 1,
+             prior_course_count: 1),
+        # never edited
+        stat(sessions_during: 0, days_to_return: 30, sessions_after: 0, edits_60_90: 0),
+        # long-term Wikipedian: counted as a participant, excluded from the rest
+        stat(sessions_during: 9, days_to_return: 1, sessions_after: 5, edits_60_90: 20,
+             long_term_wikipedian: true)
+      ]
+    end
+
+    it 'counts every participant but leaves long-term Wikipedians out of the rest' do
+      expect(metrics.participants).to eq(4)
+      expect(metrics.long_term_wikipedians).to eq(1)
+      expect(metrics.counted_participants).to eq(3)
+      expect(metrics.sessions_during).to eq(6)
+    end
+
+    it 'averages over counted participants' do
+      expect(metrics.avg_sessions_during).to eq(2.0)
+      expect(metrics.avg_days_to_return).to eq(23.3)
+      expect(metrics.avg_sessions_after).to eq(0.7)
+    end
+
+    it 'reports zero-edit participants and the share of active ones who returned' do
+      expect(metrics.zero_edit_participants).to eq(1)
+      expect(metrics.editors_after_course).to eq(1)
+      expect(metrics.pct_active_editors_after).to eq(50.0)
+    end
+
+    it 'counts both survival thresholds and the returning share of each' do
+      expect(metrics.any_survival_edits).to eq(2)
+      expect(metrics.any_survival_edits_returning).to eq(1)
+      expect(metrics.survivors).to eq(1)
+      expect(metrics.survivors_returning).to eq(0)
+    end
+  end
+
+  context 'before the post-course windows have closed' do
+    subject(:metrics) { described_class.new([stat(sessions_during: 3), stat(sessions_during: 0)]) }
+
+    it 'reports the during-course figures and nothing else' do
+      expect(metrics.sessions_during).to eq(3)
+      expect(metrics.zero_edit_participants).to eq(1)
+      expect(metrics.editors_after_course).to be_nil
+      expect(metrics.pct_active_editors_after).to be_nil
+      expect(metrics.avg_days_to_return).to be_nil
+      expect(metrics.avg_sessions_after).to be_nil
+      expect(metrics.any_survival_edits).to be_nil
+      expect(metrics.survivors).to be_nil
+    end
+  end
+
+  context 'when nothing has been computed' do
+    subject(:metrics) { described_class.new([]) }
+
+    it 'has no participants and no figures' do
+      expect(metrics.participants).to eq(0)
+      expect(metrics.long_term_wikipedians).to be_nil
+      expect(metrics.sessions_during).to be_nil
+      expect(metrics.zero_edit_participants).to be_nil
+      expect(metrics.avg_sessions_during).to be_nil
+    end
+  end
+
+  context 'when every participant is a long-term Wikipedian' do
+    subject(:metrics) do
+      described_class.new([stat(sessions_during: 3, long_term_wikipedian: true),
+                           stat(sessions_during: 5, long_term_wikipedian: true)])
+    end
+
+    it 'counts them and leaves every aggregate blank rather than zero' do
+      expect(metrics.participants).to eq(2)
+      expect(metrics.long_term_wikipedians).to eq(2)
+      expect(metrics.sessions_during).to be_nil
+      expect(metrics.zero_edit_participants).to be_nil
+    end
+  end
+
+  context 'when nobody edited during the course' do
+    subject(:metrics) do
+      described_class.new([stat(sessions_during: 0, days_to_return: 30, sessions_after: 0)])
+    end
+
+    it 'leaves the percentage blank instead of dividing by zero' do
+      expect(metrics.editors_after_course).to eq(0)
+      expect(metrics.pct_active_editors_after).to be_nil
+    end
+  end
+
+  context 'across courses at different stages' do
+    subject(:metrics) do
+      described_class.new([
+                            stat(sessions_during: 2, days_to_return: 3, sessions_after: 1,
+                                 edits_60_90: 7),
+                            stat(sessions_during: 1, days_to_return: 30, sessions_after: 0)
+                          ])
+    end
+
+    it 'aggregates each figure over the rows that have reached it' do
+      expect(metrics.sessions_during).to eq(3)
+      expect(metrics.avg_days_to_return).to eq(16.5)
+      expect(metrics.survivors).to eq(1)
+      expect(metrics.any_survival_edits).to eq(1)
+    end
+  end
+end

--- a/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
+++ b/spec/lib/analytics/retention_predictors_csv_builder_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 require "#{Rails.root}/lib/analytics/retention_predictors_csv_builder"
 
 describe RetentionPredictorsCsvBuilder do
+  include RetentionApiStubs
+
   let(:wiki1) { Wiki.find_or_create_by(language: 'en', project: 'wikipedia') }
   let(:wiki2) { Wiki.find_or_create_by(language: 'es', project: 'wikipedia') }
   let(:user1) { create(:user, username: 'user1') }
@@ -16,43 +18,6 @@ describe RetentionPredictorsCsvBuilder do
     course.wikis = course_wikis
     create(:courses_user, course:, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)
     create(:courses_user, course:, user: user2, role: CoursesUsers::Roles::STUDENT_ROLE)
-  end
-
-  # Builds a stub MediaWiki API response object for a list of edit Times.
-  def response_for(times, continue: nil)
-    contribs = times.map { |t| { 'timestamp' => t.utc.strftime('%Y-%m-%dT%H:%M:%SZ') } }
-    instance_double(MediawikiApi::Response).tap do |response|
-      allow(response).to receive(:data).and_return('usercontribs' => contribs)
-      allow(response).to receive(:[]).with('continue').and_return(continue)
-    end
-  end
-
-  # One page of a user's pre-course contributions, out of `total` of them.
-  # Pages at 250 per response (the API may return fewer than the requested
-  # max), so the builder's stop-counting-at-the-threshold pagination gets
-  # exercised for real.
-  def prior_edits_response(total, params)
-    offset = (params['uccontinue'] || params[:uccontinue]).to_i
-    remaining = total - offset
-    page = [remaining, 250].min
-    continue = remaining > page ? { 'uccontinue' => (offset + page).to_s } : nil
-    response_for([Time.zone.now] * page, continue:)
-  end
-
-  # Stubs WikiApi.new(wiki) for both queries the builder makes. The during-course
-  # timeline query is bounded by :ucend; the pre-course edit count query is not,
-  # which is how the stub tells them apart. `contribs_by_user` maps
-  # username => [Time, ...]; `prior_edits` maps username => edit count.
-  def stub_wiki(wiki, contribs_by_user, prior_edits = {})
-    api = instance_double(WikiApi)
-    allow(WikiApi).to receive(:new).with(wiki).and_return(api)
-    allow(api).to receive(:query) do |params|
-      if params.key?(:ucend)
-        response_for(contribs_by_user.fetch(params[:ucuser], []))
-      else
-        prior_edits_response(prior_edits.fetch(params[:ucuser], 0), params)
-      end
-    end
   end
 
   let(:table) { CSV.parse(described_class.new(course).generate_csv) }

--- a/spec/lib/analytics/retention_report_card_row_spec.rb
+++ b/spec/lib/analytics/retention_report_card_row_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/retention_report_card_row"
+
+# The row's figures are covered through RetentionReportCard; this covers what
+# is easier to see with a hand-built course.
+describe RetentionReportCardRow do
+  def course_with(word_count:, user_count:)
+    instance_double(Course, retention_stats: [], user_count:, upload_count: 0, word_count:)
+  end
+
+  it 'rounds average words once, to the nearest whole word' do
+    # 1105 / 11 = 100.4545…, which rounding via one decimal (100.5) would make 101.
+    row = described_class.new([course_with(word_count: 1105, user_count: 11)], number: 1)
+    expect(row.avg_words).to eq(100)
+  end
+
+  it 'leaves the per-participant figures blank for a course with nobody in it' do
+    row = described_class.new([course_with(word_count: 0, user_count: 0)], number: 1)
+    expect(row.avg_words).to be_nil
+    expect(row.avg_uploads).to be_nil
+  end
+end

--- a/spec/lib/analytics/retention_report_card_spec.rb
+++ b/spec/lib/analytics/retention_report_card_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/retention_report_card"
+
+describe RetentionReportCard do
+  subject(:card) { described_class.new(campaign) }
+
+  let(:campaign) { create(:campaign, title: 'Scholars and Scientists 2025-26', slug: 'ss_2025_26') }
+  let(:instructor) { create(:user, username: 'Wkent', real_name: 'Will Kent') }
+  let(:finished) do
+    create(:course, type: 'FellowsCohort', slug: 'S/finished', title: 'Finished course',
+                    start: 200.days.ago, end: 120.days.ago, upload_count: 10, character_sum: 10_350)
+  end
+  let(:in_window) do
+    create(:course, type: 'FellowsCohort', slug: 'S/in_window', title: 'In window',
+                    start: 100.days.ago, end: 50.days.ago, character_sum: 5175)
+  end
+  let(:running) do
+    create(:course, type: 'FellowsCohort', slug: 'S/running', title: 'Running course',
+                    start: 10.days.ago, end: 30.days.from_now, user_count: 5)
+  end
+  let(:classroom) do
+    create(:course, slug: 'S/classroom', title: 'Classroom course', start: 200.days.ago,
+                    end: 120.days.ago)
+  end
+
+  before do
+    campaign.courses << [finished, in_window, running, classroom]
+    create(:courses_user, course: finished, user: instructor,
+                          role: CoursesUsers::Roles::INSTRUCTOR_ROLE)
+    s1, s2, s3 = %w[s1 s2 s3].map { |name| create(:user, username: name) }
+    create(:retention_stat, course: finished, user: s1, sessions_during: 3, days_to_return: 10,
+                            sessions_after: 2, edits_60_90: 6, computed_at: 20.days.ago)
+    create(:retention_stat, course: finished, user: s2, sessions_during: 0, days_to_return: 30,
+                            sessions_after: 0, edits_60_90: 0, prior_course_count: 1,
+                            computed_at: 20.days.ago)
+    create(:retention_stat, course: in_window, user: s3, sessions_during: 2, days_to_return: 5,
+                            sessions_after: 1, computed_at: 10.days.ago)
+  end
+
+  it 'has one numbered row per Scholars & Scientists course, oldest first' do
+    expect(card.rows.map(&:title)).to eq(['Finished course', 'In window', 'Running course'])
+    expect(card.rows.map(&:number)).to eq([1, 2, 3])
+  end
+
+  it 'fills every column for a course past its last checkpoint' do
+    expect(card.rows[0].instructors).to eq('Will Kent')
+    expect(card.rows[0]).to have_attributes(
+      participants: 2, long_term_wikipedians: 0, sessions_during: 3, avg_sessions_during: 1.5,
+      zero_edit_participants: 1, uploads: 10, avg_uploads: 5.0, words: 2000, avg_words: 1000,
+      editors_after_course: 1, pct_active_editors_after: 100.0, avg_days_to_return: 20.0,
+      avg_sessions_after: 1.0, any_survival_edits: 1, any_survival_edits_returning: 0,
+      survivors: 1, survivors_returning: 0
+    )
+  end
+
+  it 'leaves the survival columns blank for a course still inside that window' do
+    expect(card.rows[1]).to have_attributes(participants: 1, sessions_during: 2,
+                                            editors_after_course: 1, avg_days_to_return: 5.0,
+                                            any_survival_edits: nil, survivors: nil)
+  end
+
+  it 'shows only the cached student count for a course not yet computed' do
+    expect(card.rows[2]).to have_attributes(participants: 5, long_term_wikipedians: nil,
+                                            sessions_during: nil, zero_edit_participants: nil,
+                                            editors_after_course: nil, avg_words: 0)
+  end
+
+  it 'totals the courses, aggregating each figure over the courses that have reached it' do
+    expect(card.totals).to be_total
+    expect(card.totals).to have_attributes(number: nil, instructors: nil, participants: 8,
+                                           uploads: 10, words: 3000, sessions_during: 5,
+                                           editors_after_course: 2, survivors: 1,
+                                           avg_days_to_return: 15.0)
+  end
+
+  it 'renders the same table as CSV, with blanks for pending figures' do
+    csv = CSV.parse(card.to_csv)
+    expect(csv.first.first(4)).to eq(['#', 'Course', 'Instructor', 'Participants'])
+    expect(csv[1].first(4)).to eq(['1', 'Finished course', 'Will Kent', '2'])
+    expect(csv[3][0..2]).to eq(['3', 'Running course', ''])
+    expect(csv[3][12]).to be_nil
+    expect(csv.last[1]).to eq('Total')
+  end
+end

--- a/spec/lib/analytics/retention_report_card_spec.rb
+++ b/spec/lib/analytics/retention_report_card_spec.rb
@@ -67,12 +67,20 @@ describe RetentionReportCard do
                                             editors_after_course: nil, avg_words: 0)
   end
 
+  it 'knows which checkpoints each course\'s stored rows have reached' do
+    expect(card.rows[0]).to be_reached(3)
+    expect(card.rows[1]).to be_reached(2)
+    expect(card.rows[1]).not_to be_reached(3)
+    expect(card.rows[2]).not_to be_reached(1)
+  end
+
   it 'totals the courses, aggregating each figure over the courses that have reached it' do
     expect(card.totals).to be_total
     expect(card.totals).to have_attributes(number: nil, instructors: nil, participants: 8,
                                            uploads: 10, words: 3000, sessions_during: 5,
                                            editors_after_course: 2, survivors: 1,
                                            avg_days_to_return: 15.0)
+    expect(card.totals).to be_reached(3)
   end
 
   it 'renders the same table as CSV, with blanks for pending figures' do

--- a/spec/lib/analytics/retention_student_stats_spec.rb
+++ b/spec/lib/analytics/retention_student_stats_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Rails.root}/lib/analytics/retention_student_stats"
+
+# The metrics themselves are covered end to end by the CSV builder spec; this
+# covers what the report card additionally relies on.
+describe RetentionStudentStats do
+  include RetentionApiStubs
+
+  let(:wiki) { Wiki.find_or_create_by(language: 'en', project: 'wikipedia') }
+  let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
+  let(:student) { create(:user, username: 'user1') }
+
+  before do
+    allow_any_instance_of(Wiki).to receive(:ensure_wiki_exists)
+    course.wikis = [wiki]
+    create(:courses_user, course:, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+
+  describe '.stage' do
+    it 'is 0 until a day after the course ends' do
+      expect(described_class.stage(course, course.end - 1.day)).to eq(0)
+      expect(described_class.stage(course, course.end + 23.hours)).to eq(0)
+    end
+
+    it 'is 1 once during-course sessions are final' do
+      expect(described_class.stage(course, course.end + 1.day)).to eq(1)
+      expect(described_class.stage(course, course.end + 30.days)).to eq(1)
+    end
+
+    it 'is 2 once the 30-day return window has closed' do
+      expect(described_class.stage(course, course.end + 31.days)).to eq(2)
+    end
+
+    it 'is final once the 60-90-day survival window has closed' do
+      expect(described_class.stage(course, course.end + 91.days)).to eq(3)
+      expect(described_class.stage(course, course.end + 5.years))
+        .to eq(described_class::FINAL_STAGE)
+    end
+  end
+
+  describe '#stats' do
+    it 'identifies each student and reports the numeric prior edit count' do
+      stub_wiki(wiki, { 'user1' => [course.end - 1.day] }, { 'user1' => 12 })
+      stats = described_class.new(course).stats
+      expect(stats.size).to eq(1)
+      expect(stats.first).to include(user_id: student.id, username: 'user1', sessions_during: 1,
+                                     prior_edit_count: 12, prior_edits: '12', long_term: false,
+                                     returning: false, prior_courses: 0)
+    end
+
+    context 'when fetching the edit timeline' do
+      let(:queries) { [] }
+
+      before do
+        api = instance_double(WikiApi)
+        allow(WikiApi).to receive(:new).with(wiki).and_return(api)
+        allow(api).to receive(:query) do |params|
+          queries << params
+          response_for([])
+        end
+      end
+
+      it 'stops at the end of the survival window rather than the present' do
+        described_class.new(course)
+        timeline_query = queries.find { |q| q.key?(:ucend) }
+        expect(timeline_query[:ucstart]).to eq((course.end + 90.days).strftime('%Y%m%d%H%M%S'))
+        expect(timeline_query[:ucend]).to eq(course.start.strftime('%Y%m%d%H%M%S'))
+      end
+
+      context 'while the survival window is still open' do
+        let(:course) { create(:course, start: 40.days.ago, end: 10.days.ago) }
+
+        it 'fetches through the present' do
+          now = Time.zone.now
+          described_class.new(course, now:)
+          timeline_query = queries.find { |q| q.key?(:ucend) }
+          expect(timeline_query[:ucstart]).to eq(now.strftime('%Y%m%d%H%M%S'))
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/analytics/retention_student_stats_spec.rb
+++ b/spec/lib/analytics/retention_student_stats_spec.rb
@@ -50,6 +50,39 @@ describe RetentionStudentStats do
                                      returning: false, prior_courses: 0)
     end
 
+    context 'when a usercontribs request fails' do
+      # WikiApi#query returns nil once its retries are exhausted.
+      def stub_failing_query(&fails)
+        api = instance_double(WikiApi)
+        allow(WikiApi).to receive(:new).with(wiki).and_return(api)
+        allow(api).to receive(:query) do |params|
+          fails.call(params) ? nil : response_for([])
+        end
+      end
+
+      it 'raises rather than reporting the student as somebody who never edited' do
+        stub_failing_query { |params| params.key?(:ucend) }
+        expect { described_class.new(course) }
+          .to raise_error(RetentionFetchError, /user1.*en\.wikipedia\.org/)
+      end
+
+      it 'raises when a continuation page fails' do
+        api = instance_double(WikiApi)
+        allow(WikiApi).to receive(:new).with(wiki).and_return(api)
+        first_page = response_for([course.end - 1.day], continue: { 'uccontinue' => 'x' })
+        allow(api).to receive(:query) do |params|
+          next response_for([]) unless params.key?(:ucend)
+          params['uccontinue'] ? nil : first_page
+        end
+        expect { described_class.new(course) }.to raise_error(RetentionFetchError)
+      end
+
+      it 'raises when the pre-course edit count cannot be fetched' do
+        stub_failing_query { |params| !params.key?(:ucend) }
+        expect { described_class.new(course) }.to raise_error(RetentionFetchError)
+      end
+    end
+
     context 'when fetching the edit timeline' do
       let(:queries) { [] }
 

--- a/spec/lib/data_cycle/daily_update_spec.rb
+++ b/spec/lib/data_cycle/daily_update_spec.rb
@@ -29,6 +29,10 @@ describe DailyUpdate do
       expect(WikiDiscouragedArticleWorker).to receive(:set).with(queue: described_class::QUEUE)
                                           .and_return(worker_double)
       expect(worker_double).to receive(:perform_async)
+      retention_double = class_double(UpdateRetentionStatsWorker)
+      expect(UpdateRetentionStatsWorker).to receive(:set).with(queue: described_class::QUEUE)
+                                         .and_return(retention_double)
+      expect(retention_double).to receive(:perform_async)
       update = described_class.new
       sentry_logs = update.instance_variable_get(:@sentry_logs)
       expect(sentry_logs.grep(/Pushing course data to Salesforce/).any?).to eq(true)

--- a/spec/models/retention_stat_spec.rb
+++ b/spec/models/retention_stat_spec.rb
@@ -20,6 +20,11 @@ describe RetentionStat do
       expect(described_class.update_due?(course)).to be(true)
     end
 
+    it 'is not due for a course with no students, since there is nothing to store' do
+      course.courses_users.delete_all
+      expect(described_class.update_due?(course)).to be(false)
+    end
+
     it 'is due when a metric window has closed since the rows were computed' do
       # Computed 5 days after the end, before the 30-day return window closed.
       create(:retention_stat, course:, user: student, computed_at: 35.days.ago)

--- a/spec/models/retention_stat_spec.rb
+++ b/spec/models/retention_stat_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RetentionStat do
+  let(:course) { create(:course, type: 'FellowsCohort', start: 100.days.ago, end: 40.days.ago) }
+  let(:student) { create(:user, username: 'student') }
+
+  before do
+    create(:courses_user, course:, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+  end
+
+  describe '.update_due?' do
+    it 'is not due before the first checkpoint, a day after the course ends' do
+      course.update(end: 12.hours.ago)
+      expect(described_class.update_due?(course)).to be(false)
+    end
+
+    it 'is due once the course has ended and nothing has been stored' do
+      expect(described_class.update_due?(course)).to be(true)
+    end
+
+    it 'is due when a metric window has closed since the rows were computed' do
+      # Computed 5 days after the end, before the 30-day return window closed.
+      create(:retention_stat, course:, user: student, computed_at: 35.days.ago)
+      expect(described_class.update_due?(course)).to be(true)
+    end
+
+    it 'is not due when the rows are as complete as the calendar allows' do
+      # Computed 35 days after the end; the survival window is still open now.
+      create(:retention_stat, course:, user: student, computed_at: 5.days.ago)
+      expect(described_class.update_due?(course)).to be(false)
+    end
+
+    it 'is due when the roster has changed since the rows were computed' do
+      create(:retention_stat, course:, user: student, computed_at: 5.days.ago)
+      create(:courses_user, course:, user: create(:user, username: 'late'),
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      expect(described_class.update_due?(course)).to be(true)
+    end
+
+    it 'is never due again after the final checkpoint' do
+      course.update(end: 100.days.ago)
+      create(:retention_stat, course:, user: student, computed_at: 5.days.ago)
+      expect(described_class.update_due?(course)).to be(false)
+    end
+  end
+
+  describe '#returning?' do
+    it 'is true for a participant who took an earlier course' do
+      expect(described_class.new(prior_course_count: 1)).to be_returning
+      expect(described_class.new(prior_course_count: 0)).not_to be_returning
+    end
+  end
+end

--- a/spec/services/update_course_retention_stats_spec.rb
+++ b/spec/services/update_course_retention_stats_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdateCourseRetentionStats do
+  include RetentionApiStubs
+
+  let(:wiki) { Wiki.find_or_create_by(language: 'en', project: 'wikipedia') }
+  let(:course) { create(:course, start: 130.days.ago, end: 100.days.ago) }
+  let(:user1) { create(:user, username: 'user1') }
+  let(:user2) { create(:user, username: 'user2') }
+  let(:now) { Time.zone.now.change(usec: 0) }
+
+  before do
+    allow_any_instance_of(Wiki).to receive(:ensure_wiki_exists)
+    course.wikis = [wiki]
+    create(:courses_user, course:, user: user1, role: CoursesUsers::Roles::STUDENT_ROLE)
+    create(:courses_user, course:, user: user2, role: CoursesUsers::Roles::STUDENT_ROLE)
+    e = course.end
+    timeline = [e - 26.days, e - 21.days, e + 14.days,
+                e + 70.days, e + 71.days, e + 72.days, e + 73.days, e + 74.days]
+    stub_wiki(wiki, { 'user1' => timeline }, { 'user1' => 500 })
+  end
+
+  it 'stores one row per student with the computed metrics' do
+    described_class.new(course, now:)
+    expect(course.retention_stats.find_by(user: user1))
+      .to have_attributes(sessions_during: 2, days_to_return: 14, sessions_after: 1, edits_60_90: 5,
+                          prior_edit_count: 500, long_term_wikipedian: true, prior_course_count: 0,
+                          computed_at: now)
+    expect(course.retention_stats.find_by(user: user2))
+      .to have_attributes(sessions_during: 0, days_to_return: 30, sessions_after: 0, edits_60_90: 0,
+                          prior_edit_count: 0, long_term_wikipedian: false)
+  end
+
+  it 'drops the row of a student who is no longer enrolled' do
+    create(:retention_stat, course:, user: create(:user, username: 'gone'))
+    described_class.new(course, now:)
+    expect(course.retention_stats.pluck(:user_id)).to contain_exactly(user1.id, user2.id)
+  end
+
+  it 'replaces earlier rows rather than adding to them' do
+    described_class.new(course, now: now - 1.day)
+    described_class.new(course, now:)
+    expect(course.retention_stats.count).to eq(2)
+    expect(course.retention_stats.pluck(:computed_at).uniq).to eq([now])
+  end
+
+  it 'leaves nil the metrics whose windows have not closed' do
+    described_class.new(course, now: course.end + 5.days)
+    expect(course.retention_stats.find_by(user: user1))
+      .to have_attributes(sessions_during: 2, days_to_return: nil, sessions_after: nil,
+                          edits_60_90: nil)
+  end
+end

--- a/spec/services/update_course_retention_stats_spec.rb
+++ b/spec/services/update_course_retention_stats_spec.rb
@@ -46,6 +46,25 @@ describe UpdateCourseRetentionStats do
     expect(course.retention_stats.pluck(:computed_at).uniq).to eq([now])
   end
 
+  context 'when a usercontribs request fails' do
+    before do
+      create(:retention_stat, course:, user: user1, sessions_during: 7, computed_at: 1.day.ago)
+      api = instance_double(WikiApi)
+      allow(WikiApi).to receive(:new).with(wiki).and_return(api)
+      allow(api).to receive(:query).and_return(nil)
+    end
+
+    it 'raises and leaves the previous rows in place' do
+      expect { described_class.new(course, now:) }.to raise_error(RetentionFetchError)
+      expect(course.retention_stats.pluck(:user_id, :sessions_during)).to eq([[user1.id, 7]])
+    end
+
+    it 'leaves the course due for another attempt' do
+      expect { described_class.new(course, now:) }.to raise_error(RetentionFetchError)
+      expect(RetentionStat.update_due?(course, now:)).to be(true)
+    end
+  end
+
   it 'leaves nil the metrics whose windows have not closed' do
     described_class.new(course, now: course.end + 5.days)
     expect(course.retention_stats.find_by(user: user1))

--- a/spec/support/retention_api_stubs.rb
+++ b/spec/support/retention_api_stubs.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Stubs for the two usercontribs queries RetentionStudentStats makes per student
+# and wiki: the edit timeline (bounded by :ucend) and the pre-course edit count
+# (not bounded), which is how the stub tells them apart.
+module RetentionApiStubs
+  # Builds a stub MediaWiki API response object for a list of edit Times.
+  def response_for(times, continue: nil)
+    contribs = times.map { |t| { 'timestamp' => t.utc.strftime('%Y-%m-%dT%H:%M:%SZ') } }
+    instance_double(MediawikiApi::Response).tap do |response|
+      allow(response).to receive(:data).and_return('usercontribs' => contribs)
+      allow(response).to receive(:[]).with('continue').and_return(continue)
+    end
+  end
+
+  # One page of a user's pre-course contributions, out of `total` of them.
+  # Pages at 250 per response (the API may return fewer than the requested
+  # max), so the stop-counting-at-the-threshold pagination gets exercised for
+  # real.
+  def prior_edits_response(total, params)
+    offset = (params['uccontinue'] || params[:uccontinue]).to_i
+    remaining = total - offset
+    page = [remaining, 250].min
+    continue = remaining > page ? { 'uccontinue' => (offset + page).to_s } : nil
+    response_for([Time.zone.now] * page, continue:)
+  end
+
+  # Stubs WikiApi.new(wiki) for both queries. `contribs_by_user` maps
+  # username => [Time, ...]; `prior_edits` maps username => edit count.
+  def stub_wiki(wiki, contribs_by_user, prior_edits = {})
+    api = instance_double(WikiApi)
+    allow(WikiApi).to receive(:new).with(wiki).and_return(api)
+    allow(api).to receive(:query) do |params|
+      if params.key?(:ucend)
+        response_for(contribs_by_user.fetch(params[:ucuser], []))
+      else
+        prior_edits_response(prior_edits.fetch(params[:ucuser], 0), params)
+      end
+    end
+  end
+end

--- a/spec/workers/update_retention_stats_worker_spec.rb
+++ b/spec/workers/update_retention_stats_worker_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UpdateRetentionStatsWorker do
+  let(:recent) do
+    create(:course, type: 'FellowsCohort', slug: 'S/recent', start: 60.days.ago, end: 10.days.ago)
+  end
+  let(:old) do
+    create(:course, type: 'FellowsCohort', slug: 'S/old', start: 300.days.ago, end: 200.days.ago)
+  end
+  let(:running) do
+    create(:course, type: 'FellowsCohort', slug: 'S/running', start: 10.days.ago,
+                    end: 10.days.from_now)
+  end
+  let(:student_program) do
+    create(:course, slug: 'S/classroom', start: 60.days.ago, end: 10.days.ago)
+  end
+  let(:current) do
+    create(:course, type: 'FellowsCohort', slug: 'S/current', start: 60.days.ago, end: 10.days.ago)
+  end
+
+  before do
+    allow(UpdateCourseRetentionStats).to receive(:new)
+    student = create(:user, username: 'student')
+    create(:courses_user, course: current, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+    create(:retention_stat, course: current, user: student, computed_at: 2.days.ago)
+    [recent, old, running, student_program]
+  end
+
+  it 'recomputes only recently ended Scholars & Scientists courses that are due' do
+    described_class.new.perform
+    expect(UpdateCourseRetentionStats).to have_received(:new).once
+    expect(UpdateCourseRetentionStats).to have_received(:new)
+      .with(an_object_having_attributes(slug: 'S/recent'), now: kind_of(Time))
+  end
+end

--- a/spec/workers/update_retention_stats_worker_spec.rb
+++ b/spec/workers/update_retention_stats_worker_spec.rb
@@ -25,7 +25,9 @@ describe UpdateRetentionStatsWorker do
     student = create(:user, username: 'student')
     create(:courses_user, course: current, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
     create(:retention_stat, course: current, user: student, computed_at: 2.days.ago)
-    [recent, old, running, student_program]
+    [recent, old, running, student_program].each do |course|
+      create(:courses_user, course:, user: student, role: CoursesUsers::Roles::STUDENT_ROLE)
+    end
   end
 
   it 'recomputes only recently ended Scholars & Scientists courses that are due' do
@@ -33,5 +35,30 @@ describe UpdateRetentionStatsWorker do
     expect(UpdateCourseRetentionStats).to have_received(:new).once
     expect(UpdateCourseRetentionStats).to have_received(:new)
       .with(an_object_having_attributes(slug: 'S/recent'), now: kind_of(Time))
+  end
+
+  context 'when one course\'s fetch fails' do
+    let(:also_due) do
+      create(:course, type: 'FellowsCohort', slug: 'S/also_due', start: 60.days.ago,
+                      end: 10.days.ago)
+    end
+    let(:wiki) { instance_double(Wiki, domain: 'en.wikipedia.org') }
+
+    before do
+      create(:courses_user, course: also_due, user: User.find_by(username: 'student'),
+                            role: CoursesUsers::Roles::STUDENT_ROLE)
+      allow(UpdateCourseRetentionStats).to receive(:new)
+        .with(an_object_having_attributes(slug: 'S/recent'), now: kind_of(Time))
+        .and_raise(RetentionFetchError.new('student', wiki))
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it 'reports it and goes on to the next course' do
+      described_class.new.perform
+      expect(Sentry).to have_received(:capture_exception)
+        .with(kind_of(RetentionFetchError), extra: { course: 'S/recent' })
+      expect(UpdateCourseRetentionStats).to have_received(:new)
+        .with(an_object_having_attributes(slug: 'S/also_due'), now: kind_of(Time))
+    end
   end
 end


### PR DESCRIPTION
## What this PR does

Adds an admin-only, Wiki Education Dashboard-only **report card** page for Scholars & Scientists courses, automating the staff spreadsheet that has been assembled by hand from the retention predictors CSV (`lib/analytics/retention_predictors_csv_builder.rb`). `/report_cards` lists campaigns that have computed data; `/report_cards/:campaign_slug` shows one row per `FellowsCohort` course in that campaign, in the spreadsheet's three column groups (General / During the course / After the course), with a totals row and a CSV download.

The retention metrics come from the live `usercontribs` API and are far too slow to compute on request, so this PR also adds a store for them: a `retention_stats` table with one row per course × student, filled by `UpdateCourseRetentionStats` from the per-student calculator extracted out of the CSV builder (`RetentionStudentStats`; the CSV's output is unchanged). A daily worker keeps the rows current for recently ended `FellowsCohort` courses only — each course is recomputed at most three times, at the checkpoints where a metric becomes final (end + 1, + 31 and + 91 days) — and `rake retention_stats:backfill[campaign_slug]` fills in historical cohorts one campaign at a time. Student-program courses are never touched, and the worker cannot reach courses older than four months, so it can never silently backfill history.

Semantics follow the CSV: long-term Wikipedians (500+ edits before the course) are counted under Participants and left out of every other figure. The spreadsheet's two "…of which is a long-term Wikipedian" sub-columns under the survival counts are therefore omitted (they would always be zero); words and uploads per participant divide by all participants, since those course totals include everyone's work.

**Review follow-up (second commit).** The review comment below found that a `usercontribs` request failing after `WikiApi`'s retries was read as "no edits", so a student whose edits could not be fetched would have been stored as a non-editor and never recomputed. A failed fetch (of any page, in either fetcher) now raises `RetentionFetchError`; the daily worker and the backfill task rescue it per course, so the course keeps its previous rows, stays due, and the other courses are not held up. The on-demand retention CSV now fails its job on a fetch error rather than producing a wrong download. Separately, a cell that will never fill in (nobody edited during the course, or every participant is a long-term Wikipedian) now shows a dash rather than "pending": each column carries the checkpoint its figure becomes final at, and the row knows which checkpoints its stored data has reached. Also from the review: a course with no students no longer stays due every day, the average-words figure rounds once, and the feature spec's totals check was tightened.

### Checked against the spreadsheet with real data

To illustrate the page with real numbers, the new backfill task was run locally against a copy of the production database (the 2026-06-21 dump) for `wikipedia_scholars__scientists_202425`: 20 courses, 299 students, about 20 minutes of serial `usercontribs` calls. The screenshots below are that data. Comparing the page's figures with the 2024–25 tab of the staff spreadsheet (which covers 13 of those 20 courses):

| Course | Spreadsheet: participants / editing sessions / edited in 30 days / survivors | Page | Why they differ |
|---|---|---|---|
| 250 by 2026-1 | 18 / 108 / 5 / 2 | 18 / 108 / 5 / 2 | Identical in every column. (The sheet's typed-in 31% is 29.4% by its own formula.) |
| 250 by 2026-2 | 28 / 228 / 4 / 1 | 28 / 228 / 4 / 1 | Identical in every column. |
| Anthology of Latino Poets | 17 / 75 / 2 / 1 | 17 / 75 / 2 / 1 | Identical in every column. |
| APS Wiki Scientists 8 | 17 / 66 / 1 / 0 | 17 / 66 / 1 / 0 | Identical in every column. |
| RAO Wiki Scientist Training-2 | 15 / 61 / 1 / 1 | 15 / 60 / 1 / 1 | One editing session fewer. |
| Histories of Social Movements and Political Change | 20 / 104 / 1 / 0 | 20 / 103 / 1 / 0 | One editing session fewer. |
| 250 by 2026-3 | 22 / 189 / 5 / 2 | 22 / 171 / 4 / 2 | One participant's edits no longer come back from the API at all; the survival counts are unchanged. |
| Latinx Past Wiki Scholars | 23 / 150 / 2 / 1 | 23 (1 long-term) / 108 / 1 / 0 | The one survivor is a long-term Wikipedian, excluded here. |
| Climate Finance Biographies | 26 (2 long-term) / 171 / 5 / 5 | 26 (3) / 78 / 3 / 4 | A third participant crosses the 500-edit threshold that the sheet still labels as 1000. |
| Global Approaches to Climate Finance 3 | 25 (3) / 141 / 7 / 0 | 25 (5) / 101 / 4 / 0 | Same threshold effect. |
| Global Approaches to Climate Finance 4 | 11 (3) / 315 / 8 / 4 | 11 (5) / 33 / 3 / 3 | Same. |
| Global Approaches to Climate Finance 5 | 11 (5) / 369 / 9 / 3 | 11 (5) / 33 / 4 / 3 | The sheet's during-course and 30-day figures include the five long-term Wikipedians; its survival figures don't. |
| The 2024 Election Editing Workshop | 14 / 169 / 8 / 5 | 14 (9) / 9 / 1 / 1 | Nine of the fourteen participants were long-term Wikipedians. |

Where no long-term Wikipedians are involved, the page reproduces the spreadsheet exactly. The session drift on three courses looks like a property of the source rather than the code: `usercontribs` does not return edits to pages that have since been deleted, so a participant whose sandbox or draft was deleted loses those sessions (inferred from the pattern, not verified per participant). Storing each course's figures once its windows close, as this PR does, also freezes them against that kind of drift. The other seven courses in the campaign (The 2024 Election-2 through -6, WITH Wiki Scientists 7 and 8) were never on the sheet and now appear alongside.

## AI usage

All of the code, specs and the commit message in this PR were written by Claude Code (Claude Fable 5.1) under Sage Ross's direction, in one session on 2026-09-11. Sage supplied the spreadsheet to automate and the goal; Claude Code did the reconnaissance (mapping every spreadsheet column to Dashboard data and checking the mapping against a prod-copy database), wrote a plan with the design decisions laid out as explicit choices, and Sage approved the recommended option on each. One question from Sage during planning caught a real flaw — the daily worker as first drafted would have backfilled every historical course on its first run — which was fixed in the plan before any code was written. Sage wrote the two pieces of user-facing copy (the legend and the empty state); the column headers are the spreadsheet's own text. The illustration below was produced by running the new backfill task locally against a copy of production data and screenshotting the resulting page.

The first commit was made at the end of that session (about an hour and a half of wall-clock time, planning included). The second commit came from a separate Claude Code session on the same day: Sage asked it to read the review findings (themselves posted from a Claude Code review session), decide which warranted changes, and make them. Claude Code triaged the eight items, implemented five and set three aside with reasons, in one autonomous pass; Sage's input on the result was to remove a `[PLACEHOLDER]` it had left in the legend for a sentence explaining the dash, judging the dash self-explanatory. This PR description, and the summary above, were also drafted by Claude Code using the `prepare-pr` skill, then revised by it for the second commit, and may contain errors.

## Screenshots

No "before": the page is new. These are the real 2024–25 figures described above, rendered in the test environment from an export of the computed rows (students replaced by placeholder accounts, which the page never shows; instructor names and course titles are the real, public ones). They predate the second commit; no 2024–25 course has a figure with nobody to count, so the dash marker does not appear in them.

**Report cards index**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/retention-report-card/screenshots/after/01_report_cards_index.png) |

**Report card at the default page width (the table scrolls horizontally)**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/retention-report-card/screenshots/after/02_report_card_default_width.png) |

**The whole 2024–25 report card, all 20 courses and the totals row**

| Before | After |
|--------|-------|
| _(did not exist on master)_ | ![after](https://raw.githubusercontent.com/WikiEducationFoundation/WikiEduDashboard/pr-screenshots/retention-report-card/screenshots/after/03_report_card_2024_25_full_table.png) |

## Open questions and concerns

- **Two judgment calls to confirm**: dropping the always-zero "…of which long-term Wikipedian" survival sub-columns, and dividing words/uploads by all participants rather than the counted ones. The review found both readings consistent with the exclusion rule; both are one-line changes if the other reading is preferred.
- **Set aside from the review, deliberately**: the "percentage of active participants who edited after" can exceed 100%, as the spreadsheet's own `M / (D − H)` does (a participant who edited only after the course counts in the numerator but not the denominator); noted in a code comment rather than changed. The predicted `RecordNotUnique` from running the backfill while the daily worker is on the same course cannot occur, since `insert_all` skips duplicates on MySQL. CSV cells are not formula-escaped, consistent with the other exports.
- **Instructor column**: the spreadsheet names one lead facilitator per course; the Dashboard only knows the instructor role, and Will Kent is a co-instructor on nearly every course. The page lists every instructor by real name.
- **Numbers will differ from the hand-built spreadsheet in places**: several of its "average" cells were typed over rather than computed, and the 2024–25 tab counted long-term Wikipedians in some denominators. The comparison above shows where the automated figures line up and where they don't.
- **After deploy**: run `bundle exec rake "retention_stats:backfill[wikipedia_scholars__scientists_202526]"` (and `_202425`) once on the server. Each is a few thousand serial API calls, about a minute per course.
- Follow-up candidate, not in this PR: serve the on-demand retention CSV from stored rows once a course has passed its last checkpoint, so that download becomes instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(PR description written by Claude Code.)

